### PR TITLE
Fix flaky SafeWaitHandle.IsClosed assertions in BackgroundWorkerTests

### DIFF
--- a/Game.Infrastructure.Tests/BackgroundWorkerTests.cs
+++ b/Game.Infrastructure.Tests/BackgroundWorkerTests.cs
@@ -192,12 +192,16 @@ namespace Game.Infrastructure.Tests
             // The fix this characterizes is the release of the AutoResetEvent's OS wait handle, which the class
             // previously left to the SafeWaitHandle finalizer. There is no public seam exposing it, so the disposal
             // is verified directly on the private field — the one deliberate white-box assertion in this suite.
-            var resetEvent = GetResetEvent(worker);
-            Assert.False(resetEvent.SafeWaitHandle.IsClosed);
+            var handle = GetResetEvent(worker).SafeWaitHandle;
+            Assert.False(handle.IsClosed);
 
             worker.Dispose();
 
-            Assert.True(resetEvent.SafeWaitHandle.IsClosed);
+            // Dispose() implies Kill(), whose Unregister(null) requests cancellation without blocking for the thread
+            // pool to drop its reference on the handle. The SafeWaitHandle is reference-counted, so its count can
+            // reach zero (closing the handle) a short, non-deterministic time after Dispose() returns — poll rather
+            // than assert synchronously to absorb that window.
+            WaitUntil(() => handle.IsClosed);
         }
 
         [Theory]
@@ -241,10 +245,14 @@ namespace Game.Infrastructure.Tests
 
             // Kill() and Dispose() are distinct steps; disposing an already-killed worker still releases the handle
             // and must not throw.
+            var handle = GetResetEvent(worker).SafeWaitHandle;
             worker.Kill();
             worker.Dispose();
 
-            Assert.True(GetResetEvent(worker).SafeWaitHandle.IsClosed);
+            // Unregister(null) does not block for the thread pool to drop its reference on the reference-counted
+            // handle, so its closure settles asynchronously after Dispose() returns — poll rather than assert
+            // synchronously to absorb that window.
+            WaitUntil(() => handle.IsClosed);
             Assert.Throws<ObjectDisposedException>(worker.Start);
         }
 


### PR DESCRIPTION
## Summary

Fixes the timing-flaky `BackgroundWorkerTests` assertions from #271. The failure observed at `BackgroundWorkerTests.cs:247` (`Dispose_AfterKill_DoesNotThrow`) is an **assertion** race, not a production bug.

## Root cause (confirmed against the production code)

`BackgroundWorker.Dispose()` implies `Kill()`, whose `RegisteredWaitHandle.Unregister(null)` (`BackgroundWorker.cs:105`) **requests** cancellation but does **not block** for the thread pool to release its reference on the `AutoResetEvent`'s `SafeWaitHandle`. Because the `SafeWaitHandle` is reference-counted (the thread pool's `RegisterWaitForSingleObject` took a reference), `_resetEvent.Dispose()` decrements the count but the thread pool's outstanding reference may not be released yet — so `SafeWaitHandle.IsClosed` legitimately reads `false` for a short, non-deterministic window after `Dispose()` returns. The production teardown is correct; only the synchronous assertion was racy.

## Change

I took **Option 2** from the issue (bounded poll), not Option 1 (drop the assertion): `Dispose_ReleasesResetEventHandle` exists specifically to characterize the handle-release fix (its own comment says so), so dropping the `IsClosed` assertion would gut the test's purpose. Polling keeps the white-box verification meaningful while making it deterministic.

- **`Dispose_ReleasesResetEventHandle`** and **`Dispose_AfterKill_DoesNotThrow`** — replaced the synchronous `Assert.True(...IsClosed)` with a bounded `WaitUntil(() => handle.IsClosed)`, reusing the suite's existing helper (already how it waits on thread-pool-settled conditions) rather than introducing `SpinWait.SpinUntil`. The handle is captured into a local once so the poll observes a stable reference.

Note: the issue only flagged line 247, but `Dispose_ReleasesResetEventHandle` goes through the identical `Kill()` → `Unregister(null)` → `Dispose()` path and has the same race, so both were fixed. Scope stays within `Game.Infrastructure.Tests`; no production change.

## Test plan

- [x] `dotnet build Game.Infrastructure.Tests` — clean, 0 warnings.
- [x] Ran the `BackgroundWorkerTests` filter **5×** consecutively — 26/26 passed every run (previously flaky on first attempt).
- [x] Full `Game.Infrastructure.Tests` suite green (26/26).

Closes #271

https://claude.ai/code/session_01PAa7fuEkcKK1ByH5HeQFDn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAa7fuEkcKK1ByH5HeQFDn)_