### PR TITLE
Add unit tests for fight screen frontend components

### DIFF
--- a/UI/new-svelte/src/tests/routes/game/screens/fight/BattlerCard.test.ts
+++ b/UI/new-svelte/src/tests/routes/game/screens/fight/BattlerCard.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EAttribute, type IAttribute } from '$lib/api';
+
+// The card renders a Skills -> SkillTooltip subtree, which imports the battle engine and the
+// reference-data store at module load; both are mocked even though no hover happens here.
+const { mockBattleEngine, staticData } = vi.hoisted(() => ({
+	mockBattleEngine: { getOpponent: vi.fn() },
+	staticData: { attributes: [] as IAttribute[] }
+}));
+
+vi.mock('$lib/engine', () => ({ battleEngine: mockBattleEngine }));
+vi.mock('$stores', () => ({ staticData }));
+
+import BattlerCard from '$routes/game/screens/fight/BattlerCard.svelte';
+import { makeBattler, makeSkill } from './fight-fixtures';
+
+afterEach(cleanup);
+
+describe('BattlerCard', () => {
+	it('renders the battler name, level and current/max health', () => {
+		const battler = makeBattler({
+			name: 'Aelara',
+			level: 12,
+			attributes: [{ attributeId: EAttribute.MaxHealth, amount: 100 }],
+			currentHealth: 80
+		});
+		const { getByTestId } = render(BattlerCard, { props: { battler, side: 'player' } });
+
+		const card = getByTestId('player-card');
+		expect(card.querySelector('.battler-name')?.textContent).toBe('Aelara');
+		expect(card.querySelector('.battler-level')?.textContent).toContain('12');
+		expect(card.querySelector('.hp-text')?.textContent).toContain('80 / 100');
+	});
+
+	it('sizes the health bar to the remaining health percentage', () => {
+		const battler = makeBattler({
+			attributes: [{ attributeId: EAttribute.MaxHealth, amount: 200 }],
+			currentHealth: 50
+		});
+		const { container } = render(BattlerCard, { props: { battler, side: 'player' } });
+		// 50 / 200 = 25%.
+		expect((container.querySelector('.hp-remaining') as HTMLElement).getAttribute('style')).toContain('width: 25%');
+	});
+
+	it('clamps the health bar to full when the battler has no max health', () => {
+		const battler = makeBattler({
+			attributes: [{ attributeId: EAttribute.MaxHealth, amount: 0 }],
+			currentHealth: 0
+		});
+		const { container } = render(BattlerCard, { props: { battler, side: 'player' } });
+		expect((container.querySelector('.hp-remaining') as HTMLElement).getAttribute('style')).toContain('width: 100%');
+	});
+
+	it('accents the card by side', () => {
+		const player = render(BattlerCard, { props: { battler: makeBattler(), side: 'player' } });
+		expect(player.getByTestId('player-card')).toBeTruthy();
+		expect((player.container.querySelector('.accent-bar') as HTMLElement).getAttribute('style')).toContain(
+			'var(--accent)'
+		);
+		cleanup();
+
+		const enemy = render(BattlerCard, { props: { battler: makeBattler({ name: 'Dire Wolf' }), side: 'enemy' } });
+		expect(enemy.getByTestId('enemy-card')).toBeTruthy();
+		expect((enemy.container.querySelector('.accent-bar') as HTMLElement).getAttribute('style')).toContain(
+			'var(--enemy-accent)'
+		);
+	});
+
+	it("renders the battler's skills", () => {
+		const battler = makeBattler();
+		battler.skills = [makeSkill(battler, { name: 'Slash', iconPath: '/slash.png' })];
+		const { getByAltText, getByText } = render(BattlerCard, { props: { battler, side: 'player' } });
+		expect(getByAltText('Slash')).toBeTruthy();
+		expect(getByText('Slash')).toBeTruthy();
+	});
+});

--- a/UI/new-svelte/src/tests/routes/game/screens/fight/Fight.test.ts
+++ b/UI/new-svelte/src/tests/routes/game/screens/fight/Fight.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/svelte';
+import type { IAttribute, IZone } from '$lib/api';
+
+// Fight composes the screen from the live battle engine (the two battlers) and the zone nav
+// (player manager + reference data); all data sources are mocked.
+const { mockBattleEngine, mockPlayerManager, staticData } = vi.hoisted(() => ({
+	mockBattleEngine: { player: undefined as unknown, enemy: undefined as unknown, getOpponent: vi.fn() },
+	mockPlayerManager: { currentZone: 0 },
+	staticData: { attributes: [] as IAttribute[], zones: [] as IZone[] }
+}));
+
+vi.mock('$lib/engine', () => ({ battleEngine: mockBattleEngine, playerManager: mockPlayerManager }));
+vi.mock('$stores', () => ({ staticData }));
+
+import Fight from '$routes/game/screens/fight/Fight.svelte';
+import { makeBattler } from './fight-fixtures';
+
+beforeEach(() => {
+	mockBattleEngine.player = makeBattler({ name: 'Aelara' });
+	mockBattleEngine.enemy = makeBattler({ name: 'Dire Wolf' });
+	mockPlayerManager.currentZone = 10;
+	staticData.zones = [{ id: 10, name: 'Verdant Hollow', description: '', order: 1, levelMin: 1, levelMax: 10 }];
+});
+
+afterEach(cleanup);
+
+describe('Fight', () => {
+	it('lays out the player and enemy cards with a versus badge', () => {
+		render(Fight);
+		expect(screen.getByTestId('fight-screen')).toBeTruthy();
+		expect(screen.getByTestId('vs-badge')).toBeTruthy();
+		expect(screen.getByTestId('player-card')).toBeTruthy();
+		expect(screen.getByTestId('enemy-card')).toBeTruthy();
+	});
+
+	it('wires each battler to its own card', () => {
+		render(Fight);
+		expect(screen.getByTestId('player-card').textContent).toContain('Aelara');
+		expect(screen.getByTestId('enemy-card').textContent).toContain('Dire Wolf');
+	});
+
+	it('renders the zone navigation for the current zone', () => {
+		render(Fight);
+		expect(screen.getByTestId('zone-nav').textContent).toContain('Verdant Hollow');
+	});
+});

--- a/UI/new-svelte/src/tests/routes/game/screens/fight/SkillTooltip.test.ts
+++ b/UI/new-svelte/src/tests/routes/game/screens/fight/SkillTooltip.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EAttribute, type IAttribute } from '$lib/api';
+
+// The tooltip resolves the opponent through the battle engine and attribute names through the
+// reference-data store; both are mocked so the damage maths is fully controlled by the test.
+const { mockBattleEngine, staticData } = vi.hoisted(() => ({
+	mockBattleEngine: { getOpponent: vi.fn() },
+	staticData: { attributes: [] as IAttribute[] }
+}));
+
+vi.mock('$lib/engine', () => ({ battleEngine: mockBattleEngine }));
+vi.mock('$stores', () => ({ staticData }));
+
+import SkillTooltip from '$routes/game/screens/fight/SkillTooltip.svelte';
+import { makeBattler, makeSkill } from './fight-fixtures';
+import type { Battler } from '$lib/battle';
+
+let owner: Battler;
+let opponent: Battler;
+
+beforeEach(() => {
+	owner = makeBattler({ name: 'Aelara', attributes: [{ attributeId: EAttribute.Strength, amount: 20 }] });
+	opponent = makeBattler({ name: 'Dire Wolf', attributes: [{ attributeId: EAttribute.Defense, amount: 5 }] });
+	mockBattleEngine.getOpponent.mockReturnValue(opponent);
+	staticData.attributes = [];
+});
+
+afterEach(cleanup);
+
+describe('SkillTooltip', () => {
+	it('renders only the hidden anchor when no skill is provided', () => {
+		const { container, queryByText } = render(SkillTooltip, { props: { skill: undefined } });
+		expect(queryByText('Damage breakdown')).toBeNull();
+		// The container stays mounted (hidden) so the tooltip system can still anchor to it.
+		const panel = container.querySelector('.skill-tooltip') as HTMLElement;
+		expect(panel.getAttribute('style')).toContain('display: none');
+	});
+
+	it('shows the damage breakdown: base, per-attribute multiplier, enemy defense and total', () => {
+		staticData.attributes[EAttribute.Strength] = { id: EAttribute.Strength, name: 'Strength', description: '' };
+		const skill = makeSkill(owner, {
+			name: 'Cleave',
+			baseDamage: 10,
+			damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 2 }],
+			cooldownMs: 1000
+		});
+		const { container, getByText } = render(SkillTooltip, { props: { skill } });
+
+		expect(getByText('Cleave')).toBeTruthy();
+		const list = container.querySelector('.tt-dmg-list') as HTMLElement;
+		// base 10, STR(20) x2 = +40, enemy defense -5  ->  total 10 + 40 - 5 = 45
+		expect(list.textContent).toContain('Strength');
+		expect(list.textContent).toContain('10');
+		expect(list.textContent).toContain('+40');
+		expect(list.textContent).toContain('-5');
+		expect((container.querySelector('.tt-total-value') as HTMLElement).textContent).toContain('45');
+	});
+
+	it('omits the enemy-defense row and uses raw damage when there is no opponent', () => {
+		mockBattleEngine.getOpponent.mockReturnValue(undefined);
+		const skill = makeSkill(owner, {
+			baseDamage: 10,
+			damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 2 }]
+		});
+		const { container } = render(SkillTooltip, { props: { skill } });
+		expect(container.textContent).not.toContain('Enemy defense');
+		// total = base 10 + STR(20) x2 (40), with no defense subtracted = 50
+		expect((container.querySelector('.tt-total-value') as HTMLElement).textContent).toContain('50');
+	});
+
+	it('falls back to the enum attribute name when reference data is missing', () => {
+		// staticData.attributes is left empty, so attributeName falls back to EAttribute[id].
+		const skill = makeSkill(owner, { damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 1 }] });
+		const { container } = render(SkillTooltip, { props: { skill } });
+		expect((container.querySelector('.tt-dmg-list') as HTMLElement).textContent).toContain('Strength');
+	});
+
+	it('derives cooldown and DPS, shortening the cooldown for a faster battler', () => {
+		const fast = makeBattler({ attributes: [{ attributeId: EAttribute.Strength, amount: 20 }] });
+		fast.cdMultiplier = 2;
+		const skill = makeSkill(fast, {
+			baseDamage: 10,
+			damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 2 }],
+			cooldownMs: 1000
+		});
+		const { container } = render(SkillTooltip, { props: { skill } });
+		const metrics = container.querySelector('.tt-metrics') as HTMLElement;
+		// adjustedCd = 1000ms / 1000 / cdMult(2) = 0.5s; total 45; DPS = 45 / 0.5 = 90
+		expect(metrics.textContent).toContain('0.5s');
+		expect(metrics.textContent).toContain('90');
+	});
+
+	it('reads READY for a fully-charged skill and a remaining time for one on cooldown', () => {
+		const ready = makeSkill(owner, { cooldownMs: 1000 });
+		ready.renderChargeTime = 1000; // fully charged
+		const readyRender = render(SkillTooltip, { props: { skill: ready } });
+		expect(readyRender.getByText('READY')).toBeTruthy();
+		cleanup();
+
+		const cooling = makeSkill(owner, { cooldownMs: 1000 });
+		cooling.renderChargeTime = 0; // just used
+		const coolingRender = render(SkillTooltip, { props: { skill: cooling } });
+		expect(coolingRender.queryByText('READY')).toBeNull();
+		expect((coolingRender.container.querySelector('.tt-cooldown-text') as HTMLElement).textContent).toContain('s');
+	});
+});

--- a/UI/new-svelte/src/tests/routes/game/screens/fight/Skills.test.ts
+++ b/UI/new-svelte/src/tests/routes/game/screens/fight/Skills.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import type { IAttribute } from '$lib/api';
+
+// Skills renders a SkillTooltip child, which resolves the opponent through the battle engine
+// and attribute names through the reference-data store; both are mocked.
+const { mockBattleEngine, staticData } = vi.hoisted(() => ({
+	mockBattleEngine: { getOpponent: vi.fn() },
+	staticData: { attributes: [] as IAttribute[] }
+}));
+
+vi.mock('$lib/engine', () => ({ battleEngine: mockBattleEngine }));
+vi.mock('$stores', () => ({ staticData }));
+
+import Skills from '$routes/game/screens/fight/Skills.svelte';
+import { makeBattler, makeSkill } from './fight-fixtures';
+import type { Battler } from '$lib/battle';
+
+let battler: Battler;
+
+beforeEach(() => {
+	battler = makeBattler();
+	// Consulted by the SkillTooltip child once a slot is hovered.
+	mockBattleEngine.getOpponent.mockReturnValue(makeBattler({ name: 'Dire Wolf' }));
+});
+
+afterEach(cleanup);
+
+describe('Skills', () => {
+	it('renders a slot with icon and label for each defined skill', () => {
+		battler.skills = [
+			makeSkill(battler, { name: 'Slash', iconPath: '/slash.png' }),
+			makeSkill(battler, { id: 2, name: 'Cleave', iconPath: '/cleave.png' })
+		];
+		const { container, getByAltText, getByText } = render(Skills, { props: { battler, side: 'player' } });
+
+		expect(container.querySelectorAll('.skill-slot')).toHaveLength(2);
+		expect(getByAltText('Slash')).toBeTruthy();
+		expect(getByAltText('Cleave')).toBeTruthy();
+		expect(getByText('Slash')).toBeTruthy();
+		expect(getByText('Cleave')).toBeTruthy();
+	});
+
+	it('renders an empty column with no icon or label for an unfilled skill slot', () => {
+		battler.skills = [makeSkill(battler, { name: 'Slash' }), undefined];
+		const { container } = render(Skills, { props: { battler, side: 'player' } });
+
+		// Two columns are laid out, but only the filled one carries an icon and label.
+		expect(container.querySelectorAll('.skill-column')).toHaveLength(2);
+		expect(container.querySelectorAll('.skill-icon')).toHaveLength(1);
+		expect(container.querySelectorAll('.skill-label')).toHaveLength(1);
+	});
+
+	it('marks a fully-charged skill ready and leaves one mid-cooldown un-ready', () => {
+		const ready = makeSkill(battler, { name: 'Ready', cooldownMs: 1000 });
+		ready.renderChargeTime = 1000; // 100% charged
+		const charging = makeSkill(battler, { id: 2, name: 'Charging', cooldownMs: 1000 });
+		charging.renderChargeTime = 500; // 50% charged
+		battler.skills = [ready, charging];
+
+		const { container } = render(Skills, { props: { battler, side: 'player' } });
+		const slots = container.querySelectorAll('.skill-slot');
+		expect(slots[0].classList.contains('ready')).toBe(true);
+		expect(slots[1].classList.contains('ready')).toBe(false);
+		// The cooldown sweep tracks the charge percentage (50% -> 180 of 360 degrees).
+		expect((slots[1] as HTMLElement).getAttribute('style')).toContain('180deg');
+	});
+
+	it('right-aligns the enemy skill row', () => {
+		battler.skills = [makeSkill(battler)];
+		const { container } = render(Skills, { props: { battler, side: 'enemy' } });
+		expect(container.querySelector('.skills-row')?.classList.contains('reversed')).toBe(true);
+	});
+
+	it('reveals the skill tooltip for the hovered slot and hides it on leave', async () => {
+		battler.skills = [makeSkill(battler, { name: 'Slash' })];
+		const { container, queryByText } = render(Skills, { props: { battler, side: 'player' } });
+
+		// The tooltip body is absent until a slot is hovered.
+		expect(queryByText('Damage breakdown')).toBeNull();
+
+		const slot = container.querySelector('.skill-slot') as HTMLElement;
+		await fireEvent.mouseEnter(slot);
+		expect(queryByText('Damage breakdown')).not.toBeNull();
+
+		await fireEvent.mouseLeave(slot);
+		expect(queryByText('Damage breakdown')).toBeNull();
+	});
+});

--- a/UI/new-svelte/src/tests/routes/game/screens/fight/ZoneNav.test.ts
+++ b/UI/new-svelte/src/tests/routes/game/screens/fight/ZoneNav.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+import type { IZone } from '$lib/api';
+
+// ZoneNav reads the zone list from the reference-data store and the active zone from the
+// player manager; both are mocked so the test controls the navigation state directly.
+const { mockPlayerManager, staticData } = vi.hoisted(() => ({
+	mockPlayerManager: { currentZone: 0 },
+	staticData: { zones: [] as IZone[] }
+}));
+
+vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager }));
+vi.mock('$stores', () => ({ staticData }));
+
+import ZoneNav from '$routes/game/screens/fight/ZoneNav.svelte';
+
+const zone = (id: number, order: number, name: string): IZone => ({
+	id,
+	name,
+	description: '',
+	order,
+	levelMin: 1,
+	levelMax: 10
+});
+
+beforeEach(() => {
+	// Deliberately out of array order to prove the component orders by `order`, not index.
+	staticData.zones = [zone(30, 3, 'Frozen Summit'), zone(10, 1, 'Verdant Hollow'), zone(20, 2, 'Ashen Wastes')];
+	mockPlayerManager.currentZone = 20;
+});
+
+afterEach(cleanup);
+
+describe('ZoneNav', () => {
+	it('shows the current zone name and a 1-based, zero-padded number ordered by zone order', () => {
+		render(ZoneNav);
+		const nav = screen.getByTestId('zone-nav');
+		expect(nav.textContent).toContain('Zone · 02');
+		expect(nav.textContent).toContain('Ashen Wastes');
+	});
+
+	it('disables the left button on the first zone', () => {
+		mockPlayerManager.currentZone = 10;
+		render(ZoneNav);
+		const [left, right] = screen.getAllByRole('button') as HTMLButtonElement[];
+		expect(left.disabled).toBe(true);
+		expect(right.disabled).toBe(false);
+	});
+
+	it('disables the right button on the last zone', () => {
+		mockPlayerManager.currentZone = 30;
+		render(ZoneNav);
+		const [left, right] = screen.getAllByRole('button') as HTMLButtonElement[];
+		expect(left.disabled).toBe(false);
+		expect(right.disabled).toBe(true);
+	});
+
+	it('advances to the next zone (by order) when the right button is clicked', async () => {
+		render(ZoneNav);
+		const [, right] = screen.getAllByRole('button') as HTMLButtonElement[];
+		await fireEvent.click(right);
+		// From order 2 (id 20) forward to order 3 (id 30).
+		expect(mockPlayerManager.currentZone).toBe(30);
+	});
+
+	it('moves to the previous zone (by order) when the left button is clicked', async () => {
+		render(ZoneNav);
+		const [left] = screen.getAllByRole('button') as HTMLButtonElement[];
+		await fireEvent.click(left);
+		// From order 2 (id 20) back to order 1 (id 10).
+		expect(mockPlayerManager.currentZone).toBe(10);
+	});
+
+	it('falls back to the first ordered zone when the current zone is unknown', () => {
+		mockPlayerManager.currentZone = 999;
+		render(ZoneNav);
+		const nav = screen.getByTestId('zone-nav');
+		expect(nav.textContent).toContain('Zone · 01');
+		expect(nav.textContent).toContain('Verdant Hollow');
+	});
+});

--- a/UI/new-svelte/src/tests/routes/game/screens/fight/fight-fixtures.ts
+++ b/UI/new-svelte/src/tests/routes/game/screens/fight/fight-fixtures.ts
@@ -1,0 +1,46 @@
+/* Shared fixtures for the Fight screen tests. Not a test file (no
+   .test/.spec suffix) so vitest does not collect it. */
+
+import { EAttribute, type IBattlerAttribute, type ISkill } from '$lib/api';
+import { Battler, Skill } from '$lib/battle';
+
+/** Builds a real Skill bound to an owner, overriding only what a test cares about. */
+export const makeSkill = (owner: Battler, over: Partial<ISkill> = {}): Skill =>
+	new Skill(
+		{
+			id: 1,
+			name: 'Slash',
+			baseDamage: 10,
+			damageMultipliers: [],
+			description: 'A basic slash.',
+			cooldownMs: 1000,
+			iconPath: '/icons/slash.png',
+			...over
+		},
+		owner
+	);
+
+interface BattlerOverrides {
+	name?: string;
+	level?: number;
+	attributes?: IBattlerAttribute[];
+	currentHealth?: number;
+}
+
+/** Builds a real Battler with exact (non-derived) attribute values so the health and
+ *  damage maths in the cards/tooltip stay predictable. Skills, when a test needs them,
+ *  are attached by the caller (e.g. `battler.skills = [makeSkill(battler)]`). */
+export const makeBattler = ({
+	name = 'Aelara',
+	level = 12,
+	attributes = [{ attributeId: EAttribute.MaxHealth, amount: 100 }],
+	currentHealth
+}: BattlerOverrides = {}): Battler => {
+	const battler = new Battler();
+	battler.name = name;
+	battler.level = level;
+	// setData(.., false) skips the derived-stat pass, so the values are exactly what we pass.
+	battler.attributes.setData(attributes, false);
+	battler.currentHealth = currentHealth ?? battler.attributes.getValue(EAttribute.MaxHealth);
+	return battler;
+};


### PR DESCRIPTION
## Summary

The fight screen (`src/routes/game/screens/fight/`) had **no test coverage at all**, despite being the most user-visible and complex screen in the game. This PR adds component tests for all five fight-screen components, following the testing guideline (unit tests for all pages/components/lib code) and mirroring the existing `challenges` screen pattern (component render + key interactions, mocking out engine/store dependencies).

No production code was changed — this is purely added test coverage.

## How this addresses #91

Adds the five test files requested in the issue under `UI/new-svelte/src/tests/routes/game/screens/fight/`, mirroring the component structure:

| Test file | What it covers |
|-----------|----------------|
| `Fight.test.ts` | Screen scaffold (fight-screen / vs-badge / both cards), each battler wired to its own card, zone nav rendered for the current zone |
| `ZoneNav.test.ts` | Current zone name + zero-padded number, ordering by zone `order`, left/right disabled bounds, navigation updating the active zone, fallback to the first zone when the current one is unknown |
| `Skills.test.ts` | One slot per defined skill (icon + label), empty column for an unfilled slot, ready vs mid-cooldown state + cooldown sweep, enemy-side row reversal, tooltip reveal/hide on hover |
| `BattlerCard.test.ts` | Name / level / current-max health, health-bar width sizing, clamp-to-full when max health is 0, player vs enemy side accents, skill rendering |
| `SkillTooltip.test.ts` | Damage breakdown (base + per-attribute multiplier − enemy defense = total), no-opponent case, attribute-name fallback to the enum, derived cooldown/DPS with haste, READY vs on-cooldown display |

A shared `fight-fixtures.ts` (following the existing `stat-fixtures.ts` precedent — a non-`.test` file so vitest doesn't collect it) builds **real** `Battler`/`Skill` domain objects via the actual classes, so the components are exercised against the real domain model rather than ad-hoc casts. Attribute values are set with the derived-stat pass skipped so health/damage maths stays predictable.

## Test plan

- [x] `npm run test:unit` — **482 passed** (59 files), including the **25 new** fight tests
- [x] `npm run lint` — clean (eslint + prettier)
- [x] `npm run check` — svelte-check 0 errors / 0 warnings

## Notes

- The cooldown tests assert observable behaviour (fully-charged → `READY`, just-fired → shows remaining time) rather than the exact intermediate value. While writing them I examined the `remainingCd` expression in `SkillTooltip.svelte` (the `+ cdMultiplier` term reads oddly); working through the units it only introduces a constant ~1 ms offset that is rounded away by `formatNum`, so it is functionally invisible and not worth a separate fix.

Closes #91


---
_Generated by [Claude Code](https://claude.ai/code/session_01L6dkNGRN2ivvcweGevzgKn)_