### PR TITLE
Make the combat-log resize handle keyboard-operable

### DIFF
--- a/UI/src/components/log-panel/LogPanel.svelte
+++ b/UI/src/components/log-panel/LogPanel.svelte
@@ -5,13 +5,26 @@
 	style:height="{view.height}px"
 	bind:this={panelEl}
 >
+	<!--
+		Keyboard-operable window splitter: a focusable ARIA separator with live
+		aria-value* and arrow/Home/End handling. Svelte's a11y heuristic treats
+		role="separator" as non-interactive and flags the tabindex + key handler, but
+		a focusable splitter is exactly the intended, spec-endorsed pattern here.
+	-->
+	<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+	<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 	<div
 		class="log-resize-handle"
 		role="separator"
+		tabindex="0"
 		aria-orientation="horizontal"
 		aria-label="Resize combat log"
+		aria-valuenow={Math.round(view.height)}
+		aria-valuemin={MIN_LOG_PANEL_HEIGHT}
+		aria-valuemax={view.ariaMax}
 		data-testid="log-resize-handle"
 		onpointerdown={onHandleDown}
+		onkeydown={onHandleKey}
 	></div>
 
 	<div class="log-header">
@@ -34,7 +47,7 @@
 import { untrack, onMount } from 'svelte';
 import { logs } from '$stores';
 import LogRow from './LogRow.svelte';
-import { LogPanelView } from './log-panel-view.svelte';
+import { LogPanelView, MIN_LOG_PANEL_HEIGHT, LOG_PANEL_KEYBOARD_STEP } from './log-panel-view.svelte';
 
 const rowHeight = 30;
 
@@ -50,6 +63,30 @@ const onHandleDown = (e: PointerEvent) => {
 	e.preventDefault();
 	view.beginResize(e.clientY, availableHeight() ?? view.height);
 	document.body.classList.add('log-resizing');
+};
+
+// Keyboard parity for the pointer drag: arrow keys step the height (Up grows the
+// log, mirroring an upward drag of the top edge), Home/End jump to min/max. The
+// same clamping/persistence as the drag is reused via the view-model.
+const onHandleKey = (e: KeyboardEvent) => {
+	const available = availableHeight();
+	switch (e.key) {
+		case 'ArrowUp':
+			view.stepResize(LOG_PANEL_KEYBOARD_STEP, available);
+			break;
+		case 'ArrowDown':
+			view.stepResize(-LOG_PANEL_KEYBOARD_STEP, available);
+			break;
+		case 'Home':
+			view.resizeTo('min', available);
+			break;
+		case 'End':
+			view.resizeTo('max', available);
+			break;
+		default:
+			return; // Leave other keys (Tab, etc.) to their default behaviour.
+	}
+	e.preventDefault(); // Only when handled — stops the key from also scrolling the page.
 };
 
 // Logs are stored newest-first (unshifted), so index 0 is the newest entry.
@@ -163,9 +200,16 @@ onMount(() => {
 	&:hover::after {
 		background: color-mix(in srgb, var(--accent) 55%, transparent);
 	}
+
+	// Keyboard focus reuses the accent line as a clearly visible, on-theme focus
+	// indicator (the thin strip has no border of its own to outline).
+	&:focus-visible {
+		outline: none;
+	}
 }
 
-.log-panel.resizing .log-resize-handle::after {
+.log-panel.resizing .log-resize-handle::after,
+.log-resize-handle:focus-visible::after {
 	background: var(--accent);
 }
 

--- a/UI/src/components/log-panel/log-panel-view.svelte.ts
+++ b/UI/src/components/log-panel/log-panel-view.svelte.ts
@@ -17,6 +17,8 @@ export const MIN_LOG_PANEL_HEIGHT = 96;
 export const DEFAULT_LOG_PANEL_HEIGHT = 168;
 /** Keep at least this much room for the screen content above the log. */
 export const MIN_SCREEN_HEIGHT = 160;
+/** Height change per keyboard arrow step on the resize separator. */
+export const LOG_PANEL_KEYBOARD_STEP = 16;
 
 const STORAGE_KEY = 'gameserver.logPanelHeight';
 
@@ -38,19 +40,29 @@ const storage = (): Storage | null => {
 };
 
 export class LogPanelView {
-	/** Current panel height in px (drives the inline style). */
+	/** Current panel height in px (drives the inline style and aria-valuenow). */
 	height = $state(DEFAULT_LOG_PANEL_HEIGHT);
 	/** True while a resize drag is in progress (drives the grabbing cursor). */
 	dragging = $state(false);
+	/** Latest known upper bound on the height — the container's share minus the
+	 *  screen reserve. Unbounded until a container has been measured (e.g. SSR);
+	 *  kept current at every measurement so the drag and aria-valuemax agree. */
+	maxHeight = $state(Number.POSITIVE_INFINITY);
 
 	private startY = 0;
 	private startHeight = DEFAULT_LOG_PANEL_HEIGHT;
-	private maxHeight = DEFAULT_LOG_PANEL_HEIGHT;
 
 	/** Upper bound for a given container height — its share minus the screen reserve.
 	 *  `undefined` (no measurement yet, e.g. SSR) leaves the height unbounded above. */
 	private maxFor(available: number | undefined): number {
 		return available === undefined ? Number.POSITIVE_INFINITY : available - MIN_SCREEN_HEIGHT;
+	}
+
+	/** The effective upper bound to report as aria-valuemax — the live max floored at
+	 *  the minimum (mirroring `clampLogPanelHeight`), or `undefined` before any
+	 *  container has been measured (so the attribute is omitted rather than `Infinity`). */
+	get ariaMax(): number | undefined {
+		return Number.isFinite(this.maxHeight) ? Math.round(Math.max(MIN_LOG_PANEL_HEIGHT, this.maxHeight)) : undefined;
 	}
 
 	/** Load any persisted height. Call after mount so the initial client render
@@ -59,20 +71,22 @@ export class LogPanelView {
 	 *  measured) caps the restored value so a size saved on a larger viewport can't
 	 *  overflow a smaller one. */
 	hydrate(available?: number): void {
+		this.maxHeight = this.maxFor(available);
 		const raw = storage()?.getItem(STORAGE_KEY);
 		if (raw === null || raw === undefined) {
 			return;
 		}
 		const parsed = Number(raw);
 		if (Number.isFinite(parsed)) {
-			this.height = clampLogPanelHeight(parsed, this.maxFor(available));
+			this.height = clampLogPanelHeight(parsed, this.maxHeight);
 		}
 	}
 
 	/** Re-clamp the current height to fit a (possibly shrunken) container — e.g. on
 	 *  window resize — so it can never overflow the space it shares with the screen. */
 	clampToAvailable(available: number): void {
-		this.height = clampLogPanelHeight(this.height, this.maxFor(available));
+		this.maxHeight = this.maxFor(available);
+		this.height = clampLogPanelHeight(this.height, this.maxHeight);
 	}
 
 	/** Begin a resize. `available` is the height of the container the panel shares
@@ -99,6 +113,33 @@ export class LogPanelView {
 			return;
 		}
 		this.dragging = false;
+		this.persist();
+	}
+
+	/** Resize by a fixed keyboard step: a positive `delta` grows the log, a negative
+	 *  one shrinks it. `available` is the live container height used to cap growth
+	 *  (as in a drag). The result is clamped and persisted, mirroring a completed drag. */
+	stepResize(delta: number, available?: number): void {
+		this.maxHeight = this.maxFor(available);
+		this.height = clampLogPanelHeight(this.height + delta, this.maxHeight);
+		this.persist();
+	}
+
+	/** Jump the height to the smallest (`'min'`) or largest (`'max'`) the container
+	 *  allows — the keyboard Home/End affordance. `available` caps the maximum; with
+	 *  no measured container a `'max'` jump is a no-op (the bound is unknown). */
+	resizeTo(edge: 'min' | 'max', available?: number): void {
+		this.maxHeight = this.maxFor(available);
+		if (edge === 'max' && !Number.isFinite(this.maxHeight)) {
+			return;
+		}
+		const target = edge === 'min' ? MIN_LOG_PANEL_HEIGHT : this.maxHeight;
+		this.height = clampLogPanelHeight(target, this.maxHeight);
+		this.persist();
+	}
+
+	/** Persist the current height (best-effort; ignore quota/availability errors). */
+	private persist(): void {
 		try {
 			storage()?.setItem(STORAGE_KEY, String(Math.round(this.height)));
 		} catch {

--- a/UI/src/tests/components/log-panel/LogPanel.test.ts
+++ b/UI/src/tests/components/log-panel/LogPanel.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { render, cleanup, screen } from '@testing-library/svelte';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
 import { ELogType } from '$lib/api';
 import type { LogMessage } from '$lib/engine/log';
+import { MIN_LOG_PANEL_HEIGHT, DEFAULT_LOG_PANEL_HEIGHT } from '../../../components/log-panel/log-panel-view.svelte';
 
 const logData: LogMessage[] = [];
 
@@ -52,5 +53,33 @@ describe('LogPanel', () => {
 		// The panel height is driven by an inline style from the resize view-model.
 		const panel = screen.getByTestId('log-panel');
 		expect(panel.style.height).toMatch(/\d+px/);
+	});
+
+	it('exposes the resize handle as a keyboard-operable separator', () => {
+		render(LogPanel);
+		const handle = screen.getByTestId('log-resize-handle');
+		expect(handle.getAttribute('tabindex')).toBe('0');
+		expect(handle.getAttribute('aria-orientation')).toBe('horizontal');
+		expect(handle.getAttribute('aria-valuenow')).toBe(String(DEFAULT_LOG_PANEL_HEIGHT));
+		expect(handle.getAttribute('aria-valuemin')).toBe(String(MIN_LOG_PANEL_HEIGHT));
+		// aria-valuemax is populated once the container is measured on mount.
+		expect(handle.getAttribute('aria-valuemax')).not.toBeNull();
+	});
+
+	it('resizes from the keyboard and reports the new height via aria-valuenow', async () => {
+		render(LogPanel);
+		const handle = screen.getByTestId('log-resize-handle');
+		const before = handle.getAttribute('aria-valuenow');
+		// ArrowDown is handled: it cancels the default page scroll and updates the value.
+		const notCancelled = await fireEvent.keyDown(handle, { key: 'ArrowDown' });
+		expect(notCancelled).toBe(false); // preventDefault was called
+		expect(handle.getAttribute('aria-valuenow')).not.toBe(before);
+	});
+
+	it('leaves keys it does not handle to their default behaviour', async () => {
+		render(LogPanel);
+		const handle = screen.getByTestId('log-resize-handle');
+		const notCancelled = await fireEvent.keyDown(handle, { key: 'a' });
+		expect(notCancelled).toBe(true); // default not prevented
 	});
 });

--- a/UI/src/tests/components/log-panel/log-panel-view.test.ts
+++ b/UI/src/tests/components/log-panel/log-panel-view.test.ts
@@ -4,7 +4,8 @@ import {
 	clampLogPanelHeight,
 	MIN_LOG_PANEL_HEIGHT,
 	DEFAULT_LOG_PANEL_HEIGHT,
-	MIN_SCREEN_HEIGHT
+	MIN_SCREEN_HEIGHT,
+	LOG_PANEL_KEYBOARD_STEP
 } from '../../../components/log-panel/log-panel-view.svelte';
 
 const STORAGE_KEY = 'gameserver.logPanelHeight';
@@ -88,6 +89,84 @@ describe('LogPanelView resize gesture', () => {
 	it('leaves the height untouched when it still fits the container', () => {
 		view.clampToAvailable(800);
 		expect(view.height).toBe(DEFAULT_LOG_PANEL_HEIGHT);
+	});
+});
+
+describe('LogPanelView keyboard step', () => {
+	let view: LogPanelView;
+
+	beforeEach(() => {
+		view = new LogPanelView();
+	});
+
+	it('grows the log by one step on a positive delta', () => {
+		view.stepResize(LOG_PANEL_KEYBOARD_STEP, 800);
+		expect(view.height).toBe(DEFAULT_LOG_PANEL_HEIGHT + LOG_PANEL_KEYBOARD_STEP);
+	});
+
+	it('shrinks the log by one step on a negative delta', () => {
+		view.stepResize(-LOG_PANEL_KEYBOARD_STEP, 800);
+		expect(view.height).toBe(DEFAULT_LOG_PANEL_HEIGHT - LOG_PANEL_KEYBOARD_STEP);
+	});
+
+	it('never shrinks below the minimum height when stepped repeatedly', () => {
+		for (let i = 0; i < 50; i++) {
+			view.stepResize(-LOG_PANEL_KEYBOARD_STEP, 800);
+		}
+		expect(view.height).toBe(MIN_LOG_PANEL_HEIGHT);
+	});
+
+	it('never grows past the available container height minus the screen reserve', () => {
+		const available = 400; // max share = 240
+		for (let i = 0; i < 50; i++) {
+			view.stepResize(LOG_PANEL_KEYBOARD_STEP, available);
+		}
+		expect(view.height).toBe(available - MIN_SCREEN_HEIGHT);
+	});
+
+	it('persists the stepped height', () => {
+		view.stepResize(LOG_PANEL_KEYBOARD_STEP, 800);
+		expect(localStorage.getItem(STORAGE_KEY)).toBe(String(DEFAULT_LOG_PANEL_HEIGHT + LOG_PANEL_KEYBOARD_STEP));
+	});
+
+	it('jumps to the minimum height on a Home (min) request', () => {
+		view.resizeTo('min', 800);
+		expect(view.height).toBe(MIN_LOG_PANEL_HEIGHT);
+		expect(localStorage.getItem(STORAGE_KEY)).toBe(String(MIN_LOG_PANEL_HEIGHT));
+	});
+
+	it('jumps to the maximum available height on an End (max) request', () => {
+		view.resizeTo('max', 800);
+		expect(view.height).toBe(800 - MIN_SCREEN_HEIGHT);
+		expect(localStorage.getItem(STORAGE_KEY)).toBe(String(800 - MIN_SCREEN_HEIGHT));
+	});
+
+	it('leaves the height unchanged on a max request with no measured container', () => {
+		view.resizeTo('max'); // bound is unknown — no-op
+		expect(view.height).toBe(DEFAULT_LOG_PANEL_HEIGHT);
+		expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+	});
+});
+
+describe('LogPanelView aria bounds', () => {
+	let view: LogPanelView;
+
+	beforeEach(() => {
+		view = new LogPanelView();
+	});
+
+	it('reports no maximum before a container has been measured', () => {
+		expect(view.ariaMax).toBeUndefined();
+	});
+
+	it('reports the container-derived maximum once measured', () => {
+		view.clampToAvailable(800);
+		expect(view.ariaMax).toBe(800 - MIN_SCREEN_HEIGHT);
+	});
+
+	it('floors the reported maximum at the minimum height for a tiny container', () => {
+		view.clampToAvailable(200); // raw max (40) is below the minimum
+		expect(view.ariaMax).toBe(MIN_LOG_PANEL_HEIGHT);
 	});
 });
 


### PR DESCRIPTION
## Summary

Closes #218.

The combat-log panel's resize handle (`LogPanel.svelte`) is exposed as `role="separator"` — which the ARIA spec implies is an operable window-splitter — but it was **pointer-only**. This wires it up as a proper focusable splitter so it can be operated entirely from the keyboard, with live `aria-value*` reporting.

## How it addresses the issue

- **Keyboard operation.** The handle now has `tabindex="0"` and an `onkeydown` handler:
  - **Arrow Up / Down** grow / shrink the log by a small step (`LOG_PANEL_KEYBOARD_STEP = 16px`). Up grows, mirroring an upward drag of the top edge.
  - **Home / End** jump to the minimum / maximum allowed height.
  - `preventDefault()` is called **only** when a key is handled, so Tab and everything else behave normally (and the page doesn't also scroll).
- **Reused gesture logic.** The DOM-free `LogPanelView` view-model gains a small `stepResize(delta, available)` and `resizeTo('min'|'max', available)` helper that reuse the same `clampLogPanelHeight` clamping and persistence as the pointer drag, so keyboard and pointer resizing stay consistent. A `persist()` helper was extracted (DRY with `endResize`).
- **Live ARIA values.** The handle surfaces `aria-valuenow` (current height), `aria-valuemin` (the floor) and `aria-valuemax`. `maxHeight` is now reactive state kept current at every measurement (hydrate / window-resize / drag / keyboard), and an `ariaMax` getter reports the effective (floored) bound — omitted until a container has been measured, so the attribute is never `Infinity`. `aria-orientation="horizontal"` was already present.
- **Visible focus.** A `:focus-visible` rule lights the existing accent line so the thin handle has a clear, on-theme focus indicator.

The Svelte a11y heuristic classifies `role="separator"` as non-interactive and flags the `tabindex` + key handler; a focusable splitter is the intended, spec-endorsed pattern, so the two rules are suppressed with a justified `svelte-ignore` (matching the project's existing use of `svelte-ignore` for legitimate cases).

## Test plan

- [x] `npm run lint` — eslint + `svelte-check` clean (0 errors, 0 warnings).
- [x] `npm run test:unit:ci` — **969 passed**.
- [x] New view-model unit tests cover the keyboard step and Home/End jumps, clamped at min/max, plus the `ariaMax` bounds — mirroring the existing gesture coverage style.
- [x] New component tests assert the a11y wiring (focusable separator, `aria-value*`, handled vs. unhandled keys).
- [x] No regression to the pointer drag (existing gesture/persistence tests unchanged and green).

## Follow-up note

The card-game board drag (`Board.svelte` + `card-game-view.svelte.ts`) has the same pointer-only limitation. As #218 notes, it's intentionally out of scope here — there's now exactly one keyboard-resizable surface, so extracting a shared "resizable handle" primitive isn't yet warranted. Worth revisiting if/when a second such surface appears, to avoid duplicating the key handling.

https://claude.ai/code/session_01LRmh9H5P1bKZe2WHB5aMUv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRmh9H5P1bKZe2WHB5aMUv)_