### PR TITLE
Persist favorited items via write-behind event

### DIFF
--- a/Game.Api/Sockets/Commands/SaveLogPreferences.cs
+++ b/Game.Api/Sockets/Commands/SaveLogPreferences.cs
@@ -6,9 +6,10 @@ using LogPreferenceModel = Game.Api.Models.Player.LogPreference;
 namespace Game.Api.Sockets.Commands
 {
     /// <summary>
-    /// Persists the player's combat-log display preferences. Mirrors
-    /// <see cref="SetItemFavorite"/>: the change is applied to the cached domain
-    /// player (the source of truth for player data) and persisted from there.
+    /// Persists the player's combat-log display preferences. Like
+    /// <see cref="SetItemFavorite"/>, the change is applied to the cached domain player
+    /// (the source of truth) and persisted to the database via the write-behind
+    /// <see cref="Game.Core.Players.Events.LogPreferenceChangedEvent"/>.
     /// </summary>
     public class SaveLogPreferences : AbstractSocketCommandWithParams<List<LogPreferenceModel>>
     {

--- a/Game.Api/Sockets/Commands/SetItemFavorite.cs
+++ b/Game.Api/Sockets/Commands/SetItemFavorite.cs
@@ -5,8 +5,9 @@ using Game.Application.Services;
 namespace Game.Api.Sockets.Commands
 {
     /// <summary>
-    /// Toggles whether an unlocked item is favorited. Persists the change on the
-    /// cached domain player (the source of truth for player data).
+    /// Toggles whether an unlocked item is favorited. Applies the change to the cached
+    /// domain player (the source of truth) and persists it to the database via the
+    /// write-behind <see cref="Game.Core.Players.Events.ItemFavoriteChangedEvent"/>.
     /// </summary>
     public class SetItemFavorite : AbstractSocketCommandWithParams<SetItemFavoriteRequest>
     {

--- a/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
@@ -1,13 +1,17 @@
 using Game.Abstractions.DataAccess;
+using Game.Abstractions.Infrastructure;
 using Game.Application.Services;
 using Game.Core;
 using Game.Core.Attributes.Modifiers;
 using Game.Core.Players;
+using Game.DataAccess;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Game.Application.Tests.Services
@@ -293,6 +297,51 @@ namespace Game.Application.Tests.Services
             var modifiers = player.Inventory.GetEquippedAttributeModifiers().ToList();
             Assert.Contains(modifiers, m => m.Attribute == EAttribute.Strength && m.Amount == 5.0 && m.Source == EAttributeModifierSource.Item);
             Assert.Contains(modifiers, m => m.Attribute == EAttribute.Dexterity && m.Amount == 7.0 && m.Source == EAttributeModifierSource.ItemMod);
+        }
+
+        [Fact]
+        public async Task SetFavorite_PersistsFavoriteFlagToDatabase()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+            var item = await TestDataSeeder.CreateItemAsync(context);
+            context.UnlockedItems.Add(new Infrastructure.Entities.UnlockedItem
+            {
+                PlayerId = playerEntity.Id,
+                ItemId = item.Id,
+            });
+            await context.SaveChangesAsync(CancellationToken);
+
+            var playerService = scope.ServiceProvider.GetRequiredService<PlayerService>();
+            var player = await playerService.LoadPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var success = await playerService.SetFavorite(player, item.Id, favorite: true);
+            Assert.True(success);
+
+            // The write-behind queue is drained by the synchronizer; run it directly (the hosted
+            // worker is disabled in the test harness) so the change reaches the database.
+            await DrainPlayerUpdateQueue(scope.ServiceProvider);
+
+            // Read the row from a fresh context (the cache-flush equivalent): the favorite flag must
+            // have been persisted to the database, not just the cached domain player.
+            using var verifyScope = CreateScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
+            var persisted = await verifyContext.UnlockedItems
+                .FirstOrDefaultAsync(ui => ui.PlayerId == playerEntity.Id && ui.ItemId == item.Id, CancellationToken);
+            Assert.NotNull(persisted);
+            Assert.True(persisted.Favorite);
+        }
+
+        private async Task DrainPlayerUpdateQueue(IServiceProvider services)
+        {
+            var pubsub = services.GetRequiredService<IPubSubService>();
+            var synchronizer = new DataProviderSynchronizer(
+                services, pubsub, NullLogger<DataProviderSynchronizer>.Instance, PlayerUpdateRetryPolicy.Default);
+            await synchronizer.ProcessQueue(pubsub.GetQueue(Constants.PUBSUB_PLAYER_QUEUE));
         }
 
         private record SimpleAttributeUpdate(EAttribute Attribute, int Amount) : IAttributeUpdate;

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -171,6 +171,54 @@ namespace Game.Core.Tests.Players
             Assert.Equal(5, evt.ItemModId);
         }
 
+        // ── TrySetFavorite ───────────────────────────────────────────────────
+
+        [Fact]
+        public void TrySetFavorite_UnlockedItem_SetsFlagAndRaisesItemFavoriteChangedEvent()
+        {
+            var player = MakePlayer();
+            player.UnlockItem(MakeItem(id: 10));
+            player.ClearEvents();
+
+            var result = player.TrySetFavorite(10, true);
+
+            Assert.True(result);
+            Assert.True(player.Inventory.UnlockedItems.Single().Favorite);
+            var evt = player.DomainEvents.OfType<ItemFavoriteChangedEvent>().SingleOrDefault();
+            Assert.NotNull(evt);
+            Assert.Equal(player.Id, evt.PlayerId);
+            Assert.Equal(10, evt.ItemId);
+            Assert.True(evt.Favorite);
+        }
+
+        [Fact]
+        public void TrySetFavorite_CanUnfavorite_RaisesEventWithFalse()
+        {
+            var player = MakePlayer();
+            player.UnlockItem(MakeItem(id: 10));
+            player.TrySetFavorite(10, true);
+            player.ClearEvents();
+
+            var result = player.TrySetFavorite(10, false);
+
+            Assert.True(result);
+            Assert.False(player.Inventory.UnlockedItems.Single().Favorite);
+            var evt = player.DomainEvents.OfType<ItemFavoriteChangedEvent>().SingleOrDefault();
+            Assert.NotNull(evt);
+            Assert.False(evt.Favorite);
+        }
+
+        [Fact]
+        public void TrySetFavorite_ItemNotUnlocked_ReturnsFalseAndRaisesNoEvent()
+        {
+            var player = MakePlayer();
+
+            var result = player.TrySetFavorite(999, true);
+
+            Assert.False(result);
+            Assert.Empty(player.DomainEvents.OfType<ItemFavoriteChangedEvent>());
+        }
+
         // ── UpdateLogPreference ──────────────────────────────────────────────
 
         [Fact]

--- a/Game.Core/Players/Events/ItemFavoriteChangedEvent.cs
+++ b/Game.Core/Players/Events/ItemFavoriteChangedEvent.cs
@@ -1,0 +1,12 @@
+using Game.Core.Events;
+
+namespace Game.Core.Players.Events
+{
+    /// <summary>
+    /// Raised when a player favorites or unfavorites an unlocked item.
+    /// </summary>
+    public record ItemFavoriteChangedEvent(
+        int PlayerId,
+        int ItemId,
+        bool Favorite) : IDomainEvent;
+}

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -135,9 +135,13 @@ namespace Game.Core.Players
 
         public bool TrySetFavorite(int itemId, bool favorite)
         {
-            // No domain event: the favorite flag lives on the cached domain
-            // player (the source of truth) and is persisted whole on save.
-            return Inventory.TrySetFavorite(itemId, favorite);
+            if (!Inventory.TrySetFavorite(itemId, favorite))
+            {
+                return false;
+            }
+
+            RaiseEvent(new ItemFavoriteChangedEvent(Id, itemId, favorite));
+            return true;
         }
 
         public void UpdateLogPreference(ELogType logType, bool enabled)

--- a/Game.DataAccess/DataProviderSynchronizer.cs
+++ b/Game.DataAccess/DataProviderSynchronizer.cs
@@ -160,6 +160,11 @@ namespace Game.DataAccess
                     await HandleModRemoved(context, modRemoveEvt);
                     break;
 
+                case nameof(ItemFavoriteChangedEvent):
+                    var favoriteEvt = Deserialize<ItemFavoriteChangedEvent>(envelope.Payload);
+                    await HandleItemFavoriteChanged(context, favoriteEvt);
+                    break;
+
                 case nameof(LogPreferenceChangedEvent):
                     var logEvt = Deserialize<LogPreferenceChangedEvent>(envelope.Payload);
                     await HandleLogPreferenceChanged(context, logEvt);
@@ -293,6 +298,14 @@ namespace Game.DataAccess
             await context.AppliedMods
                 .Where(am => am.PlayerId == evt.PlayerId && am.ItemId == evt.ItemId && am.ItemModSlotId == evt.ItemModSlotId)
                 .ExecuteDeleteAsync();
+        }
+
+        private static async Task HandleItemFavoriteChanged(GameContext context, ItemFavoriteChangedEvent evt)
+        {
+            // Idempotent absolute update: set the flag to the event's value for the player's unlocked item.
+            await context.UnlockedItems
+                .Where(ui => ui.PlayerId == evt.PlayerId && ui.ItemId == evt.ItemId)
+                .ExecuteUpdateAsync(s => s.SetProperty(ui => ui.Favorite, evt.Favorite));
         }
 
         private static async Task HandleLogPreferenceChanged(GameContext context, LogPreferenceChangedEvent evt)

--- a/Game.DataAccess/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Game.DataAccess/DependencyInjection/ServiceCollectionExtensions.cs
@@ -97,6 +97,7 @@ namespace Game.DataAccess.DependencyInjection
             DomainEventDispatcher.RegisterDomainEventHandler<ModUnlockedEvent, PlayerPersistencePublisher>();
             DomainEventDispatcher.RegisterDomainEventHandler<ModAppliedEvent, PlayerPersistencePublisher>();
             DomainEventDispatcher.RegisterDomainEventHandler<ModRemovedEvent, PlayerPersistencePublisher>();
+            DomainEventDispatcher.RegisterDomainEventHandler<ItemFavoriteChangedEvent, PlayerPersistencePublisher>();
             DomainEventDispatcher.RegisterDomainEventHandler<LogPreferenceChangedEvent, PlayerPersistencePublisher>();
         }
 

--- a/Game.DataAccess/Mapping/PlayerMapper.cs
+++ b/Game.DataAccess/Mapping/PlayerMapper.cs
@@ -100,6 +100,7 @@ namespace Game.DataAccess.Mapping
                     ItemId = ui.ItemId,
                     Item = coreItem,
                     AppliedMods = appliedMods,
+                    Favorite = ui.Favorite,
                 };
 
                 inventory.UnlockedItems.Add(slot);

--- a/Game.DataAccess/PlayerPersistencePublisher.cs
+++ b/Game.DataAccess/PlayerPersistencePublisher.cs
@@ -20,6 +20,7 @@ namespace Game.DataAccess
         IDomainEventHandler<ModUnlockedEvent>,
         IDomainEventHandler<ModAppliedEvent>,
         IDomainEventHandler<ModRemovedEvent>,
+        IDomainEventHandler<ItemFavoriteChangedEvent>,
         IDomainEventHandler<LogPreferenceChangedEvent>
     {
         private readonly IPubSubService _pubsub = pubsub;
@@ -32,6 +33,7 @@ namespace Game.DataAccess
         public Task HandleAsync(ModUnlockedEvent domainEvent, CancellationToken cancellationToken = default) => PublishAsync(domainEvent);
         public Task HandleAsync(ModAppliedEvent domainEvent, CancellationToken cancellationToken = default) => PublishAsync(domainEvent);
         public Task HandleAsync(ModRemovedEvent domainEvent, CancellationToken cancellationToken = default) => PublishAsync(domainEvent);
+        public Task HandleAsync(ItemFavoriteChangedEvent domainEvent, CancellationToken cancellationToken = default) => PublishAsync(domainEvent);
         public Task HandleAsync(LogPreferenceChangedEvent domainEvent, CancellationToken cancellationToken = default) => PublishAsync(domainEvent);
 
         private async Task PublishAsync<T>(T domainEvent) where T : IDomainEvent

--- a/Game.Infrastructure/Entities/UnlockedItem.cs
+++ b/Game.Infrastructure/Entities/UnlockedItem.cs
@@ -5,6 +5,7 @@ namespace Game.Infrastructure.Entities
         public int PlayerId { get; set; }
         public int ItemId { get; set; }
         public int? EquipmentSlotId { get; set; }
+        public bool Favorite { get; set; }
 
         public virtual Player Player { get => field ?? throw new NotLoadedException(nameof(Player)); set; }
         public virtual Item Item { get => field ?? throw new NotLoadedException(nameof(Item)); set; }

--- a/Game.Infrastructure/Migrations/20260609061146_AddUnlockedItemFavorite.Designer.cs
+++ b/Game.Infrastructure/Migrations/20260609061146_AddUnlockedItemFavorite.Designer.cs
@@ -4,6 +4,7 @@ using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Game.Infrastructure.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20260609061146_AddUnlockedItemFavorite")]
+    partial class AddUnlockedItemFavorite
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Game.Infrastructure/Migrations/20260609061146_AddUnlockedItemFavorite.cs
+++ b/Game.Infrastructure/Migrations/20260609061146_AddUnlockedItemFavorite.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Game.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUnlockedItemFavorite : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Favorite",
+                table: "UnlockedItems",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Favorite",
+                table: "UnlockedItems");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the data-loss bug where the inventory **Favorite** flag was never persisted: it lived only on the cached domain player, so every Redis player-cache eviction silently reset every favorite to `false`.

The root cause was the player write-behind path being event-driven while the favorite path raised no event and had no DB column to persist to (as diagnosed in #251). This PR brings favorites in line with the log-preference path, which persists correctly.

## Changes

- **DB column** — added `Favorite` to the `UnlockedItem` EF entity + an EF migration (`AddUnlockedItemFavorite`, `defaultValue: false` so existing rows migrate cleanly).
- **Domain event** — `Player.TrySetFavorite` now raises `ItemFavoriteChangedEvent` on success (and nothing on failure), instead of relying on a non-existent "persisted whole on save" path.
- **Write-behind** — registered the event in `PlayerPersistencePublisher` + `RegisterPlayerPersistenceHandlers`, and added `DataProviderSynchronizer.HandleItemFavoriteChanged` (an idempotent absolute `ExecuteUpdate` on the flag, matching the other handlers' retry-safe shape).
- **Mapping** — `PlayerMapper.ToCore` now reads `Favorite` onto the `UnlockedItemSlot` so a freshly-loaded player carries it.
- **Comment fixes** — corrected the misleading comments on `Player.TrySetFavorite`, `SetItemFavorite`, and `SaveLogPreferences` (favorites now persist via an event, exactly like log preferences).

## How it addresses the issue

All four root-cause items from #251 are covered: the missing event, the missing column, the missing mapper wiring, and the misleading comments. `PlayerData` already exposed `Favorite` on the wire, so no API-model/TS-client change was needed (codegen produces no diff).

## Notes

- `PlayerMapper.ToEntity` only builds the brand-new-player graph from a `NewPlayer` blueprint, which has no unlocked items, so there is nothing to map there — favorites are an in-game mutation persisted through the event path, never at account creation.
- The synchronizer handler is a delete-free absolute update keyed on `(PlayerId, ItemId)`, so re-applying the event converges to the same state (consistent with the retry-then-dead-letter resilience guarantees).

## Test plan

- [x] **Domain unit tests** (`PlayerTests`) — `TrySetFavorite` raises `ItemFavoriteChangedEvent` (favorite + unfavorite), and raises **no** event when the item isn't unlocked. (Inventory-level flag behavior was already covered in `InventoryTests`.)
- [x] **Integration test** (`PlayerServiceIntegrationTests.SetFavorite_PersistsFavoriteFlagToDatabase`) — sets a favorite through `PlayerService`, drains the write-behind queue via the synchronizer, and asserts the flag is present when the row is read back from a fresh DB context (the cache-flush equivalent), mirroring the log-preference persistence approach.
- [x] `dotnet build` clean (0 warnings).
- [x] `Game.Core.Tests` (316), `Game.Application.Tests` (89), `Game.Api.Tests` (283) all green.
- [x] `dotnet run --project Game.Api -- codegen` produces no TS diff.

Closes #251

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rwh7oKJidQ8Kpzf7ManFk9)_