### PR TITLE
Minor code cleanups: dead members, redundant predicates, and small DRY/semantic nits

### DIFF
--- a/Game.Api/Controllers/LoginController.cs
+++ b/Game.Api/Controllers/LoginController.cs
@@ -75,7 +75,7 @@ namespace Game.Api.Controllers
         [HttpGet]
         public async Task<ApiResponse<PlayerData>> Status()
         {
-            if (!_sessionService.SessionAvailable)
+            if (!_sessionService.Authenticated)
             {
                 return ApiResponse.Error("Not logged in");
             }
@@ -92,7 +92,7 @@ namespace Game.Api.Controllers
         [HttpGet]
         public async Task<ApiResponse<ActiveSessionResult>> ActiveSession()
         {
-            if (!_sessionService.SessionAvailable)
+            if (!_sessionService.Authenticated)
             {
                 return ApiResponse.Error("Not logged in");
             }

--- a/Game.Api/Middleware/SocketInterceptorMiddleware.cs
+++ b/Game.Api/Middleware/SocketInterceptorMiddleware.cs
@@ -19,7 +19,7 @@ namespace Game.Api.Middleware
             {
                 await _next(context);
             }
-            else if (!sessionService.SessionAvailable)
+            else if (!sessionService.Authenticated)
             {
                 context.Response.StatusCode = StatusCodes.Status401Unauthorized;
             }

--- a/Game.Api/Services/SessionService.cs
+++ b/Game.Api/Services/SessionService.cs
@@ -14,8 +14,6 @@ namespace Game.Api.Services
         private readonly ISessionStore _sessionStore = sessionStore;
         private Player? _player;
 
-        public string SessionId { get; set; } = string.Empty;
-
         public int UserId { get; private set; }
 
         public int SelectedPlayerId => PlayerState.PlayerId;
@@ -26,8 +24,6 @@ namespace Game.Api.Services
         /// The access roles granted to the authenticated user, sourced from the auth token claims.
         /// </summary>
         public IReadOnlyList<string> Roles { get; private set; } = [];
-
-        public bool SessionAvailable => UserId > 0;
 
         /// <summary>
         /// True when UserId is set to a valid authenticated user.
@@ -70,7 +66,7 @@ namespace Game.Api.Services
         /// </summary>
         public void ClearSession()
         {
-            if (SessionAvailable)
+            if (Authenticated)
             {
                 _sessionStore.Clear(UserId);
             }
@@ -97,11 +93,6 @@ namespace Game.Api.Services
         public void SavePlayerState()
         {
             _sessionStore.Update(PlayerState, UserId);
-        }
-
-        public void ClearPlayerDomainEvents()
-        {
-            _player?.ClearEvents();
         }
     }
 }

--- a/Game.Core/Players/Inventories/EquipmentSlot.cs
+++ b/Game.Core/Players/Inventories/EquipmentSlot.cs
@@ -44,6 +44,24 @@ namespace Game.Core.Players.Inventories
         }
 
         /// <summary>
+        /// Equips the given <paramref name="item"/> into this slot.
+        /// </summary>
+        public void Set(Item item)
+        {
+            ItemId = item.Id;
+            Item = item;
+        }
+
+        /// <summary>
+        /// Empties this slot.
+        /// </summary>
+        public void Clear()
+        {
+            ItemId = null;
+            Item = null;
+        }
+
+        /// <summary>
         /// Gets the <see cref="EItemCategory"/> associated with the given <paramref name="slot"/>.
         /// </summary>
         /// <param name="slot"></param>

--- a/Game.Core/Players/Inventories/Inventory.cs
+++ b/Game.Core/Players/Inventories/Inventory.cs
@@ -70,21 +70,10 @@ namespace Game.Core.Players.Inventories
 
             // Unequip from any other slot first
             var currentSlot = EquipmentSlots.FirstOrDefault(s => s.ItemId == itemId);
-            if (currentSlot is not null)
-            {
-                currentSlot.ItemId = null;
-                currentSlot.Item = null;
-            }
+            currentSlot?.Clear();
 
-            // Unequip whatever is in the target slot
-            if (equipSlot.ItemId.HasValue)
-            {
-                equipSlot.ItemId = null;
-                equipSlot.Item = null;
-            }
-
-            equipSlot.ItemId = itemId;
-            equipSlot.Item = unlocked.Item;
+            // Equipping overwrites whatever already occupies the target slot.
+            equipSlot.Set(unlocked.Item);
             return true;
         }
 
@@ -96,8 +85,7 @@ namespace Game.Core.Players.Inventories
                 return false;
             }
 
-            equipSlot.ItemId = null;
-            equipSlot.Item = null;
+            equipSlot.Clear();
             return true;
         }
 

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -15,6 +15,12 @@ namespace Game.Core.Players
     /// </summary>
     public class Player : AggregateRoot
     {
+        /// <summary>The experience required to advance a level scales linearly as <c>Level * <see cref="ExpPerLevel"/></c>.</summary>
+        private const int ExpPerLevel = 100;
+
+        /// <summary>The number of stat points awarded on each level-up.</summary>
+        private const int StatPointsPerLevel = 6;
+
         public required int Id { get; set; }
         public required string Name { get; set; }
         public required int Level { get; set; }
@@ -53,11 +59,11 @@ namespace Game.Core.Players
         public void GrantExp(int amount)
         {
             Exp += amount;
-            while (Exp > Level * 100)
+            while (Exp > Level * ExpPerLevel)
             {
-                Exp -= Level * 100;
+                Exp -= Level * ExpPerLevel;
                 Level++;
-                StatPoints.StatPointsGained += 6;
+                StatPoints.StatPointsGained += StatPointsPerLevel;
                 RaiseEvent(new PlayerLeveledUpEvent(this, Level, StatPoints.StatPointsGained));
             }
 

--- a/Game.Infrastructure/Database/GameContext.cs
+++ b/Game.Infrastructure/Database/GameContext.cs
@@ -545,12 +545,12 @@ namespace Game.Infrastructure.Database
 
         public override int SaveChanges()
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException("Synchronous SaveChanges is intentionally unavailable; use SaveChangesAsync.");
         }
 
         public override int SaveChanges(bool acceptAllChangesOnSuccess)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException("Synchronous SaveChanges is intentionally unavailable; use SaveChangesAsync.");
         }
     }
 }

--- a/UI/src/lib/battle/attribute-collection.ts
+++ b/UI/src/lib/battle/attribute-collection.ts
@@ -171,6 +171,9 @@ export function groupBySource<T extends AttributeModifier>(
 			groups.set(line.source, { source: line.source, total: line.applied, lines: [line] });
 		}
 	}
-	const ordered = SOURCE_ORDER.filter((s) => groups.has(s)).map((s) => groups.get(s)!);
+	const ordered = SOURCE_ORDER.flatMap((s) => {
+		const group = groups.get(s);
+		return group ? [group] : [];
+	});
 	return { groups: ordered, mults };
 }

--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -90,8 +90,8 @@ export class InventoryManager {
 
 		// Unequip from any current slot
 		for (let i = 0; i < this.equippedSlots.length; i++) {
-			if (this.equippedSlots[i]?.itemId === itemId) {
-				const old = this.equippedSlots[i]!;
+			const old = this.equippedSlots[i];
+			if (old?.itemId === itemId) {
 				old.equipped = false;
 				old.equipmentSlotId = undefined;
 				this.equippedSlots[i] = undefined;
@@ -99,8 +99,8 @@ export class InventoryManager {
 		}
 
 		// Unequip whatever is in the target slot
-		if (this.equippedSlots[slotId]) {
-			const displaced = this.equippedSlots[slotId]!;
+		const displaced = this.equippedSlots[slotId];
+		if (displaced) {
 			displaced.equipped = false;
 			displaced.equipmentSlotId = undefined;
 		}

--- a/UI/src/routes/admin/workbench/entities/zone.ts
+++ b/UI/src/routes/admin/workbench/entities/zone.ts
@@ -20,12 +20,10 @@ const refresh = async (): Promise<WorkbenchZone[]> => {
 		bossEnemyId: zone.bossEnemyId ?? -1,
 		// Likewise normalise the optional unlock-gate FK to the "None" sentinel (-1).
 		unlockChallengeId: zone.unlockChallengeId ?? -1,
-		zoneEnemies: enemies
-			.filter((enemy) => enemy.spawns.some((spawn) => spawn.zoneId === zone.id))
-			.map((enemy) => ({
-				enemyId: enemy.id,
-				weight: enemy.spawns.find((spawn) => spawn.zoneId === zone.id)!.weight
-			}))
+		zoneEnemies: enemies.flatMap((enemy) => {
+			const spawn = enemy.spawns.find((s) => s.zoneId === zone.id);
+			return spawn ? [{ enemyId: enemy.id, weight: spawn.weight }] : [];
+		})
 	}));
 };
 


### PR DESCRIPTION
## Summary

Addresses the grab-bag of small, low-risk cleanups in #254. None are user-facing — each just tightens the code against the project guidelines (no dead code, DRY, honest semantics). Behavior is unchanged throughout.

## Backend

- **Dead `SessionService.SessionId`** — removed (initialized to `string.Empty`, never read/written; a leftover from the pre-JWT cookie/session scheme).
- **Dead `SessionService.ClearPlayerDomainEvents()`** — removed (zero callers across Api/Application/tests).
- **Redundant `Authenticated` vs `SessionAvailable`** — both were `UserId > 0`. Consolidated onto **`Authenticated`** (the accurate post-JWT name; `SessionAvailable` was a stale pre-JWT label) and updated the three call sites (`SocketInterceptorMiddleware`, `LoginController.Status`/`ActiveSession`).
- **`GameContext.SaveChanges` exception type** — the sync overrides are an intentional "use the async path" guard, so they now throw `NotSupportedException` ("intentionally unavailable") rather than `NotImplementedException` ("not built yet"); the latter also polluted TODO/NotImplemented scans.
- **Magic numbers in the leveling formula** — `Player.GrantExp` now uses named `ExpPerLevel` (= 100) and `StatPointsPerLevel` (= 6) constants instead of inline literals. Correctly located in the domain; values unchanged.
- **Duplicated unequip logic** — the repeated `ItemId = null; Item = null;` pair is now an `EquipmentSlot.Clear()` helper, with a matching `Set(item)` for the equip assignment. The previously-redundant "clear the target slot then overwrite it" block collapses into a single `Set()` (the overwrite already supersedes the clear).

## Frontend (drop guarded non-null assertions `!`)

All were already safe, just cleaned up per the guideline that discourages `!`:

- **`routes/admin/workbench/entities/zone.ts`** — the `find(...)!.weight` re-ran a `find` already guarded by `.some()`. Replaced the `filter(...).map(...)` with a single `flatMap` that captures the matching spawn once, dropping both the `!` and the double lookup.
- **`lib/battle/attribute-collection.ts`** — `groupBySource` built its ordered list via `filter(has).map(get(s)!)`. Now a single `flatMap` that captures `groups.get(s)` once, dropping the `!`.
- **`lib/engine/player/inventory-manager.ts`** — capture the equipped-slot entry into a local before mutating, dropping the two `this.equippedSlots[i]!` / `[slotId]!` assertions.

## Note on the one item I did *not* change

The issue flagged **`LoginStatus.Success`** as possibly an "unused enum member… remove if truly unused." It is **not** unused: `AccountLoginResult.Success` is the computed property `Status == LoginStatus.Success`, and the `Succeeded` factory sets it. The `LoginErrorMessage` switch only handling failures is expected (success isn't an error message). So I kept it.

## Test plan

- [x] `dotnet build` — clean, 0 warnings.
- [x] `dotnet test` — all green (Core 313, Application 88, Api 283, Infrastructure 26). The refactored equip/unequip and `GrantExp` paths are already covered by existing `InventoryTests`/`PlayerTests` (including move-to-new-slot, target-slot-occupied replacement, and multi-level-up), so the pure refactors are exercised without new tests.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.
- [x] `npm run test:unit:ci` — 988 tests green.

These are behavior-preserving cleanups, so no docs/`Important Design Decisions` updates are warranted.

Closes #254

https://claude.ai/code/session_01PuFFb7NimJioboDoMtqZ7N

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuFFb7NimJioboDoMtqZ7N)_