### PR TITLE
Consolidate BattleAttributes onto the computeAttributes pipeline

### DIFF
--- a/UI/new-svelte/src/lib/battle/battle-attributes.ts
+++ b/UI/new-svelte/src/lib/battle/battle-attributes.ts
@@ -1,5 +1,12 @@
 import { IBattlerAttribute, EAttribute } from '$lib/api';
 import { normalizeText } from '$lib/common';
+import {
+	STATIC_ATTRIBUTE_MODIFIERS,
+	EModifierType,
+	EAttributeModifierSource,
+	type AttributeModifier
+} from './attribute-modifier';
+import { computeAttributes } from './attribute-collection';
 
 const attributesMaxId = Object.values(EAttribute)[Object.values(EAttribute).length - 1] as number;
 
@@ -13,12 +20,28 @@ export class BattleAttributes {
 
 	public setData(attList: IBattlerAttribute[] = [], calcDerivedStats: boolean = true) {
 		this.attributes.fill(0, 0, attributesMaxId + 1);
-		for (const att of attList) {
-			this.attributes[att.attributeId] += att.amount;
-		}
 
 		if (calcDerivedStats) {
-			this.calculateDerivedStats();
+			const modifiers: AttributeModifier[] = [
+				...attList.map((att) => ({
+					attribute: att.attributeId,
+					amount: att.amount,
+					type: EModifierType.Additive,
+					source: EAttributeModifierSource.AttributeDistribution
+				})),
+				...STATIC_ATTRIBUTE_MODIFIERS
+			];
+			const computed = computeAttributes(modifiers);
+			for (const [attr, result] of computed) {
+				this.attributes[attr] = result.total;
+			}
+			// DropBonus uses log10(Luck), which cannot be expressed as a constant
+			// modifier in the pipeline; computed as a post-step once Luck is resolved.
+			this.attributes[EAttribute.DropBonus] += Math.log10(this.attributes[EAttribute.Luck]);
+		} else {
+			for (const att of attList) {
+				this.attributes[att.attributeId] += att.amount;
+			}
 		}
 	}
 
@@ -30,20 +53,5 @@ export class BattleAttributes {
 		return this.attributes
 			.map((att, i) => ({ name: normalizeText(EAttribute[i]), value: att }))
 			.filter((att) => att.value != 0 || includeZeroes);
-	};
-
-	private calculateDerivedStats = () => {
-		this.attributes[EAttribute.MaxHealth] +=
-			50 + 20 * this.attributes[EAttribute.Endurance] + 5 * this.attributes[EAttribute.Strength];
-		this.attributes[EAttribute.Defense] +=
-			2 + this.attributes[EAttribute.Endurance] + 0.5 * this.attributes[EAttribute.Agility];
-		this.attributes[EAttribute.CooldownRecovery] +=
-			0.4 * this.attributes[EAttribute.Agility] + 0.1 * this.attributes[EAttribute.Dexterity];
-		this.attributes[EAttribute.DropBonus] += Math.log10(this.attributes[EAttribute.Luck]);
-		// this.attributes[EAttribute.CriticalChance] = 0;
-		// this.attributes[EAttribute.CriticalDamage] = 0;
-		// this.attributes[EAttribute.DodgeChance] = 0;
-		// this.attributes[EAttribute.BlockChance] = 0;
-		// this.attributes[EAttribute.BlockReduction] = 0;
 	};
 }

--- a/UI/new-svelte/src/tests/lib/battle/attribute-collection.test.ts
+++ b/UI/new-svelte/src/tests/lib/battle/attribute-collection.test.ts
@@ -126,11 +126,11 @@ describe('groupBySource', () => {
 });
 
 /* ── parity with the battle model ─────────────────────────────────────────────
-   The breakdown must never disagree with the numbers the battle simulation
-   actually produces. `BattleAttributes` is the frontend battle calculator; this
-   asserts the modifier pipeline yields identical totals for the implemented
-   attributes given the same additive inputs. If a formula constant drifts in one
-   place but not the other, this fails. */
+   `BattleAttributes` is now a thin wrapper over the same `computeAttributes`
+   pipeline, so formula constants live in one place (`STATIC_ATTRIBUTE_MODIFIERS`).
+   These cases serve as a regression guard: they verify that `BattleAttributes`
+   delegates correctly and that changes to the pipeline or the static modifiers
+   don't silently break the battle simulation's derived-stat totals. */
 describe('parity with BattleAttributes', () => {
 	const IMPLEMENTED: EAttribute[] = [
 		EAttribute.Strength,

--- a/UI/new-svelte/src/tests/lib/battle/battle-attributes.test.ts
+++ b/UI/new-svelte/src/tests/lib/battle/battle-attributes.test.ts
@@ -34,7 +34,7 @@ describe('BattleAttributes', () => {
 		});
 	});
 
-	describe('calculateDerivedStats', () => {
+	describe('derived stat computation', () => {
 		it('calculates MaxHealth = 50 + 20*End + 5*Str', () => {
 			const ba = new BattleAttributes(makeAttrs([EAttribute.Strength, 10], [EAttribute.Endurance, 20]));
 			expect(ba.getValue(EAttribute.MaxHealth)).toBe(50 + 20 * 20 + 5 * 10);


### PR DESCRIPTION
## Summary

- Removes `calculateDerivedStats` from `BattleAttributes` and replaces it with a call to the shared `computeAttributes` pipeline (`STATIC_ATTRIBUTE_MODIFIERS` + the input list converted to `AttributeModifier`s).
- Formula constants (`MaxHealth = 50 + 20×END + 5×STR`, etc.) now live exclusively in `STATIC_ATTRIBUTE_MODIFIERS` — a single frontend attribute calculator as described in the issue.
- `DropBonus` (`log10(Luck)`) cannot be expressed as a constant linear modifier, so it is retained as a post-step after the pipeline resolves `Luck`.
- Updated the parity test comment in `attribute-collection.test.ts` to reflect that both callers now share the same pipeline (the test is now a regression guard rather than a divergence detector).
- Renamed the `describe('calculateDerivedStats', ...)` block in `battle-attributes.test.ts` since the private method no longer exists; all test cases are unchanged.

## Test plan

- [x] All 558 existing unit tests pass (`npm run test:unit:ci`)
- [x] Lint passes (`npm run lint`)
- [x] Parity test (`attribute-collection.test.ts` → "parity with BattleAttributes") continues to pass
- [x] All `BattleAttributes` behavioral tests (MaxHealth/Defense/CooldownRecovery/DropBonus formulas, zero builds, `calcDerivedStats: false` path) continue to pass

Closes #117

https://claude.ai/code/session_01WLcyoQedmgwakbce7eD4UW

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLcyoQedmgwakbce7eD4UW)_