### PR TITLE
Refactor login page into components and themeable styles (#6)

### DIFF
--- a/UI/new-svelte/src/routes/+layout.svelte
+++ b/UI/new-svelte/src/routes/+layout.svelte
@@ -64,6 +64,7 @@ $effect(() => {
 	--text-secondary: #{colors.$text-secondary};
 	--text-tertiary: #{colors.$text-tertiary};
 	--text-muted: #{colors.$text-muted};
+	--text-on-accent: #{colors.$text-on-accent};
 	--border-subtle: #{colors.$border-subtle};
 	--border-light: #{colors.$border-light};
 	--border-medium: #{colors.$border-medium};

--- a/UI/new-svelte/src/routes/+page.svelte
+++ b/UI/new-svelte/src/routes/+page.svelte
@@ -1,11 +1,6 @@
 <div class="login-screen" data-testid="login-screen">
 	<div class="login-form">
-		<!-- Diamond mark -->
-		<div class="diamond-container">
-			<div class="diamond">
-				<div class="diamond-inner"></div>
-			</div>
-		</div>
+		<DiamondMark />
 
 		<div class="heading">
 			<h1 data-testid="login-heading">{mode === 'login' ? 'Welcome back.' : 'Begin a new run.'}</h1>
@@ -15,166 +10,72 @@
 		</div>
 
 		<form onsubmit={preventDefault(handleSubmit)}>
-			<!-- Username -->
-			<div class="field-group">
-				<input
-					data-testid="username-input"
-					type="text"
-					placeholder="Username"
-					bind:value={username}
-					onblur={() => (touched.username = true)}
-					class="underline-input"
-					class:error={usernameError}
-					class:valid={username && usernameValid}
-				/>
-				{#if username}
-					<div class="field-icon">
-						{#if usernameError}
-							<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-								<path d="M4 4l8 8M12 4l-8 8" stroke="var(--error)" stroke-width="2" stroke-linecap="round" />
-							</svg>
-						{:else if usernameValid}
-							<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-								<path
-									d="M3 8.5l3 3 7-7"
-									stroke="var(--success)"
-									stroke-width="2"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-								/>
-							</svg>
-						{/if}
-					</div>
-				{/if}
-			</div>
-
-			<!-- Password -->
-			<div class="field-group" class:extra-margin={mode === 'signup'}>
-				<input
-					data-testid="password-input"
-					type={showPassword ? 'text' : 'password'}
-					placeholder="Password"
-					bind:value={password}
-					onblur={() => (touched.password = true)}
-					onkeydown={detectCapsLock}
-					onkeyup={detectCapsLock}
-					class="underline-input"
-					class:error={passwordError}
-					class:valid={password && passwordValid}
-				/>
-				<button
-					type="button"
-					class="eye-button"
-					data-testid="password-toggle"
-					onclick={() => (showPassword = !showPassword)}
-				>
-					{#if showPassword}
-						<svg width="16" height="16" viewBox="0 0 20 20" fill="none">
-							<path d="M2 10s3-5 8-5 8 5 8 5-3 5-8 5-8-5-8-5z" stroke="rgba(240,240,240,0.75)" stroke-width="1.4" />
-							<circle cx="10" cy="10" r="2.5" stroke="rgba(240,240,240,0.75)" stroke-width="1.4" />
-						</svg>
-					{:else}
-						<svg width="16" height="16" viewBox="0 0 20 20" fill="none">
-							<path
-								d="M2 10s3-5 8-5c2 0 3.7.8 5 1.8M18 10s-3 5-8 5c-2 0-3.7-.8-5-1.8"
-								stroke="rgba(240,240,240,0.75)"
-								stroke-width="1.4"
-							/>
-							<path d="M3 3l14 14" stroke="rgba(240,240,240,0.75)" stroke-width="1.4" stroke-linecap="round" />
-						</svg>
+			<UnderlineInput
+				testid="username-input"
+				placeholder="Username"
+				bind:value={username}
+				onblur={() => (touched.username = true)}
+				error={!!usernameError}
+				valid={!!username && usernameValid}
+			>
+				{#snippet trailing()}
+					{#if username}
+						<ValidationIcon type={usernameError ? 'err' : 'ok'} />
 					{/if}
-				</button>
-				{#if mode === 'signup' && password}
-					<div class="strength-meter" data-testid="strength-meter">
-						{#each [0, 1, 2, 3] as i (i)}
-							<div
-								class="strength-segment"
-								style:background={i < strengthScore
-									? strengthScore >= 3
-										? 'var(--success)'
-										: strengthScore >= 2
-											? '#e8b850'
-											: '#e0907a'
-									: 'rgba(240,240,240,0.22)'}
-							></div>
-						{/each}
-					</div>
-				{/if}
-			</div>
+				{/snippet}
+			</UnderlineInput>
 
-			<!-- Confirm password -->
+			<UnderlineInput
+				testid="password-input"
+				type={showPassword ? 'text' : 'password'}
+				placeholder="Password"
+				bind:value={password}
+				onblur={() => (touched.password = true)}
+				onkeydown={detectCapsLock}
+				onkeyup={detectCapsLock}
+				error={!!passwordError}
+				valid={!!password && passwordValid}
+			>
+				{#snippet trailing()}
+					<button
+						type="button"
+						class="eye-button"
+						data-testid="password-toggle"
+						onclick={() => (showPassword = !showPassword)}
+					>
+						<EyeIcon visible={showPassword} />
+					</button>
+				{/snippet}
+				{#snippet below()}
+					{#if mode === 'signup' && password}
+						<PasswordStrengthMeter score={strength.score} />
+					{/if}
+				{/snippet}
+			</UnderlineInput>
+
 			{#if mode === 'signup'}
-				<div class="field-group">
-					<input
-						data-testid="confirm-input"
-						type={showPassword ? 'text' : 'password'}
-						placeholder="Confirm password"
-						bind:value={confirm}
-						onblur={() => (touched.confirm = true)}
-						class="underline-input"
-						class:error={confirmError}
-						class:valid={confirm && confirmValid}
-					/>
-					{#if confirm}
-						<div class="field-icon">
-							{#if confirmError}
-								<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-									<path d="M4 4l8 8M12 4l-8 8" stroke="var(--error)" stroke-width="2" stroke-linecap="round" />
-								</svg>
-							{:else if confirmValid}
-								<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-									<path
-										d="M3 8.5l3 3 7-7"
-										stroke="var(--success)"
-										stroke-width="2"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-									/>
-								</svg>
-							{/if}
-						</div>
-					{/if}
-				</div>
+				<UnderlineInput
+					testid="confirm-input"
+					type={showPassword ? 'text' : 'password'}
+					placeholder="Confirm password"
+					bind:value={confirm}
+					onblur={() => (touched.confirm = true)}
+					error={!!confirmError}
+					valid={!!confirm && confirmValid}
+				>
+					{#snippet trailing()}
+						{#if confirm}
+							<ValidationIcon type={confirmError ? 'err' : 'ok'} />
+						{/if}
+					{/snippet}
+				</UnderlineInput>
 			{/if}
 
-			<!-- Status line -->
-			<div class="status-line" data-testid="status-line" style:color={statusColor}>
-				{#if statusLine.type === 'ok'}
-					<svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-						<path
-							d="M3 8.5l3 3 7-7"
-							stroke={statusColor}
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-						/>
-					</svg>
-				{:else if statusLine.type === 'err'}
-					<svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-						<path d="M4 4l8 8M12 4l-8 8" stroke={statusColor} stroke-width="2" stroke-linecap="round" />
-					</svg>
-				{/if}
-				{statusLine.text}
-			</div>
+			<StatusLine type={statusLine.type} text={statusLine.text} />
 
-			<!-- Submit button -->
-			<button
-				data-testid="submit-button"
-				type="submit"
-				class="submit-button"
-				disabled={!formValid || submitting}
-				class:ready={formValid}
-			>
-				{#if submitting}
-					<div class="submit-spinner"></div>
-					...
-				{:else}
-					{mode === 'login' ? 'Sign In' : 'Create'}
-				{/if}
-			</button>
+			<SubmitButton ready={formValid} {submitting} label={mode === 'login' ? 'Sign In' : 'Create'} />
 		</form>
 
-		<!-- Mode toggle -->
 		<div class="mode-toggle">
 			{mode === 'login' ? 'No account yet?' : 'Already a hero?'}
 			<button class="mode-link" data-testid="mode-toggle" onclick={toggleMode}>
@@ -191,10 +92,22 @@ import { playerManager } from '$lib/engine';
 import { preventDefault } from '$lib/common/event-wrappers';
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
+import DiamondMark from './login/DiamondMark.svelte';
+import EyeIcon from './login/EyeIcon.svelte';
+import PasswordStrengthMeter from './login/PasswordStrengthMeter.svelte';
+import StatusLine, { type StatusType } from './login/StatusLine.svelte';
+import SubmitButton from './login/SubmitButton.svelte';
+import UnderlineInput from './login/UnderlineInput.svelte';
+import ValidationIcon from './login/ValidationIcon.svelte';
+import {
+	passwordStrength,
+	validateConfirm,
+	validatePassword,
+	validateUsername,
+	type LoginMode
+} from './login/login-validation';
 
-type Mode = 'login' | 'signup';
-
-let mode = $state<Mode>('login');
+let mode = $state<LoginMode>('login');
 let username = $state('');
 let password = $state('');
 let confirm = $state('');
@@ -206,54 +119,10 @@ let serverError = $state<string | null>(null);
 let success = $state(false);
 let touched = $state({ username: false, password: false, confirm: false });
 
-const USERNAME_RE = /^[a-zA-Z][a-zA-Z0-9_-]{2,19}$/;
-
-const usernameValidation = $derived.by(() => {
-	if (!username) return { ok: false, msg: 'Required' };
-	if (username.length < 3) return { ok: false, msg: 'At least 3 characters' };
-	if (username.length > 20) return { ok: false, msg: 'Max 20 characters' };
-	if (/^[0-9]/.test(username)) return { ok: false, msg: "Can't start with a number" };
-	if (!USERNAME_RE.test(username)) return { ok: false, msg: 'Letters, numbers, _ or - only' };
-	return { ok: true, msg: 'Looks good' };
-});
-
-const passwordValidation = $derived.by(() => {
-	if (!password) return { ok: false, msg: 'Required' };
-	if (mode === 'login') return { ok: true, msg: '' };
-	if (password.length < 8) return { ok: false, msg: 'At least 8 characters' };
-	if (!/[a-zA-Z]/.test(password) || !/[0-9]/.test(password)) return { ok: false, msg: 'Mix letters and numbers' };
-	return { ok: true, msg: '' };
-});
-
-const confirmValidation = $derived.by(() => {
-	if (mode === 'login') return { ok: true, msg: '' };
-	if (!confirm) return { ok: false, msg: 'Required' };
-	if (confirm !== password) return { ok: false, msg: "Passwords don't match" };
-	return { ok: true, msg: 'Match' };
-});
-
-const strengthScore = $derived.by(() => {
-	if (!password) return 0;
-	let s = 0;
-	if (password.length >= 8) s++;
-	if (password.length >= 12) s++;
-	if (/[a-z]/.test(password) && /[A-Z]/.test(password)) s++;
-	if (/[0-9]/.test(password)) s++;
-	if (/[^A-Za-z0-9]/.test(password)) s++;
-	return Math.min(s, 4);
-});
-
-const strengthLabel = $derived.by(() => {
-	const labels = ['Too short', 'Weak', 'Fair', 'Good', 'Strong', 'Strong'];
-	if (!password) return '—';
-	let s = 0;
-	if (password.length >= 8) s++;
-	if (password.length >= 12) s++;
-	if (/[a-z]/.test(password) && /[A-Z]/.test(password)) s++;
-	if (/[0-9]/.test(password)) s++;
-	if (/[^A-Za-z0-9]/.test(password)) s++;
-	return labels[s];
-});
+const usernameValidation = $derived(validateUsername(username));
+const passwordValidation = $derived(validatePassword(password, mode));
+const confirmValidation = $derived(validateConfirm(confirm, password, mode));
+const strength = $derived(passwordStrength(password));
 
 const usernameValid = $derived(usernameValidation.ok);
 const passwordValid = $derived(passwordValidation.ok);
@@ -266,32 +135,36 @@ const confirmError = $derived(showErr('confirm') && !confirmValid ? confirmValid
 
 const formValid = $derived(usernameValid && passwordValid && (mode === 'login' || confirmValid));
 
-const statusLine = $derived.by(() => {
-	if (serverError) return { type: 'err' as const, text: serverError };
-	if (success)
+const statusLine = $derived.by((): { type: StatusType; text: string } => {
+	if (serverError) {
+		return { type: 'err', text: serverError };
+	}
+	if (success) {
 		return {
-			type: 'ok' as const,
+			type: 'ok',
 			text: mode === 'login' ? 'Signed in — loading world…' : 'Account created — entering…'
 		};
-	if (usernameError) return { type: 'err' as const, text: 'Username · ' + usernameError.toLowerCase() };
-	if (passwordError) return { type: 'err' as const, text: 'Password · ' + passwordError.toLowerCase() };
-	if (confirmError) return { type: 'err' as const, text: 'Confirm · ' + confirmError.toLowerCase() };
-	if (capsLock) return { type: 'warn' as const, text: 'Caps Lock is on' };
-	if (mode === 'signup' && password)
-		return { type: 'info' as const, text: `Strength · ${strengthLabel.toLowerCase()}` };
-	if (formValid && username) return { type: 'ok' as const, text: 'Ready' };
-	return { type: 'idle' as const, text: ' ' };
+	}
+	if (usernameError) {
+		return { type: 'err', text: 'Username · ' + usernameError.toLowerCase() };
+	}
+	if (passwordError) {
+		return { type: 'err', text: 'Password · ' + passwordError.toLowerCase() };
+	}
+	if (confirmError) {
+		return { type: 'err', text: 'Confirm · ' + confirmError.toLowerCase() };
+	}
+	if (capsLock) {
+		return { type: 'warn', text: 'Caps Lock is on' };
+	}
+	if (mode === 'signup' && password) {
+		return { type: 'info', text: `Strength · ${strength.label.toLowerCase()}` };
+	}
+	if (formValid && username) {
+		return { type: 'ok', text: 'Ready' };
+	}
+	return { type: 'idle', text: ' ' };
 });
-
-const statusColor = $derived(
-	{
-		err: 'var(--error)',
-		ok: 'var(--success)',
-		warn: 'var(--warning)',
-		info: 'var(--text-secondary)',
-		idle: 'var(--text-tertiary)'
-	}[statusLine.type]
-);
 
 const detectCapsLock = (e: KeyboardEvent) => {
 	if (typeof e.getModifierState === 'function') {
@@ -308,39 +181,38 @@ const toggleMode = () => {
 	success = false;
 };
 
+const enterWorld = (data: Parameters<typeof playerManager.initialize>[0]) => {
+	success = true;
+	playerManager.initialize(data);
+	setTimeout(() => goto(resolve('/loading')), 600);
+};
+
 const handleSubmit = async () => {
 	submitted = true;
 	serverError = null;
-	if (!formValid) return;
+	if (!formValid) {
+		return;
+	}
 
 	submitting = true;
 
-	if (mode === 'login') {
-		const response = await new ApiRequest('Login').post({ username, password });
-		submitting = false;
-		if (response.status === 200) {
-			success = true;
-			playerManager.initialize(response.data);
-			setTimeout(() => goto(resolve('/loading')), 600);
-		} else {
-			serverError = response.error ?? 'Incorrect username or password.';
+	if (mode === 'signup') {
+		const created = await new ApiRequest('Login/CreateAccount').post({ username, password });
+		if (created.status !== 200) {
+			submitting = false;
+			serverError = created.error ?? 'Could not create account.';
+			return;
 		}
+	}
+
+	const response = await new ApiRequest('Login').post({ username, password });
+	submitting = false;
+	if (response.status === 200) {
+		enterWorld(response.data);
+	} else if (mode === 'signup') {
+		serverError = response.error ?? 'Account created but login failed.';
 	} else {
-		const response = await new ApiRequest('Login/CreateAccount').post({ username, password });
-		if (response.status === 200) {
-			const loginResponse = await new ApiRequest('Login').post({ username, password });
-			submitting = false;
-			if (loginResponse.status === 200) {
-				success = true;
-				playerManager.initialize(loginResponse.data);
-				setTimeout(() => goto(resolve('/loading')), 600);
-			} else {
-				serverError = loginResponse.error ?? 'Account created but login failed.';
-			}
-		} else {
-			submitting = false;
-			serverError = response.error ?? 'Could not create account.';
-		}
+		serverError = response.error ?? 'Incorrect username or password.';
 	}
 };
 
@@ -373,27 +245,6 @@ onMount(async () => {
 	max-width: 100%;
 }
 
-.diamond-container {
-	display: flex;
-	justify-content: center;
-	margin-bottom: 36px;
-}
-
-.diamond {
-	width: 18px;
-	height: 18px;
-	transform: rotate(45deg);
-	border: 1px solid var(--accent);
-	box-shadow: 0 0 8px rgba(161, 194, 247, 0.4);
-	position: relative;
-}
-
-.diamond-inner {
-	position: absolute;
-	inset: 4px;
-	background: var(--accent);
-}
-
 .heading {
 	text-align: center;
 	margin-bottom: 42px;
@@ -412,54 +263,12 @@ onMount(async () => {
 		margin: 10px 0 0;
 		font-size: 12.5px;
 		color: var(--text-secondary);
-		font-family: 'Geist Mono', monospace;
+		font-family: var(--mono);
 		letter-spacing: 0.6px;
 	}
 }
 
-.field-group {
-	position: relative;
-	margin-bottom: 22px;
-
-	&.extra-margin {
-		margin-bottom: 22px;
-	}
-}
-
-.underline-input {
-	width: 100%;
-	height: 44px;
-	padding: 0 36px 0 0;
-	background: transparent;
-	border: none;
-	border-bottom: 1px solid rgba(240, 240, 240, 0.45);
-	outline: none;
-	color: var(--text-primary);
-	font-size: 18px;
-	font-family: inherit;
-	letter-spacing: 0.2px;
-	transition: border-color 160ms;
-
-	&.error {
-		border-bottom-color: #e08778;
-	}
-
-	&.valid {
-		border-bottom-color: rgba(168, 212, 160, 0.85);
-	}
-}
-
-.field-icon {
-	position: absolute;
-	right: 0;
-	top: 14px;
-	display: flex;
-}
-
 .eye-button {
-	position: absolute;
-	right: 0;
-	top: 10px;
 	border: none;
 	background: transparent;
 	cursor: pointer;
@@ -467,79 +276,12 @@ onMount(async () => {
 	display: flex;
 }
 
-.strength-meter {
-	display: flex;
-	gap: 4px;
-	justify-content: space-between;
-	margin-top: 10px;
-}
-
-.strength-segment {
-	flex: 1;
-	height: 2px;
-	transition: background 160ms;
-}
-
-.status-line {
-	font-family: 'Geist Mono', monospace;
-	font-size: 11.5px;
-	letter-spacing: 0.6px;
-	text-align: center;
-	min-height: 18px;
-	margin-bottom: 22px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 6px;
-	transition: color 160ms;
-}
-
-.submit-button {
-	width: 100%;
-	padding: 13px 0;
-	background: transparent;
-	color: var(--text-tertiary);
-	border: 1px solid rgba(240, 240, 240, 0.35);
-	border-radius: 2px;
-	cursor: not-allowed;
-	font-size: 13px;
-	font-weight: 500;
-	font-family: inherit;
-	letter-spacing: 2px;
-	text-transform: uppercase;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 10px;
-	transition: all 180ms;
-
-	&.ready {
-		background: var(--accent);
-		color: #111;
-		border-color: var(--accent);
-		cursor: pointer;
-	}
-
-	&:disabled {
-		cursor: not-allowed;
-	}
-}
-
-.submit-spinner {
-	width: 11px;
-	height: 11px;
-	border: 2px solid rgba(0, 0, 0, 0.25);
-	border-top-color: #111;
-	border-radius: 50%;
-	animation: spin 0.8s linear infinite;
-}
-
 .mode-toggle {
 	margin-top: 28px;
 	text-align: center;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 11px;
-	color: rgba(240, 240, 240, 0.65);
+	color: var(--text-secondary);
 	letter-spacing: 0.4px;
 }
 
@@ -548,7 +290,7 @@ onMount(async () => {
 	cursor: pointer;
 	background: none;
 	border: none;
-	border-bottom: 1px solid rgba(192, 216, 255, 0.55);
+	border-bottom: 1px solid color-mix(in srgb, var(--accent-light) 55%, transparent);
 	padding: 0 0 1px;
 	font-family: inherit;
 	font-size: inherit;

--- a/UI/new-svelte/src/routes/login/DiamondMark.svelte
+++ b/UI/new-svelte/src/routes/login/DiamondMark.svelte
@@ -1,0 +1,28 @@
+<div class="diamond-container">
+	<div class="diamond">
+		<div class="diamond-inner"></div>
+	</div>
+</div>
+
+<style lang="scss">
+.diamond-container {
+	display: flex;
+	justify-content: center;
+	margin-bottom: 36px;
+}
+
+.diamond {
+	width: 18px;
+	height: 18px;
+	transform: rotate(45deg);
+	border: 1px solid var(--accent);
+	box-shadow: 0 0 8px color-mix(in srgb, var(--accent) 40%, transparent);
+	position: relative;
+}
+
+.diamond-inner {
+	position: absolute;
+	inset: 4px;
+	background: var(--accent);
+}
+</style>

--- a/UI/new-svelte/src/routes/login/EyeIcon.svelte
+++ b/UI/new-svelte/src/routes/login/EyeIcon.svelte
@@ -1,0 +1,20 @@
+{#if visible}
+	<svg width="16" height="16" viewBox="0 0 20 20" fill="none">
+		<path d="M2 10s3-5 8-5 8 5 8 5-3 5-8 5-8-5-8-5z" stroke="var(--text-secondary)" stroke-width="1.4" />
+		<circle cx="10" cy="10" r="2.5" stroke="var(--text-secondary)" stroke-width="1.4" />
+	</svg>
+{:else}
+	<svg width="16" height="16" viewBox="0 0 20 20" fill="none">
+		<path
+			d="M2 10s3-5 8-5c2 0 3.7.8 5 1.8M18 10s-3 5-8 5c-2 0-3.7-.8-5-1.8"
+			stroke="var(--text-secondary)"
+			stroke-width="1.4"
+		/>
+		<path d="M3 3l14 14" stroke="var(--text-secondary)" stroke-width="1.4" stroke-linecap="round" />
+	</svg>
+{/if}
+
+<script lang="ts">
+/** Shows the open-eye glyph when the password is visible, otherwise the struck-through eye. */
+let { visible = false }: { visible?: boolean } = $props();
+</script>

--- a/UI/new-svelte/src/routes/login/PasswordStrengthMeter.svelte
+++ b/UI/new-svelte/src/routes/login/PasswordStrengthMeter.svelte
@@ -1,0 +1,29 @@
+<div class="strength-meter" data-testid="strength-meter">
+	{#each [0, 1, 2, 3] as i (i)}
+		<div class="strength-segment" style:background={i < score ? fillColor : EMPTY_COLOR}></div>
+	{/each}
+</div>
+
+<script lang="ts">
+const EMPTY_COLOR = 'color-mix(in srgb, var(--text-primary) 22%, transparent)';
+
+/** Number of filled segments, 0–4 (see {@link passwordStrength}). */
+let { score }: { score: number } = $props();
+
+const fillColor = $derived(score >= 3 ? 'var(--success)' : score >= 2 ? 'var(--warning)' : 'var(--error)');
+</script>
+
+<style lang="scss">
+.strength-meter {
+	display: flex;
+	gap: 4px;
+	justify-content: space-between;
+	margin-top: 10px;
+}
+
+.strength-segment {
+	flex: 1;
+	height: 2px;
+	transition: background 160ms;
+}
+</style>

--- a/UI/new-svelte/src/routes/login/StatusLine.svelte
+++ b/UI/new-svelte/src/routes/login/StatusLine.svelte
@@ -1,0 +1,40 @@
+<div class="status-line" data-testid="status-line" style:color>
+	{#if type === 'ok' || type === 'err'}
+		<ValidationIcon {type} size={14} {color} />
+	{/if}
+	{text}
+</div>
+
+<script lang="ts">
+import ValidationIcon from './ValidationIcon.svelte';
+
+export type StatusType = 'ok' | 'err' | 'warn' | 'info' | 'idle';
+
+const COLORS: Record<StatusType, string> = {
+	err: 'var(--error)',
+	ok: 'var(--success)',
+	warn: 'var(--warning)',
+	info: 'var(--text-secondary)',
+	idle: 'var(--text-tertiary)'
+};
+
+let { type, text }: { type: StatusType; text: string } = $props();
+
+const color = $derived(COLORS[type]);
+</script>
+
+<style lang="scss">
+.status-line {
+	font-family: var(--mono);
+	font-size: 11.5px;
+	letter-spacing: 0.6px;
+	text-align: center;
+	min-height: 18px;
+	margin-bottom: 22px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	transition: color 160ms;
+}
+</style>

--- a/UI/new-svelte/src/routes/login/SubmitButton.svelte
+++ b/UI/new-svelte/src/routes/login/SubmitButton.svelte
@@ -1,0 +1,68 @@
+<button data-testid="submit-button" type="submit" class="submit-button" class:ready disabled={!ready || submitting}>
+	{#if submitting}
+		<div class="submit-spinner"></div>
+		...
+	{:else}
+		{label}
+	{/if}
+</button>
+
+<script lang="ts">
+interface Props {
+	/** Whether the form is valid and ready to submit (drives the active styling). */
+	ready: boolean;
+	/** Whether a submission is in flight. */
+	submitting?: boolean;
+	label: string;
+}
+
+let { ready, submitting = false, label }: Props = $props();
+</script>
+
+<style lang="scss">
+.submit-button {
+	width: 100%;
+	padding: 13px 0;
+	background: transparent;
+	color: var(--text-tertiary);
+	border: 1px solid color-mix(in srgb, var(--text-primary) 35%, transparent);
+	border-radius: 2px;
+	cursor: not-allowed;
+	font-size: 13px;
+	font-weight: 500;
+	font-family: inherit;
+	letter-spacing: 2px;
+	text-transform: uppercase;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	transition: all 180ms;
+
+	&.ready {
+		background: var(--accent);
+		color: var(--text-on-accent);
+		border-color: var(--accent);
+		cursor: pointer;
+	}
+
+	&:disabled {
+		cursor: not-allowed;
+	}
+}
+
+.submit-spinner {
+	width: 11px;
+	height: 11px;
+	border: 2px solid color-mix(in srgb, var(--text-on-accent) 25%, transparent);
+	border-top-color: var(--text-on-accent);
+	border-radius: 50%;
+	animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+</style>

--- a/UI/new-svelte/src/routes/login/UnderlineInput.svelte
+++ b/UI/new-svelte/src/routes/login/UnderlineInput.svelte
@@ -1,0 +1,97 @@
+<div class="field-group">
+	<input
+		{type}
+		{placeholder}
+		bind:value
+		data-testid={testid}
+		{onblur}
+		{onkeydown}
+		{onkeyup}
+		class="underline-input"
+		class:error
+		class:valid
+	/>
+	{#if trailing}
+		<div class="field-trailing">
+			{@render trailing()}
+		</div>
+	{/if}
+	{#if below}
+		{@render below()}
+	{/if}
+</div>
+
+<script lang="ts">
+import type { Snippet } from 'svelte';
+
+interface Props {
+	/** Two-way bound input value. */
+	value: string;
+	type?: 'text' | 'password';
+	placeholder: string;
+	testid: string;
+	/** Applies the error accent to the underline. */
+	error?: boolean;
+	/** Applies the valid accent to the underline. */
+	valid?: boolean;
+	onblur?: (event: FocusEvent) => void;
+	onkeydown?: (event: KeyboardEvent) => void;
+	onkeyup?: (event: KeyboardEvent) => void;
+	/** Trailing affordance pinned to the right edge (validation icon, reveal toggle, …). */
+	trailing?: Snippet;
+	/** Optional content rendered in-flow beneath the input (e.g. a strength meter). */
+	below?: Snippet;
+}
+
+let {
+	value = $bindable(),
+	type = 'text',
+	placeholder,
+	testid,
+	error = false,
+	valid = false,
+	onblur,
+	onkeydown,
+	onkeyup,
+	trailing,
+	below
+}: Props = $props();
+</script>
+
+<style lang="scss">
+.field-group {
+	position: relative;
+	margin-bottom: 22px;
+}
+
+.underline-input {
+	width: 100%;
+	height: 44px;
+	padding: 0 36px 0 0;
+	background: transparent;
+	border: none;
+	border-bottom: 1px solid color-mix(in srgb, var(--text-primary) 45%, transparent);
+	outline: none;
+	color: var(--text-primary);
+	font-size: 18px;
+	font-family: inherit;
+	letter-spacing: 0.2px;
+	transition: border-color 160ms;
+
+	&.error {
+		border-bottom-color: var(--error);
+	}
+
+	&.valid {
+		border-bottom-color: var(--success);
+	}
+}
+
+.field-trailing {
+	position: absolute;
+	right: 0;
+	top: 22px;
+	transform: translateY(-50%);
+	display: flex;
+}
+</style>

--- a/UI/new-svelte/src/routes/login/ValidationIcon.svelte
+++ b/UI/new-svelte/src/routes/login/ValidationIcon.svelte
@@ -1,0 +1,22 @@
+<svg width={size} height={size} viewBox="0 0 16 16" fill="none">
+	{#if type === 'ok'}
+		<path d="M3 8.5l3 3 7-7" stroke={resolvedColor} stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+	{:else}
+		<path d="M4 4l8 8M12 4l-8 8" stroke={resolvedColor} stroke-width="2" stroke-linecap="round" />
+	{/if}
+</svg>
+
+<script lang="ts">
+interface Props {
+	/** Whether to render the success check or the error cross. */
+	type: 'ok' | 'err';
+	/** Square size in pixels. */
+	size?: number;
+	/** Stroke colour; defaults to the themed success/error colour for the type. */
+	color?: string;
+}
+
+let { type, size = 16, color }: Props = $props();
+
+const resolvedColor = $derived(color ?? (type === 'ok' ? 'var(--success)' : 'var(--error)'));
+</script>

--- a/UI/new-svelte/src/routes/login/login-validation.ts
+++ b/UI/new-svelte/src/routes/login/login-validation.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure validation + password-strength helpers for the login/signup form.
+ * Kept free of Svelte/DOM dependencies so they can be unit-tested directly and
+ * reused across the login components without duplicating the rules inline.
+ */
+
+export type LoginMode = 'login' | 'signup';
+
+export interface FieldValidity {
+	/** Whether the field currently satisfies its rules. */
+	ok: boolean;
+	/** A short human-readable message describing the state (empty when nothing to say). */
+	msg: string;
+}
+
+export interface PasswordStrength {
+	/** Number of filled meter segments, 0–4. */
+	score: number;
+	/** Human-readable strength label. */
+	label: string;
+}
+
+const USERNAME_RE = /^[a-zA-Z][a-zA-Z0-9_-]{2,19}$/;
+
+// Indexed by the raw strength point total (0–5).
+const STRENGTH_LABELS = ['Too short', 'Weak', 'Fair', 'Good', 'Strong', 'Strong'];
+
+export const validateUsername = (username: string): FieldValidity => {
+	if (!username) {
+		return { ok: false, msg: 'Required' };
+	}
+	if (username.length < 3) {
+		return { ok: false, msg: 'At least 3 characters' };
+	}
+	if (username.length > 20) {
+		return { ok: false, msg: 'Max 20 characters' };
+	}
+	if (/^[0-9]/.test(username)) {
+		return { ok: false, msg: "Can't start with a number" };
+	}
+	if (!USERNAME_RE.test(username)) {
+		return { ok: false, msg: 'Letters, numbers, _ or - only' };
+	}
+	return { ok: true, msg: 'Looks good' };
+};
+
+export const validatePassword = (password: string, mode: LoginMode): FieldValidity => {
+	if (!password) {
+		return { ok: false, msg: 'Required' };
+	}
+	// When signing in we only require that something was entered; the strength
+	// rules are reserved for choosing a new password during signup.
+	if (mode === 'login') {
+		return { ok: true, msg: '' };
+	}
+	if (password.length < 8) {
+		return { ok: false, msg: 'At least 8 characters' };
+	}
+	if (!/[a-zA-Z]/.test(password) || !/[0-9]/.test(password)) {
+		return { ok: false, msg: 'Mix letters and numbers' };
+	}
+	return { ok: true, msg: '' };
+};
+
+export const validateConfirm = (confirm: string, password: string, mode: LoginMode): FieldValidity => {
+	if (mode === 'login') {
+		return { ok: true, msg: '' };
+	}
+	if (!confirm) {
+		return { ok: false, msg: 'Required' };
+	}
+	if (confirm !== password) {
+		return { ok: false, msg: "Passwords don't match" };
+	}
+	return { ok: true, msg: 'Match' };
+};
+
+/**
+ * Scores a password from 0–4 (filled meter segments) and resolves a matching
+ * label. Single source of truth for both the meter and the status line, which
+ * previously duplicated the scoring rules.
+ */
+export const passwordStrength = (password: string): PasswordStrength => {
+	if (!password) {
+		return { score: 0, label: '—' };
+	}
+
+	let points = 0;
+	if (password.length >= 8) {
+		points++;
+	}
+	if (password.length >= 12) {
+		points++;
+	}
+	if (/[a-z]/.test(password) && /[A-Z]/.test(password)) {
+		points++;
+	}
+	if (/[0-9]/.test(password)) {
+		points++;
+	}
+	if (/[^A-Za-z0-9]/.test(password)) {
+		points++;
+	}
+
+	return { score: Math.min(points, 4), label: STRENGTH_LABELS[points] };
+};

--- a/UI/new-svelte/src/styles/_colors.scss
+++ b/UI/new-svelte/src/styles/_colors.scss
@@ -13,6 +13,8 @@ $text-primary: #f0f0f0;
 $text-secondary: rgba(240, 240, 240, 0.78);
 $text-tertiary: rgba(240, 240, 240, 0.55);
 $text-muted: rgba(240, 240, 240, 0.4);
+// Near-black text/icon colour for drawing on top of light accent surfaces.
+$text-on-accent: #111;
 $border-subtle: rgba(255, 255, 255, 0.08);
 $border-light: rgba(255, 255, 255, 0.14);
 $border-medium: rgba(255, 255, 255, 0.18);

--- a/UI/new-svelte/src/tests/routes/login/login-validation.test.ts
+++ b/UI/new-svelte/src/tests/routes/login/login-validation.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+	passwordStrength,
+	validateConfirm,
+	validatePassword,
+	validateUsername
+} from '../../../routes/login/login-validation';
+
+describe('validateUsername', () => {
+	it('rejects an empty username as required', () => {
+		expect(validateUsername('')).toEqual({ ok: false, msg: 'Required' });
+	});
+
+	it('rejects usernames shorter than 3 characters', () => {
+		expect(validateUsername('ab')).toEqual({ ok: false, msg: 'At least 3 characters' });
+	});
+
+	it('rejects usernames longer than 20 characters', () => {
+		expect(validateUsername('a'.repeat(21))).toEqual({ ok: false, msg: 'Max 20 characters' });
+	});
+
+	it('rejects usernames starting with a number', () => {
+		expect(validateUsername('1abc')).toEqual({ ok: false, msg: "Can't start with a number" });
+	});
+
+	it('rejects usernames with disallowed characters', () => {
+		expect(validateUsername('ab cd')).toEqual({ ok: false, msg: 'Letters, numbers, _ or - only' });
+		expect(validateUsername('ab!cd')).toEqual({ ok: false, msg: 'Letters, numbers, _ or - only' });
+	});
+
+	it('accepts a valid username with letters, numbers, underscores and dashes', () => {
+		expect(validateUsername('hero_99-x')).toEqual({ ok: true, msg: 'Looks good' });
+	});
+
+	it('accepts the boundary lengths of 3 and 20', () => {
+		expect(validateUsername('abc').ok).toBe(true);
+		expect(validateUsername('a' + '1'.repeat(19)).ok).toBe(true);
+	});
+});
+
+describe('validatePassword', () => {
+	it('rejects an empty password in either mode', () => {
+		expect(validatePassword('', 'login')).toEqual({ ok: false, msg: 'Required' });
+		expect(validatePassword('', 'signup')).toEqual({ ok: false, msg: 'Required' });
+	});
+
+	it('accepts any non-empty password when logging in', () => {
+		expect(validatePassword('x', 'login')).toEqual({ ok: true, msg: '' });
+	});
+
+	it('enforces a minimum length when signing up', () => {
+		expect(validatePassword('ab12', 'signup')).toEqual({ ok: false, msg: 'At least 8 characters' });
+	});
+
+	it('requires a mix of letters and numbers when signing up', () => {
+		expect(validatePassword('abcdefgh', 'signup')).toEqual({
+			ok: false,
+			msg: 'Mix letters and numbers'
+		});
+		expect(validatePassword('12345678', 'signup')).toEqual({
+			ok: false,
+			msg: 'Mix letters and numbers'
+		});
+	});
+
+	it('accepts a valid signup password', () => {
+		expect(validatePassword('abcd1234', 'signup')).toEqual({ ok: true, msg: '' });
+	});
+});
+
+describe('validateConfirm', () => {
+	it('is always valid when logging in', () => {
+		expect(validateConfirm('', 'anything', 'login')).toEqual({ ok: true, msg: '' });
+	});
+
+	it('requires a value when signing up', () => {
+		expect(validateConfirm('', 'pw', 'signup')).toEqual({ ok: false, msg: 'Required' });
+	});
+
+	it('flags a mismatch with the password', () => {
+		expect(validateConfirm('nope', 'pw', 'signup')).toEqual({
+			ok: false,
+			msg: "Passwords don't match"
+		});
+	});
+
+	it('accepts a matching confirmation', () => {
+		expect(validateConfirm('pw', 'pw', 'signup')).toEqual({ ok: true, msg: 'Match' });
+	});
+});
+
+describe('passwordStrength', () => {
+	it('scores an empty password as zero with a placeholder label', () => {
+		expect(passwordStrength('')).toEqual({ score: 0, label: '—' });
+	});
+
+	it('scores a short weak password', () => {
+		// 8+ chars only → 1 point.
+		expect(passwordStrength('aaaaaaaa')).toEqual({ score: 1, label: 'Weak' });
+	});
+
+	it('caps the score at 4 filled segments while still labelling the highest tier', () => {
+		// length>=8, length>=12, mixed case, digit, symbol → 5 points, capped to 4.
+		expect(passwordStrength('Abcdefgh1234!')).toEqual({ score: 4, label: 'Strong' });
+	});
+
+	it('keeps the score and label in step for a mid-strength password', () => {
+		// length>=8 (1) + digit (1) = 2 points.
+		expect(passwordStrength('abcde123')).toEqual({ score: 2, label: 'Fair' });
+	});
+});


### PR DESCRIPTION
Closes #6 (scoped to the login page — see the note at the bottom for the remaining follow-up).

## Background

Issue #6 calls out the login page as the prime example of a component that's not up to the frontend guidelines: `src/routes/+page.svelte` was a ~560-line monolith built entirely from raw HTML elements, with inline logic, duplicated password-strength code, hardcoded colours, and hardcoded font-family declarations. The issue explicitly suggests focusing on one or two pages and filing follow-ups for the rest, so this PR tackles the login page end to end.

## What changed

**Logic extracted into pure, tested helpers** (`src/routes/login/login-validation.ts`)
- `validateUsername`, `validatePassword`, `validateConfirm`, and `passwordStrength` are now pure functions with no Svelte/DOM dependencies, unit-tested in `src/tests/routes/login/login-validation.test.ts` (Detroit-school, no doubles).
- This also **fixes a latent bug**: the strength *score* (`strengthScore`) and the strength *label* (`strengthLabel`) were computed by two separate, independently-maintained blocks of incrementing logic. They now share a single source of truth, so the meter fill and the status-line label can't drift apart.

**Page decomposed into small components** (`src/routes/login/`)
- `DiamondMark`, `ValidationIcon`, `EyeIcon`, `UnderlineInput`, `PasswordStrengthMeter`, `StatusLine`, `SubmitButton`.
- `+page.svelte` is now just state + derived values (via the helpers) composing these components.

**Hardcoded theming removed**
- Replaced literal colours (`#e8b850`, `#e0907a`, `#111`, `rgba(240,240,240,…)`, `rgba(161,194,247,…)`, `rgba(192,216,255,…)`, etc.) with existing theme CSS vars and `color-mix(...)` blends, following the documented styling pattern. The strength-meter colours now map to the semantic `--success`/`--warning`/`--error` vars.
- Replaced the hardcoded `'Geist Mono', monospace` font declarations with the existing `--mono` var.
- Added one new themeable var, `--text-on-accent` (near-black text/icons drawn on light accent surfaces), wired through `_colors.scss` → `+layout.svelte`.

## Behaviour / compatibility
- All `data-testid`s are preserved, so the existing unit tests and the Playwright login spec selectors are unaffected.
- Dropped a no-op `.extra-margin` style (it set the same margin as the base rule).

## Verification
- `npm run check` — 0 errors
- `npm run lint` — clean
- `npm run build` — succeeds
- `npx vitest run` — 304/304 unit tests pass (including 19 new helper tests; the existing 12 login component tests still pass unchanged)

## Follow-up
The same `#111` dark-on-accent literal still exists in `src/routes/loading/+page.svelte` and could adopt the new `--text-on-accent` var. I've left it out to keep this PR scoped to login; it (and the other pages #6 mentions) would be covered by the broader follow-up work for that issue.

https://claude.ai/code/session_01MWTGbK23hqmKHjHe8LJdgh

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWTGbK23hqmKHjHe8LJdgh)_