### PR TITLE
Add direct unit tests for Battler and AttributeDistribution (#266)

### DIFF
--- a/Game.Core.Tests/Attributes/AttributeDistributionTests.cs
+++ b/Game.Core.Tests/Attributes/AttributeDistributionTests.cs
@@ -1,0 +1,62 @@
+using Game.Core.Attributes;
+using Game.Core.Attributes.Modifiers;
+using Xunit;
+
+namespace Game.Core.Tests.Attributes
+{
+    /// <summary>
+    /// Locks down the level-scaling formula on <see cref="AttributeDistribution.GetDistributionModifier"/>:
+    /// an enemy's level-scaled attribute is <c>BaseAmount + (AmountPerLevel * level)</c>, wrapped in an
+    /// additive <see cref="AttributeModifier"/> sourced from <see cref="EAttributeModifierSource.AttributeDistribution"/>.
+    /// </summary>
+    public class AttributeDistributionTests
+    {
+        [Fact]
+        public void GetDistributionModifier_AtLevelZero_UsesBaseAmount()
+        {
+            var distribution = new AttributeDistribution
+            {
+                AttributeId = EAttribute.Strength,
+                BaseAmount = 10m,
+                AmountPerLevel = 3m,
+            };
+
+            var modifier = distribution.GetDistributionModifier(0);
+
+            Assert.Equal(10, modifier.Amount);
+        }
+
+        [Fact]
+        public void GetDistributionModifier_ScalesLinearlyWithLevel()
+        {
+            var distribution = new AttributeDistribution
+            {
+                AttributeId = EAttribute.Endurance,
+                BaseAmount = 10m,
+                AmountPerLevel = 3m,
+            };
+
+            var modifier = distribution.GetDistributionModifier(5);
+
+            // BaseAmount(10) + AmountPerLevel(3) * level(5) = 25.
+            Assert.Equal(25, modifier.Amount);
+        }
+
+        [Fact]
+        public void GetDistributionModifier_ProducesAdditiveModifierForTheDistributedAttribute()
+        {
+            var distribution = new AttributeDistribution
+            {
+                AttributeId = EAttribute.Agility,
+                BaseAmount = 4m,
+                AmountPerLevel = 1m,
+            };
+
+            var modifier = distribution.GetDistributionModifier(2);
+
+            Assert.Equal(EAttribute.Agility, modifier.Attribute);
+            Assert.Equal(EModifierType.Additive, modifier.Type);
+            Assert.Equal(EAttributeModifierSource.AttributeDistribution, modifier.Source);
+        }
+    }
+}

--- a/Game.Core.Tests/Battle/BattlerTests.cs
+++ b/Game.Core.Tests/Battle/BattlerTests.cs
@@ -1,0 +1,130 @@
+using Game.Core.Attributes;
+using Game.Core.Attributes.Modifiers;
+using Game.Core.Battle;
+using Game.Core.Skills;
+using Xunit;
+
+namespace Game.Core.Tests.Battle
+{
+    /// <summary>
+    /// Direct unit tests for the combat arithmetic on <see cref="Battler"/>.
+    /// <para>
+    /// These mirror the frontend suite <c>UI/src/tests/lib/battle/battler.test.ts</c>:
+    /// the <see cref="Battler.TakeDamage"/> defense-floor/death cases and the
+    /// <see cref="Battler.GetCooldownMultiplier"/> formula are asserted here with the
+    /// <b>same scenarios and the same expected results</b> as the frontend, so a future
+    /// divergence in the defense/cooldown math fails on both sides (the same parity
+    /// discipline used for <see cref="Mulberry32ParityTests"/> ⇄ <c>mulberry32-parity.test.ts</c>).
+    /// Frontend-only concerns (skill-slot filling, render cooldowns, name/level wiring) are
+    /// not part of the backend <see cref="Battler"/> and are intentionally not mirrored.
+    /// </para>
+    /// </summary>
+    public class BattlerTests
+    {
+        // ── Construction (mirrors the frontend "reset" cases that apply here) ──
+
+        [Fact]
+        public void Constructor_CalculatesCurrentHealthFromDerivedMaxHealth()
+        {
+            // MaxHealth = base(50) + Endurance(20)*20 + Strength(10)*5 = 50 + 400 + 50 = 500.
+            var battler = MakeBattler((EAttribute.Strength, 10), (EAttribute.Endurance, 20));
+
+            Assert.Equal(500, battler.CurrentHealth);
+        }
+
+        [Fact]
+        public void Constructor_StartsNotDead()
+        {
+            var battler = MakeBattler((EAttribute.Endurance, 10));
+
+            Assert.False(battler.IsDead);
+        }
+
+        // ── GetCooldownMultiplier ─────────────────────────────────────────────
+
+        [Fact]
+        public void GetCooldownMultiplier_CalculatedFromCooldownRecovery()
+        {
+            // CooldownRecovery = Agility(20)*0.4 + Dexterity(10)*0.1 = 8 + 1 = 9.
+            var battler = MakeBattler((EAttribute.Agility, 20), (EAttribute.Dexterity, 10));
+
+            var expected = 1 + (0.4 * 20 + 0.1 * 10) / 100;
+            Assert.Equal(expected, battler.GetCooldownMultiplier(), 10);
+        }
+
+        // ── TakeDamage ────────────────────────────────────────────────────────
+
+        [Fact]
+        public void TakeDamage_ReducesHealthByDamageMinusDefense()
+        {
+            // Defense = base(2) + Endurance(10)*1.0 = 12. MaxHealth = base(50) + Endurance(10)*20 = 250.
+            var battler = MakeBattler((EAttribute.Endurance, 10));
+            var initialHealth = battler.CurrentHealth;
+            const double rawDamage = 50;
+
+            var finalDamage = battler.TakeDamage(rawDamage);
+
+            Assert.Equal(rawDamage - 12, finalDamage);
+            Assert.Equal(initialHealth - finalDamage, battler.CurrentHealth);
+        }
+
+        [Fact]
+        public void TakeDamage_FloorsDamageAtZero_WhenDefenseExceedsRawDamage()
+        {
+            // Defense = base(2) + Endurance(100)*1.0 = 102, which exceeds the raw damage of 5.
+            var battler = MakeBattler((EAttribute.Endurance, 100));
+            var initialHealth = battler.CurrentHealth;
+
+            var finalDamage = battler.TakeDamage(5);
+
+            Assert.Equal(0, finalDamage);
+            Assert.Equal(initialHealth, battler.CurrentHealth);
+        }
+
+        [Fact]
+        public void TakeDamage_SetsIsDead_WhenHealthDropsToZero()
+        {
+            // No attribute modifiers: Defense = base(2), MaxHealth = base(50).
+            var battler = MakeBattler();
+            var lethalRawDamage = battler.CurrentHealth + 2;
+
+            battler.TakeDamage(lethalRawDamage);
+
+            Assert.Equal(0, battler.CurrentHealth);
+            Assert.True(battler.IsDead);
+        }
+
+        [Fact]
+        public void TakeDamage_SetsIsDead_WhenHealthDropsBelowZero()
+        {
+            var battler = MakeBattler();
+
+            battler.TakeDamage(99999);
+
+            Assert.True(battler.CurrentHealth < 0);
+            Assert.True(battler.IsDead);
+        }
+
+        // ── Helpers ───────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Builds a <see cref="Battler"/> from a set of additive attribute amounts (sourced as
+        /// <see cref="EAttributeModifierSource.AttributeDistribution"/>, matching how the frontend
+        /// <c>BattleAttributes</c> feeds raw battler attributes) with no skills at level 1.
+        /// </summary>
+        private static Battler MakeBattler(params (EAttribute Attribute, double Amount)[] attributes)
+        {
+            var modifiers = attributes
+                .Select(a => new AttributeModifier
+                {
+                    Attribute = a.Attribute,
+                    Amount = a.Amount,
+                    Type = EModifierType.Additive,
+                    Source = EAttributeModifierSource.AttributeDistribution,
+                })
+                .ToList();
+
+            return new Battler(new AttributeCollection(modifiers), [], 1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the backend coverage / frontend-parity gap from #266 by adding direct unit tests for two pieces of `Game.Core` combat arithmetic that were previously only exercised indirectly. **Test-only additions to `Game.Core.Tests` — no production code changed.**

### `Game.Core.Tests/Battle/BattlerTests.cs`
Mirrors the existing frontend suite `UI/src/tests/lib/battle/battler.test.ts` with the **same scenarios and the same expected results**, so a future divergence in the defense/cooldown math fails on both sides (the same parity discipline already used for `Mulberry32ParityTests` ⇄ `mulberry32-parity.test.ts`):

- `TakeDamage` — reduces health by `rawDamage - Defense`; floors damage at `0` when `Defense` exceeds raw damage (health unchanged); sets `IsDead` when health drops **to** `0` and **below** `0`.
- `GetCooldownMultiplier` — the `1 + (CooldownRecovery / 100)` formula.
- Plus the constructor's `CurrentHealth = MaxHealth` derivation and initial `IsDead == false`, mirroring the applicable frontend `reset` cases.

Frontend-only concerns (skill-slot filling, render cooldowns, name wiring) aren't part of the backend `Battler` and are intentionally not mirrored — noted in the class doc comment.

### `Game.Core.Tests/Attributes/AttributeDistributionTests.cs`
Locks the `GetDistributionModifier(level)` scaling formula directly: level `0` → `BaseAmount`, level `N` → linear `BaseAmount + (AmountPerLevel * level)`, and that the produced modifier is `Additive`, sourced from `AttributeDistribution`, and targets the distributed attribute.

## How it addresses the issue
The backend `Battler` was the one half of the `Battler`/`battler.test.ts` parity pair without a mirrored unit test, and `AttributeDistribution.GetDistributionModifier` had no direct test. Both gaps are now covered with edge cases (defense floor, health-to/below-zero death transition, level-0 base case), satisfying CLAUDE.md's coverage and frontend/backend battle-parity requirements.

## Test plan
- [x] `dotnet build Game.Core.Tests/Game.Core.Tests.csproj` — succeeds, 0 warnings / 0 errors
- [x] `BattlerTests` — 7 passed
- [x] `AttributeDistributionTests` — 3 passed
- [x] Full `Game.Core.Tests` suite — 325 passed, 0 failed

Companion to the frontend coverage gap #255 and the parity-matrix gap #256; this PR covers the backend units those did not.

Closes #266

https://claude.ai/code/session_01UMrEqrZoRtdpoUYvQa5UUu

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMrEqrZoRtdpoUYvQa5UUu)_