### PR TITLE
Make staticData getters honestly nullable (drop undefined-masking casts)

### DIFF
--- a/UI/src/lib/battle/battler.ts
+++ b/UI/src/lib/battle/battler.ts
@@ -78,7 +78,7 @@ export class Battler {
 	}
 
 	private fillSelectedSkills(battlerData: BattlerData) {
-		const skillData = staticData.skills;
+		const skillData = staticData.skills ?? [];
 		const skills: (Skill | undefined)[] = battlerData.selectedSkills.map(
 			(skillId) => new Skill(skillData[skillId], this)
 		);

--- a/UI/src/lib/battle/item-mod.ts
+++ b/UI/src/lib/battle/item-mod.ts
@@ -4,7 +4,7 @@ import { staticData } from '$stores';
 export interface ItemMod extends Omit<IAppliedModModel, 'itemModId'>, IItemMod {}
 
 export const newItemMod = (appliedMod: IAppliedModModel) => {
-	const itemModData = staticData.itemMods[appliedMod.itemModId];
+	const itemModData = (staticData.itemMods ?? [])[appliedMod.itemModId];
 	return {
 		...itemModData,
 		itemModSlotId: appliedMod.itemModSlotId

--- a/UI/src/lib/battle/item.ts
+++ b/UI/src/lib/battle/item.ts
@@ -13,7 +13,7 @@ export interface Item extends IItem {
 }
 
 export const newItem = (invItem: IInventoryItem): Item => {
-	const itemData = staticData.items[invItem.itemId];
+	const itemData = (staticData.items ?? [])[invItem.itemId];
 	const appliedMods = invItem.appliedMods.map((am) => newItemMod(am));
 	const allAttributes = [...itemData.attributes, ...appliedMods.flatMap((mod) => mod.attributes)];
 	const totalAttributes = new BattleAttributes(allAttributes, false);

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -68,7 +68,7 @@ export class BattleEngine {
 	};
 
 	public reset = (enemyInstance: IEnemyInstance) => {
-		const enemyData = staticData.enemies;
+		const enemyData = staticData.enemies ?? [];
 		this.timeElapsed = 0;
 		this.player.reset(playerManager, inventoryManager.equipmentStats);
 		this.enemy.reset({ ...enemyInstance, ...enemyData[enemyInstance.id] });

--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -242,7 +242,7 @@ export class EnemyManager {
 	 */
 	private async claimVictory(): Promise<number> {
 		if (this.currentEnemy) {
-			logMessage(ELogType.EnemyDefeated, staticData.enemies[this.currentEnemy.id].name + ' was defeated!');
+			logMessage(ELogType.EnemyDefeated, (staticData.enemies ?? [])[this.currentEnemy.id].name + ' was defeated!');
 		}
 		const defeatResponse = await apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: Date.now() });
 		if (!defeatResponse.error && defeatResponse.data?.rewards) {

--- a/UI/src/lib/engine/reference-data.ts
+++ b/UI/src/lib/engine/reference-data.ts
@@ -55,7 +55,7 @@ function refSource<C extends ApiSocketCommandNoRequest>(
 	key: string,
 	label: string,
 	command: C,
-	read: () => ApiSocketResponseTypes[C],
+	read: () => ApiSocketResponseTypes[C] | undefined,
 	write: (data: ApiSocketResponseTypes[C]) => void
 ): RefDataSource {
 	return {

--- a/UI/src/routes/admin/workbench/entities/zone.ts
+++ b/UI/src/routes/admin/workbench/entities/zone.ts
@@ -55,7 +55,7 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 		if (z.bossEnemyId == null || z.bossEnemyId < 0) {
 			return '';
 		}
-		const boss = staticData.enemies.find((e) => e.id === z.bossEnemyId);
+		const boss = (staticData.enemies ?? []).find((e) => e.id === z.bossEnemyId);
 		return boss ? `Boss: ${boss.name} · LV ${z.bossLevel}` : '';
 	},
 	sections: [

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -73,19 +73,19 @@ class WorkbenchReference {
 	modTypeOptions = (): SelectOption[] => toOptions(enumPairs(EItemModType));
 	tagCategoryOptions = (): SelectOption[] => this.tagCategories.map((c) => ({ value: c.id, text: c.name }));
 	zoneOptions = (): SelectOption[] =>
-		staticData.zones.map((z) => ({ value: z.id, text: `${z.name} · L${z.levelMin}–${z.levelMax}` }));
-	enemyOptions = (): SelectOption[] => staticData.enemies.map((e) => ({ value: e.id, text: e.name }));
+		(staticData.zones ?? []).map((z) => ({ value: z.id, text: `${z.name} · L${z.levelMin}–${z.levelMax}` }));
+	enemyOptions = (): SelectOption[] => (staticData.enemies ?? []).map((e) => ({ value: e.id, text: e.name }));
 	/** Dedicated-boss picker options: a "None" sentinel (-1) plus every enemy flagged as a boss. */
 	bossEnemyOptions = (): SelectOption[] => [
 		{ value: -1, text: 'None' },
-		...staticData.enemies.filter((e) => e.isBoss).map((e) => ({ value: e.id, text: e.name }))
+		...(staticData.enemies ?? []).filter((e) => e.isBoss).map((e) => ({ value: e.id, text: e.name }))
 	];
 	/** Zone unlock-gate picker options: a "None" sentinel (-1) plus every challenge. */
 	unlockChallengeOptions = (): SelectOption[] => [
 		{ value: -1, text: 'None (always open)' },
 		...(staticData.challenges ?? []).map((c) => ({ value: c.id, text: c.name }))
 	];
-	skillCatalogue = () => staticData.skills.map((s) => ({ id: s.id, name: s.name, baseDamage: s.baseDamage }));
+	skillCatalogue = () => (staticData.skills ?? []).map((s) => ({ id: s.id, name: s.name, baseDamage: s.baseDamage }));
 
 	// ── Challenges ──
 	challengeTypeOptions = (): SelectOption[] => this.challengeTypes.map((t) => ({ value: t.id, text: t.name }));

--- a/UI/src/stores/static-data.svelte.ts
+++ b/UI/src/stores/static-data.svelte.ts
@@ -20,64 +20,69 @@ let challenges = $state<IChallenge[]>();
 let challengeTypes = $state<IChallengeType[]>();
 let statisticTypes = $state<IStatisticType[]>();
 
+/* The backing `$state` slots are genuinely `undefined` until the loading screen (or the silent
+   session-resume path) populates them, so the getters honestly expose `T[] | undefined` rather than
+   casting the pre-load `undefined` away. The `undefined` state is load-bearing — `loaded` and the
+   reference-data orchestration (`reference-data.ts`) detect "not yet loaded" by the slot being
+   null — so it must stay observable. Callers that may run before load already guard with `?.`/`?? []`. */
 export const staticData = {
-	get zones() {
-		return zones as IZone[];
+	get zones(): IZone[] | undefined {
+		return zones;
 	},
-	set zones(value) {
+	set zones(value: IZone[] | undefined) {
 		zones = value;
 	},
-	get enemies() {
-		return enemies as IEnemy[];
+	get enemies(): IEnemy[] | undefined {
+		return enemies;
 	},
-	set enemies(value) {
+	set enemies(value: IEnemy[] | undefined) {
 		enemies = value;
 	},
-	get items() {
-		return items as IItem[];
+	get items(): IItem[] | undefined {
+		return items;
 	},
-	set items(value) {
+	set items(value: IItem[] | undefined) {
 		items = value;
 	},
-	get skills() {
-		return skills as ISkill[];
+	get skills(): ISkill[] | undefined {
+		return skills;
 	},
-	set skills(value) {
+	set skills(value: ISkill[] | undefined) {
 		skills = value;
 	},
-	get itemMods() {
-		return itemMods as IItemMod[];
+	get itemMods(): IItemMod[] | undefined {
+		return itemMods;
 	},
-	set itemMods(value) {
+	set itemMods(value: IItemMod[] | undefined) {
 		itemMods = value;
 	},
-	get attributes() {
-		return attributes as IAttribute[];
+	get attributes(): IAttribute[] | undefined {
+		return attributes;
 	},
-	set attributes(value) {
+	set attributes(value: IAttribute[] | undefined) {
 		attributes = value;
 	},
-	get challenges() {
-		return challenges as IChallenge[];
+	get challenges(): IChallenge[] | undefined {
+		return challenges;
 	},
-	set challenges(value) {
+	set challenges(value: IChallenge[] | undefined) {
 		challenges = value;
 	},
-	get challengeTypes() {
-		return challengeTypes as IChallengeType[];
+	get challengeTypes(): IChallengeType[] | undefined {
+		return challengeTypes;
 	},
-	set challengeTypes(value) {
+	set challengeTypes(value: IChallengeType[] | undefined) {
 		challengeTypes = value;
 	},
-	get statisticTypes() {
-		return statisticTypes as IStatisticType[];
+	get statisticTypes(): IStatisticType[] | undefined {
+		return statisticTypes;
 	},
-	set statisticTypes(value) {
+	set statisticTypes(value: IStatisticType[] | undefined) {
 		statisticTypes = value;
 	},
-	get loaded() {
-		return (
-			zones && enemies && items && skills && itemMods && attributes && challenges && challengeTypes && statisticTypes
+	get loaded(): boolean {
+		return [zones, enemies, items, skills, itemMods, attributes, challenges, challengeTypes, statisticTypes].every(
+			(set) => set != null
 		);
 	}
 };

--- a/UI/src/tests/stores/static-data.test.ts
+++ b/UI/src/tests/stores/static-data.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { staticData } from '$stores/static-data.svelte';
+
+// The nine reference-data slots the store exposes. Keeping the list here lets each test
+// reset every slot and populate the full set without repeating the names inline.
+const SLOTS = [
+	'zones',
+	'enemies',
+	'items',
+	'skills',
+	'itemMods',
+	'attributes',
+	'challenges',
+	'challengeTypes',
+	'statisticTypes'
+] as const;
+
+const clearAll = () => {
+	for (const slot of SLOTS) {
+		staticData[slot] = undefined;
+	}
+};
+
+const populateAll = () => {
+	for (const slot of SLOTS) {
+		staticData[slot] = [];
+	}
+};
+
+beforeEach(clearAll);
+
+describe('staticData store', () => {
+	it('exposes each slot as undefined before it is loaded', () => {
+		for (const slot of SLOTS) {
+			expect(staticData[slot]).toBeUndefined();
+		}
+	});
+
+	it('returns the value a slot was set to (including an empty array, distinct from undefined)', () => {
+		const zones = [{ id: 1 }] as unknown as NonNullable<typeof staticData.zones>;
+		staticData.zones = zones;
+		expect(staticData.zones).toEqual(zones);
+
+		staticData.enemies = [];
+		expect(staticData.enemies).toEqual([]);
+		expect(staticData.enemies).not.toBeUndefined();
+	});
+
+	it('reports loaded=false until every slot is populated', () => {
+		expect(staticData.loaded).toBe(false);
+
+		// Populate all but the last slot — still not loaded.
+		for (const slot of SLOTS.slice(0, -1)) {
+			staticData[slot] = [];
+		}
+		expect(staticData.loaded).toBe(false);
+
+		// Populating the final slot flips it to loaded.
+		staticData[SLOTS[SLOTS.length - 1]] = [];
+		expect(staticData.loaded).toBe(true);
+	});
+
+	it('treats an empty array as loaded (not-loaded is detected by null, not emptiness)', () => {
+		populateAll();
+		expect(staticData.loaded).toBe(true);
+	});
+
+	it('reports loaded=false again if any slot is cleared after a full load', () => {
+		populateAll();
+		expect(staticData.loaded).toBe(true);
+
+		staticData.skills = undefined;
+		expect(staticData.loaded).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #253: every getter on the `staticData` store cast an `undefined`-able `$state` slot to a non-nullable `T[]` (`return zones as IZone[]`), lying about a type that is genuinely `undefined` until reference data loads — exactly the "unsafe cast masking nullability" the project guidelines warn against.

## Decision: Option A (honest `T[] | undefined`), not Option B (seed `[]`)

The issue offered two fixes. I chose **Option A** because the `undefined` pre-load state is **load-bearing**, not incidental:

- `staticData.loaded` and the reference-data orchestration (`reference-data.ts` — `refSource.loaded: () => read() != null`, `hydrateFromCacheIfCurrent`, `hydrateAllFromCache`) all detect "this set isn't loaded yet" by the slot being `null`/`undefined`.
- `engine.ts` gates `startGame()` on `staticData.loaded`, and the silent session-resume path resolves cache all-or-nothing off the same signal.

Seeding `[]` (Option B) would make every slot read as already-loaded the instant the module imports — the loading screen would never fetch, the resume gate would fire prematurely, and "loaded but legitimately empty" would be indistinguishable from "not loaded." So honesty here means exposing the `undefined`, not erasing it.

## Changes

- **`stores/static-data.svelte.ts`** — getters/setters now type each slot as `T[] | undefined`; the nine `as` casts are gone. `loaded` now returns a proper `boolean` via `every(set => set != null)` instead of a truthy `&&` chain.
- **Unguarded post-load callers** now read through `?? []`, matching the many callers that already guarded with `?.`/`?? []` (the issue cited `enemy-manager.ts:198` as evidence the type was wrong). Behavior is identical — these run only after load — but the array-level access is now type-honest and consistent across the file:
  - `lib/battle/item.ts`, `lib/battle/item-mod.ts`, `lib/battle/battler.ts`
  - `lib/engine/battle/battle-engine.ts`, `lib/engine/battle/enemy-manager.ts`
  - `routes/admin/workbench/reference.svelte.ts` (the `zoneOptions`/`enemyOptions`/`bossEnemyOptions`/`skillCatalogue` lookups that were inconsistently unguarded vs. the `?? []` ones right beside them), `routes/admin/workbench/entities/zone.ts`
- **`lib/engine/reference-data.ts`** — `refSource.read` now allows `| undefined` so the table type-checks against the honest getters; `loaded()`/`current()` already null-tolerant.

## How it addresses the issue

Every `as` cast is dropped and the getters tell the truth, picked consistently (Option A) per the issue's "pick one consistently" instruction. The existing `?? []`/`?.` guards are now legitimate handling rather than workarounds papering over a lying type.

## Test plan

- [x] Added `tests/stores/static-data.test.ts` — slots read `undefined` pre-load, round-trip set values (incl. empty array ≠ undefined), and `loaded` flips true only once all nine slots are populated and back to false if any is cleared.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.
- [x] `npm run test:unit:ci` — full suite green (993 tests).

## Notes

While touching `zone.ts` I noticed the pre-existing `!` on line 27 (`enemy.spawns.find(...)!.weight`) — that's already tracked in #254, so I left it alone to keep this PR scoped.

Closes #253


---
_Generated by [Claude Code](https://claude.ai/code/session_01JhQK84kA9fHGFXcJTguLpN)_