### PR TITLE
Remove avoidable null-forgiving operator usages in production code (#165)

### DIFF
--- a/Game.Api/Startup.cs
+++ b/Game.Api/Startup.cs
@@ -102,7 +102,8 @@ namespace Game.Api
             {
                 // Regenerate the frontend's TypeScript API client from the running API's types. This
                 // writes into the UI source tree, so it is strictly a local-development concern.
-                var rootFolder = Directory.GetParent(app.Environment.ContentRootPath)!.FullName;
+                var rootFolder = (Directory.GetParent(app.Environment.ContentRootPath)
+                    ?? throw new InvalidOperationException($"Could not resolve parent directory of '{app.Environment.ContentRootPath}'.")).FullName;
                 var targetDir = CodeGenPaths.ResolveTargetDirectory(rootFolder);
                 var codeGen = app.Services.GetRequiredService<ApiCodeGenerator>();
                 codeGen.GenerateCode(typeof(Startup).Assembly, new CodeGenOptions { TargetDirectory = targetDir, NewLine = "\n" });

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -57,7 +57,7 @@ namespace Game.Application.Services
 
         public async Task<DefeatResult?> EndBattleVictory(Player player, PlayerState state, DateTime claimedTimestamp)
         {
-            if (state.ActiveEnemyId is not { } enemyId || state.Snapshot is null)
+            if (state.ActiveEnemyId is not int enemyId || state.Snapshot is null)
             {
                 return null;
             }
@@ -105,7 +105,7 @@ namespace Game.Application.Services
 
         public async Task<bool> EndBattleLoss(Player player, PlayerState state)
         {
-            if (state.ActiveEnemyId is not { } enemyId || state.Snapshot is null)
+            if (state.ActiveEnemyId is not int enemyId || state.Snapshot is null)
             {
                 return false;
             }
@@ -135,7 +135,7 @@ namespace Game.Application.Services
 
         private async Task AbandonBattle(Player player, PlayerState state)
         {
-            if (state.ActiveEnemyId is not { } enemyId || state.Snapshot is null)
+            if (state.ActiveEnemyId is not int enemyId || state.Snapshot is null)
             {
                 state.ClearBattle();
                 return;

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -57,12 +57,11 @@ namespace Game.Application.Services
 
         public async Task<DefeatResult?> EndBattleVictory(Player player, PlayerState state, DateTime claimedTimestamp)
         {
-            if (!state.HasActiveBattle || state.Snapshot is null)
+            if (state.ActiveEnemyId is not { } enemyId || state.Snapshot is null)
             {
                 return null;
             }
 
-            var enemyId = state.ActiveEnemyId!.Value;
             var level = state.ActiveEnemyLevel ?? 1;
             var enemySkillIds = state.ActiveEnemySkillIds ?? [];
 
@@ -106,12 +105,11 @@ namespace Game.Application.Services
 
         public async Task<bool> EndBattleLoss(Player player, PlayerState state)
         {
-            if (!state.HasActiveBattle || state.Snapshot is null)
+            if (state.ActiveEnemyId is not { } enemyId || state.Snapshot is null)
             {
                 return false;
             }
 
-            var enemyId = state.ActiveEnemyId!.Value;
             var level = state.ActiveEnemyLevel ?? 1;
             var enemySkillIds = state.ActiveEnemySkillIds ?? [];
 
@@ -137,13 +135,12 @@ namespace Game.Application.Services
 
         private async Task AbandonBattle(Player player, PlayerState state)
         {
-            if (state.Snapshot is null)
+            if (state.ActiveEnemyId is not { } enemyId || state.Snapshot is null)
             {
                 state.ClearBattle();
                 return;
             }
 
-            var enemyId = state.ActiveEnemyId!.Value;
             var level = state.ActiveEnemyLevel ?? 1;
             var enemySkillIds = state.ActiveEnemySkillIds ?? [];
 

--- a/Game.DataAccess/DataProviderSynchronizer.cs
+++ b/Game.DataAccess/DataProviderSynchronizer.cs
@@ -318,6 +318,7 @@ namespace Game.DataAccess
             await context.SaveChangesAsync();
         }
 
-        private static T Deserialize<T>(string json) => json.Deserialize<T>()!;
+        private static T Deserialize<T>(string json)
+            => json.Deserialize<T>() ?? throw new JsonException($"Deserialized '{typeof(T).Name}' payload was null.");
     }
 }

--- a/UI/src/lib/battle/attribute-collection.ts
+++ b/UI/src/lib/battle/attribute-collection.ts
@@ -99,7 +99,7 @@ export function computeAttributes<T extends AttributeModifier>(
 		const lines: AppliedModifier<T>[] = [];
 
 		for (const mod of adds) {
-			const derivedValue = mod.source === EAttributeModifierSource.Derived ? valueOf(mod.derivedSource!) : undefined;
+			const derivedValue = mod.source === EAttributeModifierSource.Derived ? valueOf(mod.derivedSource) : undefined;
 			const applied = derivedValue === undefined ? mod.amount : mod.amount * derivedValue;
 			running += applied;
 			lines.push({ ...mod, applied, running, multiplied: false, derivedValue });
@@ -108,7 +108,7 @@ export function computeAttributes<T extends AttributeModifier>(
 		const additiveSubtotal = running;
 
 		for (const mod of mults) {
-			const derivedValue = mod.source === EAttributeModifierSource.Derived ? valueOf(mod.derivedSource!) : undefined;
+			const derivedValue = mod.source === EAttributeModifierSource.Derived ? valueOf(mod.derivedSource) : undefined;
 			const factor = derivedValue === undefined ? mod.amount : mod.amount * derivedValue;
 			const before = running;
 			running *= factor;

--- a/UI/src/lib/battle/attribute-modifier.ts
+++ b/UI/src/lib/battle/attribute-modifier.ts
@@ -28,18 +28,27 @@ export enum EAttributeModifierSource {
 	ItemMod = 6
 }
 
-/** Mirrors `Game.Core.Attributes.Modifiers.AttributeModifier`. A `Derived`
- *  modifier's {@link amount} is multiplied by the final value of
- *  {@link derivedSource} before being applied. */
-export interface AttributeModifier {
+/** A modifier whose amount is scaled by the final value of another attribute. */
+export interface DerivedAttributeModifier {
 	attribute: EAttribute;
 	amount: number;
 	type: EModifierType;
-	source: EAttributeModifierSource;
-	/** Only meaningful when `source === Derived`: the attribute whose final value
-	 *  scales this modifier's amount. */
-	derivedSource?: EAttribute;
+	source: EAttributeModifierSource.Derived;
+	/** The attribute whose final value scales this modifier's amount. */
+	derivedSource: EAttribute;
 }
+
+/** A modifier with a fixed amount not derived from another attribute. */
+export interface BaseAttributeModifier {
+	attribute: EAttribute;
+	amount: number;
+	type: EModifierType;
+	source: Exclude<EAttributeModifierSource, EAttributeModifierSource.Derived>;
+}
+
+/** Mirrors `Game.Core.Attributes.Modifiers.AttributeModifier`. Discriminated on
+ *  `source`: only `Derived` modifiers carry a non-optional `derivedSource`. */
+export type AttributeModifier = DerivedAttributeModifier | BaseAttributeModifier;
 
 /** Mirrors `Game.Core.Attributes.Modifiers.StaticAttributeModifiers` plus
  *  `AttributeCollection.AddStaticModifiers` — the engine base values and derived

--- a/UI/src/lib/battle/battle-attributes.ts
+++ b/UI/src/lib/battle/battle-attributes.ts
@@ -4,7 +4,8 @@ import {
 	STATIC_ATTRIBUTE_MODIFIERS,
 	EModifierType,
 	EAttributeModifierSource,
-	type AttributeModifier
+	type AttributeModifier,
+	type BaseAttributeModifier
 } from './attribute-modifier';
 import { computeAttributes } from './attribute-collection';
 
@@ -23,12 +24,14 @@ export class BattleAttributes {
 
 		if (calcDerivedStats) {
 			const modifiers: AttributeModifier[] = [
-				...attList.map((att) => ({
-					attribute: att.attributeId,
-					amount: att.amount,
-					type: EModifierType.Additive,
-					source: EAttributeModifierSource.AttributeDistribution
-				})),
+				...attList.map(
+					(att): BaseAttributeModifier => ({
+						attribute: att.attributeId,
+						amount: att.amount,
+						type: EModifierType.Additive,
+						source: EAttributeModifierSource.AttributeDistribution
+					})
+				),
 				...STATIC_ATTRIBUTE_MODIFIERS
 			];
 			const computed = computeAttributes(modifiers);

--- a/UI/src/routes/game/screens/attribute-breakdown/BySourceBreakdown.svelte
+++ b/UI/src/routes/game/screens/attribute-breakdown/BySourceBreakdown.svelte
@@ -15,9 +15,9 @@
 				<div class="line">
 					<span class="line-label">
 						{#if line.source === EAttributeModifierSource.Derived}
-							{attributeName(line.derivedSource!)} ({line.amount}× of {fmtNum(line.derivedValue ?? 0, 1)})
-						{:else if line.source === EAttributeModifierSource.ItemMod}
-							{modifierLabel(line)} · {modTypeLabel(line.modType!)}
+							{attributeName(line.derivedSource)} ({line.amount}× of {fmtNum(line.derivedValue ?? 0, 1)})
+						{:else if line.source === EAttributeModifierSource.ItemMod && line.modType !== undefined}
+							{modifierLabel(line)} · {modTypeLabel(line.modType)}
 						{:else}
 							{modifierLabel(line)}
 						{/if}

--- a/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
+++ b/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
@@ -36,7 +36,7 @@ import { staticData } from '$stores';
  *  breakdown can label each contribution (which item/mod it came from). The core
  *  domain fields still mirror the backend exactly; the extra fields are ignored
  *  by the aggregation and simply flow through onto the computed lines. */
-export interface LabeledModifier extends AttributeModifier {
+export type LabeledModifier = AttributeModifier & {
 	/** The equipped item or applied mod name; absent for base/points/derived,
 	 *  which are labelled by their source. */
 	label?: string;
@@ -44,7 +44,7 @@ export interface LabeledModifier extends AttributeModifier {
 	slot?: EEquipmentSlot;
 	/** The mod type (Component/Prefix/Suffix) for an `ItemMod` contribution. */
 	modType?: EItemModType;
-}
+};
 
 export type AttributeGroup = 'core' | 'derived';
 
@@ -123,7 +123,7 @@ export function slotLabel(slot: number | undefined): string {
 export function modifierLabel(line: AppliedModifier<LabeledModifier>): string {
 	switch (line.source) {
 		case EAttributeModifierSource.Derived:
-			return attributeName(line.derivedSource!);
+			return attributeName(line.derivedSource);
 		case EAttributeModifierSource.PlayerStatPoints:
 			return 'Allocated stat points';
 		case EAttributeModifierSource.BaseValue:
@@ -138,7 +138,7 @@ export function modifierLabel(line: AppliedModifier<LabeledModifier>): string {
 export function traceLabel(line: AppliedModifier<LabeledModifier>): string {
 	switch (line.source) {
 		case EAttributeModifierSource.Derived:
-			return attributeName(line.derivedSource!);
+			return attributeName(line.derivedSource);
 		case EAttributeModifierSource.PlayerStatPoints:
 			return 'Stat points';
 		case EAttributeModifierSource.BaseValue:

--- a/UI/src/routes/game/screens/inventory/EquipSlot.svelte
+++ b/UI/src/routes/game/screens/inventory/EquipSlot.svelte
@@ -12,31 +12,31 @@
 		style:border-color={tileBorder}
 		style:background={over
 			? tintColor('var(--accent)', 0.14)
-			: filled
-				? rarityTint(item!.rarityId, 0.07)
+			: item
+				? rarityTint(item.rarityId, 0.07)
 				: tintColor('var(--white)', 0.03)}
 		ondragover={handleDragOver}
 		ondragleave={() => (over = false)}
 		ondrop={handleDrop}
-		onclick={() => filled && onSelect?.(item!)}
+		onclick={() => item && onSelect?.(item)}
 		onkeydown={(e) => {
-			if (filled && (e.key === 'Enter' || e.key === ' ')) {
+			if (item && (e.key === 'Enter' || e.key === ' ')) {
 				e.preventDefault();
-				onSelect?.(item!);
+				onSelect?.(item);
 			}
 		}}
 		onmouseenter={(e) => {
 			hover = true;
-			if (filled) onHoverEnter?.(item!, e);
+			if (item) onHoverEnter?.(item, e);
 		}}
-		onmousemove={(e) => filled && onHoverMove?.(e)}
+		onmousemove={(e) => item && onHoverMove?.(e)}
 		onmouseleave={() => {
 			hover = false;
 			onHoverLeave?.();
 		}}
 	>
-		{#if filled}
-			<CategoryGlyph cat={item!.itemCategoryId} color={itemCategoryColor(item!.itemCategoryId)} size={20} />
+		{#if item}
+			<CategoryGlyph cat={item.itemCategoryId} color={itemCategoryColor(item.itemCategoryId)} size={20} />
 			{#if hover}
 				<button
 					class="unequip"
@@ -47,8 +47,8 @@
 					}}>×</button
 				>
 			{/if}
-			{#if item!.appliedMods.length}
-				<span class="mod-count">{item!.appliedMods.length}◈</span>
+			{#if item.appliedMods.length}
+				<span class="mod-count">{item.appliedMods.length}◈</span>
 			{/if}
 		{:else}
 			<CategoryGlyph cat={slot.category} color={tintColor('var(--text-primary)', 0.18)} size={19} />
@@ -56,12 +56,12 @@
 	</div>
 
 	<div class="row-info">
-		{#if filled}
-			<div class="item-name">{item!.name}</div>
+		{#if item}
+			<div class="item-name">{item.name}</div>
 			<div class="rarity-tag">
-				<span class="rarity-dot" style:background={rc} style:box-shadow="0 0 6px {rarityTint(item!.rarityId, 0.65)}"
+				<span class="rarity-dot" style:background={rc} style:box-shadow="0 0 6px {rarityTint(item.rarityId, 0.65)}"
 				></span>
-				<span class="rarity-label" style:color={rc}>{rarityLabel(item!.rarityId)}</span>
+				<span class="rarity-label" style:color={rc}>{rarityLabel(item.rarityId)}</span>
 			</div>
 		{:else}
 			<div class="empty-label">Empty</div>
@@ -101,8 +101,8 @@ const canAccept = $derived(!!dragItem && dragItem.itemCategoryId === slot.catego
 const tileBorder = $derived(
 	over || selected
 		? 'var(--accent)'
-		: filled
-			? rarityTint(item!.rarityId, 0.6)
+		: item
+			? rarityTint(item.rarityId, 0.6)
 			: canAccept
 				? tintColor('var(--accent)', 0.5)
 				: 'var(--border-light)'

--- a/UI/src/tests/lib/battle/attribute-collection.test.ts
+++ b/UI/src/tests/lib/battle/attribute-collection.test.ts
@@ -22,7 +22,10 @@ const withStatics = (contribs: AttributeModifier[]): AttributeModifier[] => [
 const additive = (
 	attribute: EAttribute,
 	amount: number,
-	source = EAttributeModifierSource.PlayerStatPoints
+	source: Exclude<
+		EAttributeModifierSource,
+		EAttributeModifierSource.Derived
+	> = EAttributeModifierSource.PlayerStatPoints
 ): AttributeModifier => ({ attribute, amount, type: EModifierType.Additive, source });
 
 describe('computeAttributes', () => {
@@ -47,7 +50,9 @@ describe('computeAttributes', () => {
 		const hp = computed.get(EAttribute.MaxHealth)!;
 		expect(hp.total).toBe(50 + 20 * 12 + 5 * 14);
 
-		const enduranceLine = hp.lines.find((l) => l.derivedSource === EAttribute.Endurance)!;
+		const enduranceLine = hp.lines.find(
+			(l) => l.source === EAttributeModifierSource.Derived && l.derivedSource === EAttribute.Endurance
+		)!;
 		expect(enduranceLine.derivedValue).toBe(12);
 		expect(enduranceLine.applied).toBe(240);
 	});


### PR DESCRIPTION
## Summary

- **Frontend — discriminated union for `AttributeModifier`:** Split the single interface into `DerivedAttributeModifier` (with `derivedSource: EAttribute` required) and `BaseAttributeModifier`, united as `AttributeModifier = DerivedAttributeModifier | BaseAttributeModifier`. TypeScript 6's generic narrowing then removes all `derivedSource!` accesses from `attribute-collection.ts`, `attribute-breakdown-view.svelte.ts`, and `BySourceBreakdown.svelte` without any casts. `LabeledModifier` becomes a type alias (intersection with the union distributes correctly).
- **Frontend — `EquipSlot`:** Replaces all `item!` usages by switching `{#if filled}` blocks to `{#if item}` (functionally equivalent since `filled = !!item`) and changing event-handler guards from `filled && ... item!` to `item && ... item`, letting TypeScript narrow without the operator. The `tileBorder` derived and `onmousemove` handler are updated the same way.
- **Backend — `BattleService`:** Replaces `state.ActiveEnemyId!.Value` in `EndBattleVictory`, `EndBattleLoss`, and `AbandonBattle` with C# pattern matching (`ActiveEnemyId is not { } enemyId`), which extracts the value while making the null check explicit and readable.
- **Backend — `Startup`:** Wraps `Directory.GetParent(...)` with `?? throw new InvalidOperationException(...)` so a null result at a filesystem root surfaces as a clear error rather than an NRE.
- **Backend — `DataProviderSynchronizer`:** The `Deserialize<T>` helper now throws a `JsonException` on a null result instead of suppressing it with `!`, surfacing the failure as a proper dead-letterable error.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 609 tests passing (Core: 269, Application: 68, Api: 272)
- [x] `npm run lint` (ESLint + svelte-check) — 0 errors, 0 warnings across 776 files
- [x] `npm run test:unit:ci` — 831 tests passing across 100 test files

Closes #165

https://claude.ai/code/session_0192cd5i3Qju6CTNbhDAiiUt

---
_Generated by [Claude Code](https://claude.ai/code/session_0192cd5i3Qju6CTNbhDAiiUt)_