### PR TITLE
Consolidate entity→core mapping for ItemMod and Skill catalogs (#102)

### DIFF
--- a/Game.Abstractions/DataAccess/IItemMods.cs
+++ b/Game.Abstractions/DataAccess/IItemMods.cs
@@ -1,4 +1,5 @@
 ﻿using Game.Abstractions.Entities;
+using CoreItemMod = Game.Core.Items.ItemMod;
 
 namespace Game.Abstractions.DataAccess
 {
@@ -8,6 +9,6 @@ namespace Game.Abstractions.DataAccess
         public List<ItemMod> All(bool refreshCache = false);
         public Dictionary<int, IEnumerable<ItemMod>> GetModsForItemByType(int itemId);
         public ItemMod? LookupItemMod(int itemModId);
-        public ItemMod GetItemMod(int itemModId);
+        public CoreItemMod GetItemMod(int itemModId);
     }
 }

--- a/Game.Abstractions/DataAccess/ISkills.cs
+++ b/Game.Abstractions/DataAccess/ISkills.cs
@@ -1,4 +1,5 @@
 ﻿using Game.Abstractions.Entities;
+using CoreSkill = Game.Core.Skills.Skill;
 
 namespace Game.Abstractions.DataAccess
 {
@@ -7,6 +8,6 @@ namespace Game.Abstractions.DataAccess
         public void InvalidateCache();
         public List<Skill> AllSkills(bool refreshCache = false);
         public Skill? LookupSkill(int skillId);
-        public Skill GetSkill(int skillId);
+        public CoreSkill GetSkill(int skillId);
     }
 }

--- a/Game.Application/Services/BattleSnapshotService.cs
+++ b/Game.Application/Services/BattleSnapshotService.cs
@@ -3,11 +3,7 @@ using Game.Core;
 using Game.Core.Attributes;
 using Game.Core.Attributes.Modifiers;
 using Game.Core.Battle;
-using Game.Core.Items;
 using Game.Core.Players;
-using Game.Core.Skills;
-using EntityItemMod = Game.Abstractions.Entities.ItemMod;
-using EntitySkill = Game.Abstractions.Entities.Skill;
 
 namespace Game.Application.Services
 {
@@ -84,12 +80,12 @@ namespace Game.Application.Services
             foreach (var equip in snapshot.EquippedItems)
             {
                 var item = _items.GetItem(equip.ItemId);
-                modifiers.AddRange(MapItemAttributes(item));
+                modifiers.AddRange(item.Attributes);
 
                 foreach (var modId in equip.AppliedModIds)
                 {
                     var mod = _itemMods.GetItemMod(modId);
-                    modifiers.AddRange(MapItemModAttributes(mod));
+                    modifiers.AddRange(mod.Attributes);
                 }
             }
 
@@ -97,52 +93,10 @@ namespace Game.Application.Services
 
             // 3. Resolve skills from catalog by ID
             var resolvedSkills = snapshot.SkillIds
-                .Select(id => MapSkill(_skills.GetSkill(id)))
+                .Select(id => _skills.GetSkill(id))
                 .ToList();
 
             return new Battler(attributes, resolvedSkills, snapshot.Level);
-        }
-
-        private static IEnumerable<AttributeModifier> MapItemAttributes(Item item)
-        {
-            return item.Attributes.Select(ia => new AttributeModifier
-            {
-                Attribute = ia.Attribute,
-                Amount = ia.Amount,
-                Type = EModifierType.Additive,
-                Source = EAttributeModifierSource.Item,
-            });
-        }
-
-        private static IEnumerable<AttributeModifier> MapItemModAttributes(EntityItemMod entity)
-        {
-            return entity.ItemModAttributes.Select(ima => new AttributeModifier
-            {
-                Attribute = (EAttribute)ima.AttributeId,
-                Amount = (double)ima.Amount,
-                Type = EModifierType.Additive,
-                Source = EAttributeModifierSource.ItemMod,
-            });
-        }
-
-        private static Skill MapSkill(EntitySkill entity)
-        {
-            return new Skill
-            {
-                Id = entity.Id,
-                Name = entity.Name,
-                BaseDamage = (double)entity.BaseDamage,
-                Description = entity.Description,
-                CooldownMs = entity.CooldownMs,
-                DamageMultipliers = (entity.SkillDamageMultipliers ?? [])
-                    .Select(sdm => new AttributeModifier
-                    {
-                        Attribute = (EAttribute)sdm.AttributeId,
-                        Amount = (double)sdm.Multiplier,
-                        Type = EModifierType.Multiplicative,
-                        Source = EAttributeModifierSource.Derived,
-                    }).ToList(),
-            };
         }
     }
 }

--- a/Game.Application/Services/PlayerService.cs
+++ b/Game.Application/Services/PlayerService.cs
@@ -1,7 +1,5 @@
 using Game.Abstractions.DataAccess;
 using Game.Core;
-using Game.Core.Attributes.Modifiers;
-using Game.Core.Items;
 using Game.Core.Players;
 
 namespace Game.Application.Services
@@ -64,28 +62,10 @@ namespace Game.Application.Services
 
         public async Task<bool> ApplyMod(Player player, int itemId, int itemModId, int itemModSlotId)
         {
-            var modEntity = _itemMods.LookupItemMod(itemModId);
-            if (modEntity is null)
+            if (_itemMods.LookupItemMod(itemModId) is null)
                 return false;
 
-            var mod = new ItemMod
-            {
-                Id = itemModId,
-                Name = modEntity.Name,
-                Description = modEntity.Description ?? string.Empty,
-                Type = (EItemModType)modEntity.ItemModTypeId,
-                Rarity = (ERarity)modEntity.RarityId,
-                Attributes = modEntity.ItemModAttributes
-                    .Select(ima => new AttributeModifier
-                    {
-                        Attribute = (EAttribute)ima.AttributeId,
-                        Amount = (double)ima.Amount,
-                        Type = EModifierType.Additive,
-                        Source = EAttributeModifierSource.ItemMod,
-                    })
-                    .ToList(),
-                Tags = [],
-            };
+            var mod = _itemMods.GetItemMod(itemModId);
 
             if (!player.TryApplyMod(itemId, itemModId, itemModSlotId, mod))
                 return false;

--- a/Game.DataAccess/Mapping/PlayerMapper.cs
+++ b/Game.DataAccess/Mapping/PlayerMapper.cs
@@ -41,7 +41,7 @@ namespace Game.DataAccess.Mapping
                         {
                             ItemModId = am.ItemModId,
                             ItemModSlotId = am.ItemModSlotId,
-                            ItemMod = ItemMapper.ModToCore(itemMods.GetItemMod(am.ItemModId)),
+                            ItemMod = itemMods.GetItemMod(am.ItemModId),
                         });
                     }
                 }
@@ -75,7 +75,7 @@ namespace Game.DataAccess.Mapping
 
             // Map player skills, resolving each skill from the cached catalog by id
             var skillsById = entity.PlayerSkills
-                .ToDictionary(ps => ps.SkillId, ps => SkillMapper.ToCore(skills.GetSkill(ps.SkillId)));
+                .ToDictionary(ps => ps.SkillId, ps => skills.GetSkill(ps.SkillId));
 
             var playerSkills = skillsById.Values.ToList();
 

--- a/Game.DataAccess/Repositories/ItemMods.cs
+++ b/Game.DataAccess/Repositories/ItemMods.cs
@@ -1,8 +1,9 @@
 ﻿using Game.Abstractions.DataAccess;
 using Game.Abstractions.Entities;
+using Game.DataAccess.Mapping;
 using Game.Infrastructure.Database;
-
 using Microsoft.EntityFrameworkCore;
+using CoreItemMod = Game.Core.Items.ItemMod;
 
 namespace Game.DataAccess.Repositories
 {
@@ -69,10 +70,10 @@ namespace Game.DataAccess.Repositories
             return itemMods.Count <= itemModId || itemModId < 0 ? null : itemMods[itemModId];
         }
 
-        public ItemMod GetItemMod(int itemModId)
+        public CoreItemMod GetItemMod(int itemModId)
         {
             var itemMods = All();
-            return itemMods[itemModId];
+            return ItemMapper.ModToCore(itemMods[itemModId]);
         }
 
         private Dictionary<int, IEnumerable<ItemMod>> ModsForItemByType(int itemId)

--- a/Game.DataAccess/Repositories/Skills.cs
+++ b/Game.DataAccess/Repositories/Skills.cs
@@ -1,8 +1,9 @@
 ﻿using Game.Abstractions.DataAccess;
 using Game.Abstractions.Entities;
+using Game.DataAccess.Mapping;
 using Game.Infrastructure.Database;
-
 using Microsoft.EntityFrameworkCore;
+using CoreSkill = Game.Core.Skills.Skill;
 
 namespace Game.DataAccess.Repositories
 {
@@ -38,10 +39,10 @@ namespace Game.DataAccess.Repositories
             return skills.Count <= skillId || skillId < 0 ? null : skills[skillId];
         }
 
-        public Skill GetSkill(int skillId)
+        public CoreSkill GetSkill(int skillId)
         {
             var skills = AllSkills();
-            return skills[skillId];
+            return SkillMapper.ToCore(skills[skillId]);
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #102

- `IItemMods.GetItemMod` and `ISkills.GetSkill` now return core domain objects (`Game.Core.Items.ItemMod` / `Game.Core.Skills.Skill`) instead of entity models, following the same pattern that `IItems.GetItem` already used.
- Mapping is performed once in the data-access layer via the existing `ItemMapper.ModToCore` / `SkillMapper.ToCore` mappers (both `internal` to `Game.DataAccess`, so the repositories can access them directly).
- Eliminates three duplicated entity→domain mapping implementations that had accumulated in the Application layer: `BattleSnapshotService.MapItemModAttributes`, `BattleSnapshotService.MapSkill`, and the inline `ItemMod` construction in `PlayerService.ApplyMod`.
- `PlayerMapper.ToCore` simplifies: the `ItemMapper.ModToCore(itemMods.GetItemMod(...))` and `SkillMapper.ToCore(skills.GetSkill(...))` double-call chains collapse to single catalog calls that already return the core type.
- Entity-returning `LookupItemMod` / `LookupSkill` are left unchanged — admin persistence controllers need them to interact with `IEntityStore` (mutation, tracking, tag management).

## Approach

The issue offered two options. Option 1 (have the catalog interfaces return core domain objects) is the right fit here because `IItems.GetItem` already established this exact pattern. Admin persistence operations are orthogonal: they use the `Lookup*` variants that still return entity models, so they're unaffected.

## Test plan

- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet test` — 545 tests pass (244 `Game.Core.Tests`, 53 `Game.Application.Tests`, 248 `Game.Api.Tests`)
- [x] `PlayerServiceIntegrationTests.ApplyMod_EquippedItem_AddsModAttributesToEquippedModifiers` — validates the `ApplyMod` path end-to-end
- [x] `PlayerServiceIntegrationTests.LoadPlayer_ResolvesReferenceDataFromCache` — validates the `PlayerMapper` simplification end-to-end

https://claude.ai/code/session_01RN2Q7MvAHBxr9pQaf1qpT4

---
_Generated by [Claude Code](https://claude.ai/code/session_01RN2Q7MvAHBxr9pQaf1qpT4)_