### PR TITLE
Add Game.Infrastructure.Tests to backend CI path filter

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,6 +40,7 @@ jobs:
             - 'Game.Core.Tests/**'
             - 'Game.DataAccess/**'
             - 'Game.Infrastructure/**'
+            - 'Game.Infrastructure.Tests/**'
             - 'Game.TestInfrastructure/**'
             - 'Game.sln'
             - 'docker-compose.yml'


### PR DESCRIPTION
## Summary

The `detect-changes` `backend` path filter in `.github/workflows/run-tests.yml` listed every backend project **except `Game.Infrastructure.Tests/**`**. As a result, a PR scoped to that project (e.g. #272, which fixed flaky assertions in `BackgroundWorkerTests`) did **not** trigger the `test-backend` job — the entire backend suite was skipped, and the PR merged green without the changed/affected tests ever running in CI. Because skipped jobs count as a pass for the `all-checks-passed` gate, the gap was silent.

## How it addresses the issue

- Adds `Game.Infrastructure.Tests/**` to the `backend` filter, placed right after `Game.Infrastructure/**` to match the existing `Project` → `Project.Tests` grouping (e.g. `Game.Api` then `Game.Api.Tests`).
- **Audited the full filter** against the solution's csproj-bearing directories. The backend projects are: `Game.Abstractions`, `Game.Api`, `Game.Api.Tests`, `Game.Application`, `Game.Application.Tests`, `Game.Core`, `Game.Core.Tests`, `Game.DataAccess`, `Game.Infrastructure`, `Game.Infrastructure.Tests`, `Game.TestInfrastructure`. Every one is now present in the filter — `Game.Infrastructure.Tests` was the only one missing.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` confirms the workflow YAML still parses.
- [x] Workflow-only change; no application code touched, so no `dotnet`/`npm` suites to run.

## Notes

This change is itself a workflow-only change, so the `test-backend` job won't run on this PR — that broader coverage gap (workflow-only and frontend-only changes not exercising the backend guards) is already tracked separately in #274 / #275 and is intentionally out of scope here.

Closes #276

https://claude.ai/code/session_01KRqx1YGLF6o5evCa2UWbM3

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRqx1YGLF6o5evCa2UWbM3)_