### PR TITLE
Delete via fresh key-only entities in admin relationship setters

### DIFF
--- a/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
@@ -239,6 +239,34 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task SetEnemySkills_DropsUnlistedSkill_RemovesIt()
+        {
+            // Arrange — an enemy already linked to two skills.
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context, "Skilled");
+            var keptSkill = await TestDataSeeder.CreateSkillAsync(context, "Slash");
+            var removedSkill = await TestDataSeeder.CreateSkillAsync(context, "Bite");
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, keptSkill.Id);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, removedSkill.Id);
+
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            // Act — narrow the skill pool to a single skill, dropping the other.
+            var data = new
+            {
+                EnemyId = enemy.Id,
+                SkillIds = new[] { keptSkill.Id }
+            };
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/SetEnemySkills", data, CancellationToken);
+
+            // Assert — only the kept skill survives the delete path.
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var saved = Assert.Single(GetEnemies(), e => e.Id == enemy.Id);
+            Assert.Equal(keptSkill.Id, Assert.Single(saved.SkillPool));
+        }
+
+        [Fact]
         public async Task SetZoneEnemies_ValidZone_Succeeds()
         {
             // Arrange
@@ -268,6 +296,42 @@ namespace Game.Api.Tests.Integration
             var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
             Assert.NotNull(result);
             Assert.Null(result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SetZoneEnemies_DropsUnlistedEnemy_RemovesIt()
+        {
+            // Arrange — a zone with two enemies assigned.
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var zone = await TestDataSeeder.CreateZoneAsync(context, "Crowded Zone");
+            var keptEnemy = await TestDataSeeder.CreateEnemyAsync(context, "Resident");
+            var removedEnemy = await TestDataSeeder.CreateEnemyAsync(context, "Evicted");
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, keptEnemy.Id, 10);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, removedEnemy.Id, 20);
+
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            // Act — keep only one enemy assigned to the zone.
+            var data = new
+            {
+                ZoneId = zone.Id,
+                ZoneEnemies = new[]
+                {
+                    new { EnemyId = keptEnemy.Id, Weight = 10 }
+                }
+            };
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/SetZoneEnemies", data, CancellationToken);
+
+            // Assert — only the kept enemy remains linked to the zone.
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            using var verifyScope = CreateScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
+            var remaining = await verifyContext.Set<Game.Infrastructure.Entities.ZoneEnemy>()
+                .Where(ze => ze.ZoneId == zone.Id)
+                .Select(ze => ze.EnemyId)
+                .ToListAsync(CancellationToken);
+            Assert.Equal(keptEnemy.Id, Assert.Single(remaining));
         }
 
         [Fact]
@@ -333,6 +397,37 @@ namespace Game.Api.Tests.Integration
             var spawn = Assert.Single(saved.Spawns);
             Assert.Equal(zone.Id, spawn.ZoneId);
             Assert.Equal(42, spawn.Weight);
+        }
+
+        [Fact]
+        public async Task SetEnemySpawns_DropsUnlistedSpawn_RemovesIt()
+        {
+            // Arrange — an enemy spawning in two zones.
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context, "Wanderer");
+            var keptZone = await TestDataSeeder.CreateZoneAsync(context, "Kept Zone");
+            var removedZone = await TestDataSeeder.CreateZoneAsync(context, "Removed Zone");
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, keptZone.Id, enemy.Id, 10);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, removedZone.Id, enemy.Id, 20);
+
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            // Act — keep only one spawn, dropping the other zone.
+            var data = new
+            {
+                EnemyId = enemy.Id,
+                Spawns = new[]
+                {
+                    new { ZoneId = keptZone.Id, Weight = 10 }
+                }
+            };
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/SetEnemySpawns", data, CancellationToken);
+
+            // Assert — only the kept spawn survives the delete path.
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var saved = Assert.Single(GetEnemies(), e => e.Id == enemy.Id);
+            Assert.Equal(keptZone.Id, Assert.Single(saved.Spawns).ZoneId);
         }
 
         [Fact]

--- a/Game.DataAccess/Repositories/Admin/AdminEnemies.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminEnemies.cs
@@ -48,7 +48,11 @@ namespace Game.DataAccess.Repositories.Admin
             var newIds = data.AttributeDistributions.Select(ad => (int)ad.AttributeId).ToList();
             foreach (var dist in enemy.AttributeDistributions.Where(ad => !newIds.Contains(ad.AttributeId)))
             {
-                _entityStore.Delete(dist);
+                _entityStore.Delete(new Entities.AttributeDistribution
+                {
+                    EnemyId = enemy.Id,
+                    AttributeId = dist.AttributeId,
+                });
             }
 
             foreach (var dist in enemy.AttributeDistributions.Where(ad => newIds.Contains(ad.AttributeId)))
@@ -89,7 +93,11 @@ namespace Game.DataAccess.Repositories.Admin
             var newIds = data.SkillIds;
             foreach (var skill in enemy.EnemySkills.Where(e => !newIds.Contains(e.SkillId)))
             {
-                _entityStore.Delete(skill);
+                _entityStore.Delete(new Entities.EnemySkill
+                {
+                    EnemyId = enemy.Id,
+                    SkillId = skill.SkillId,
+                });
             }
 
             var existingIds = enemy.EnemySkills.Select(es => es.SkillId).ToList();
@@ -116,7 +124,11 @@ namespace Game.DataAccess.Repositories.Admin
             var newZoneIds = data.Spawns.Select(s => s.ZoneId).ToList();
             foreach (var spawn in enemy.ZoneEnemies.Where(ze => !newZoneIds.Contains(ze.ZoneId)))
             {
-                _entityStore.Delete(spawn);
+                _entityStore.Delete(new Entities.ZoneEnemy
+                {
+                    ZoneId = spawn.ZoneId,
+                    EnemyId = enemy.Id,
+                });
             }
 
             foreach (var spawn in enemy.ZoneEnemies.Where(ze => newZoneIds.Contains(ze.ZoneId)))

--- a/Game.DataAccess/Repositories/Admin/AdminZones.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminZones.cs
@@ -74,7 +74,11 @@ namespace Game.DataAccess.Repositories.Admin
             var newIds = data.ZoneEnemies.Select(ze => ze.EnemyId).ToList();
             foreach (var enemy in zone.ZoneEnemies.Where(e => !newIds.Contains(e.EnemyId)))
             {
-                _entityStore.Delete(enemy);
+                _entityStore.Delete(new Entities.ZoneEnemy
+                {
+                    ZoneId = enemy.ZoneId,
+                    EnemyId = enemy.EnemyId,
+                });
             }
 
             foreach (var enemy in zone.ZoneEnemies.Where(e => newIds.Contains(e.EnemyId)))


### PR DESCRIPTION
## Summary

Follow-up from the review of PR #172. The Content Authoring admin relationship setters in `Game.DataAccess/Repositories/Admin` correctly build fresh, navigation-free entities for their insert/update paths, but their **delete** paths passed the cached `AsNoTracking().Include(...)` child entity straight to `IEntityStore.Delete(...)`. This contradicts the documented invariant in `backend.md` → *Admin Tools API surface* → "Don't update/delete cached entities directly", and leaves a latent graph-attach risk: a cached entity carries a loaded back-reference to its parent/siblings, which could be dragged into the change tracker if the read query's `Include`s ever change.

## Changes

Each delete path now constructs a fresh entity keyed only by the row's own key(s), mirroring the insert/update paths:

| Setter | Entity | Keys |
| --- | --- | --- |
| `AdminEnemies.SetAttributeDistributions` | `AttributeDistribution` | `{ EnemyId, AttributeId }` |
| `AdminEnemies.SetSkills` | `EnemySkill` | `{ EnemyId, SkillId }` |
| `AdminEnemies.SetSpawns` | `ZoneEnemy` | `{ ZoneId, EnemyId }` |
| `AdminZones.SetEnemies` | `ZoneEnemy` | `{ ZoneId, EnemyId }` |

`IEntityStore.Delete` only needs the primary key — it marks the detached entity `Unchanged` then `Remove`s it, emitting a key-based `DELETE`. Since reference reads are `AsNoTracking()` and the delete/update sets are disjoint by their `Where` filters, there is no tracking conflict.

No documentation change was needed: `backend.md` already documents this as the correct behavior; this just brings the delete paths into line with it.

## Test coverage note

While implementing, I found the issue's premise — that the existing integration tests already exercise all four delete paths — was only partly accurate. Only `SetEnemyAttributeDistributions_ValidEnemy_PersistsDistribution` genuinely triggers a delete (the seeded enemy starts with Strength + Endurance, and the request drops Endurance). The skill, spawn, and zone-enemy tests seeded no pre-existing relationship rows, so their delete loops never ran.

I added three integration tests that actually exercise the delete branch:
- `SetEnemySkills_DropsUnlistedSkill_RemovesIt`
- `SetEnemySpawns_DropsUnlistedSpawn_RemovesIt`
- `SetZoneEnemies_DropsUnlistedEnemy_RemovesIt`

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings
- [x] `Game.Api.Tests` integration suite — 275 passed (incl. the 3 new delete-path tests)
- [x] `Game.Core.Tests` — 269 passed
- [x] `Game.Application.Tests` — 68 passed

Pure consistency refactor — no user-facing behavior change.

Closes #173


---
_Generated by [Claude Code](https://claude.ai/code/session_019vzYCwz81uqpFuAdfwzsDp)_