### PR TITLE
Strengthen battle-logic test parity between frontend and backend

### DIFF
--- a/Game.Core.Tests/Attributes/BattleAttributesParityTests.cs
+++ b/Game.Core.Tests/Attributes/BattleAttributesParityTests.cs
@@ -1,0 +1,73 @@
+using Game.Core.Attributes;
+using Game.Core.Attributes.Modifiers;
+using Xunit;
+
+namespace Game.Core.Tests.Attributes
+{
+    /// <summary>
+    /// Parity guard for the shared derived-stat formulas. These cases mirror,
+    /// with identical inputs and identical expected values, the
+    /// "derived stat computation" block of the frontend suite
+    /// <c>UI/new-svelte/src/tests/lib/battle/battle-attributes.test.ts</c>.
+    /// The formula constants live in two hand-maintained places —
+    /// <see cref="StaticAttributeModifiers"/> on the backend and
+    /// <c>STATIC_ATTRIBUTE_MODIFIERS</c> on the frontend — and the battle
+    /// simulation on both sides depends on them agreeing, so these assertions
+    /// exist to make any silent drift between the two fail a build.
+    /// </summary>
+    public class BattleAttributesParityTests
+    {
+        [Fact]
+        public void MaxHealth_Is50Plus20EndurancePlus5Strength()
+        {
+            var collection = MakeCollection(
+                (EAttribute.Strength, 10),
+                (EAttribute.Endurance, 20));
+
+            Assert.Equal(50 + 20 * 20 + 5 * 10, collection[EAttribute.MaxHealth]);
+        }
+
+        [Fact]
+        public void Defense_Is2PlusEndurancePlusHalfAgility()
+        {
+            var collection = MakeCollection(
+                (EAttribute.Endurance, 30),
+                (EAttribute.Agility, 20));
+
+            Assert.Equal(2 + 30 + 0.5 * 20, collection[EAttribute.Defense]);
+        }
+
+        [Fact]
+        public void CooldownRecovery_IsFourTenthsAgilityPlusOneTenthDexterity()
+        {
+            var collection = MakeCollection(
+                (EAttribute.Agility, 20),
+                (EAttribute.Dexterity, 10));
+
+            Assert.Equal(0.4 * 20 + 0.1 * 10, collection[EAttribute.CooldownRecovery]);
+        }
+
+        [Fact]
+        public void ZeroBaseStats_StillHaveDerivedBaseValues()
+        {
+            var collection = MakeCollection();
+
+            Assert.Equal(50, collection[EAttribute.MaxHealth]);
+            Assert.Equal(2, collection[EAttribute.Defense]);
+            Assert.Equal(0, collection[EAttribute.CooldownRecovery]);
+        }
+
+        private static AttributeCollection MakeCollection(params (EAttribute Attribute, double Amount)[] allocations)
+        {
+            var modifiers = allocations.Select(a => new AttributeModifier
+            {
+                Attribute = a.Attribute,
+                Amount = a.Amount,
+                Type = EModifierType.Additive,
+                Source = EAttributeModifierSource.PlayerStatPoints,
+            });
+
+            return new AttributeCollection(modifiers);
+        }
+    }
+}

--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -10,118 +10,149 @@ using Xunit;
 namespace Game.Core.Tests.Battle
 {
     /// <summary>
-    /// Tests that produce deterministic totalMs values for cross-checking
-    /// against the frontend battle simulation.
+    /// Cross-implementation parity matrix for the deterministic battle simulation.
+    /// Every scenario here MUST be mirrored — with identical inputs and identical
+    /// expected <c>totalMs</c>/outcome — in the frontend suite
+    /// <c>UI/new-svelte/src/tests/lib/battle/battle-simulation-parity.test.ts</c>.
+    /// The two simulators run on both the client and the server (the anti-cheat
+    /// replay depends on them agreeing), so any new battle behaviour added on one
+    /// side should gain a matching row here on the other.
     /// </summary>
     public class BattleSimulatorParityTests
     {
         /// <summary>
-        /// Scenario with CooldownRecovery > 0 to exercise the cdMultiplier path.
-        /// Frontend must produce the same totalMs when using RAW stat allocations
-        /// (not pre-computed final attribute values from the API).
+        /// A single deterministic battle scenario: the inputs that build both
+        /// combatants plus the exact result the simulation must produce.
         /// </summary>
-        [Fact]
-        public void Parity_WithCooldownRecovery_MatchesExpectedTotalMs()
+        public sealed record ParityScenario(
+            Func<Battler> Player,
+            Func<Battler> Enemy,
+            bool ExpectedVictory,
+            bool ExpectedPlayerDied,
+            int ExpectedTotalMs,
+            int? MaxMs = null);
+
+        /// <summary>
+        /// The shared scenario table. Keyed by name so xUnit can drive a
+        /// <see cref="TheoryAttribute"/> over the names without serializing the
+        /// (non-serializable) builders; the test resolves the full scenario by name.
+        /// </summary>
+        public static readonly IReadOnlyDictionary<string, ParityScenario> Scenarios =
+            new Dictionary<string, ParityScenario>
+            {
+                // Single skill, CooldownRecovery > 0 — exercises the cdMultiplier path.
+                //   Player: MaxHealth=900, Def=42, CDR=9 → cdMult=1.09
+                //     charge/tick = 40*1.09 = 43.6, fires every 28 ticks (28*43.6=1220.8≥1200)
+                //     damage = 10 + 50*1.5 = 85, after def = 85-17 = 68
+                //   Enemy:  MaxHealth=400, Def=17, CDR=0; damage = 5-42 = 0 (clamped)
+                //   6 hits to kill (6*68=408>400), at ticks 28,56,84,112,140,168 → 6720ms
+                ["cooldownRecovery"] = new ParityScenario(
+                    Player: () => MakeBattler(
+                        strength: 50, endurance: 30, agility: 20, dexterity: 10,
+                        skills: [MakeSkill(1, baseDamage: 10, cooldownMs: 1200, mult: EAttribute.Strength, multAmount: 1.5)]),
+                    Enemy: () => MakeEnemy(
+                        strength: 10, endurance: 15,
+                        skills: [MakeSkill(2, baseDamage: 5, cooldownMs: 2000)]),
+                    ExpectedVictory: true,
+                    ExpectedPlayerDied: false,
+                    ExpectedTotalMs: 6720),
+
+                // Two player skills firing on different cooldowns against an enemy
+                // that deals real (non-clamped) damage — a genuine multi-skill exchange.
+                //   Player: MaxHealth=600, Def=22, cdMult=1
+                //     skillA: 20 + 30*1.0 = 50 raw, after def = 33, fires every 20 ticks
+                //     skillB: 25 raw, after def = 8, fires every 30 ticks
+                //   Enemy:  MaxHealth=450, Def=17; attack 30 raw, after def = 8, every 25 ticks
+                //   Cumulative player damage first reaches 450 at tick 240 → 9600ms.
+                ["multiSkill"] = new ParityScenario(
+                    Player: () => MakeBattler(
+                        strength: 30, endurance: 20,
+                        skills:
+                        [
+                            MakeSkill(1, baseDamage: 20, cooldownMs: 800, mult: EAttribute.Strength, multAmount: 1.0),
+                            MakeSkill(2, baseDamage: 25, cooldownMs: 1200),
+                        ]),
+                    Enemy: () => MakeEnemy(
+                        strength: 20, endurance: 15,
+                        skills: [MakeSkill(3, baseDamage: 30, cooldownMs: 1000)]),
+                    ExpectedVictory: true,
+                    ExpectedPlayerDied: false,
+                    ExpectedTotalMs: 9600),
+
+                // Both combatants have so much Defense that every hit clamps to 0,
+                // so neither can ever win — the battle runs to the timeout.
+                //   Player/Enemy: Def=52 each; attacks 5 raw → 5-52 clamped to 0.
+                ["highDefenseFloor"] = new ParityScenario(
+                    Player: () => MakeBattler(
+                        strength: 0, endurance: 50,
+                        skills: [MakeSkill(1, baseDamage: 5, cooldownMs: 1000)]),
+                    Enemy: () => MakeEnemy(
+                        strength: 0, endurance: 50,
+                        skills: [MakeSkill(2, baseDamage: 5, cooldownMs: 1000)]),
+                    ExpectedVictory: false,
+                    ExpectedPlayerDied: false,
+                    ExpectedTotalMs: 40 * 10000),
+
+                // Neither side has any skills, so no damage is ever dealt and the
+                // battle runs to the default timeout.
+                ["noSkills"] = new ParityScenario(
+                    Player: () => MakeBattler(strength: 10, endurance: 10, skills: []),
+                    Enemy: () => MakeEnemy(strength: 10, endurance: 10, skills: []),
+                    ExpectedVictory: false,
+                    ExpectedPlayerDied: false,
+                    ExpectedTotalMs: 40 * 10000),
+
+                // The cooldownRecovery matchup capped well before either skill fires:
+                // the simulation stops at maxMs with no winner.
+                ["maxMsCap"] = new ParityScenario(
+                    Player: () => MakeBattler(
+                        strength: 50, endurance: 30, agility: 20, dexterity: 10,
+                        skills: [MakeSkill(1, baseDamage: 10, cooldownMs: 1200, mult: EAttribute.Strength, multAmount: 1.5)]),
+                    Enemy: () => MakeEnemy(
+                        strength: 10, endurance: 15,
+                        skills: [MakeSkill(2, baseDamage: 5, cooldownMs: 2000)]),
+                    ExpectedVictory: false,
+                    ExpectedPlayerDied: false,
+                    ExpectedTotalMs: 200,
+                    MaxMs: 200),
+            };
+
+        public static IEnumerable<object[]> ScenarioNames =>
+            Scenarios.Keys.Select(name => new object[] { name });
+
+        [Theory]
+        [MemberData(nameof(ScenarioNames))]
+        public void Parity_Scenario_MatchesExpectedResult(string scenarioName)
         {
-            var playerSkill = new Skill
-            {
-                Id = 1,
-                Name = "Slash",
-                Description = "",
-                CooldownMs = 1200,
-                BaseDamage = 10,
-                DamageMultipliers =
-                [
-                    new AttributeModifier
-                    {
-                        Attribute = EAttribute.Strength,
-                        Amount = 1.5,
-                        Type = EModifierType.Multiplicative,
-                        Source = EAttributeModifierSource.Derived,
-                    }
-                ],
-            };
+            var scenario = Scenarios[scenarioName];
 
-            var enemySkill = new Skill
-            {
-                Id = 2,
-                Name = "Bite",
-                Description = "",
-                CooldownMs = 2000,
-                BaseDamage = 5,
-                DamageMultipliers = [],
-            };
+            var sim = new BattleSimulator(scenario.Player(), scenario.Enemy());
+            var result = sim.Simulate(scenario.MaxMs);
 
-            var player = MakePlayer(
-                strength: 50, endurance: 30, agility: 20, dexterity: 10,
-                skills: [playerSkill]);
-
-            var enemy = MakeEnemy(
-                strength: 10, endurance: 15,
-                skills: [enemySkill]);
-
-            var sim = new BattleSimulator(new Battler(player), enemy);
-            var result = sim.Simulate();
-
-            Assert.True(result.Victory, "Player should win this matchup.");
+            Assert.Equal(scenario.ExpectedVictory, result.Victory);
+            Assert.Equal(scenario.ExpectedPlayerDied, result.PlayerDied);
+            Assert.Equal(scenario.ExpectedTotalMs, result.TotalMs);
             Assert.Equal(0, result.TotalMs % 40);
-
-            // Record the authoritative value — the frontend test must match this exactly.
-            // Player: MaxHealth=900, Def=42, CDR=9 → cdMult=1.09
-            //   charge/tick = 40*1.09 = 43.6, fires every 28 ticks (28*43.6=1220.8≥1200)
-            //   damage = 10 + 50*1.5 = 85, after def = 85-17 = 68
-            // Enemy:  MaxHealth=400, Def=17, CDR=0
-            //   damage = 5-42 = 0 (clamped)
-            // 6 hits to kill (6*68=408>400), at ticks 28,56,84,112,140,168 → 6720ms
-            Assert.Equal(6720, result.TotalMs);
         }
 
         /// <summary>
-        /// Demonstrates what happens if the player's derived stats are doubled
-        /// (the bug the frontend currently has). CooldownRecovery doubles from 9→18,
-        /// cdMultiplier goes from 1.09→1.18, skills fire every 26 ticks instead of 28.
+        /// Demonstrates what happens if the player's derived stats are double-counted
+        /// (the bug the frontend used to have). CooldownRecovery doubles from 9→18,
+        /// cdMultiplier goes from 1.09→1.18, skills fire every 26 ticks instead of 28,
+        /// so the same matchup as the <c>cooldownRecovery</c> scenario ends sooner.
+        /// Kept separate from the matrix because it builds the player from already-final
+        /// attribute values rather than raw allocations.
         /// </summary>
         [Fact]
         public void Parity_DoubleDerivedStats_ProducesShorterBattle()
         {
-            var playerSkill = new Skill
-            {
-                Id = 1,
-                Name = "Slash",
-                Description = "",
-                CooldownMs = 1200,
-                BaseDamage = 10,
-                DamageMultipliers =
-                [
-                    new AttributeModifier
-                    {
-                        Attribute = EAttribute.Strength,
-                        Amount = 1.5,
-                        Type = EModifierType.Multiplicative,
-                        Source = EAttributeModifierSource.Derived,
-                    }
-                ],
-            };
-
-            var enemySkill = new Skill
-            {
-                Id = 2,
-                Name = "Bite",
-                Description = "",
-                CooldownMs = 2000,
-                BaseDamage = 5,
-                DamageMultipliers = [],
-            };
-
-            // Simulate what the frontend does: start with FINAL attribute values
-            // (which already include derived stats), then add derived stats AGAIN.
             var player = MakePlayerWithDoubleDerivedStats(
                 strength: 50, endurance: 30, agility: 20, dexterity: 10,
-                skills: [playerSkill]);
+                skills: [MakeSkill(1, baseDamage: 10, cooldownMs: 1200, mult: EAttribute.Strength, multAmount: 1.5)]);
 
             var enemy = MakeEnemy(
                 strength: 10, endurance: 15,
-                skills: [enemySkill]);
+                skills: [MakeSkill(2, baseDamage: 5, cooldownMs: 2000)]);
 
             var sim = new BattleSimulator(new Battler(player), enemy);
             var result = sim.Simulate();
@@ -131,6 +162,36 @@ namespace Game.Core.Tests.Battle
             // charge/tick = 47.2, fires every 26 ticks → 6240ms
             Assert.Equal(6240, result.TotalMs);
             Assert.True(result.TotalMs < 6720, "Double-counted stats should end the battle sooner.");
+        }
+
+        private static Skill MakeSkill(
+            int id, double baseDamage, int cooldownMs,
+            EAttribute? mult = null, double multAmount = 0) => new()
+            {
+                Id = id,
+                Name = $"Skill {id}",
+                Description = "",
+                CooldownMs = cooldownMs,
+                BaseDamage = baseDamage,
+                DamageMultipliers = mult is null
+                    ? []
+                    :
+                    [
+                        new AttributeModifier
+                        {
+                            Attribute = mult.Value,
+                            Amount = multAmount,
+                            Type = EModifierType.Multiplicative,
+                            Source = EAttributeModifierSource.Derived,
+                        }
+                    ],
+            };
+
+        private static Battler MakeBattler(
+            double strength, double endurance, double agility = 0, double dexterity = 0,
+            List<Skill>? skills = null)
+        {
+            return new Battler(MakePlayer(strength, endurance, agility, dexterity, skills));
         }
 
         private static Player MakePlayer(

--- a/UI/new-svelte/src/lib/battle/battle-attributes.ts
+++ b/UI/new-svelte/src/lib/battle/battle-attributes.ts
@@ -35,9 +35,6 @@ export class BattleAttributes {
 			for (const [attr, result] of computed) {
 				this.attributes[attr] = result.total;
 			}
-			// DropBonus uses log10(Luck), which cannot be expressed as a constant
-			// modifier in the pipeline; computed as a post-step once Luck is resolved.
-			this.attributes[EAttribute.DropBonus] += Math.log10(this.attributes[EAttribute.Luck]);
 		} else {
 			for (const att of attList) {
 				this.attributes[att.attributeId] += att.amount;

--- a/UI/new-svelte/src/tests/lib/battle/battle-attributes.test.ts
+++ b/UI/new-svelte/src/tests/lib/battle/battle-attributes.test.ts
@@ -50,21 +50,11 @@ describe('BattleAttributes', () => {
 			expect(ba.getValue(EAttribute.CooldownRecovery)).toBe(0.4 * 20 + 0.1 * 10);
 		});
 
-		it('calculates DropBonus = log10(Luck)', () => {
-			const ba = new BattleAttributes(makeAttrs([EAttribute.Luck, 100]));
-			expect(ba.getValue(EAttribute.DropBonus)).toBeCloseTo(2, 10);
-		});
-
 		it('handles zero base stats (MaxHealth still has base 50)', () => {
 			const ba = new BattleAttributes([]);
 			expect(ba.getValue(EAttribute.MaxHealth)).toBe(50);
 			expect(ba.getValue(EAttribute.Defense)).toBe(2);
 			expect(ba.getValue(EAttribute.CooldownRecovery)).toBe(0);
-		});
-
-		it('DropBonus is -Infinity when Luck is 0 (log10(0))', () => {
-			const ba = new BattleAttributes(makeAttrs([EAttribute.Luck, 0]));
-			expect(ba.getValue(EAttribute.DropBonus)).toBe(-Infinity);
 		});
 	});
 

--- a/UI/new-svelte/src/tests/lib/battle/battle-simulation-parity.test.ts
+++ b/UI/new-svelte/src/tests/lib/battle/battle-simulation-parity.test.ts
@@ -3,21 +3,35 @@ import { EAttribute } from '$lib/api';
 import { BattleAttributes } from '$lib/battle/battle-attributes';
 
 /**
- * Pure simulation loop that mirrors the backend BattleSimulator exactly.
- * No runtime dependencies — just math.
+ * Pure simulation loop that mirrors the backend Game.Core.Battle.BattleSimulator
+ * exactly. No runtime dependencies — just math. Returning the same shape as the
+ * backend's BattleResult lets the parity matrix below assert the full outcome
+ * (victory / playerDied / totalMs), not just the duration.
  */
-function simulateBattle(player: SimBattler, enemy: SimBattler): number {
-	const msPerTick = 40;
-	const maxMs = msPerTick * 10000;
+const msPerTick = 40;
+const defaultMaxMs = msPerTick * 10000;
 
-	for (let totalMs = msPerTick; totalMs <= maxMs; totalMs += msPerTick) {
+interface SimResult {
+	victory: boolean;
+	playerDied: boolean;
+	totalMs: number;
+}
+
+function simulateBattle(player: SimBattler, enemy: SimBattler, maxMs: number = defaultMaxMs): SimResult {
+	let totalMs = msPerTick;
+	for (; totalMs <= maxMs; totalMs += msPerTick) {
 		updateBattler(player, enemy, msPerTick);
-		if (enemy.currentHealth <= 0) return totalMs;
+		if (enemy.currentHealth <= 0) {
+			return { victory: true, playerDied: false, totalMs };
+		}
 
 		updateBattler(enemy, player, msPerTick);
-		if (player.currentHealth <= 0) return totalMs;
+		if (player.currentHealth <= 0) {
+			return { victory: false, playerDied: true, totalMs };
+		}
 	}
-	return maxMs + msPerTick;
+	// Mirror the backend's timeout return: the last simulated tick (maxMs), not maxMs + one tick.
+	return { victory: false, playerDied: false, totalMs: totalMs - msPerTick };
 }
 
 function updateBattler(attacker: SimBattler, defender: SimBattler, timeDelta: number) {
@@ -72,61 +86,143 @@ function makeBattlerFromRaw(attrs: { id: EAttribute; amount: number }[], skills:
 	};
 }
 
-/**
- * Creates a battler from FINAL attribute values (as the API sends for the player),
- * then recalculates derived stats — reproducing the double-counting bug.
- */
-function makeBattlerFromFinalValues(attrs: { id: EAttribute; amount: number }[], skills: SimSkill[]): SimBattler {
-	const battlerAttrs = attrs.map((a) => ({ attributeId: a.id, amount: a.amount }));
-	// calcDerivedStats=true adds derived stats on top of the already-final values
-	const ba = new BattleAttributes(battlerAttrs, true);
-	return {
-		attributes: ba,
-		currentHealth: ba.getValue(EAttribute.MaxHealth),
-		cdMultiplier: 1 + ba.getValue(EAttribute.CooldownRecovery) / 100,
-		skills
-	};
+// ── Shared parity matrix ───────────────────────────────────────────────────────
+// Every scenario here MUST mirror — with identical inputs and identical expected
+// totalMs/outcome — a row in the backend suite
+// Game.Core.Tests/Battle/BattleSimulatorParityTests.cs (the `Scenarios` table).
+// The two simulators run on both the client and the server, so a divergence here
+// would let the anti-cheat replay disagree with the live battle.
+
+interface ParityScenario {
+	name: string;
+	player: () => SimBattler;
+	enemy: () => SimBattler;
+	maxMs?: number;
+	expected: SimResult;
 }
 
-// ── Test scenario ────────────────────────────────────────────────────────────
-// Must match Game.Core.Tests.Battle.BattleSimulatorParityTests exactly.
-//
-// Player raw stats: Str=50, End=30, Agi=20, Dex=10
-//   Derived: MaxHealth=900, Defense=42, CooldownRecovery=9
-// Player skill: BaseDmg=10, {Str*1.5}, CD=1200
-//
-// Enemy raw stats: Str=10, End=15
-//   Derived: MaxHealth=400, Defense=17, CooldownRecovery=0
-// Enemy skill: BaseDmg=5, no multipliers, CD=2000
+const scenarios: ParityScenario[] = [
+	// Single skill, CooldownRecovery > 0 — exercises the cdMultiplier path.
+	//   Player: MaxHealth=900, Def=42, CDR=9 → cdMult=1.09; damage 85, after def 68.
+	//   Enemy:  MaxHealth=400, Def=17; damage 5-42 clamped to 0.
+	//   6 hits at ticks 28,56,84,112,140,168 → 6720ms.
+	{
+		name: 'cooldownRecovery',
+		player: () =>
+			makeBattlerFromRaw(
+				[
+					{ id: EAttribute.Strength, amount: 50 },
+					{ id: EAttribute.Endurance, amount: 30 },
+					{ id: EAttribute.Agility, amount: 20 },
+					{ id: EAttribute.Dexterity, amount: 10 }
+				],
+				[makeSkill(10, 1200, [{ attributeId: EAttribute.Strength, amount: 1.5 }])]
+			),
+		enemy: () =>
+			makeBattlerFromRaw(
+				[
+					{ id: EAttribute.Strength, amount: 10 },
+					{ id: EAttribute.Endurance, amount: 15 }
+				],
+				[makeSkill(5, 2000)]
+			),
+		expected: { victory: true, playerDied: false, totalMs: 6720 }
+	},
 
-const playerRawAttrs = [
-	{ id: EAttribute.Strength, amount: 50 },
-	{ id: EAttribute.Endurance, amount: 30 },
-	{ id: EAttribute.Agility, amount: 20 },
-	{ id: EAttribute.Dexterity, amount: 10 }
+	// Two player skills on different cooldowns vs an enemy that deals real damage.
+	//   Player: MaxHealth=600, Def=22; skillA 50 raw→33 every 20 ticks, skillB 25 raw→8 every 30 ticks.
+	//   Enemy:  MaxHealth=450, Def=17; attack 30 raw→8 every 25 ticks.
+	//   Cumulative player damage first reaches 450 at tick 240 → 9600ms.
+	{
+		name: 'multiSkill',
+		player: () =>
+			makeBattlerFromRaw(
+				[
+					{ id: EAttribute.Strength, amount: 30 },
+					{ id: EAttribute.Endurance, amount: 20 }
+				],
+				[makeSkill(20, 800, [{ attributeId: EAttribute.Strength, amount: 1.0 }]), makeSkill(25, 1200)]
+			),
+		enemy: () =>
+			makeBattlerFromRaw(
+				[
+					{ id: EAttribute.Strength, amount: 20 },
+					{ id: EAttribute.Endurance, amount: 15 }
+				],
+				[makeSkill(30, 1000)]
+			),
+		expected: { victory: true, playerDied: false, totalMs: 9600 }
+	},
+
+	// Both sides have so much Defense that every hit clamps to 0 — runs to timeout.
+	//   Player/Enemy: Def=52 each; attacks 5 raw → 5-52 clamped to 0.
+	{
+		name: 'highDefenseFloor',
+		player: () => makeBattlerFromRaw([{ id: EAttribute.Endurance, amount: 50 }], [makeSkill(5, 1000)]),
+		enemy: () => makeBattlerFromRaw([{ id: EAttribute.Endurance, amount: 50 }], [makeSkill(5, 1000)]),
+		expected: { victory: false, playerDied: false, totalMs: msPerTick * 10000 }
+	},
+
+	// Neither side has skills, so no damage is dealt — runs to the default timeout.
+	{
+		name: 'noSkills',
+		player: () =>
+			makeBattlerFromRaw(
+				[
+					{ id: EAttribute.Strength, amount: 10 },
+					{ id: EAttribute.Endurance, amount: 10 }
+				],
+				[]
+			),
+		enemy: () =>
+			makeBattlerFromRaw(
+				[
+					{ id: EAttribute.Strength, amount: 10 },
+					{ id: EAttribute.Endurance, amount: 10 }
+				],
+				[]
+			),
+		expected: { victory: false, playerDied: false, totalMs: msPerTick * 10000 }
+	},
+
+	// The cooldownRecovery matchup capped before either skill fires: stops at maxMs.
+	{
+		name: 'maxMsCap',
+		player: () =>
+			makeBattlerFromRaw(
+				[
+					{ id: EAttribute.Strength, amount: 50 },
+					{ id: EAttribute.Endurance, amount: 30 },
+					{ id: EAttribute.Agility, amount: 20 },
+					{ id: EAttribute.Dexterity, amount: 10 }
+				],
+				[makeSkill(10, 1200, [{ attributeId: EAttribute.Strength, amount: 1.5 }])]
+			),
+		enemy: () =>
+			makeBattlerFromRaw(
+				[
+					{ id: EAttribute.Strength, amount: 10 },
+					{ id: EAttribute.Endurance, amount: 15 }
+				],
+				[makeSkill(5, 2000)]
+			),
+		maxMs: 200,
+		expected: { victory: false, playerDied: false, totalMs: 200 }
+	}
 ];
-
-const enemyRawAttrs = [
-	{ id: EAttribute.Strength, amount: 10 },
-	{ id: EAttribute.Endurance, amount: 15 }
-];
-
-function playerSkill(): SimSkill {
-	return makeSkill(10, 1200, [{ attributeId: EAttribute.Strength, amount: 1.5 }]);
-}
-
-function enemySkill(): SimSkill {
-	return makeSkill(5, 2000);
-}
-
-// ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('Battle simulation parity with backend', () => {
-	it('produces the correct totalMs with raw stat allocations (should match backend)', () => {
-		const player = makeBattlerFromRaw(playerRawAttrs, [playerSkill()]);
-		const enemy = makeBattlerFromRaw(enemyRawAttrs, [enemySkill()]);
+	for (const scenario of scenarios) {
+		it(`matches the backend for the ${scenario.name} scenario`, () => {
+			const result = simulateBattle(scenario.player(), scenario.enemy(), scenario.maxMs);
+			expect(result).toEqual(scenario.expected);
+		});
+	}
 
-		// Verify derived stats match expected values
+	it('resolves the cooldownRecovery derived stats to the expected values', () => {
+		const player = scenarios[0].player();
+		const enemy = scenarios[0].enemy();
+
 		expect(player.attributes.getValue(EAttribute.MaxHealth)).toBe(900);
 		expect(player.attributes.getValue(EAttribute.Defense)).toBe(42);
 		expect(player.attributes.getValue(EAttribute.CooldownRecovery)).toBe(9);
@@ -134,64 +230,35 @@ describe('Battle simulation parity with backend', () => {
 
 		expect(enemy.attributes.getValue(EAttribute.MaxHealth)).toBe(400);
 		expect(enemy.attributes.getValue(EAttribute.Defense)).toBe(17);
-
-		const totalMs = simulateBattle(player, enemy);
-
-		// Must match the backend's BattleSimulatorParityTests.Parity_WithCooldownRecovery_MatchesExpectedTotalMs
-		expect(totalMs).toBe(6720);
 	});
 
-	it('demonstrates the double-counting bug: final API values + re-derived stats', () => {
-		// Compute the final attribute values as the API would send them
-		// (this is what PlayerData.FromPlayer produces)
+	it('ends sooner if the player double-counts derived stats (the historical bug)', () => {
+		// The frontend used to pass the API's already-final attribute values to
+		// BattleAttributes with calcDerivedStats=true, adding derived stats AGAIN.
+		// Mirrors BattleSimulatorParityTests.Parity_DoubleDerivedStats_ProducesShorterBattle.
 		const playerFinalAttrs = [
 			{ id: EAttribute.Strength, amount: 50 },
 			{ id: EAttribute.Endurance, amount: 30 },
 			{ id: EAttribute.Agility, amount: 20 },
 			{ id: EAttribute.Dexterity, amount: 10 },
-			// These are the FINAL values including derived stats:
+			// The FINAL values including derived stats, re-fed into the derived pipeline:
 			{ id: EAttribute.MaxHealth, amount: 900 }, // 50 + 20*30 + 5*50
 			{ id: EAttribute.Defense, amount: 42 }, // 2 + 30 + 0.5*20
 			{ id: EAttribute.CooldownRecovery, amount: 9 } // 0.4*20 + 0.1*10
 		];
+		const player = makeBattlerFromRaw(playerFinalAttrs, [
+			makeSkill(10, 1200, [{ attributeId: EAttribute.Strength, amount: 1.5 }])
+		]);
+		const enemy = scenarios[0].enemy();
 
-		// This is how the frontend currently constructs the player battler:
-		// it passes the final API values to BattleAttributes with calcDerivedStats=true,
-		// causing derived stats to be added AGAIN on top of the already-computed values.
-		const player = makeBattlerFromFinalValues(playerFinalAttrs, [playerSkill()]);
-		const enemy = makeBattlerFromRaw(enemyRawAttrs, [enemySkill()]);
-
-		// Derived stats are now DOUBLED
-		expect(player.attributes.getValue(EAttribute.MaxHealth)).toBe(1800); // 900 + 900
-		expect(player.attributes.getValue(EAttribute.Defense)).toBe(84); // 42 + 42
-		expect(player.attributes.getValue(EAttribute.CooldownRecovery)).toBe(18); // 9 + 9
+		// Derived stats are now DOUBLED.
+		expect(player.attributes.getValue(EAttribute.MaxHealth)).toBe(1800);
+		expect(player.attributes.getValue(EAttribute.Defense)).toBe(84);
+		expect(player.attributes.getValue(EAttribute.CooldownRecovery)).toBe(18);
 		expect(player.cdMultiplier).toBeCloseTo(1.18, 10);
 
-		const totalMs = simulateBattle(player, enemy);
-
-		// Battle ends sooner because player has inflated stats
-		expect(totalMs).toBe(6240);
-		expect(totalMs).toBeLessThan(6720);
-	});
-
-	it('the difference matches the ~300ms discrepancy range', () => {
-		const playerCorrect = makeBattlerFromRaw(playerRawAttrs, [playerSkill()]);
-		const enemyA = makeBattlerFromRaw(enemyRawAttrs, [enemySkill()]);
-		const correctMs = simulateBattle(playerCorrect, enemyA);
-
-		const playerFinalAttrs = [
-			...playerRawAttrs,
-			{ id: EAttribute.MaxHealth, amount: 900 },
-			{ id: EAttribute.Defense, amount: 42 },
-			{ id: EAttribute.CooldownRecovery, amount: 9 }
-		];
-		const playerBugged = makeBattlerFromFinalValues(playerFinalAttrs, [playerSkill()]);
-		const enemyB = makeBattlerFromRaw(enemyRawAttrs, [enemySkill()]);
-		const buggedMs = simulateBattle(playerBugged, enemyB);
-
-		const differenceMs = correctMs - buggedMs;
-		expect(differenceMs).toBe(480);
-		expect(differenceMs).toBeGreaterThanOrEqual(200);
-		expect(differenceMs).toBeLessThanOrEqual(600);
+		const result = simulateBattle(player, enemy);
+		expect(result.totalMs).toBe(6240);
+		expect(result.totalMs).toBeLessThan(6720);
 	});
 });


### PR DESCRIPTION
## Summary

Closes #144.

The end-to-end battle simulation was cross-verified by essentially a single shared scenario (the `6720ms` cooldown-recovery case), with most other battle behaviours tested on one side only — so an implementation divergence could pass CI. This PR widens the deterministic-simulation parity coverage, mirrors the derived-stat formulas across both suites, and resolves the one-sided `DropBonus` formula.

## What changed

### 1. Shared battle-simulation parity matrix
Both `Game.Core.Tests/Battle/BattleSimulatorParityTests.cs` and `UI/new-svelte/src/tests/lib/battle/battle-simulation-parity.test.ts` are now driven by a data-driven scenario matrix with **identical inputs and identical expected `totalMs`/outcome** on both sides:

| Scenario | Exercises | Expected |
| --- | --- | --- |
| `cooldownRecovery` | single skill, `cdMultiplier` path (Agi/Dex) | victory @ 6720ms |
| `multiSkill` | two player skills on different cooldowns vs. an enemy dealing real damage | victory @ 9600ms |
| `highDefenseFloor` | every hit clamps to 0 → stalemate | timeout @ 400000ms |
| `noSkills` | no damage dealt either side | timeout @ 400000ms |
| `maxMsCap` | simulation capped before any skill fires | no winner @ 200ms |

The double-counted-derived-stats demonstration (the historical `6240ms` bug repro) is kept as a dedicated case on both sides.

### 2. Fixed a real one-sided divergence
Making the frontend mirror assert the **full** `BattleResult` shape (victory / playerDied / totalMs) surfaced that its timeout path returned `maxMs + msPerTick` while the backend returns `maxMs`. The mirror now matches backend loop semantics exactly — previously no test exercised the timeout path, so the gap was invisible.

### 3. Backend derived-stat parity test
Added `Game.Core.Tests/Attributes/BattleAttributesParityTests.cs`, mirroring the exact numeric expectations of the frontend's `battle-attributes.test.ts` derived-stat block (`MaxHealth = 50 + 20·End + 5·Str`, `Defense = 2 + End + 0.5·Agi`, `CooldownRecovery = 0.4·Agi + 0.1·Dex`, and the zero-base case), so the two hand-maintained formula sources (`StaticAttributeModifiers` ↔ `STATIC_ATTRIBUTE_MODIFIERS`) can't silently drift.

### 4. DropBonus decision — removed from the frontend
The issue asked whether the frontend-only `DropBonus = log10(Luck)` formula should be removed or mirrored on the backend. The drop system was replaced by challenge-based unlocks; `DropBonus` is already `[Obsolete]` on the backend, has no modifiers there, and is deliberately unsurfaced in the UI. Mirroring an obsolete formula would add dead code, so the formula (and its two tests) were removed. This also eliminates a latent `-Infinity` value the formula produced whenever `Luck == 0`.

Out of scope (intentionally): the legacy `UI/Battle/BattleAttributes.ts` still carries the old `DropBonus` line — that vanilla-TS frontend is being retired wholesale, so it was left untouched. Also out of scope per the issue: server-authoritative exp-reward and per-skill statistics tracking, which the frontend never re-simulates.

## Test plan
- [x] `dotnet build` + `dotnet test Game.Core.Tests` → **269 passed**
- [x] `npm run test:unit:ci` → **644 passed**
- [x] `npm run lint` → clean

https://claude.ai/code/session_01YCMjnkfTQJCz8JY7YdZT7d

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCMjnkfTQJCz8JY7YdZT7d)_