### PR TITLE
Game.Core cleanup: relocate BackgroundWorker to Infrastructure, remove dead constructors and extension methods

### DIFF
--- a/Game.Core/Extensions.cs
+++ b/Game.Core/Extensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using static Game.Core.EAttribute;
 
 namespace Game.Core
 {
@@ -21,16 +20,6 @@ namespace Game.Core
         public static string ToBase64<T>(this T obj)
         {
             return Convert.ToBase64String(Encoding.UTF8.GetBytes(obj?.ToString() ?? ""));
-        }
-
-        /// <summary>
-        /// Converts this string from base64 to a UTF8 encoding representation.
-        /// </summary>
-        /// <param name="str"></param>
-        /// <returns>This string in a UTF8 representation.</returns>
-        public static string FromBase64(this string str)
-        {
-            return Encoding.UTF8.GetString(Convert.FromBase64String(str));
         }
 
         /// <summary>
@@ -157,17 +146,6 @@ namespace Game.Core
         public static string SnakeCase(this string str)
         {
             return WordBreakRegex().Replace(str, "$1-$2").ToLower();
-        }
-
-        /// <summary>
-        /// Returns true if this is one of the core attributes: <see cref="Strength"/>, <see cref="Endurance"/>, <see cref="Intellect"/>,
-        /// <see cref="Agility"/>, <see cref="Dexterity"/>, or <see cref="Luck"/>.
-        /// </summary>
-        /// <param name="att"></param>
-        /// <returns></returns>
-        public static bool IsCoreAttribute(this EAttribute att)
-        {
-            return att is Strength or Endurance or Intellect or Agility or Dexterity or Luck;
         }
 
         [GeneratedRegex("([a-z])([A-Z])")]

--- a/Game.Core/Game.Core.csproj
+++ b/Game.Core/Game.Core.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
   </ItemGroup>
 

--- a/Game.Infrastructure/BackgroundWorker.cs
+++ b/Game.Infrastructure/BackgroundWorker.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 
-namespace Game.Core
+namespace Game.Infrastructure
 {
     /// <summary>
     /// A lightweight container for managing and repeatedly executing a delegate using a background <see cref="Task"/>.
@@ -24,18 +24,7 @@ namespace Game.Core
         public bool IsRunning { get; private set; } = false;
 
         /// <summary>
-        /// Initializes the <see cref="BackgroundWorker"/> with a synchronous delegate expecting an <see cref="ILogger"/> parameter. 
-        /// </summary>
-        /// <param name="logger"></param>
-        /// <param name="action"></param>
-        public BackgroundWorker(ILogger<BackgroundWorker> logger, Action<ILogger> action)
-        {
-            _logger = logger;
-            _workerHandle = RegisterWorker(CreateWorkerLoop(() => action(logger)));
-        }
-
-        /// <summary>
-        /// Initializes the <see cref="BackgroundWorker"/> with a synchronous delegate expecting no parameters. 
+        /// Initializes the <see cref="BackgroundWorker"/> with a synchronous delegate expecting no parameters.
         /// </summary>
         /// <param name="logger"></param>
         /// <param name="action"></param>
@@ -46,18 +35,7 @@ namespace Game.Core
         }
 
         /// <summary>
-        /// Initializes the <see cref="BackgroundWorker"/> with an asynchronous delegate expecting an <see cref="ILogger"/> parameter. 
-        /// </summary>
-        /// <param name="logger"></param>
-        /// <param name="action"></param>
-        public BackgroundWorker(ILogger<BackgroundWorker> logger, Func<ILogger, Task> action)
-        {
-            _logger = logger;
-            _workerHandle = RegisterWorker(CreateAsyncWorkerLoop(async () => await action(logger)));
-        }
-
-        /// <summary>
-        /// Initializes the <see cref="BackgroundWorker"/> with an asynchronous delegate expecting no parameters. 
+        /// Initializes the <see cref="BackgroundWorker"/> with an asynchronous delegate expecting no parameters.
         /// </summary>
         /// <param name="logger"></param>
         /// <param name="action"></param>

--- a/Game.Infrastructure/Game.Infrastructure.csproj
+++ b/Game.Infrastructure/Game.Infrastructure.csproj
@@ -17,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.13.1" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Hygiene cleanup in `Game.Core`, addressing all three items in #209. Each was verified by repo-wide grep before changing.

### 1. Relocated `BackgroundWorker` out of the domain project
`BackgroundWorker` is pure infrastructure plumbing (ThreadPool wait handles, `ILogger`, an async run/`Kill` lifecycle) with no domain content. Its only consumer is `Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs`, so it moved into `Game.Infrastructure`.

- **Placed at the project root (`Game.Infrastructure/BackgroundWorker.cs`, namespace `Game.Infrastructure`)** rather than inside `PubSub/Redis/`. It's a generic threading primitive, not Redis-specific, so it sits alongside the other general-purpose infra types (`NotLoadedException`, `InfrastructureOptions`) instead of being buried in a Redis namespace. `RedisPubSubService` resolves it via the parent namespace, so no `using` change was needed there.

### 2. Removed two dead constructors
The class declared four constructors; only the `Action` and `Func<Task>` overloads have call sites. The `Action<ILogger>` and `Func<ILogger, Task>` overloads had zero usages and were removed.

### 3. Removed dead extension methods
From `Game.Core/Extensions.cs`:
- `FromBase64` — no usages anywhere (its inverse `ToBase64` is still used and is kept).
- `IsCoreAttribute` — zero call sites.
- The now-unused `using static Game.Core.EAttribute;` (only `IsCoreAttribute` referenced it).

### Bonus dependency hygiene
`BackgroundWorker` was the only consumer of `Microsoft.Extensions.Logging` in `Game.Core`, so that package reference became dead there. Moved `Microsoft.Extensions.Logging.Abstractions` from `Game.Core.csproj` to `Game.Infrastructure.csproj` (now a direct dependency).

## How it addresses the issue
Keeps the domain layer free of infrastructure concerns and removes accumulated dead code (unused constructors and methods), per the project guidelines. All low-risk relocations/deletions with no behavior change.

## Test plan
- [x] `dotnet build` — succeeds, 0 warnings / 0 errors
- [x] `dotnet test` — all suites green (Game.Core.Tests 282, Game.Application.Tests 83, Game.Api.Tests 283)

## Follow-up
The issue suggested *considering* unit tests for `BackgroundWorker`'s `Start`/`Kill` state machine. There is no `Game.Infrastructure.Tests` project yet, so adding those tests means standing up a new test project — out of scope for this focused cleanup. Filed as #226.

Closes #209

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVSiRjUeiQLykeBxU2LsSp)_