### PR TITLE
Migrate frontend API client from XMLHttpRequest to fetch (#49)

### DIFF
--- a/UI/new-svelte/src/lib/api/api-request.ts
+++ b/UI/new-svelte/src/lib/api/api-request.ts
@@ -108,35 +108,41 @@ export class ApiRequest<U extends ApiEndpoint> {
 		return response;
 	}
 
-	private send(
+	private async send(
 		method: 'GET' | 'POST',
 		url: string,
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- the typed overloads above guarantee the payload matches the endpoint; this is the shared implementation.
 		payload?: any
 	): Promise<ApiResponse<ApiResponseTypes[U]>> {
-		const r = new XMLHttpRequest();
-		r.open(method, url, true);
+		const headers: Record<string, string> = {};
 		if (method === 'POST') {
-			r.setRequestHeader('content-type', 'application/json');
+			headers['content-type'] = 'application/json';
 		}
 
 		if (this.requiresAuth) {
 			const accessToken = getAccessToken();
 			if (accessToken) {
-				r.setRequestHeader('Authorization', `Bearer ${accessToken}`);
+				headers['Authorization'] = `Bearer ${accessToken}`;
 			}
 		}
 
-		return new Promise<ApiResponse<ApiResponseTypes[U]>>((resolved) => {
-			r.onload = () => resolved(new ApiResponse(r));
-			r.onerror = r.onload;
-			r.onabort = r.onerror;
-			try {
-				r.send(payload === undefined ? undefined : JSON.stringify(payload));
-			} catch {
-				resolved(new ApiResponse(r));
-			}
-		});
+		try {
+			const response = await fetch(url, {
+				method,
+				headers,
+				body: payload === undefined ? undefined : JSON.stringify(payload)
+			});
+			const responseText = await response.text();
+			return new ApiResponse({
+				status: response.status,
+				statusText: response.statusText,
+				responseText
+			});
+		} catch {
+			// Network error / aborted request: surface a 0-status, bodyless response so callers handle it
+			// the same way the previous XHR `onerror`/`onabort` path did.
+			return new ApiResponse({ status: 0, statusText: '', responseText: '' });
+		}
 	}
 
 	private encodeParams(urlParams?: Record<string, string | number | boolean>) {

--- a/UI/new-svelte/src/lib/api/api-response.ts
+++ b/UI/new-svelte/src/lib/api/api-response.ts
@@ -5,16 +5,27 @@ interface ApiResponseJson<T> {
 	errorMessage?: string;
 }
 
+/**
+ * The pieces of an HTTP response the API client needs, decoupled from the underlying transport.
+ * The request layer reads the body to text before constructing the response so the getters below can
+ * stay synchronous regardless of how the bytes were fetched.
+ */
+export interface RawApiResponse {
+	status: number;
+	statusText: string;
+	responseText: string;
+}
+
 export class ApiResponse<T extends ApiResponseType> {
-	#r: XMLHttpRequest;
+	readonly #raw: RawApiResponse;
 	#responseJson?: ApiResponseJson<T>;
 
-	constructor(r: XMLHttpRequest) {
-		this.#r = r;
+	constructor(raw: RawApiResponse) {
+		this.#raw = raw;
 	}
 
 	public get status() {
-		return this.#r.status;
+		return this.#raw.status;
 	}
 
 	public get data(): T {
@@ -26,11 +37,11 @@ export class ApiResponse<T extends ApiResponseType> {
 	}
 
 	public get error() {
-		return this.responseJson?.errorMessage || this.#r.statusText || 'Failed to communicate with server.';
+		return this.responseJson?.errorMessage || this.#raw.statusText || 'Failed to communicate with server.';
 	}
 
 	public get responseText() {
-		return this.#r.responseText;
+		return this.#raw.responseText;
 	}
 
 	private get responseJson() {
@@ -38,9 +49,9 @@ export class ApiResponse<T extends ApiResponseType> {
 	}
 
 	private parseJson() {
-		if (this.#r.responseText) {
+		if (this.#raw.responseText) {
 			try {
-				return JSON.parse(this.#r.responseText) as ApiResponseJson<T>;
+				return JSON.parse(this.#raw.responseText) as ApiResponseJson<T>;
 			} catch {
 				return { data: undefined, errorMessage: 'Invalid server response.' } as ApiResponseJson<T>;
 			}

--- a/UI/new-svelte/src/tests/lib/api/api-request.test.ts
+++ b/UI/new-svelte/src/tests/lib/api/api-request.test.ts
@@ -1,50 +1,49 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-interface MockXhr {
-	open: Mock;
-	send: Mock;
-	setRequestHeader: Mock;
+interface FetchCall {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	body: string | undefined;
+}
+
+interface StubResponse {
 	status: number;
-	statusText: string;
-	responseText: string;
-	onload: (() => void) | null;
-	onerror: (() => void) | null;
-	onabort: (() => void) | null;
+	statusText?: string;
+	body: string;
 }
 
-let xhrInstances: MockXhr[] = [];
+let fetchCalls: FetchCall[] = [];
 
-function createMockXhr(): MockXhr {
-	const xhr: MockXhr = {
-		open: vi.fn(),
-		send: vi.fn(),
-		setRequestHeader: vi.fn(),
-		status: 0,
-		statusText: 'OK',
-		responseText: '',
-		onload: null,
-		onerror: null,
-		onabort: null
+// Per-test hook to drive each `fetch` call. Tests that need specific status codes (e.g. a 401 then a
+// retry, or a token refresh) install a responder; otherwise a successful 200 is returned.
+let fetchResponder: ((call: FetchCall) => StubResponse) | null = null;
+
+// A minimal stand-in for the parts of the `fetch` Response the API client touches (`status`,
+// `statusText`, `text()`).
+const makeResponse = ({ status, statusText, body }: StubResponse): Response =>
+	({
+		status,
+		statusText: statusText ?? 'OK',
+		ok: status >= 200 && status < 300,
+		text: async () => body,
+		json: async () => JSON.parse(body)
+	}) as Response;
+
+const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+	const call: FetchCall = {
+		url,
+		method: init?.method ?? 'GET',
+		headers: (init?.headers as Record<string, string>) ?? {},
+		body: init?.body as string | undefined
 	};
-	// Default behaviour: a successful response that synchronously fires the onload handler. Tests that
-	// need other status codes (e.g. a 401 then a retry) install an `xhrResponder` to drive each call.
-	xhr.send.mockImplementation(() => {
-		if (xhrResponder) {
-			xhrResponder(xhr);
-		} else {
-			xhr.status = 200;
-			xhr.responseText = JSON.stringify({ data: 'test-result' });
-		}
-		xhr.onload?.();
-	});
-	xhrInstances.push(xhr);
-	return xhr;
-}
+	fetchCalls.push(call);
 
-let xhrResponder: ((xhr: MockXhr) => void) | null = null;
+	const stub = fetchResponder?.(call) ?? { status: 200, body: JSON.stringify({ data: 'test-result' }) };
+	return makeResponse(stub);
+});
 
-// Returning an object from a constructor makes `new XMLHttpRequest()` resolve to that object.
-vi.stubGlobal('XMLHttpRequest', vi.fn(createMockXhr));
+vi.stubGlobal('fetch', fetchMock);
 vi.stubGlobal('window', { encodeURIComponent });
 
 import { ApiRequest } from '$lib/api/api-request';
@@ -58,31 +57,31 @@ function makeAccessToken(secondsFromNow: number): string {
 	return `header.${payload}.signature`;
 }
 
-const authHeader = (xhr: MockXhr): string | undefined =>
-	xhr.setRequestHeader.mock.calls.find((call) => call[0] === 'Authorization')?.[1];
+const authHeader = (call: FetchCall): string | undefined => call.headers['Authorization'];
+const callsTo = (url: string): FetchCall[] => fetchCalls.filter((call) => call.url === url);
 
 describe('ApiRequest', () => {
 	beforeEach(() => {
-		xhrInstances = [];
-		xhrResponder = null;
+		fetchCalls = [];
+		fetchResponder = null;
 		localStorage.clear();
 	});
 
-	const lastXhr = () => xhrInstances[xhrInstances.length - 1];
+	const lastCall = () => fetchCalls[fetchCalls.length - 1];
 
 	describe('get (instance)', () => {
-		it('opens a GET request to /api/{endpoint}', async () => {
+		it('sends a GET request to /api/{endpoint}', async () => {
 			await new ApiRequest('Items').get();
 
-			expect(lastXhr().open).toHaveBeenCalledWith('GET', '/api/Items', true);
+			expect(lastCall().method).toBe('GET');
+			expect(lastCall().url).toBe('/api/Items');
 		});
 
 		it('appends URL params when provided', async () => {
 			await new ApiRequest('Items/SlotsForItem').get({ itemId: 5, refreshCache: true });
 
-			const url = lastXhr().open.mock.calls[0][1] as string;
-			expect(url).toContain('itemId=5');
-			expect(url).toContain('refreshCache=true');
+			expect(lastCall().url).toContain('itemId=5');
+			expect(lastCall().url).toContain('refreshCache=true');
 		});
 
 		it('attaches the bearer access token when one is stored', async () => {
@@ -90,13 +89,13 @@ describe('ApiRequest', () => {
 
 			await new ApiRequest('Items').get();
 
-			expect(authHeader(lastXhr())).toMatch(/^Bearer header\./);
+			expect(authHeader(lastCall())).toMatch(/^Bearer header\./);
 		});
 
 		it('sends no Authorization header when not logged in', async () => {
 			await new ApiRequest('Items').get();
 
-			expect(authHeader(lastXhr())).toBeUndefined();
+			expect(authHeader(lastCall())).toBeUndefined();
 		});
 
 		it('returns an ApiResponse with parsed data', async () => {
@@ -106,58 +105,61 @@ describe('ApiRequest', () => {
 			expect(data).toBe('test-result');
 		});
 
-		it('resolves even when send throws', async () => {
-			xhrResponder = () => {
+		it('resolves even when the request fails', async () => {
+			fetchResponder = () => {
 				throw new Error('Network error');
 			};
 
 			const response = await new ApiRequest('Items').get();
 			expect(response).toBeDefined();
+			expect(response.status).toBe(0);
 		});
 
 		it('skips undefined URL params', async () => {
 			await new ApiRequest('Items/SlotsForItem').get({ itemId: 5, refreshCache: undefined });
 
-			const url = lastXhr().open.mock.calls[0][1] as string;
-			expect(url).toContain('itemId=5');
-			expect(url).not.toContain('refreshCache');
+			expect(lastCall().url).toContain('itemId=5');
+			expect(lastCall().url).not.toContain('refreshCache');
 		});
 	});
 
 	describe('post', () => {
-		it('opens a POST request to /api/{endpoint}', async () => {
+		it('sends a POST request to /api/{endpoint}', async () => {
 			await new ApiRequest('Login').post({ username: 'u', password: 'p' });
 
-			expect(lastXhr().open).toHaveBeenCalledWith('POST', '/api/Login', true);
+			expect(lastCall().method).toBe('POST');
+			expect(lastCall().url).toBe('/api/Login');
 		});
 
 		it('sets content-type to application/json', async () => {
 			await new ApiRequest('Login').post({ username: 'u', password: 'p' });
 
-			expect(lastXhr().setRequestHeader).toHaveBeenCalledWith('content-type', 'application/json');
+			expect(lastCall().headers['content-type']).toBe('application/json');
 		});
 
 		it('sends JSON-stringified payload', async () => {
 			const payload = { username: 'user', password: 'pass' };
 			await new ApiRequest('Login').post(payload);
 
-			expect(lastXhr().send).toHaveBeenCalledWith(JSON.stringify(payload));
+			expect(lastCall().body).toBe(JSON.stringify(payload));
 		});
 
-		it('resolves even when send throws', async () => {
-			xhrResponder = () => {
+		it('resolves even when the request fails', async () => {
+			fetchResponder = () => {
 				throw new Error('Network error');
 			};
 
 			const response = await new ApiRequest('Login').post({ username: 'u', password: 'p' });
 			expect(response).toBeDefined();
+			expect(response.status).toBe(0);
 		});
 
 		it('sends an empty body for endpoints with no request payload', async () => {
 			await new ApiRequest('Login/Logout').post();
 
-			expect(lastXhr().open).toHaveBeenCalledWith('POST', '/api/Login/Logout', true);
-			expect(lastXhr().send).toHaveBeenCalledWith(undefined);
+			expect(lastCall().method).toBe('POST');
+			expect(lastCall().url).toBe('/api/Login/Logout');
+			expect(lastCall().body).toBeUndefined();
 		});
 	});
 
@@ -179,49 +181,40 @@ describe('ApiRequest', () => {
 		it('refreshes the token pair and retries the request once', async () => {
 			setTokens({ accessToken: makeAccessToken(600), refreshToken: 'refresh-1' });
 
-			const fetchMock = vi.fn(async () => ({
-				ok: true,
-				json: async () => ({ data: { accessToken: makeAccessToken(900), refreshToken: 'refresh-2' } })
-			}));
-			vi.stubGlobal('fetch', fetchMock);
-
-			let calls = 0;
-			xhrResponder = (xhr) => {
-				calls += 1;
-				if (calls === 1) {
-					xhr.status = 401;
-					xhr.responseText = JSON.stringify({ errorMessage: 'expired' });
-				} else {
-					xhr.status = 200;
-					xhr.responseText = JSON.stringify({ data: 'retried' });
+			let itemsCalls = 0;
+			fetchResponder = (call) => {
+				if (call.url === '/api/Login/Refresh') {
+					return {
+						status: 200,
+						body: JSON.stringify({ data: { accessToken: makeAccessToken(900), refreshToken: 'refresh-2' } })
+					};
 				}
+				itemsCalls += 1;
+				return itemsCalls === 1
+					? { status: 401, body: JSON.stringify({ errorMessage: 'expired' }) }
+					: { status: 200, body: JSON.stringify({ data: 'retried' }) };
 			};
 
 			const response = await new ApiRequest('Items').get();
 
-			expect(fetchMock).toHaveBeenCalledTimes(1);
-			expect(xhrInstances).toHaveLength(2);
+			expect(callsTo('/api/Login/Refresh')).toHaveLength(1);
+			const itemsRequests = callsTo('/api/Items');
+			expect(itemsRequests).toHaveLength(2);
 			expect(response.status).toBe(200);
 			expect(response.data as unknown).toBe('retried');
 			// The retry carries the freshly rotated access token, not the one that was rejected.
-			expect(authHeader(xhrInstances[1])).not.toBe(authHeader(xhrInstances[0]));
+			expect(authHeader(itemsRequests[1])).not.toBe(authHeader(itemsRequests[0]));
 		});
 
 		it('does not refresh anonymous endpoints', async () => {
 			setTokens({ accessToken: makeAccessToken(600), refreshToken: 'refresh-1' });
 
-			const fetchMock = vi.fn();
-			vi.stubGlobal('fetch', fetchMock);
-
-			xhrResponder = (xhr) => {
-				xhr.status = 401;
-				xhr.responseText = JSON.stringify({ errorMessage: 'nope' });
-			};
+			fetchResponder = () => ({ status: 401, body: JSON.stringify({ errorMessage: 'nope' }) });
 
 			const response = await new ApiRequest('Login').post({ username: 'u', password: 'p' });
 
-			expect(fetchMock).not.toHaveBeenCalled();
-			expect(xhrInstances).toHaveLength(1);
+			expect(callsTo('/api/Login/Refresh')).toHaveLength(0);
+			expect(fetchCalls).toHaveLength(1);
 			expect(response.status).toBe(401);
 		});
 	});

--- a/UI/new-svelte/src/tests/lib/api/api-response.test.ts
+++ b/UI/new-svelte/src/tests/lib/api/api-response.test.ts
@@ -1,49 +1,49 @@
 import { describe, it, expect } from 'vitest';
-import { ApiResponse } from '$lib/api/api-response';
+import { ApiResponse, type RawApiResponse } from '$lib/api/api-response';
 
-const makeXhr = (overrides: Partial<XMLHttpRequest> = {}): XMLHttpRequest => {
+const makeRaw = (overrides: Partial<RawApiResponse> = {}): RawApiResponse => {
 	return {
 		status: 200,
 		statusText: 'OK',
 		responseText: JSON.stringify({ data: null, errorMessage: undefined }),
 		...overrides
-	} as XMLHttpRequest;
+	};
 };
 
 describe('ApiResponse', () => {
 	describe('data', () => {
 		it('returns parsed data from response', () => {
-			const xhr = makeXhr({
+			const raw = makeRaw({
 				responseText: JSON.stringify({ data: { id: 1, name: 'Test' } })
 			});
-			const response = new ApiResponse(xhr);
+			const response = new ApiResponse(raw);
 
 			expect(response.data).toEqual({ id: 1, name: 'Test' });
 		});
 
 		it('returns array data', () => {
-			const xhr = makeXhr({
+			const raw = makeRaw({
 				responseText: JSON.stringify({ data: [1, 2, 3] })
 			});
-			const response = new ApiResponse(xhr);
+			const response = new ApiResponse(raw);
 
 			expect(response.data).toEqual([1, 2, 3]);
 		});
 
 		it('throws when data is null and errorMessage exists', () => {
-			const xhr = makeXhr({
+			const raw = makeRaw({
 				responseText: JSON.stringify({ data: null, errorMessage: 'Not found' })
 			});
-			const response = new ApiResponse(xhr);
+			const response = new ApiResponse(raw);
 
 			expect(() => response.data).toThrow('Not found');
 		});
 
 		it('returns null data when no errorMessage', () => {
-			const xhr = makeXhr({
+			const raw = makeRaw({
 				responseText: JSON.stringify({ data: null })
 			});
-			const response = new ApiResponse(xhr);
+			const response = new ApiResponse(raw);
 
 			expect(response.data).toBeNull();
 		});
@@ -51,30 +51,30 @@ describe('ApiResponse', () => {
 
 	describe('error', () => {
 		it('returns errorMessage from response body', () => {
-			const xhr = makeXhr({
+			const raw = makeRaw({
 				responseText: JSON.stringify({ data: null, errorMessage: 'Bad request' })
 			});
-			const response = new ApiResponse(xhr);
+			const response = new ApiResponse(raw);
 
 			expect(response.error).toBe('Bad request');
 		});
 
 		it('falls back to statusText when no errorMessage', () => {
-			const xhr = makeXhr({
+			const raw = makeRaw({
 				statusText: 'Internal Server Error',
 				responseText: JSON.stringify({ data: null })
 			});
-			const response = new ApiResponse(xhr);
+			const response = new ApiResponse(raw);
 
 			expect(response.error).toBe('Internal Server Error');
 		});
 
 		it('falls back to default message when no errorMessage or statusText', () => {
-			const xhr = makeXhr({
+			const raw = makeRaw({
 				statusText: '',
 				responseText: JSON.stringify({ data: null })
 			});
-			const response = new ApiResponse(xhr);
+			const response = new ApiResponse(raw);
 
 			expect(response.error).toBe('Failed to communicate with server.');
 		});
@@ -82,7 +82,7 @@ describe('ApiResponse', () => {
 
 	describe('status', () => {
 		it('returns HTTP status code', () => {
-			const response = new ApiResponse(makeXhr({ status: 404 }));
+			const response = new ApiResponse(makeRaw({ status: 404 }));
 			expect(response.status).toBe(404);
 		});
 	});
@@ -90,31 +90,31 @@ describe('ApiResponse', () => {
 	describe('responseText', () => {
 		it('returns raw response text', () => {
 			const text = '{"data": "raw"}';
-			const response = new ApiResponse(makeXhr({ responseText: text }));
+			const response = new ApiResponse(makeRaw({ responseText: text }));
 			expect(response.responseText).toBe(text);
 		});
 	});
 
 	describe('empty response', () => {
 		it('handles empty responseText gracefully', () => {
-			const response = new ApiResponse(makeXhr({ responseText: '' }));
+			const response = new ApiResponse(makeRaw({ responseText: '' }));
 			expect(response.data).toBeUndefined();
 		});
 	});
 
 	describe('malformed response', () => {
 		it('returns structured error for unparseable JSON', () => {
-			const response = new ApiResponse(makeXhr({ responseText: 'not-json' }));
+			const response = new ApiResponse(makeRaw({ responseText: 'not-json' }));
 			expect(() => response.data).toThrow('Invalid server response.');
 		});
 	});
 
 	describe('json caching', () => {
 		it('parses JSON only once (lazy caching)', () => {
-			const xhr = makeXhr({
+			const raw = makeRaw({
 				responseText: JSON.stringify({ data: 'cached' })
 			});
-			const response = new ApiResponse(xhr);
+			const response = new ApiResponse(raw);
 
 			const first = response.data;
 			const second = response.data;


### PR DESCRIPTION
Closes #49.

Swaps the `XMLHttpRequest`-based transport in the frontend API client for the modern `fetch` API. This also brings the request layer in line with the auth/refresh layer (`auth.ts`), which already uses `fetch`.

## Changes

- **`lib/api/api-request.ts`** — `send()` now issues a `fetch` call, reads the body to text (`await response.text()`), and constructs an `ApiResponse` from the resulting `status` / `statusText` / body. Network errors / aborts are caught and surfaced as a `0`-status, bodyless response, preserving the behaviour of the old XHR `onerror`/`onabort` handlers (callers see the same generic error fallback). All auth/401-retry logic in `execute()` is untouched.
- **`lib/api/api-response.ts`** — decoupled `ApiResponse` from `XMLHttpRequest`. It now takes a small transport-agnostic `RawApiResponse` (`{ status, statusText, responseText }`). Because the body is read to text before construction, the existing synchronous getters (`status`, `data`, `error`, `responseText`, lazy JSON caching) keep working unchanged.
- **Tests** — `api-request.test.ts` now mocks `fetch` instead of `XMLHttpRequest`; `api-response.test.ts` builds responses from the `RawApiResponse` shape. Behavioural coverage (URL/param building, bearer attachment, payload serialization, empty-body endpoints, silent refresh + retry on 401, anonymous-endpoint handling, network-failure resilience) is preserved.

## Verification

- `npm run check` — 0 errors / 0 warnings
- `npm run lint` — clean
- `npx vitest run` — 332 passed (39 files)
- `npm run build` — succeeds

## Notes

- The only places that constructed or consumed `ApiResponse`/used `XMLHttpRequest` were these API-client files (the socket layer uses `WebSocket`), so the migration is self-contained.
- Minor caveat worth flagging: with HTTP/2, browsers report an empty `Response.statusText`. The error-message fallback chain (`errorMessage` → `statusText` → generic message) already handles this gracefully, and the backend returns a structured `errorMessage` in the body for error responses, so user-facing error text is unaffected.

⚠️ Heads up: the repo's `package.json` declares `engines.node >= 26` with `engine-strict=true`, but the session environment only provides Node 22, so `npm ci` refused to install and the `package-lock.json` showed drift (missing `picomatch@4.0.4`) under npm 10. I installed via `npm install` with engine-strict disabled to run the toolchain and reverted the lockfile so this PR contains no unrelated lock changes. Flagging in case the lockfile is genuinely stale on `main`.

https://claude.ai/code/session_011vNjyzKMDCfLLrfGMiVKwM

---
_Generated by [Claude Code](https://claude.ai/code/session_011vNjyzKMDCfLLrfGMiVKwM)_