### PR TITLE
Resolve player reference data from in-memory caches on load (#74)

### DIFF
--- a/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
@@ -255,8 +255,9 @@ namespace Game.Application.Tests.Services
             Assert.Equal(12.0, loadedSkill.BaseDamage);
             Assert.Equal(1500, loadedSkill.CooldownMs);
             Assert.NotEmpty(loadedSkill.DamageMultipliers);
+            // Skills and SelectedSkills share the same resolved instance (immutable template data)
             var selectedSkill = Assert.Single(player.SelectedSkills);
-            Assert.Equal(loadedSkill.Id, selectedSkill.Id);
+            Assert.Same(loadedSkill, selectedSkill);
 
             // Item definition (with its attributes and mod slots) resolved from the cached catalog
             var unlocked = Assert.Single(player.Inventory.UnlockedItems);

--- a/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
@@ -202,6 +202,78 @@ namespace Game.Application.Tests.Services
             Assert.Contains(modifiers, m => m.Attribute == EAttribute.Dexterity && m.Amount == 7.0 && m.Source == EAttributeModifierSource.ItemMod);
         }
 
+        [Fact]
+        public async Task LoadPlayer_ResolvesReferenceDataFromCache()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // Reference data (skill, item with attribute + mod slot, mod) authored independently of
+            // the player; PlayerRepository must stitch these in from the in-memory catalogs.
+            var skill = await TestDataSeeder.CreateSkillAsync(context, name: "Fireball", baseDamage: 12m, cooldownMs: 1500);
+            var item = await TestDataSeeder.CreateItemAsync(context, name: "Sword", attributeId: EAttribute.Strength, attributeAmount: 5m);
+            var modSlot = new Abstractions.Entities.ItemModSlot
+            {
+                ItemId = item.Id,
+                ItemModSlotTypeId = (int)EItemModType.Prefix,
+                Index = 0,
+            };
+            context.ItemModSlots.Add(modSlot);
+            var mod = await TestDataSeeder.CreateItemModAsync(context, attributeId: EAttribute.Dexterity, attributeAmount: 7m);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, skill.Id, selected: true);
+            context.UnlockedItems.Add(new Abstractions.Entities.UnlockedItem
+            {
+                PlayerId = playerEntity.Id,
+                ItemId = item.Id,
+                EquipmentSlotId = (int)EEquipmentSlot.WeaponSlot,
+            });
+            context.UnlockedMods.Add(new Abstractions.Entities.UnlockedMod
+            {
+                PlayerId = playerEntity.Id,
+                ItemModId = mod.Id,
+            });
+            context.AppliedMods.Add(new Abstractions.Entities.AppliedMod
+            {
+                PlayerId = playerEntity.Id,
+                ItemId = item.Id,
+                ItemModSlotId = modSlot.Id,
+                ItemModId = mod.Id,
+            });
+            await context.SaveChangesAsync(CancellationToken);
+
+            var playerService = scope.ServiceProvider.GetRequiredService<PlayerService>();
+            var player = await playerService.LoadPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            // Skill definition resolved from the cached catalog
+            var loadedSkill = Assert.Single(player.Skills);
+            Assert.Equal("Fireball", loadedSkill.Name);
+            Assert.Equal(12.0, loadedSkill.BaseDamage);
+            Assert.Equal(1500, loadedSkill.CooldownMs);
+            Assert.NotEmpty(loadedSkill.DamageMultipliers);
+            var selectedSkill = Assert.Single(player.SelectedSkills);
+            Assert.Equal(loadedSkill.Id, selectedSkill.Id);
+
+            // Item definition (with its attributes and mod slots) resolved from the cached catalog
+            var unlocked = Assert.Single(player.Inventory.UnlockedItems);
+            Assert.Equal("Sword", unlocked.Item.Name);
+            Assert.Contains(unlocked.Item.Attributes, a => a.Attribute == EAttribute.Strength && a.Amount == 5.0);
+            Assert.NotEmpty(unlocked.Item.ModSlots);
+
+            // Applied mod resolved with its attributes, and folded into the equipped modifiers
+            var appliedMod = Assert.Single(unlocked.AppliedMods);
+            Assert.Equal(mod.Id, appliedMod.ItemModId);
+            Assert.Contains(appliedMod.ItemMod.Attributes, a => a.Attribute == EAttribute.Dexterity && a.Amount == 7.0);
+
+            var modifiers = player.Inventory.GetEquippedAttributeModifiers().ToList();
+            Assert.Contains(modifiers, m => m.Attribute == EAttribute.Strength && m.Amount == 5.0 && m.Source == EAttributeModifierSource.Item);
+            Assert.Contains(modifiers, m => m.Attribute == EAttribute.Dexterity && m.Amount == 7.0 && m.Source == EAttributeModifierSource.ItemMod);
+        }
+
         private record SimpleAttributeUpdate(EAttribute Attribute, int Amount) : IAttributeUpdate;
     }
 }

--- a/Game.DataAccess/Mapping/PlayerMapper.cs
+++ b/Game.DataAccess/Mapping/PlayerMapper.cs
@@ -1,3 +1,4 @@
+using Game.Abstractions.DataAccess;
 using Game.Core.Players;
 using Game.Core.Players.Inventories;
 using EntityPlayer = Game.Abstractions.Entities.Player;
@@ -6,9 +7,14 @@ namespace Game.DataAccess.Mapping
 {
     internal static class PlayerMapper
     {
-        public static Player ToCore(EntityPlayer entity)
+        /// <summary>
+        /// Maps a player entity (carrying only player-specific relational data) to a domain
+        /// <see cref="Player"/>, resolving the reference-data portion (items, item mods, skills)
+        /// from the in-memory cached catalogs rather than from EF-loaded navigation properties.
+        /// </summary>
+        public static Player ToCore(EntityPlayer entity, IItems items, IItemMods itemMods, ISkills skills)
         {
-            var statAllocations = (entity.PlayerAttributes ?? [])
+            var statAllocations = entity.PlayerAttributes
                 .Select(pa => new StatAllocation
                 {
                     Attribute = (Core.EAttribute)pa.AttributeId,
@@ -18,27 +24,24 @@ namespace Game.DataAccess.Mapping
             var inventory = new Inventory();
 
             // Map unlocked items with their applied mods
-            var appliedModsByItem = (entity.AppliedMods ?? [])
+            var appliedModsByItem = entity.AppliedMods
                 .GroupBy(am => am.ItemId)
                 .ToDictionary(g => g.Key, g => g.ToList());
 
-            foreach (var ui in entity.UnlockedItems ?? [])
+            foreach (var ui in entity.UnlockedItems)
             {
-                if (ui.Item is null) continue;
-
-                var coreItem = ItemMapper.ToCore(ui.Item);
+                var coreItem = items.GetItem(ui.ItemId);
                 var appliedMods = new List<AppliedModSlot>();
 
                 if (appliedModsByItem.TryGetValue(ui.ItemId, out var mods))
                 {
                     foreach (var am in mods)
                     {
-                        if (am.ItemMod is null) continue;
                         appliedMods.Add(new AppliedModSlot
                         {
                             ItemModId = am.ItemModId,
                             ItemModSlotId = am.ItemModSlotId,
-                            ItemMod = ItemMapper.ModToCore(am.ItemMod),
+                            ItemMod = ItemMapper.ModToCore(itemMods.GetItemMod(am.ItemModId)),
                         });
                     }
                 }
@@ -65,26 +68,23 @@ namespace Game.DataAccess.Mapping
             }
 
             // Map unlocked mods
-            foreach (var um in entity.UnlockedMods ?? [])
+            foreach (var um in entity.UnlockedMods)
             {
                 inventory.UnlockedMods.Add(um.ItemModId);
             }
 
-            // Map player skills
-            var playerSkills = (entity.PlayerSkills ?? [])
-                .Where(ps => ps.Skill is not null)
-                .ToList();
+            // Map player skills, resolving each skill from the cached catalog by id
+            var skillsById = entity.PlayerSkills
+                .ToDictionary(ps => ps.SkillId, ps => SkillMapper.ToCore(skills.GetSkill(ps.SkillId)));
 
-            var skills = playerSkills
-                .Select(ps => SkillMapper.ToCore(ps.Skill))
-                .ToList();
+            var playerSkills = skillsById.Values.ToList();
 
-            var selectedSkills = playerSkills
+            var selectedSkills = entity.PlayerSkills
                 .Where(ps => ps.Selected)
-                .Select(ps => SkillMapper.ToCore(ps.Skill))
+                .Select(ps => skillsById[ps.SkillId])
                 .ToList();
 
-            var logPreferences = (entity.LogPreferences ?? [])
+            var logPreferences = entity.LogPreferences
                 .Select(lp => new Core.Players.LogPreference
                 {
                     LogType = (Core.ELogType)lp.LogTypeId,
@@ -104,7 +104,7 @@ namespace Game.DataAccess.Mapping
                     StatPointsUsed = entity.StatPointsUsed,
                 },
                 Inventory = inventory,
-                Skills = skills,
+                Skills = playerSkills,
                 SelectedSkills = selectedSkills,
                 LogPreferences = logPreferences,
             };

--- a/Game.DataAccess/Repositories/PlayerRepository.cs
+++ b/Game.DataAccess/Repositories/PlayerRepository.cs
@@ -15,12 +15,24 @@ namespace Game.DataAccess.Repositories
         private readonly GameContext _context;
         private readonly ICacheService _cache;
         private readonly IDomainEventDispatcher _dispatcher;
+        private readonly IItems _items;
+        private readonly IItemMods _itemMods;
+        private readonly ISkills _skills;
 
-        public PlayerRepository(GameContext context, ICacheService cache, IDomainEventDispatcher dispatcher)
+        public PlayerRepository(
+            GameContext context,
+            ICacheService cache,
+            IDomainEventDispatcher dispatcher,
+            IItems items,
+            IItemMods itemMods,
+            ISkills skills)
         {
             _context = context;
             _cache = cache;
             _dispatcher = dispatcher;
+            _items = items;
+            _itemMods = itemMods;
+            _skills = skills;
         }
 
         public async Task<Player?> GetPlayer(int playerId)
@@ -50,28 +62,21 @@ namespace Game.DataAccess.Repositories
 
         private async Task<Player?> GetPlayerFromDb(int playerId)
         {
-            //TODO: remove a lot of these sub-includes and utilize the in-memory cached reference data where it's actually needed.
+            // Only the player-specific relational data is fetched here; the reference-data portion
+            // (item/skill/mod definitions and their attributes) is resolved from the in-memory cached
+            // catalogs in PlayerMapper.ToCore, avoiding redundant deep joins on every player load.
             var entity = await _context.Players
                 .AsNoTracking()
                 .Include(p => p.PlayerAttributes)
                 .Include(p => p.PlayerSkills)
-                    .ThenInclude(ps => ps.Skill)
-                        .ThenInclude(s => s.SkillDamageMultipliers)
                 .Include(p => p.UnlockedItems)
-                    .ThenInclude(ui => ui.Item)
-                        .ThenInclude(i => i.ItemAttributes)
-                .Include(p => p.UnlockedItems)
-                    .ThenInclude(ui => ui.Item)
-                        .ThenInclude(i => i.ItemModSlots)
                 .Include(p => p.UnlockedMods)
                 .Include(p => p.AppliedMods)
-                    .ThenInclude(am => am.ItemMod)
-                        .ThenInclude(im => im.ItemModAttributes)
                 .Include(p => p.LogPreferences)
                 .AsSplitQuery()
                 .FirstOrDefaultAsync(p => p.Id == playerId);
 
-            return entity is null ? null : PlayerMapper.ToCore(entity);
+            return entity is null ? null : PlayerMapper.ToCore(entity, _items, _itemMods, _skills);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the over-fetching called out in **#74**. `PlayerRepository.GetPlayerFromDb` previously eager-loaded the full reference-data graph on **every** player fetch:

```csharp
.Include(p => p.PlayerSkills)
    .ThenInclude(ps => ps.Skill)
        .ThenInclude(s => s.SkillDamageMultipliers)
.Include(p => p.UnlockedItems)
    .ThenInclude(ui => ui.Item).ThenInclude(i => i.ItemAttributes)
    // ... item mod slots, applied-mod attributes, etc.
```

All of that skill / item / item-mod definition data is already held in the in-memory cached catalogs (`ISkills`, `IItems`, `IItemMods`) per the [Reference Data](docs/backend.md#reference-data) design decision, so loading it through EF on every player read produced redundant, expensive multi-join SQL.

## How it addresses the issue

- **`PlayerRepository.GetPlayerFromDb`** now fetches only the **player-specific** relational rows — `PlayerAttributes`, `PlayerSkills`, `UnlockedItems`, `UnlockedMods`, `AppliedMods`, `LogPreferences` — and drops every reference-data `ThenInclude`. The stale `//TODO` is removed.
- **`PlayerMapper.ToCore`** takes the `IItems` / `IItemMods` / `ISkills` catalogs and resolves each definition by id:
  - items via `IItems.GetItem` (already returns a core `Item`),
  - applied mods via `IItemMods.GetItemMod` → `ItemMapper.ModToCore`,
  - skills via `ISkills.GetSkill` → `SkillMapper.ToCore`.
- `PlayerRepository` injects the three catalogs (all already registered scoped in `AddDataAccess`).

This aligns the player load with the documented reference-data caching strategy and is the same id→catalog resolution `BattleSnapshotService` already uses.

### Notes
- The mapper now reuses a single resolved `Skill` instance across `Skills` / `SelectedSkills`; `Skill` is explicitly documented as immutable template data (battle runtime state lives in `BattleSkill`), so the previous distinct-instance behavior carried no meaning.
- The dropped `?? []` null-guards on the navigation collections were dead — the entity getters throw `NotLoadedException` rather than returning null — and the now-required collections are still loaded.
- **Follow-up:** the entity→core mapping for skills/mods still goes through the `Game.DataAccess` mappers while `IItems.GetItem` returns a core object directly. That inconsistency / duplication is already tracked by **#102** (consolidate entity→core mapping), so no new issue is filed.

## Test plan

- [x] `dotnet build` — clean (0 warnings / 0 errors)
- [x] `Game.Application.Tests` — 29 passing. Added `LoadPlayer_ResolvesReferenceDataFromCache`, which seeds a skill, an item (attribute + mod slot) and a mod independently of the player, then loads the player fresh and asserts the skill definition, item attributes/mod slots, applied-mod attributes, and resulting equipped modifiers are all stitched in from the catalogs. The existing `LoadPlayer_*` / `ApplyMod_*` round-trip tests now genuinely exercise the cache-resolution path.
- [x] `Game.Api.Tests` — 248 passing (battle/socket integration unaffected).

Closes #74

https://claude.ai/code/session_01QpXmXAhRbinBrvJpSH3V65

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpXmXAhRbinBrvJpSH3V65)_