### PR TITLE
Fix flaky admin e2e navigation (Firefox/WebKit) + traces on retry

### DIFF
--- a/UI/new-svelte/e2e-tests/helpers.ts
+++ b/UI/new-svelte/e2e-tests/helpers.ts
@@ -61,16 +61,24 @@ export async function createAccountAndStartGame(page: Page, prefix = 'e') {
 }
 
 /**
- * Open the admin route from the in-game sidebar. The sidebar expands on hover with a width
- * transition, so under parallel load a single synthetic click can land on the still-moving
- * button and be dropped without navigating. Retry the click until the route actually changes.
+ * Open the admin route from the in-game sidebar. Two things make a naive click flaky on the slower
+ * engines (Firefox/WebKit):
+ *   1. The /game page mounts the battle/render engine and opens its socket on entry, so a click
+ *      fired while that's still settling can be swallowed without triggering navigation.
+ *   2. The navigation is client-side (`goto('/admin')`); under load it can take more than a couple
+ *      of seconds, and the old 2s retry window expired mid-navigation so the loop re-clicked and
+ *      interrupted it — leaving the page stuck on /game until the retry budget ran out.
+ * So: wait for the game screen to render first, then retry the click with a window wide enough for
+ * the navigation to actually complete before re-clicking.
  */
 export async function gotoAdmin(page: Page) {
+	await expect(page.getByTestId('game-screen')).toBeVisible({ timeout: 10000 });
+
 	await expect(async () => {
 		if (!new URL(page.url()).pathname.startsWith('/admin')) {
 			await page.getByTestId('sidebar-item-admin').click();
 		}
-		await expect(page).toHaveURL('/admin', { timeout: 2000 });
+		await expect(page).toHaveURL('/admin', { timeout: 5000 });
 	}).toPass({ timeout: 15000 });
 
 	await expect(page.getByTestId('admin-screen')).toBeVisible();

--- a/UI/new-svelte/e2e-tests/helpers.ts
+++ b/UI/new-svelte/e2e-tests/helpers.ts
@@ -53,7 +53,10 @@ export async function createAccountAndStartGame(page: Page, prefix = 'e') {
 	const enterButton = page.getByTestId('enter-button');
 	await expect(enterButton).toBeEnabled({ timeout: 10000 });
 	await enterButton.click();
-	await expect(page).toHaveURL('/game', { timeout: 5000 });
+	// Entering the game loads battle/zone state before /game renders, which on the slower engines
+	// (WebKit/Firefox) under parallel load routinely takes longer than 5s and flakes. Use the same
+	// 10s budget as the other navigations in this file.
+	await expect(page).toHaveURL('/game', { timeout: 10000 });
 	return username;
 }
 

--- a/UI/new-svelte/playwright.config.ts
+++ b/UI/new-svelte/playwright.config.ts
@@ -16,6 +16,11 @@ const config: PlaywrightTestConfig = {
 	fullyParallel: true,
 	use: {
 		baseURL: 'http://localhost:4173',
+		// Capture a full Playwright trace (DOM snapshots, network, console, every action) of the
+		// failed attempt whenever a test is retried. Traces land in the uploaded test-results
+		// artifact, so an intermittent CI flake can be opened in the trace viewer and root-caused
+		// instead of guessed at from log lines.
+		trace: 'on-first-retry',
 		// Emulate the OS "reduce motion" preference so the app's CSS transitions/animations collapse
 		// to ~0ms (see the reduced-motion block in styles/common.scss). This removes a class of
 		// flakiness where a click landed on a still-animating element — e.g. the hover-expand admin


### PR DESCRIPTION
-