### PR TITLE
fix(session-start): symlink nvm Node into ~/.local/bin so all shell types use v26

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -38,6 +38,26 @@ if [ -f /etc/profile.d/nvm.sh ] && ! grep -q "nvm use default" /etc/profile.d/nv
   echo "[session-start] Added 'nvm use default' to /etc/profile.d/nvm.sh"
 fi
 
+# Ensure the nvm-managed Node (default alias) wins over any system Node (e.g. /opt/node22)
+# for ALL shell types — including the non-interactive shells Claude Code's Bash tool runs,
+# which inherit PATH from the Claude Code process and never source /etc/profile.d scripts.
+# $HOME/.local/bin is first in PATH, so symlinking there overrides /opt/node22/bin.
+if [ -f "$HOME/.nvm/nvm.sh" ]; then
+  export NVM_DIR="$HOME/.nvm"
+  # Load nvm without activating any version so we can query it
+  . "$NVM_DIR/nvm.sh" --no-use 2>/dev/null
+  _nvm_node_path=$(nvm which default 2>/dev/null)
+  if [ -n "$_nvm_node_path" ] && [ -x "$_nvm_node_path" ]; then
+    _nvm_node_bin=$(dirname "$_nvm_node_path")
+    mkdir -p "$HOME/.local/bin"
+    for _bin in node npm npx corepack; do
+      [ -f "$_nvm_node_bin/$_bin" ] && ln -sf "$_nvm_node_bin/$_bin" "$HOME/.local/bin/$_bin"
+    done
+    _node_ver=$("$HOME/.local/bin/node" --version 2>/dev/null)
+    echo "[session-start] Symlinked Node ${_node_ver} (nvm default) into \$HOME/.local/bin — overrides system Node"
+  fi
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 MARKER_FILE="$PROJECT_ROOT/.container-info.json"


### PR DESCRIPTION
## Problem

The previous fix patched `/etc/profile.d/nvm.sh` to point at `~/.nvm` and call `nvm use default`, which works for **login shells**. But Claude Code's Bash tool runs **non-interactive, non-login shells** that inherit PATH from the Claude Code process — those shells never source `profile.d`, so `/opt/node22/bin/node` (v22) kept winning over the nvm-managed v26.

## Root cause

- `node` resolved to `/opt/node22/bin/node` (v22.22.2) — a system install baked into PATH at process startup
- `NVM_DIR` was unset; nvm was never loaded in tool shells
- `/root/.local/bin` is first in PATH but had no `node` symlink
- `/etc/profile.d/nvm.sh` changes only apply to new login shells, not to the already-running Claude Code process

## Fix

After loading nvm with `--no-use` (so it doesn't switch the active version), resolve the default alias path via `nvm which default` and symlink `node`/`npm`/`npx`/`corepack` into `$HOME/.local/bin`. Since that directory is first in PATH, the symlinks take effect immediately in all shell types — no login shell required.

## Test plan

- [ ] Start a new remote session and confirm `node --version` reports v26.x.x
- [ ] Confirm session-start log shows `Symlinked Node v26.x.x (nvm default) into $HOME/.local/bin`
- [ ] Confirm `which node` points to `/root/.local/bin/node`

https://claude.ai/code/session_01PvfKZxS85uAj6cUeGhB7bJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvfKZxS85uAj6cUeGhB7bJ)_