### PR TITLE
Validate password hash on login (#32)

### DIFF
--- a/Game.Api.Tests/Integration/LoginControllerTests.cs
+++ b/Game.Api.Tests/Integration/LoginControllerTests.cs
@@ -61,6 +61,32 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task Login_WrongPassword_ReturnsError()
+        {
+            // Arrange — a real user whose stored hash won't match the supplied password.
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context, "wrongpassuser", "correctpass");
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
+
+            var creds = new { Username = "wrongpassuser", Password = "wrongpass" };
+
+            // Act
+            var response = await Client.PostAsJsonAsync("/api/Login", creds, CancellationToken);
+
+            // Assert — authentication is rejected and no auth cookie is issued.
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse<PlayerData>>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.NotNull(result.ErrorMessage);
+            Assert.Null(result.Data);
+            Assert.False(response.Headers.Contains("Set-Cookie"));
+        }
+
+        [Fact]
         public async Task CreateAccount_ValidCredentials_Succeeds()
         {
             // Arrange — CreateAccount inserts PlayerSkills with SkillId 0, 1, 2

--- a/Game.Api/Controllers/LoginController.cs
+++ b/Game.Api/Controllers/LoginController.cs
@@ -39,12 +39,10 @@ namespace Game.Api.Controllers
             }
 
             var user = await _users.GetUser(creds.Username);
-            if (user is null)
+            if (user is null || !creds.Password.VerifyHash(user.Salt.ToString(), user.PassHash))
             {
-                return ApiResponse.Error("Username not found");
+                return ApiResponse.Error("Invalid username or password");
             }
-
-            // TODO: validate password hash against user entity
 
             var player = user.Players.FirstOrDefault();
             if (player is null)

--- a/Game.Core.Tests/Hashing/HashingTests.cs
+++ b/Game.Core.Tests/Hashing/HashingTests.cs
@@ -1,0 +1,56 @@
+using Game.Core;
+using Xunit;
+
+namespace Game.Core.Tests.Hashing
+{
+    public class HashingTests
+    {
+        private const string Salt = "a-test-salt";
+
+        [Fact]
+        public void VerifyHash_CorrectPassword_ReturnsTrue()
+        {
+            var hash = "correct horse battery staple".Hash(Salt);
+
+            var result = "correct horse battery staple".VerifyHash(Salt, hash);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void VerifyHash_WrongPassword_ReturnsFalse()
+        {
+            var hash = "correct horse battery staple".Hash(Salt);
+
+            var result = "wrong password".VerifyHash(Salt, hash);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void VerifyHash_WrongSalt_ReturnsFalse()
+        {
+            var hash = "password".Hash(Salt);
+
+            var result = "password".VerifyHash("a-different-salt", hash);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void VerifyHash_EmptyExpectedHash_ReturnsFalse()
+        {
+            var result = "password".VerifyHash(Salt, string.Empty);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void VerifyHash_GarbageExpectedHash_ReturnsFalse()
+        {
+            var result = "password".VerifyHash(Salt, "not-a-real-hash");
+
+            Assert.False(result);
+        }
+    }
+}

--- a/Game.Core/Hashing.cs
+++ b/Game.Core/Hashing.cs
@@ -38,6 +38,18 @@ namespace Game.Core
             return Convert.ToBase64String(hashedBytes);
         }
 
+        /// <summary>
+        /// Verifies that <paramref name="input"/> hashes to <paramref name="expectedHash"/> using the
+        /// supplied <paramref name="salt"/>. The comparison is performed in constant time to avoid
+        /// leaking information about the stored hash via timing side channels.
+        /// </summary>
+        public static bool VerifyHash(this string input, string salt, string expectedHash, int? iterations = ITERATIONS)
+        {
+            var computedHash = Encoding.UTF8.GetBytes(input.Hash(salt, iterations));
+            var expectedBytes = Encoding.UTF8.GetBytes(expectedHash);
+            return CryptographicOperations.FixedTimeEquals(computedHash, expectedBytes);
+        }
+
         public static void SetPepper(string pepper)
         {
             _pepper = Encoding.UTF8.GetBytes(pepper);


### PR DESCRIPTION
Fixes #32.

## Problem

`LoginController.Login` authenticated a user **without verifying the password** — the check was left as a `// TODO: validate password hash against user entity`. Any known (active) username could log in with any password.

## Fix

- **Added `Hashing.VerifyHash` (`Game.Core/Hashing.cs`)** — hashes the supplied password with the stored salt and compares it against the stored hash using `CryptographicOperations.FixedTimeEquals` (constant-time, avoids timing side channels). The actual comparison logic lives in `Game.Core` (the domain layer, alongside the existing `Hash`) rather than the controller, keeping the API layer thin and the logic unit-testable, per the backend guidelines.
- **Updated `LoginController.Login`** to reject the request when the user is missing *or* the password doesn't verify, returning a single generic **"Invalid username or password"** message in both cases. Previously the unknown-username path returned a distinct "Username not found", which leaks whether an account exists; collapsing both into one message closes that username-enumeration vector.

## Tests

- **Unit (`Game.Core.Tests/Hashing/HashingTests.cs`):** correct password verifies, wrong password / wrong salt / empty / malformed stored hash all fail.
- **Integration (`LoginControllerTests`):** new `Login_WrongPassword_ReturnsError` asserts a real user with the wrong password is rejected (400) and **no auth cookie is issued**. The existing valid-login and unknown-username tests still pass.

All 186 `Game.Core.Tests` and 192 `Game.Api.Tests` pass locally.

## Note / possible follow-up

`CreateAccount` still returns "There is already an account with this username." which is itself a username-enumeration vector. That's harder to avoid cleanly since account creation legitimately needs to tell the user a name is taken, so I left it as-is rather than filing an issue — happy to open one if you'd like it tracked.

https://claude.ai/code/session_01KHfnqacB9UpQbzyAtwwDbC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHfnqacB9UpQbzyAtwwDbC)_