### PR TITLE
Add standalone codegen command (no API/database required)

### DIFF
--- a/Game.Api.Tests/CodeGen/CodeGenCommandTests.cs
+++ b/Game.Api.Tests/CodeGen/CodeGenCommandTests.cs
@@ -1,0 +1,51 @@
+using Game.Api.CodeGen;
+using Xunit;
+
+namespace Game.Api.Tests.CodeGen
+{
+    public class CodeGenCommandTests : IDisposable
+    {
+        private readonly string _outputDirectory;
+
+        public CodeGenCommandTests()
+        {
+            _outputDirectory = Path.Combine(Path.GetTempPath(), "codegen_cmd_" + Guid.NewGuid().ToString("N"));
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_outputDirectory))
+            {
+                Directory.Delete(_outputDirectory, recursive: true);
+            }
+        }
+
+        [Theory]
+        [InlineData("codegen", true)]
+        [InlineData("CODEGEN", true)]
+        [InlineData("serve", false)]
+        public void Matches_DetectsCommandVerb(string arg, bool expected)
+        {
+            Assert.Equal(expected, CodeGenCommand.Matches([arg]));
+        }
+
+        [Fact]
+        public void Matches_IsFalse_WhenNoArgs()
+        {
+            Assert.False(CodeGenCommand.Matches([]));
+        }
+
+        [Fact]
+        public void Run_GeneratesClientFiles_IntoProvidedDirectory_WithoutWebHost()
+        {
+            // Exercises the full reflection-based generation against the real API assembly, with no
+            // web host, database, or cache — proving codegen is runnable in restricted environments.
+            CodeGenCommand.Run(["codegen", _outputDirectory]);
+
+            Assert.True(File.Exists(Path.Combine(_outputDirectory, "api-type-map.ts")));
+            Assert.True(File.Exists(Path.Combine(_outputDirectory, "api-socket-type-map.ts")));
+            Assert.True(File.Exists(Path.Combine(_outputDirectory, "index.ts")));
+            Assert.True(Directory.Exists(Path.Combine(_outputDirectory, "interfaces")));
+        }
+    }
+}

--- a/Game.Api.Tests/CodeGen/CodeGenPathsTests.cs
+++ b/Game.Api.Tests/CodeGen/CodeGenPathsTests.cs
@@ -1,0 +1,55 @@
+using Game.Api.CodeGen;
+using Xunit;
+
+namespace Game.Api.Tests.CodeGen
+{
+    public class CodeGenPathsTests
+    {
+        [Fact]
+        public void ResolveTargetDirectory_BuildsFrontendTypesPath()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "repo");
+
+            var result = CodeGenPaths.ResolveTargetDirectory(root);
+
+            var expected = Path.Combine(root, "UI", "new-svelte", "src", "lib", "api", "types");
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void FindRepositoryRoot_ReturnsDirectoryContainingSolution_WhenNested()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "codegen_root_" + Guid.NewGuid().ToString("N"));
+            var nested = Path.Combine(root, "bin", "Debug", "net10.0");
+            Directory.CreateDirectory(nested);
+            File.WriteAllText(Path.Combine(root, "Game.sln"), "");
+
+            try
+            {
+                var result = CodeGenPaths.FindRepositoryRoot(nested);
+
+                Assert.Equal(new DirectoryInfo(root).FullName, result);
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void FindRepositoryRoot_Throws_WhenSolutionNotFound()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "codegen_noroot_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+
+            try
+            {
+                Assert.Throws<InvalidOperationException>(() => CodeGenPaths.FindRepositoryRoot(root));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+}

--- a/Game.Api/CodeGen/CodeGenCommand.cs
+++ b/Game.Api/CodeGen/CodeGenCommand.cs
@@ -1,0 +1,44 @@
+namespace Game.Api.CodeGen
+{
+    /// <summary>
+    /// Standalone entry point for the TypeScript API client code generation. Runs the same
+    /// reflection-based generation as the dev-time startup hook, but without building the web host or
+    /// touching any out-of-process dependency (database/cache), so the client types can be
+    /// regenerated in CI or restricted environments via
+    /// <c>dotnet run --project Game.Api -- codegen [outputDirectory]</c>.
+    /// </summary>
+    public static class CodeGenCommand
+    {
+        /// <summary>The CLI verb that selects this command.</summary>
+        public const string CommandName = "codegen";
+
+        /// <summary>
+        /// Returns whether the supplied process arguments invoke the standalone code generator.
+        /// </summary>
+        public static bool Matches(string[] args)
+        {
+            return args.Length > 0 && string.Equals(args[0], CommandName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Runs code generation against the API assembly. An optional output directory may be supplied
+        /// as the second argument; when omitted, the frontend types directory is resolved relative to
+        /// the repository root.
+        /// </summary>
+        public static void Run(string[] args)
+        {
+            using var loggerFactory = LoggerFactory.Create(builder => builder.AddSimpleConsole());
+            var logger = loggerFactory.CreateLogger<ApiCodeGenerator>();
+
+            var targetDirectory = args.Length > 1 && !string.IsNullOrWhiteSpace(args[1])
+                ? Path.GetFullPath(args[1])
+                : CodeGenPaths.ResolveTargetDirectory(CodeGenPaths.FindRepositoryRoot());
+
+            new ApiCodeGenerator(logger).GenerateCode(
+                typeof(Startup).Assembly,
+                new CodeGenOptions { TargetDirectory = targetDirectory, NewLine = "\n" });
+
+            logger.LogInformation("Generated TypeScript API client into {TargetDirectory}.", targetDirectory);
+        }
+    }
+}

--- a/Game.Api/CodeGen/CodeGenPaths.cs
+++ b/Game.Api/CodeGen/CodeGenPaths.cs
@@ -1,0 +1,47 @@
+namespace Game.Api.CodeGen
+{
+    /// <summary>
+    /// Resolves the filesystem paths used by the API code generator. Centralized so the dev-time
+    /// startup hook (<see cref="Startup"/>) and the standalone <see cref="CodeGenCommand"/> compute
+    /// the frontend target directory the same way.
+    /// </summary>
+    public static class CodeGenPaths
+    {
+        // Path segments, relative to the repository root, of the frontend directory the generated
+        // TypeScript API client is written into.
+        private static readonly string[] TypesDirectorySegments =
+            ["UI", "new-svelte", "src", "lib", "api", "types"];
+
+        /// <summary>
+        /// Builds the absolute path of the generated-types directory under the given repository root.
+        /// </summary>
+        public static string ResolveTargetDirectory(string repositoryRoot)
+        {
+            return Path.Combine([repositoryRoot, .. TypesDirectorySegments]);
+        }
+
+        /// <summary>
+        /// Walks up from <paramref name="startDirectory"/> (defaulting to the running assembly's base
+        /// directory) until it finds the repository root, identified by the presence of the
+        /// <c>Game.sln</c> solution file.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when no <c>Game.sln</c> is found.</exception>
+        public static string FindRepositoryRoot(string? startDirectory = null)
+        {
+            var origin = startDirectory ?? AppContext.BaseDirectory;
+            var directory = new DirectoryInfo(origin);
+            while (directory is not null)
+            {
+                if (directory.EnumerateFiles("Game.sln").Any())
+                {
+                    return directory.FullName;
+                }
+
+                directory = directory.Parent;
+            }
+
+            throw new InvalidOperationException(
+                $"Could not locate the repository root (no 'Game.sln' found walking up from '{origin}').");
+        }
+    }
+}

--- a/Game.Api/Startup.cs
+++ b/Game.Api/Startup.cs
@@ -25,10 +25,23 @@ namespace Game.Api
         /// <summary>
         /// The entry point of the application.
         /// </summary>
-        /// <param name="args">No parameters are currently supported.</param>
+        /// <param name="args">
+        /// Pass <c>codegen [outputDirectory]</c> to regenerate the frontend's TypeScript API client
+        /// and exit without starting the web host (see <see cref="CodeGenCommand"/>); otherwise no
+        /// arguments are supported and the API starts normally.
+        /// </param>
         /// <returns>An empty <see cref="Task"/>.</returns>
         public static async Task Main(string[] args)
         {
+            // Standalone TypeScript codegen: regenerate the frontend API client without building the
+            // web host or touching the database/cache, so types can be regenerated in CI / restricted
+            // environments. Intercepted before host construction to stay independent of environment.
+            if (CodeGenCommand.Matches(args))
+            {
+                CodeGenCommand.Run(args);
+                return;
+            }
+
             var builder = WebApplication.CreateBuilder(args);
             Hashing.SetPepper(builder.Configuration["HashPepper"] ?? throw new InvalidOperationException("HashPepper not set"));
 
@@ -87,7 +100,7 @@ namespace Game.Api
                 // Regenerate the frontend's TypeScript API client from the running API's types. This
                 // writes into the UI source tree, so it is strictly a local-development concern.
                 var rootFolder = Directory.GetParent(app.Environment.ContentRootPath)!.FullName;
-                var targetDir = Path.Combine(rootFolder, "UI", "new-svelte", "src", "lib", "api", "types");
+                var targetDir = CodeGenPaths.ResolveTargetDirectory(rootFolder);
                 var codeGen = app.Services.GetRequiredService<ApiCodeGenerator>();
                 codeGen.GenerateCode(typeof(Startup).Assembly, new CodeGenOptions { TargetDirectory = targetDir, NewLine = "\n" });
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -73,6 +73,21 @@ Authenticated users are gated out of the admin tooling unless they hold the `Adm
   - **Ban = block while keeping the username reserved.** A banned user still counts toward username availability (so the name cannot be reused) and remains visible in the admin roster for later management. Surfacing the ban to the user at login time is intentionally out of scope for now.
 - **Role changes take effect on next login.** As noted under [Access Roles and Admin Authorization](#access-roles-and-admin-authorization), roles live in the signed auth token, so a `SetUserRoles` change is reflected only after the affected user logs in again.
 
+## Standalone TypeScript codegen
+
+The reflection-based code generator (`Game.Api/CodeGen/ApiCodeGenerator`) that emits the frontend's TypeScript API client only needs the API **assembly** — it inspects controller/socket-command type metadata and writes `.ts` files, with no database, cache, or DI graph involved. Historically it was reachable only as a side effect of running the API in `Development`, so regenerating types meant standing up the full web host (and its Postgres/Redis dependencies), which is awkward in CI and impossible in restricted environments.
+
+It is now also runnable as a standalone command that exits before the web host is built:
+
+```
+dotnet run --project Game.Api -- codegen [outputDirectory]
+```
+
+- **`CodeGenCommand`** (intercepted at the top of `Startup.Main`, before `WebApplication.CreateBuilder`) builds a throwaway console `ILogger`, resolves the target directory, runs `ApiCodeGenerator.GenerateCode`, and returns. Because it short-circuits before host construction, it is independent of `ASPNETCORE_ENVIRONMENT` and never touches an out-of-process dependency. An explicit output directory may be passed; otherwise it defaults to the committed frontend location.
+- **`CodeGenPaths`** centralizes path resolution so the dev-startup hook and the standalone command compute the same target directory. The default directory is found by walking up from the running assembly to the repository root (the directory containing `Game.sln`) and appending the canonical `UI/new-svelte/src/lib/api/types` segments. Resolving the root from the assembly rather than the current working directory keeps the command location-independent (the dev hook continues to derive the root from `ContentRootPath`).
+
+The output is byte-identical to the dev-time generation, so CI can run the command and assert a clean `git diff` to catch DTO/client drift.
+
 ## Integration-Test Containers in Constrained Environments
 
 Integration tests get a real PostgreSQL + Redis via **Testcontainers** (`PostgresContainerFixture`, `RedisContainerFixture`, composed by `IntegrationTestContainers`). Testcontainers depends on Docker **bridge networking**, which is unavailable in constrained sandboxes such as the Claude Code web environment (old kernel, no iptables, no usable bridge). There, Testcontainers cannot create networks or map ports and every integration test fails before it runs. See [anthropics/claude-code#29515](https://github.com/anthropics/claude-code/issues/29515).

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -38,7 +38,7 @@ The frontend authenticates against the backend's JWT scheme (see the backend doc
 - **`api-request.ts`** attaches `Authorization: Bearer <accessToken>` to every authenticated request, refreshes pre-emptively before sending, and on a `401` refreshes once and retries. The `[AllowAnonymous]` auth endpoints (`Login`, `Login/CreateAccount`, `Login/Refresh`, `Login/Logout`) are exempt from this machinery.
 - **`api-socket.ts`** passes the access token as the `?access_token=` query parameter (browsers can't set headers on the WS handshake) and, if a handshake is rejected for auth reasons (the socket closes before it ever opens), refreshes once and reconnects.
 
-Login stores the pair from the `LoginResult` and enters the game; logout sends the refresh token so the backend can revoke it, then clears storage. The generated API types (`lib/api/types`) are produced by the backend's dev-time codegen — when changing a DTO, run the backend in Development to regenerate them rather than editing the files by hand.
+Login stores the pair from the `LoginResult` and enters the game; logout sends the refresh token so the backend can revoke it, then clears storage. The generated API types (`lib/api/types`) are produced by the backend's codegen — when changing a DTO, regenerate them rather than editing the files by hand, either by running the backend in Development or, without standing up the API/database, via `dotnet run --project Game.Api -- codegen` (see [backend.md](backend.md#standalone-typescript-codegen)).
 
 ## Reference Data
 


### PR DESCRIPTION
Resolves #51.

## Problem

The reflection-based TypeScript client codegen (`Game.Api/CodeGen/ApiCodeGenerator`) only ran as a side effect of starting the API in `Development`. Regenerating the frontend's API types therefore required standing up the full web host **and** its Postgres/Redis dependencies — awkward in CI and impossible in restricted environments. But `GenerateCode` only inspects type metadata from the API **assembly**; it needs no database, cache, or DI graph.

## Change

Expose the generator as a standalone CLI verb that exits before the web host is built:

```
dotnet run --project Game.Api -- codegen [outputDirectory]
```

- **`CodeGenCommand`** is intercepted at the top of `Startup.Main`, *before* `WebApplication.CreateBuilder`. It builds a throwaway console logger, resolves the target directory, runs the generator, and returns. Because it short-circuits before host construction, it is independent of `ASPNETCORE_ENVIRONMENT` and never touches an out-of-process dependency. An explicit output directory may be passed; otherwise it defaults to the committed frontend location.
- **`CodeGenPaths`** centralizes target-directory resolution so the dev-startup hook and the new command compute the same path (DRY — the dev path now calls it too). The default directory is found by walking up from the running assembly to the repo root (the directory containing `Game.sln`) and appending the canonical `UI/new-svelte/src/lib/api/types` segments.

Output is **byte-identical** to the dev-time generation, so CI can run the command and assert a clean `git diff` to catch DTO/client drift.

## Tests

- `CodeGenPathsTests` — target-path construction, repo-root discovery via `Game.sln`, and the not-found error case.
- `CodeGenCommandTests` — verb matching plus an end-to-end test that runs the generator against the **real** API assembly into a temp dir with no web host, asserting the client files are produced.

All 151 `Game.Api.Tests` CodeGen tests pass. Verified manually that `dotnet run --project Game.Api --no-launch-profile -- codegen` (Production env, no DB/Redis) regenerates the client and leaves the committed `UI/.../types` with a clean `git diff`.

## Docs

Added a "Standalone TypeScript codegen" design-decision section to `docs/backend.md` and updated the codegen note in `docs/frontend.md`.

https://claude.ai/code/session_01RozeB7oWxYjeWvHYtMR4DE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RozeB7oWxYjeWvHYtMR4DE)_