### PR TITLE
Dedicated per-zone boss data model + admin authoring (#186)

### DIFF
--- a/Game.Abstractions/Contracts/Zone.cs
+++ b/Game.Abstractions/Contracts/Zone.cs
@@ -9,5 +9,13 @@ namespace Game.Abstractions.Contracts
         public int Order { get; set; }
         public int LevelMin { get; set; }
         public int LevelMax { get; set; }
+
+        /// <summary>The zone's single dedicated boss enemy, fought via the "Challenge Boss" action.
+        /// Null when no boss has been authored.</summary>
+        public int? BossEnemyId { get; set; }
+
+        /// <summary>The fixed level the dedicated boss is fought at. Only meaningful when
+        /// <see cref="BossEnemyId"/> is set.</summary>
+        public int BossLevel { get; set; }
     }
 }

--- a/Game.Abstractions/DataAccess/Admin/IAdminZones.cs
+++ b/Game.Abstractions/DataAccess/Admin/IAdminZones.cs
@@ -9,8 +9,12 @@ namespace Game.Abstractions.DataAccess.Admin
     /// </summary>
     public interface IAdminZones
     {
-        /// <summary>Applies an identity-level Add/Edit/Delete change set to the zone catalogue.</summary>
-        void SaveZones(IReadOnlyList<Change<Zone>> changes);
+        /// <summary>
+        /// Applies an identity-level Add/Edit/Delete change set to the zone catalogue. Returns <c>false</c>
+        /// (applying nothing) when an Add/Edit sets a <see cref="Zone.BossEnemyId"/> that does not reference
+        /// an existing boss enemy.
+        /// </summary>
+        bool SaveZones(IReadOnlyList<Change<Zone>> changes);
 
         /// <summary>Replaces a zone's enemy spawns. Returns <c>false</c> if the zone does not exist.</summary>
         bool SetEnemies(SetZoneEnemiesData data);

--- a/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
@@ -100,6 +100,117 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task AddEditZones_WithDedicatedBoss_PersistsBossEnemyAndLevel()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var boss = await TestDataSeeder.CreateEnemyAsync(context, "Catacomb Lich", isBoss: true);
+
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            var changes = new[]
+            {
+                new
+                {
+                    Item = new
+                    {
+                        Id = 0,
+                        Name = "Forgotten Catacombs",
+                        Description = "Endless night.",
+                        Order = 3,
+                        LevelMin = 8,
+                        LevelMax = 11,
+                        BossEnemyId = (int?)boss.Id,
+                        BossLevel = 18
+                    },
+                    ChangeType = 0 // Add
+                }
+            };
+
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/AddEditZones", changes, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Null(result.ErrorMessage);
+
+            var saved = Assert.Single(GetZones(), z => z.Name == "Forgotten Catacombs");
+            Assert.Equal(boss.Id, saved.BossEnemyId);
+            Assert.Equal(18, saved.BossLevel);
+        }
+
+        [Fact]
+        public async Task AddEditZones_BossEnemyNotMarkedAsBoss_ReturnsErrorAndPersistsNothing()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var normalEnemy = await TestDataSeeder.CreateEnemyAsync(context, "Plague Rat"); // isBoss: false
+
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            var changes = new[]
+            {
+                new
+                {
+                    Item = new
+                    {
+                        Id = 0,
+                        Name = "Rejected Zone",
+                        Description = "x",
+                        Order = 0,
+                        LevelMin = 1,
+                        LevelMax = 5,
+                        BossEnemyId = (int?)normalEnemy.Id,
+                        BossLevel = 5
+                    },
+                    ChangeType = 0 // Add
+                }
+            };
+
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/AddEditZones", changes, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Contains("boss", result.ErrorMessage ?? "", StringComparison.OrdinalIgnoreCase);
+
+            // The rejected batch must not have been partially applied.
+            Assert.DoesNotContain(GetZones(), z => z.Name == "Rejected Zone");
+        }
+
+        [Fact]
+        public async Task AddEditZones_NonexistentBossEnemy_ReturnsError()
+        {
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            var changes = new[]
+            {
+                new
+                {
+                    Item = new
+                    {
+                        Id = 0,
+                        Name = "Ghost Zone",
+                        Description = "x",
+                        Order = 0,
+                        LevelMin = 1,
+                        LevelMax = 5,
+                        BossEnemyId = (int?)999999,
+                        BossLevel = 5
+                    },
+                    ChangeType = 0 // Add
+                }
+            };
+
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/AddEditZones", changes, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.DoesNotContain(GetZones(), z => z.Name == "Ghost Zone");
+        }
+
+        [Fact]
         public async Task SetEnemySkills_ValidEnemy_Succeeds()
         {
             // Arrange — seed enemy and skills

--- a/Game.Api/Controllers/Admin/AdminZonesController.cs
+++ b/Game.Api/Controllers/Admin/AdminZonesController.cs
@@ -23,8 +23,9 @@ namespace Game.Api.Controllers.Admin
         [HttpPost]
         public ApiResponse AddEditZones([FromBody] List<Change<Zone>> changes)
         {
-            _adminZones.SaveZones(changes);
-            return ApiResponse.Success();
+            return _adminZones.SaveZones(changes)
+                ? ApiResponse.Success()
+                : ApiResponse.Error("Boss enemy is invalid. A zone's boss must be an existing enemy marked as a boss.");
         }
 
         [HttpPost]

--- a/Game.Application.Tests/DataAccess/ZonesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/ZonesIntegrationTests.cs
@@ -41,6 +41,39 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task GetZone_WithDedicatedBoss_ReturnsBossFields()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var boss = await TestDataSeeder.CreateEnemyAsync(context, "Catacomb Lich", isBoss: true);
+            var zone = await TestDataSeeder.CreateZoneAsync(
+                context, "Forgotten Catacombs", levelMin: 8, levelMax: 11, bossEnemyId: boss.Id, bossLevel: 18);
+
+            var zones = scope.ServiceProvider.GetRequiredService<IZones>();
+
+            var result = zones.GetZone(zone.Id);
+
+            Assert.Equal(boss.Id, result.BossEnemyId);
+            Assert.Equal(18, result.BossLevel);
+        }
+
+        [Fact]
+        public async Task GetZone_WithoutBoss_ReturnsNullBossEnemyId()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var zone = await TestDataSeeder.CreateZoneAsync(context, "Bossless Glade");
+
+            var zones = scope.ServiceProvider.GetRequiredService<IZones>();
+
+            var result = zones.GetZone(zone.Id);
+
+            Assert.Null(result.BossEnemyId);
+        }
+
+        [Fact]
         public void GetZone_InvalidId_Throws()
         {
             using var scope = CreateScope();

--- a/Game.DataAccess/Mapping/ZoneMapper.cs
+++ b/Game.DataAccess/Mapping/ZoneMapper.cs
@@ -17,6 +17,8 @@ namespace Game.DataAccess.Mapping
                 Order = entity.Order,
                 LevelMin = entity.LevelMin,
                 LevelMax = entity.LevelMax,
+                BossEnemyId = entity.BossEnemyId,
+                BossLevel = entity.BossLevel,
             };
         }
     }

--- a/Game.DataAccess/Repositories/Admin/AdminZones.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminZones.cs
@@ -1,3 +1,4 @@
+using Game.Abstractions;
 using Game.Abstractions.Contracts.Admin;
 using Game.Abstractions.DataAccess.Admin;
 using Contracts = Game.Abstractions.Contracts;
@@ -7,16 +8,29 @@ namespace Game.DataAccess.Repositories.Admin
 {
     /// <summary>
     /// Content Authoring persistence for zones and their enemy spawn assignments. Reuses the cached
-    /// entity lookup (<see cref="IZoneEntityCache.LookupZone"/>) for existence/diff and builds fresh,
-    /// navigation-free entities for every write.
+    /// entity lookups (<see cref="IZoneEntityCache.LookupZone"/>, <see cref="IEnemyEntityCache.GetEnemy"/>)
+    /// for existence/diff and builds fresh, navigation-free entities for every write.
     /// </summary>
-    internal class AdminZones(IZoneEntityCache zones, IEntityStore entityStore) : IAdminZones
+    internal class AdminZones(IZoneEntityCache zones, IEnemyEntityCache enemies, IEntityStore entityStore) : IAdminZones
     {
         private readonly IZoneEntityCache _zones = zones;
+        private readonly IEnemyEntityCache _enemies = enemies;
         private readonly IEntityStore _entityStore = entityStore;
 
-        public void SaveZones(IReadOnlyList<Change<Contracts.Zone>> changes)
+        public bool SaveZones(IReadOnlyList<Change<Contracts.Zone>> changes)
         {
+            // A zone's dedicated boss must reference an existing enemy flagged IsBoss. Validate the whole
+            // change set up front so an invalid reference rejects the batch rather than partially applying.
+            foreach (var change in changes)
+            {
+                if (change.ChangeType != EChangeType.Delete
+                    && change.Item.BossEnemyId is int bossEnemyId
+                    && _enemies.GetEnemy(bossEnemyId) is not { IsBoss: true })
+                {
+                    return false;
+                }
+            }
+
             ChangeSetProcessor.Apply(changes,
                 add: item => _entityStore.Insert(new Entities.Zone
                 {
@@ -25,6 +39,8 @@ namespace Game.DataAccess.Repositories.Admin
                     LevelMin = item.LevelMin,
                     LevelMax = item.LevelMax,
                     Order = item.Order,
+                    BossEnemyId = item.BossEnemyId,
+                    BossLevel = item.BossLevel,
                 }),
                 edit: item => _entityStore.Update(new Entities.Zone
                 {
@@ -34,6 +50,8 @@ namespace Game.DataAccess.Repositories.Admin
                     LevelMin = item.LevelMin,
                     LevelMax = item.LevelMax,
                     Order = item.Order,
+                    BossEnemyId = item.BossEnemyId,
+                    BossLevel = item.BossLevel,
                 }),
                 delete: item => _entityStore.Delete(new Entities.Zone
                 {
@@ -41,6 +59,8 @@ namespace Game.DataAccess.Repositories.Admin
                     Name = "",
                     Description = "",
                 }));
+
+            return true;
         }
 
         public bool SetEnemies(SetZoneEnemiesData data)

--- a/Game.Infrastructure/Database/GameContext.cs
+++ b/Game.Infrastructure/Database/GameContext.cs
@@ -481,6 +481,16 @@ namespace Game.Infrastructure.Database
 
                 entity.Property(z => z.Name)
                     .HasMaxLength(50);
+
+                entity.Property(z => z.BossLevel)
+                    .HasDefaultValue(1);
+
+                // The dedicated boss is an optional reference to an enemy. Navigation-less FK: deleting the
+                // referenced enemy clears the zone's boss (SetNull) rather than blocking the delete.
+                entity.HasOne<Enemy>()
+                    .WithMany()
+                    .HasForeignKey(z => z.BossEnemyId)
+                    .OnDelete(DeleteBehavior.SetNull);
             });
 
             modelBuilder.Entity<ZoneEnemy>()

--- a/Game.Infrastructure/Entities/Zone.cs
+++ b/Game.Infrastructure/Entities/Zone.cs
@@ -9,6 +9,14 @@
         public int LevelMin { get; set; }
         public int LevelMax { get; set; }
 
+        /// <summary>The zone's single dedicated boss, fought via the "Challenge Boss" action. Null when no
+        /// boss has been authored. Distinct from the random <see cref="ZoneEnemies"/> spawn table.</summary>
+        public int? BossEnemyId { get; set; }
+
+        /// <summary>The fixed level the dedicated boss is fought at, independent of <see cref="LevelMin"/>/
+        /// <see cref="LevelMax"/>. Only meaningful when <see cref="BossEnemyId"/> is set.</summary>
+        public int BossLevel { get; set; }
+
         public virtual List<ZoneEnemy> ZoneEnemies { get => field ?? throw new NotLoadedException(nameof(ZoneEnemies)); set; }
     }
 }

--- a/Game.Infrastructure/Migrations/20260608030023_AddZoneBoss.Designer.cs
+++ b/Game.Infrastructure/Migrations/20260608030023_AddZoneBoss.Designer.cs
@@ -4,6 +4,7 @@ using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Game.Infrastructure.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20260608030023_AddZoneBoss")]
+    partial class AddZoneBoss
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Game.Infrastructure/Migrations/20260608030023_AddZoneBoss.cs
+++ b/Game.Infrastructure/Migrations/20260608030023_AddZoneBoss.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Game.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddZoneBoss : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "BossEnemyId",
+                table: "Zones",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "BossLevel",
+                table: "Zones",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Zones_BossEnemyId",
+                table: "Zones",
+                column: "BossEnemyId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Zones_Enemies_BossEnemyId",
+                table: "Zones",
+                column: "BossEnemyId",
+                principalTable: "Enemies",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Zones_Enemies_BossEnemyId",
+                table: "Zones");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Zones_BossEnemyId",
+                table: "Zones");
+
+            migrationBuilder.DropColumn(
+                name: "BossEnemyId",
+                table: "Zones");
+
+            migrationBuilder.DropColumn(
+                name: "BossLevel",
+                table: "Zones");
+        }
+    }
+}

--- a/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
+++ b/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
@@ -162,9 +162,10 @@ namespace Game.TestInfrastructure.Helpers
             decimal strengthBase = 5m,
             decimal strengthPerLevel = 1m,
             decimal enduranceBase = 5m,
-            decimal endurancePerLevel = 1m)
+            decimal endurancePerLevel = 1m,
+            bool isBoss = false)
         {
-            var enemy = new Enemy { Name = name };
+            var enemy = new Enemy { Name = name, IsBoss = isBoss };
             context.Enemies.Add(enemy);
             await context.SaveChangesAsync();
 
@@ -193,7 +194,9 @@ namespace Game.TestInfrastructure.Helpers
             string name = "Test Zone",
             int levelMin = 1,
             int levelMax = 10,
-            int order = 0)
+            int order = 0,
+            int? bossEnemyId = null,
+            int bossLevel = 1)
         {
             var zone = new Zone
             {
@@ -202,6 +205,8 @@ namespace Game.TestInfrastructure.Helpers
                 Order = order,
                 LevelMin = levelMin,
                 LevelMax = levelMax,
+                BossEnemyId = bossEnemyId,
+                BossLevel = bossLevel,
             };
 
             context.Zones.Add(zone);

--- a/UI/src/lib/api/types/interfaces/contracts.ts
+++ b/UI/src/lib/api/types/interfaces/contracts.ts
@@ -120,6 +120,8 @@ export interface IZone {
 	order: number;
 	levelMin: number;
 	levelMax: number;
+	bossEnemyId?: number;
+	bossLevel: number;
 }
 
 export interface IZoneEnemy {

--- a/UI/src/routes/admin/workbench/entities/zone.ts
+++ b/UI/src/routes/admin/workbench/entities/zone.ts
@@ -16,6 +16,8 @@ const refresh = async (): Promise<WorkbenchZone[]> => {
 	staticData.enemies = enemies;
 	return zones.map((zone) => ({
 		...zone,
+		// Normalise the optional boss FK to the select's "None" sentinel (-1) so the picker stays consistent.
+		bossEnemyId: zone.bossEnemyId ?? -1,
 		zoneEnemies: enemies
 			.filter((enemy) => enemy.spawns.some((spawn) => spawn.zoneId === zone.id))
 			.map((enemy) => ({
@@ -31,11 +33,28 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 	singular: 'Zone',
 	glyph: 'map',
 	blankName: 'Unnamed zone',
-	newItem: (id) => ({ id, name: '', description: '', order: 0, levelMin: 1, levelMax: 10, zoneEnemies: [] }),
+	newItem: (id) => ({
+		id,
+		name: '',
+		description: '',
+		order: 0,
+		levelMin: 1,
+		levelMax: 10,
+		bossEnemyId: -1,
+		bossLevel: 1,
+		zoneEnemies: []
+	}),
 	meta: (z) => [
 		['', `L${z.levelMin}–${z.levelMax}`],
 		['enemy', z.zoneEnemies.length]
 	],
+	headline: (z) => {
+		if (z.bossEnemyId == null || z.bossEnemyId < 0) {
+			return '';
+		}
+		const boss = staticData.enemies.find((e) => e.id === z.bossEnemyId);
+		return boss ? `Boss: ${boss.name} · LV ${z.bossLevel}` : '';
+	},
 	sections: [
 		{
 			key: 'identity',
@@ -56,6 +75,14 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 				{ key: 'order', label: 'Order', type: 'number', width: 110 },
 				{ key: 'levelMin', label: 'Level Min', type: 'number', suffix: 'lv', width: 130 },
 				{ key: 'levelMax', label: 'Level Max', type: 'number', suffix: 'lv', width: 130 },
+				{
+					key: 'bossEnemyId',
+					label: 'Dedicated Boss',
+					type: 'select',
+					options: reference.bossEnemyOptions,
+					width: 220
+				},
+				{ key: 'bossLevel', label: 'Boss Level', type: 'number', suffix: 'lv', width: 130 },
 				{
 					key: 'description',
 					label: 'Description',
@@ -98,13 +125,16 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 	persist: (diff) =>
 		persistEntity({
 			diff,
-			toPrimaryDto: ({ id, name, description, order, levelMin, levelMax }) => ({
+			toPrimaryDto: ({ id, name, description, order, levelMin, levelMax, bossEnemyId, bossLevel }) => ({
 				id,
 				name,
 				description,
 				order,
 				levelMin,
-				levelMax
+				levelMax,
+				// Map the "None" sentinel (-1) back to an absent boss for the API.
+				bossEnemyId: bossEnemyId === -1 ? undefined : bossEnemyId,
+				bossLevel
 			}),
 			postPrimary: (changes) => ApiRequest.post('AdminTools/AddEditZones', changes),
 			refresh,

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -72,6 +72,11 @@ class WorkbenchReference {
 	zoneOptions = (): SelectOption[] =>
 		staticData.zones.map((z) => ({ value: z.id, text: `${z.name} · L${z.levelMin}–${z.levelMax}` }));
 	enemyOptions = (): SelectOption[] => staticData.enemies.map((e) => ({ value: e.id, text: e.name }));
+	/** Dedicated-boss picker options: a "None" sentinel (-1) plus every enemy flagged as a boss. */
+	bossEnemyOptions = (): SelectOption[] => [
+		{ value: -1, text: 'None' },
+		...staticData.enemies.filter((e) => e.isBoss).map((e) => ({ value: e.id, text: e.name }))
+	];
 	skillCatalogue = () => staticData.skills.map((s) => ({ id: s.id, name: s.name, baseDamage: s.baseDamage }));
 
 	// ── Challenges ──

--- a/UI/src/tests/routes/game/screens/fight/Fight.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/Fight.test.ts
@@ -20,7 +20,9 @@ beforeEach(() => {
 	mockBattleEngine.player = makeBattler({ name: 'Aelara' });
 	mockBattleEngine.enemy = makeBattler({ name: 'Dire Wolf' });
 	mockPlayerManager.currentZone = 10;
-	staticData.zones = [{ id: 10, name: 'Verdant Hollow', description: '', order: 1, levelMin: 1, levelMax: 10 }];
+	staticData.zones = [
+		{ id: 10, name: 'Verdant Hollow', description: '', order: 1, levelMin: 1, levelMax: 10, bossLevel: 1 }
+	];
 });
 
 afterEach(cleanup);

--- a/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
@@ -20,7 +20,8 @@ const zone = (id: number, order: number, name: string): IZone => ({
 	description: '',
 	order,
 	levelMin: 1,
-	levelMax: 10
+	levelMax: 10,
+	bossLevel: 1
 });
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

Foundation slice of the boss-encounter rework (#96): a zone can now have a **single dedicated boss**, modeled distinctly from its random `ZoneEnemy` spawn table, and authored through the admin Workbench. No gameplay battle path or fight-screen UI yet — those land in #187 (backend `ChallengeBoss` action) and #189 (frontend), which build on this.

## How it addresses the issue

Implements the locked decisions from the #96 spike for the data-model + admin layer:

- **`Zone.BossEnemyId`** — nullable FK → `Enemy` (`ON DELETE SET NULL`, so deleting an enemy clears any zone that referenced it rather than blocking the delete). Null when no boss is authored.
- **`Zone.BossLevel`** — fixed level the boss is fought at, independent of `[LevelMin, LevelMax]` (DB default `1`; only meaningful when a boss is set).
- Both added to the `Zone` read/write contract and the regenerated TS types (`bossEnemyId?`, `bossLevel`).
- **`IsBoss` repurposed** as "is a dedicated zone boss": `AddEditZones` rejects the whole change set (persisting nothing) when an Add/Edit sets a `BossEnemyId` that isn't an existing `IsBoss` enemy; the controller maps that to a user-facing error.
- **Admin Workbench** Zone identity tab: a "Dedicated Boss" picker (enemies filtered to `IsBoss`, plus a "None" sentinel mapped to/from `null` at the API boundary) and a "Boss Level" field, with a headline preview of the configured boss.

## Test plan

- [x] `dotnet build Game.sln` clean (0 warnings/errors)
- [x] Backend tests pass — Core (269), Application (68), Api (268), including:
  - `AddEditZones_WithDedicatedBoss_PersistsBossEnemyAndLevel`
  - `AddEditZones_BossEnemyNotMarkedAsBoss_ReturnsErrorAndPersistsNothing`
  - `AddEditZones_NonexistentBossEnemy_ReturnsError`
  - `GetZone_WithDedicatedBoss_ReturnsBossFields` / `GetZone_WithoutBoss_ReturnsNullBossEnemyId`
- [x] `npm run lint` (eslint + svelte-check) clean — 0 errors across 749 files
- [x] `npm run test:unit:ci` — 685 passed
- [x] EF migration `AddZoneBoss` generated; model snapshot updated; `e2e-seed.sql` unaffected (explicit column list + nullable/defaulted columns)
- [x] TS codegen re-run; committed output is clean

## Notes / follow-ups

- Assigning bosses to seeded/`e2e-seed.sql` zones is deferred (the fight path that would exercise them is #187/#189).
- The admin Workbench boss picker was verified via lint/type-check + unit tests rather than a live browser session, since exercising it requires a full admin login against a seeded backend; the end-to-end boss UX is covered by #189.

Closes #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)