### PR TITLE
Add CI guard for TypeScript codegen drift

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -78,8 +78,18 @@ jobs:
     - name: Build solution
       run: dotnet build
 
+    - name: Verify TypeScript codegen is up to date
+      # The generated frontend API client (UI/src/lib/api/types) must stay byte-identical to what the
+      # backend DTOs/controllers produce. Regenerate and assert a clean diff so a backend change that
+      # forgets to regenerate fails here instead of landing stale client types. The codegen command
+      # short-circuits before host construction (no Postgres/Redis/DI), so it's safe in CI; reuse the
+      # binaries from "Build solution" (--no-build --no-restore), mirroring the test step below.
+      run: |
+        dotnet run --project Game.Api --no-build --no-restore -- codegen
+        git diff --exit-code -- UI/src/lib/api/types
+
     - name: Run formatter (verify only)
-      run: dotnet format --verify-no-changes 
+      run: dotnet format --verify-no-changes
 
     - name: Execute full test suite
       # The build above already restored and compiled everything; reuse those binaries instead of


### PR DESCRIPTION
## Summary

Wires the documented codegen-drift guard into CI. `docs/infrastructure.md` ("Standalone TypeScript codegen") states the generated frontend API client is byte-identical to the committed output "so CI can run the command and assert a clean `git diff` to catch api model/client drift" — but that guard was never actually in `.github/workflows/run-tests.yml`. Until now, the only thing keeping `UI/src/lib/api/types` in sync with the backend DTOs/controllers was the author remembering to regenerate.

## Change

Added a **Verify TypeScript codegen is up to date** step to the `test-backend` job (which already has the .NET SDK and a built solution):

```yaml
- name: Verify TypeScript codegen is up to date
  run: |
    dotnet run --project Game.Api --no-build --no-restore -- codegen
    git diff --exit-code -- UI/src/lib/api/types
```

A backend DTO/controller change merged without regenerating the client now fails this step instead of silently landing stale types.

## Notes / decisions

- **Placed in `test-backend`, right after `Build solution`.** It only needs the API assembly, gives fast feedback before the full suite, and the codegen command short-circuits before host construction (no Postgres/Redis/DI), so it's safe in CI.
- **`--no-build --no-restore`** rather than the issue's bare `dotnet run`, to reuse the binaries from the `Build solution` step — mirroring the existing `dotnet test --no-build --no-restore` convention in the same job. (Default config is Debug for both `dotnet build` and `dotnet run`, so the reuse is valid.)
- **Diff scoped to `UI/src/lib/api/types`** as the issue suggests — that's the only directory the generator writes to.
- **Known gap (not expanding scope here):** the `test-backend` job only runs when a backend path changes (per the `detect-changes` filter), so a hand-edit of the generated types under a *frontend-only* change wouldn't trigger this guard. That's an edge case (the types are generated, not hand-authored) and orthogonal to the issue's goal of catching forgotten regeneration after backend changes; happy to file a follow-up if you'd like it covered.

## Test plan

- [x] `dotnet build Game.Api` — clean, 0 warnings.
- [x] `dotnet run --project Game.Api --no-build --no-restore -- codegen` then `git diff --exit-code -- UI/src/lib/api/types` — **no diff** (starts from green, confirming the committed output is currently in sync, exactly as the new CI step will run it).
- [x] Workflow YAML validated (`yaml.safe_load`).

Closes #257

---
_Generated by [Claude Code](https://claude.ai/code/session_011cyhDdfZtZMMddM9KW9vpr)_