### PR TITLE
Replace hardcoded brand/neutral colors with CSS theme tokens (#210)

### DIFF
--- a/UI/src/routes/game/screens/cardGame/CardGame.svelte
+++ b/UI/src/routes/game/screens/cardGame/CardGame.svelte
@@ -170,8 +170,8 @@ onMount(() => {
 		color-mix(in srgb, var(--surface) 85%, black)
 	);
 	box-shadow:
-		0 0 0 1px rgba(0, 0, 0, 0.4),
-		0 30px 70px -30px rgba(0, 0, 0, 0.8),
+		0 0 0 1px color-mix(in srgb, var(--black) 40%, transparent),
+		0 30px 70px -30px color-mix(in srgb, var(--black) 80%, transparent),
 		inset 0 1px 0 color-mix(in srgb, var(--white) 4%, transparent);
 }
 

--- a/UI/src/routes/game/screens/cardGame/loom/Board.svelte
+++ b/UI/src/routes/game/screens/cardGame/loom/Board.svelte
@@ -122,7 +122,7 @@ onMount(() => {
 	background:
 		linear-gradient(180deg, color-mix(in srgb, var(--enemy-accent) 6%, transparent), transparent 42%),
 		linear-gradient(0deg, color-mix(in srgb, var(--log-enemy) 4%, transparent), transparent 42%), var(--surface);
-	box-shadow: inset 0 2px 18px rgba(0, 0, 0, 0.5);
+	box-shadow: inset 0 2px 18px color-mix(in srgb, var(--black) 50%, transparent);
 }
 
 .gridlayer {
@@ -235,9 +235,9 @@ onMount(() => {
 		color-mix(in srgb, var(--enemy-accent) 52%, var(--surface)),
 		color-mix(in srgb, var(--enemy-accent) 34%, var(--surface))
 	);
-	color: color-mix(in srgb, var(--enemy-accent) 12%, white);
+	color: color-mix(in srgb, var(--enemy-accent) 12%, var(--white));
 	box-shadow:
-		0 2px 10px rgba(0, 0, 0, 0.45),
+		0 2px 10px color-mix(in srgb, var(--black) 45%, transparent),
 		0 0 14px -4px color-mix(in srgb, var(--enemy-accent) 70%, transparent);
 
 	.tip {
@@ -254,7 +254,7 @@ onMount(() => {
 		color-mix(in srgb, var(--enemy-accent) 42%, var(--surface)),
 		color-mix(in srgb, var(--enemy-accent) 24%, var(--surface))
 	);
-	color: color-mix(in srgb, var(--enemy-accent) 12%, white);
+	color: color-mix(in srgb, var(--enemy-accent) 12%, var(--white));
 	letter-spacing: 0.04em;
 	box-shadow:
 		0 0 22px -2px color-mix(in srgb, var(--enemy-accent) 85%, transparent),
@@ -266,9 +266,9 @@ onMount(() => {
 		font-weight: 700;
 	}
 	.tip {
-		background: white;
+		background: var(--white);
 		box-shadow:
-			0 0 10px white,
+			0 0 10px var(--white),
 			0 0 18px var(--enemy-accent);
 	}
 }
@@ -281,11 +281,11 @@ onMount(() => {
 		color-mix(in srgb, var(--log-enemy) 46%, var(--surface)),
 		color-mix(in srgb, var(--log-enemy) 30%, var(--surface))
 	);
-	color: color-mix(in srgb, var(--log-enemy) 12%, white);
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+	color: color-mix(in srgb, var(--log-enemy) 12%, var(--white));
+	box-shadow: 0 2px 10px color-mix(in srgb, var(--black) 45%, transparent);
 
 	.tip {
-		background: color-mix(in srgb, var(--log-enemy) 60%, white);
+		background: color-mix(in srgb, var(--log-enemy) 60%, var(--white));
 		box-shadow: 0 0 8px color-mix(in srgb, var(--log-enemy) 70%, transparent);
 	}
 }
@@ -298,9 +298,9 @@ onMount(() => {
 		color-mix(in srgb, var(--rarity-epic) 50%, var(--surface)),
 		color-mix(in srgb, var(--rarity-epic) 32%, var(--surface))
 	);
-	color: color-mix(in srgb, var(--rarity-epic) 12%, white);
+	color: color-mix(in srgb, var(--rarity-epic) 12%, var(--white));
 	box-shadow:
-		0 2px 10px rgba(0, 0, 0, 0.45),
+		0 2px 10px color-mix(in srgb, var(--black) 45%, transparent),
 		0 0 14px -4px color-mix(in srgb, var(--rarity-epic) 60%, transparent);
 
 	.tip {
@@ -320,7 +320,7 @@ onMount(() => {
 	border-color: color-mix(in srgb, var(--health-remaining-color) 50%, transparent);
 	background: color-mix(in srgb, var(--health-remaining-color) 12%, transparent);
 	box-shadow: inset 0 0 16px color-mix(in srgb, var(--health-remaining-color) 12%, transparent);
-	color: color-mix(in srgb, var(--health-remaining-color) 35%, white);
+	color: color-mix(in srgb, var(--health-remaining-color) 35%, var(--white));
 	font-size: 10px;
 	letter-spacing: 0.12em;
 }
@@ -373,7 +373,7 @@ onMount(() => {
 	padding-bottom: 4px;
 	font-family: var(--mono);
 	font-weight: 700;
-	color: color-mix(in srgb, var(--gold) 55%, white);
+	color: color-mix(in srgb, var(--gold) 55%, var(--white));
 	font-size: 12px;
 	text-shadow: 0 0 8px color-mix(in srgb, var(--gold) 90%, transparent);
 
@@ -424,7 +424,7 @@ onMount(() => {
 	padding-top: 3px;
 	border-color: color-mix(in srgb, var(--health-remaining-color) 70%, transparent);
 	background: color-mix(in srgb, var(--health-remaining-color) 10%, transparent);
-	color: color-mix(in srgb, var(--health-remaining-color) 35%, white);
+	color: color-mix(in srgb, var(--health-remaining-color) 35%, var(--white));
 }
 
 .preview.attack {

--- a/UI/src/routes/game/screens/cardGame/loom/CardFace.svelte
+++ b/UI/src/routes/game/screens/cardGame/loom/CardFace.svelte
@@ -40,7 +40,7 @@ const { card, index, slot, view }: Props = $props();
 	border-left: 3px solid var(--attr-strength);
 	border-radius: 10px;
 	background: linear-gradient(180deg, color-mix(in srgb, var(--white) 7%, var(--surface)), var(--panel-2));
-	box-shadow: 0 8px 20px -10px rgba(0, 0, 0, 0.8);
+	box-shadow: 0 8px 20px -10px color-mix(in srgb, var(--black) 80%, transparent);
 	cursor: grab;
 	padding: 9px 9px 8px;
 	display: flex;
@@ -67,7 +67,7 @@ const { card, index, slot, view }: Props = $props();
 .card:hover {
 	transform: translateY(-8px);
 	box-shadow:
-		0 16px 30px -12px rgba(0, 0, 0, 0.85),
+		0 16px 30px -12px color-mix(in srgb, var(--black) 85%, transparent),
 		0 0 18px -6px var(--card-glow);
 	border-color: var(--border-medium);
 }

--- a/UI/src/routes/game/screens/cardGame/loom/Combatants.svelte
+++ b/UI/src/routes/game/screens/cardGame/loom/Combatants.svelte
@@ -102,7 +102,7 @@ const { game }: Props = $props();
 	border-radius: 30px;
 	background: color-mix(in srgb, var(--white) 6%, transparent);
 	overflow: hidden;
-	box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.4);
+	box-shadow: inset 0 1px 2px color-mix(in srgb, var(--black) 40%, transparent);
 
 	> i {
 		display: block;

--- a/UI/src/styles/common.scss
+++ b/UI/src/styles/common.scss
@@ -83,7 +83,7 @@ h1 {
 }
 
 input::placeholder {
-	color: rgba(240, 240, 240, 0.55);
+	color: var(--text-tertiary);
 }
 
 // Themed scrollbars. Without this the OS-default scrollbar renders as a bright bar
@@ -123,10 +123,10 @@ input::placeholder {
 @keyframes pulse-glow {
 	0%,
 	100% {
-		box-shadow: 0 0 6px rgba(161, 194, 247, 0.35);
+		box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 35%, transparent);
 	}
 	50% {
-		box-shadow: 0 0 14px rgba(161, 194, 247, 0.85);
+		box-shadow: 0 0 14px color-mix(in srgb, var(--accent) 85%, transparent);
 	}
 }
 
@@ -155,10 +155,10 @@ input::placeholder {
 @keyframes ready-pulse {
 	0%,
 	100% {
-		box-shadow: 0 0 6px var(--pulse-color, rgba(161, 194, 247, 0.4));
+		box-shadow: 0 0 6px var(--pulse-color, color-mix(in srgb, var(--accent) 40%, transparent));
 	}
 	50% {
-		box-shadow: 0 0 14px var(--pulse-color, rgba(161, 194, 247, 0.8));
+		box-shadow: 0 0 14px var(--pulse-color, color-mix(in srgb, var(--accent) 80%, transparent));
 	}
 }
 
@@ -166,10 +166,10 @@ input::placeholder {
 	0%,
 	100% {
 		opacity: 0.6;
-		box-shadow: 0 0 6px rgba(161, 194, 247, 0.5);
+		box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 50%, transparent);
 	}
 	50% {
 		opacity: 1;
-		box-shadow: 0 0 12px rgba(161, 194, 247, 0.95);
+		box-shadow: 0 0 12px color-mix(in srgb, var(--accent) 95%, transparent);
 	}
 }


### PR DESCRIPTION
## Summary

Closes #210

Every brand/semantic/neutral color must flow through a CSS variable so theme overrides propagate. Two clusters were violating this invariant:

- **`styles/common.scss`** — app-wide animation keyframes (`pulse-glow`, `ready-pulse`, `pulse-dot`) and the `input::placeholder` rule were using hardcoded `rgba(161,194,247,…)` (= `--accent`) and `rgba(240,240,240,0.55)` (= `--text-tertiary`). All replaced with `color-mix(in srgb, var(--accent) N%, transparent)` and `var(--text-tertiary)`.

- **`loom/Board.svelte`**, **`CardGame.svelte`**, **`loom/Combatants.svelte`**, **`loom/CardFace.svelte`** — literal `white` keyword (plain and inside `color-mix(…, white)` blends) replaced with `var(--white)`, and `rgba(0,0,0,…)` shadows replaced with `color-mix(in srgb, var(--black) N%, transparent)`. This fulfils the documented invariant in `docs/frontend-screens.md` that the card-game board folder uses no hard-coded `rgba` / base-token-only.

No logic changes — purely mechanical token swaps. All 913 unit tests pass and lint/type-check is clean.

## Test plan

- [x] `npm run lint` — no errors
- [x] `npm run test:unit:ci` — 913/913 tests pass
- [ ] Visual smoke-check: open the card-game screen and confirm the board, cards, and combat animations render identically to before (colours are semantically identical since `--white`=`white`, `--black`=`black`, `--accent`=`#a1c2f7`, `--text-tertiary`=`rgba(240,240,240,0.55)`)

https://claude.ai/code/session_01AMHnLqwKhr4GZpBztxPT9p

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMHnLqwKhr4GZpBztxPT9p)_