### PR TITLE
Migrate hardcoded colors to theme vars: fight & challenges screens (#43)

### DIFF
--- a/UI/new-svelte/src/routes/+layout.svelte
+++ b/UI/new-svelte/src/routes/+layout.svelte
@@ -57,6 +57,7 @@ $effect(() => {
 	--error-color: #{colors.$error};
 	--health-missing-color: #{colors.$hp-red-bg};
 	--health-remaining-color: #{colors.$hp-green};
+	--health-remaining-dark: #{colors.$hp-green-dark};
 	--health-disappearing-color: #{colors.$hp-red-disappearing};
 	--slot-background-color: #{colors.$white};
 	--surface: #{colors.$surface};

--- a/UI/new-svelte/src/routes/game/screens/challenges/ModTooltip.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/ModTooltip.svelte
@@ -54,12 +54,12 @@ const effects = $derived(
 .mod-tooltip {
 	width: 280px;
 	border-radius: 3px;
-	box-shadow: -4px 0 16px rgba(0, 0, 0, 0.15);
+	box-shadow: -4px 0 16px color-mix(in srgb, var(--black) 15%, transparent);
 }
 
 .tt-title-section {
 	padding: 14px 16px 12px;
-	border-bottom: 1px solid rgba(240, 240, 240, 0.08);
+	border-bottom: 1px solid color-mix(in srgb, var(--text-primary) 8%, transparent);
 }
 
 .tt-type-row {
@@ -110,7 +110,7 @@ const effects = $derived(
 		font-size: 11.5px;
 		letter-spacing: 0.3px;
 		text-align: right;
-		color: rgba(240, 240, 240, 0.7);
+		color: color-mix(in srgb, var(--text-primary) 70%, transparent);
 
 		&.positive {
 			color: var(--success);
@@ -124,7 +124,7 @@ const effects = $derived(
 .tt-description {
 	font-size: 11.5px;
 	font-style: italic;
-	color: rgba(240, 240, 240, 0.6);
+	color: color-mix(in srgb, var(--text-primary) 60%, transparent);
 	line-height: 1.55;
 }
 </style>

--- a/UI/new-svelte/src/routes/game/screens/challenges/ProgressBar.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/ProgressBar.svelte
@@ -35,7 +35,7 @@ const col = $derived(done ? 'var(--success)' : accent);
 .bar-track {
 	position: relative;
 	overflow: hidden;
-	background: rgba(255, 255, 255, 0.07);
+	background: color-mix(in srgb, var(--white) 7%, transparent);
 }
 
 .bar-fill {

--- a/UI/new-svelte/src/routes/game/screens/challenges/RewardIcon.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/RewardIcon.svelte
@@ -97,7 +97,12 @@ const revealGlow = $derived(`0 0 calc(4px + ${reward.glow} * 16px) ${tintColor(a
 		position: absolute;
 		inset: 0;
 		pointer-events: none;
-		background: linear-gradient(115deg, transparent 38%, rgba(255, 255, 255, 0.16) 50%, transparent 62%);
+		background: linear-gradient(
+			115deg,
+			transparent 38%,
+			color-mix(in srgb, var(--white) 16%, transparent) 50%,
+			transparent 62%
+		);
 		transform: translateX(-130%);
 		animation: seal-sweep 3.4s ease-in-out infinite;
 	}

--- a/UI/new-svelte/src/routes/game/screens/challenges/RingMeter.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/RingMeter.svelte
@@ -1,6 +1,13 @@
 <div class="ring" style:width="{size}px" style:height="{size}px">
 	<svg width={size} height={size} style="transform: rotate(-90deg)">
-		<circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke="rgba(255,255,255,0.09)" stroke-width={stroke} />
+		<circle
+			cx={size / 2}
+			cy={size / 2}
+			r={radius}
+			fill="none"
+			stroke="color-mix(in srgb, var(--white) 9%, transparent)"
+			stroke-width={stroke}
+		/>
 		<circle
 			cx={size / 2}
 			cy={size / 2}

--- a/UI/new-svelte/src/routes/game/screens/challenges/SealedHeader.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/SealedHeader.svelte
@@ -37,7 +37,7 @@ const { rarityAccent, catAccent, typeLabel }: Props = $props();
 <style lang="scss">
 .sealed-head {
 	padding: 14px 16px 12px;
-	border-bottom: 1px solid rgba(240, 240, 240, 0.08);
+	border-bottom: 1px solid color-mix(in srgb, var(--text-primary) 8%, transparent);
 }
 
 .head-top {
@@ -79,7 +79,7 @@ const { rarityAccent, catAccent, typeLabel }: Props = $props();
 .masked-name {
 	font-size: 18px;
 	font-weight: 400;
-	color: rgba(240, 240, 240, 0.45);
+	color: color-mix(in srgb, var(--text-primary) 45%, transparent);
 	letter-spacing: 2px;
 }
 </style>

--- a/UI/new-svelte/src/routes/game/screens/challenges/SealedItemTooltip.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/SealedItemTooltip.svelte
@@ -18,14 +18,7 @@
 				<div class="sealed-slots">
 					{#each item.modSlots as slot (slot.id)}
 						<div class="sealed-slot" style:border-left="2px solid {tintColor(accent, 0.5)}">
-							<svg
-								width="10"
-								height="10"
-								viewBox="0 0 16 16"
-								fill="none"
-								stroke="rgba(240,240,240,0.4)"
-								stroke-width="1.5"
-							>
+							<svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="var(--text-muted)" stroke-width="1.5">
 								<rect x="3.5" y="7" width="9" height="6.5" rx="1" />
 								<path d="M5.5 7V5.2a2.5 2.5 0 0 1 5 0V7" />
 							</svg>
@@ -70,7 +63,7 @@ const STAT_BAR_WIDTHS = [78, 60, 92, 70];
 .sealed-tooltip {
 	width: 280px;
 	border-radius: 3px;
-	box-shadow: -4px 0 16px rgba(0, 0, 0, 0.15);
+	box-shadow: -4px 0 16px color-mix(in srgb, var(--black) 15%, transparent);
 }
 
 .tt-body {
@@ -103,7 +96,7 @@ const STAT_BAR_WIDTHS = [78, 60, 92, 70];
 
 .sealed-slot {
 	padding: 6px 10px;
-	border: 1px dashed rgba(255, 255, 255, 0.14);
+	border: 1px dashed var(--border-light);
 	display: flex;
 	align-items: center;
 	gap: 8px;
@@ -111,7 +104,7 @@ const STAT_BAR_WIDTHS = [78, 60, 92, 70];
 
 .sealed-slot-label {
 	font-size: 11.5px;
-	color: rgba(240, 240, 240, 0.45);
+	color: color-mix(in srgb, var(--text-primary) 45%, transparent);
 	font-style: italic;
 }
 

--- a/UI/new-svelte/src/routes/game/screens/challenges/SealedModTooltip.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/SealedModTooltip.svelte
@@ -50,7 +50,7 @@ const EFFECT_BAR_WIDTHS = [70, 88, 58];
 .sealed-tooltip {
 	width: 280px;
 	border-radius: 3px;
-	box-shadow: -4px 0 16px rgba(0, 0, 0, 0.15);
+	box-shadow: -4px 0 16px color-mix(in srgb, var(--black) 15%, transparent);
 }
 
 .tt-body {

--- a/UI/new-svelte/src/routes/game/screens/challenges/TooltipSection.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/TooltipSection.svelte
@@ -42,6 +42,6 @@ const { label, last = false, children }: Props = $props();
 .tt-section-line {
 	flex: 1;
 	height: 1px;
-	background: rgba(240, 240, 240, 0.06);
+	background: color-mix(in srgb, var(--text-primary) 6%, transparent);
 }
 </style>

--- a/UI/new-svelte/src/routes/game/screens/challenges/TypeRail.svelte
+++ b/UI/new-svelte/src/routes/game/screens/challenges/TypeRail.svelte
@@ -52,7 +52,7 @@ const { groups, selected, onSelect }: Props = $props();
 
 	&.active {
 		border-color: var(--border-light);
-		background: rgba(255, 255, 255, 0.06);
+		background: color-mix(in srgb, var(--white) 6%, transparent);
 	}
 }
 
@@ -64,7 +64,7 @@ const { groups, selected, onSelect }: Props = $props();
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background: rgba(255, 255, 255, 0.05);
+	background: color-mix(in srgb, var(--white) 5%, transparent);
 	border: 1px solid var(--border-light);
 }
 

--- a/UI/new-svelte/src/routes/game/screens/fight/BattlerCard.svelte
+++ b/UI/new-svelte/src/routes/game/screens/fight/BattlerCard.svelte
@@ -2,7 +2,7 @@
 	<!-- Name + Level -->
 	<div class="battler-header" class:reversed={side === 'enemy'}>
 		<div class="battler-identity" class:reversed={side === 'enemy'}>
-			<div class="accent-bar" style:background={accent} style:box-shadow="0 0 8px {accent}80"></div>
+			<div class="accent-bar" style:background={accent} style:box-shadow="0 0 8px {tintColor(accent, 0.5)}"></div>
 			<span class="battler-name">{battler.name}</span>
 		</div>
 		<span class="battler-level">LV · {battler.level}</span>
@@ -22,7 +22,7 @@
 <script lang="ts">
 import { EAttribute } from '$lib/api';
 import { type Battler } from '$lib/battle';
-import { formatNum } from '$lib/common';
+import { formatNum, tintColor } from '$lib/common';
 import Skills from './Skills.svelte';
 
 type Props = {
@@ -32,7 +32,7 @@ type Props = {
 
 const { battler, side }: Props = $props();
 
-const accent = $derived(side === 'player' ? '#a1c2f7' : '#e08778');
+const accent = $derived(side === 'player' ? 'var(--accent)' : 'var(--enemy-accent)');
 const maxHealth = $derived(battler.attributes.getValue(EAttribute.MaxHealth));
 const healthText = $derived(`${formatNum(battler.currentHealth)} / ${maxHealth}`);
 const healthPerc = $derived(maxHealth ? formatNum(Math.max((battler.currentHealth * 100) / maxHealth, 0)) : 100);
@@ -40,27 +40,27 @@ const healthPerc = $derived(maxHealth ? formatNum(Math.max((battler.currentHealt
 
 <style lang="scss">
 .battler-card {
-	background: rgba(255, 255, 255, 0.03);
-	border: 1px solid rgba(255, 255, 255, 0.14);
+	background: color-mix(in srgb, var(--white) 3%, transparent);
+	border: 1px solid var(--border-light);
 	border-radius: 3px;
 	padding: 18px 20px;
-	color: #f0f0f0;
+	color: var(--text-primary);
 	width: 360px;
 	min-width: 200px;
 	flex-shrink: 1;
 
 	&.player {
-		border-left: 3px solid #a1c2f7;
+		border-left: 3px solid var(--accent);
 		box-shadow:
-			0 0 0 1px rgba(0, 0, 0, 0.4),
-			-4px 0 18px rgba(161, 194, 247, 0.1);
+			0 0 0 1px color-mix(in srgb, var(--black) 40%, transparent),
+			-4px 0 18px color-mix(in srgb, var(--accent) 10%, transparent);
 	}
 
 	&.enemy {
-		border-right: 3px solid #e08778;
+		border-right: 3px solid var(--enemy-accent);
 		box-shadow:
-			0 0 0 1px rgba(0, 0, 0, 0.4),
-			4px 0 18px rgba(224, 135, 120, 0.1);
+			0 0 0 1px color-mix(in srgb, var(--black) 40%, transparent),
+			4px 0 18px color-mix(in srgb, var(--enemy-accent) 10%, transparent);
 	}
 }
 
@@ -99,15 +99,15 @@ const healthPerc = $derived(maxHealth ? formatNum(Math.max((battler.currentHealt
 .battler-level {
 	font-family: var(--mono);
 	font-size: 10.5px;
-	color: rgba(240, 240, 240, 0.6);
+	color: color-mix(in srgb, var(--text-primary) 60%, transparent);
 	letter-spacing: 0.6px;
 }
 
 .hp-bar {
 	position: relative;
 	height: 20px;
-	background: rgba(224, 138, 120, 0.18);
-	border: 1px solid rgba(255, 255, 255, 0.12);
+	background: var(--health-missing-color);
+	border: 1px solid color-mix(in srgb, var(--white) 12%, transparent);
 	border-radius: 2px;
 	overflow: hidden;
 	margin-bottom: 14px;
@@ -116,14 +116,14 @@ const healthPerc = $derived(maxHealth ? formatNum(Math.max((battler.currentHealt
 .hp-disappearing {
 	position: absolute;
 	inset: 0;
-	background: rgba(224, 138, 120, 0.55);
+	background: var(--health-disappearing-color);
 	transition: width 1s ease-out;
 }
 
 .hp-remaining {
 	position: absolute;
 	inset: 0;
-	background: linear-gradient(180deg, #7fc28b 0%, #5da66a 100%);
+	background: linear-gradient(180deg, var(--health-remaining-color) 0%, var(--health-remaining-dark) 100%);
 	transition: width 120ms ease-out;
 }
 
@@ -135,8 +135,8 @@ const healthPerc = $derived(maxHealth ? formatNum(Math.max((battler.currentHealt
 	justify-content: center;
 	font-family: var(--mono);
 	font-size: 11px;
-	color: #fff;
-	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
+	color: var(--white);
+	text-shadow: 0 1px 2px color-mix(in srgb, var(--black) 70%, transparent);
 	letter-spacing: 0.3px;
 }
 </style>

--- a/UI/new-svelte/src/routes/game/screens/fight/Fight.svelte
+++ b/UI/new-svelte/src/routes/game/screens/fight/Fight.svelte
@@ -61,17 +61,17 @@ import { battleEngine } from '$lib/engine';
 .vs-diamond {
 	position: absolute;
 	inset: 0;
-	border: 1px solid rgba(255, 255, 255, 0.18);
+	border: 1px solid var(--border-medium);
 	transform: rotate(45deg);
-	background: rgba(20, 21, 27, 0.6);
+	background: color-mix(in srgb, var(--surface) 60%, transparent);
 }
 
 .vs-diamond-inner {
 	position: absolute;
 	inset: 14px;
-	background: rgba(255, 255, 255, 0.04);
+	background: color-mix(in srgb, var(--white) 4%, transparent);
 	transform: rotate(45deg);
-	box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.08);
+	box-shadow: inset 0 0 12px var(--border-subtle);
 }
 
 .vs-text {
@@ -80,6 +80,6 @@ import { battleEngine } from '$lib/engine';
 	font-size: 10px;
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
-	color: rgba(240, 240, 240, 0.85);
+	color: color-mix(in srgb, var(--text-primary) 85%, transparent);
 }
 </style>

--- a/UI/new-svelte/src/routes/game/screens/fight/SkillTooltip.svelte
+++ b/UI/new-svelte/src/routes/game/screens/fight/SkillTooltip.svelte
@@ -121,12 +121,12 @@ const attributeName = (attrId: number) => {
 .skill-tooltip {
 	width: 280px;
 	border-radius: 3px;
-	box-shadow: -4px 0 16px rgba(161, 194, 247, 0.13);
+	box-shadow: -4px 0 16px color-mix(in srgb, var(--accent) 13%, transparent);
 }
 
 .tt-title-section {
 	padding: 14px 16px 12px;
-	border-bottom: 1px solid rgba(240, 240, 240, 0.08);
+	border-bottom: 1px solid color-mix(in srgb, var(--text-primary) 8%, transparent);
 }
 
 .tt-category-row {
@@ -141,7 +141,7 @@ const attributeName = (attrId: number) => {
 	height: 5px;
 	transform: rotate(45deg);
 	background: var(--accent);
-	box-shadow: 0 0 6px rgba(161, 194, 247, 0.68);
+	box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 68%, transparent);
 }
 
 .tt-category-label {
@@ -157,8 +157,8 @@ const attributeName = (attrId: number) => {
 	position: relative;
 	width: 60px;
 	height: 18px;
-	background: rgba(240, 240, 240, 0.06);
-	border: 1px solid rgba(255, 255, 255, 0.14);
+	background: color-mix(in srgb, var(--text-primary) 6%, transparent);
+	border: 1px solid var(--border-light);
 	border-radius: 2px;
 	overflow: hidden;
 }
@@ -166,10 +166,18 @@ const attributeName = (attrId: number) => {
 .tt-cooldown-fill {
 	position: absolute;
 	inset: 0;
-	background: linear-gradient(90deg, rgba(161, 194, 247, 0.5), rgba(161, 194, 247, 0.18));
+	background: linear-gradient(
+		90deg,
+		color-mix(in srgb, var(--accent) 50%, transparent),
+		color-mix(in srgb, var(--accent) 18%, transparent)
+	);
 
 	&.ready {
-		background: linear-gradient(90deg, rgba(189, 224, 180, 0.55), rgba(189, 224, 180, 0.2));
+		background: linear-gradient(
+			90deg,
+			color-mix(in srgb, var(--success) 55%, transparent),
+			color-mix(in srgb, var(--success) 20%, transparent)
+		);
 	}
 }
 
@@ -181,18 +189,18 @@ const attributeName = (attrId: number) => {
 	justify-content: center;
 	font-family: var(--mono);
 	font-size: 9px;
-	color: #c0d8ff;
+	color: var(--accent-light);
 	letter-spacing: 0.6px;
 
 	&.ready {
-		color: #bde0b4;
+		color: var(--success);
 	}
 }
 
 .tt-skill-name {
 	font-size: 18px;
 	font-weight: 400;
-	color: #f0f0f0;
+	color: var(--text-primary);
 	letter-spacing: -0.2px;
 }
 
@@ -213,7 +221,7 @@ const attributeName = (attrId: number) => {
 	font-size: 9.5px;
 	letter-spacing: 1.8px;
 	text-transform: uppercase;
-	color: rgba(240, 240, 240, 0.4);
+	color: var(--text-muted);
 	margin-bottom: 7px;
 	display: flex;
 	align-items: center;
@@ -223,7 +231,7 @@ const attributeName = (attrId: number) => {
 .tt-section-line {
 	flex: 1;
 	height: 1px;
-	background: rgba(240, 240, 240, 0.06);
+	background: color-mix(in srgb, var(--text-primary) 6%, transparent);
 }
 
 .tt-dmg-list {
@@ -240,37 +248,37 @@ const attributeName = (attrId: number) => {
 }
 
 .tt-dmg-label {
-	color: rgba(240, 240, 240, 0.78);
+	color: var(--text-secondary);
 }
 
 .tt-mult-dim {
-	color: rgba(240, 240, 240, 0.45);
+	color: color-mix(in srgb, var(--text-primary) 45%, transparent);
 }
 
 .tt-dmg-value {
 	font-family: var(--mono);
 	font-size: 11.5px;
-	color: #f0f0f0;
+	color: var(--text-primary);
 	letter-spacing: 0.3px;
 
 	&.positive {
-		color: #bde0b4;
+		color: var(--success);
 	}
 	&.negative {
-		color: #f0a094;
+		color: var(--error);
 	}
 }
 
 .tt-dmg-total {
 	margin-top: 4px;
 	padding-top: 6px;
-	border-top: 1px solid rgba(240, 240, 240, 0.1);
+	border-top: 1px solid color-mix(in srgb, var(--text-primary) 10%, transparent);
 	display: flex;
 	justify-content: space-between;
 	align-items: baseline;
 	font-size: 13px;
 	font-weight: 600;
-	color: #f0f0f0;
+	color: var(--text-primary);
 }
 
 .tt-total-value {
@@ -287,8 +295,8 @@ const attributeName = (attrId: number) => {
 
 .tt-metric {
 	padding: 7px 10px;
-	background: rgba(255, 255, 255, 0.03);
-	border: 1px solid rgba(255, 255, 255, 0.08);
+	background: color-mix(in srgb, var(--white) 3%, transparent);
+	border: 1px solid var(--border-subtle);
 	border-radius: 2px;
 }
 
@@ -297,14 +305,14 @@ const attributeName = (attrId: number) => {
 	font-size: 9px;
 	letter-spacing: 1.3px;
 	text-transform: uppercase;
-	color: rgba(240, 240, 240, 0.5);
+	color: color-mix(in srgb, var(--text-primary) 50%, transparent);
 	margin-bottom: 2px;
 }
 
 .tt-metric-value {
 	font-family: var(--mono);
 	font-size: 14px;
-	color: #f0f0f0;
+	color: var(--text-primary);
 	letter-spacing: 0.3px;
 }
 </style>

--- a/UI/new-svelte/src/routes/game/screens/fight/Skills.svelte
+++ b/UI/new-svelte/src/routes/game/screens/fight/Skills.svelte
@@ -30,7 +30,7 @@
 
 <script lang="ts">
 import type { Battler, Skill } from '$lib/battle';
-import { formatNum } from '$lib/common';
+import { formatNum, tintColor } from '$lib/common';
 import { registerTooltipComponent, type TooltipComponent } from '$stores/tooltip.svelte';
 import SkillTooltip from './SkillTooltip.svelte';
 
@@ -45,7 +45,9 @@ let tooltip = $state<TooltipComponent>();
 let tooltipSkillIndex = $state(-1);
 
 const tooltipSkill = $derived(battler.skills[tooltipSkillIndex]);
-const pulseColor = $derived(side === 'player' ? 'rgba(161, 194, 247, 0.6)' : 'rgba(224, 135, 120, 0.6)');
+const pulseColor = $derived(
+	side === 'player' ? tintColor('var(--accent)', 0.6) : tintColor('var(--enemy-accent)', 0.6)
+);
 
 const { setTooltipPosition, showTooltip, hideTooltip } = registerTooltipComponent(() => tooltip);
 
@@ -107,8 +109,8 @@ const isReady = (skill: Skill) => {
 	width: 46px;
 	height: 46px;
 	position: relative;
-	background: rgba(255, 255, 255, 0.05);
-	border: 1px solid rgba(255, 255, 255, 0.14);
+	background: color-mix(in srgb, var(--white) 5%, transparent);
+	border: 1px solid var(--border-light);
 	border-radius: 2px;
 	overflow: hidden;
 	cursor: default;
@@ -117,8 +119,8 @@ const isReady = (skill: Skill) => {
 		box-shadow 140ms;
 
 	&.ready {
-		border-color: rgba(161, 194, 247, 0.53);
-		box-shadow: inset 0 0 8px rgba(161, 194, 247, 0.35);
+		border-color: color-mix(in srgb, var(--accent) 53%, transparent);
+		box-shadow: inset 0 0 8px color-mix(in srgb, var(--accent) 35%, transparent);
 	}
 }
 
@@ -133,7 +135,10 @@ const isReady = (skill: Skill) => {
 .cooldown-overlay {
 	position: absolute;
 	inset: 0;
-	background: conic-gradient(transparent var(--skill-sweep), rgba(0, 0, 0, 0.65) var(--skill-sweep));
+	background: conic-gradient(
+		transparent var(--skill-sweep),
+		color-mix(in srgb, var(--black) 65%, transparent) var(--skill-sweep)
+	);
 	pointer-events: none;
 }
 
@@ -150,7 +155,7 @@ const isReady = (skill: Skill) => {
 	font-size: 9px;
 	letter-spacing: 0.5px;
 	text-transform: uppercase;
-	color: rgba(240, 240, 240, 0.6);
+	color: color-mix(in srgb, var(--text-primary) 60%, transparent);
 	white-space: nowrap;
 
 	&.ready-label {

--- a/UI/new-svelte/src/routes/game/screens/fight/ZoneNav.svelte
+++ b/UI/new-svelte/src/routes/game/screens/fight/ZoneNav.svelte
@@ -36,8 +36,8 @@ const handleClickRight = () => changeZone(1);
 	display: inline-flex;
 	align-items: center;
 	gap: 12px;
-	background: rgba(255, 255, 255, 0.04);
-	border: 1px solid rgba(255, 255, 255, 0.14);
+	background: color-mix(in srgb, var(--white) 4%, transparent);
+	border: 1px solid var(--border-light);
 	border-radius: 3px;
 	padding: 6px 10px 6px 6px;
 }
@@ -45,9 +45,9 @@ const handleClickRight = () => changeZone(1);
 .zone-btn {
 	width: 24px;
 	height: 24px;
-	background: rgba(255, 255, 255, 0.03);
-	border: 1px solid rgba(255, 255, 255, 0.18);
-	color: rgba(240, 240, 240, 0.85);
+	background: color-mix(in srgb, var(--white) 3%, transparent);
+	border: 1px solid var(--border-medium);
+	color: color-mix(in srgb, var(--text-primary) 85%, transparent);
 	border-radius: 2px;
 	cursor: pointer;
 	display: flex;
@@ -58,7 +58,7 @@ const handleClickRight = () => changeZone(1);
 	transition: background 140ms;
 
 	&:hover:not(:disabled) {
-		background: rgba(255, 255, 255, 0.08);
+		background: var(--border-subtle);
 	}
 
 	&:disabled {
@@ -80,12 +80,12 @@ const handleClickRight = () => changeZone(1);
 	font-size: 10.5px;
 	letter-spacing: 1.5px;
 	text-transform: uppercase;
-	color: rgba(192, 216, 255, 0.85);
+	color: color-mix(in srgb, var(--accent-light) 85%, transparent);
 }
 
 .zone-name {
 	font-size: 16px;
-	color: #f0f0f0;
+	color: var(--text-primary);
 	font-weight: 400;
 	letter-spacing: 0.1px;
 }


### PR DESCRIPTION
## Summary

Resolves #43. Migrates the hardcoded color literals (~84 across the two screens) in `routes/game/screens/fight` and `routes/game/screens/challenges` to the existing theme CSS vars / `color-mix` blends / `tintColor` helper, per the [styling guidelines](docs/frontend.md#styling) and the pattern established in #40.

This is a **visual-equivalence refactor** — colors render identically (literals are exact copies of the design-system palette), but now flow through the root variables so a theme can restyle these screens by overriding the variables alone.

## What changed

**Fight** (`BattlerCard`, `Fight`, `SkillTooltip`, `Skills`, `ZoneNav`)
- The per-side accent (`#a1c2f7`/`#e08778`) now resolves to `var(--accent)`/`var(--enemy-accent)`; the `{accent}80` hex-alpha box-shadow became `tintColor(accent, 0.5)`, and the skill `--pulse-color` became `tintColor(var(--accent|--enemy-accent), 0.6)`.
- HP bar maps onto the existing `--health-missing-color` / `--health-disappearing-color`; its gradient's darker stop now uses a new `--health-remaining-dark` var (see below).

**Challenges** (`ModTooltip`, `SealedItemTooltip`, `SealedModTooltip`, `SealedHeader`, `TooltipSection`, `TypeRail`, `RingMeter`, `ProgressBar`, `RewardIcon`)
- Remaining straggler neutrals/tints migrated; SVG `stroke` literals replaced (the file already passed `var(...)` to `stroke` dynamically, so this is consistent).

**Mapping rules applied**
- Exact opacity blends → the semantic var when one exists (`--text-secondary`/`-tertiary`/`-muted`, `--border-subtle`/`-light`/`-medium`, the health vars).
- Everything else → `color-mix(in srgb, var(--…) N%, transparent)` over the matching base token (`--text-primary`, `--white`, `--black`, `--accent`, `--accent-light`, `--success`, `--error`, `--surface`).

**One new var:** `--health-remaining-dark` (`$hp-green-dark`, already in `_colors.scss`) so the HP bar gradient's darker stop is no longer hardcoded.

## Testing

- `npm run check` — 0 errors / 0 warnings
- `npm run lint` — clean
- `npx vitest run` — 347 passed
- `npm run build` — succeeds

No `data-testid`s changed.

## Notes

- The pre-existing follow-up note in `docs/frontend.md` (Options screen section) about other game screens carrying hardcoded neutrals is now partly addressed; the remaining surfaces (inventory, loading, shared/admin) are tracked by the sibling issues #42, #44, #45.

https://claude.ai/code/session_01R9M67KnH9jVnfq6SbhhFGf

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9M67KnH9jVnfq6SbhhFGf)_