### PR TITLE
Replace hardcoded 'Geist Mono' font with the --mono CSS var

### DIFF
--- a/UI/new-svelte/src/components/log-panel/LogPanel.svelte
+++ b/UI/new-svelte/src/components/log-panel/LogPanel.svelte
@@ -74,7 +74,7 @@ $effect(() => {
 }
 
 .log-title {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.5px;
 	text-transform: uppercase;
@@ -88,7 +88,7 @@ $effect(() => {
 }
 
 .log-count {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 0.5px;
 	color: rgba(240, 240, 240, 0.45);
@@ -121,7 +121,7 @@ $effect(() => {
 
 .log-empty {
 	padding: 16px 14px;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 11px;
 	letter-spacing: 0.5px;
 	color: rgba(240, 240, 240, 0.35);

--- a/UI/new-svelte/src/components/log-panel/LogRow.svelte
+++ b/UI/new-svelte/src/components/log-panel/LogRow.svelte
@@ -60,7 +60,7 @@ const rowOpacity = $derived(isLatest ? 1 : Math.max(0.4, 0.9 - index * 0.1));
 }
 
 .row-time {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 10.5px;
 	letter-spacing: 0.4px;
 	min-width: 38px;

--- a/UI/new-svelte/src/components/nav-menu/NavSidebar.svelte
+++ b/UI/new-svelte/src/components/nav-menu/NavSidebar.svelte
@@ -210,7 +210,7 @@ $expanded-width: 240px;
 }
 
 .wordmark {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 11px;
 	letter-spacing: 2px;
 	text-transform: uppercase;
@@ -272,7 +272,7 @@ $expanded-width: 240px;
 
 .group-label {
 	padding: 8px 22px 4px;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.8px;
 	text-transform: uppercase;
@@ -338,7 +338,7 @@ $expanded-width: 240px;
 }
 
 .wip-badge {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 8.5px;
 	color: rgba(240, 240, 240, 0.42);
 	letter-spacing: 0.5px;
@@ -388,7 +388,7 @@ $expanded-width: 240px;
 	display: flex;
 	align-items: center;
 	gap: 10px;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 10.5px;
 	color: rgba(240, 240, 240, 0.55);
 	letter-spacing: 0.5px;

--- a/UI/new-svelte/src/components/table/TableCell.svelte
+++ b/UI/new-svelte/src/components/table/TableCell.svelte
@@ -146,7 +146,7 @@ const onNumberInput = (e: Event) => {
 }
 
 .id-cell {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 12px;
 	letter-spacing: 0.5px;
 	color: rgba(240, 240, 240, 0.45);
@@ -200,7 +200,7 @@ const onNumberInput = (e: Event) => {
 		background 140ms ease;
 
 	&.num {
-		font-family: 'Geist Mono', monospace;
+		font-family: var(--mono);
 		text-align: right;
 	}
 

--- a/UI/new-svelte/src/components/table/TableEditor.svelte
+++ b/UI/new-svelte/src/components/table/TableEditor.svelte
@@ -297,7 +297,7 @@ $effect(() => {
 }
 
 .eyebrow {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 10px;
 	letter-spacing: 2px;
 	text-transform: uppercase;
@@ -337,7 +337,7 @@ $effect(() => {
 	}
 
 	th {
-		font-family: 'Geist Mono', monospace;
+		font-family: var(--mono);
 		font-size: 9.5px;
 		font-weight: 400;
 		letter-spacing: 1.4px;
@@ -379,7 +379,7 @@ $effect(() => {
 	display: flex;
 	align-items: center;
 	gap: 16px;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 11.5px;
 	letter-spacing: 0.4px;
 	color: rgba(240, 240, 240, 0.55);
@@ -449,7 +449,7 @@ $effect(() => {
 	background: transparent;
 	border: 1px solid rgba(255, 255, 255, 0.14);
 	color: rgba(240, 240, 240, 0.85);
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 11.5px;
 	letter-spacing: 0.6px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/components/table/TableRow.svelte
+++ b/UI/new-svelte/src/components/table/TableRow.svelte
@@ -117,7 +117,7 @@ tr {
 .index-cell {
 	padding: 6px 10px;
 	border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 12px;
 	color: rgba(240, 240, 240, 0.45);
 	text-align: center;
@@ -141,7 +141,7 @@ tr {
 	background: transparent;
 	border: 1px solid rgba(255, 255, 255, 0.12);
 	color: rgba(240, 240, 240, 0.55);
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 10.5px;
 	letter-spacing: 0.5px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/admin/AdminSidebar.svelte
+++ b/UI/new-svelte/src/routes/admin/AdminSidebar.svelte
@@ -206,7 +206,7 @@ $expanded-width: 240px;
 }
 
 .wordmark {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 11px;
 	letter-spacing: 2px;
 	text-transform: uppercase;
@@ -214,7 +214,7 @@ $expanded-width: 240px;
 }
 
 .wordmark-tag {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9px;
 	letter-spacing: 2.4px;
 	text-transform: uppercase;
@@ -268,7 +268,7 @@ $expanded-width: 240px;
 
 .group-label {
 	padding: 8px 22px 4px;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.8px;
 	text-transform: uppercase;
@@ -357,7 +357,7 @@ $expanded-width: 240px;
 }
 
 .footer-status {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 10.5px;
 	color: rgba(240, 240, 240, 0.55);
 	letter-spacing: 0.5px;

--- a/UI/new-svelte/src/routes/game/screens/PlaceholderScreen.svelte
+++ b/UI/new-svelte/src/routes/game/screens/PlaceholderScreen.svelte
@@ -62,7 +62,7 @@ const { label }: Props = $props();
 
 .placeholder-subtitle {
 	margin-top: 4px;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 11px;
 	color: rgba(240, 240, 240, 0.5);
 	letter-spacing: 1px;

--- a/UI/new-svelte/src/routes/game/screens/challenges/ChallengeDetailCard.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/ChallengeDetailCard.svelte
@@ -68,7 +68,7 @@ const done = $derived(c.state === 'done');
 }
 
 .card-target {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9px;
 	letter-spacing: 0.5px;
 	border-radius: 2px;
@@ -80,7 +80,7 @@ const done = $derived(c.state === 'done');
 }
 
 .card-completed {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 8.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/challenges/Challenges.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/Challenges.svelte
@@ -137,7 +137,7 @@ onMount(async () => {
 }
 
 .mono-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
@@ -164,13 +164,13 @@ onMount(async () => {
 }
 
 .summary-done {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 22px;
 	color: var(--success);
 }
 
 .summary-total {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 13px;
 	color: var(--text-muted);
 }

--- a/UI/new-svelte/src/routes/game/screens/challenges/ModTooltip.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/ModTooltip.svelte
@@ -76,7 +76,7 @@ const effects = $derived(
 }
 
 .tt-type-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.8px;
 	text-transform: uppercase;
@@ -106,7 +106,7 @@ const effects = $derived(
 	}
 
 	.tt-stat-value {
-		font-family: 'Geist Mono', monospace;
+		font-family: var(--mono);
 		font-size: 11.5px;
 		letter-spacing: 0.3px;
 		text-align: right;

--- a/UI/new-svelte/src/routes/game/screens/challenges/OverviewPane.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/OverviewPane.svelte
@@ -108,7 +108,7 @@ const { summary, nextUp, groups, onPick }: Props = $props();
 }
 
 .mono-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
@@ -139,14 +139,14 @@ const { summary, nextUp, groups, onPick }: Props = $props();
 }
 
 .summary-done {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 32px;
 	color: var(--success);
 	line-height: 1;
 }
 
 .summary-total {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 14px;
 	color: var(--text-muted);
 }
@@ -231,7 +231,7 @@ const { summary, nextUp, groups, onPick }: Props = $props();
 }
 
 .all-unlocked {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/challenges/ProgressReadout.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/ProgressReadout.svelte
@@ -63,7 +63,7 @@ const done = $derived(c.state === 'done');
 }
 
 .best-value {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 13px;
 	color: var(--text-primary);
 
@@ -76,7 +76,7 @@ const done = $derived(c.state === 'done');
 }
 
 .best-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	color: var(--text-muted);
 }
@@ -88,19 +88,19 @@ const done = $derived(c.state === 'done');
 }
 
 .beat-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9px;
 	letter-spacing: 1px;
 	color: var(--text-muted);
 }
 
 .beat-target {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 12px;
 }
 
 .count {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 12px;
 	letter-spacing: 0.3px;
 	color: var(--text-primary);
@@ -114,7 +114,7 @@ const done = $derived(c.state === 'done');
 }
 
 .pct {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 10.5px;
 	color: var(--text-tertiary);
 }

--- a/UI/new-svelte/src/routes/game/screens/challenges/RailButton.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/RailButton.svelte
@@ -69,7 +69,7 @@ const unit = $derived(challengeTypeUnit(group.typeId));
 }
 
 .rail-unit {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 8px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
@@ -77,7 +77,7 @@ const unit = $derived(challengeTypeUnit(group.typeId));
 }
 
 .rail-count {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 10px;
 	color: var(--text-tertiary);
 	flex-shrink: 0;

--- a/UI/new-svelte/src/routes/game/screens/challenges/RewardAffordance.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/RewardAffordance.svelte
@@ -143,7 +143,7 @@ const onLeave = () => {
 
 .tile-sub {
 	margin-top: 4px;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 8px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/challenges/SealedHeader.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/SealedHeader.svelte
@@ -54,7 +54,7 @@ const { rarityAccent, catAccent, typeLabel }: Props = $props();
 }
 
 .cat-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.8px;
 	text-transform: uppercase;
@@ -69,7 +69,7 @@ const { rarityAccent, catAccent, typeLabel }: Props = $props();
 	border-radius: 2px;
 
 	span {
-		font-family: 'Geist Mono', monospace;
+		font-family: var(--mono);
 		font-size: 9px;
 		letter-spacing: 1.2px;
 		text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/challenges/SealedItemTooltip.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/SealedItemTooltip.svelte
@@ -90,7 +90,7 @@ const STAT_BAR_WIDTHS = [78, 60, 92, 70];
 }
 
 .qmark {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 11.5px;
 	letter-spacing: 1px;
 }

--- a/UI/new-svelte/src/routes/game/screens/challenges/SealedModTooltip.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/SealedModTooltip.svelte
@@ -70,7 +70,7 @@ const EFFECT_BAR_WIDTHS = [70, 88, 58];
 }
 
 .qmark {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 11.5px;
 	letter-spacing: 1px;
 }

--- a/UI/new-svelte/src/routes/game/screens/challenges/SortControl.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/SortControl.svelte
@@ -33,7 +33,7 @@ const { value, onChange }: Props = $props();
 }
 
 .sort-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/challenges/TooltipSection.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/TooltipSection.svelte
@@ -28,7 +28,7 @@ const { label, last = false, children }: Props = $props();
 }
 
 .tt-section-header {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.8px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/challenges/TypeHero.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/TypeHero.svelte
@@ -79,7 +79,7 @@ const blurb = $derived(challengeTypeBlurb(group.typeId));
 }
 
 .hero-eyebrow {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
@@ -111,7 +111,7 @@ const blurb = $derived(challengeTypeBlurb(group.typeId));
 }
 
 .hero-done {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 26px;
 	color: var(--text-primary);
 	line-height: 1;
@@ -122,13 +122,13 @@ const blurb = $derived(challengeTypeBlurb(group.typeId));
 }
 
 .hero-total {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 14px;
 	color: var(--text-muted);
 }
 
 .hero-pct {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 8.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/fight/BattlerCard.svelte
+++ b/UI/new-svelte/src/routes/game/screens/fight/BattlerCard.svelte
@@ -97,7 +97,7 @@ const healthPerc = $derived(maxHealth ? formatNum(Math.max((battler.currentHealt
 }
 
 .battler-level {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 10.5px;
 	color: rgba(240, 240, 240, 0.6);
 	letter-spacing: 0.6px;
@@ -133,7 +133,7 @@ const healthPerc = $derived(maxHealth ? formatNum(Math.max((battler.currentHealt
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 11px;
 	color: #fff;
 	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);

--- a/UI/new-svelte/src/routes/game/screens/fight/Fight.svelte
+++ b/UI/new-svelte/src/routes/game/screens/fight/Fight.svelte
@@ -76,7 +76,7 @@ import { battleEngine } from '$lib/engine';
 
 .vs-text {
 	position: relative;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 10px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/fight/SkillTooltip.svelte
+++ b/UI/new-svelte/src/routes/game/screens/fight/SkillTooltip.svelte
@@ -145,7 +145,7 @@ const attributeName = (attrId: number) => {
 }
 
 .tt-category-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.8px;
 	text-transform: uppercase;
@@ -179,7 +179,7 @@ const attributeName = (attrId: number) => {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9px;
 	color: #c0d8ff;
 	letter-spacing: 0.6px;
@@ -209,7 +209,7 @@ const attributeName = (attrId: number) => {
 }
 
 .tt-section-header {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.8px;
 	text-transform: uppercase;
@@ -248,7 +248,7 @@ const attributeName = (attrId: number) => {
 }
 
 .tt-dmg-value {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 11.5px;
 	color: #f0f0f0;
 	letter-spacing: 0.3px;
@@ -274,7 +274,7 @@ const attributeName = (attrId: number) => {
 }
 
 .tt-total-value {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	color: var(--accent);
 	letter-spacing: 0.3px;
 }
@@ -293,7 +293,7 @@ const attributeName = (attrId: number) => {
 }
 
 .tt-metric-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9px;
 	letter-spacing: 1.3px;
 	text-transform: uppercase;
@@ -302,7 +302,7 @@ const attributeName = (attrId: number) => {
 }
 
 .tt-metric-value {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 14px;
 	color: #f0f0f0;
 	letter-spacing: 0.3px;

--- a/UI/new-svelte/src/routes/game/screens/fight/Skills.svelte
+++ b/UI/new-svelte/src/routes/game/screens/fight/Skills.svelte
@@ -146,7 +146,7 @@ const isReady = (skill: Skill) => {
 }
 
 .skill-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9px;
 	letter-spacing: 0.5px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/fight/ZoneNav.svelte
+++ b/UI/new-svelte/src/routes/game/screens/fight/ZoneNav.svelte
@@ -53,7 +53,7 @@ const handleClickRight = () => changeZone(1);
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 12px;
 	transition: background 140ms;
 
@@ -76,7 +76,7 @@ const handleClickRight = () => changeZone(1);
 }
 
 .zone-num {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 10.5px;
 	letter-spacing: 1.5px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/inventory/EquipSlot.svelte
+++ b/UI/new-svelte/src/routes/game/screens/inventory/EquipSlot.svelte
@@ -133,7 +133,7 @@ const handleDrop = (e: DragEvent) => {
 	width: 64px;
 	text-align: right;
 	flex-shrink: 0;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
@@ -189,7 +189,7 @@ const handleDrop = (e: DragEvent) => {
 	position: absolute;
 	bottom: 3px;
 	right: 4px;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 8px;
 	color: rgba(240, 240, 240, 0.55);
 }
@@ -222,7 +222,7 @@ const handleDrop = (e: DragEvent) => {
 }
 
 .rarity-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/inventory/EquippedRail.svelte
+++ b/UI/new-svelte/src/routes/game/screens/inventory/EquippedRail.svelte
@@ -103,7 +103,7 @@ const handleDrop = (slotId: number) => {
 }
 
 .mono-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
@@ -127,7 +127,7 @@ const handleDrop = (slotId: number) => {
 
 .group-label {
 	margin-bottom: 8px;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/inventory/EquippedTotals.svelte
+++ b/UI/new-svelte/src/routes/game/screens/inventory/EquippedTotals.svelte
@@ -42,7 +42,7 @@ const { view }: { view: InventoryView } = $props();
 }
 
 .mono-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
@@ -69,7 +69,7 @@ const { view }: { view: InventoryView } = $props();
 }
 
 .filled-value {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 12px;
 	color: rgba(240, 240, 240, 0.78);
 }

--- a/UI/new-svelte/src/routes/game/screens/inventory/GridSlot.svelte
+++ b/UI/new-svelte/src/routes/game/screens/inventory/GridSlot.svelte
@@ -226,7 +226,7 @@ const handleDragStart = (e: DragEvent) => {
 	position: absolute;
 	top: 3px;
 	left: 4px;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 8px;
 	letter-spacing: 0.4px;
 	color: rgba(240, 240, 240, 0.55);

--- a/UI/new-svelte/src/routes/game/screens/inventory/Inventory.svelte
+++ b/UI/new-svelte/src/routes/game/screens/inventory/Inventory.svelte
@@ -73,7 +73,7 @@ const view = new InventoryView();
 }
 
 .inv-subtitle {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
@@ -109,7 +109,7 @@ const view = new InventoryView();
 .totals-hint {
 	margin-top: 18px;
 	text-align: center;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 8.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/inventory/InventoryGrid.svelte
+++ b/UI/new-svelte/src/routes/game/screens/inventory/InventoryGrid.svelte
@@ -138,7 +138,7 @@ const handleHoverLeave = () => {
 }
 
 .mono-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
@@ -159,7 +159,7 @@ const handleHoverLeave = () => {
 	cursor: pointer;
 	background: transparent;
 	color: rgba(240, 240, 240, 0.78);
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 12px;
 
 	&:disabled {
@@ -169,7 +169,7 @@ const handleHoverLeave = () => {
 }
 
 .page-indicator {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/inventory/InventoryToolbar.svelte
+++ b/UI/new-svelte/src/routes/game/screens/inventory/InventoryToolbar.svelte
@@ -124,7 +124,7 @@ const sortKeys = Object.keys(SORTS) as SortKey[];
 }
 
 .chip-count {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	opacity: 0.6;
 }
@@ -137,7 +137,7 @@ const sortKeys = Object.keys(SORTS) as SortKey[];
 }
 
 .mono-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/inventory/ItemDrawer.svelte
+++ b/UI/new-svelte/src/routes/game/screens/inventory/ItemDrawer.svelte
@@ -83,7 +83,7 @@ const stats = $derived(
 }
 
 .cat-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.8px;
 	text-transform: uppercase;
@@ -103,7 +103,7 @@ const stats = $derived(
 }
 
 .rarity-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
@@ -145,7 +145,7 @@ const stats = $derived(
 }
 
 .mono-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
@@ -203,7 +203,7 @@ const stats = $derived(
 }
 
 .equip-hint {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 8.5px;
 	opacity: 0.7;
 }

--- a/UI/new-svelte/src/routes/game/screens/inventory/ItemTooltip.svelte
+++ b/UI/new-svelte/src/routes/game/screens/inventory/ItemTooltip.svelte
@@ -165,7 +165,7 @@ const modTypeLabel = (modType: number) =>
 }
 
 .tt-category-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.8px;
 	text-transform: uppercase;
@@ -182,7 +182,7 @@ const modTypeLabel = (modType: number) =>
 	border-radius: 2px;
 
 	span {
-		font-family: 'Geist Mono', monospace;
+		font-family: var(--mono);
 		font-size: 9px;
 		color: #bde0b4;
 		letter-spacing: 1.2px;
@@ -219,7 +219,7 @@ const modTypeLabel = (modType: number) =>
 }
 
 .tt-section-header {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.8px;
 	text-transform: uppercase;
@@ -248,7 +248,7 @@ const modTypeLabel = (modType: number) =>
 	}
 
 	.tt-stat-value {
-		font-family: 'Geist Mono', monospace;
+		font-family: var(--mono);
 		font-size: 11.5px;
 		letter-spacing: 0.3px;
 		text-align: right;
@@ -304,7 +304,7 @@ const modTypeLabel = (modType: number) =>
 }
 
 .tt-mod-type {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9px;
 	letter-spacing: 1.2px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/inventory/ModSlots.svelte
+++ b/UI/new-svelte/src/routes/game/screens/inventory/ModSlots.svelte
@@ -173,7 +173,7 @@ const modAccent = (type: number) => MOD_ACCENTS[type] ?? 'rgba(240, 240, 240, 0.
 }
 
 .mod-type {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 8.5px;
 	letter-spacing: 1.2px;
 	text-transform: uppercase;
@@ -221,7 +221,7 @@ const modAccent = (type: number) => MOD_ACCENTS[type] ?? 'rgba(240, 240, 240, 0.
 }
 
 .picker-label {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 9.5px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;

--- a/UI/new-svelte/src/routes/game/screens/inventory/StatList.svelte
+++ b/UI/new-svelte/src/routes/game/screens/inventory/StatList.svelte
@@ -38,7 +38,7 @@ const formatValue = (v: number) => (Number.isInteger(v) ? v.toString() : v.toFix
 }
 
 .stat-value {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 11.5px;
 	letter-spacing: 0.3px;
 	text-align: right;

--- a/UI/new-svelte/src/routes/loading/+page.svelte
+++ b/UI/new-svelte/src/routes/loading/+page.svelte
@@ -471,7 +471,7 @@ onMount(async () => {
 		margin: 8px 0 0;
 		font-size: 12.5px;
 		color: var(--text-secondary);
-		font-family: 'Geist Mono', monospace;
+		font-family: var(--mono);
 		letter-spacing: 0.5px;
 		min-height: 18px;
 	}
@@ -515,7 +515,7 @@ onMount(async () => {
 	display: flex;
 	justify-content: space-between;
 	margin-top: 5px;
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 10.5px;
 	color: rgba(240, 240, 240, 0.65);
 	letter-spacing: 0.5px;
@@ -590,7 +590,7 @@ onMount(async () => {
 }
 
 .row-status {
-	font-family: 'Geist Mono', monospace;
+	font-family: var(--mono);
 	font-size: 10.5px;
 	letter-spacing: 0.5px;
 	color: rgba(240, 240, 240, 0.4);
@@ -633,7 +633,7 @@ onMount(async () => {
 	gap: 12px;
 
 	.error-message {
-		font-family: 'Geist Mono', monospace;
+		font-family: var(--mono);
 		font-size: 11px;
 		color: var(--error);
 		flex: 1;


### PR DESCRIPTION
Closes #41.

## What

Mechanical, frontend-wide sweep replacing the hardcoded literal `font-family: 'Geist Mono', monospace;` with `font-family: var(--mono);` in component `<style>` blocks. The `--mono` var is already defined in `routes/+layout.svelte` (`--mono: 'Geist Mono', ui-monospace, monospace;`), so fonts now flow through the root theme variable — per the [styling guidelines](docs/frontend.md#styling), fonts (like colors) should be overridable from one place by a future theme. This follows the pattern the login refactor (#40) established.

## Scope

95 literal occurrences across **38 component files** were replaced — every file from `grep -rl "Geist Mono" src --include=*.svelte`, excluding `+layout.svelte` (which keeps the canonical definition). This covers the full affected-files list in #41: `log-panel`, `table`, `nav-menu`, `admin/AdminSidebar`, `loading/+page`, and the `fight`/`inventory`/`challenges`/`PlaceholderScreen` game screens.

Every literal was identical (`'Geist Mono', monospace`), so each became `var(--mono)` 1:1 — no behavioural or visual change.

## Verification

- `npm run check` → 621 files, 0 errors, 0 warnings
- `npm run lint` → clean
- `npx vitest run` → 304 tests passing (36 files)


---
_Generated by [Claude Code](https://claude.ai/code/session_014VDr2KHUcN3kCPDp5mqZVT)_