### PR TITLE
Throw ModifierTypeNotSupportedException for unsupported modifier types

### DIFF
--- a/Game.Core.Tests/Attributes/AttributeModifierTests.cs
+++ b/Game.Core.Tests/Attributes/AttributeModifierTests.cs
@@ -87,15 +87,13 @@ namespace Game.Core.Tests.Attributes
         // ── Unsupported modifier type ───────────────────────────────────────
 
         [Fact]
-        public void Apply_UnsupportedModifierType_ReturnsCurrentValueUnchanged()
+        public void Apply_UnsupportedModifierType_ThrowsModifierTypeNotSupportedException()
         {
             // EModifierType only defines Additive(1) and Multiplicative(2); an out-of-range value
-            // exercises the defensive default branch, which is a no-op.
+            // represents a programming error and must surface loudly rather than silently no-op.
             var modifier = MakeModifier((EModifierType)99, amount: 5.0);
 
-            var result = modifier.Apply(10.0, EmptyStore());
-
-            Assert.Equal(10.0, result);
+            Assert.Throws<ModifierTypeNotSupportedException>(() => modifier.Apply(10.0, EmptyStore()));
         }
 
         // ── Helpers ──────────────────────────────────────────────────────────

--- a/Game.Core/Attributes/Modifiers/AttributeModifier.cs
+++ b/Game.Core/Attributes/Modifiers/AttributeModifier.cs
@@ -46,7 +46,7 @@ namespace Game.Core.Attributes.Modifiers
             {
                 Additive => currentValue + modifierAmount,
                 Multiplicative => currentValue * modifierAmount,
-                _ => currentValue,
+                _ => throw new ModifierTypeNotSupportedException(Type),
             };
         }
     }

--- a/UI/new-svelte/src/lib/battle/attribute-collection.ts
+++ b/UI/new-svelte/src/lib/battle/attribute-collection.ts
@@ -83,8 +83,17 @@ export function computeAttributes<T extends AttributeModifier>(
 		inProgress.add(attr);
 
 		const list = byAttr.get(attr) ?? [];
-		const adds = list.filter((m) => m.type === EModifierType.Additive);
-		const mults = list.filter((m) => m.type === EModifierType.Multiplicative);
+		const adds: T[] = [];
+		const mults: T[] = [];
+		for (const mod of list) {
+			if (mod.type === EModifierType.Additive) {
+				adds.push(mod);
+			} else if (mod.type === EModifierType.Multiplicative) {
+				mults.push(mod);
+			} else {
+				throw new Error(`Unsupported EModifierType: ${mod.type}`);
+			}
+		}
 
 		let running = 0;
 		const lines: AppliedModifier<T>[] = [];

--- a/UI/new-svelte/src/tests/lib/battle/attribute-collection.test.ts
+++ b/UI/new-svelte/src/tests/lib/battle/attribute-collection.test.ts
@@ -77,6 +77,18 @@ describe('computeAttributes', () => {
 		// Intellect was never referenced, so it is simply absent.
 		expect(computed.get(EAttribute.Intellect)).toBeUndefined();
 	});
+
+	it('throws for an unsupported modifier type', () => {
+		// EModifierType only defines Additive(1) and Multiplicative(2); an out-of-range value
+		// represents a programming error and must surface loudly rather than silently no-op.
+		const modifier: AttributeModifier = {
+			attribute: EAttribute.Strength,
+			amount: 5,
+			type: 99 as EModifierType,
+			source: EAttributeModifierSource.Item
+		};
+		expect(() => computeAttributes([modifier])).toThrow('Unsupported EModifierType: 99');
+	});
 });
 
 describe('groupBySource', () => {


### PR DESCRIPTION
## Summary

- `ModifierTypeNotSupportedException` was dead code — defined but never thrown anywhere
- `AttributeModifier.Apply`'s default branch silently returned `currentValue` unchanged for any unrecognized `EModifierType`, swallowing what is fundamentally a programming error
- The frontend's `computeAttributes` similarly filtered unknown types into neither the additive nor multiplicative buckets, silently ignoring them

This PR activates the exception and makes both backend and frontend fail loudly (rather than silently no-op) when an unsupported modifier type is encountered — consistent fail-fast behavior that surfaces programming errors immediately.

## Changes

- **`AttributeModifier.cs`**: Default branch in `Apply` now throws `ModifierTypeNotSupportedException(Type)` instead of returning `currentValue`
- **`attribute-collection.ts`**: Classifier loop now throws `Error('Unsupported EModifierType: N')` for any type that is neither `Additive` nor `Multiplicative`, mirroring the backend behavior
- **`AttributeModifierTests.cs`**: Updated the unsupported-type test to assert `ModifierTypeNotSupportedException` is thrown
- **`attribute-collection.test.ts`**: Added matching frontend test asserting an `Error` is thrown for an out-of-range `EModifierType`

## Test plan

- [x] Backend: `dotnet test` — all tests pass (Game.Core.Tests, Game.Application.Tests, Game.Api.Tests)
- [x] Frontend: `npm run lint` — no lint errors
- [x] Frontend: `npm run test:unit:ci` — all 558 tests pass, including the new unsupported-type test

Closes #109

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJa7fbFi7NUEh3KASfUvN1)_