### PR TITLE
Fix eslint errors in frontend

### DIFF
--- a/UI/new-svelte/src/lib/api/api-request.ts
+++ b/UI/new-svelte/src/lib/api/api-request.ts
@@ -21,6 +21,7 @@ export class ApiRequest<U extends ApiEndpoint> {
 	public get(
 		urlParams: U extends ApiEndpointWithRequest ? ApiRequestTypes[U] : never
 	): Promise<ApiResponse<ApiResponseTypes[U]>>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- implementation signature behind the typed overloads above; the per-endpoint request DTOs aren't assignable to a concrete index signature.
 	public get(urlParams?: Record<string, any>) {
 		const params = this.encodeParams(urlParams);
 		const endpoint = params ? this.endpoint + '?' + params : this.endpoint;
@@ -45,6 +46,7 @@ export class ApiRequest<U extends ApiEndpoint> {
 		endpoint: U,
 		urlParams: ApiRequestTypes[U]
 	): Promise<ApiResponseTypes[U]>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- implementation signature behind the typed overloads above; the per-endpoint request DTOs can't be expressed as a single concrete param type.
 	public static async get<U extends ApiEndpoint>(endpoint: U, urlParams?: any) {
 		const request = new ApiRequest(endpoint);
 		const result = await request.get(urlParams);

--- a/UI/new-svelte/src/lib/api/api-socket.ts
+++ b/UI/new-svelte/src/lib/api/api-socket.ts
@@ -26,10 +26,12 @@ export const onPingMeasured = pingHook.onNotified;
 
 type InFlightRequest = {
 	startTime: number;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- heterogeneous queue of requests for differing commands; ApiSocketRequest<T> is invariant in T so a common supertype isn't expressible.
 	command: ApiSocketRequest<any>;
 };
 
 export class ApiSocket {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- heterogeneous queue of requests for differing commands; ApiSocketRequest<T> is invariant in T so a common supertype isn't expressible.
 	private socketCommandQueue: ApiSocketRequest<any>[] = [];
 	private inFlightRequests: InFlightRequest[] = [];
 	private commandCounter = 0;
@@ -53,6 +55,7 @@ export class ApiSocket {
 		commandName: T,
 		params: ApiSocketRequestTypes[T]
 	): Promise<IApiSocketResponse<T>>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- implementation signature behind the typed overloads above; TS cannot narrow the conditional param type from the generic T here.
 	public async sendSocketCommand<T extends ApiSocketCommand>(commandName: T, params?: any) {
 		const id = (this.commandCounter++).toString();
 		const request = new ApiSocketRequest(id, commandName, params);

--- a/UI/new-svelte/src/tests/lib/api/api-request.test.ts
+++ b/UI/new-svelte/src/tests/lib/api/api-request.test.ts
@@ -1,28 +1,46 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
-let xhrInstances: any[];
+interface MockXhr {
+	open: Mock;
+	send: Mock;
+	setRequestHeader: Mock;
+	withCredentials: boolean;
+	status: number;
+	statusText: string;
+	responseText: string;
+	onload: (() => void) | null;
+	onerror: (() => void) | null;
+	onabort: (() => void) | null;
+}
 
-vi.stubGlobal('XMLHttpRequest', function (this: any) {
-	this.open = vi.fn();
-	this.send = vi.fn(
-		function (this: any) {
-			this.status = 200;
-			this.responseText = JSON.stringify({ data: 'test-result' });
-			if (this.onload) this.onload();
-		}.bind(this)
-	);
-	this.setRequestHeader = vi.fn();
-	this.withCredentials = false;
-	this.status = 0;
-	this.statusText = 'OK';
-	this.responseText = '';
-	this.onload = null;
-	this.onerror = null;
-	this.onabort = null;
-	xhrInstances.push(this);
-});
+let xhrInstances: MockXhr[] = [];
 
-vi.stubGlobal('window', { encodeURIComponent: encodeURIComponent });
+function createMockXhr(): MockXhr {
+	const xhr: MockXhr = {
+		open: vi.fn(),
+		send: vi.fn(),
+		setRequestHeader: vi.fn(),
+		withCredentials: false,
+		status: 0,
+		statusText: 'OK',
+		responseText: '',
+		onload: null,
+		onerror: null,
+		onabort: null
+	};
+	// Default behaviour: a successful response that synchronously fires the onload handler.
+	xhr.send.mockImplementation(() => {
+		xhr.status = 200;
+		xhr.responseText = JSON.stringify({ data: 'test-result' });
+		xhr.onload?.();
+	});
+	xhrInstances.push(xhr);
+	return xhr;
+}
+
+// Returning an object from a constructor makes `new XMLHttpRequest()` resolve to that object.
+vi.stubGlobal('XMLHttpRequest', vi.fn(createMockXhr));
+vi.stubGlobal('window', { encodeURIComponent });
 
 import { ApiRequest } from '$lib/api/api-request';
 
@@ -31,45 +49,39 @@ describe('ApiRequest', () => {
 		xhrInstances = [];
 	});
 
-	function lastXhr() {
-		return xhrInstances[xhrInstances.length - 1];
-	}
+	const lastXhr = () => xhrInstances[xhrInstances.length - 1];
 
 	describe('get (instance)', () => {
 		it('opens a GET request to /api/{endpoint}', async () => {
-			const request = new ApiRequest('Items' as any);
-			await request.get();
+			await new ApiRequest('Items').get();
 
 			expect(lastXhr().open).toHaveBeenCalledWith('GET', '/api/Items', true);
 		});
 
 		it('appends URL params when provided', async () => {
-			const request = new ApiRequest('Items' as any);
-			await (request as any).get({ id: 5, name: 'sword' });
+			await new ApiRequest('Items/SlotsForItem').get({ itemId: 5, refreshCache: true });
 
 			const url = lastXhr().open.mock.calls[0][1] as string;
-			expect(url).toContain('id=5');
-			expect(url).toContain('name=sword');
+			expect(url).toContain('itemId=5');
+			expect(url).toContain('refreshCache=true');
 		});
 
 		it('sets withCredentials to true', async () => {
-			const request = new ApiRequest('Items' as any);
-			await request.get();
+			await new ApiRequest('Items').get();
 
 			expect(lastXhr().withCredentials).toBe(true);
 		});
 
 		it('returns an ApiResponse with parsed data', async () => {
-			const request = new ApiRequest('Items' as any);
-			const response = await request.get();
+			const response = await new ApiRequest('Items').get();
 
-			expect(response.data).toBe('test-result');
+			const data: unknown = response.data;
+			expect(data).toBe('test-result');
 		});
 
 		it('resolves even when send throws', async () => {
-			const request = new ApiRequest('Items' as any);
-			const xhr = lastXhr();
-			xhr.send = vi.fn(() => {
+			const request = new ApiRequest('Items');
+			lastXhr().send.mockImplementation(() => {
 				throw new Error('Network error');
 			});
 
@@ -78,60 +90,55 @@ describe('ApiRequest', () => {
 		});
 
 		it('skips undefined URL params', async () => {
-			const request = new ApiRequest('Items' as any);
-			await (request as any).get({ id: 5, missing: undefined });
+			await new ApiRequest('Items/SlotsForItem').get({ itemId: 5, refreshCache: undefined });
 
 			const url = lastXhr().open.mock.calls[0][1] as string;
-			expect(url).toContain('id=5');
-			expect(url).not.toContain('missing');
+			expect(url).toContain('itemId=5');
+			expect(url).not.toContain('refreshCache');
 		});
 	});
 
 	describe('post', () => {
 		it('opens a POST request to /api/{endpoint}', async () => {
-			const request = new ApiRequest('Login' as any);
-			await request.post({ username: 'u', password: 'p' } as any);
+			await new ApiRequest('Login').post({ username: 'u', password: 'p' });
 
 			expect(lastXhr().open).toHaveBeenCalledWith('POST', '/api/Login', true);
 		});
 
 		it('sets content-type to application/json', async () => {
-			const request = new ApiRequest('Login' as any);
-			await request.post({ username: 'u', password: 'p' } as any);
+			await new ApiRequest('Login').post({ username: 'u', password: 'p' });
 
 			expect(lastXhr().setRequestHeader).toHaveBeenCalledWith('content-type', 'application/json');
 		});
 
 		it('sends JSON-stringified payload', async () => {
 			const payload = { username: 'user', password: 'pass' };
-			const request = new ApiRequest('Login' as any);
-			await request.post(payload as any);
+			await new ApiRequest('Login').post(payload);
 
 			expect(lastXhr().send).toHaveBeenCalledWith(JSON.stringify(payload));
 		});
 
 		it('resolves even when send throws', async () => {
-			const request = new ApiRequest('Login' as any);
-			const xhr = lastXhr();
-			xhr.send = vi.fn(() => {
+			const request = new ApiRequest('Login');
+			lastXhr().send.mockImplementation(() => {
 				throw new Error('Network error');
 			});
 
-			const response = await request.post({ username: 'u', password: 'p' } as any);
+			const response = await request.post({ username: 'u', password: 'p' });
 			expect(response).toBeDefined();
 		});
 	});
 
 	describe('static get', () => {
 		it('creates a request and returns data directly', async () => {
-			const data = await ApiRequest.get('Items' as any);
+			const data: unknown = await ApiRequest.get('Items');
 			expect(data).toBe('test-result');
 		});
 	});
 
 	describe('static post', () => {
 		it('creates a request and returns data directly', async () => {
-			const data = await ApiRequest.post('Login' as any, { username: 'u', password: 'p' } as any);
+			const data: unknown = await ApiRequest.post('Login', { username: 'u', password: 'p' });
 			expect(data).toBe('test-result');
 		});
 	});

--- a/UI/new-svelte/src/tests/lib/api/api-socket.test.ts
+++ b/UI/new-svelte/src/tests/lib/api/api-socket.test.ts
@@ -1,21 +1,36 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 vi.mock('svelte', () => ({
 	onDestroy: vi.fn()
 }));
 
-let socketInstances: any[];
+interface MockWebSocket {
+	readyState: number;
+	OPEN: number;
+	CLOSED: number;
+	send: Mock;
+	onopen: (() => void) | null;
+	onmessage: ((ev: { data: string }) => void) | null;
+	onerror: (() => void) | null;
+}
 
-vi.stubGlobal('WebSocket', function (this: any) {
-	this.readyState = 1;
-	this.OPEN = 1;
-	this.CLOSED = 3;
-	this.send = vi.fn();
-	this.onopen = null;
-	this.onmessage = null;
-	this.onerror = null;
-	socketInstances.push(this);
-});
+let socketInstances: MockWebSocket[] = [];
+
+function createMockWebSocket(): MockWebSocket {
+	const ws: MockWebSocket = {
+		readyState: 1,
+		OPEN: 1,
+		CLOSED: 3,
+		send: vi.fn(),
+		onopen: null,
+		onmessage: null,
+		onerror: null
+	};
+	socketInstances.push(ws);
+	return ws;
+}
+
+vi.stubGlobal('WebSocket', vi.fn(createMockWebSocket));
 
 import { ApiSocket } from '$lib/api/api-socket';
 
@@ -23,21 +38,26 @@ describe('ApiSocket', () => {
 	let apiSocket: ApiSocket;
 
 	beforeEach(() => {
-		// Force the module-level socket to be seen as CLOSED so ensureSocket creates a new one
-		for (const s of socketInstances ?? []) {
-			s.readyState = 3; // CLOSED
+		// Force any socket left from a previous test to read as CLOSED so ensureSocket creates a fresh one.
+		for (const s of socketInstances) {
+			s.readyState = s.CLOSED;
 		}
 		socketInstances = [];
 		apiSocket = new ApiSocket();
 	});
 
-	function lastWs() {
-		return socketInstances[socketInstances.length - 1];
-	}
+	const lastWs = () => socketInstances[socketInstances.length - 1];
+
+	const receive = (ws: MockWebSocket, data: string) => {
+		if (!ws.onmessage) {
+			throw new Error('WebSocket has no message handler registered');
+		}
+		ws.onmessage({ data });
+	};
 
 	describe('sendSocketCommand', () => {
 		it('creates a WebSocket and sends the command', async () => {
-			const promise = apiSocket.sendSocketCommand('DefeatEnemy' as any);
+			const promise = apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: 1 });
 			const ws = lastWs();
 
 			expect(ws.send).toHaveBeenCalledTimes(1);
@@ -45,25 +65,23 @@ describe('ApiSocket', () => {
 			expect(sent.name).toBe('DefeatEnemy');
 			expect(sent.id).toBeDefined();
 
-			ws.onmessage({
-				data: JSON.stringify({ id: sent.id, name: 'DefeatEnemy', data: { exp: 100 } })
-			});
+			receive(ws, JSON.stringify({ id: sent.id, name: 'DefeatEnemy', data: { cooldown: 100 } }));
 
 			const response = await promise;
-			expect(response.data).toEqual({ exp: 100 });
+			expect(response.data).toEqual({ cooldown: 100 });
 		});
 
 		it('assigns incrementing command IDs', async () => {
-			const p1 = apiSocket.sendSocketCommand('DefeatEnemy' as any);
-			const p2 = apiSocket.sendSocketCommand('NewEnemy' as any);
+			const p1 = apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: 1 });
+			const p2 = apiSocket.sendSocketCommand('NewEnemy', { newZoneId: 1 });
 			const ws = lastWs();
 
 			const sent1 = JSON.parse(ws.send.mock.calls[0][0]);
 			const sent2 = JSON.parse(ws.send.mock.calls[1][0]);
 			expect(Number(sent2.id)).toBeGreaterThan(Number(sent1.id));
 
-			ws.onmessage({ data: JSON.stringify({ id: sent1.id, name: 'DefeatEnemy', data: {} }) });
-			ws.onmessage({ data: JSON.stringify({ id: sent2.id, name: 'NewEnemy', data: {} }) });
+			receive(ws, JSON.stringify({ id: sent1.id, name: 'DefeatEnemy', data: {} }));
+			receive(ws, JSON.stringify({ id: sent2.id, name: 'NewEnemy', data: {} }));
 
 			await p1;
 			await p2;
@@ -73,14 +91,12 @@ describe('ApiSocket', () => {
 	describe('listenCommand', () => {
 		it('calls listener when matching command arrives', () => {
 			const listener = vi.fn();
-			apiSocket.listenCommand('SocketReplaced' as any, listener, false);
+			apiSocket.listenCommand('SocketReplaced', listener, false);
 
-			apiSocket.sendSocketCommand('DefeatEnemy' as any);
+			apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: 1 });
 			const ws = lastWs();
 
-			ws.onmessage({
-				data: JSON.stringify({ name: 'SocketReplaced', data: {} })
-			});
+			receive(ws, JSON.stringify({ name: 'SocketReplaced', data: {} }));
 
 			expect(listener).toHaveBeenCalledTimes(1);
 		});
@@ -88,15 +104,13 @@ describe('ApiSocket', () => {
 		it('supports multiple listeners for the same command', () => {
 			const listener1 = vi.fn();
 			const listener2 = vi.fn();
-			apiSocket.listenCommand('SocketReplaced' as any, listener1, false);
-			apiSocket.listenCommand('SocketReplaced' as any, listener2, false);
+			apiSocket.listenCommand('SocketReplaced', listener1, false);
+			apiSocket.listenCommand('SocketReplaced', listener2, false);
 
-			apiSocket.sendSocketCommand('DefeatEnemy' as any);
+			apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: 1 });
 			const ws = lastWs();
 
-			ws.onmessage({
-				data: JSON.stringify({ name: 'SocketReplaced', data: {} })
-			});
+			receive(ws, JSON.stringify({ name: 'SocketReplaced', data: {} }));
 
 			expect(listener1).toHaveBeenCalledTimes(1);
 			expect(listener2).toHaveBeenCalledTimes(1);
@@ -104,14 +118,12 @@ describe('ApiSocket', () => {
 
 		it('does not call listeners for different commands', () => {
 			const listener = vi.fn();
-			apiSocket.listenCommand('SocketReplaced' as any, listener, false);
+			apiSocket.listenCommand('SocketReplaced', listener, false);
 
-			apiSocket.sendSocketCommand('DefeatEnemy' as any);
+			apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: 1 });
 			const ws = lastWs();
 
-			ws.onmessage({
-				data: JSON.stringify({ id: '0', name: 'DefeatEnemy', data: {} })
-			});
+			receive(ws, JSON.stringify({ id: '0', name: 'DefeatEnemy', data: {} }));
 
 			expect(listener).not.toHaveBeenCalled();
 		});
@@ -119,10 +131,10 @@ describe('ApiSocket', () => {
 
 	describe('ping/pong', () => {
 		it('responds with pong when ping received', () => {
-			apiSocket.sendSocketCommand('DefeatEnemy' as any);
+			apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: 1 });
 			const ws = lastWs();
 
-			ws.onmessage({ data: 'ping' });
+			receive(ws, 'ping');
 
 			expect(ws.send).toHaveBeenCalledWith('pong');
 		});
@@ -132,9 +144,9 @@ describe('ApiSocket', () => {
 		it('logs error and does not crash on malformed JSON', () => {
 			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-			apiSocket.sendSocketCommand('DefeatEnemy' as any);
+			apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: 1 });
 			const ws = lastWs();
-			ws.onmessage({ data: 'not-json' });
+			receive(ws, 'not-json');
 
 			expect(consoleSpy).toHaveBeenCalled();
 			consoleSpy.mockRestore();
@@ -146,13 +158,11 @@ describe('ApiSocket', () => {
 				throw new Error('listener error');
 			});
 
-			apiSocket.listenCommand('SocketReplaced' as any, badListener, false);
+			apiSocket.listenCommand('SocketReplaced', badListener, false);
 
-			apiSocket.sendSocketCommand('DefeatEnemy' as any);
+			apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: 1 });
 			const ws = lastWs();
-			ws.onmessage({
-				data: JSON.stringify({ name: 'SocketReplaced', data: {} })
-			});
+			receive(ws, JSON.stringify({ name: 'SocketReplaced', data: {} }));
 
 			expect(badListener).toHaveBeenCalled();
 			expect(consoleSpy).toHaveBeenCalled();
@@ -163,21 +173,17 @@ describe('ApiSocket', () => {
 	describe('listenCommand unhook', () => {
 		it('returns an unhook function that removes the listener', () => {
 			const listener = vi.fn();
-			const unhook = apiSocket.listenCommand('SocketReplaced' as any, listener, false);
+			const unhook = apiSocket.listenCommand('SocketReplaced', listener, false);
 
-			apiSocket.sendSocketCommand('DefeatEnemy' as any);
+			apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: 1 });
 			const ws = lastWs();
 
-			ws.onmessage({
-				data: JSON.stringify({ name: 'SocketReplaced', data: {} })
-			});
+			receive(ws, JSON.stringify({ name: 'SocketReplaced', data: {} }));
 			expect(listener).toHaveBeenCalledTimes(1);
 
 			unhook();
 
-			ws.onmessage({
-				data: JSON.stringify({ name: 'SocketReplaced', data: {} })
-			});
+			receive(ws, JSON.stringify({ name: 'SocketReplaced', data: {} }));
 			expect(listener).toHaveBeenCalledTimes(1);
 		});
 	});

--- a/UI/new-svelte/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/new-svelte/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ELogType } from '$lib/api';
-import type { ISkill } from '$lib/api';
+import type { ISkill, IEnemy, IEnemyInstance } from '$lib/api';
+
+// Callbacks captured from the mocked engine hooks. `onLogicalUpdate` emits a delta,
+// `onRenderUpdate` a (renderDelta, logicalDelta) pair, and `onNewEnemyLoaded` an enemy instance.
+type DeltaCallback = (delta: number) => void;
+type RenderCallback = (renderDelta: number, logicalDelta: number) => void;
+type EnemyLoadedCallback = (enemy: IEnemyInstance) => void;
 
 vi.mock('svelte', async (importOriginal) => ({
 	...((await importOriginal()) as Record<string, unknown>),
@@ -9,7 +15,7 @@ vi.mock('svelte', async (importOriginal) => ({
 
 const { mockSkills, mockEnemies, mockPlayerManager, mockInventoryManager } = vi.hoisted(() => {
 	const mockSkills: ISkill[] = [];
-	const mockEnemies: any[] = [];
+	const mockEnemies: IEnemy[] = [];
 	const mockPlayerManager = {
 		name: 'TestPlayer',
 		level: 5,
@@ -27,9 +33,9 @@ const { mockSkills, mockEnemies, mockPlayerManager, mockInventoryManager } = vi.
 });
 
 let { logicalUpdateCallbacks, renderUpdateCallbacks, enemyLoadedCallbacks } = vi.hoisted(() => {
-	const logicalUpdateCallbacks: Function[] = [];
-	const renderUpdateCallbacks: Function[] = [];
-	const enemyLoadedCallbacks: Function[] = [];
+	const logicalUpdateCallbacks: DeltaCallback[] = [];
+	const renderUpdateCallbacks: RenderCallback[] = [];
+	const enemyLoadedCallbacks: EnemyLoadedCallback[] = [];
 
 	return { logicalUpdateCallbacks, renderUpdateCallbacks, enemyLoadedCallbacks };
 });
@@ -63,7 +69,7 @@ vi.mock('$lib/engine/player/player-manager', () => ({
 
 vi.mock('$lib/engine/logical-engine', () => ({
 	LogicalEngine: vi.fn(class {}),
-	onLogicalUpdate: vi.fn((cb: Function) => {
+	onLogicalUpdate: vi.fn((cb: DeltaCallback) => {
 		logicalUpdateCallbacks.push(cb);
 		return () => {
 			logicalUpdateCallbacks = logicalUpdateCallbacks.filter((c) => c !== cb);
@@ -73,7 +79,7 @@ vi.mock('$lib/engine/logical-engine', () => ({
 
 vi.mock('$lib/engine/render-engine', () => ({
 	RenderEngine: vi.fn(class {}),
-	onRenderUpdate: vi.fn((cb: Function) => {
+	onRenderUpdate: vi.fn((cb: RenderCallback) => {
 		renderUpdateCallbacks.push(cb);
 		return () => {
 			renderUpdateCallbacks = renderUpdateCallbacks.filter((c) => c !== cb);
@@ -82,7 +88,7 @@ vi.mock('$lib/engine/render-engine', () => ({
 }));
 
 vi.mock('$lib/engine/battle/enemy-manager', () => ({
-	onNewEnemyLoaded: vi.fn((cb: Function) => {
+	onNewEnemyLoaded: vi.fn((cb: EnemyLoadedCallback) => {
 		enemyLoadedCallbacks.push(cb);
 		return () => {
 			enemyLoadedCallbacks = enemyLoadedCallbacks.filter((c) => c !== cb);
@@ -114,7 +120,7 @@ describe('BattleEngine', () => {
 		};
 
 		mockEnemies.length = 0;
-		mockEnemies[1] = { name: 'Goblin', selectedSkills: [0], attributes: [] };
+		mockEnemies[1] = { id: 1, name: 'Goblin', isBoss: false, attributeDistribution: [], skillPool: [0], spawns: [] };
 
 		engine = new BattleEngine();
 	});
@@ -161,7 +167,7 @@ describe('BattleEngine', () => {
 		it('transitions to Active when enemy is loaded', () => {
 			engine.start();
 
-			const enemyInstance = { id: 1, level: 1, selectedSkills: [0], attributes: [] };
+			const enemyInstance = { id: 1, level: 1, seed: 0, selectedSkills: [0], attributes: [] };
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			expect(engine.stage).toBe(BattleStage.Active);
@@ -170,7 +176,7 @@ describe('BattleEngine', () => {
 		it('transitions to Victorious when enemy dies', () => {
 			engine.start();
 
-			const enemyInstance = { id: 1, level: 1, selectedSkills: [0], attributes: [] };
+			const enemyInstance = { id: 1, level: 1, seed: 0, selectedSkills: [0], attributes: [] };
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			// Simulate enough logical updates to kill the enemy
@@ -186,7 +192,7 @@ describe('BattleEngine', () => {
 
 		it('pause sets stage to Paused', () => {
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, selectedSkills: [0], attributes: [] };
+			const enemyInstance = { id: 1, level: 1, seed: 0, selectedSkills: [0], attributes: [] };
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			engine.pause();
@@ -195,7 +201,7 @@ describe('BattleEngine', () => {
 
 		it('resume returns to Active when both alive', () => {
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, selectedSkills: [0], attributes: [] };
+			const enemyInstance = { id: 1, level: 1, seed: 0, selectedSkills: [0], attributes: [] };
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			engine.pause();
@@ -207,7 +213,7 @@ describe('BattleEngine', () => {
 	describe('logicalUpdate', () => {
 		it('logs damage messages', () => {
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, selectedSkills: [0], attributes: [] };
+			const enemyInstance = { id: 1, level: 1, seed: 0, selectedSkills: [0], attributes: [] };
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			logicalUpdateCallbacks[0](500);

--- a/UI/new-svelte/src/tests/routes/login.test.ts
+++ b/UI/new-svelte/src/tests/routes/login.test.ts
@@ -5,8 +5,8 @@ import LoginPage from '../../routes/+page.svelte';
 // Mock modules that depend on SvelteKit runtime
 vi.mock('$app/environment', () => ({ browser: true }));
 vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
-vi.mock('$app/stores', () => {
-	const { readable } = require('svelte/store');
+vi.mock('$app/stores', async () => {
+	const { readable } = await import('svelte/store');
 	return { page: readable({ url: new URL('http://localhost/') }) };
 });
 vi.mock('$lib/api', () => ({


### PR DESCRIPTION
Closes #11.

## Summary

Eliminates the ~50 eslint errors in the new Svelte frontend. As the issue notes, almost all of them came from loosely-typed test code (`any`, `Function`, `require`), with a handful in the API classes. `eslint .` now exits clean, `svelte-check` reports 0 errors, and all 247 unit tests pass.

The errors broke down as: `@typescript-eslint/no-explicit-any` (46), `@typescript-eslint/no-unsafe-function-type` (6), and `@typescript-eslint/no-require-imports` (1), across 6 files.

## Test files (the "lazy test writing")

- **`api-request.test.ts` / `api-socket.test.ts`** — replaced the `function (this: any)` constructor mocks and the pervasive `as any` casts (44 of the errors lived in these two files) with:
  - typed mock factories (`MockXhr` / `MockWebSocket`) — a constructor that *returns an object* makes `new XMLHttpRequest()` / `new WebSocket()` resolve to the mock, so no `this: any` is needed;
  - **real, type-checked endpoint and command names + payloads** instead of `'Items' as any`. Most casts were unnecessary — e.g. `'Items'` is already a valid `ApiEndpointNoRequest` (its request is optional). Where the generic return type meets a fixed mock sentinel, the result is annotated `unknown` rather than cast to `any`. The socket tests now exercise commands with their real request DTOs (`{ timestamp }`, `{ newZoneId }`) and assert against real response shapes.
  - a small `receive(ws, data)` helper replaces repeated inline `ws.onmessage({...})` calls and throws a clear error if no handler is registered.
- **`battle-engine.test.ts`** — typed the captured hook callbacks (`DeltaCallback` / `RenderCallback` / `EnemyLoadedCallback`) in place of `Function`, and made the static-data fixtures proper `IEnemy` / `IEnemyInstance` objects instead of `any[]` (the previous fixtures didn't even match the real shapes — they're now correct, e.g. `seed` is included). Test scenarios and expected results are unchanged, so battle parity is preserved.
- **`login.test.ts`** — replaced the `require('svelte/store')` inside a `vi.mock` factory (used to dodge hoisting) with an `async` factory + dynamic `import()`.

## API classes

The issue explicitly allows ignoring the API-class errors if they aren't easily solvable, and disabling the rule for those files. The remaining 5 `any`s are:

- **overload implementation signatures** (`ApiRequest.get`, `ApiRequest.get` static, `ApiSocket.sendSocketCommand`) — the public overloads are fully typed; TypeScript can't express the implementation param from the generic `T`, and the per-endpoint request DTOs aren't assignable to a single concrete type / index signature.
- **the heterogeneous in-flight request collection** (`ApiSocketRequest<any>`) — `ApiSocketRequest<T>` is invariant in `T` (it holds a `(value: IApiSocketResponse<T>) => void` resolver), so there's no common supertype. I verified this: changing it to `ApiSocketRequest<ApiSocketCommand>` produces a real svelte-check error at the `push`.

Rather than disabling the rule for the whole file, I added **targeted `eslint-disable-next-line` comments with rationale** on each of these lines, so any future stray `any` elsewhere in the files is still caught.

## Notes / follow-ups

- `npm run lint` also runs `prettier --check`, which flags 3 **pre-existing** formatting issues in files unrelated to this change (`Loading.svelte`, `Workbench.svelte`, `loading/+page.svelte`). I left them out to keep this PR focused on the eslint errors and will open a small follow-up issue for them.

https://claude.ai/code/session_01PhsLN9UoTULsf3KctbUibt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhsLN9UoTULsf3KctbUibt)_