### PR TITLE
Build enemy spawn tables from in-memory cache in GetRandomEnemy

### DIFF
--- a/Game.Application.Tests/DataAccess/EnemiesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/EnemiesIntegrationTests.cs
@@ -1,0 +1,103 @@
+using Game.Abstractions.DataAccess;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Game.Application.Tests.DataAccess
+{
+    [Collection("Integration")]
+    public class EnemiesIntegrationTests : ApplicationIntegrationTestBase
+    {
+        public EnemiesIntegrationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        [Fact]
+        public async Task GetRandomEnemy_OnlyReturnsEnemiesAssignedToTheRequestedZone()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var enemyA1 = await TestDataSeeder.CreateEnemyAsync(context, "Zone A Enemy 1");
+            var enemyA2 = await TestDataSeeder.CreateEnemyAsync(context, "Zone A Enemy 2");
+            var enemyB = await TestDataSeeder.CreateEnemyAsync(context, "Zone B Enemy");
+
+            var zoneA = await TestDataSeeder.CreateZoneAsync(context, "Zone A");
+            var zoneB = await TestDataSeeder.CreateZoneAsync(context, "Zone B");
+
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zoneA.Id, enemyA1.Id, weight: 1);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zoneA.Id, enemyA2.Id, weight: 3);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zoneB.Id, enemyB.Id, weight: 1);
+
+            var enemies = scope.ServiceProvider.GetRequiredService<IEnemies>();
+
+            var zoneAEnemyIds = new HashSet<int> { enemyA1.Id, enemyA2.Id };
+
+            // Draw many times; every draw must belong to the requested zone.
+            for (int i = 0; i < 100; i++)
+            {
+                Assert.Contains(enemies.GetRandomEnemy(zoneA.Id).Id, zoneAEnemyIds);
+                Assert.Equal(enemyB.Id, enemies.GetRandomEnemy(zoneB.Id).Id);
+            }
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(1)]
+        [InlineData(999)]
+        public async Task GetRandomEnemy_InvalidZoneId_ThrowsArgumentOutOfRange(int invalidZoneId)
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // A single valid zone (Id 0) means every other id is out of range, including a large
+            // one that previously grew the spawn-table list unbounded instead of being rejected.
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+            var zone = await TestDataSeeder.CreateZoneAsync(context);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
+
+            var enemies = scope.ServiceProvider.GetRequiredService<IEnemies>();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => enemies.GetRandomEnemy(invalidZoneId));
+        }
+
+        [Fact]
+        public async Task GetRandomEnemy_ValidZoneWithNoEnemies_ThrowsInvalidOperation()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+            var populatedZone = await TestDataSeeder.CreateZoneAsync(context, "Populated");
+            var emptyZone = await TestDataSeeder.CreateZoneAsync(context, "Empty");
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, populatedZone.Id, enemy.Id);
+
+            var enemies = scope.ServiceProvider.GetRequiredService<IEnemies>();
+
+            Assert.Throws<InvalidOperationException>(() => enemies.GetRandomEnemy(emptyZone.Id));
+        }
+
+        [Fact]
+        public async Task GetRandomDomainEnemy_ValidZone_MapsEntityAtRequestedLevel()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, skill.Id);
+            var zone = await TestDataSeeder.CreateZoneAsync(context);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
+
+            var enemies = scope.ServiceProvider.GetRequiredService<IEnemies>();
+
+            var domainEnemy = enemies.GetRandomDomainEnemy(zone.Id, level: 7);
+
+            Assert.Equal(enemy.Id, domainEnemy.Id);
+            Assert.Equal(7, domainEnemy.Level);
+            Assert.Contains(domainEnemy.Skills, s => s.Id == skill.Id);
+        }
+    }
+}

--- a/Game.DataAccess/Repositories/Enemies.cs
+++ b/Game.DataAccess/Repositories/Enemies.cs
@@ -9,19 +9,21 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Game.DataAccess.Repositories
 {
-    internal class Enemies(GameContext context, ISkills skills) : IEnemies
+    internal class Enemies(GameContext context, ISkills skills, IZones zones) : IEnemies
     {
-        private static readonly List<ProbabilityTable<int>?> zoneEnemiesTables = [];
-        private static readonly object _lock = new();
         private static List<Enemy>? _enemyList;
+        // Per-zone enemy spawn tables keyed by zone id. Derived from the in-memory enemy list
+        // (which eager-loads ZoneEnemies), so it is rebuilt whenever that list is (re)loaded.
+        private static Dictionary<int, ProbabilityTable<int>>? _zoneEnemyTables;
 
         private readonly GameContext _context = context;
         private readonly ISkills _skills = skills;
+        private readonly IZones _zones = zones;
 
         public void InvalidateCache()
         {
             _enemyList = null;
-            lock (_lock) { zoneEnemiesTables.Clear(); }
+            _zoneEnemyTables = null;
         }
 
         public List<Enemy> All(bool refreshCache = false)
@@ -34,6 +36,8 @@ namespace Game.DataAccess.Repositories
                     .Include(e => e.EnemySkills)
                     .Include(e => e.ZoneEnemies)
                     .OrderBy(e => e.Id)];
+                // Spawn tables are derived from the enemy list; drop them so they rebuild in step.
+                _zoneEnemyTables = null;
             }
 
             return _enemyList;
@@ -47,39 +51,20 @@ namespace Game.DataAccess.Repositories
 
         public Enemy GetRandomEnemy(int zoneId)
         {
+            if (!_zones.ValidateZoneId(zoneId))
+            {
+                throw new ArgumentOutOfRangeException(nameof(zoneId), zoneId, $"No zone exists with Id {zoneId}.");
+            }
+
             var enemies = All();
+            var zoneEnemyTables = _zoneEnemyTables ??= BuildZoneEnemyTables(enemies);
 
-            if (zoneEnemiesTables.Count > zoneId)
+            if (!zoneEnemyTables.TryGetValue(zoneId, out var table))
             {
-                var table = zoneEnemiesTables[zoneId];
-                if (table is not null)
-                {
-                    return enemies[table.GetRandomValue()];
-                }
+                throw new InvalidOperationException($"Zone {zoneId} has no enemies to spawn.");
             }
 
-            //TODO: Refactor to use async queries and also not require a lock
-            lock (_lock)
-            {
-                //TODO: Make this not allow adding an insane amount of values to the list if someone passes in a big id.
-                for (int i = zoneEnemiesTables.Count - 1; i < zoneId; i++)
-                {
-                    zoneEnemiesTables.Add(null);
-                }
-
-                var table = zoneEnemiesTables[zoneId];
-                if (table is null)
-                {
-                    var weightedZoneEnemies = _context.ZoneEnemies
-                        .Where(ze => ze.ZoneId == zoneId)
-                        .Select(ze => new WeightedValue<int>(ze.EnemyId, ze.Weight));
-
-                    table = new ProbabilityTable<int>(weightedZoneEnemies);
-                    zoneEnemiesTables[zoneId] = table;
-                }
-
-                return enemies[table.GetRandomValue()];
-            }
+            return enemies[table.GetRandomValue()];
         }
 
         public CoreEnemy? GetDomainEnemy(int enemyId, int level)
@@ -94,6 +79,22 @@ namespace Game.DataAccess.Repositories
         {
             var entity = GetRandomEnemy(zoneId);
             return EnemyMapper.ToCore(entity, level, _skills.AllSkills());
+        }
+
+        /// <summary>
+        /// Builds the per-zone enemy spawn tables from the in-memory enemy list. The ZoneEnemy weights are
+        /// already eager-loaded by <see cref="All"/>, so no database query (and no lock) is required, and
+        /// keying by zone id avoids the previous unbounded list growth for arbitrary or invalid ids.
+        /// </summary>
+        private static Dictionary<int, ProbabilityTable<int>> BuildZoneEnemyTables(IEnumerable<Enemy> enemies)
+        {
+            return enemies
+                .SelectMany(enemy => enemy.ZoneEnemies)
+                .GroupBy(zoneEnemy => zoneEnemy.ZoneId)
+                .ToDictionary(
+                    group => group.Key,
+                    group => new ProbabilityTable<int>(
+                        group.Select(zoneEnemy => new WeightedValue<int>(zoneEnemy.EnemyId, zoneEnemy.Weight))));
         }
     }
 }

--- a/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
+++ b/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
@@ -204,9 +204,9 @@ namespace Game.TestInfrastructure.Helpers
             await context.SaveChangesAsync();
         }
 
-        public static async Task LinkEnemyToZoneAsync(GameContext context, int zoneId, int enemyId)
+        public static async Task LinkEnemyToZoneAsync(GameContext context, int zoneId, int enemyId, int weight = 1)
         {
-            context.Set<ZoneEnemy>().Add(new ZoneEnemy { ZoneId = zoneId, EnemyId = enemyId });
+            context.Set<ZoneEnemy>().Add(new ZoneEnemy { ZoneId = zoneId, EnemyId = enemyId, Weight = weight });
             await context.SaveChangesAsync();
         }
 


### PR DESCRIPTION
## Summary

Fixes the two acknowledged problems (both marked with TODOs) in `Enemies.GetRandomEnemy` (`Game.DataAccess/Repositories/Enemies.cs`):

1. **Synchronous blocking under a lock** — the method ran a *synchronous* EF query (`_context.ZoneEnemies.Where(...)`) while holding a `lock`, from an async calling context. That blocks a thread-pool thread for the duration of the DB call (the same thread-pool-starvation class of issue as the Redis floor fix).
2. **Unbounded list growth** — for a cache miss it extended a `static List` with `null` entries up to the requested `zoneId`. A large or invalid `zoneId` could allocate an unbounded amount of memory.

## How it's addressed

The zone→enemy weights are **already eager-loaded in memory** by `All()` (`.Include(e => e.ZoneEnemies)`), so the synchronous per-request DB query was redundant. The fix derives the per-zone probability tables from that in-memory enemy list instead:

- **No DB round-trip, no lock.** `BuildZoneEnemyTables` groups the already-loaded `ZoneEnemies` by zone id into `ProbabilityTable`s. The lazy build uses the same lock-free, benign-race pattern already used by `All()`; the derived tables are dropped (`_zoneEnemyTables = null`) whenever the enemy list is (re)loaded or invalidated, so they stay in step.
- **No unbounded growth.** Tables are held in a `Dictionary<int, ProbabilityTable<int>>` keyed by zone id rather than a list indexed by `zoneId`.
- **Bounds check.** Invalid zone ids are rejected up front via the existing `IZones.ValidateZoneId`, throwing `ArgumentOutOfRangeException` (consistent with `Zones.GetZone`). A *valid* zone that has no enemies now throws a clear `InvalidOperationException` instead of an opaque `ArgumentException` from deep inside `ProbabilityTable`.

This aligns the code with the already-documented in-memory **Reference Data** design (`docs/backend.md`), so no new design-doc section was added.

## Notes
- `IZones` is injected into the `Enemies` repository for the bounds check (no dependency cycle — `Zones` depends only on `GameContext`, and `BattleService` already pairs `IEnemies`/`IZones`).
- Random enemy selection is **backend-only** (server-authoritative), so there is no frontend battle-logic parity change.
- `TestDataSeeder.LinkEnemyToZoneAsync` gained an optional `weight = 1` parameter (backward compatible; previously seeded a degenerate weight of `0`).

## Test plan
- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] New `EnemiesIntegrationTests` (in `Game.Application.Tests/DataAccess`): per-zone selection only returns that zone's enemies; invalid zone ids (`-1`, out-of-range, large `999`) throw `ArgumentOutOfRangeException`; a valid empty zone throws `InvalidOperationException`; `GetRandomDomainEnemy` maps the entity at the requested level.
- [x] Full backend suite green: **Game.Core.Tests 210**, **Game.Application.Tests 26**, **Game.Api.Tests 237** — 473 total, 0 failures.

Closes #75

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQDhEweu6pQoiGBNLqgzY9)_