### PR TITLE
Persist skill loadout order + loadout-cap foundation (#260)

### DIFF
--- a/Game.Application.Tests/Services/AccountServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/AccountServiceIntegrationTests.cs
@@ -68,6 +68,8 @@ namespace Game.Application.Tests.Services
                 .ToListAsync(CancellationToken);
             Assert.Equal(new[] { 0, 1, 2 }, skills.Select(skill => skill.SkillId).OrderBy(id => id));
             Assert.All(skills, skill => Assert.True(skill.Selected));
+            // Starter skills carry a sequential loadout order (0..n-1), persisted by PlayerMapper.ToEntity.
+            Assert.Equal(new[] { 0, 1, 2 }, skills.OrderBy(skill => skill.SkillId).Select(skill => skill.Order));
 
             var attributes = await verifyContext.Set<PlayerAttribute>()
                 .Where(attribute => attribute.PlayerId == createdPlayer.Id)

--- a/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
@@ -300,6 +300,47 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task LoadPlayer_OrdersSelectedSkillsByOrderThenSkillId()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // CreateSkillAsync assigns sequential ids, so these five skills have ascending ids.
+            var skillA = await TestDataSeeder.CreateSkillAsync(context, name: "A");
+            var skillB = await TestDataSeeder.CreateSkillAsync(context, name: "B");
+            var skillC = await TestDataSeeder.CreateSkillAsync(context, name: "C");
+            var skillD = await TestDataSeeder.CreateSkillAsync(context, name: "D");
+            var skillE = await TestDataSeeder.CreateSkillAsync(context, name: "E");
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+
+            // Linked in a deliberately scrambled order so the assertion proves the mapper sorts rather
+            // than echoing insertion order. skillA and skillC share Order = 2 to exercise the SkillId
+            // tie-break (which also covers legacy rows that all default to Order = 0).
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, skillC.Id, selected: true, order: 2);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, skillA.Id, selected: true, order: 2);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, skillD.Id, selected: true, order: 0);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, skillB.Id, selected: true, order: 1);
+            // An unlocked-but-unselected skill must stay out of the equipped loadout.
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, skillE.Id, selected: false, order: 0);
+
+            var playerService = scope.ServiceProvider.GetRequiredService<PlayerService>();
+            var player = await playerService.LoadPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            // Equipped set is a stable total order by (Order, SkillId): D (0), B (1), then A and C
+            // tie at 2 → A before C because its SkillId is lower.
+            Assert.Equal(
+                new[] { skillD.Id, skillB.Id, skillA.Id, skillC.Id },
+                player.SelectedSkills.Select(skill => skill.Id));
+
+            // The unselected skill is still unlocked but never equipped.
+            Assert.Contains(player.Skills, skill => skill.Id == skillE.Id);
+            Assert.DoesNotContain(player.SelectedSkills, skill => skill.Id == skillE.Id);
+        }
+
+        [Fact]
         public async Task SetFavorite_PersistsFavoriteFlagToDatabase()
         {
             using var scope = CreateScope();

--- a/Game.Core.Tests/Players/NewPlayerFactoryTests.cs
+++ b/Game.Core.Tests/Players/NewPlayerFactoryTests.cs
@@ -33,6 +33,16 @@ namespace Game.Core.Tests.Players
         }
 
         [Fact]
+        public void Create_AssignsSequentialLoadoutOrderToStarterSkills()
+        {
+            var newPlayer = _factory.Create("hero");
+
+            Assert.Equal(
+                Enumerable.Range(0, NewPlayerFactory.StarterSkillCount),
+                newPlayer.Skills.Select(skill => skill.Order));
+        }
+
+        [Fact]
         public void Create_GrantsEachCoreAttributeAtStartingAmount()
         {
             var newPlayer = _factory.Create("hero");

--- a/Game.Core/Players/NewPlayerFactory.cs
+++ b/Game.Core/Players/NewPlayerFactory.cs
@@ -35,7 +35,7 @@ namespace Game.Core.Players
                 StatPointsGained = 0,
                 StatPointsUsed = 0,
                 Skills = Enumerable.Range(0, StarterSkillCount)
-                    .Select(id => new NewPlayerSkill { SkillId = id, Selected = true })
+                    .Select((id, index) => new NewPlayerSkill { SkillId = id, Selected = true, Order = index })
                     .ToList(),
                 Attributes = Enumerable.Range(0, AttributeCount)
                     .Select(id => new StatAllocation { Attribute = (EAttribute)id, Amount = StartingAttributeAmount })

--- a/Game.Core/Players/NewPlayerSkill.cs
+++ b/Game.Core/Players/NewPlayerSkill.cs
@@ -1,13 +1,17 @@
 namespace Game.Core.Players
 {
     /// <summary>
-    /// A starter skill granted to a freshly created player: the skill to unlock and whether it
-    /// begins selected. Part of the <see cref="NewPlayer"/> blueprint.
+    /// A starter skill granted to a freshly created player: the skill to unlock, whether it
+    /// begins selected, and its position in the equipped loadout. Part of the
+    /// <see cref="NewPlayer"/> blueprint.
     /// </summary>
     public class NewPlayerSkill
     {
         public required int SkillId { get; init; }
 
         public required bool Selected { get; init; }
+
+        /// <summary>The skill's position in the equipped loadout (used as the persisted loadout order).</summary>
+        public required int Order { get; init; }
     }
 }

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -21,6 +21,14 @@ namespace Game.Core.Players
         /// <summary>The number of stat points awarded on each level-up.</summary>
         private const int StatPointsPerLevel = 6;
 
+        /// <summary>
+        /// The maximum number of skills a player may equip in their battle loadout. Fixed at the
+        /// enemy loadout cap (<see cref="Enemies.Enemy"/> brings ≤ 4 skills into a battle) for
+        /// player/enemy symmetry. This is the single source of truth for the cap; enforcement of a
+        /// loadout change against it is added with the set-loadout command (#263).
+        /// </summary>
+        public const int MaxSelectedSkills = 4;
+
         public required int Id { get; set; }
         public required string Name { get; set; }
         public required int Level { get; set; }

--- a/Game.DataAccess/Mapping/PlayerMapper.cs
+++ b/Game.DataAccess/Mapping/PlayerMapper.cs
@@ -35,6 +35,7 @@ namespace Game.DataAccess.Mapping
                     Player = player,
                     SkillId = skill.SkillId,
                     Selected = skill.Selected,
+                    Order = skill.Order,
                 }).ToList();
 
             player.PlayerAttributes = newPlayer.Attributes
@@ -129,8 +130,14 @@ namespace Game.DataAccess.Mapping
 
             var playerSkills = skillsById.Values.ToList();
 
+            // Order the equipped set by (Order, SkillId) for a stable total order. The equipped
+            // order is captured into BattleSnapshot.SkillIds and sent to the client, so the
+            // backend's order must be deterministic to preserve battle parity — including for
+            // legacy rows that default to Order = 0 (SkillId is the deterministic tie-break).
             var selectedSkills = entity.PlayerSkills
                 .Where(ps => ps.Selected)
+                .OrderBy(ps => ps.Order)
+                .ThenBy(ps => ps.SkillId)
                 .Select(ps => skillsById[ps.SkillId])
                 .ToList();
 

--- a/Game.Infrastructure/Entities/PlayerSkill.cs
+++ b/Game.Infrastructure/Entities/PlayerSkill.cs
@@ -5,6 +5,7 @@
         public int PlayerId { get; set; }
         public int SkillId { get; set; }
         public bool Selected { get; set; }
+        public int Order { get; set; }
 
         public virtual Player Player { get => field ?? throw new NotLoadedException(nameof(Player)); set; }
         public virtual Skill Skill { get => field ?? throw new NotLoadedException(nameof(Skill)); set; }

--- a/Game.Infrastructure/Migrations/20260609153634_AddPlayerSkillOrder.Designer.cs
+++ b/Game.Infrastructure/Migrations/20260609153634_AddPlayerSkillOrder.Designer.cs
@@ -4,6 +4,7 @@ using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Game.Infrastructure.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20260609153634_AddPlayerSkillOrder")]
+    partial class AddPlayerSkillOrder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Game.Infrastructure/Migrations/20260609153634_AddPlayerSkillOrder.cs
+++ b/Game.Infrastructure/Migrations/20260609153634_AddPlayerSkillOrder.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Game.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlayerSkillOrder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Order",
+                table: "PlayerSkills",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Order",
+                table: "PlayerSkills");
+        }
+    }
+}

--- a/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
+++ b/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
@@ -241,13 +241,14 @@ namespace Game.TestInfrastructure.Helpers
             await context.SaveChangesAsync();
         }
 
-        public static async Task LinkSkillToPlayerAsync(GameContext context, int playerId, int skillId, bool selected = true)
+        public static async Task LinkSkillToPlayerAsync(GameContext context, int playerId, int skillId, bool selected = true, int order = 0)
         {
             context.PlayerSkills.Add(new PlayerSkill
             {
                 PlayerId = playerId,
                 SkillId = skillId,
                 Selected = selected,
+                Order = order,
             });
             await context.SaveChangesAsync();
         }


### PR DESCRIPTION
## Summary

Foundation for the skill-selection feature — **spike #179, area B**. It makes the equipped skill set **ordered and deterministic** so the read (#262) and write (#263) issues can build on it. There is **no player-facing behavior change** on its own.

- **`PlayerSkill.Order`** — add an `Order int` column to the `PlayerSkill` entity alongside the existing `Selected` flag (additive — see the spike's "Loadout column shape" sub-decision for why we kept `Selected` rather than replacing it with a nullable order). + **EF migration** (`AddPlayerSkillOrder`; existing rows default to `Order = 0`).
- **Deterministic ordered mapping** — `PlayerMapper.ToCore` orders `SelectedSkills` by `(Order, SkillId)`, a stable total order even for legacy rows that all default to `Order = 0` (`SkillId` is the deterministic tie-break). This matters for **battle parity**: the equipped order is captured into `BattleSnapshot.SkillIds` and sent to the client, so the backend's order must be deterministic.
- **Starter skills get an order** — `NewPlayerSkill` gains `Order`; `NewPlayerFactory` assigns `0..n-1`; `PlayerMapper.ToEntity` persists it.
- **Loadout-cap constant** — `Player.MaxSelectedSkills = 4` as the single source of truth for the cap (matching the enemy loadout cap, `Enemy` brings ≤ 4 skills into a battle). Enforcement lands with the set-loadout command in **#263**; this issue just establishes the constant.

## How it addresses the issue

Implements every bullet of the #260 scope (entity column + migration, ordered mapping, starter-skill order, cap constant). It is the foundation that **#262** and **#263** depend on.

## Tests

- **`LoadPlayer_OrdersSelectedSkillsByOrderThenSkillId`** (integration, real load path): seeds skills in a scrambled order — including two equipped skills sharing an `Order` to exercise the `SkillId` tie-break, plus an unlocked-but-unselected skill — and asserts the resolved `SelectedSkills` come back in `(Order, SkillId)` order with the unselected skill excluded.
- **`AccountServiceIntegrationTests`**: extended to assert the starter skills are persisted with sequential `Order` (`PlayerMapper.ToEntity`, end-to-end).
- **`NewPlayerFactoryTests.Create_AssignsSequentialLoadoutOrderToStarterSkills`** (domain unit test): the factory assigns `0..n-1`.

Tests follow the project's classical/no-doubles guidance — the mapping is verified through the real repository + cached `ISkills` rather than a fake.

### Test plan
- [x] `dotnet build` — clean (0 warnings)
- [x] `Game.Core.Tests` — 316 passed
- [x] `Game.Application.Tests` — 103 passed (migration applied to the reused DB)
- [x] `Game.Api.Tests` — 283 passed (architecture + battle-parity suites)

## Notes
- **No `docs/` update in this PR.** The spike's documentation checklist defers the game-design.md "skills are equippable up to a cap of 4, with a meaningful loadout order" note to "when A/B/D land" — i.e. when the feature is player-facing. Since this is foundation-only with no visible behavior, updating it now would document a feature players can't use yet; the underlying design decisions are already recorded in [`docs/spikes/179-skill-unlock-and-selection.md`](https://github.com/ginderjeremiah/GameServer/blob/main/docs/spikes/179-skill-unlock-and-selection.md).
- No battle-logic or frontend change, so no new battle-parity vector is required (consistent with the spike's parity note).

Closes #260

https://claude.ai/code/session_01Syhn7GYVZ3CrEj3x9zsdLd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Syhn7GYVZ3CrEj3x9zsdLd)_