### PR TITLE
Extract confirmQuit into game-actions.ts and add unit tests (#158)

### DIFF
--- a/UI/new-svelte/src/routes/game/+page.svelte
+++ b/UI/new-svelte/src/routes/game/+page.svelte
@@ -15,13 +15,13 @@
 import { NavSidebar, LogPanel } from '$components';
 import { screenMap, type GameScreen, GAME_SCREENS, visibleScreens } from './screens';
 import { startGame } from '$lib/engine';
-import { getRoles, logout } from '$lib/api';
-import { confirmModal } from '$stores';
+import { getRoles } from '$lib/api';
 import { browser } from '$app/environment';
 import type { Component } from 'svelte';
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
 import { onMount } from 'svelte';
+import { confirmQuit } from './game-actions';
 
 if (browser) {
 	try {
@@ -70,20 +70,6 @@ const handleNavigate = (key: string) => {
 	const mapped = screenKeyMap[key];
 	if (mapped && mapped in screenMap) {
 		CurrentScreen = screenMap[mapped] as Component;
-	}
-};
-
-// Confirm before ending the session — logging out tears down all in-memory game state, so guard
-// against an accidental click on the quit control.
-const confirmQuit = async () => {
-	const confirmed = await confirmModal({
-		title: 'Log out?',
-		body: "You'll be signed out and returned to the login screen.",
-		confirmLabel: 'Log out',
-		cancelLabel: 'Stay'
-	});
-	if (confirmed) {
-		logout();
 	}
 };
 </script>

--- a/UI/new-svelte/src/routes/game/game-actions.ts
+++ b/UI/new-svelte/src/routes/game/game-actions.ts
@@ -1,0 +1,19 @@
+import { confirmModal } from '$stores';
+import { logout } from '$lib/api';
+
+/**
+ * Asks the user to confirm before logging out. Logging out tears down all in-memory game state
+ * (engines, managers, websocket connection), so this guard prevents an accidental click on the
+ * quit control from ending the session without warning.
+ */
+export const confirmQuit = async (): Promise<void> => {
+	const confirmed = await confirmModal({
+		title: 'Log out?',
+		body: "You'll be signed out and returned to the login screen.",
+		confirmLabel: 'Log out',
+		cancelLabel: 'Stay'
+	});
+	if (confirmed) {
+		void logout();
+	}
+};

--- a/UI/new-svelte/src/tests/routes/game/game-actions.test.ts
+++ b/UI/new-svelte/src/tests/routes/game/game-actions.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { confirmModal, logout } = vi.hoisted(() => ({
+	confirmModal: vi.fn<() => Promise<boolean>>(),
+	logout: vi.fn()
+}));
+
+vi.mock('$stores', () => ({ confirmModal }));
+vi.mock('$lib/api', () => ({ logout }));
+
+import { confirmQuit } from '$routes/game/game-actions';
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('confirmQuit', () => {
+	it('opens a confirm modal with the correct title, body, and button labels', async () => {
+		confirmModal.mockResolvedValue(false);
+
+		await confirmQuit();
+
+		expect(confirmModal).toHaveBeenCalledWith({
+			title: 'Log out?',
+			body: "You'll be signed out and returned to the login screen.",
+			confirmLabel: 'Log out',
+			cancelLabel: 'Stay'
+		});
+	});
+
+	it('calls logout when the user confirms', async () => {
+		confirmModal.mockResolvedValue(true);
+
+		await confirmQuit();
+
+		expect(logout).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not call logout when the user cancels', async () => {
+		confirmModal.mockResolvedValue(false);
+
+		await confirmQuit();
+
+		expect(logout).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

- Extracts `confirmQuit` from `+page.svelte`'s script block into a standalone `src/routes/game/game-actions.ts` module, following the same pattern as `admin-access.ts`
- Adds three unit tests in `src/tests/routes/game/game-actions.test.ts` covering the full quit → confirm → logout flow
- The game page now imports `confirmQuit` from the new module; `confirmModal` and `logout` are no longer imported directly in the page component

## Why this approach

The game page's `+page.svelte` is untestable as a component because `startGame()` runs at module-init time under `browser`. Extracting just the quit logic into a plain `.ts` module lets the tests mock `$stores` (`confirmModal`) and `$lib/api` (`logout`) without rendering the full page. This is the same technique used by `admin-access.ts` / its test.

## Test plan

- [ ] `confirmQuit` opens a confirm modal with title `"Log out?"`, body, and the `"Log out"` / `"Stay"` button labels
- [ ] Confirming the modal calls `logout()`
- [ ] Cancelling (or dismissing) the modal does **not** call `logout()`
- [ ] All 82 test files (645 tests) pass: `npm run test:unit:ci`
- [ ] Lint is clean: `npm run lint`

Closes #158

https://claude.ai/code/session_01YafP5F1deoexwq6omLqmCH

---
_Generated by [Claude Code](https://claude.ai/code/session_01YafP5F1deoexwq6omLqmCH)_