### PR TITLE
Update item tooltip styling: accent by rarity, see-through panel, modded name + stats (#9)

### DIFF
--- a/UI/new-svelte/src/components/Tooltip.svelte
+++ b/UI/new-svelte/src/components/Tooltip.svelte
@@ -50,16 +50,19 @@ const style = $derived.by(() => {
 .tooltip-container {
 	position: absolute;
 	display: none;
-	background: rgba(20, 21, 27, 0.96);
-	border: 1px solid rgba(255, 255, 255, 0.14);
-	border-radius: 3px;
+	// See-through panel driven by the themeable `--tooltip-bg` opacity knob; the
+	// backdrop blur keeps content legible over busy backgrounds. The translucency
+	// lives entirely in the background (not an element `opacity`) so the text and
+	// accents stay crisp.
+	background: var(--tooltip-bg);
+	border: 1px solid var(--border-light);
+	border-radius: var(--border-radius);
 	box-shadow:
-		0 12px 28px rgba(0, 0, 0, 0.55),
-		0 0 0 1px rgba(0, 0, 0, 0.4);
+		0 12px 28px color-mix(in srgb, var(--black) 55%, transparent),
+		0 0 0 1px color-mix(in srgb, var(--black) 40%, transparent);
 	backdrop-filter: blur(6px);
 	z-index: 15;
-	color: #f0f0f0;
+	color: var(--text-primary);
 	overflow: hidden;
-	opacity: 0.93;
 }
 </style>

--- a/UI/new-svelte/src/lib/common/item-display.ts
+++ b/UI/new-svelte/src/lib/common/item-display.ts
@@ -34,3 +34,17 @@ export const modTypeLabel = (id: EItemModType): string => EItemModType[id] ?? ''
 
 /** Themeable item-mod-type accent hue, e.g. `var(--mod-prefix)`. */
 export const modTypeColor = (id: EItemModType): string => `var(--mod-${MOD_TYPE_KEY[id] ?? 'component'})`;
+
+/**
+ * Composes an item's display name from its base name plus the names of its
+ * applied prefix/suffix mods, e.g. `Flaming Iron Sword of the Bear`. Prefix mod
+ * names are prepended and suffix mod names appended, both in applied order;
+ * component mods do not affect the name. Kept as a pure helper (taking only the
+ * mod fields it needs) so it stays testable and free of a `$lib/battle` import
+ * cycle, and so the inventory grid can reuse it alongside the tooltip.
+ */
+export const composeItemName = (baseName: string, mods: { name: string; itemModTypeId: EItemModType }[]): string => {
+	const prefixes = mods.filter((m) => m.itemModTypeId === EItemModType.Prefix).map((m) => m.name);
+	const suffixes = mods.filter((m) => m.itemModTypeId === EItemModType.Suffix).map((m) => m.name);
+	return [...prefixes, baseName, ...suffixes].join(' ');
+};

--- a/UI/new-svelte/src/routes/+layout.svelte
+++ b/UI/new-svelte/src/routes/+layout.svelte
@@ -61,6 +61,10 @@ $effect(() => {
 	--slot-background-color: #{colors.$white};
 	--surface: #{colors.$surface};
 	--surface-alpha: #{colors.$surface-alpha};
+	// Tooltip panel background. The surface tint percentage is the configurable
+	// opacity knob — lower it for a more see-through tooltip — and flows through
+	// theme overrides. Paired with the container's backdrop blur for legibility.
+	--tooltip-bg: color-mix(in srgb, var(--surface) 92%, transparent);
 	--page: #0f1014;
 	--panel: #16171e;
 	--panel-2: #1b1c24;

--- a/UI/new-svelte/src/routes/game/screens/inventory/ItemTooltip.svelte
+++ b/UI/new-svelte/src/routes/game/screens/inventory/ItemTooltip.svelte
@@ -2,7 +2,7 @@
 	class="item-tooltip"
 	bind:this={container}
 	style={item ? '' : 'display: none;'}
-	style:border-left="3px solid {accentColor}"
+	style:border-left="3px solid {rarityAccent}"
 >
 	{#if item}
 		<!-- Title section -->
@@ -10,10 +10,10 @@
 			<div class="tt-category-row">
 				<div
 					class="tt-category-diamond"
-					style:background={accentColor}
-					style:box-shadow="0 0 6px {tintColor(accentColor, 0.67)}"
+					style:background={categoryColor}
+					style:box-shadow="0 0 6px {tintColor(categoryColor, 0.67)}"
 				></div>
-				<span class="tt-category-label" style:color={accentColor}>{categoryName}</span>
+				<span class="tt-category-label" style:color={categoryColor}>{categoryName}</span>
 				{#if item.equipped}
 					<div class="tt-equipped-badge">
 						<div class="tt-equipped-dot"></div>
@@ -21,7 +21,7 @@
 					</div>
 				{/if}
 			</div>
-			<div class="tt-item-name">{item.name}</div>
+			<div class="tt-item-name">{displayName}</div>
 		</div>
 
 		<div class="tt-body">
@@ -53,7 +53,7 @@
 					<div class="tt-mods-list">
 						{#each modSlots as slot (slot.slotId)}
 							{#if slot.mod}
-								<div class="tt-mod-tile" style:border-left-color={modTypeColor(slot.type)}>
+								<div class="tt-mod-tile" style:border-left-color={rarityColor(slot.mod.rarityId)}>
 									<div class="tt-mod-header">
 										<span class="tt-mod-name" style:color={rarityColor(slot.mod.rarityId)}>{slot.mod.name}</span>
 										<span class="tt-mod-type" style:color={modTypeColor(slot.type)}>{modTypeLabel(slot.type)}</span>
@@ -87,7 +87,15 @@
 
 <script lang="ts">
 import type { Item } from '$lib/battle';
-import { itemCategoryColor, itemCategoryName, modTypeColor, modTypeLabel, rarityColor, tintColor } from '$lib/common';
+import {
+	composeItemName,
+	itemCategoryColor,
+	itemCategoryName,
+	modTypeColor,
+	modTypeLabel,
+	rarityColor,
+	tintColor
+} from '$lib/common';
 
 export const getBaseNode = () => container;
 
@@ -111,8 +119,14 @@ const modSlots = $derived(
 );
 const filledCount = $derived(modSlots.filter((s) => s.mod).length);
 
-const accentColor = $derived(item ? itemCategoryColor(item.itemCategoryId) : 'var(--category-armor)');
+// The tooltip's main accent (left border) reflects the item's rarity, while the
+// category row (diamond + label) stays category-coloured — mirroring how
+// ModTooltip accents its border by rarity and its diamond/label by mod type.
+const rarityAccent = $derived(item ? rarityColor(item.rarityId) : 'var(--rarity-common)');
+const categoryColor = $derived(item ? itemCategoryColor(item.itemCategoryId) : 'var(--category-armor)');
 const categoryName = $derived(item ? itemCategoryName(item.itemCategoryId) : 'Item');
+// Item name reflects its applied mods: prefix mod names prepend, suffix names append.
+const displayName = $derived(item ? composeItemName(item.name, item.appliedMods) : '');
 </script>
 
 <style lang="scss">

--- a/UI/new-svelte/src/tests/lib/battle/item.test.ts
+++ b/UI/new-svelte/src/tests/lib/battle/item.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EAttribute, EItemCategory, EItemModType, ERarity } from '$lib/api';
+import type { IInventoryItem, IItem, IItemMod } from '$lib/api';
+
+const { mockItems, mockItemMods } = vi.hoisted(() => ({
+	mockItems: [] as IItem[],
+	mockItemMods: [] as IItemMod[]
+}));
+
+vi.mock('$stores', () => ({
+	staticData: {
+		get items() {
+			return mockItems;
+		},
+		get itemMods() {
+			return mockItemMods;
+		}
+	}
+}));
+
+import { newItem } from '$lib/battle/item';
+
+mockItems[1] = {
+	id: 1,
+	name: 'Sword',
+	description: '',
+	itemCategoryId: EItemCategory.Weapon,
+	rarityId: ERarity.Epic,
+	iconPath: '',
+	attributes: [{ attributeId: EAttribute.Strength, amount: 5 }],
+	modSlots: [],
+	tags: []
+};
+mockItemMods[7] = {
+	id: 7,
+	name: 'Flaming',
+	description: '',
+	itemModTypeId: EItemModType.Prefix,
+	rarityId: ERarity.Legendary,
+	attributes: [
+		{ attributeId: EAttribute.Strength, amount: 3 },
+		{ attributeId: EAttribute.Agility, amount: 2 }
+	],
+	tags: []
+};
+
+const invItem: IInventoryItem = {
+	itemId: 1,
+	equipped: false,
+	favorite: false,
+	appliedMods: [{ itemModId: 7, itemModSlotId: 10 }]
+};
+
+describe('newItem', () => {
+	it('merges the applied mods stats into totalAttributes', () => {
+		const item = newItem(invItem);
+		// Strength: item 5 + mod 3 = 8; Agility: mod 2.
+		expect(item.totalAttributes.getValue(EAttribute.Strength)).toBe(8);
+		expect(item.totalAttributes.getValue(EAttribute.Agility)).toBe(2);
+	});
+
+	it('exposes the applied mods with their slot binding', () => {
+		const item = newItem(invItem);
+		expect(item.appliedMods).toHaveLength(1);
+		expect(item.appliedMods[0]).toMatchObject({
+			name: 'Flaming',
+			itemModTypeId: EItemModType.Prefix,
+			itemModSlotId: 10
+		});
+	});
+});

--- a/UI/new-svelte/src/tests/lib/common/item-display.test.ts
+++ b/UI/new-svelte/src/tests/lib/common/item-display.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { EItemCategory, EItemModType, ERarity } from '$lib/api';
+import {
+	composeItemName,
+	itemCategoryColor,
+	itemCategoryName,
+	modTypeColor,
+	modTypeLabel
+} from '$lib/common/item-display';
+
+describe('item-display helpers', () => {
+	it('maps item categories to themeable accent groups and names', () => {
+		expect(itemCategoryColor(EItemCategory.Helm)).toBe('var(--category-armor)');
+		expect(itemCategoryColor(EItemCategory.Boot)).toBe('var(--category-armor)');
+		expect(itemCategoryColor(EItemCategory.Weapon)).toBe('var(--category-weapon)');
+		expect(itemCategoryColor(EItemCategory.Accessory)).toBe('var(--category-accessory)');
+		expect(itemCategoryName(EItemCategory.Weapon)).toBe('Weapon');
+	});
+
+	it('maps mod types to themeable accents and labels', () => {
+		expect(modTypeColor(EItemModType.Component)).toBe('var(--mod-component)');
+		expect(modTypeColor(EItemModType.Prefix)).toBe('var(--mod-prefix)');
+		expect(modTypeColor(EItemModType.Suffix)).toBe('var(--mod-suffix)');
+		expect(modTypeLabel(EItemModType.Prefix)).toBe('Prefix');
+	});
+});
+
+describe('composeItemName', () => {
+	const prefix = (name: string) => ({ name, itemModTypeId: EItemModType.Prefix });
+	const suffix = (name: string) => ({ name, itemModTypeId: EItemModType.Suffix });
+	const component = (name: string) => ({ name, itemModTypeId: EItemModType.Component });
+
+	it('returns the base name when there are no mods', () => {
+		expect(composeItemName('Iron Sword', [])).toBe('Iron Sword');
+	});
+
+	it('prepends prefix mod names and appends suffix mod names', () => {
+		expect(composeItemName('Sword', [prefix('Flaming'), suffix('of the Bear')])).toBe('Flaming Sword of the Bear');
+	});
+
+	it('ignores component mods when building the name', () => {
+		expect(composeItemName('Sword', [component('Tempered Core'), suffix('of Power')])).toBe('Sword of Power');
+	});
+
+	it('keeps applied order for multiple prefixes and suffixes', () => {
+		const mods = [prefix('Flaming'), prefix('Heavy'), suffix('of Power'), suffix('of the Bear')];
+		expect(composeItemName('Sword', mods)).toBe('Flaming Heavy Sword of Power of the Bear');
+	});
+
+	it('is unaffected by the rarity of the mods', () => {
+		const mods = [
+			{ ...prefix('Flaming'), rarityId: ERarity.Mythic },
+			{ ...suffix('of Power'), rarityId: ERarity.Common }
+		];
+		expect(composeItemName('Sword', mods)).toBe('Flaming Sword of Power');
+	});
+});

--- a/UI/new-svelte/src/tests/routes/game/screens/inventory/ItemTooltip.test.ts
+++ b/UI/new-svelte/src/tests/routes/game/screens/inventory/ItemTooltip.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EAttribute, EItemCategory, EItemModType, ERarity } from '$lib/api';
+import { BattleAttributes } from '$lib/battle/battle-attributes';
+import type { Item } from '$lib/battle';
+import ItemTooltip from '$routes/game/screens/inventory/ItemTooltip.svelte';
+
+// A weapon with one prefix and one suffix mod applied. `totalAttributes` is built
+// from the item's stats plus the mods' stats (Strength 5 + 3 = 8), mirroring how
+// `newItem` merges them, so the rendered Stats section reflects the mod totals.
+const makeItem = (): Item => {
+	const totalAttributes = new BattleAttributes(
+		[
+			{ attributeId: EAttribute.Strength, amount: 5 },
+			{ attributeId: EAttribute.Strength, amount: 3 },
+			{ attributeId: EAttribute.Agility, amount: 2 }
+		],
+		false
+	);
+	return {
+		id: 1,
+		itemId: 1,
+		name: 'Sword',
+		description: 'A blade.',
+		itemCategoryId: EItemCategory.Weapon,
+		rarityId: ERarity.Epic,
+		iconPath: '',
+		tags: [],
+		modSlots: [
+			{ id: 10, itemId: 1, itemModSlotTypeId: EItemModType.Prefix },
+			{ id: 11, itemId: 1, itemModSlotTypeId: EItemModType.Suffix }
+		],
+		appliedMods: [
+			{
+				id: 100,
+				name: 'Flaming',
+				description: '+3 Strength',
+				itemModTypeId: EItemModType.Prefix,
+				rarityId: ERarity.Legendary,
+				attributes: [{ attributeId: EAttribute.Strength, amount: 3 }],
+				tags: [],
+				itemModSlotId: 10
+			},
+			{
+				id: 101,
+				name: 'of the Bear',
+				description: '+2 Agility',
+				itemModTypeId: EItemModType.Suffix,
+				rarityId: ERarity.Rare,
+				attributes: [{ attributeId: EAttribute.Agility, amount: 2 }],
+				tags: [],
+				itemModSlotId: 11
+			}
+		],
+		equipped: false,
+		favorite: false,
+		totalAttributes
+	} as unknown as Item;
+};
+
+afterEach(cleanup);
+
+describe('ItemTooltip', () => {
+	it('accents the tooltip border by rarity, not category', () => {
+		const { container } = render(ItemTooltip, { props: { item: makeItem() } });
+		const tooltip = container.querySelector('.item-tooltip') as HTMLElement;
+		expect(tooltip.getAttribute('style')).toContain('var(--rarity-epic)');
+		expect(tooltip.getAttribute('style')).not.toContain('var(--category-weapon)');
+	});
+
+	it('keeps the category label coloured by category', () => {
+		const { container } = render(ItemTooltip, { props: { item: makeItem() } });
+		const label = container.querySelector('.tt-category-label') as HTMLElement;
+		expect(label.textContent).toBe('Weapon');
+		expect(label.getAttribute('style')).toContain('var(--category-weapon)');
+	});
+
+	it('builds the item name from prefix and suffix mods', () => {
+		const { container } = render(ItemTooltip, { props: { item: makeItem() } });
+		const name = container.querySelector('.tt-item-name') as HTMLElement;
+		expect(name.textContent).toBe('Flaming Sword of the Bear');
+	});
+
+	it('includes the stats contributed by applied mods', () => {
+		const { container } = render(ItemTooltip, { props: { item: makeItem() } });
+		const text = (container.querySelector('.tt-stats-grid') as HTMLElement).textContent ?? '';
+		// Item Strength (5) + mod Strength (3) is shown as a single merged total.
+		expect(text).toContain('Strength');
+		expect(text).toContain('+8');
+		expect(text).toContain('Agility');
+		expect(text).toContain('+2');
+	});
+
+	it('accents each filled mod tile by the mod rarity', () => {
+		const { container } = render(ItemTooltip, { props: { item: makeItem() } });
+		const tiles = Array.from(container.querySelectorAll('.tt-mod-tile')) as HTMLElement[];
+		expect(tiles).toHaveLength(2);
+		expect(tiles[0].getAttribute('style')).toContain('var(--rarity-legendary)');
+		expect(tiles[1].getAttribute('style')).toContain('var(--rarity-rare)');
+	});
+});

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -83,6 +83,12 @@ Rarity visuals (used by both the in-game inventory and the admin workbench) foll
 
 The rarity pattern is now the template for every data-driven accent. Challenge-type accents (`--challenge-*`, one per `EChallengeType`), item-category accents (`--category-armor`/`-weapon`/`-accessory`) and item-mod-type accents (`--mod-component`/`-prefix`/`-suffix`) are all declared as CSS variables in `+layout.svelte` and read only through helpers in `$lib/common` (`challengeTypeColor`/`challengeTypeTint`, `itemCategoryColor`/`itemCategoryName`, `modTypeColor`/`modTypeLabel`). The generic `tintColor(color, alpha)` helper produces a `color-mix(in srgb, …)` for **any** colour (hex, named, or a `var(--x)`), so partial-opacity blends stay theme-overridable; `rarityTint` is now a thin wrapper over it. Prefer `var(--…)` + `tintColor` over hard-coded hex/rgba.
 
+### Tooltip surface & item-tooltip accents
+
+The global tooltip container (`components/Tooltip.svelte`, shared by every tooltip) paints its panel with the themeable `--tooltip-bg` var — a `color-mix` over `--surface` whose tint percentage is the single, theme-overridable see-through knob (paired with a backdrop blur for legibility; the translucency lives in the background, not an element `opacity`, so text/accents stay crisp). Item/mod tooltips set no background of their own and inherit it.
+
+For the inventory **item tooltip** (`ItemTooltip.svelte`) the convention mirrors `ModTooltip`: the panel's **left-border accent reflects the item's rarity** (`rarityColor(item.rarityId)`), while the category row (diamond + label) stays **category-coloured**, and each filled mod tile is accented by **that mod's** rarity. The displayed item name is composed from its applied mods via `composeItemName(baseName, mods)` (prefix mod names prepend, suffix names append, components are name-neutral), and the Stats section reflects the merged item + applied-mod attributes (`Item.totalAttributes`).
+
 ## Challenge screen (the Type Rail)
 
 The in-game Challenges screen (`src/routes/game/screens/challenges`) is a **type-driven master/detail** view: a left rail lists each `ChallengeType` (ring meter + done/total) plus an "Overview" entry; selecting a type swaps the right pane to a hero banner + that type's challenge cards with an in-page Progress/Rarity/Name sort, while "Overview" shows overall progress, a pulsing "next up" reward, and a per-type grid. It reuses the existing screen chrome (dark frame, diamond mark, Geist/Geist Mono) and is decomposed into many small components per the component-size guideline.


### PR DESCRIPTION
## Summary

Resolves #9. Updates the inventory **item tooltip** (`routes/game/screens/inventory/ItemTooltip.svelte`) and the shared tooltip surface per the issue's five points. The mod tooltip (`ModTooltip`) already accented by rarity, so this PR focuses on the item tooltip and the shared container.

## What changed (mapped to the issue)

1. **Accent by rarity, not category** — the panel's left-border accent now reflects the item's rarity (`rarityColor(item.rarityId)`). The category row (diamond + label) stays **category-coloured**, exactly mirroring how `ModTooltip` accents its border by rarity and its diamond/label by mod type.
2. **Configurable see-through** — added a themeable `--tooltip-bg` root var (`+layout.svelte`): a `color-mix` over `--surface` whose tint **percentage is the single opacity knob**. The shared `components/Tooltip.svelte` (used by every tooltip) now paints with it. The translucency lives in the background (not an element `opacity`) so text/accents stay crisp over the existing backdrop blur. While there, `Tooltip.svelte`'s remaining hard-coded colours migrate to the existing theme vars (`--border-light`, `--black` blends, `--text-primary`) per the styling guideline.
3. **Mod cards accented by rarity** — each *filled* mod tile's border now uses that mod's rarity (`rarityColor(slot.mod.rarityId)`); empty slots keep the mod-type accent (no rarity exists).
4. **Stats include applied-mod stats** — `Item.totalAttributes` already merges item + applied-mod attributes (`newItem` in `lib/battle/item.ts`), so the Stats grid already reflects mods. This PR locks that in with tests rather than changing behaviour.
5. **Name includes prefixes/suffixes** — the displayed name is composed via a new pure helper `composeItemName(baseName, mods)` in `$lib/common/item-display` (prefix mod names prepend, suffix names append, components are name-neutral). Kept dependency-free so it stays testable and the inventory grid can reuse it.

## Testing

- `npm run check` — 0 errors / 0 warnings
- `npm run lint` — clean
- `npm run test:unit -- --run` — **362 passed** (43 files), incl. new tests for `composeItemName` + the item-display helpers, the `newItem` mod-stat merge, and an `ItemTooltip` render test (rarity border, category label, modded name, merged stats, per-mod rarity tiles).
- `npm run build` — succeeds

## Notes

- Documented under a new **Tooltip surface & item-tooltip accents** note in `docs/frontend.md`.
- The see-through `--tooltip-bg` is applied at the shared container, so all tooltips (skill/challenge/etc.) get the same subtle translucency — consistent and theme-overridable by a single var.
- `ModTooltip`'s hard-coded colours are intentionally left untouched here; they're in the scope of the challenges color-migration (#43/PR #62).

Closes #9.

https://claude.ai/code/session_01UyxXhvqG9egUYk23xBoQGW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyxXhvqG9egUYk23xBoQGW)_