### PR TITLE
Complete RequestLoggingMiddleware with structured context, timing, and status code

### DIFF
--- a/Game.Api.Tests/Integration/ApiIntegrationTestBase.cs
+++ b/Game.Api.Tests/Integration/ApiIntegrationTestBase.cs
@@ -25,7 +25,12 @@ namespace Game.Api.Tests.Integration
         protected ApiIntegrationTestBase(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
         {
             Containers = containers;
-            Factory = new GameServerFactory(containers, testOutputHelper);
+            Factory = CreateFactory(containers, testOutputHelper);
+        }
+
+        protected virtual GameServerFactory CreateFactory(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+        {
+            return new GameServerFactory(containers, testOutputHelper);
         }
 
         public async ValueTask InitializeAsync()

--- a/Game.Api.Tests/Integration/RequestLoggingTests.cs
+++ b/Game.Api.Tests/Integration/RequestLoggingTests.cs
@@ -1,0 +1,119 @@
+using Game.Api.Middleware;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    [Collection("Integration")]
+    public class RequestLoggingTests : ApiIntegrationTestBase
+    {
+        // Field initializer runs before the base constructor so _capturingProvider is ready
+        // when CreateFactory is called from the base constructor.
+        private readonly CapturingLoggerProvider _capturingProvider = new();
+
+        private static readonly string LoggerCategory = typeof(RequestLoggingMiddleware).FullName!;
+
+        public RequestLoggingTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        protected override GameServerFactory CreateFactory(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+        {
+            return new GameServerFactory(containers, testOutputHelper, [_capturingProvider]);
+        }
+
+        [Fact]
+        public async Task UnauthenticatedRequest_LogsRequestStartWithNullUserId()
+        {
+            var startIndex = _capturingProvider.Entries.Count;
+
+            await Client.GetAsync("/api/Login/Status", CancellationToken);
+
+            var entries = GetMiddlewareEntries(startIndex);
+            var startEntry = Assert.Single(entries, e => e.Message == "Request Start");
+            var scope = Assert.IsType<Dictionary<string, object?>>(startEntry.ScopeStates.Single());
+            Assert.Equal("GET", scope["Method"]);
+            Assert.Equal("/api/Login/Status", scope["Path"]);
+            Assert.Null(scope["UserId"]);
+            Assert.NotNull(scope["RequestId"]);
+        }
+
+        [Fact]
+        public async Task UnauthenticatedRequest_LogsRequestEndedWithStatusCodeAndElapsedTime()
+        {
+            var startIndex = _capturingProvider.Entries.Count;
+
+            var response = await Client.GetAsync("/api/Login/Status", CancellationToken);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+            var entries = GetMiddlewareEntries(startIndex);
+            var endedEntry = Assert.Single(entries, e => e.Message.StartsWith("Request Ended"));
+            Assert.Equal(LogLevel.Information, endedEntry.Level);
+
+            var statusCode = (int)endedEntry.Properties.Single(p => p.Key == "StatusCode").Value!;
+            Assert.Equal(401, statusCode);
+
+            var elapsedMs = (long)endedEntry.Properties.Single(p => p.Key == "ElapsedMs").Value!;
+            Assert.True(elapsedMs >= 0);
+        }
+
+        [Fact]
+        public async Task AuthenticatedRequest_LogsUserIdInScope()
+        {
+            var userId = await SeedUserAsync("logtest_userid", "testpass");
+            var login = await LoginAndBuildClientAsync("logtest_userid", "testpass");
+            using var authClient = login.Client;
+
+            var startIndex = _capturingProvider.Entries.Count;
+            var response = await authClient.GetAsync("/api/Login/Status", CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var entries = GetMiddlewareEntries(startIndex);
+            var startEntry = Assert.Single(entries, e => e.Message == "Request Start");
+            var scope = Assert.IsType<Dictionary<string, object?>>(startEntry.ScopeStates.Single());
+            Assert.Equal(userId, scope["UserId"]);
+        }
+
+        [Fact]
+        public async Task AuthenticatedRequest_LogsRequestEndedWithStatusCode200()
+        {
+            await SeedUserAsync("logtest_status200", "testpass");
+            var login = await LoginAndBuildClientAsync("logtest_status200", "testpass");
+            using var authClient = login.Client;
+
+            var startIndex = _capturingProvider.Entries.Count;
+            await authClient.GetAsync("/api/Login/Status", CancellationToken);
+
+            var entries = GetMiddlewareEntries(startIndex);
+            var endedEntry = Assert.Single(entries, e => e.Message.StartsWith("Request Ended"));
+            var statusCode = (int)endedEntry.Properties.Single(p => p.Key == "StatusCode").Value!;
+            Assert.Equal(200, statusCode);
+        }
+
+        private async Task<int> SeedUserAsync(string username, string password)
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context, username, password);
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
+            return user.Id;
+        }
+
+        private IReadOnlyList<CapturingEntry> GetMiddlewareEntries(int startIndex)
+        {
+            return _capturingProvider.Entries
+                .Skip(startIndex)
+                .Where(e => e.Category == LoggerCategory)
+                .ToList();
+        }
+    }
+}

--- a/Game.Api/Middleware/RequestLoggingMiddleware.cs
+++ b/Game.Api/Middleware/RequestLoggingMiddleware.cs
@@ -1,25 +1,51 @@
 ﻿using Game.Api.Services;
+using System.Diagnostics;
 
 namespace Game.Api.Middleware
 {
-    public class RequestLoggingMiddleware
+    /// <summary>
+    /// Logs structured request start and end events for each HTTP request, including the HTTP method,
+    /// path, requesting user, response status code, and elapsed time.
+    /// </summary>
+    public class RequestLoggingMiddleware(RequestDelegate next, ILogger<RequestLoggingMiddleware> logger)
     {
-        private readonly RequestDelegate _next;
-        private readonly ILogger<RequestLoggingMiddleware> _logger;
-
-        public RequestLoggingMiddleware(RequestDelegate next, ILogger<RequestLoggingMiddleware> logger)
-        {
-            _next = next;
-            _logger = logger;
-        }
+        private readonly RequestDelegate _next = next;
+        private readonly ILogger<RequestLoggingMiddleware> _logger = logger;
 
         public async Task InvokeAsync(HttpContext context, SessionService sessionService)
         {
-            var loggingContext = new object(); //TODO: load some useful context data into this object;
+            var loggingContext = new Dictionary<string, object?>
+            {
+                ["Method"] = context.Request.Method,
+                ["Path"] = context.Request.Path.Value,
+                ["RequestId"] = context.TraceIdentifier,
+                ["UserId"] = sessionService.Authenticated ? sessionService.UserId : (int?)null
+            };
+
+            var stopwatch = Stopwatch.StartNew();
             using var scope = _logger.BeginScope(loggingContext);
             _logger.LogInformation("Request Start");
+
             await _next(context);
-            _logger.LogInformation("Request Ended");
+
+            stopwatch.Stop();
+            _logger.LogInformation("Request Ended {StatusCode} {ElapsedMs}ms",
+                context.Response.StatusCode, stopwatch.ElapsedMilliseconds);
+        }
+    }
+
+    /// <summary>
+    /// Extension methods for adding <see cref="RequestLoggingMiddleware"/> to the application pipeline.
+    /// </summary>
+    public static class RequestLoggingMiddlewareExtensions
+    {
+        /// <summary>
+        /// Adds middleware that logs structured request start and end events. Must run after
+        /// <c>UseSessionLoader</c> so the requesting user's identity is available.
+        /// </summary>
+        public static IApplicationBuilder UseRequestLogging(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<RequestLoggingMiddleware>();
         }
     }
 }

--- a/Game.Api/Startup.cs
+++ b/Game.Api/Startup.cs
@@ -135,6 +135,7 @@ namespace Game.Api
             //app.UseHttpsRedirection();
             app.UseAuthentication();
             app.UseSessionLoader();
+            app.UseRequestLogging();
             app.UseLoginTracking();
             app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(15) });
             app.UseSocketInterceptor();

--- a/Game.TestInfrastructure/Base/GameServerFactory.cs
+++ b/Game.TestInfrastructure/Base/GameServerFactory.cs
@@ -15,11 +15,16 @@ namespace Game.TestInfrastructure.Base
     {
         private readonly IntegrationTestContainers _containers;
         private readonly ITestOutputHelper _testOutputHelper;
+        private readonly IEnumerable<ILoggerProvider> _additionalLoggerProviders;
 
-        public GameServerFactory(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+        public GameServerFactory(
+            IntegrationTestContainers containers,
+            ITestOutputHelper testOutputHelper,
+            IEnumerable<ILoggerProvider>? additionalLoggerProviders = null)
         {
             _containers = containers;
             _testOutputHelper = testOutputHelper;
+            _additionalLoggerProviders = additionalLoggerProviders ?? [];
         }
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -46,7 +51,14 @@ namespace Game.TestInfrastructure.Base
 
             builder.ConfigureServices(services =>
             {
-                services.AddLogging(builder => builder.ClearProviders().AddProvider(new XunitLoggerProvider(_testOutputHelper)));
+                services.AddLogging(loggingBuilder =>
+                {
+                    loggingBuilder.ClearProviders().AddProvider(new XunitLoggerProvider(_testOutputHelper));
+                    foreach (var provider in _additionalLoggerProviders)
+                    {
+                        loggingBuilder.AddProvider(provider);
+                    }
+                });
 
                 var hostedServiceDescriptors = services
                     .Where(d => d.ServiceType == typeof(IHostedService))

--- a/Game.TestInfrastructure/Helpers/CapturingLogger.cs
+++ b/Game.TestInfrastructure/Helpers/CapturingLogger.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Logging;
+
+namespace Game.TestInfrastructure.Helpers;
+
+public record CapturingEntry(
+    string Category,
+    LogLevel Level,
+    string Message,
+    IReadOnlyList<object?> ScopeStates,
+    IReadOnlyList<KeyValuePair<string, object?>> Properties);
+
+public class CapturingLoggerProvider : ILoggerProvider
+{
+    private readonly List<CapturingEntry> _entries = [];
+    private readonly object _lock = new();
+
+    public IReadOnlyList<CapturingEntry> Entries
+    {
+        get { lock (_lock) { return [.. _entries]; } }
+    }
+
+    public ILogger CreateLogger(string categoryName) =>
+        new CapturingLogger(categoryName, _entries, _lock);
+
+    public void Dispose() { }
+}
+
+internal class CapturingLogger(string categoryName, List<CapturingEntry> entries, object lockObj) : ILogger
+{
+    private readonly AsyncLocal<List<object?>> _scopeStack = new();
+
+    private List<object?> ScopeStack => _scopeStack.Value ??= [];
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+    {
+        var stack = ScopeStack;
+        stack.Add(state);
+        return new ScopeHandle(() =>
+        {
+            if (stack.Count > 0)
+            {
+                stack.RemoveAt(stack.Count - 1);
+            }
+        });
+    }
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        var properties = state is IEnumerable<KeyValuePair<string, object?>> kvps
+            ? (IReadOnlyList<KeyValuePair<string, object?>>)kvps.ToList()
+            : [];
+
+        var entry = new CapturingEntry(
+            categoryName,
+            logLevel,
+            formatter(state, exception),
+            [.. ScopeStack],
+            properties);
+
+        lock (lockObj)
+        {
+            entries.Add(entry);
+        }
+    }
+
+    private sealed class ScopeHandle(Action onDispose) : IDisposable
+    {
+        public void Dispose() => onDispose();
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the `new object()` stub and bare "Request Start/Ended" strings in `RequestLoggingMiddleware` with a complete structured-logging implementation
- Adds a `CapturingLoggerProvider` to `Game.TestInfrastructure` and a `virtual CreateFactory` hook to `ApiIntegrationTestBase` to support log-content assertions in tests

## Changes

**`Game.Api/Middleware/RequestLoggingMiddleware.cs`**
- Scope: `Dictionary<string, object?>` carrying `Method`, `Path`, `RequestId`, and `UserId` (null when unauthenticated)
- "Request Start" logged with scope active
- `Stopwatch` captures elapsed time before `await _next(context)`
- "Request Ended" logged with structured `{StatusCode}` and `{ElapsedMs}ms` parameters
- Added `RequestLoggingMiddlewareExtensions.UseRequestLogging()` extension method

**`Game.Api/Startup.cs`**
- Registered `app.UseRequestLogging()` after `app.UseSessionLoader()` so `UserId` is populated

**`Game.TestInfrastructure`**
- `Helpers/CapturingLogger.cs` — new `CapturingLoggerProvider` / `CapturingLogger` / `CapturingEntry` types for asserting on log content in integration tests; uses `AsyncLocal` for per-request scope stacks
- `Base/GameServerFactory.cs` — optional `additionalLoggerProviders` constructor parameter

**`Game.Api.Tests`**
- `Integration/ApiIntegrationTestBase.cs` — virtual `CreateFactory` hook so subclasses can inject providers
- `Integration/RequestLoggingTests.cs` — four new integration tests covering:
  - Unauthenticated request: scope has null `UserId`, correct `Method`/`Path`/`RequestId`
  - Unauthenticated request: "Request Ended" carries `StatusCode=401` and non-negative `ElapsedMs`
  - Authenticated request: scope has the real `UserId`
  - Authenticated request: "Request Ended" carries `StatusCode=200`

## Test plan

- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] `dotnet test` — all 609 tests pass across `Game.Core.Tests`, `Game.Application.Tests`, and `Game.Api.Tests` (including the 4 new `RequestLoggingTests`)

Closes #92

https://claude.ai/code/session_01BpNcR7xhA2u7oFnjqeMTCi

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpNcR7xhA2u7oFnjqeMTCi)_