### PR TITLE
Capture BattleSnapshot StatAllocations as an immutable copy

### DIFF
--- a/Game.Core.Tests/Battle/BattleSnapshotTests.cs
+++ b/Game.Core.Tests/Battle/BattleSnapshotTests.cs
@@ -28,11 +28,31 @@ namespace Game.Core.Tests.Battle
             var snapshot = BattleSnapshot.FromPlayer(player);
 
             Assert.Equal(9, snapshot.Level);
-            Assert.Same(player.StatPoints.StatAllocations, snapshot.StatAllocations);
+            // The snapshot captures an independent copy of the allocations, not the live list/elements.
+            Assert.NotSame(player.StatPoints.StatAllocations, snapshot.StatAllocations);
+            var allocation = Assert.Single(snapshot.StatAllocations);
+            Assert.NotSame(player.StatPoints.StatAllocations[0], allocation);
+            Assert.Equal(EAttribute.Strength, allocation.Attribute);
+            Assert.Equal(4, allocation.Amount);
             Assert.Equal([2, 3], snapshot.SkillIds);
             var equipped = Assert.Single(snapshot.EquippedItems);
             Assert.Equal(1, equipped.ItemId);
             Assert.Equal([10], equipped.AppliedModIds);
+        }
+
+        [Fact]
+        public void FromPlayer_StatAllocations_AreImmuneToLaterLiveMutation()
+        {
+            var player = MakePlayer(allocations: [Alloc(EAttribute.Strength, 4)]);
+
+            var snapshot = BattleSnapshot.FromPlayer(player);
+
+            // Reallocating stats mutates StatAllocation.Amount in place on the live player; the snapshot
+            // is an immutable capture taken at battle start and must not be affected.
+            player.StatPoints.StatAllocations[0].Amount = 99;
+
+            var captured = Assert.Single(snapshot.StatAllocations);
+            Assert.Equal(4, captured.Amount);
         }
 
         [Fact]

--- a/Game.Core/Battle/BattleSnapshot.cs
+++ b/Game.Core/Battle/BattleSnapshot.cs
@@ -62,7 +62,9 @@ namespace Game.Core.Battle
             return new BattleSnapshot
             {
                 Level = player.Level,
-                StatAllocations = player.StatPoints.StatAllocations,
+                // Copy each allocation so a later in-place stat reallocation on the live player cannot
+                // retroactively mutate this snapshot, consistent with the other projected fields.
+                StatAllocations = player.StatPoints.StatAllocations.Select(allocation => allocation.Copy()).ToList(),
                 EquippedItems = equippedItems,
                 SkillIds = player.SelectedSkills.Select(s => s.Id).ToList(),
             };

--- a/Game.Core/Players/StatAllocation.cs
+++ b/Game.Core/Players/StatAllocation.cs
@@ -27,5 +27,21 @@ namespace Game.Core.Players
                 Source = EAttributeModifierSource.PlayerStatPoints,
             };
         }
+
+        /// <summary>
+        /// Creates an independent copy of this allocation. Used to capture an immutable point-in-time
+        /// copy for the battle snapshot (<see cref="Battle.BattleSnapshot.FromPlayer"/>) so that later
+        /// in-place mutations of the live allocation (e.g. <see cref="PlayerStatPoints.TryUpdateAttributes"/>
+        /// adjusting <see cref="Amount"/>) cannot retroactively alter the snapshot. Centralizing the copy
+        /// here keeps it correct if the allocation ever gains additional fields.
+        /// </summary>
+        public StatAllocation Copy()
+        {
+            return new StatAllocation
+            {
+                Attribute = Attribute,
+                Amount = Amount,
+            };
+        }
     }
 }


### PR DESCRIPTION
## Summary

`BattleSnapshot.FromPlayer` (`Game.Core/Battle/BattleSnapshot.cs`) projected every captured field into a fresh, independent value **except** `StatAllocations`, which it assigned directly from the live player. Because `StatAllocations` shared both the list instance and its `StatAllocation` elements with the live `PlayerStatPoints` — and `PlayerStatPoints.TryUpdateAttributes` mutates `StatAllocation.Amount` **in place** — an in-memory snapshot could be retroactively altered by a later stat reallocation.

This is a latent foot-gun on the most battle-parity/anti-cheat-sensitive path. It is currently masked only because `PlayerState` is serialized to Redis at battle start (so validation uses a freshly deserialized copy), but any future in-memory fast path would silently break the immutability guarantee, and the inconsistency with the other (copied) fields makes it easy to miss.

## How it addresses the issue

- Added `StatAllocation.Copy()` — a single source of truth for an independent copy of an allocation, sitting alongside the existing domain method `ToModifier()`. Centralizing it keeps the copy correct if `StatAllocation` ever gains additional fields (avoiding a repeat of exactly this class of bug).
- `FromPlayer` now projects `StatAllocations` via `.Select(a => a.Copy()).ToList()`, consistent with how `EquippedItems` and `SkillIds` are already projected.
- No documentation change: the snapshot was always *meant* to be an immutable capture; this aligns one field with that intent rather than changing the architecture.

## Test plan

- Flipped `BattleSnapshotTests.FromPlayer_CapturesLevelStatsEquipmentAndSkills` from `Assert.Same(...)` to verify an **independent** copy (distinct list + element instances, equal content).
- Added `FromPlayer_StatAllocations_AreImmuneToLaterLiveMutation`: mutating the live allocation's `Amount` in place after snapshotting leaves the snapshot unchanged.
- The existing `RoundTrip_*` battle-parity tests still pass — the copy preserves `Attribute`/`Amount`, so reconstruction composes identical attributes.
- `dotnet build Game.sln` — clean (0 warnings).
- `dotnet test Game.Core.Tests` — all 313 tests pass.

Closes #229
Found during review of #228.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1jSgXZBLPx4AuYGaDJLvh)_