### PR TITLE
Log exceptions in DataProviderSynchronizer queue processing

### DIFF
--- a/Game.DataAccess/DataProviderSynchronizer.cs
+++ b/Game.DataAccess/DataProviderSynchronizer.cs
@@ -6,6 +6,7 @@ using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using System.Text.Json;
 
 namespace Game.DataAccess
@@ -14,11 +15,13 @@ namespace Game.DataAccess
     {
         private readonly IServiceProvider _services;
         private readonly IPubSubService _pubsub;
+        private readonly ILogger<DataProviderSynchronizer> _logger;
 
-        public DataProviderSynchronizer(IServiceProvider services, IPubSubService pubsub)
+        public DataProviderSynchronizer(IServiceProvider services, IPubSubService pubsub, ILogger<DataProviderSynchronizer> logger)
         {
             _services = services;
             _pubsub = pubsub;
+            _logger = logger;
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
@@ -50,9 +53,17 @@ namespace Game.DataAccess
                         await HandleEvent(envelope);
                     }
                 }
-                catch
+                catch (JsonException ex)
                 {
-                    // TODO: add logging; for now skip malformed events
+                    // Malformed payload (envelope or event body) — log and skip so one bad
+                    // message can't stall persistence of the rest of the queue.
+                    _logger.LogWarning(ex, "Skipping malformed player update event: {Payload}", next);
+                }
+                catch (Exception ex)
+                {
+                    // Unexpected failure while persisting the event (e.g. a database write error).
+                    // Without this the player's data could silently fail to persist with no trace.
+                    _logger.LogError(ex, "Failed to process player update event: {Payload}", next);
                 }
 
                 next = await queue.GetNextAsync();


### PR DESCRIPTION
## Summary

Fixes #73 — the write-behind pub/sub processing loop in `DataProviderSynchronizer` swallowed **every** exception with a bare `catch` and no logging. Any failure to persist player data (a malformed payload, a deserialization error, or a database write error inside `HandleEvent`) was completely invisible: a player's progress could silently fail to reach the database with no trace in any log.

## Changes

- Injected `ILogger<DataProviderSynchronizer>` via the constructor (same `Microsoft.Extensions.Logging.ILogger<T>` pattern used elsewhere in the codebase, e.g. `LoginTrackingMiddleware`, `DatabaseMigrator`, `LoggingEventHandler`).
- Split the single bare `catch` into two:
  - `catch (JsonException)` — a malformed envelope or event body. Logged at **warning** level and skipped (these are known-bad messages that can't be processed).
  - `catch (Exception)` — any other unexpected failure (notably a database write error inside `HandleEvent`). Logged at **error** level.
- The loop continues after either case, so a single poison message can't stall persistence of the rest of the queue (preserving the previous skip-and-continue behavior, now with visibility).

## Design notes

- **No rethrow / retry in this PR.** The issue suggested *considering* bubbling up or retrying unexpected exceptions. Rethrowing would abort the processing loop and silently drop the already-dequeued event plus everything still queued — strictly worse than logging-and-continuing for the observability goal this issue targets. A proper retry / dead-letter mechanism for transient persistence failures is a more substantial reliability change with its own trade-offs; I've opened a follow-up issue (#85) to track it rather than expand this PR's scope.
- **No new tests.** Per `docs/backend.md` (Testing Guidelines), classes that depend on out-of-process dependencies — `DataProviderSynchronizer` uses the EF `GameContext` and the Redis pub/sub queue — "should NOT contain any logic worth unit testing"; they're covered via integration tests only. This change adds observability (logging), not domain logic, so it introduces nothing unit-testable. The class is also `internal` with no `InternalsVisibleTo` exposure to the test projects.

## Test plan

- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] `dotnet test --no-build --no-restore` — all 463 tests pass (210 Core unit + 16 Application integration + 237 Api integration), confirming the constructor signature change resolves cleanly through DI everywhere.

Closes #73

https://claude.ai/code/session_019x8FMnNkH2XkNewerS2aJE

---
_Generated by [Claude Code](https://claude.ai/code/session_019x8FMnNkH2XkNewerS2aJE)_