### PR TITLE
Migrate inventory ItemDrawer header onto shared TooltipTitle primitive

### DIFF
--- a/UI/src/components/tooltip/TooltipTitle.svelte
+++ b/UI/src/components/tooltip/TooltipTitle.svelte
@@ -50,6 +50,7 @@ const { label, name, diamondColor, labelColor, trailing, masked = false }: Props
 	width: 5px;
 	height: 5px;
 	transform: rotate(45deg);
+	flex-shrink: 0;
 }
 
 .tt-category-label {

--- a/UI/src/routes/game/screens/inventory/ItemDrawer.svelte
+++ b/UI/src/routes/game/screens/inventory/ItemDrawer.svelte
@@ -1,15 +1,19 @@
 <div class="drawer-header" style:border-left-color={accent}>
-	<div class="header-top">
-		<span class="cat-diamond" style:background={accent} style:box-shadow="0 0 6px {tintColor(accent, 0.67)}"></span>
-		<span class="cat-label" style:color={accent}>{itemCategoryName(item.itemCategoryId)}</span>
-		<span class="rarity-tag">
-			<span class="rarity-dot" style:background={rc} style:box-shadow="0 0 6px {rarityTint(item.rarityId, 0.65)}"
-			></span>
-			<span class="rarity-label" style:color={rc}>{rarityLabel(item.rarityId)}</span>
-		</span>
-		<button class="close" onclick={() => view.select(null)} aria-label="Close">×</button>
-	</div>
-	<div class="item-name">{item.name}</div>
+	<TooltipTitle
+		label={itemCategoryName(item.itemCategoryId)}
+		name={item.name}
+		diamondColor={accent}
+		labelColor={accent}
+	>
+		{#snippet trailing()}
+			<span class="rarity-tag">
+				<span class="rarity-dot" style:background={rc} style:box-shadow="0 0 6px {rarityTint(item.rarityId, 0.65)}"
+				></span>
+				<span class="rarity-label" style:color={rc}>{rarityLabel(item.rarityId)}</span>
+			</span>
+			<button class="close" onclick={() => view.select(null)} aria-label="Close">×</button>
+		{/snippet}
+	</TooltipTitle>
 </div>
 
 <div class="drawer-body">
@@ -44,8 +48,9 @@
 <script lang="ts">
 import StatList from './StatList.svelte';
 import ModSlots from './ModSlots.svelte';
+import TooltipTitle from '$components/tooltip/TooltipTitle.svelte';
 import { BattleAttributes, type Item } from '$lib/battle';
-import { itemCategoryColor, itemCategoryName, rarityColor, rarityLabel, rarityTint, tintColor } from '$lib/common';
+import { itemCategoryColor, itemCategoryName, rarityColor, rarityLabel, rarityTint } from '$lib/common';
 import { type InventoryView } from './inventory-view.svelte';
 
 const { item, view }: { item: Item; view: InventoryView } = $props();
@@ -62,31 +67,10 @@ const stats = $derived(
 </script>
 
 <style lang="scss">
+// Padding + the category-row/name chrome now come from the shared TooltipTitle
+// primitive; the drawer keeps only its category-coloured left-accent stripe.
 .drawer-header {
-	padding: 16px 18px 14px;
-	border-bottom: 1px solid var(--border-subtle);
 	border-left: 3px solid;
-}
-
-.header-top {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	margin-bottom: 6px;
-}
-
-.cat-diamond {
-	width: 5px;
-	height: 5px;
-	transform: rotate(45deg);
-	flex-shrink: 0;
-}
-
-.cat-label {
-	font-family: var(--mono);
-	font-size: 9.5px;
-	letter-spacing: 1.8px;
-	text-transform: uppercase;
 }
 
 .rarity-tag {
@@ -118,13 +102,6 @@ const stats = $derived(
 	line-height: 1;
 	padding: 0;
 	margin-left: 4px;
-}
-
-.item-name {
-	font-size: 18px;
-	font-weight: 400;
-	letter-spacing: -0.2px;
-	color: var(--text-primary);
 }
 
 .drawer-body {

--- a/UI/src/tests/routes/game/screens/inventory/ItemDrawer.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/ItemDrawer.test.ts
@@ -66,6 +66,16 @@ describe('ItemDrawer', () => {
 		expect(getByText('Iron Sword')).toBeTruthy();
 	});
 
+	it('renders the category and rarity labels in the migrated TooltipTitle header', () => {
+		const { container, getByText } = render(ItemDrawer, {
+			props: { item: makeItem(), view: makeView() }
+		});
+		// Category label is owned by the shared TooltipTitle primitive.
+		expect((container.querySelector('.tt-category-label') as HTMLElement).textContent).toBe('Weapon');
+		// Rarity tag rides along in TooltipTitle's `trailing` snippet.
+		expect(getByText('Common')).toBeTruthy();
+	});
+
 	it('shows "Equip" for an unequipped item', () => {
 		const { getByText } = render(ItemDrawer, {
 			props: { item: makeItem({ equipmentSlotId: undefined }), view: makeView() }


### PR DESCRIPTION
## Summary

Closes #224.

`routes/game/screens/inventory/ItemDrawer.svelte` hand-rolled the same diamond / category-label / headline-name title row that the shared `components/tooltip/TooltipTitle` primitive now owns (surfaced in review of #194 / PR #222). This migrates the drawer header onto the primitive:

- The category diamond, category label and item name now come from `TooltipTitle`.
- The trailing **rarity tag + close button** ride along in `TooltipTitle`'s `trailing` snippet — the same composition pattern `ItemTooltip` uses for `EquippedBadge` and `SealedHeader` uses for the SEALED badge.
- The drawer keeps only its category-coloured **left-accent stripe** (`.drawer-header { border-left: 3px solid }`); padding, border-bottom and the title chrome are now the primitive's.
- Removed the now-dead `.header-top` / `.cat-diamond` / `.cat-label` / `.item-name` styles and the unused `tintColor` import.

## Design call (from the issue)

The issue flagged that the drawer is tuned ~2px more generously than the tooltip variant (`16/18/14` padding & `6px` category-row margin vs the primitive's `14/16/12` & `4px`). Per the chosen approach this is a **pure swap that accepts those minor deltas** rather than adding a density/variant prop to the shared primitive — keeping the primitive's API lean. The border-bottom colours were already effectively identical (`--border-subtle` = `rgba(255,255,255,.08)` vs the primitive's `#f0f0f0`@8%), so the only visible change is the ~2px tightening.

As noted in the issue, `inventory/item-tooltip/ModList.svelte`'s `.tt-mod-name` was correctly **left untouched** — it's a different per-mod-slot tile concept, not the title row.

## Incidental hardening

`TooltipTitle`'s diamond gains `flex-shrink: 0` — the drawer previously carried this locally so the 5px glyph never squishes when the category row is tight. Moving it into the primitive benefits every consumer (skill / item / mod / sealed tooltips).

## Test plan

- [x] `npm run lint` (eslint + `svelte-check`) — clean, 0 errors/warnings.
- [x] `npm run test:unit:ci` — **970 passed** (115 files), including the unchanged `TooltipTitle` suite (the `flex-shrink` change touches no assertions).
- [x] Added `ItemDrawer` coverage asserting the migrated header renders the category label via `.tt-category-label` and the rarity label via the `trailing` snippet; existing name / close-button / equip / mod-slot tests still pass.

No gameplay or battle-parity impact — pure frontend DRY cleanup.

https://claude.ai/code/session_01WvvieRKoXtnumTBegBHfLp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvvieRKoXtnumTBegBHfLp)_