### PR TITLE
Add unit tests for AttributeModifier, EquipmentSlot, and Inventory

### DIFF
--- a/Game.Core.Tests/Attributes/AttributeModifierTests.cs
+++ b/Game.Core.Tests/Attributes/AttributeModifierTests.cs
@@ -1,0 +1,133 @@
+using Game.Core.Attributes;
+using Game.Core.Attributes.Modifiers;
+using Xunit;
+
+namespace Game.Core.Tests.Attributes
+{
+    public class AttributeModifierTests
+    {
+        // ── Non-derived sources use the raw Amount ──────────────────────────
+
+        [Fact]
+        public void Apply_Additive_AddsAmountToCurrentValue()
+        {
+            var modifier = MakeModifier(EModifierType.Additive, amount: 5.0);
+
+            var result = modifier.Apply(10.0, EmptyStore());
+
+            Assert.Equal(15.0, result);
+        }
+
+        [Fact]
+        public void Apply_Multiplicative_MultipliesCurrentValueByAmount()
+        {
+            var modifier = MakeModifier(EModifierType.Multiplicative, amount: 2.0);
+
+            var result = modifier.Apply(10.0, EmptyStore());
+
+            Assert.Equal(20.0, result);
+        }
+
+        [Fact]
+        public void Apply_AdditiveWithNegativeAmount_SubtractsFromCurrentValue()
+        {
+            var modifier = MakeModifier(EModifierType.Additive, amount: -3.0);
+
+            var result = modifier.Apply(10.0, EmptyStore());
+
+            Assert.Equal(7.0, result);
+        }
+
+        [Fact]
+        public void Apply_MultiplicativeByZero_ReturnsZero()
+        {
+            var modifier = MakeModifier(EModifierType.Multiplicative, amount: 0.0);
+
+            var result = modifier.Apply(10.0, EmptyStore());
+
+            Assert.Equal(0.0, result);
+        }
+
+        // ── Derived sources scale the Amount by the source attribute ────────
+
+        [Fact]
+        public void Apply_AdditiveDerived_ScalesAmountByDerivedSourceValue()
+        {
+            // modifierAmount = Amount(3) * store[Strength](10) = 30, then additive onto 5.
+            var modifier = MakeDerivedModifier(EModifierType.Additive, amount: 3.0, derivedSource: EAttribute.Strength);
+
+            var result = modifier.Apply(5.0, StoreWith(EAttribute.Strength, 10.0));
+
+            Assert.Equal(35.0, result);
+        }
+
+        [Fact]
+        public void Apply_MultiplicativeDerived_ScalesAmountByDerivedSourceValue()
+        {
+            // modifierAmount = Amount(2) * store[Strength](10) = 20, then multiplicative onto 5.
+            var modifier = MakeDerivedModifier(EModifierType.Multiplicative, amount: 2.0, derivedSource: EAttribute.Strength);
+
+            var result = modifier.Apply(5.0, StoreWith(EAttribute.Strength, 10.0));
+
+            Assert.Equal(100.0, result);
+        }
+
+        [Fact]
+        public void Apply_AdditiveDerived_WhenDerivedSourceIsZero_LeavesCurrentValueUnchanged()
+        {
+            // The derived source has no contributing modifiers, so it resolves to 0 and the
+            // additive amount becomes 0.
+            var modifier = MakeDerivedModifier(EModifierType.Additive, amount: 3.0, derivedSource: EAttribute.Strength);
+
+            var result = modifier.Apply(5.0, EmptyStore());
+
+            Assert.Equal(5.0, result);
+        }
+
+        // ── Unsupported modifier type ───────────────────────────────────────
+
+        [Fact]
+        public void Apply_UnsupportedModifierType_ReturnsCurrentValueUnchanged()
+        {
+            // EModifierType only defines Additive(1) and Multiplicative(2); an out-of-range value
+            // exercises the defensive default branch, which is a no-op.
+            var modifier = MakeModifier((EModifierType)99, amount: 5.0);
+
+            var result = modifier.Apply(10.0, EmptyStore());
+
+            Assert.Equal(10.0, result);
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────────
+
+        private static AttributeModifier MakeModifier(EModifierType type, double amount) => new()
+        {
+            Attribute = EAttribute.Strength,
+            Amount = amount,
+            Type = type,
+            Source = EAttributeModifierSource.Item,
+        };
+
+        private static AttributeModifier MakeDerivedModifier(EModifierType type, double amount, EAttribute derivedSource) => new()
+        {
+            Attribute = EAttribute.Strength,
+            Amount = amount,
+            Type = type,
+            Source = EAttributeModifierSource.Derived,
+            DerivedSource = derivedSource,
+        };
+
+        private static AttributeCollection EmptyStore() => new([]);
+
+        private static AttributeCollection StoreWith(EAttribute attribute, double value) => new(
+        [
+            new AttributeModifier
+            {
+                Attribute = attribute,
+                Amount = value,
+                Type = EModifierType.Additive,
+                Source = EAttributeModifierSource.PlayerStatPoints,
+            },
+        ]);
+    }
+}

--- a/Game.Core.Tests/Players/EquipmentSlotTests.cs
+++ b/Game.Core.Tests/Players/EquipmentSlotTests.cs
@@ -1,0 +1,44 @@
+using Game.Core.Players.Inventories;
+using Xunit;
+
+namespace Game.Core.Tests.Players
+{
+    public class EquipmentSlotTests
+    {
+        // ── Constructor derives Value, Name, and ItemCategory ───────────────
+
+        [Theory]
+        [InlineData(EEquipmentSlot.HelmSlot, "Helm Slot", EItemCategory.Helm)]
+        [InlineData(EEquipmentSlot.ChestSlot, "Chest Slot", EItemCategory.Chest)]
+        [InlineData(EEquipmentSlot.LegSlot, "Leg Slot", EItemCategory.Leg)]
+        [InlineData(EEquipmentSlot.BootSlot, "Boot Slot", EItemCategory.Boot)]
+        [InlineData(EEquipmentSlot.WeaponSlot, "Weapon Slot", EItemCategory.Weapon)]
+        [InlineData(EEquipmentSlot.AccessorySlot, "Accessory Slot", EItemCategory.Accessory)]
+        public void Constructor_SetsValueHumanReadableNameAndCategory(
+            EEquipmentSlot slot, string expectedName, EItemCategory expectedCategory)
+        {
+            var equipmentSlot = new EquipmentSlot(slot);
+
+            Assert.Equal(slot, equipmentSlot.Value);
+            Assert.Equal(expectedName, equipmentSlot.Name);
+            Assert.Equal(expectedCategory, equipmentSlot.ItemCategory);
+        }
+
+        [Fact]
+        public void Constructor_NewSlot_IsEmpty()
+        {
+            var equipmentSlot = new EquipmentSlot(EEquipmentSlot.WeaponSlot);
+
+            Assert.Null(equipmentSlot.ItemId);
+            Assert.Null(equipmentSlot.Item);
+        }
+
+        [Fact]
+        public void Constructor_UnmappedSlot_Throws()
+        {
+            // Every defined EEquipmentSlot maps to a category; an out-of-range value exercises the
+            // guard that prevents constructing a slot with no associated item category.
+            Assert.Throws<ArgumentException>(() => new EquipmentSlot((EEquipmentSlot)99));
+        }
+    }
+}

--- a/Game.Core.Tests/Players/InventoryTests.cs
+++ b/Game.Core.Tests/Players/InventoryTests.cs
@@ -110,6 +110,26 @@ namespace Game.Core.Tests.Players
             Assert.NotNull(oldSlot.Item);
         }
 
+        [Fact]
+        public void TryEquipItem_TargetSlotOccupied_ReplacesPreviousItem()
+        {
+            var inventory = new Inventory();
+            var itemA = MakeItem(1, EItemCategory.Accessory);
+            var itemB = MakeItem(2, EItemCategory.Accessory);
+            AddUnlockedItem(inventory, itemA);
+            AddUnlockedItem(inventory, itemB);
+            inventory.TryEquipItem(1, EEquipmentSlot.AccessorySlot);
+
+            var result = inventory.TryEquipItem(2, EEquipmentSlot.AccessorySlot);
+
+            Assert.True(result);
+            var slot = inventory.EquipmentSlots.First(s => s.Value == EEquipmentSlot.AccessorySlot);
+            Assert.Equal(2, slot.ItemId);
+            Assert.Equal(itemB, slot.Item);
+            // The previously equipped item must no longer occupy any slot.
+            Assert.DoesNotContain(inventory.EquipmentSlots, s => s.ItemId == 1);
+        }
+
         // ── TryUnequipItem ──────────────────────────────────────────────────
 
         [Fact]
@@ -224,6 +244,55 @@ namespace Game.Core.Tests.Players
             Assert.False(result);
         }
 
+        [Fact]
+        public void TryApplyMod_SlotAlreadyHasMod_ReplacesExistingMod()
+        {
+            var inventory = new Inventory();
+            var item = MakeItem(1, modSlots:
+            [
+                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+            ]);
+            AddUnlockedItem(inventory, item);
+            inventory.UnlockMod(10);
+            inventory.UnlockMod(11);
+            inventory.TryApplyMod(1, 10, 0, MakeMod(10, EItemModType.Prefix));
+
+            var result = inventory.TryApplyMod(1, 11, 0, MakeMod(11, EItemModType.Prefix));
+
+            Assert.True(result);
+            var applied = inventory.UnlockedItems[0].AppliedMods;
+            Assert.Single(applied);
+            Assert.Equal(11, applied[0].ItemModId);
+        }
+
+        [Fact]
+        public void TryApplyMod_ItemNotUnlocked_ReturnsFalse()
+        {
+            var inventory = new Inventory();
+            inventory.UnlockMod(10);
+
+            var result = inventory.TryApplyMod(999, 10, 0, MakeMod(10, EItemModType.Prefix));
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void TryApplyMod_ModSlotIndexNotFound_ReturnsFalse()
+        {
+            var inventory = new Inventory();
+            var item = MakeItem(1, modSlots:
+            [
+                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+            ]);
+            AddUnlockedItem(inventory, item);
+            inventory.UnlockMod(10);
+
+            // The item has only slot index 0; index 5 does not exist.
+            var result = inventory.TryApplyMod(1, 10, 5, MakeMod(10, EItemModType.Prefix));
+
+            Assert.False(result);
+        }
+
         // ── TryRemoveMod ────────────────────────────────────────────────────
 
         [Fact]
@@ -263,6 +332,53 @@ namespace Game.Core.Tests.Players
             AddUnlockedItem(inventory, item);
 
             var result = inventory.TryRemoveMod(1, 0);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void TryRemoveMod_ItemNotUnlocked_ReturnsFalse()
+        {
+            var inventory = new Inventory();
+
+            var result = inventory.TryRemoveMod(999, 0);
+
+            Assert.False(result);
+        }
+
+        // ── TrySetFavorite ──────────────────────────────────────────────────
+
+        [Fact]
+        public void TrySetFavorite_UnlockedItem_SetsFavorite()
+        {
+            var inventory = new Inventory();
+            AddUnlockedItem(inventory, MakeItem(1));
+
+            var result = inventory.TrySetFavorite(1, true);
+
+            Assert.True(result);
+            Assert.True(inventory.UnlockedItems[0].Favorite);
+        }
+
+        [Fact]
+        public void TrySetFavorite_CanUnsetFavorite()
+        {
+            var inventory = new Inventory();
+            AddUnlockedItem(inventory, MakeItem(1));
+            inventory.TrySetFavorite(1, true);
+
+            var result = inventory.TrySetFavorite(1, false);
+
+            Assert.True(result);
+            Assert.False(inventory.UnlockedItems[0].Favorite);
+        }
+
+        [Fact]
+        public void TrySetFavorite_ItemNotUnlocked_ReturnsFalse()
+        {
+            var inventory = new Inventory();
+
+            var result = inventory.TrySetFavorite(999, true);
 
             Assert.False(result);
         }


### PR DESCRIPTION
## Summary

Adds direct unit tests for previously-untested domain **logic** in `Game.Core`, following the existing classical (Detroit) test style used by `InventoryTests`, `AttributeCollectionTests`, etc.

- **`AttributeModifierTests`** (new) — covers `AttributeModifier.Apply`:
  - additive and multiplicative application against the raw `Amount`
  - derived-source scaling (`Amount × store[DerivedSource]`) for both additive and multiplicative types, including the zero-source edge case
  - the defensive default branch (an out-of-range `EModifierType` is a no-op)
  - **The multiplicative branch previously had no coverage anywhere** — `AttributeCollectionTests` only exercises additive/derived modifiers.
- **`EquipmentSlotTests`** (new) — covers the `EquipmentSlot` constructor: human-readable `Name` derivation and `ItemCategory` mapping for all six slots, the empty-on-construction invariant, and the `ArgumentException` guard for an unmapped slot value.
- **`InventoryTests`** (enhanced) — fills gaps in the existing suite: `TrySetFavorite` (set/unset/not-unlocked), `TryApplyMod` replacing an existing mod in an occupied slot, `TryApplyMod` failure paths (item not unlocked, mod-slot index not found), `TryEquipItem` replacing the item already in the target slot, and `TryRemoveMod` on a non-unlocked item.

## How this addresses #76

#76 asks for unit tests across several untested `Game.Core` domain areas. Per the project's classical/Detroit testing guidelines (test behavior, not the compiler), this PR targets the classes that actually contain logic:

| Area from the issue | Outcome |
|---|---|
| `Attributes/Modifiers` | `AttributeModifier.Apply` now directly tested; the internal `StaticAttributeModifiers` and `AttributeModifierNullUnsafeTypeComparer` remain covered indirectly via `AttributeCollectionTests` (no `InternalsVisibleTo` added). |
| `Players/Inventories` | `Inventory` gaps filled; `EquipmentSlot` constructor logic now tested. `AppliedModSlot`/`UnlockedItemSlot` are anemic data holders — see below. |
| `Items` | `Item`, `ItemMod`, `ItemModSlot` are anemic data holders — see below. |
| `Zones` | `Zone` is an anemic data holder — see below. |

**Intentionally not tested:** `Item`, `ItemMod`, `ItemModSlot`, `Zone`, `AppliedModSlot`, and `UnlockedItemSlot` are pure data classes with only auto-properties — no validation, methods, computed properties, or invariants. Property round-trip tests for them would assert C# compiler behavior rather than domain logic, which contradicts the project's testing docs ("classes... should NOT contain any logic worth unit testing"). This scope was confirmed with the repo owner before implementation.

## Follow-up

- **#109** — `ModifierTypeNotSupportedException` is dead code (defined, never thrown). It's likely meant for `AttributeModifier.Apply`'s default branch, which currently silently ignores unsupported modifier types. Resolving it (remove vs. throw) is a small design decision, so it's tracked separately; this PR's regression test pins the current silent-no-op behavior.

## Test plan

- [x] `dotnet build Game.Core.Tests` — clean, 0 warnings / 0 errors
- [x] `dotnet test Game.Core.Tests` — **244 passed, 0 failed** (24 new: 8 `AttributeModifierTests`, 8 `EquipmentSlotTests`, 8 added `InventoryTests`)
- [x] All new tests confirmed discovered + green via the xUnit v3 query filter

No production code was changed (test-only PR), so the rest of the suite is unaffected.

Closes #76

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euat6DXxPCobV5rH13GGsq)_