### PR TITLE
Adopt TooltipShell in SkillTooltip with accent-tinted glow (#248)

### DIFF
--- a/UI/src/components/tooltip/TooltipShell.svelte
+++ b/UI/src/components/tooltip/TooltipShell.svelte
@@ -1,7 +1,9 @@
 <div
 	class="tt-shell"
+	class:glow
 	bind:this={base}
 	style:display={hidden ? 'none' : undefined}
+	style:--tt-glow={glow ? accent : undefined}
 	style:border-left="3px solid {accent}"
 >
 	{#if !hidden}
@@ -19,6 +21,12 @@ interface Props {
 	/** Rarity/teaser accent painted as the panel's 3px left border. */
 	accent: string;
 	/**
+	 * Tint the panel's drop shadow with {@link accent} instead of the neutral black glow.
+	 * `SkillTooltip` opts in for its accent-tinted glow; the mod/item tooltips leave it
+	 * `false` and keep the neutral shadow.
+	 */
+	glow?: boolean;
+	/**
 	 * Render the panel hidden and empty. The inventory `ItemTooltip` keeps a single
 	 * instance mounted so the global tooltip can anchor to it, but shows nothing until an
 	 * item is hovered; the sealed/mod tooltips always carry data and leave this `false`.
@@ -35,7 +43,7 @@ interface Props {
 	children?: Snippet;
 }
 
-let { accent, hidden = false, base = $bindable(), header, children }: Props = $props();
+let { accent, glow = false, hidden = false, base = $bindable(), header, children }: Props = $props();
 </script>
 
 <style lang="scss">
@@ -43,6 +51,12 @@ let { accent, hidden = false, base = $bindable(), header, children }: Props = $p
 	width: 280px;
 	border-radius: 3px;
 	box-shadow: -4px 0 16px color-mix(in srgb, var(--black) 15%, transparent);
+
+	// Opt-in accent-tinted glow (see the `glow` prop); the tint flows from the same
+	// `accent` that paints the left border, carried in via the `--tt-glow` custom property.
+	&.glow {
+		box-shadow: -4px 0 16px color-mix(in srgb, var(--tt-glow) 13%, transparent);
+	}
 }
 
 .tt-body {

--- a/UI/src/routes/game/screens/fight/SkillTooltip.svelte
+++ b/UI/src/routes/game/screens/fight/SkillTooltip.svelte
@@ -1,33 +1,27 @@
-<div
-	class="skill-tooltip"
-	bind:this={container}
-	style={skill ? '' : 'display: none;'}
-	style:border-left="3px solid var(--accent)"
->
-	{#if skill}
-		<TooltipTitle label="Skill" name={skill.name} diamondColor="var(--accent)" labelColor="var(--accent)">
+<TooltipShell accent="var(--accent)" glow hidden={!skill} bind:base={container}>
+	{#snippet header()}
+		<TooltipTitle label="Skill" name={skill?.name ?? ''} diamondColor="var(--accent)" labelColor="var(--accent)">
 			{#snippet trailing()}
 				<CooldownPill progress={cooldownProgress} ready={isReady} remainingFormatted={remainingCdFormatted} />
 			{/snippet}
 		</TooltipTitle>
+	{/snippet}
 
-		<div class="tt-body">
-			<TooltipSection label="Damage breakdown">
-				<DamageBreakdown base={baseDamage} {multipliers} enemyDefense={opponent ? enemyDefense : undefined} {total} />
-			</TooltipSection>
+	<TooltipSection label="Damage breakdown">
+		<DamageBreakdown base={baseDamage} {multipliers} enemyDefense={opponent ? enemyDefense : undefined} {total} />
+	</TooltipSection>
 
-			<TooltipSection label="Tempo" last>
-				<TempoMetrics cooldown={adjustedCd} dps={total / adjustedCd} />
-			</TooltipSection>
-		</div>
-	{/if}
-</div>
+	<TooltipSection label="Tempo" last>
+		<TempoMetrics cooldown={adjustedCd} dps={total / adjustedCd} />
+	</TooltipSection>
+</TooltipShell>
 
 <script lang="ts">
 import { EAttribute, type IAttributeMultiplier } from '$lib/api';
 import { type Skill } from '$lib/battle';
 import { battleEngine } from '$lib/engine';
 import { staticData } from '$stores';
+import TooltipShell from '$components/tooltip/TooltipShell.svelte';
 import TooltipSection from '$components/tooltip/TooltipSection.svelte';
 import TooltipTitle from '$components/tooltip/TooltipTitle.svelte';
 import CooldownPill from './skill-tooltip/CooldownPill.svelte';
@@ -42,7 +36,9 @@ type Props = {
 
 const { skill }: Props = $props();
 
-let container: HTMLDivElement;
+// Bound to the shell's root element and relocated into the global tooltip container
+// by getBaseNode(); reactive so the relocation runs once the shell has mounted.
+let container = $state<HTMLDivElement>();
 
 const opponent = $derived(skill?.owner ? battleEngine.getOpponent(skill.owner) : undefined);
 
@@ -72,15 +68,3 @@ const attributeName = (attrId: number) => {
 	return staticData.attributes?.[attrId]?.name ?? EAttribute[attrId] ?? 'Unknown';
 };
 </script>
-
-<style lang="scss">
-.skill-tooltip {
-	width: 280px;
-	border-radius: 3px;
-	box-shadow: -4px 0 16px color-mix(in srgb, var(--accent) 13%, transparent);
-}
-
-.tt-body {
-	padding: 12px 16px 14px;
-}
-</style>

--- a/UI/src/tests/components/tooltip/TooltipShell.test.ts
+++ b/UI/src/tests/components/tooltip/TooltipShell.test.ts
@@ -41,6 +41,21 @@ describe('TooltipShell', () => {
 		expect(container.querySelector('.tt-body')).not.toBeNull();
 	});
 
+	it('keeps the neutral shadow with no glow opt-in by default', () => {
+		const { container } = render(TooltipShell, { props: { accent: 'var(--accent)' } });
+		const shell = container.querySelector('.tt-shell') as HTMLElement;
+		expect(shell.classList.contains('glow')).toBe(false);
+		expect(shell.getAttribute('style') ?? '').not.toContain('--tt-glow');
+	});
+
+	it('opts into an accent-tinted glow when glow is set', () => {
+		const { container } = render(TooltipShell, { props: { accent: 'var(--accent)', glow: true } });
+		const shell = container.querySelector('.tt-shell') as HTMLElement;
+		expect(shell.classList.contains('glow')).toBe(true);
+		// The glow tint flows from the same accent that paints the left border.
+		expect(shell.getAttribute('style')).toContain('--tt-glow: var(--accent)');
+	});
+
 	it('hides the panel and renders no contents when hidden', () => {
 		const { container } = render(TooltipShell, {
 			props: { accent: 'var(--accent)', hidden: true, header, children: body }

--- a/UI/src/tests/routes/game/screens/fight/SkillTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/SkillTooltip.test.ts
@@ -32,9 +32,19 @@ describe('SkillTooltip', () => {
 	it('renders only the hidden anchor when no skill is provided', () => {
 		const { container, queryByText } = render(SkillTooltip, { props: { skill: undefined } });
 		expect(queryByText('Damage breakdown')).toBeNull();
-		// The container stays mounted (hidden) so the tooltip system can still anchor to it.
-		const panel = container.querySelector('.skill-tooltip') as HTMLElement;
-		expect(panel.getAttribute('style')).toContain('display: none');
+		// The shell stays mounted (hidden) so the tooltip system can still anchor to it.
+		const panel = container.querySelector('.tt-shell') as HTMLElement;
+		expect(panel.style.display).toBe('none');
+	});
+
+	it('composes the tooltip shell with an accent-tinted glow', () => {
+		const skill = makeSkill(owner, { name: 'Cleave', cooldownMs: 1000 });
+		const { container } = render(SkillTooltip, { props: { skill } });
+		const shell = container.querySelector('.tt-shell') as HTMLElement;
+		expect(shell).not.toBeNull();
+		// Migrated to TooltipShell: accent left border + opt-in accent-tinted glow.
+		expect(shell.classList.contains('glow')).toBe(true);
+		expect(shell.getAttribute('style')).toContain('border-left: 3px solid var(--accent)');
 	});
 
 	it('shows the damage breakdown: base, per-attribute multiplier, enemy defense and total', () => {


### PR DESCRIPTION
## Summary

Follow-up to #237 (PR #246), which extracted the shared `TooltipShell` wrapper for the four mod/item tooltips. `SkillTooltip` was intentionally out of that scope but repeated nearly the same chrome (280px panel + radius + shadow + left-border accent + padded `.tt-body`). This PR folds `SkillTooltip` into the shared shell.

- **Extend `TooltipShell`** with an opt-in boolean `glow` prop. When set, the panel's drop shadow is tinted with the same `accent` that paints the left border (carried in via a `--tt-glow` custom property), instead of the neutral `var(--black) 15%` shadow. Default behaviour is unchanged — the mod/item tooltips keep their neutral shadow.
- **Migrate `SkillTooltip`** to compose `TooltipShell`: forwards `base` via `getBaseNode`, renders `hidden` while no skill is hovered, and opts into the accent-tinted glow with `glow`. Its duplicated `.skill-tooltip` panel chrome and `.tt-body` styling (and the whole now-empty `<style>` block) are removed.

The skill tooltip's two deliberate differences from the shell are preserved exactly: the accent-tinted (`var(--accent) 13%`) shadow via the new `glow` opt-in, and the fixed `var(--accent)` left border via the shell's existing `accent` prop.

## How it addresses the issue

Resolves the DRY follow-up in #248. `SkillTooltip` no longer re-implements the shared tooltip chrome — it composes the same primitive the mod/item tooltips do, the way `frontend.md` directs ("extend the shared primitive rather than copying it"). Purely presentational: it renders identically, and the cooldown pill / live-update behaviour is untouched. No gameplay or battle-parity impact (`RewardTooltip`, a bare dispatcher with no panel chrome, remains correctly out of scope).

## Test plan

- [x] Frontend: `npm run lint` (eslint + svelte-check) → **0 errors, 0 warnings**
- [x] Frontend: `npm run test:unit:ci` → **979 passed**
- New/updated tests:
  - `TooltipShell.test.ts` — added coverage for the default (no `glow` class, no `--tt-glow`) and the opt-in glow (`glow` class + accent-tinted `--tt-glow`).
  - `SkillTooltip.test.ts` — updated the hidden-anchor assertion to target the shell root (`.tt-shell`) and added a test verifying the migrated tooltip composes the shell with its accent border + glow. The existing damage-breakdown / cooldown / DPS assertions are unchanged and still pass, confirming identical rendering.

Closes #248

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxiQfZs9NgHEeEsWM1YdmE)_