### PR TITLE
Use thread-safe Random.Shared in ProbabilityTable (#95)

### DIFF
--- a/Game.Core.Tests/Probability/ProbabilityTableTests.cs
+++ b/Game.Core.Tests/Probability/ProbabilityTableTests.cs
@@ -60,6 +60,57 @@ namespace Game.Core.Tests.Probability
             AssertDistributionIsReasonable(list, buckets);
         }
 
+        [Fact]
+        public async Task ConcurrentGetRandomValue_StaysValidAndNonDegenerate()
+        {
+            // ProbabilityTable instances are cached in process-wide static collections (e.g. the per-zone
+            // enemy spawn tables) and drawn from concurrently, so GetRandomValue must be safe to call from
+            // many threads at once — the reason it now draws from the thread-safe Random.Shared.
+            //
+            // This is a best-effort concurrency guard, not a deterministic detector of the fix: it hammers
+            // the table from every core and asserts the draws stay in range, complete without throwing, and
+            // keep an even spread (every value drawn, none dominating). On .NET's modern unseeded Random
+            // (xoshiro256**, used by new Random() on this target) a data race over the shared instance is
+            // undefined behaviour but degrades gracefully on typical hardware rather than collapsing the
+            // distribution, so this would not reliably fail against the old per-instance RNG. It instead
+            // documents and locks in the concurrent contract and catches gross regressions.
+            var valueCount = 10;
+            var list = Enumerable.Range(0, valueCount)
+                .Select(value => new WeightedValue<int>(value, 1))
+                .ToList();
+            var table = new ProbabilityTable<int>(list);
+
+            var buckets = new long[valueCount];
+            var iterationsPerTask = 100_000;
+            var taskCount = Math.Max(Environment.ProcessorCount, 4);
+
+            using var startGate = new ManualResetEventSlim(false);
+            var tasks = Enumerable.Range(0, taskCount)
+                .Select(_ => Task.Run(() =>
+                {
+                    // Block every task until all are spun up so the draws actually overlap.
+                    startGate.Wait();
+                    for (int i = 0; i < iterationsPerTask; i++)
+                    {
+                        var value = table.GetRandomValue();
+                        Assert.InRange(value, 0, valueCount - 1);
+                        Interlocked.Increment(ref buckets[value]);
+                    }
+                }))
+                .ToArray();
+
+            startGate.Set();
+            await Task.WhenAll(tasks);
+
+            // Every value must be drawn at least once; a degenerate run collapses onto a single bucket.
+            Assert.All(buckets, count => Assert.True(count > 0, "Expected every value to be drawn at least once."));
+
+            // And with equal weights no single value should dominate far beyond its ~1/valueCount share.
+            var totalDraws = buckets.Sum();
+            var maxShare = buckets.Max() / (double)totalDraws;
+            Assert.True(maxShare < 0.5, $"Distribution is degenerate; one value took {maxShare:P0} of draws.");
+        }
+
         private static List<WeightedValue<int>> SetupMultiElementList()
         {
             // total weight is 45 so the last element is exactly equal 1/5 probability.

--- a/Game.Core/Probability/ProbabilityTable.cs
+++ b/Game.Core/Probability/ProbabilityTable.cs
@@ -7,7 +7,6 @@
     {
         private readonly ProbabilityData<T>[] _values;
         private readonly T[] _aliases;
-        private readonly Random _random = new();
 
         /// <summary>
         /// Generates a probability table based on a collection of <see cref="WeightedValue{T}"/> objects.
@@ -102,10 +101,14 @@
         /// <summary>
         /// Gets a random <typeparamref name="T"/> based on the weight distribution of the probability table.
         /// </summary>
+        /// <remarks>
+        /// Uses the thread-safe <see cref="Random.Shared"/> because table instances are cached in
+        /// process-wide static collections (e.g. per-zone enemy spawn tables) and drawn from concurrently.
+        /// </remarks>
         /// <returns>A random <typeparamref name="T"/>.</returns>
         public T GetRandomValue()
         {
-            var rand = _random.NextDouble() * _values.Length;
+            var rand = Random.Shared.NextDouble() * _values.Length;
             var randInt = (int)double.Floor(rand);
             var remainder = rand - randInt;
             var data = _values[randInt];


### PR DESCRIPTION
## Summary

`ProbabilityTable<T>` held a per-instance `System.Random` and called it lock-free from `GetRandomValue()`:

```csharp
private readonly Random _random = new();
// ...
var rand = _random.NextDouble() * _values.Length;
```

`Random` instance methods are **not thread-safe**, and these tables are cached in process-wide `static` collections and drawn from concurrently — the per-zone enemy spawn tables in `Enemies._zoneEnemyTables` and `Zone.EnemyTable`. Concurrent `GetRandomValue()` calls (multiple players starting battles at once) were therefore a data race over the shared RNG.

## How it addresses the issue

- Switched `GetRandomValue()` to the thread-safe **`Random.Shared`** (the issue's recommended option) and removed the now-unused `_random` field. The table RNG was unseeded, so no seeding behavior is lost.
- Added an XML `<remarks>` note documenting *why* `Random.Shared` is used, so the choice isn't accidentally reverted.
- Added a concurrency-oriented unit test that hammers `GetRandomValue()` from every core and asserts the draws stay in range, complete without throwing, and keep an even spread.

## ⚠️ Note on the concurrency test (please read)

The issue suggested a test "asserting the distribution isn't degenerate," expecting the old code to "collapse toward the first table entry." **I verified that a degeneracy-based test does _not_ reliably fail against the pre-fix code on this target**, so I reframed the test as an honest best-effort guard rather than letting it imply it catches the race.

Why: the issue's "biased / all-zero output" failure mode describes the **legacy** `System.Random` (the subtractive generator, e.g. .NET Framework / seeded `new Random(seed)`). On `net10.0`, unseeded `new Random()` uses **`xoshiro256**`**, whose 64-bit-aligned state words don't tear on x64 — a data race there is genuine undefined behaviour but degrades gracefully instead of collapsing the distribution. I confirmed empirically: the old per-instance implementation passed the degeneracy assertions across repeated runs.

The fix is still correct and worthwhile — it eliminates documented-unsafe concurrent use / a data race — but the test is positioned as a concurrent-**contract** guard (in-range, no throw, non-degenerate spread, exercised under heavy parallel load) and documents that limitation in a comment, rather than overstating what it proves.

## Test plan

- [x] `dotnet build Game.sln` — succeeds, 0 warnings (the test was adjusted to clear the xUnit `xUnit1031`/`xUnit1051` analyzer warnings).
- [x] `dotnet test Game.Core.Tests` — **220 passed, 0 failed**, including the new `ConcurrentGetRandomValue_StaysValidAndNonDegenerate`.
- [x] Confirmed the new test passes against the fixed implementation; confirmed (and documented) that it does not deterministically fail the pre-fix one on this runtime, hence the best-effort framing.

## Notes

Pure domain bug fix — no public API change and no behavioral change beyond thread-safety, so no `docs/` design-decision entry was warranted.

Closes #95


---
_Generated by [Claude Code](https://claude.ai/code/session_01YLMZCgEcR4rv8oZH8q7rqN)_