### PR TITLE
Add missing unit tests for frontend Svelte components (#119)

### DIFF
--- a/UI/new-svelte/src/tests/components/Loading.test.ts
+++ b/UI/new-svelte/src/tests/components/Loading.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import Loading from '$components/Loading.svelte';
+
+afterEach(cleanup);
+
+describe('Loading', () => {
+	it('shows the spinner when loading=true', () => {
+		const { container } = render(Loading, { props: { loading: true } });
+		expect(container.querySelector('.loading-spinner-container')).toBeTruthy();
+	});
+
+	it('hides the spinner when loading=false', () => {
+		const { container } = render(Loading, { props: { loading: false } });
+		expect(container.querySelector('.loading-spinner-container')).toBeNull();
+	});
+
+	it('shows the overlay by default', () => {
+		const { container } = render(Loading, { props: { loading: true } });
+		expect(container.querySelector('.overlay')).toBeTruthy();
+	});
+
+	it('hides the overlay when hideOverlay=true', () => {
+		const { container } = render(Loading, { props: { loading: true, hideOverlay: true } });
+		expect(container.querySelector('.overlay')).toBeNull();
+	});
+
+	it('suppresses the spinner immediately when a delay is set', () => {
+		// With delay > 0, waitingOnDelay stays true after onMount, so the spinner is hidden
+		// until the timeout fires even though loading=true.
+		const { container } = render(Loading, { props: { loading: true, delay: 500 } });
+		expect(container.querySelector('.loading-spinner-container')).toBeNull();
+	});
+});

--- a/UI/new-svelte/src/tests/components/Select.test.ts
+++ b/UI/new-svelte/src/tests/components/Select.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import Select from '$components/Select.svelte';
+
+afterEach(cleanup);
+
+const options = [
+	{ id: 1, name: 'Alpha' },
+	{ id: 2, name: 'Beta' },
+	{ id: 3, name: 'Gamma' }
+];
+
+describe('Select', () => {
+	it('renders a label element when label is provided', () => {
+		const { getByText } = render(Select, { props: { value: 1, options, label: 'My Field' } });
+		expect(getByText('My Field')).toBeTruthy();
+	});
+
+	it('does not render a label element when label is omitted', () => {
+		const { container } = render(Select, { props: { value: 1, options } });
+		expect(container.querySelector('label')).toBeNull();
+	});
+
+	it('prepends a blank option by default', () => {
+		const { container } = render(Select, { props: { value: 1, options } });
+		const optionEls = container.querySelectorAll('option');
+		// blank + 3 real options
+		expect(optionEls.length).toBe(4);
+		expect((optionEls[0] as HTMLOptionElement).value).toBe('-1');
+		expect(optionEls[0].textContent).toBe('');
+	});
+
+	it('omits the blank option when disableBlanks=true', () => {
+		const { container } = render(Select, { props: { value: 1, options, disableBlanks: true } });
+		const optionEls = container.querySelectorAll('option');
+		expect(optionEls.length).toBe(3);
+	});
+
+	it('renders all provided options with their names', () => {
+		const { container } = render(Select, { props: { value: 1, options, disableBlanks: true } });
+		const optionEls = container.querySelectorAll('option');
+		expect(optionEls[0].textContent?.trim()).toBe('Alpha');
+		expect(optionEls[1].textContent?.trim()).toBe('Beta');
+		expect(optionEls[2].textContent?.trim()).toBe('Gamma');
+	});
+});

--- a/UI/new-svelte/src/tests/components/Tooltip.test.ts
+++ b/UI/new-svelte/src/tests/components/Tooltip.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { flushSync } from 'svelte';
+import Tooltip from '$components/Tooltip.svelte';
+
+afterEach(cleanup);
+
+interface TooltipProps {
+	component: () => { getBaseNode: () => HTMLElement } | undefined;
+	visible: boolean;
+	position?: { x: number; y: number };
+	id?: number;
+}
+
+const makeProps = (overrides: Partial<TooltipProps> = {}): TooltipProps => ({
+	id: 1,
+	component: () => undefined,
+	visible: false,
+	position: undefined,
+	...overrides
+});
+
+describe('Tooltip', () => {
+	it('renders a container with role="tooltip"', () => {
+		const { container } = render(Tooltip, { props: makeProps() });
+		expect(container.querySelector('[role="tooltip"]')).toBeTruthy();
+	});
+
+	it('does not set display:block when not visible', () => {
+		const { container } = render(Tooltip, { props: makeProps({ visible: false, position: { x: 50, y: 50 } }) });
+		const tooltip = container.querySelector('[role="tooltip"]') as HTMLElement;
+		expect(tooltip.style.display).not.toBe('block');
+	});
+
+	it('appends the component node into the tooltip container', () => {
+		const node = document.createElement('span');
+		node.textContent = 'tooltip-content';
+		const props = makeProps({
+			component: () => ({ getBaseNode: () => node }),
+			visible: false
+		});
+		const { container } = render(Tooltip, { props });
+		flushSync();
+		// The $effect in Tooltip calls container.appendChild(comp.getBaseNode()),
+		// so the node should be a child of the tooltip container.
+		const tooltipEl = container.querySelector('[role="tooltip"]') as HTMLElement;
+		expect(tooltipEl.querySelector('span')?.textContent).toBe('tooltip-content');
+	});
+});

--- a/UI/new-svelte/src/tests/components/TooltipBase.test.ts
+++ b/UI/new-svelte/src/tests/components/TooltipBase.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { flushSync } from 'svelte';
+
+// Use vi.hoisted so the array reference is available inside the vi.mock factory.
+const { mockTooltipsData } = vi.hoisted(() => ({
+	mockTooltipsData: [] as { id: number; component: () => undefined; visible: boolean }[]
+}));
+
+// Mocking $stores lets us control the tooltip data without touching the real tooltip store
+// (which uses SvelteMap and is a global singleton).
+vi.mock('$stores', () => ({
+	tooltips: {
+		get data() {
+			return mockTooltipsData;
+		}
+	}
+}));
+
+import TooltipBase from '$components/TooltipBase.svelte';
+
+afterEach(() => {
+	cleanup();
+	mockTooltipsData.length = 0;
+});
+
+describe('TooltipBase', () => {
+	it('renders no tooltip containers when there are no tooltips', () => {
+		const { container } = render(TooltipBase);
+		expect(container.querySelectorAll('[role="tooltip"]').length).toBe(0);
+	});
+
+	it('renders one tooltip container per tooltip in the store', () => {
+		mockTooltipsData.push({ id: 1, component: () => undefined, visible: false });
+		mockTooltipsData.push({ id: 2, component: () => undefined, visible: false });
+
+		const { container } = render(TooltipBase);
+		flushSync();
+
+		expect(container.querySelectorAll('[role="tooltip"]').length).toBe(2);
+	});
+});

--- a/UI/new-svelte/src/tests/routes/admin/workbench/Workbench.test.ts
+++ b/UI/new-svelte/src/tests/routes/admin/workbench/Workbench.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, waitFor } from '@testing-library/svelte';
+
+vi.mock('$stores', () => ({
+	staticData: {
+		zones: [],
+		enemies: [],
+		items: [],
+		skills: [],
+		itemMods: [],
+		attributes: [],
+		challenges: [],
+		challengeTypes: [],
+		statisticTypes: []
+	},
+	toastError: vi.fn(),
+	// LogPanel (re-exported from $components barrel) imports `logs`.
+	logs: () => []
+}));
+
+import Workbench from '$routes/admin/workbench/Workbench.svelte';
+import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+
+interface Row extends Identified {
+	id: number;
+	name: string;
+}
+
+const seed: Row[] = [
+	{ id: 1, name: 'Alpha' },
+	{ id: 2, name: 'Beta' }
+];
+
+const makeConfig = (overrides: Partial<EntityConfig<Row>> = {}): EntityConfig<Row> => ({
+	key: 'rows',
+	label: 'Enemies',
+	singular: 'Enemy',
+	glyph: 'box',
+	blankName: 'Unnamed',
+	newItem: (id) => ({ id, name: '' }),
+	meta: () => [],
+	sections: [
+		{
+			key: 'identity',
+			label: 'Identity',
+			glyph: 'box',
+			kind: 'fields',
+			fields: [{ key: 'name', label: 'Name', type: 'text' }]
+		}
+	],
+	refresh: async () => seed,
+	persist: async () => [],
+	...overrides
+});
+
+afterEach(cleanup);
+
+describe('Workbench', () => {
+	it('does not show workbench content before the entity data is fetched', () => {
+		// Use a never-resolving promise so the store stays unset.
+		const entity = makeConfig({ refresh: () => new Promise(() => {}) });
+		const { container } = render(Workbench, { props: { entity } });
+		// While store is undefined, the workbench title is not rendered (Loading is shown instead).
+		// Note: the Loading component uses delay=150, so the spinner itself may be suppressed;
+		// checking for the absent workbench title is more reliable.
+		expect(container.querySelector('[data-testid="workbench-title"]')).toBeNull();
+	});
+
+	it('renders the entity label once data has loaded', async () => {
+		render(Workbench, { props: { entity: makeConfig() } });
+		// Wait for onMount → entity.refresh() → store to be set → DOM update.
+		await waitFor(() => expect(screen.getByTestId('workbench-title')).toBeTruthy());
+		expect(screen.getByTestId('workbench-title').textContent).toBe('Enemies');
+	});
+
+	it('shows the record count in the page summary after data loads', async () => {
+		render(Workbench, { props: { entity: makeConfig() } });
+		await waitFor(() => expect(screen.getByTestId('workbench-title')).toBeTruthy());
+		// The summary reads "2 enemies" (liveItems.length + entity.label.toLowerCase())
+		expect(screen.getByText('2 enemies')).toBeTruthy();
+	});
+
+	it('renders the list and detail panes after data loads', async () => {
+		render(Workbench, { props: { entity: makeConfig() } });
+		await waitFor(() => expect(screen.getByTestId('workbench-list')).toBeTruthy());
+		expect(screen.getByTestId('workbench-list')).toBeTruthy();
+	});
+
+	it('passes an optional group label into the eyebrow', async () => {
+		render(Workbench, { props: { entity: makeConfig(), groupLabel: 'Combat' } });
+		await waitFor(() => expect(screen.getByTestId('workbench-title')).toBeTruthy());
+		expect(screen.getByText('Admin Console · Combat')).toBeTruthy();
+	});
+});

--- a/UI/new-svelte/src/tests/routes/admin/workbench/WorkbenchDetail.test.ts
+++ b/UI/new-svelte/src/tests/routes/admin/workbench/WorkbenchDetail.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+
+vi.mock('$stores', () => ({
+	staticData: {
+		zones: [],
+		enemies: [],
+		items: [],
+		skills: [],
+		itemMods: [],
+		attributes: [],
+		challenges: [],
+		challengeTypes: [],
+		statisticTypes: []
+	},
+	toastError: vi.fn()
+}));
+
+import WorkbenchDetail from '$routes/admin/workbench/components/WorkbenchDetail.svelte';
+import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
+import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+
+interface Row extends Identified {
+	id: number;
+	name: string;
+	value: number;
+}
+
+const makeConfig = (): EntityConfig<Row> => ({
+	key: 'rows',
+	label: 'Skills',
+	singular: 'Skill',
+	glyph: 'box',
+	blankName: 'Unnamed',
+	newItem: (id) => ({ id, name: '', value: 0 }),
+	meta: () => [],
+	sections: [
+		{
+			key: 'identity',
+			label: 'Identity',
+			glyph: 'box',
+			kind: 'fields',
+			fields: [
+				{ key: 'name', label: 'Name', type: 'text' },
+				{ key: 'value', label: 'Value', type: 'number' }
+			]
+		}
+	],
+	refresh: async () => [],
+	persist: async () => []
+});
+
+const seed: Row[] = [{ id: 1, name: 'Fireball', value: 50 }];
+
+afterEach(cleanup);
+
+describe('WorkbenchDetail — empty state', () => {
+	it('shows the empty state message when no record is provided', () => {
+		const store = new EntityStore(makeConfig(), seed);
+		render(WorkbenchDetail, {
+			props: {
+				entity: makeConfig(),
+				store,
+				record: undefined,
+				baseline: undefined,
+				tab: 'identity',
+				onTab: vi.fn(),
+				onNew: vi.fn()
+			}
+		});
+		expect(screen.getByText('No skills left')).toBeTruthy();
+	});
+
+	it('shows a "New Skill" button in the empty state', () => {
+		const store = new EntityStore(makeConfig(), seed);
+		render(WorkbenchDetail, {
+			props: {
+				entity: makeConfig(),
+				store,
+				record: undefined,
+				baseline: undefined,
+				tab: 'identity',
+				onTab: vi.fn(),
+				onNew: vi.fn()
+			}
+		});
+		expect(screen.getByText(/New Skill/)).toBeTruthy();
+	});
+});
+
+describe('WorkbenchDetail — with a record', () => {
+	const store = () => new EntityStore(makeConfig(), seed);
+
+	const renderDetail = (record: Row) => {
+		const s = store();
+		const rec = s.items.find((r) => r.id === record.id)!;
+		return render(WorkbenchDetail, {
+			props: {
+				entity: makeConfig(),
+				store: s,
+				record: rec,
+				baseline: s.baselineOf(rec.id),
+				tab: 'identity',
+				onTab: vi.fn(),
+				onNew: vi.fn()
+			}
+		});
+	};
+
+	it('renders the record name as the heading', () => {
+		renderDetail(seed[0]);
+		expect(screen.getByRole('heading', { level: 2 }).textContent).toBe('Fireball');
+	});
+
+	it('renders the record id prefix', () => {
+		renderDetail(seed[0]);
+		expect(screen.getByText('#1')).toBeTruthy();
+	});
+
+	it('renders the section tab button', () => {
+		const { container } = renderDetail(seed[0]);
+		// There's a tab button AND a section title both labeled "Identity"; use the
+		// .tab CSS class to target only the tab button.
+		const tab = container.querySelector('.tab') as HTMLElement;
+		expect(tab).toBeTruthy();
+		expect(tab.textContent?.trim()).toContain('Identity');
+	});
+
+	it('Save Changes button is disabled when there are no pending changes', () => {
+		renderDetail(seed[0]);
+		const saveBtn = screen.getByText('Save Changes') as HTMLButtonElement;
+		expect(saveBtn.disabled).toBe(true);
+	});
+
+	it('Discard button is disabled when there are no pending changes', () => {
+		renderDetail(seed[0]);
+		const discardBtn = screen.getByText('Discard') as HTMLButtonElement;
+		expect(discardBtn.disabled).toBe(true);
+	});
+
+	it('shows the "new" spill badge for a newly added record', () => {
+		const s = store();
+		const newId = s.addItem();
+		const newRecord = s.items.find((r) => r.id === newId)!;
+		const { container } = render(WorkbenchDetail, {
+			props: {
+				entity: makeConfig(),
+				store: s,
+				record: newRecord,
+				baseline: s.baselineOf(newId),
+				tab: 'identity',
+				onTab: vi.fn(),
+				onNew: vi.fn()
+			}
+		});
+		// The "added" spill badge renders as <span class="spill added">new</span>.
+		const spillBadge = container.querySelector('.spill.added') as HTMLElement;
+		expect(spillBadge).toBeTruthy();
+		expect(spillBadge.textContent).toBe('new');
+	});
+
+	it('calls store.removeItem when the Delete button is clicked', async () => {
+		const s = store();
+		const rec = s.items[0];
+		render(WorkbenchDetail, {
+			props: {
+				entity: makeConfig(),
+				store: s,
+				record: rec,
+				baseline: s.baselineOf(rec.id),
+				tab: 'identity',
+				onTab: vi.fn(),
+				onNew: vi.fn()
+			}
+		});
+		await fireEvent.click(screen.getByText('Delete'));
+		expect(s.status(rec)).toBe('deleted');
+	});
+});

--- a/UI/new-svelte/src/tests/routes/admin/workbench/WorkbenchList.test.ts
+++ b/UI/new-svelte/src/tests/routes/admin/workbench/WorkbenchList.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+import { flushSync } from 'svelte';
+
+// entity-store.svelte.ts imports toastError from $stores; reference.svelte.ts
+// (imported transitively via SectionRenderer) imports staticData from $stores.
+vi.mock('$stores', () => ({
+	staticData: {
+		zones: [],
+		enemies: [],
+		items: [],
+		skills: [],
+		itemMods: [],
+		attributes: [],
+		challenges: [],
+		challengeTypes: [],
+		statisticTypes: []
+	},
+	toastError: vi.fn()
+}));
+
+import WorkbenchList from '$routes/admin/workbench/components/WorkbenchList.svelte';
+import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
+import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+
+interface Row extends Identified {
+	id: number;
+	name: string;
+}
+
+const makeConfig = (): EntityConfig<Row> => ({
+	key: 'rows',
+	label: 'Enemies',
+	singular: 'Enemy',
+	glyph: 'box',
+	blankName: 'Unnamed',
+	newItem: (id) => ({ id, name: '' }),
+	meta: () => [],
+	sections: [],
+	refresh: async () => [],
+	persist: async () => []
+});
+
+const seed: Row[] = [
+	{ id: 1, name: 'Goblin' },
+	{ id: 2, name: 'Orc' },
+	{ id: 3, name: 'Dragon' }
+];
+
+afterEach(cleanup);
+
+describe('WorkbenchList', () => {
+	it('renders a row for each item in the store', () => {
+		const store = new EntityStore(makeConfig(), seed);
+		render(WorkbenchList, {
+			props: { entity: makeConfig(), store, selectedId: 1, onSelect: vi.fn(), onNew: vi.fn() }
+		});
+		const rows = screen.getAllByTestId('workbench-row');
+		expect(rows.length).toBe(3);
+	});
+
+	it('renders the entity label in the list header', () => {
+		const store = new EntityStore(makeConfig(), seed);
+		render(WorkbenchList, {
+			props: { entity: makeConfig(), store, selectedId: 1, onSelect: vi.fn(), onNew: vi.fn() }
+		});
+		expect(screen.getByTestId('workbench-list').textContent).toContain('Enemies');
+	});
+
+	it('marks the selected row with the selected class', () => {
+		const store = new EntityStore(makeConfig(), seed);
+		render(WorkbenchList, {
+			props: { entity: makeConfig(), store, selectedId: 2, onSelect: vi.fn(), onNew: vi.fn() }
+		});
+		const rows = screen.getAllByTestId('workbench-row');
+		expect(rows[1].classList.contains('selected')).toBe(true);
+	});
+
+	it('calls onNew when the New button is clicked', async () => {
+		const onNew = vi.fn();
+		const store = new EntityStore(makeConfig(), seed);
+		render(WorkbenchList, {
+			props: { entity: makeConfig(), store, selectedId: 1, onSelect: vi.fn(), onNew }
+		});
+		await fireEvent.click(screen.getByTestId('workbench-new'));
+		expect(onNew).toHaveBeenCalledTimes(1);
+	});
+
+	it('filters rows by the search query', async () => {
+		const store = new EntityStore(makeConfig(), seed);
+		const { container } = render(WorkbenchList, {
+			props: { entity: makeConfig(), store, selectedId: 1, onSelect: vi.fn(), onNew: vi.fn() }
+		});
+		const input = container.querySelector('input') as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: 'gob' } });
+		flushSync();
+		expect(screen.getAllByTestId('workbench-row').length).toBe(1);
+		expect(screen.getAllByTestId('workbench-row')[0].textContent).toContain('Goblin');
+	});
+
+	it('shows the "new" spill badge for added records', () => {
+		const store = new EntityStore(makeConfig(), seed);
+		store.addItem();
+		const { container } = render(WorkbenchList, {
+			props: { entity: makeConfig(), store, selectedId: 1, onSelect: vi.fn(), onNew: vi.fn() }
+		});
+		expect(container.textContent).toContain('new');
+	});
+});

--- a/UI/new-svelte/src/tests/routes/game/screens/inventory/Inventory.test.ts
+++ b/UI/new-svelte/src/tests/routes/game/screens/inventory/Inventory.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/svelte';
+
+// InventoryView (constructed inside Inventory.svelte) imports from $lib/engine and $stores.
+vi.mock('$lib/engine', () => ({
+	EEquipmentSlot: { HelmSlot: 0, ChestSlot: 1, LegSlot: 2, BootSlot: 3, WeaponSlot: 4, AccessorySlot: 5 },
+	getEquipmentSlotForCategory: vi.fn((cat: number) => cat - 1),
+	inventoryManager: {
+		get unlockedItemList() {
+			return [];
+		},
+		equippedSlots: [],
+		unlockedMods: new Set<number>(),
+		equipItem: vi.fn(),
+		unequipItem: vi.fn(),
+		setFavorite: vi.fn(),
+		applyMod: vi.fn(),
+		removeMod: vi.fn()
+	}
+}));
+
+vi.mock('$stores', () => ({
+	staticData: { itemMods: [] },
+	registerTooltipComponent: vi.fn(() => ({
+		setTooltipPosition: vi.fn(),
+		showTooltip: vi.fn(),
+		hideTooltip: vi.fn()
+	}))
+}));
+
+import Inventory from '$routes/game/screens/inventory/Inventory.svelte';
+
+afterEach(cleanup);
+
+describe('Inventory screen', () => {
+	it('renders the screen container', () => {
+		render(Inventory);
+		expect(screen.getByTestId('inventory-screen')).toBeTruthy();
+	});
+
+	it('renders the "Inventory" title', () => {
+		render(Inventory);
+		expect(screen.getByText('Inventory')).toBeTruthy();
+	});
+
+	it('does not show the detail drawer initially (no item selected)', () => {
+		const { container } = render(Inventory);
+		// The drawer has class "open" only when an item is selected.
+		const drawer = container.querySelector('.drawer') as HTMLElement;
+		expect(drawer.classList.contains('open')).toBe(false);
+	});
+
+	it('renders the equipped rail', () => {
+		const { container } = render(Inventory);
+		expect(container.querySelector('.rail')).toBeTruthy();
+	});
+});

--- a/UI/new-svelte/src/tests/routes/game/screens/inventory/InventoryGrid.test.ts
+++ b/UI/new-svelte/src/tests/routes/game/screens/inventory/InventoryGrid.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EItemCategory, ERarity } from '$lib/api';
+import { BattleAttributes, type Item } from '$lib/battle';
+
+vi.mock('$lib/engine', () => ({
+	EEquipmentSlot: { HelmSlot: 0, ChestSlot: 1, LegSlot: 2, BootSlot: 3, WeaponSlot: 4, AccessorySlot: 5 },
+	getEquipmentSlotForCategory: vi.fn(),
+	inventoryManager: {
+		get unlockedItemList() {
+			return [];
+		},
+		unlockedMods: new Set<number>(),
+		equipItem: vi.fn(),
+		unequipItem: vi.fn(),
+		setFavorite: vi.fn(),
+		applyMod: vi.fn(),
+		removeMod: vi.fn()
+	}
+}));
+
+vi.mock('$stores', () => ({
+	staticData: { itemMods: [] },
+	registerTooltipComponent: vi.fn(() => ({
+		setTooltipPosition: vi.fn(),
+		showTooltip: vi.fn(),
+		hideTooltip: vi.fn()
+	}))
+}));
+
+import InventoryGrid from '$routes/game/screens/inventory/InventoryGrid.svelte';
+import type { InventoryView } from '$routes/game/screens/inventory/inventory-view.svelte';
+
+const makeGridItem = (itemId: number): Item =>
+	({
+		id: itemId,
+		itemId,
+		name: `Item ${itemId}`,
+		description: '',
+		itemCategoryId: EItemCategory.Weapon,
+		rarityId: ERarity.Common,
+		iconPath: '',
+		attributes: [],
+		appliedMods: [],
+		modSlots: [],
+		tags: [],
+		equipped: false,
+		favorite: false,
+		totalAttributes: new BattleAttributes([], false)
+	}) as unknown as Item;
+
+const makeView = (items: Item[] = [], overrides: Partial<InventoryView> = {}): InventoryView =>
+	({
+		visible: items,
+		selectedId: null,
+		dragItemId: null,
+		page: 0,
+		filterCat: null,
+		favOnly: false,
+		sort: 'category',
+		counts: { all: items.length, cats: {} as Record<EItemCategory, number>, fav: 0 },
+		select: vi.fn(),
+		toggleEquip: vi.fn(),
+		toggleFavorite: vi.fn(),
+		...overrides
+	}) as unknown as InventoryView;
+
+afterEach(cleanup);
+
+describe('InventoryGrid', () => {
+	it('shows the empty message when there are no visible items', () => {
+		const { getByText } = render(InventoryGrid, { props: { view: makeView([]) } });
+		expect(getByText('No items match this filter.')).toBeTruthy();
+	});
+
+	it('shows the item count in the footer', () => {
+		const items = [makeGridItem(1), makeGridItem(2), makeGridItem(3)];
+		const { getByText } = render(InventoryGrid, { props: { view: makeView(items) } });
+		expect(getByText('3 items')).toBeTruthy();
+	});
+
+	it('does not show pager when items fit on one page', () => {
+		const items = Array.from({ length: 10 }, (_, i) => makeGridItem(i + 1));
+		const { container } = render(InventoryGrid, { props: { view: makeView(items) } });
+		expect(container.querySelector('.pager')).toBeNull();
+	});
+
+	it('shows the pager when items exceed a single page', () => {
+		const items = Array.from({ length: 50 }, (_, i) => makeGridItem(i + 1));
+		const { container } = render(InventoryGrid, { props: { view: makeView(items) } });
+		expect(container.querySelector('.pager')).toBeTruthy();
+	});
+
+	it('disables the previous-page button on the first page', () => {
+		const items = Array.from({ length: 50 }, (_, i) => makeGridItem(i + 1));
+		const { container } = render(InventoryGrid, { props: { view: makeView(items) } });
+		const prevBtn = container.querySelector('.page-btn') as HTMLButtonElement;
+		expect(prevBtn.disabled).toBe(true);
+	});
+
+	it('renders one GridSlot per visible item on the current page', () => {
+		const items = [makeGridItem(1), makeGridItem(2)];
+		const { container } = render(InventoryGrid, { props: { view: makeView(items) } });
+		const slots = container.querySelectorAll('.grid-slot');
+		expect(slots.length).toBe(2);
+	});
+});

--- a/UI/new-svelte/src/tests/routes/game/screens/inventory/InventoryToolbar.test.ts
+++ b/UI/new-svelte/src/tests/routes/game/screens/inventory/InventoryToolbar.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EItemCategory } from '$lib/api';
+
+// inventory-view.svelte.ts imports from $lib/engine and $stores at module level.
+vi.mock('$lib/engine', () => ({
+	EEquipmentSlot: { HelmSlot: 0, ChestSlot: 1, LegSlot: 2, BootSlot: 3, WeaponSlot: 4, AccessorySlot: 5 },
+	getEquipmentSlotForCategory: vi.fn((cat: number) => cat - 1),
+	inventoryManager: {
+		get unlockedItemList() {
+			return [];
+		},
+		unlockedMods: new Set<number>(),
+		equipItem: vi.fn(),
+		unequipItem: vi.fn(),
+		setFavorite: vi.fn(),
+		applyMod: vi.fn(),
+		removeMod: vi.fn()
+	}
+}));
+
+vi.mock('$stores', () => ({
+	staticData: { itemMods: [] }
+}));
+
+import InventoryToolbar from '$routes/game/screens/inventory/InventoryToolbar.svelte';
+import {
+	FILTER_CATEGORIES,
+	SORTS,
+	type InventoryView,
+	type SortKey
+} from '$routes/game/screens/inventory/inventory-view.svelte';
+
+const makeView = (overrides: Partial<{ filterCat: EItemCategory | null; favOnly: boolean; sort: SortKey }> = {}) =>
+	({
+		filterCat: null,
+		favOnly: false,
+		sort: 'category' as SortKey,
+		counts: { all: 10, cats: {} as Record<EItemCategory, number>, fav: 2 },
+		...overrides
+	}) as unknown as InventoryView;
+
+afterEach(cleanup);
+
+describe('InventoryToolbar', () => {
+	it('renders the "All" chip as active when no category filter is set', () => {
+		const { container } = render(InventoryToolbar, { props: { view: makeView() } });
+		const allChip = Array.from(container.querySelectorAll('button.chip')).find((b) =>
+			b.textContent?.includes('All')
+		) as HTMLElement;
+		expect(allChip).toBeTruthy();
+		expect(allChip.classList.contains('active')).toBe(true);
+	});
+
+	it('renders a chip for each filter category', () => {
+		const { container } = render(InventoryToolbar, { props: { view: makeView() } });
+		const chips = Array.from(container.querySelectorAll('button.chip'));
+		// One "All" chip, one per FILTER_CATEGORY, one favorites chip
+		expect(chips.length).toBe(FILTER_CATEGORIES.length + 2);
+	});
+
+	it('renders the Favorites chip', () => {
+		const { container } = render(InventoryToolbar, { props: { view: makeView() } });
+		const favChip = Array.from(container.querySelectorAll('button.chip.fav'))[0];
+		expect(favChip).toBeTruthy();
+		expect(favChip.textContent).toContain('Favorites');
+	});
+
+	it('renders a sort button for each sort key', () => {
+		const { container } = render(InventoryToolbar, { props: { view: makeView() } });
+		const sortKeys = Object.keys(SORTS) as SortKey[];
+		const sortButtons = container.querySelectorAll('.sort-option');
+		expect(sortButtons.length).toBe(sortKeys.length);
+	});
+
+	it('marks the active sort button with the active class', () => {
+		const { container } = render(InventoryToolbar, { props: { view: makeView({ sort: 'name' }) } });
+		const activeSort = Array.from(container.querySelectorAll('.sort-option')).find(
+			(b) => b.textContent?.trim() === SORTS.name.label
+		) as HTMLElement;
+		expect(activeSort).toBeTruthy();
+		expect(activeSort.classList.contains('active')).toBe(true);
+	});
+});

--- a/UI/new-svelte/src/tests/routes/game/screens/inventory/ItemDrawer.test.ts
+++ b/UI/new-svelte/src/tests/routes/game/screens/inventory/ItemDrawer.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { EAttribute, EItemCategory, EItemModType, ERarity } from '$lib/api';
+import { BattleAttributes, type Item } from '$lib/battle';
+
+// inventory-view.svelte.ts (imported as a type) pulls in $lib/engine at module level.
+vi.mock('$lib/engine', () => ({
+	EEquipmentSlot: { HelmSlot: 0, ChestSlot: 1, LegSlot: 2, BootSlot: 3, WeaponSlot: 4, AccessorySlot: 5 },
+	getEquipmentSlotForCategory: vi.fn(),
+	inventoryManager: {
+		get unlockedItemList() {
+			return [];
+		},
+		unlockedMods: new Set<number>(),
+		equipItem: vi.fn(),
+		unequipItem: vi.fn(),
+		setFavorite: vi.fn(),
+		applyMod: vi.fn(),
+		removeMod: vi.fn()
+	}
+}));
+
+vi.mock('$stores', () => ({
+	staticData: { itemMods: [] }
+}));
+
+import ItemDrawer from '$routes/game/screens/inventory/ItemDrawer.svelte';
+import type { InventoryView } from '$routes/game/screens/inventory/inventory-view.svelte';
+
+const makeItem = (overrides: Partial<Item> = {}): Item =>
+	({
+		id: 1,
+		itemId: 1,
+		name: 'Iron Sword',
+		description: 'A trusty blade.',
+		itemCategoryId: EItemCategory.Weapon,
+		rarityId: ERarity.Common,
+		iconPath: '',
+		attributes: [{ attributeId: EAttribute.Strength, amount: 10 }],
+		appliedMods: [],
+		modSlots: [],
+		tags: [],
+		equipped: false,
+		equipmentSlotId: undefined,
+		favorite: false,
+		totalAttributes: new BattleAttributes([{ attributeId: EAttribute.Strength, amount: 10 }], false),
+		...overrides
+	}) as unknown as Item;
+
+const makeView = (overrides = {}): InventoryView =>
+	({
+		select: vi.fn(),
+		toggleEquip: vi.fn(),
+		removeMod: vi.fn(),
+		applyMod: vi.fn(),
+		compatibleMods: vi.fn(() => []),
+		selectedId: null,
+		...overrides
+	}) as unknown as InventoryView;
+
+afterEach(cleanup);
+
+describe('ItemDrawer', () => {
+	it('renders the item name', () => {
+		const { getByText } = render(ItemDrawer, { props: { item: makeItem(), view: makeView() } });
+		expect(getByText('Iron Sword')).toBeTruthy();
+	});
+
+	it('shows "Equip" for an unequipped item', () => {
+		const { getByText } = render(ItemDrawer, {
+			props: { item: makeItem({ equipmentSlotId: undefined }), view: makeView() }
+		});
+		expect(getByText(/Equip/, { exact: false })).toBeTruthy();
+	});
+
+	it('shows "Unequip" for an equipped item', () => {
+		const { getByText } = render(ItemDrawer, {
+			props: { item: makeItem({ equipmentSlotId: 4 }), view: makeView() }
+		});
+		expect(getByText(/Unequip/, { exact: false })).toBeTruthy();
+	});
+
+	it('calls view.select(null) when the close button is clicked', async () => {
+		const view = makeView();
+		const { getByLabelText } = render(ItemDrawer, { props: { item: makeItem(), view } });
+		await fireEvent.click(getByLabelText('Close'));
+		expect(view.select).toHaveBeenCalledWith(null);
+	});
+
+	it('renders the mod slots section', () => {
+		const item = makeItem({
+			modSlots: [{ id: 10, itemId: 1, itemModSlotTypeId: EItemModType.Prefix }]
+		});
+		const { getByText } = render(ItemDrawer, { props: { item, view: makeView() } });
+		expect(getByText(/Mod slots/)).toBeTruthy();
+	});
+
+	it('shows "No mod slots" text when item has no mod slots', () => {
+		const { getByText } = render(ItemDrawer, { props: { item: makeItem(), view: makeView() } });
+		expect(getByText('This item has no mod slots.')).toBeTruthy();
+	});
+
+	it('renders the item description when present', () => {
+		const { getByText } = render(ItemDrawer, { props: { item: makeItem(), view: makeView() } });
+		expect(getByText('A trusty blade.')).toBeTruthy();
+	});
+});


### PR DESCRIPTION
## Summary

Closes #119

Adds unit tests for 11 previously-uncovered Svelte components, bringing all components listed in the issue to full test coverage:

**Shared components (`src/components/`)**
- `Loading.svelte` — spinner visibility, overlay, delay suppression
- `Select.svelte` — label rendering, blank option, option list
- `Tooltip.svelte` — role attribute, hidden-when-not-visible, node appending via the `$effect`
- `TooltipBase.svelte` — renders zero/one tooltip containers based on store data

**Inventory screen (`src/routes/game/screens/inventory/`)**
- `Inventory.svelte` — screen container, title, drawer initially closed, equipped rail
- `InventoryGrid.svelte` — empty state, item count, pager visibility and disabled state, slot count
- `InventoryToolbar.svelte` — active "All" chip, category chips, favorites chip, sort buttons, active sort class
- `ItemDrawer.svelte` — item name, Equip/Unequip button, close action, mod slots section, description

**Admin Workbench (`src/routes/admin/workbench/`)**
- `WorkbenchList.svelte` — row rendering, entity label, selected row, New button, search filtering, "new" spill badge
- `WorkbenchDetail.svelte` — empty state, record name/id, section tab, Save/Discard button states, "new" spill badge, delete action
- `Workbench.svelte` — pre-load state (no content), entity label after load, record count, list pane, group label in eyebrow

## Approach

- Follows established patterns: `vi.hoisted` + `vi.mock` for `$lib/engine` and `$stores` dependencies; real `EntityStore` instances for workbench tests; `flushSync` where Svelte reactive effects need flushing mid-test.
- The `$stores` mock includes the `logs` export for test files that transitively import from the `$components` barrel (which re-exports `LogPanel`).
- The Tooltip `style` computed via `$derived.by` depends on `bind:this` timing; the test verifies node-appending behavior instead of the position-derived inline style, which is more reliable in JSDOM.

## Test plan

- [x] All 624 unit tests pass (`npm run test:unit:ci`)
- [x] Lint clean (`npm run lint`)
- [x] Backend builds clean (`dotnet build`)

https://claude.ai/code/session_01ELqCNcdg8kocq6ye1gU3ii

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELqCNcdg8kocq6ye1gU3ii)_