### PR TITLE
Migrate challenge tooltips to the shared tooltip primitives

### DIFF
--- a/UI/src/components/tooltip/TooltipTitle.svelte
+++ b/UI/src/components/tooltip/TooltipTitle.svelte
@@ -8,7 +8,7 @@
 		<span class="tt-category-label" style:color={labelColor}>{label}</span>
 		{@render trailing?.()}
 	</div>
-	<div class="tt-title-name">{name}</div>
+	<div class="tt-title-name" class:masked>{name}</div>
 </div>
 
 <script lang="ts">
@@ -26,9 +26,11 @@ interface Props {
 	labelColor: string;
 	/** Optional trailing content on the category row (e.g. a cooldown pill or equipped badge). */
 	trailing?: Snippet;
+	/** Render the name as a dimmed, wide-tracked placeholder (sealed/teaser tooltips). */
+	masked?: boolean;
 }
 
-const { label, name, diamondColor, labelColor, trailing }: Props = $props();
+const { label, name, diamondColor, labelColor, trailing, masked = false }: Props = $props();
 </script>
 
 <style lang="scss">
@@ -63,5 +65,10 @@ const { label, name, diamondColor, labelColor, trailing }: Props = $props();
 	color: var(--text-primary);
 	letter-spacing: -0.2px;
 	line-height: 1.15;
+
+	&.masked {
+		color: color-mix(in srgb, var(--text-primary) 45%, transparent);
+		letter-spacing: 2px;
+	}
 }
 </style>

--- a/UI/src/routes/game/screens/challenges/ModTooltip.svelte
+++ b/UI/src/routes/game/screens/challenges/ModTooltip.svelte
@@ -1,27 +1,15 @@
 <div class="mod-tooltip" style:border-left="3px solid {rarityColor(mod.rarityId)}">
-	<div class="tt-title-section">
-		<div class="tt-type-row">
-			<div
-				class="tt-type-diamond"
-				style:background={typeColor}
-				style:box-shadow="0 0 6px {tintColor(typeColor, 0.67)}"
-			></div>
-			<span class="tt-type-label" style:color={typeColor}>{modTypeLabel(mod.itemModTypeId)}</span>
-		</div>
-		<div class="tt-mod-name">{mod.name}</div>
-	</div>
+	<TooltipTitle
+		label={modTypeLabel(mod.itemModTypeId)}
+		name={mod.name}
+		diamondColor={typeColor}
+		labelColor={typeColor}
+	/>
 
 	<div class="tt-body">
 		{#if effects.length}
 			<TooltipSection label="Effects" last={!mod.description}>
-				<div class="tt-stats-grid">
-					{#each effects as effect (effect.name)}
-						<div class="tt-stat-name">{effect.name}</div>
-						<div class="tt-stat-value" class:positive={effect.value > 0} class:negative={effect.value < 0}>
-							{effect.value > 0 ? '+' : ''}{effect.value}
-						</div>
-					{/each}
-				</div>
+				<TooltipStatsGrid entries={effects} />
 			</TooltipSection>
 		{/if}
 
@@ -35,8 +23,10 @@
 
 <script lang="ts">
 import { EAttribute, type IItemMod } from '$lib/api';
-import { modTypeColor, modTypeLabel, normalizeText, rarityColor, tintColor } from '$lib/common';
+import { modTypeColor, modTypeLabel, normalizeText, rarityColor } from '$lib/common';
 import TooltipSection from '$components/tooltip/TooltipSection.svelte';
+import TooltipStatsGrid from '$components/tooltip/TooltipStatsGrid.svelte';
+import TooltipTitle from '$components/tooltip/TooltipTitle.svelte';
 
 interface Props {
 	mod: IItemMod;
@@ -57,68 +47,8 @@ const effects = $derived(
 	box-shadow: -4px 0 16px color-mix(in srgb, var(--black) 15%, transparent);
 }
 
-.tt-title-section {
-	padding: 14px 16px 12px;
-	border-bottom: 1px solid color-mix(in srgb, var(--text-primary) 8%, transparent);
-}
-
-.tt-type-row {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	margin-bottom: 4px;
-}
-
-.tt-type-diamond {
-	width: 5px;
-	height: 5px;
-	transform: rotate(45deg);
-}
-
-.tt-type-label {
-	font-family: var(--mono);
-	font-size: 9.5px;
-	letter-spacing: 1.8px;
-	text-transform: uppercase;
-}
-
-.tt-mod-name {
-	font-size: 18px;
-	font-weight: 400;
-	color: var(--text-primary);
-	letter-spacing: -0.2px;
-	line-height: 1.15;
-}
-
 .tt-body {
 	padding: 12px 16px 14px;
-}
-
-.tt-stats-grid {
-	display: grid;
-	grid-template-columns: 1fr auto;
-	row-gap: 4px;
-	column-gap: 12px;
-
-	.tt-stat-name {
-		font-size: 12px;
-		color: var(--text-secondary);
-	}
-
-	.tt-stat-value {
-		font-family: var(--mono);
-		font-size: 11.5px;
-		letter-spacing: 0.3px;
-		text-align: right;
-		color: color-mix(in srgb, var(--text-primary) 70%, transparent);
-
-		&.positive {
-			color: var(--success);
-		}
-		&.negative {
-			color: var(--error);
-		}
-	}
 }
 
 .tt-description {

--- a/UI/src/routes/game/screens/challenges/SealedHeader.svelte
+++ b/UI/src/routes/game/screens/challenges/SealedHeader.svelte
@@ -1,9 +1,7 @@
-<div class="sealed-head">
-	<div class="head-top">
-		<!-- Diamond + category label are colour-matched to the (still-visible) category. -->
-		<div class="cat-diamond" style:background={catAccent} style:box-shadow="0 0 6px {tintColor(catAccent, 0.67)}"></div>
-		<div class="cat-label" style:color={catAccent}>{typeLabel}</div>
-		<!-- Sealed badge + border accent carry the rarity tier (the teaser). -->
+<!-- Diamond + category label stay colour-matched to the (still-visible) category, while the
+	sealed badge + masked name carry the rarity teaser — composed over the shared TooltipTitle. -->
+<TooltipTitle label={typeLabel} name="?????????" diamondColor={catAccent} labelColor={catAccent} masked>
+	{#snippet trailing()}
 		<div
 			class="sealed-badge"
 			style:background={tintColor(rarityAccent, 0.1)}
@@ -15,12 +13,12 @@
 			</svg>
 			<span style:color={rarityAccent}>Sealed</span>
 		</div>
-	</div>
-	<div class="masked-name">?????????</div>
-</div>
+	{/snippet}
+</TooltipTitle>
 
 <script lang="ts">
 import { tintColor } from '$lib/common';
+import TooltipTitle from '$components/tooltip/TooltipTitle.svelte';
 
 interface Props {
 	/** Rarity hue — drives the SEALED badge and the tooltip's left border. */
@@ -35,31 +33,6 @@ const { rarityAccent, catAccent, typeLabel }: Props = $props();
 </script>
 
 <style lang="scss">
-.sealed-head {
-	padding: 14px 16px 12px;
-	border-bottom: 1px solid color-mix(in srgb, var(--text-primary) 8%, transparent);
-}
-
-.head-top {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	margin-bottom: 5px;
-}
-
-.cat-diamond {
-	width: 5px;
-	height: 5px;
-	transform: rotate(45deg);
-}
-
-.cat-label {
-	font-family: var(--mono);
-	font-size: 9.5px;
-	letter-spacing: 1.8px;
-	text-transform: uppercase;
-}
-
 .sealed-badge {
 	margin-left: auto;
 	display: flex;
@@ -74,12 +47,5 @@ const { rarityAccent, catAccent, typeLabel }: Props = $props();
 		letter-spacing: 1.2px;
 		text-transform: uppercase;
 	}
-}
-
-.masked-name {
-	font-size: 18px;
-	font-weight: 400;
-	color: color-mix(in srgb, var(--text-primary) 45%, transparent);
-	letter-spacing: 2px;
 }
 </style>

--- a/UI/src/tests/components/tooltip/TooltipTitle.test.ts
+++ b/UI/src/tests/components/tooltip/TooltipTitle.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import TooltipTitle from '$components/tooltip/TooltipTitle.svelte';
+
+afterEach(cleanup);
+
+describe('TooltipTitle', () => {
+	const baseProps = {
+		label: 'Prefix',
+		name: 'Flaming',
+		diamondColor: 'var(--mod-prefix)',
+		labelColor: 'var(--mod-prefix)'
+	};
+
+	it('renders the label and name, colouring the diamond and label by accent', () => {
+		const { container } = render(TooltipTitle, { props: baseProps });
+		const label = container.querySelector('.tt-category-label') as HTMLElement;
+		expect(label.textContent).toBe('Prefix');
+		expect(label.getAttribute('style')).toContain('var(--mod-prefix)');
+		expect((container.querySelector('.tt-category-diamond') as HTMLElement).getAttribute('style')).toContain(
+			'var(--mod-prefix)'
+		);
+		expect((container.querySelector('.tt-title-name') as HTMLElement).textContent).toBe('Flaming');
+	});
+
+	it('does not mask the name by default', () => {
+		const { container } = render(TooltipTitle, { props: baseProps });
+		expect((container.querySelector('.tt-title-name') as HTMLElement).classList.contains('masked')).toBe(false);
+	});
+
+	it('marks the name masked when the masked prop is set', () => {
+		const { container } = render(TooltipTitle, { props: { ...baseProps, name: '?????????', masked: true } });
+		const name = container.querySelector('.tt-title-name') as HTMLElement;
+		expect(name.classList.contains('masked')).toBe(true);
+		expect(name.textContent).toBe('?????????');
+	});
+});

--- a/UI/src/tests/routes/game/screens/challenges/ModTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/ModTooltip.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EAttribute, EItemModType, ERarity, type IItemMod } from '$lib/api';
+import ModTooltip from '$routes/game/screens/challenges/ModTooltip.svelte';
+
+// A prefix mod with a positive and a negative attribute, so the signed/positive/negative
+// rendering of the shared TooltipStatsGrid is exercised. `MaxHealth` also covers the
+// `normalizeText` split (camelCase -> "Max Health").
+const makeMod = (overrides: Partial<IItemMod> = {}): IItemMod => ({
+	id: 1,
+	name: 'Flaming',
+	description: 'Wreathed in flame.',
+	itemModTypeId: EItemModType.Prefix,
+	rarityId: ERarity.Legendary,
+	attributes: [
+		{ attributeId: EAttribute.Strength, amount: 5 },
+		{ attributeId: EAttribute.MaxHealth, amount: 12 },
+		{ attributeId: EAttribute.Defense, amount: -2 }
+	],
+	tags: [],
+	...overrides
+});
+
+afterEach(cleanup);
+
+describe('ModTooltip', () => {
+	it('accents the tooltip border by the mod rarity', () => {
+		const { container } = render(ModTooltip, { props: { mod: makeMod() } });
+		const tooltip = container.querySelector('.mod-tooltip') as HTMLElement;
+		expect(tooltip.getAttribute('style')).toContain('var(--rarity-legendary)');
+	});
+
+	it('labels and colours the title by the mod type', () => {
+		const { container } = render(ModTooltip, { props: { mod: makeMod() } });
+		const label = container.querySelector('.tt-category-label') as HTMLElement;
+		expect(label.textContent).toBe('Prefix');
+		expect(label.getAttribute('style')).toContain('var(--mod-prefix)');
+		const name = container.querySelector('.tt-title-name') as HTMLElement;
+		expect(name.textContent).toBe('Flaming');
+	});
+
+	it('renders each attribute as a normalized, signed effect row', () => {
+		const { container } = render(ModTooltip, { props: { mod: makeMod() } });
+		const grid = container.querySelector('.tt-stats-grid') as HTMLElement;
+		const names = Array.from(grid.querySelectorAll('.tt-stat-name')).map((n) => n.textContent);
+		expect(names).toEqual(['Strength', 'Max Health', 'Defense']);
+
+		const values = Array.from(grid.querySelectorAll('.tt-stat-value')) as HTMLElement[];
+		expect(values.map((v) => v.textContent?.trim())).toEqual(['+5', '+12', '-2']);
+		// Positive amounts are accented positive, negative amounts negative.
+		expect(values[0].classList.contains('positive')).toBe(true);
+		expect(values[2].classList.contains('negative')).toBe(true);
+	});
+
+	it('omits the Effects section when the mod has no attributes', () => {
+		const { container } = render(ModTooltip, { props: { mod: makeMod({ attributes: [] }) } });
+		expect(container.querySelector('.tt-stats-grid')).toBeNull();
+	});
+
+	it('renders the description when present and omits it otherwise', () => {
+		const { container, rerender } = render(ModTooltip, { props: { mod: makeMod() } });
+		expect((container.querySelector('.tt-description') as HTMLElement).textContent).toBe('Wreathed in flame.');
+
+		rerender({ mod: makeMod({ description: '' }) });
+		expect(container.querySelector('.tt-description')).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

Closes #194.

#145 (PR #193) promoted the shared tooltip chrome into reusable primitives under `components/tooltip/` (`TooltipSection`, `TooltipTitle`, `TooltipStatsGrid`). The challenge-screen tooltips still re-implemented the title row and stats grid inline. This migrates them to compose the shared primitives, removing the duplicated markup and SCSS.

## Changes

- **`ModTooltip`** now composes `TooltipTitle` + `TooltipStatsGrid`, dropping its inline `.tt-type-*` / `.tt-mod-name` title markup and the `.tt-stats-grid` grid (markup **and** ~70 lines of duplicated SCSS), plus the now-unused `tintColor` import.
- **`SealedHeader`** (used by both `SealedModTooltip` and `SealedItemTooltip`) now composes `TooltipTitle` rather than forking the title-section chrome — the SEALED badge is supplied via the primitive's `trailing` snippet, and the masked name via a new opt-in flag. Refactoring the shared header covers both sealed tooltips in one place.
- **`TooltipTitle`** gains an optional `masked` prop (dimmed, wide-tracked name) so the sealed/teaser variant extends the shared primitive instead of duplicating it, exactly as the issue suggested.
- **`RewardTooltip`** is a pure dispatcher (it just renders `ItemTooltip`/`ModTooltip`/`SealedItemTooltip`/`SealedModTooltip`) with no title/stats markup of its own, so it needs no change despite being listed in the issue.

This is a behaviour-preserving refactor. The only visual deltas are two negligible values consolidated onto the shared primitive: the sealed header's category-row margin (5px → 4px) and the masked name now inheriting `line-height: 1.15`.

### Note on remaining duplication (out of scope)

`SealedModTooltip` and `SealedItemTooltip` still share their own masked-bar grid markup/SCSS (`.masked-grid` / `.qmark` / `.masked-desc`). That's a deliberately *masked* presentation (`???`, not real values), so it has no counterpart among the current shared primitives and is outside this issue's "migrate to `TooltipTitle`/`TooltipStatsGrid`" scope. Flagging rather than expanding the blast radius — happy to file a follow-up if we want a shared masked-grid primitive.

## Test plan

- [x] Added `ModTooltip.test.ts` — covers the `effects` derivation (normalized attribute names via `normalizeText`, signed `+`/`-` values, positive/negative accenting), the rarity border and mod-type-coloured title, and the conditional Effects/Description sections.
- [x] Added `TooltipTitle.test.ts` — covers base label/name/diamond rendering and the new `masked` variant.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.
- [x] `npm run test:unit:ci` — 913/913 passing.

https://claude.ai/code/session_01UThZL7fkTjG1wTwKGRDTP6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UThZL7fkTjG1wTwKGRDTP6)_