### PR TITLE
Remove dead ISkills.SaveSkillsAsync interface surface

### DIFF
--- a/Game.Abstractions/DataAccess/ISkills.cs
+++ b/Game.Abstractions/DataAccess/ISkills.cs
@@ -8,6 +8,5 @@ namespace Game.Abstractions.DataAccess
         public List<Skill> AllSkills(bool refreshCache = false);
         public Skill? LookupSkill(int skillId);
         public Skill GetSkill(int skillId);
-        public Task SaveSkillsAsync(List<int> skillIds);
     }
 }

--- a/Game.DataAccess/Repositories/Skills.cs
+++ b/Game.DataAccess/Repositories/Skills.cs
@@ -43,10 +43,5 @@ namespace Game.DataAccess.Repositories
             var skills = AllSkills();
             return skills[skillId];
         }
-
-        public Task SaveSkillsAsync(List<int> skillIds)
-        {
-            throw new NotImplementedException();
-        }
     }
 }


### PR DESCRIPTION
## Summary

Removes `ISkills.SaveSkillsAsync(List<int> skillIds)` and its throwing stub implementation. The method was declared on `ISkills` (`Game.Abstractions/DataAccess/ISkills.cs`) and implemented in `Skills` (`Game.DataAccess/Repositories/Skills.cs`) as a `throw new NotImplementedException()`, with **zero callers** anywhere in the codebase — pure dead interface surface.

## How this addresses #70

The issue offered a remove-or-implement fork. Removal is the correct, architecture-aligned choice:

- **Skills are read-only static reference data** (`docs/backend.md` § Reference Data). `Skills` is purely a cached-read repository (`AllSkills`/`LookupSkill`/`GetSkill` + `InvalidateCache`), and a repo-wide audit shows every `ISkills` consumer uses only those read methods.
- **Admin edits to skill records already go through `IEntityStore`** (`AdminSkillsController.AddEditSkills`/`SetSkillMultipliers`), not through `ISkills`. Player-specific data belongs to the player repository. A write-shaped persistence method therefore does not belong on a reference-data repository.
- The "implement" branch was explicitly conditioned in the issue on a planned feature + tracking issue, neither of which exists; implementing it would contradict the documented design.

`Skills` was the sole implementer of `ISkills` (the project avoids test doubles per the testing guidelines), so removing the member from the interface and its one implementation is complete. No orphaned `using`s result (`Task`/`List` come from global usings; `Game.Abstractions.Entities` is still used by `Skill`).

## Test plan

- [x] `dotnet build` — clean (0 warnings, 0 errors) across all projects, proving nothing referenced the removed method
- [x] `dotnet test --no-build --no-restore` — **463 passed**, 0 failed, 0 skipped (Core 210, Application 16, Api 237)

No new tests added: removing a throwing stub introduces no domain logic, and per the backend testing guidelines the DB-dependent `Skills` repository holds no unit-testable logic. No docs change: removal reinforces the already-documented read-only reference-data decision.

Closes #70

https://claude.ai/code/session_01CMbwuamtdAVHAqukH1yvPW

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMbwuamtdAVHAqukH1yvPW)_