### PR TITLE
Add distinct descriptions for each attribute

### DIFF
--- a/Game.Core.Tests/Attributes/AttributeTests.cs
+++ b/Game.Core.Tests/Attributes/AttributeTests.cs
@@ -1,0 +1,54 @@
+using Game.Core;
+using Xunit;
+using Attribute = Game.Core.Attributes.Attribute;
+
+namespace Game.Core.Tests.Attributes
+{
+    public class AttributeTests
+    {
+        [Theory]
+        [InlineData(EAttribute.Strength, "Strength")]
+        [InlineData(EAttribute.MaxHealth, "Max Health")]
+        [InlineData(EAttribute.CooldownRecovery, "Cooldown Recovery")]
+        [InlineData(EAttribute.CriticalChance, "Critical Chance")]
+        public void Constructor_SetsIdAndHumanReadableName(EAttribute id, string expectedName)
+        {
+            var attribute = new Attribute(id);
+
+            Assert.Equal(id, attribute.Id);
+            Assert.Equal(expectedName, attribute.Name);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllAttributes))]
+        public void Constructor_AssignsNonEmptyDescription(EAttribute id)
+        {
+            var attribute = new Attribute(id);
+
+            Assert.False(string.IsNullOrWhiteSpace(attribute.Description));
+        }
+
+        [Fact]
+        public void Description_IsDistinctForEachAttribute()
+        {
+            var descriptions = Attribute.GetAllAttributes().Select(a => a.Description).ToList();
+
+            Assert.Equal(descriptions.Count, descriptions.Distinct().Count());
+        }
+
+        [Fact]
+        public void GetAllAttributes_ReturnsOneEntryPerAttribute()
+        {
+            var all = Attribute.GetAllAttributes().ToList();
+
+            var expectedIds = Enum.GetValues<EAttribute>();
+            Assert.Equal(expectedIds.Length, all.Count);
+            Assert.Equal(expectedIds, all.Select(a => a.Id).ToArray());
+        }
+
+        public static IEnumerable<object[]> AllAttributes()
+        {
+            return Enum.GetValues<EAttribute>().Select(a => new object[] { a });
+        }
+    }
+}

--- a/Game.Core/Attributes/Attribute.cs
+++ b/Game.Core/Attributes/Attribute.cs
@@ -33,11 +33,27 @@ namespace Game.Core.Attributes
 
         private static string GetDescription(EAttribute value)
         {
+#pragma warning disable CS0618 // DropBonus is obsolete but still seeded for data integrity.
             return value switch
             {
-                Strength => "A measure of one's raw physical force.",
-                _ => "A measure of one's raw physical force."
+                Strength => "A measure of one's raw physical force. Increases the damage of some physical skills and contributes to maximum health.",
+                Endurance => "A measure of one's resilience and physical fortitude. Contributes to maximum health and defense.",
+                Intellect => "A measure of one's mental acuity and command of the arcane. Increases the damage of magical skills.",
+                Agility => "A measure of one's speed and reflexes. Improves cooldown recovery and contributes to defense.",
+                Dexterity => "A measure of one's precision and finesse. Increases the damage of some physical skills and improves cooldown recovery.",
+                Luck => "A measure of one's fortune, influencing various chance-based outcomes.",
+                MaxHealth => "The amount of health a character has at the start of a battle.",
+                Defense => "A flat reduction applied to all incoming damage.",
+                CooldownRecovery => "A percentage multiplier to the rate at which skills become available again after being used.",
+                DropBonus => "Obsolete. Previously increased the rate at which items were dropped by enemies.",
+                CriticalChance => "The percentage chance for an attack to deal increased damage.",
+                CriticalDamage => "The additional percentage of damage dealt when a critical hit occurs.",
+                DodgeChance => "The percentage chance to completely avoid the damage from an incoming attack.",
+                BlockChance => "The percentage chance to block part of the damage from an incoming attack.",
+                BlockReduction => "A flat reduction applied to damage received when an attack is blocked.",
+                _ => throw new ArgumentOutOfRangeException(nameof(value), value, "No description defined for the given attribute.")
             };
+#pragma warning restore CS0618
         }
 
         public static IEnumerable<Attribute> GetAllAttributes()

--- a/Game.Infrastructure/Migrations/20260606160719_UpdateAttributeDescriptions.Designer.cs
+++ b/Game.Infrastructure/Migrations/20260606160719_UpdateAttributeDescriptions.Designer.cs
@@ -4,6 +4,7 @@ using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Game.Infrastructure.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20260606160719_UpdateAttributeDescriptions")]
+    partial class UpdateAttributeDescriptions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Game.Infrastructure/Migrations/20260606160719_UpdateAttributeDescriptions.cs
+++ b/Game.Infrastructure/Migrations/20260606160719_UpdateAttributeDescriptions.cs
@@ -1,0 +1,228 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Game.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateAttributeDescriptions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 0,
+                column: "Description",
+                value: "A measure of one's raw physical force. Increases the damage of some physical skills and contributes to maximum health.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "Description",
+                value: "A measure of one's resilience and physical fortitude. Contributes to maximum health and defense.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "Description",
+                value: "A measure of one's mental acuity and command of the arcane. Increases the damage of magical skills.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "Description",
+                value: "A measure of one's speed and reflexes. Improves cooldown recovery and contributes to defense.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "Description",
+                value: "A measure of one's precision and finesse. Increases the damage of some physical skills and improves cooldown recovery.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "Description",
+                value: "A measure of one's fortune, influencing various chance-based outcomes.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "Description",
+                value: "The amount of health a character has at the start of a battle.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "Description",
+                value: "A flat reduction applied to all incoming damage.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "Description",
+                value: "A percentage multiplier to the rate at which skills become available again after being used.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 9,
+                column: "Description",
+                value: "Obsolete. Previously increased the rate at which items were dropped by enemies.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 10,
+                column: "Description",
+                value: "The percentage chance for an attack to deal increased damage.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 11,
+                column: "Description",
+                value: "The additional percentage of damage dealt when a critical hit occurs.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 12,
+                column: "Description",
+                value: "The percentage chance to completely avoid the damage from an incoming attack.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 13,
+                column: "Description",
+                value: "The percentage chance to block part of the damage from an incoming attack.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 14,
+                column: "Description",
+                value: "A flat reduction applied to damage received when an attack is blocked.");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 0,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 9,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 10,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 11,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 12,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 13,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+
+            migrationBuilder.UpdateData(
+                table: "Attributes",
+                keyColumn: "Id",
+                keyValue: 14,
+                column: "Description",
+                value: "A measure of one's raw physical force.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #71. `Attribute.GetDescription` had only an explicit `Strength` case and a wildcard default that returned the **same** Strength text. Every non-Strength attribute therefore fell through to that default, so every non-Strength row seeded into the `Attributes` table carried the identical (wrong) player-visible description.

## Changes

- **`Game.Core/Attributes/Attribute.cs`** — give each `EAttribute` a real description, derived from the enum summaries in `Game.Core/Enums.cs`. Replaced the duplicate wildcard default with an `ArgumentOutOfRangeException` guard so that adding a new attribute without a description fails loudly instead of silently inheriting another attribute's text. (`DropBonus` is `[Obsolete]` but still seeded for data integrity, so its case is wrapped in a localized `#pragma warning disable CS0618`.)
- **`Game.Infrastructure/Migrations/20260606160719_UpdateAttributeDescriptions.cs`** — EF migration that `UpdateData`s the 15 seeded `Attributes` rows to the new descriptions (with a `Down` that restores the prior placeholder text). Snapshot updated accordingly.
- **`Game.Core.Tests/Attributes/AttributeTests.cs`** — new unit tests (classical/Detroit style, matching `StatisticTypeTests`) covering id/name mapping, non-empty descriptions for every enum value, distinct descriptions across all attributes, and full enum coverage of `GetAllAttributes`.

## Test plan

- [x] `dotnet build` (Core / Api / Infrastructure) — clean, 0 warnings
- [x] `dotnet test Game.Core.Tests` — 210 passed, 0 failed (includes the new `AttributeTests`)
- [ ] On deploy, the migration updates existing seeded rows in any environment that has already applied earlier migrations.

## Notes

The "operation was scaffolded that may result in the loss of data" message from `dotnet ef` is the standard conservative warning for `UpdateData` and does not apply here — the migration only overwrites description text and provides a `Down` that restores the previous values.

https://claude.ai/code/session_01D5y7Sh3dAErjn9QqBXy7eN

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5y7Sh3dAErjn9QqBXy7eN)_