### PR TITLE
Include applied item mod attributes in equipped modifiers

### DIFF
--- a/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
@@ -148,6 +148,60 @@ namespace Game.Application.Tests.Services
             Assert.Contains(modifiers, m => m.Attribute == EAttribute.Dexterity && m.Amount == 7.0 && m.Source == EAttributeModifierSource.ItemMod);
         }
 
+        [Fact]
+        public async Task LoadPlayer_PersistedAppliedMod_IncludesModAttributesInEquippedModifiers()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+
+            // A weapon (base Strength +5) with one Prefix mod slot, equipped in the weapon slot.
+            var item = await TestDataSeeder.CreateItemAsync(context);
+            var modSlot = new Abstractions.Entities.ItemModSlot
+            {
+                ItemId = item.Id,
+                ItemModSlotTypeId = (int)EItemModType.Prefix,
+                Index = 0,
+            };
+            context.ItemModSlots.Add(modSlot);
+            context.UnlockedItems.Add(new Abstractions.Entities.UnlockedItem
+            {
+                PlayerId = playerEntity.Id,
+                ItemId = item.Id,
+                EquipmentSlotId = (int)EEquipmentSlot.WeaponSlot,
+            });
+
+            // A Prefix mod granting Dexterity +7, unlocked for the player.
+            var mod = await TestDataSeeder.CreateItemModAsync(context, attributeId: EAttribute.Dexterity, attributeAmount: 7m);
+            context.UnlockedMods.Add(new Abstractions.Entities.UnlockedMod
+            {
+                PlayerId = playerEntity.Id,
+                ItemModId = mod.Id,
+            });
+            await context.SaveChangesAsync(CancellationToken);
+
+            // Persist the applied mod as if it had been applied in a previous session, so the
+            // player is loaded fresh from the DB with it already in place (the #90 scenario).
+            context.AppliedMods.Add(new Abstractions.Entities.AppliedMod
+            {
+                PlayerId = playerEntity.Id,
+                ItemId = item.Id,
+                ItemModSlotId = modSlot.Id,
+                ItemModId = mod.Id,
+            });
+            await context.SaveChangesAsync(CancellationToken);
+
+            var playerService = scope.ServiceProvider.GetRequiredService<PlayerService>();
+            var player = await playerService.LoadPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var modifiers = player.Inventory.GetEquippedAttributeModifiers().ToList();
+            Assert.Contains(modifiers, m => m.Attribute == EAttribute.Strength && m.Amount == 5.0 && m.Source == EAttributeModifierSource.Item);
+            Assert.Contains(modifiers, m => m.Attribute == EAttribute.Dexterity && m.Amount == 7.0 && m.Source == EAttributeModifierSource.ItemMod);
+        }
+
         private record SimpleAttributeUpdate(EAttribute Attribute, int Amount) : IAttributeUpdate;
     }
 }

--- a/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
@@ -1,6 +1,7 @@
 using Game.Abstractions.DataAccess;
 using Game.Application.Services;
 using Game.Core;
+using Game.Core.Attributes.Modifiers;
 using Game.Core.Players;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Base;
@@ -100,6 +101,51 @@ namespace Game.Application.Tests.Services
             var player = await playerService.LoadPlayer(99999);
 
             Assert.Null(player);
+        }
+
+        [Fact]
+        public async Task ApplyMod_EquippedItem_AddsModAttributesToEquippedModifiers()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+
+            // A weapon (base Strength +5) with one Prefix mod slot, equipped in the weapon slot.
+            var item = await TestDataSeeder.CreateItemAsync(context);
+            context.ItemModSlots.Add(new Abstractions.Entities.ItemModSlot
+            {
+                ItemId = item.Id,
+                ItemModSlotTypeId = (int)EItemModType.Prefix,
+                Index = 0,
+            });
+            context.UnlockedItems.Add(new Abstractions.Entities.UnlockedItem
+            {
+                PlayerId = playerEntity.Id,
+                ItemId = item.Id,
+                EquipmentSlotId = (int)EEquipmentSlot.WeaponSlot,
+            });
+
+            // A Prefix mod granting Dexterity +7, unlocked for the player.
+            var mod = await TestDataSeeder.CreateItemModAsync(context, attributeId: EAttribute.Dexterity, attributeAmount: 7m);
+            context.UnlockedMods.Add(new Abstractions.Entities.UnlockedMod
+            {
+                PlayerId = playerEntity.Id,
+                ItemModId = mod.Id,
+            });
+            await context.SaveChangesAsync(CancellationToken);
+
+            var playerService = scope.ServiceProvider.GetRequiredService<PlayerService>();
+            var player = await playerService.LoadPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var applied = await playerService.ApplyMod(player, item.Id, mod.Id, itemModSlotId: 0);
+
+            Assert.True(applied);
+            var modifiers = player.Inventory.GetEquippedAttributeModifiers().ToList();
+            Assert.Contains(modifiers, m => m.Attribute == EAttribute.Strength && m.Amount == 5.0 && m.Source == EAttributeModifierSource.Item);
+            Assert.Contains(modifiers, m => m.Attribute == EAttribute.Dexterity && m.Amount == 7.0 && m.Source == EAttributeModifierSource.ItemMod);
         }
 
         private record SimpleAttributeUpdate(EAttribute Attribute, int Amount) : IAttributeUpdate;

--- a/Game.Application/Services/PlayerService.cs
+++ b/Game.Application/Services/PlayerService.cs
@@ -1,6 +1,5 @@
 using Game.Abstractions.DataAccess;
 using Game.Core;
-using Game.Core.Attributes;
 using Game.Core.Attributes.Modifiers;
 using Game.Core.Items;
 using Game.Core.Players;
@@ -24,16 +23,6 @@ namespace Game.Application.Services
 
             await _playerRepo.SavePlayer(player);
             return true;
-        }
-
-        public AttributeCollection GetPlayerAttributes(Player player)
-        {
-            return player.GetAttributes();
-        }
-
-        public IEnumerable<AttributeModifier> GetAllModifiers(Player player)
-        {
-            return player.GetAllModifiers();
         }
 
         public async Task<bool> EquipItem(Player player, int itemId, EEquipmentSlot slot)
@@ -86,7 +75,15 @@ namespace Game.Application.Services
                 Description = modEntity.Description ?? string.Empty,
                 Type = (EItemModType)modEntity.ItemModTypeId,
                 Rarity = (ERarity)modEntity.RarityId,
-                Attributes = [],
+                Attributes = modEntity.ItemModAttributes
+                    .Select(ima => new AttributeModifier
+                    {
+                        Attribute = (EAttribute)ima.AttributeId,
+                        Amount = (double)ima.Amount,
+                        Type = EModifierType.Additive,
+                        Source = EAttributeModifierSource.ItemMod,
+                    })
+                    .ToList(),
                 Tags = [],
             };
 

--- a/Game.Core.Tests/Players/InventoryTests.cs
+++ b/Game.Core.Tests/Players/InventoryTests.cs
@@ -302,6 +302,105 @@ namespace Game.Core.Tests.Players
             Assert.Empty(modifiers);
         }
 
+        [Fact]
+        public void GetEquippedAttributeModifiers_EquippedItemWithAppliedMod_IncludesModAttributes()
+        {
+            var inventory = new Inventory();
+            var item = MakeItem(1, EItemCategory.Accessory, modSlots:
+            [
+                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+            ]);
+            AddUnlockedItem(inventory, item);
+            inventory.TryEquipItem(1, EEquipmentSlot.AccessorySlot);
+            inventory.UnlockMod(10);
+            inventory.TryApplyMod(1, 10, 0, MakeMod(10, EItemModType.Prefix, attributes:
+            [
+                MakeModifier(EAttribute.Dexterity, 7.0),
+            ]));
+
+            var modifiers = inventory.GetEquippedAttributeModifiers().ToList();
+
+            Assert.Single(modifiers);
+            Assert.Equal(EAttribute.Dexterity, modifiers[0].Attribute);
+            Assert.Equal(7.0, modifiers[0].Amount);
+            Assert.Equal(EAttributeModifierSource.ItemMod, modifiers[0].Source);
+        }
+
+        [Fact]
+        public void GetEquippedAttributeModifiers_EquippedItemWithBaseAndModAttributes_IncludesBoth()
+        {
+            var inventory = new Inventory();
+            var item = MakeItem(1, EItemCategory.Accessory,
+                attributes: [MakeModifier(EAttribute.Strength, 5.0, EAttributeModifierSource.Item)],
+                modSlots:
+                [
+                    new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+                ]);
+            AddUnlockedItem(inventory, item);
+            inventory.TryEquipItem(1, EEquipmentSlot.AccessorySlot);
+            inventory.UnlockMod(10);
+            inventory.TryApplyMod(1, 10, 0, MakeMod(10, EItemModType.Prefix, attributes:
+            [
+                MakeModifier(EAttribute.Dexterity, 7.0),
+            ]));
+
+            var modifiers = inventory.GetEquippedAttributeModifiers().ToList();
+
+            Assert.Equal(2, modifiers.Count);
+            Assert.Contains(modifiers, m => m.Attribute == EAttribute.Strength && m.Amount == 5.0 && m.Source == EAttributeModifierSource.Item);
+            Assert.Contains(modifiers, m => m.Attribute == EAttribute.Dexterity && m.Amount == 7.0 && m.Source == EAttributeModifierSource.ItemMod);
+        }
+
+        [Fact]
+        public void GetEquippedAttributeModifiers_AppliedModOnUnequippedItem_NotIncluded()
+        {
+            var inventory = new Inventory();
+            var item = MakeItem(1, EItemCategory.Accessory, modSlots:
+            [
+                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+            ]);
+            AddUnlockedItem(inventory, item);
+            inventory.UnlockMod(10);
+            inventory.TryApplyMod(1, 10, 0, MakeMod(10, EItemModType.Prefix, attributes:
+            [
+                MakeModifier(EAttribute.Dexterity, 7.0),
+            ]));
+            // The item is unlocked and modded but never equipped, so it must not contribute.
+
+            var modifiers = inventory.GetEquippedAttributeModifiers().ToList();
+
+            Assert.Empty(modifiers);
+        }
+
+        [Fact]
+        public void GetEquippedAttributeModifiers_MultipleAppliedMods_IncludesAll()
+        {
+            var inventory = new Inventory();
+            var item = MakeItem(1, EItemCategory.Accessory, modSlots:
+            [
+                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 1, Index = 1, Type = EItemModType.Suffix },
+            ]);
+            AddUnlockedItem(inventory, item);
+            inventory.TryEquipItem(1, EEquipmentSlot.AccessorySlot);
+            inventory.UnlockMod(10);
+            inventory.UnlockMod(11);
+            inventory.TryApplyMod(1, 10, 0, MakeMod(10, EItemModType.Prefix, attributes:
+            [
+                MakeModifier(EAttribute.Strength, 3.0),
+            ]));
+            inventory.TryApplyMod(1, 11, 1, MakeMod(11, EItemModType.Suffix, attributes:
+            [
+                MakeModifier(EAttribute.Dexterity, 4.0),
+            ]));
+
+            var modifiers = inventory.GetEquippedAttributeModifiers().ToList();
+
+            Assert.Equal(2, modifiers.Count);
+            Assert.Contains(modifiers, m => m.Attribute == EAttribute.Strength && m.Amount == 3.0);
+            Assert.Contains(modifiers, m => m.Attribute == EAttribute.Dexterity && m.Amount == 4.0);
+        }
+
         // ── Helpers ──────────────────────────────────────────────────────────
 
         private static Item MakeItem(int id, EItemCategory category = EItemCategory.Accessory, ERarity rarity = ERarity.Common,
@@ -326,5 +425,25 @@ namespace Game.Core.Tests.Players
                 AppliedMods = [],
             });
         }
+
+        private static ItemMod MakeMod(int id, EItemModType type, List<AttributeModifier>? attributes = null) => new()
+        {
+            Id = id,
+            Name = $"Mod {id}",
+            Description = string.Empty,
+            Type = type,
+            Rarity = ERarity.Common,
+            Attributes = attributes ?? [],
+            Tags = [],
+        };
+
+        private static AttributeModifier MakeModifier(EAttribute attribute, double amount,
+            EAttributeModifierSource source = EAttributeModifierSource.ItemMod) => new()
+            {
+                Attribute = attribute,
+                Amount = amount,
+                Type = EModifierType.Additive,
+                Source = source,
+            };
     }
 }

--- a/Game.Core/Players/Inventories/Inventory.cs
+++ b/Game.Core/Players/Inventories/Inventory.cs
@@ -29,12 +29,24 @@ namespace Game.Core.Players.Inventories
         public IEnumerable<AttributeModifier> GetEquippedAttributeModifiers()
         {
             return EquipmentSlots.SelectNotNull(slot => slot.Item)
-                .SelectMany(item => item.Attributes
-                    .Concat(item.ModSlots
-                        .SelectNotNull(mSlot => mSlot.ItemMod)
-                        .SelectMany(mod => mod.Attributes)
-                    )
-                );
+                .SelectMany(item => item.Attributes.Concat(GetAppliedModModifiers(item.Id)));
+        }
+
+        /// <summary>
+        /// Resolves the attribute modifiers contributed by the mods currently applied to the
+        /// equipped item with the given <paramref name="itemId"/>. Applied mods live on the
+        /// player's <see cref="UnlockedItemSlot"/> rather than on the shared, reference-data
+        /// <see cref="Item.ModSlots"/> (whose <see cref="ItemModSlot.ItemMod"/> is always null).
+        /// </summary>
+        private IEnumerable<AttributeModifier> GetAppliedModModifiers(int itemId)
+        {
+            var unlocked = UnlockedItems.FirstOrDefault(u => u.ItemId == itemId);
+            if (unlocked is null)
+            {
+                return [];
+            }
+
+            return unlocked.AppliedMods.SelectMany(applied => applied.ItemMod.Attributes);
         }
 
         public bool TryEquipItem(int itemId, EEquipmentSlot slot)


### PR DESCRIPTION
## Summary

Fixes the bug where `Inventory.GetEquippedAttributeModifiers()` never included applied item mod attributes, so `Player.GetAttributes()` / `Player.GetAllModifiers()` returned **zero** contribution from applied mods.

The method iterated over `EquipmentSlot.Item.ModSlots` and read `ItemModSlot.ItemMod`, which is **always `null`** — items are loaded as shared reference-data templates and `ItemMapper.ToCore` sets every mod slot's `ItemMod = null`. The player's actual applied mods live on `UnlockedItemSlot.AppliedMods`, which the method never read.

## How it addresses #90

- **`Game.Core/Players/Inventories/Inventory.cs`** — `GetEquippedAttributeModifiers()` now resolves each equipped item's applied mods from `UnlockedItemSlot.AppliedMods` (looked up by item id) instead of the always-null `Item.ModSlots[*].ItemMod`. Base item attributes still come from the equipped item.
- **`Game.Application/Services/PlayerService.cs`** — `ApplyMod` now populates `ItemMod.Attributes` from `modEntity.ItemModAttributes` (previously initialised to `[]`), so a mod applied in-session contributes its attributes immediately, not just after a DB reload.
- **Dead code removed** — `PlayerService.GetPlayerAttributes` and `GetAllModifiers` had no callers anywhere; removed them (and the now-unused `using Game.Core.Attributes;`).

## Battle simulation is unaffected

Production battles read applied mods from `UnlockedItemSlot.AppliedMods` via `BattleSnapshotService` (the snapshot path), which was already correct. The buggy path only fed `Player.GetAttributes()` (used by the test-only `Battler(Player)` constructor and the now-removed service wrappers). The frontend's `buildPlayerModifiers` already includes applied-mod attributes, so this brings the backend **into line** with the frontend — no frontend change needed.

## Test plan

- [x] **Unit** (`Game.Core.Tests/Players/InventoryTests.cs`): equipped item with applied mod includes mod attributes; base + mod attributes both included; applied mod on an **unequipped** item is excluded; multiple applied mods all included.
- [x] **Integration** (`Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs`): `ApplyMod` end-to-end seeds an equipped item + unlocked mod, applies it, and asserts the mod's attributes appear in the equipped modifiers (covers both the `ApplyMod` mapping fix and the inventory fix through the service + DB + cache path).
- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] `Game.Core.Tests` — 219 passed
- [x] `Game.Application.Tests` — 27 passed
- [x] `Game.Api.Tests` — 240 passed

## Follow-up

Filed #102: the entity→core item-mod-attribute mapping is now duplicated in three places (`ItemMapper.ModToCore`, `BattleSnapshotService.MapItemModAttributes`, and `PlayerService.ApplyMod`), rooted in the reference-data catalogs returning entity models into the Application layer (contrary to the data-access mapper guideline). Consolidating that is out of scope here.

Closes #90

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6jHK36dYJv95MjLnCSL6a)_