### PR TITLE
Drive frontend battle-parity test through production BattleSimulator (#233)

### DIFF
--- a/UI/src/lib/battle/battle-simulator.ts
+++ b/UI/src/lib/battle/battle-simulator.ts
@@ -1,0 +1,46 @@
+import type { Battler } from './battler';
+import { battleStep } from './battle-step';
+
+const msPerTick = 40;
+const defaultMaxMs = msPerTick * 10000;
+
+/**
+ * The deterministic outcome of a simulated battle. Mirrors the shape the backend
+ * BattleResult exposes for the parity comparison (victory / playerDied / totalMs).
+ */
+export interface BattleResult {
+	victory: boolean;
+	playerDied: boolean;
+	totalMs: number;
+}
+
+/**
+ * Headless, deterministic battle runner — the frontend analogue of the backend's
+ * `Game.Core.Battle.BattleSimulator`. It drives the shared {@link battleStep} over
+ * fixed `msPerTick` ticks until one side dies or the time cap is reached, so the
+ * cross-implementation parity suite exercises the exact per-tick arithmetic the
+ * live {@link BattleEngine} runs rather than a hand-rolled copy.
+ */
+export class BattleSimulator {
+	constructor(
+		private readonly player: Battler,
+		private readonly enemy: Battler
+	) {}
+
+	public simulate(maxMs: number = defaultMaxMs): BattleResult {
+		let totalMs = msPerTick;
+		for (; totalMs <= maxMs; totalMs += msPerTick) {
+			battleStep(this.player, this.enemy, msPerTick);
+
+			if (this.enemy.isDead) {
+				return { victory: true, playerDied: false, totalMs };
+			}
+			if (this.player.isDead) {
+				return { victory: false, playerDied: true, totalMs };
+			}
+		}
+
+		// Mirror the backend's timeout return: the last simulated tick (maxMs), not maxMs + one tick.
+		return { victory: false, playerDied: false, totalMs: totalMs - msPerTick };
+	}
+}

--- a/UI/src/lib/battle/battle-step.ts
+++ b/UI/src/lib/battle/battle-step.ts
@@ -1,0 +1,46 @@
+import type { Battler } from './battler';
+import type { Skill } from './skill';
+
+/**
+ * A single skill activation produced by one battle tick: which skill fired, the
+ * final damage it dealt after the defender's defense clamp, and whether the
+ * player (true) or the enemy (false) was the attacker. The live BattleEngine
+ * turns these into combat-log messages; the headless BattleSimulator ignores them.
+ */
+export interface SkillActivation {
+	skill: Skill;
+	damage: number;
+	byPlayer: boolean;
+}
+
+/**
+ * Runs one deterministic battle tick — the player's ready skills fire at the
+ * enemy, then (only if the enemy survives) the enemy's ready skills fire back —
+ * and returns the resulting activations in the order they occurred.
+ *
+ * This is the single source of the frontend's per-tick battle arithmetic. Both
+ * the live {@link BattleEngine} (UI-driven, one call per logical tick) and the
+ * headless {@link BattleSimulator} (the parity/test loop) call it, mirroring how
+ * the backend's BattleSimulator is the single source its parity test drives.
+ * Keeping the exchange here — rather than duplicated in a test — means a change
+ * to {@link Battler.advanceCooldowns}, {@link Skill.calculateDamage} or
+ * {@link Battler.takeDamage} cannot let the live game diverge from the backend
+ * replay while a copied test stays green.
+ */
+export function battleStep(player: Battler, enemy: Battler, timeDelta: number): SkillActivation[] {
+	const activations: SkillActivation[] = [];
+
+	for (const skill of player.advanceCooldowns(timeDelta)) {
+		const damage = enemy.takeDamage(skill.calculateDamage());
+		activations.push({ skill, damage, byPlayer: true });
+	}
+
+	if (!enemy.isDead) {
+		for (const skill of enemy.advanceCooldowns(timeDelta)) {
+			const damage = player.takeDamage(skill.calculateDamage());
+			activations.push({ skill, damage, byPlayer: false });
+		}
+	}
+
+	return activations;
+}

--- a/UI/src/lib/battle/index.ts
+++ b/UI/src/lib/battle/index.ts
@@ -1,4 +1,6 @@
 export * from './battler.ts';
+export * from './battle-step';
+export * from './battle-simulator';
 export * from './battle-attributes';
 export * from './attribute-modifier';
 export * from './attribute-collection';

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -1,4 +1,4 @@
-import { Battler } from '$lib/battle';
+import { Battler, battleStep } from '$lib/battle';
 import { staticData } from '$stores';
 import { ELogType, IEnemyInstance } from '$lib/api';
 import { logMessage } from '../log';
@@ -95,19 +95,12 @@ export class BattleEngine {
 
 	private logicalUpdate(timeDelta: number) {
 		if (this.stage === Active) {
-			const playerSkillsFired = this.player.advanceCooldowns(timeDelta);
-			playerSkillsFired.forEach((skill) => {
-				const dmg = skill.calculateDamage();
-				const finalDmg = this.enemy.takeDamage(dmg);
-				logMessage(ELogType.Damage, `You used ${skill.name} and dealt ${formatNum(finalDmg)} damage!`);
-			});
-			if (!this.enemy.isDead) {
-				const enemySkillsFired = this.enemy.advanceCooldowns(timeDelta);
-				enemySkillsFired.forEach((skill) => {
-					const dmg = skill.calculateDamage();
-					const finalDmg = this.player.takeDamage(dmg);
-					logMessage(ELogType.Damage, `${this.enemy.name} used ${skill.name} and dealt ${formatNum(finalDmg)} damage!`);
-				});
+			for (const { skill, damage, byPlayer } of battleStep(this.player, this.enemy, timeDelta)) {
+				if (byPlayer) {
+					logMessage(ELogType.Damage, `You used ${skill.name} and dealt ${formatNum(damage)} damage!`);
+				} else {
+					logMessage(ELogType.Damage, `${this.enemy.name} used ${skill.name} and dealt ${formatNum(damage)} damage!`);
+				}
 			}
 			if (this.enemy.isDead) {
 				this.setBattleStage(Victorious);

--- a/UI/src/tests/lib/battle/battle-sim-test-utils.ts
+++ b/UI/src/tests/lib/battle/battle-sim-test-utils.ts
@@ -3,9 +3,9 @@ import type { EAttribute, IAttributeMultiplier, ISkill } from '$lib/api';
 
 /**
  * Shared helpers for the battle-simulation tests. They build the **real**
- * production {@link Battler}/{@link Skill} objects (the same ones the live
- * BattleEngine drives) from raw scenario inputs, so the tests exercise the
- * actual per-tick arithmetic instead of a hand-rolled copy.
+ * production `Battler`/`Skill` objects (the same ones the live BattleEngine
+ * drives) from raw scenario inputs, so the tests exercise the actual per-tick
+ * arithmetic instead of a hand-rolled copy.
  *
  * Each test file must `vi.mock('$stores')` with a `staticData.skills` getter
  * returning its own mock registry array, then pass that array to

--- a/UI/src/tests/lib/battle/battle-sim-test-utils.ts
+++ b/UI/src/tests/lib/battle/battle-sim-test-utils.ts
@@ -1,0 +1,58 @@
+import { Battler } from '$lib/battle';
+import type { EAttribute, IAttributeMultiplier, ISkill } from '$lib/api';
+
+/**
+ * Shared helpers for the battle-simulation tests. They build the **real**
+ * production {@link Battler}/{@link Skill} objects (the same ones the live
+ * BattleEngine drives) from raw scenario inputs, so the tests exercise the
+ * actual per-tick arithmetic instead of a hand-rolled copy.
+ *
+ * Each test file must `vi.mock('$stores')` with a `staticData.skills` getter
+ * returning its own mock registry array, then pass that array to
+ * {@link battlerFactory}; `makeBattler` registers each skill spec into it so the
+ * Battler resolves its skills by id exactly as it does in the running game.
+ */
+
+/** A skill's raw definition, before it is registered and given an id. */
+export interface SkillSpec {
+	baseDamage: number;
+	cooldownMs: number;
+	multipliers: IAttributeMultiplier[];
+}
+
+export const makeSkill = (
+	baseDamage: number,
+	cooldownMs: number,
+	multipliers: IAttributeMultiplier[] = []
+): SkillSpec => ({ baseDamage, cooldownMs, multipliers });
+
+/**
+ * Binds a `makeBattler` builder to a mock skill registry (the array a test's
+ * mocked `staticData.skills` returns). `makeBattler` registers each skill spec
+ * into the registry, then builds a real Battler from raw stat allocations whose
+ * `selectedSkills` reference those registered ids.
+ */
+export function battlerFactory(registry: ISkill[]) {
+	return (attrs: { id: EAttribute; amount: number }[], skills: SkillSpec[]): Battler => {
+		const selectedSkills = skills.map((spec) => {
+			const id = registry.length;
+			registry.push({
+				id,
+				name: `Skill ${id}`,
+				baseDamage: spec.baseDamage,
+				cooldownMs: spec.cooldownMs,
+				damageMultipliers: spec.multipliers,
+				description: '',
+				iconPath: ''
+			});
+			return id;
+		});
+
+		return new Battler({
+			name: 'Battler',
+			level: 1,
+			selectedSkills,
+			attributes: attrs.map((a) => ({ attributeId: a.id, amount: a.amount }))
+		});
+	};
+}

--- a/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
+++ b/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
@@ -1,90 +1,32 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EAttribute } from '$lib/api';
-import { BattleAttributes } from '$lib/battle/battle-attributes';
+import type { ISkill } from '$lib/api';
+
+// Drive the REAL production simulation. The mocked `staticData.skills` is the
+// registry `makeBattler` registers each scenario's skills into, so the Battlers
+// resolve their skills exactly as the live game does.
+const mockSkills: ISkill[] = [];
+vi.mock('$stores', () => ({
+	staticData: {
+		get skills() {
+			return mockSkills;
+		}
+	}
+}));
+
+import { BattleSimulator, Battler } from '$lib/battle';
+import type { BattleResult } from '$lib/battle';
+import { battlerFactory, makeSkill } from './battle-sim-test-utils';
 
 /**
- * Pure simulation loop that mirrors the backend Game.Core.Battle.BattleSimulator
- * exactly. No runtime dependencies — just math. Returning the same shape as the
- * backend's BattleResult lets the parity matrix below assert the full outcome
- * (victory / playerDied / totalMs), not just the duration.
+ * The parity matrix below asserts the full outcome (victory / playerDied /
+ * totalMs) of the production `BattleSimulator` — the same code the live
+ * BattleEngine runs per tick — against the backend's. Building real Battlers and
+ * running the real simulator (rather than a hand-rolled copy) means a change to
+ * the per-tick arithmetic that diverges from the backend can no longer pass here.
  */
 const msPerTick = 40;
-const defaultMaxMs = msPerTick * 10000;
-
-interface SimResult {
-	victory: boolean;
-	playerDied: boolean;
-	totalMs: number;
-}
-
-function simulateBattle(player: SimBattler, enemy: SimBattler, maxMs: number = defaultMaxMs): SimResult {
-	let totalMs = msPerTick;
-	for (; totalMs <= maxMs; totalMs += msPerTick) {
-		updateBattler(player, enemy, msPerTick);
-		if (enemy.currentHealth <= 0) {
-			return { victory: true, playerDied: false, totalMs };
-		}
-
-		updateBattler(enemy, player, msPerTick);
-		if (player.currentHealth <= 0) {
-			return { victory: false, playerDied: true, totalMs };
-		}
-	}
-	// Mirror the backend's timeout return: the last simulated tick (maxMs), not maxMs + one tick.
-	return { victory: false, playerDied: false, totalMs: totalMs - msPerTick };
-}
-
-function updateBattler(attacker: SimBattler, defender: SimBattler, timeDelta: number) {
-	for (const skill of attacker.skills) {
-		skill.chargeTime += timeDelta * attacker.cdMultiplier;
-		if (skill.chargeTime >= skill.cooldownMs) {
-			skill.chargeTime = 0;
-			const rawDmg =
-				skill.baseDamage +
-				skill.multipliers.reduce((sum, m) => sum + attacker.attributes.getValue(m.attributeId) * m.amount, 0);
-			let dmg = rawDmg - defender.attributes.getValue(EAttribute.Defense);
-			if (dmg < 0) dmg = 0;
-			defender.currentHealth -= dmg;
-		}
-	}
-}
-
-interface SimSkill {
-	baseDamage: number;
-	cooldownMs: number;
-	chargeTime: number;
-	multipliers: { attributeId: EAttribute; amount: number }[];
-}
-
-interface SimBattler {
-	attributes: BattleAttributes;
-	currentHealth: number;
-	cdMultiplier: number;
-	skills: SimSkill[];
-}
-
-function makeSkill(
-	baseDamage: number,
-	cooldownMs: number,
-	multipliers: { attributeId: EAttribute; amount: number }[] = []
-): SimSkill {
-	return { baseDamage, cooldownMs, chargeTime: 0, multipliers };
-}
-
-/**
- * Creates a battler from RAW stat allocations (like the backend does).
- * Derived stats are calculated once by BattleAttributes.
- */
-function makeBattlerFromRaw(attrs: { id: EAttribute; amount: number }[], skills: SimSkill[]): SimBattler {
-	const battlerAttrs = attrs.map((a) => ({ attributeId: a.id, amount: a.amount }));
-	const ba = new BattleAttributes(battlerAttrs, true);
-	return {
-		attributes: ba,
-		currentHealth: ba.getValue(EAttribute.MaxHealth),
-		cdMultiplier: 1 + ba.getValue(EAttribute.CooldownRecovery) / 100,
-		skills
-	};
-}
+const makeBattler = battlerFactory(mockSkills);
 
 // ── Shared parity matrix ───────────────────────────────────────────────────────
 // Every scenario here MUST mirror — with identical inputs and identical expected
@@ -95,10 +37,10 @@ function makeBattlerFromRaw(attrs: { id: EAttribute; amount: number }[], skills:
 
 interface ParityScenario {
 	name: string;
-	player: () => SimBattler;
-	enemy: () => SimBattler;
+	player: () => Battler;
+	enemy: () => Battler;
 	maxMs?: number;
-	expected: SimResult;
+	expected: BattleResult;
 }
 
 const scenarios: ParityScenario[] = [
@@ -109,17 +51,17 @@ const scenarios: ParityScenario[] = [
 	{
 		name: 'cooldownRecovery',
 		player: () =>
-			makeBattlerFromRaw(
+			makeBattler(
 				[
 					{ id: EAttribute.Strength, amount: 50 },
 					{ id: EAttribute.Endurance, amount: 30 },
 					{ id: EAttribute.Agility, amount: 20 },
 					{ id: EAttribute.Dexterity, amount: 10 }
 				],
-				[makeSkill(10, 1200, [{ attributeId: EAttribute.Strength, amount: 1.5 }])]
+				[makeSkill(10, 1200, [{ attributeId: EAttribute.Strength, multiplier: 1.5 }])]
 			),
 		enemy: () =>
-			makeBattlerFromRaw(
+			makeBattler(
 				[
 					{ id: EAttribute.Strength, amount: 10 },
 					{ id: EAttribute.Endurance, amount: 15 }
@@ -136,15 +78,15 @@ const scenarios: ParityScenario[] = [
 	{
 		name: 'multiSkill',
 		player: () =>
-			makeBattlerFromRaw(
+			makeBattler(
 				[
 					{ id: EAttribute.Strength, amount: 30 },
 					{ id: EAttribute.Endurance, amount: 20 }
 				],
-				[makeSkill(20, 800, [{ attributeId: EAttribute.Strength, amount: 1.0 }]), makeSkill(25, 1200)]
+				[makeSkill(20, 800, [{ attributeId: EAttribute.Strength, multiplier: 1.0 }]), makeSkill(25, 1200)]
 			),
 		enemy: () =>
-			makeBattlerFromRaw(
+			makeBattler(
 				[
 					{ id: EAttribute.Strength, amount: 20 },
 					{ id: EAttribute.Endurance, amount: 15 }
@@ -158,8 +100,8 @@ const scenarios: ParityScenario[] = [
 	//   Player/Enemy: Def=52 each; attacks 5 raw → 5-52 clamped to 0.
 	{
 		name: 'highDefenseFloor',
-		player: () => makeBattlerFromRaw([{ id: EAttribute.Endurance, amount: 50 }], [makeSkill(5, 1000)]),
-		enemy: () => makeBattlerFromRaw([{ id: EAttribute.Endurance, amount: 50 }], [makeSkill(5, 1000)]),
+		player: () => makeBattler([{ id: EAttribute.Endurance, amount: 50 }], [makeSkill(5, 1000)]),
+		enemy: () => makeBattler([{ id: EAttribute.Endurance, amount: 50 }], [makeSkill(5, 1000)]),
 		expected: { victory: false, playerDied: false, totalMs: msPerTick * 10000 }
 	},
 
@@ -167,7 +109,7 @@ const scenarios: ParityScenario[] = [
 	{
 		name: 'noSkills',
 		player: () =>
-			makeBattlerFromRaw(
+			makeBattler(
 				[
 					{ id: EAttribute.Strength, amount: 10 },
 					{ id: EAttribute.Endurance, amount: 10 }
@@ -175,7 +117,7 @@ const scenarios: ParityScenario[] = [
 				[]
 			),
 		enemy: () =>
-			makeBattlerFromRaw(
+			makeBattler(
 				[
 					{ id: EAttribute.Strength, amount: 10 },
 					{ id: EAttribute.Endurance, amount: 10 }
@@ -193,15 +135,15 @@ const scenarios: ParityScenario[] = [
 	{
 		name: 'bossFullLoadout',
 		player: () =>
-			makeBattlerFromRaw(
+			makeBattler(
 				[
 					{ id: EAttribute.Strength, amount: 60 },
 					{ id: EAttribute.Endurance, amount: 40 }
 				],
-				[makeSkill(10, 1000, [{ attributeId: EAttribute.Strength, amount: 2.0 }])]
+				[makeSkill(10, 1000, [{ attributeId: EAttribute.Strength, multiplier: 2.0 }])]
 			),
 		enemy: () =>
-			makeBattlerFromRaw(
+			makeBattler(
 				[
 					{ id: EAttribute.Strength, amount: 20 },
 					{ id: EAttribute.Endurance, amount: 60 }
@@ -215,17 +157,17 @@ const scenarios: ParityScenario[] = [
 	{
 		name: 'maxMsCap',
 		player: () =>
-			makeBattlerFromRaw(
+			makeBattler(
 				[
 					{ id: EAttribute.Strength, amount: 50 },
 					{ id: EAttribute.Endurance, amount: 30 },
 					{ id: EAttribute.Agility, amount: 20 },
 					{ id: EAttribute.Dexterity, amount: 10 }
 				],
-				[makeSkill(10, 1200, [{ attributeId: EAttribute.Strength, amount: 1.5 }])]
+				[makeSkill(10, 1200, [{ attributeId: EAttribute.Strength, multiplier: 1.5 }])]
 			),
 		enemy: () =>
-			makeBattlerFromRaw(
+			makeBattler(
 				[
 					{ id: EAttribute.Strength, amount: 10 },
 					{ id: EAttribute.Endurance, amount: 15 }
@@ -238,10 +180,17 @@ const scenarios: ParityScenario[] = [
 ];
 
 describe('Battle simulation parity with backend', () => {
+	beforeEach(() => {
+		mockSkills.length = 0;
+	});
+
 	for (const scenario of scenarios) {
 		it(`matches the backend for the ${scenario.name} scenario`, () => {
-			const result = simulateBattle(scenario.player(), scenario.enemy(), scenario.maxMs);
+			const sim = new BattleSimulator(scenario.player(), scenario.enemy());
+			const result = sim.simulate(scenario.maxMs);
+
 			expect(result).toEqual(scenario.expected);
+			expect(result.totalMs % msPerTick).toBe(0);
 		});
 	}
 
@@ -272,8 +221,8 @@ describe('Battle simulation parity with backend', () => {
 			{ id: EAttribute.Defense, amount: 42 }, // 2 + 30 + 0.5*20
 			{ id: EAttribute.CooldownRecovery, amount: 9 } // 0.4*20 + 0.1*10
 		];
-		const player = makeBattlerFromRaw(playerFinalAttrs, [
-			makeSkill(10, 1200, [{ attributeId: EAttribute.Strength, amount: 1.5 }])
+		const player = makeBattler(playerFinalAttrs, [
+			makeSkill(10, 1200, [{ attributeId: EAttribute.Strength, multiplier: 1.5 }])
 		]);
 		const enemy = scenarios[0].enemy();
 
@@ -283,7 +232,7 @@ describe('Battle simulation parity with backend', () => {
 		expect(player.attributes.getValue(EAttribute.CooldownRecovery)).toBe(18);
 		expect(player.cdMultiplier).toBeCloseTo(1.18, 10);
 
-		const result = simulateBattle(player, enemy);
+		const result = new BattleSimulator(player, enemy).simulate();
 		expect(result.totalMs).toBe(6240);
 		expect(result.totalMs).toBeLessThan(6720);
 	});

--- a/UI/src/tests/lib/battle/battle-simulator.test.ts
+++ b/UI/src/tests/lib/battle/battle-simulator.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EAttribute } from '$lib/api';
+import type { ISkill } from '$lib/api';
+
+const mockSkills: ISkill[] = [];
+vi.mock('$stores', () => ({
+	staticData: {
+		get skills() {
+			return mockSkills;
+		}
+	}
+}));
+
+import { BattleSimulator } from '$lib/battle';
+import { battlerFactory, makeSkill } from './battle-sim-test-utils';
+
+const msPerTick = 40;
+const makeBattler = battlerFactory(mockSkills);
+// A combatant with no Strength/Endurance has MaxHealth=50, Def=2 (the derived-stat floor).
+const baseStats = [{ id: EAttribute.Endurance, amount: 0 }];
+
+// Outcomes the cross-implementation parity matrix doesn't cover on its own — most
+// notably the player-death branch, which no parity scenario exercises.
+describe('BattleSimulator', () => {
+	beforeEach(() => {
+		mockSkills.length = 0;
+	});
+
+	it('reports victory on the tick the enemy dies', () => {
+		const player = makeBattler(baseStats, [makeSkill(100, 40)]); // one-shots on the first tick
+		const enemy = makeBattler(baseStats, []);
+
+		const result = new BattleSimulator(player, enemy).simulate();
+
+		expect(result).toEqual({ victory: true, playerDied: false, totalMs: 40 });
+	});
+
+	it('reports the player dying when the enemy lands the killing blow first', () => {
+		const player = makeBattler(baseStats, []); // never damages the enemy
+		const enemy = makeBattler(baseStats, [makeSkill(100, 40)]);
+
+		const result = new BattleSimulator(player, enemy).simulate();
+
+		expect(result).toEqual({ victory: false, playerDied: true, totalMs: 40 });
+	});
+
+	it('runs to the default timeout when neither side can deal damage', () => {
+		const player = makeBattler([{ id: EAttribute.Endurance, amount: 50 }], [makeSkill(5, 1000)]);
+		const enemy = makeBattler([{ id: EAttribute.Endurance, amount: 50 }], [makeSkill(5, 1000)]);
+
+		const result = new BattleSimulator(player, enemy).simulate();
+
+		expect(result).toEqual({ victory: false, playerDied: false, totalMs: msPerTick * 10000 });
+	});
+
+	it('stops at maxMs (not maxMs + one tick) when capped before a kill', () => {
+		const player = makeBattler(baseStats, [makeSkill(100, 1200)]); // can't fire before the cap
+		const enemy = makeBattler(baseStats, [makeSkill(100, 1200)]);
+
+		const result = new BattleSimulator(player, enemy).simulate(200);
+
+		expect(result).toEqual({ victory: false, playerDied: false, totalMs: 200 });
+	});
+});

--- a/UI/src/tests/lib/battle/battle-step.test.ts
+++ b/UI/src/tests/lib/battle/battle-step.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EAttribute } from '$lib/api';
+import type { ISkill } from '$lib/api';
+
+const mockSkills: ISkill[] = [];
+vi.mock('$stores', () => ({
+	staticData: {
+		get skills() {
+			return mockSkills;
+		}
+	}
+}));
+
+import { battleStep } from '$lib/battle';
+import { battlerFactory, makeSkill } from './battle-sim-test-utils';
+
+const makeBattler = battlerFactory(mockSkills);
+// A combatant with no Strength/Endurance has MaxHealth=50, Def=2 (the derived-stat floor).
+const baseStats = [{ id: EAttribute.Endurance, amount: 0 }];
+
+describe('battleStep', () => {
+	beforeEach(() => {
+		mockSkills.length = 0;
+	});
+
+	it('fires the player’s ready skills and damages the enemy', () => {
+		const player = makeBattler(baseStats, [makeSkill(30, 1000)]);
+		const enemy = makeBattler(baseStats, []);
+		const enemyHealth = enemy.currentHealth;
+
+		const activations = battleStep(player, enemy, 1000);
+
+		expect(activations).toHaveLength(1);
+		expect(activations[0].byPlayer).toBe(true);
+		expect(activations[0].damage).toBe(28); // 30 raw - 2 def
+		expect(enemy.currentHealth).toBe(enemyHealth - 28);
+	});
+
+	it('lets the enemy fire back when it survives the player’s hit', () => {
+		const player = makeBattler(baseStats, [makeSkill(30, 1000)]);
+		const enemy = makeBattler(baseStats, [makeSkill(20, 1000)]);
+		const playerHealth = player.currentHealth;
+
+		const activations = battleStep(player, enemy, 1000);
+
+		expect(activations.map((a) => a.byPlayer)).toEqual([true, false]);
+		expect(activations[1].damage).toBe(18); // 20 raw - 2 def
+		expect(player.currentHealth).toBe(playerHealth - 18);
+	});
+
+	it('clamps damage at zero when defense exceeds the raw hit', () => {
+		const player = makeBattler(baseStats, [makeSkill(5, 1000)]);
+		const enemy = makeBattler([{ id: EAttribute.Endurance, amount: 100 }], []);
+		const enemyHealth = enemy.currentHealth;
+
+		const activations = battleStep(player, enemy, 1000);
+
+		expect(activations[0].damage).toBe(0);
+		expect(enemy.currentHealth).toBe(enemyHealth);
+	});
+
+	it('does not let a dead enemy counterattack in the same tick', () => {
+		const player = makeBattler(baseStats, [makeSkill(100, 1000)]); // one-shots the 50-HP enemy
+		const enemy = makeBattler(baseStats, [makeSkill(20, 1000)]);
+		const playerHealth = player.currentHealth;
+
+		const activations = battleStep(player, enemy, 1000);
+
+		expect(enemy.isDead).toBe(true);
+		expect(activations).toHaveLength(1);
+		expect(activations[0].byPlayer).toBe(true);
+		// The enemy never acted: its charge did not advance and the player took no damage.
+		expect(enemy.skills[0]?.chargeTime).toBe(0);
+		expect(player.currentHealth).toBe(playerHealth);
+	});
+
+	it('returns no activations when no skill is ready', () => {
+		const player = makeBattler(baseStats, [makeSkill(30, 1000)]);
+		const enemy = makeBattler(baseStats, [makeSkill(20, 1000)]);
+
+		const activations = battleStep(player, enemy, 40);
+
+		expect(activations).toHaveLength(0);
+	});
+});

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -30,6 +30,15 @@ Unit tests should be written for all UI logic (pages/components) and lib code in
 
 # Important Architectural Design Decisions
 
+## Battle simulation & parity
+
+The frontend simulates battles in real time as an anti-cheat measure: the backend replays the battle the client reports, so the two simulators must agree tick-for-tick (see [game-design.md](./game-design.md) and the backend parity notes). The per-tick arithmetic has a **single source** on the frontend — the pure `battleStep` (`$lib/battle/battle-step.ts`): the player's ready skills fire at the enemy, then (only if the enemy survives) the enemy fires back, operating on the real `Battler`/`Skill` objects and returning the resulting skill activations. Two consumers drive that one stepper:
+
+- **`BattleEngine.logicalUpdate`** — the live, render-driven loop. It calls `battleStep` once per 40ms logical tick and layers the UI concerns (combat-log messages, stage transitions) on top of the returned activations.
+- **`BattleSimulator`** (`$lib/battle/battle-simulator.ts`) — a headless runner, the frontend analogue of the backend's `Game.Core.Battle.BattleSimulator`, that drives `battleStep` over fixed ticks until one side dies or a time cap is hit.
+
+The cross-implementation parity suite (`battle-simulation-parity.test.ts`) drives the production `BattleSimulator` (not a hand-rolled copy), so a change to `Battler.advanceCooldowns`, `Skill.calculateDamage` or `Battler.takeDamage` that diverged from the backend would fail parity rather than silently weaken the replay. Keep its scenario matrix row-for-row aligned with the backend's `BattleSimulatorParityTests`.
+
 ## Authentication (JWT bearer + rotating refresh tokens)
 
 The frontend authenticates against the backend's JWT scheme (see the backend doc for the server side). All of the token handling lives in the API client layer (`lib/api`) so the rest of the app never touches tokens directly:


### PR DESCRIPTION
## Summary

The frontend/backend battle-parity guarantee is the project's core anti-cheat mechanism — the backend replays the battle the client reports, so the two simulators must agree tick-for-tick. The two suites were **asymmetric**: the backend parity test drove the **real** `Game.Core.Battle.BattleSimulator`, but the frontend test ran a **hand-rolled copy** of the loop (`simulateBattle`/`updateBattler`) that never touched the production code (`BattleEngine.logicalUpdate`, `Battler.advanceCooldowns`, `Skill.calculateDamage`, `Battler.takeDamage`). A future edit to that real per-tick arithmetic could let the live game diverge from the backend replay **while the parity test stayed green** — precisely the divergence the suite exists to catch.

This PR makes the frontend parity test exercise the production simulation, mirroring how the backend's `BattleSimulator` is the single source its parity test drives.

## How it addresses the issue

- **Extract a single source of the per-tick arithmetic.** The exchange inlined in `BattleEngine.logicalUpdate` (player fires → check enemy dead → enemy fires → check player dead) moves into a pure, reusable `battleStep` (`$lib/battle/battle-step.ts`) operating on the real `Battler`/`Skill` objects and returning the resulting skill activations.
- **Add a headless `BattleSimulator`** (`$lib/battle/battle-simulator.ts`) — the frontend analogue of the backend's — that drives `battleStep` over fixed 40ms ticks. `BattleEngine.logicalUpdate` now also calls `battleStep` (layering combat-log/stage concerns on top), so the live loop and the parity loop share the same code.
- **Point the parity test at production code.** `battle-simulation-parity.test.ts` now builds real `Battler` instances and runs `BattleSimulator`; the duplicated `simulateBattle`/`updateBattler` copy is deleted. The scenario matrix (names + expected `totalMs`/outcome) stays **row-for-row aligned** with the backend's `BattleSimulatorParityTests`.
- **Document** the single-source `battleStep` / parity decision in `docs/frontend.md`.

`BattleEngine.logicalUpdate` behaviour is unchanged — pure test-architecture / parity-hardening, no gameplay change.

## Tests

- New focused unit tests for the extracted code (sharing a `battle-sim-test-utils` helper that builds the real production Battlers):
  - `battle-step.test.ts` — the exchange, defense clamp, and the **dead-enemy counterattack-suppression** invariant.
  - `battle-simulator.test.ts` — victory / **player-death** (a branch no parity scenario covers) / default-timeout / `maxMs` cap boundary.
- Rewritten `battle-simulation-parity.test.ts` drives the real `BattleSimulator`.

### Test plan

- [x] Frontend: `npm run test:unit -- --run` → **979 passed**
- [x] Frontend: `npm run lint` (eslint + svelte-check) → **0 errors, 0 warnings**
- [x] Backend: `dotnet test Game.Core.Tests` → **312 passed** (parity numbers unchanged and still authoritative)

Closes #233

https://claude.ai/code/session_01Kt9ND5Dmmc7Ai9jpdsZVAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kt9ND5Dmmc7Ai9jpdsZVAn)_