### PR TITLE
Add SaveLogPreferences websocket command for options page (#37)

### DIFF
--- a/Game.Api.Tests/Integration/SaveLogPreferencesSocketTests.cs
+++ b/Game.Api.Tests/Integration/SaveLogPreferencesSocketTests.cs
@@ -1,0 +1,105 @@
+using Game.Api.Models.Common;
+using Game.Api.Models.Player;
+using Game.Core;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    [Collection("Integration")]
+    public class SaveLogPreferencesSocketTests : ApiIntegrationTestBase
+    {
+        private const string Username = "logprefuser";
+        private const string Password = "logprefpass";
+
+        public SaveLogPreferencesSocketTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper) : base(containers, testOutputHelper) { }
+
+        private async Task<int> SeedPlayerAsync()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var user = await TestDataSeeder.CreateUserAsync(context, Username, Password);
+            await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+
+            return user.Id;
+        }
+
+        [Fact]
+        public async Task SaveLogPreferences_PersistsChangesToCachedPlayer()
+        {
+            var userId = await SeedPlayerAsync();
+            var (client, _) = await LoginAndBuildClientAsync(Username, Password);
+
+            await using var socketClient = new TestSocketClient();
+            var wsClient = Factory.Server.CreateWebSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+
+            var response = await socketClient.SendCommandRawAsync("SaveLogPreferences", new[]
+            {
+                new { Id = (int)ELogType.Damage, Enabled = false },
+                new { Id = (int)ELogType.Debug, Enabled = true },
+            });
+
+            Assert.Null(response.Error);
+
+            var prefs = await WaitForLogPreferenceAsync(client, ELogType.Damage, enabled: false);
+            Assert.False(prefs.Single(p => p.Id == ELogType.Damage).Enabled);
+            Assert.True(prefs.Single(p => p.Id == ELogType.Debug).Enabled);
+        }
+
+        [Fact]
+        public async Task SaveLogPreferences_UnknownLogType_ReturnsError()
+        {
+            var userId = await SeedPlayerAsync();
+            // Logging in creates the session the WebSocket handshake requires.
+            await LoginAsync(Username, Password);
+
+            await using var socketClient = new TestSocketClient();
+            var wsClient = Factory.Server.CreateWebSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+
+            var response = await socketClient.SendCommandRawAsync("SaveLogPreferences", new[]
+            {
+                new { Id = 9999, Enabled = false },
+            });
+
+            Assert.NotNull(response.Error);
+        }
+
+        private async Task<List<LogPreference>> GetLogPreferencesAsync(HttpClient client)
+        {
+            var response = await client.GetAsync("/api/Player", CancellationToken);
+            response.EnsureSuccessStatusCode();
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse<PlayerData>>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.NotNull(result.Data);
+            return result.Data.LogPreferences;
+        }
+
+        /// <summary>
+        /// The save writes the cached player fire-and-forget, so poll the player snapshot
+        /// until the expected preference lands (or fail after a short budget).
+        /// </summary>
+        private async Task<List<LogPreference>> WaitForLogPreferenceAsync(HttpClient client, ELogType type, bool enabled)
+        {
+            for (var attempt = 0; attempt < 20; attempt++)
+            {
+                var prefs = await GetLogPreferencesAsync(client);
+                if (prefs.Any(p => p.Id == type && p.Enabled == enabled))
+                {
+                    return prefs;
+                }
+
+                await Task.Delay(50, CancellationToken);
+            }
+
+            Assert.Fail($"Log preference {type} did not reach expected value {enabled}.");
+            return [];
+        }
+    }
+}

--- a/Game.Api/Controllers/PlayerController.cs
+++ b/Game.Api/Controllers/PlayerController.cs
@@ -31,12 +31,6 @@ namespace Game.Api.Controllers
         }
 
         [HttpPost]
-        public ApiResponse SaveLogPreferences([FromBody] List<Models.Player.LogPreference> prefs)
-        {
-            throw new NotImplementedException();
-        }
-
-        [HttpPost]
         public async Task<ApiResponse> EquipItem([FromBody] EquipRequest request)
         {
             var player = await _sessionService.LoadPlayer();

--- a/Game.Api/Sockets/Commands/SaveLogPreferences.cs
+++ b/Game.Api/Sockets/Commands/SaveLogPreferences.cs
@@ -1,0 +1,39 @@
+using Game.Api.Models.Common;
+using Game.Application.Services;
+using CoreLogPreference = Game.Core.Players.LogPreference;
+using LogPreferenceModel = Game.Api.Models.Player.LogPreference;
+
+namespace Game.Api.Sockets.Commands
+{
+    /// <summary>
+    /// Persists the player's combat-log display preferences. Mirrors
+    /// <see cref="SetItemFavorite"/>: the change is applied to the cached domain
+    /// player (the source of truth for player data) and persisted from there.
+    /// </summary>
+    public class SaveLogPreferences : AbstractSocketCommandWithParams<List<LogPreferenceModel>>
+    {
+        private readonly PlayerService _playerService;
+
+        public override string Name { get; set; } = nameof(SaveLogPreferences);
+
+        public SaveLogPreferences(PlayerService playerService)
+        {
+            _playerService = playerService;
+        }
+
+        public override async Task<ApiSocketResponse> ExecuteAsync(SocketContext context)
+        {
+            if (Parameters.Any(p => !Enum.IsDefined(p.Id)))
+            {
+                return Error("Unknown log type.");
+            }
+
+            var player = await context.Session.LoadPlayer();
+            await _playerService.SaveLogPreferences(
+                player,
+                Parameters.Select(p => new CoreLogPreference { LogType = p.Id, Enabled = p.Enabled }));
+
+            return Success();
+        }
+    }
+}

--- a/Game.Application/Services/PlayerService.cs
+++ b/Game.Application/Services/PlayerService.cs
@@ -63,6 +63,16 @@ namespace Game.Application.Services
             return true;
         }
 
+        public async Task SaveLogPreferences(Player player, IEnumerable<LogPreference> preferences)
+        {
+            foreach (var preference in preferences)
+            {
+                player.UpdateLogPreference(preference.LogType, preference.Enabled);
+            }
+
+            await _playerRepo.SavePlayer(player);
+        }
+
         public async Task<bool> ApplyMod(Player player, int itemId, int itemModId, int itemModSlotId)
         {
             var modEntity = _itemMods.LookupItemMod(itemModId);

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -171,6 +171,47 @@ namespace Game.Core.Tests.Players
             Assert.Equal(5, evt.ItemModId);
         }
 
+        // ── UpdateLogPreference ──────────────────────────────────────────────
+
+        [Fact]
+        public void UpdateLogPreference_NewType_AddsPreference()
+        {
+            var player = MakePlayer();
+
+            player.UpdateLogPreference(ELogType.Damage, false);
+
+            var pref = player.LogPreferences.SingleOrDefault(p => p.LogType == ELogType.Damage);
+            Assert.NotNull(pref);
+            Assert.False(pref.Enabled);
+        }
+
+        [Fact]
+        public void UpdateLogPreference_ExistingType_UpdatesInPlace()
+        {
+            var player = MakePlayer();
+            player.LogPreferences.Add(new LogPreference { LogType = ELogType.Damage, Enabled = true });
+
+            player.UpdateLogPreference(ELogType.Damage, false);
+
+            var pref = Assert.Single(player.LogPreferences);
+            Assert.Equal(ELogType.Damage, pref.LogType);
+            Assert.False(pref.Enabled);
+        }
+
+        [Fact]
+        public void UpdateLogPreference_RaisesLogPreferenceChangedEvent()
+        {
+            var player = MakePlayer();
+
+            player.UpdateLogPreference(ELogType.Debug, true);
+
+            var evt = player.DomainEvents.OfType<LogPreferenceChangedEvent>().SingleOrDefault();
+            Assert.NotNull(evt);
+            Assert.Equal(player.Id, evt.PlayerId);
+            Assert.Equal(ELogType.Debug, evt.LogType);
+            Assert.True(evt.Enabled);
+        }
+
         // ── RecordBattleCompleted ────────────────────────────────────────────
 
         [Fact]

--- a/UI/new-svelte/src/lib/api/types/api-socket-type-map.ts
+++ b/UI/new-svelte/src/lib/api/types/api-socket-type-map.ts
@@ -5,6 +5,7 @@ import type {
 	IBattleLostResponse,
 	IDefeatEnemyRequest,
 	IDefeatEnemyResponse,
+	ILogPreference,
 	INewEnemyModel,
 	INewEnemyRequest,
 	ISetItemFavoriteRequest
@@ -14,6 +15,7 @@ export type ApiSocketResponseTypes = {
 	'BattleLost': IBattleLostResponse;
 	'DefeatEnemy': IDefeatEnemyResponse;
 	'NewEnemy': INewEnemyModel;
+	'SaveLogPreferences': undefined;
 	'SetItemFavorite': undefined;
 	'SocketReplaced': undefined;
 };
@@ -21,6 +23,7 @@ export type ApiSocketResponseTypes = {
 export type ApiSocketRequestTypes = {
 	'DefeatEnemy': IDefeatEnemyRequest;
 	'NewEnemy': INewEnemyRequest;
+	'SaveLogPreferences': ILogPreference[];
 	'SetItemFavorite': ISetItemFavoriteRequest;
 };
 

--- a/UI/new-svelte/src/lib/api/types/api-type-map.ts
+++ b/UI/new-svelte/src/lib/api/types/api-type-map.ts
@@ -21,7 +21,6 @@ import type {
 	IItemModType,
 	ILoginCredentials,
 	ILoginResult,
-	ILogPreference,
 	IPlayerChallenge,
 	IPlayerData,
 	IPlayerStatistic,
@@ -84,7 +83,6 @@ export type ApiResponseTypes = {
 	'Player/ApplyMod': undefined;
 	'Player/EquipItem': undefined;
 	'Player/RemoveMod': undefined;
-	'Player/SaveLogPreferences': undefined;
 	'Player/UnequipItem': undefined;
 	'Player/UpdatePlayerStats': IBattlerAttribute[];
 	'Skills': ISkill[];
@@ -130,7 +128,6 @@ export type ApiRequestTypes = {
 	'Player/ApplyMod': IApplyModRequest;
 	'Player/EquipItem': IEquipRequest;
 	'Player/RemoveMod': IRemoveModRequest;
-	'Player/SaveLogPreferences': ILogPreference[];
 	'Player/UnequipItem': IEquipRequest;
 	'Player/UpdatePlayerStats': IAttributeUpdate[];
 	'Skills': { refreshCache?: boolean } | undefined;

--- a/UI/new-svelte/src/routes/game/screens/options/options-view.svelte.ts
+++ b/UI/new-svelte/src/routes/game/screens/options/options-view.svelte.ts
@@ -6,7 +6,7 @@
    active category's content. Adding a future category — or a new `ELogType` —
    is a one-line edit to the arrays below rather than new UI. */
 
-import { ApiRequest, ELogType, type ILogPreference } from '$lib/api';
+import { apiSocket, ELogType, type ILogPreference } from '$lib/api';
 import { playerManager } from '$lib/engine';
 import { logColors } from '$components';
 import { toastError } from '$stores';
@@ -190,8 +190,8 @@ export class OptionsView {
 		this.saving = true;
 		let ok = false;
 		try {
-			const response = await new ApiRequest('Player/SaveLogPreferences').post(changed);
-			ok = response.status >= 200 && response.status < 300;
+			const response = await apiSocket.sendSocketCommand('SaveLogPreferences', changed);
+			ok = !response.error;
 		} catch {
 			ok = false;
 		} finally {

--- a/UI/new-svelte/src/tests/routes/game/screens/options/options-view.test.ts
+++ b/UI/new-svelte/src/tests/routes/game/screens/options/options-view.test.ts
@@ -4,9 +4,9 @@ import { ELogType, type ILogPreference } from '$lib/api';
 // Mutable player-manager stand-in: `save()` reassigns `logPreferences`, so it is
 // a plain writable property (not a getter). `vi.hoisted` keeps it initialised
 // before the hoisted vi.mock factory runs.
-const { mockPlayerManager, mockPost, toastError } = vi.hoisted(() => ({
+const { mockPlayerManager, mockSendSocketCommand, toastError } = vi.hoisted(() => ({
 	mockPlayerManager: { logPreferences: [] as ILogPreference[] },
-	mockPost: vi.fn(),
+	mockSendSocketCommand: vi.fn(),
 	toastError: vi.fn()
 }));
 
@@ -23,12 +23,9 @@ vi.mock('$components', () => ({
 }));
 vi.mock('$lib/api', async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, unknown>;
-	// A real class so `new ApiRequest(...)` is constructable; `.post` delegates
-	// to the hoisted spy each test configures.
-	class MockApiRequest {
-		post = mockPost;
-	}
-	return { ...actual, ApiRequest: MockApiRequest };
+	// `save()` persists through the WebSocket command; the spy each test configures
+	// stands in for the live socket.
+	return { ...actual, apiSocket: { sendSocketCommand: mockSendSocketCommand } };
 });
 
 import { OptionsView, LOG_TYPES } from '$routes/game/screens/options/options-view.svelte';
@@ -38,7 +35,7 @@ const allEnabled = (): ILogPreference[] => LOG_TYPES.map((lt) => ({ id: lt.id, e
 let view: OptionsView;
 
 beforeEach(() => {
-	mockPost.mockReset().mockResolvedValue({ status: 200 });
+	mockSendSocketCommand.mockReset().mockResolvedValue({});
 	toastError.mockReset();
 	mockPlayerManager.logPreferences = allEnabled();
 	view = new OptionsView();
@@ -135,12 +132,12 @@ describe('OptionsView.changedPreferences', () => {
 });
 
 describe('OptionsView.save', () => {
-	it('posts only the changed preferences, applies them, and clears dirty on success', async () => {
+	it('sends only the changed preferences, applies them, and clears dirty on success', async () => {
 		view.setOne(ELogType.Damage, false);
 		await view.save();
 
-		expect(mockPost).toHaveBeenCalledTimes(1);
-		expect(mockPost).toHaveBeenCalledWith([{ id: ELogType.Damage, enabled: false }]);
+		expect(mockSendSocketCommand).toHaveBeenCalledTimes(1);
+		expect(mockSendSocketCommand).toHaveBeenCalledWith('SaveLogPreferences', [{ id: ELogType.Damage, enabled: false }]);
 		// applied to the player manager so the live log filter reflects the change
 		expect(mockPlayerManager.logPreferences.find((p) => p.id === ELogType.Damage)?.enabled).toBe(false);
 		expect(view.isDirty).toBe(false);
@@ -149,7 +146,7 @@ describe('OptionsView.save', () => {
 	});
 
 	it('still applies locally but warns when the server rejects the save', async () => {
-		mockPost.mockResolvedValue({ status: 500 });
+		mockSendSocketCommand.mockResolvedValue({ error: 'Unknown log type.' });
 		view.setOne(ELogType.Exp, false);
 		await view.save();
 
@@ -160,7 +157,7 @@ describe('OptionsView.save', () => {
 	});
 
 	it('applies locally and warns when the request throws', async () => {
-		mockPost.mockRejectedValue(new Error('network'));
+		mockSendSocketCommand.mockRejectedValue(new Error('network'));
 		view.setOne(ELogType.Exp, false);
 		await view.save();
 
@@ -171,7 +168,7 @@ describe('OptionsView.save', () => {
 	it('does nothing when there are no changes', async () => {
 		await view.save();
 
-		expect(mockPost).not.toHaveBeenCalled();
+		expect(mockSendSocketCommand).not.toHaveBeenCalled();
 		expect(toastError).not.toHaveBeenCalled();
 	});
 


### PR DESCRIPTION
## Summary

Implements the backend for the options page (resolves #37).

The options screen's logging preferences (added in #55) were being saved through a `Player/SaveLogPreferences` **REST endpoint that only ever threw `NotImplementedException`** — so the toggles were applied locally for the session but never persisted. This adds a real WebSocket command and wires the frontend to it, in line with the documented direction of moving player communication onto sockets (see _HTTP vs WebSocket Communication_ in `docs/backend.md`).

## What changed

**Backend**
- **New `SaveLogPreferences` socket command** (`Game.Api/Sockets/Commands/`), mirroring `SetItemFavorite`: it validates that every incoming log type is a defined `ELogType` (returning an error otherwise), then applies the changes to the cached domain player — the source of truth for player data — and persists from there.
- **`PlayerService.SaveLogPreferences`** orchestrates the domain calls (`Player.UpdateLogPreference` per entry) and the `SavePlayer` write, following the pattern of the other `PlayerService` mutators.
- **Removed the dead REST stub** `PlayerController.SaveLogPreferences` (the `NotImplementedException` throw the frontend was calling).
- Regenerated the TypeScript API client via the standalone codegen command — adds `SaveLogPreferences` to the socket request/response maps and drops the removed REST entry. No hand edits to generated files.

**Frontend**
- `options-view.svelte.ts` now sends `apiSocket.sendSocketCommand('SaveLogPreferences', changed)` instead of the dead REST call; success is keyed off the absence of a socket error. The existing optimistic "apply locally regardless, toast on failure" behavior is preserved.

## Notes / design

- The command reuses the existing `Models.Player.LogPreference` DTO (so the generated `ILogPreference` shape is unchanged) and only sends the **changed** preferences, matching the prior diff-only behavior.
- Persistence rides the same cache-as-source-of-truth path as `SetItemFavorite` (`SavePlayer` → domain-event dispatch + cache write). The DB write-behind for these events is tracked separately in #4 and is intentionally out of scope here.

## Testing

- **Domain unit tests** (`Game.Core.Tests/Players/PlayerTests.cs`): `UpdateLogPreference` adds a new preference, updates an existing one in place, and raises `LogPreferenceChangedEvent`.
- **Integration tests** (`Game.Api.Tests/Integration/SaveLogPreferencesSocketTests.cs`): the command persists changes (verified by reading them back through `GET /api/Player`), and an unknown log type returns an error.
- **Frontend unit tests** updated to mock the socket command instead of `ApiRequest`.

All green:
- `dotnet build Game.sln` — 0 warnings / 0 errors
- `Game.Core.Tests` — 189 passed · `Game.Api.Tests` — 223 passed
- `npm run check` — 0 errors/warnings · `npm run lint` — clean · `npx vitest run` — 347 passed · `npm run build` — succeeds

https://claude.ai/code/session_01MvduMRFodWTVkyRqCZAo6u

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvduMRFodWTVkyRqCZAo6u)_