### PR TITLE
Replace hardcoded rgba() colors with color-mix() theme tokens (#143)

### DIFF
--- a/UI/new-svelte/src/components/Loading.svelte
+++ b/UI/new-svelte/src/components/Loading.svelte
@@ -57,7 +57,7 @@ $outer-rotation-count: 3;
 	cursor: not-allowed;
 	z-index: 10;
 	inset: 0;
-	background: rgba(0, 0, 0, 0.5);
+	background: color-mix(in srgb, var(--black) 50%, transparent);
 }
 
 .loading-spinner-container {

--- a/UI/new-svelte/src/routes/game/screens/PlaceholderScreen.svelte
+++ b/UI/new-svelte/src/routes/game/screens/PlaceholderScreen.svelte
@@ -33,7 +33,7 @@ const { label }: Props = $props();
 	width: 64px;
 	height: 64px;
 	border-radius: 2px;
-	border: 1px dashed rgba(240, 240, 240, 0.18);
+	border: 1px dashed color-mix(in srgb, var(--white) 18%, transparent);
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -43,14 +43,14 @@ const { label }: Props = $props();
 	width: 16px;
 	height: 16px;
 	transform: rotate(45deg);
-	border: 1px solid rgba(240, 240, 240, 0.4);
+	border: 1px solid color-mix(in srgb, var(--white) 40%, transparent);
 	position: relative;
 }
 
 .placeholder-diamond-inner {
 	position: absolute;
 	inset: 4px;
-	background: rgba(240, 240, 240, 0.4);
+	background: color-mix(in srgb, var(--white) 40%, transparent);
 }
 
 .placeholder-title {
@@ -64,7 +64,7 @@ const { label }: Props = $props();
 	margin-top: 4px;
 	font-family: var(--mono);
 	font-size: 11px;
-	color: rgba(240, 240, 240, 0.5);
+	color: color-mix(in srgb, var(--text-primary) 50%, transparent);
 	letter-spacing: 1px;
 	text-transform: uppercase;
 }


### PR DESCRIPTION
## Summary

- **`Loading.svelte`**: overlay `rgba(0,0,0,0.5)` → `color-mix(in srgb, var(--black) 50%, transparent)`
- **`PlaceholderScreen.svelte`**: four `rgba(240,240,240,…)` literals replaced with `color-mix()` over `--white` (borders/fills) and `--text-primary` (subtitle text)
- `Toast.svelte` was already using `color-mix()` — no change needed there

All replacements use tokens already declared in `+layout.svelte`, so no new CSS variables were added. No visual change at the default theme.

## Test plan

- [x] `npm run lint` — no errors
- [x] `npm run test:unit:ci` — 642 tests pass
- [x] Verified no `rgba(...)` literals remain in any `.svelte` file under `src/`

Closes #143

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpfhcQweisiYgZbQ1mV6hC)_