### PR TITLE
Reconcile IPubSubService/IPubSubQueue nullability with their implementations

### DIFF
--- a/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
@@ -43,7 +43,7 @@ namespace Game.Infrastructure.PubSub.Redis
 
         public async Task Publish<T>(string channel, string queueName, T queueData)
         {
-            await Publish(channel, queueName, queueData!.Serialize());
+            await Publish(channel, queueName, queueData.Serialize());
         }
 
         public async Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null)

--- a/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
@@ -34,19 +34,16 @@ namespace Game.Infrastructure.PubSub.Redis
             return new RedisQueue(Redis, queueName, _loggerFactory.CreateLogger<RedisQueue>());
         }
 
-        public async Task Publish(string channel, string queueName, string? queueData)
+        public async Task Publish(string channel, string queueName, string queueData)
         {
-            // Uses the concrete RedisQueue (whose overload tolerates a null payload) rather than the
-            // IPubSubQueue-typed GetQueue, whose AddToQueueAsync contract is non-null.
-            var queue = new RedisQueue(Redis, queueName, _loggerFactory.CreateLogger<RedisQueue>());
+            var queue = GetQueue(queueName);
             await queue.AddToQueueAsync(queueData);
             await Redis.PublishAsync(RedisChannel.Literal(channel), "");
         }
 
         public async Task Publish<T>(string channel, string queueName, T queueData)
         {
-            var data = queueData?.Serialize();
-            await Publish(channel, queueName, data);
+            await Publish(channel, queueName, queueData!.Serialize());
         }
 
         public async Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null)

--- a/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
@@ -52,7 +52,7 @@ namespace Game.Infrastructure.PubSub.Redis
             return val.Deserialize<T>();
         }
 
-        public void AddToQueue(string? value)
+        public void AddToQueue(string value)
         {
             _logger.LogTrace("Retrieved value from RedisQueue: {QueueName}, value: {Value}", QueueName, value);
             _redis.ListRightPush(QueueName, value);
@@ -60,10 +60,10 @@ namespace Game.Infrastructure.PubSub.Redis
 
         public void AddToQueue<T>(T value)
         {
-            AddToQueue(value?.Serialize());
+            AddToQueue(value!.Serialize());
         }
 
-        public Task AddToQueueAsync(string? value)
+        public Task AddToQueueAsync(string value)
         {
             _logger.LogTrace("Retrieved value from RedisQueue: {QueueName}, value: {Value}", QueueName, value);
             return _redis.ListRightPushAsync(QueueName, value);
@@ -71,7 +71,7 @@ namespace Game.Infrastructure.PubSub.Redis
 
         public Task AddToQueueAsync<T>(T value)
         {
-            return AddToQueueAsync(value?.Serialize());
+            return AddToQueueAsync(value!.Serialize());
         }
     }
 }

--- a/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
@@ -1,5 +1,5 @@
-﻿using Game.Core;
-using Game.Abstractions.Infrastructure;
+﻿using Game.Abstractions.Infrastructure;
+using Game.Core;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 
@@ -60,7 +60,7 @@ namespace Game.Infrastructure.PubSub.Redis
 
         public void AddToQueue<T>(T value)
         {
-            AddToQueue(value!.Serialize());
+            AddToQueue(value.Serialize());
         }
 
         public Task AddToQueueAsync(string value)
@@ -71,7 +71,7 @@ namespace Game.Infrastructure.PubSub.Redis
 
         public Task AddToQueueAsync<T>(T value)
         {
-            return AddToQueueAsync(value!.Serialize());
+            return AddToQueueAsync(value.Serialize());
         }
     }
 }


### PR DESCRIPTION
## Summary

- Remove `string?` from `RedisQueue.AddToQueue` and `AddToQueueAsync` so the signatures match the non-nullable contract declared on `IPubSubQueue`
- Remove `string?` from `RedisPubSubService.Publish(string, string, string)` to match `IPubSubService`
- The generic `AddToQueue<T>` / `AddToQueueAsync<T>` helpers now use `value!.Serialize()` — safe because `JsonSerializer.Serialize` handles null, producing the JSON `"null"` string
- `Publish<T>` serializes then delegates to the string overload; the string overload now uses `GetQueue` instead of constructing a concrete `RedisQueue` directly, removing the workaround comment added in #121

Pure consistency/cleanup — no behavioral change intended.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 545 tests pass (Game.Core.Tests, Game.Application.Tests, Game.Api.Tests)

Closes #122

https://claude.ai/code/session_01KtVYxA4Mp52aP1tGaxzdkn

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtVYxA4Mp52aP1tGaxzdkn)_