### PR TITLE
Add equipped-item + applied-mod scenario to the battle-parity matrix

### DIFF
--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -2,6 +2,7 @@ using Game.Core.Attributes;
 using Game.Core.Attributes.Modifiers;
 using Game.Core.Battle;
 using Game.Core.Enemies;
+using Game.Core.Items;
 using Game.Core.Players;
 using Game.Core.Players.Inventories;
 using Game.Core.Skills;
@@ -139,6 +140,35 @@ namespace Game.Core.Tests.Battle
                     ExpectedPlayerDied: false,
                     ExpectedTotalMs: 200,
                     MaxMs: 200),
+
+                // The only scenario whose player is built through the equipped-item + applied-mod
+                // attribute-composition path (the rest build the player from raw stat allocations).
+                // An item and two mods (prefix + suffix) each contribute Strength, so dropping any
+                // one source changes the kill count; the item's Agility and the prefix's Dexterity
+                // additionally feed CooldownRecovery, so the whole merge is exercised end to end.
+                //   Allocations: Str=20, End=20.  Item: +10 Str, +20 Agi.  Prefix: +8 Str, +20 Dex.  Suffix: +7 Str.
+                //   Merged: Str=45, End=20, Agi=20, Dex=20 → MaxHealth=675, Def=32, CDR=10 → cdMult=1.10.
+                //   Player skill: 10 + 45*1.5 = 77.5 raw, after enemy def 17 → 60.5, fires every 28 ticks
+                //     (charge/tick = 40*1.10 = 44, 44*28=1232 ≥ 1200).
+                //   Enemy: MaxHealth=400, Def=17; attack 5-32 clamps to 0, so the player never dies.
+                //   7 hits reach 423.5 ≥ 400 at tick 196 → 7840ms (vs 21600ms for the same allocations
+                //   with no equipment — proof the merged attributes change the outcome).
+                ["equippedItemWithMods"] = new ParityScenario(
+                    Player: () => MakeBattlerWithEquipment(
+                        strength: 20, endurance: 20,
+                        skills: [MakeSkill(1, baseDamage: 10, cooldownMs: 1200, mult: EAttribute.Strength, multAmount: 1.5)],
+                        itemAttributes: [ItemAttr(EAttribute.Strength, 10), ItemAttr(EAttribute.Agility, 20)],
+                        mods:
+                        [
+                            MakeMod(10, EItemModType.Prefix, [ItemAttr(EAttribute.Strength, 8), ItemAttr(EAttribute.Dexterity, 20)]),
+                            MakeMod(11, EItemModType.Suffix, [ItemAttr(EAttribute.Strength, 7)]),
+                        ]),
+                    Enemy: () => MakeEnemy(
+                        strength: 10, endurance: 15,
+                        skills: [MakeSkill(2, baseDamage: 5, cooldownMs: 2000)]),
+                    ExpectedVictory: true,
+                    ExpectedPlayerDied: false,
+                    ExpectedTotalMs: 7840),
             };
 
         public static IEnumerable<object[]> ScenarioNames =>
@@ -186,6 +216,28 @@ namespace Game.Core.Tests.Battle
             // charge/tick = 47.2, fires every 26 ticks → 6240ms
             Assert.Equal(6240, result.TotalMs);
             Assert.True(result.TotalMs < 6720, "Double-counted stats should end the battle sooner.");
+        }
+
+        /// <summary>
+        /// Pins down the merged attribute values for the <c>equippedItemWithMods</c> scenario so a
+        /// divergence in the stat + item + applied-mod attribute composition is reported directly
+        /// (rather than only surfacing as a different battle outcome). Mirrors the frontend
+        /// "composes the equippedItemWithMods stat + item + mod attributes" expectation.
+        /// </summary>
+        [Fact]
+        public void Parity_EquippedItemWithMods_ComposesMergedAttributes()
+        {
+            var player = Scenarios["equippedItemWithMods"].Player();
+
+            // Strength 20 (allocation) + 10 (item) + 8 (prefix) + 7 (suffix) = 45.
+            Assert.Equal(45, player.GetAttributeValue(EAttribute.Strength));
+            Assert.Equal(20, player.GetAttributeValue(EAttribute.Endurance));
+            Assert.Equal(20, player.GetAttributeValue(EAttribute.Agility));
+            Assert.Equal(20, player.GetAttributeValue(EAttribute.Dexterity));
+            Assert.Equal(675, player.GetAttributeValue(EAttribute.MaxHealth));
+            Assert.Equal(32, player.GetAttributeValue(EAttribute.Defense));
+            Assert.Equal(10, player.GetAttributeValue(EAttribute.CooldownRecovery));
+            Assert.Equal(1.10, player.GetCooldownMultiplier(), 10);
         }
 
         private static Skill MakeSkill(
@@ -250,6 +302,68 @@ namespace Game.Core.Tests.Battle
                 LogPreferences = [],
             };
         }
+
+        /// <summary>
+        /// Builds a player Battler whose attributes flow through the equipped-item + applied-mod
+        /// composition path (<see cref="Item.GetAttributeModifiers"/> via the live
+        /// <see cref="Player.GetAttributes"/>), layering the item's own attributes and every applied
+        /// mod's attributes on top of the raw stat allocations. The item is given one mod slot per
+        /// mod (index- and type-aligned) so each mod applies, mirroring how the frontend
+        /// <c>makeEquipment</c> helper feeds the same merged attributes to its Battler.
+        /// </summary>
+        private static Battler MakeBattlerWithEquipment(
+            double strength, double endurance,
+            List<Skill> skills,
+            List<AttributeModifier> itemAttributes,
+            List<ItemMod> mods)
+        {
+            var item = new Item
+            {
+                Id = 1,
+                Name = "Item 1",
+                Description = string.Empty,
+                Category = EItemCategory.Accessory,
+                Rarity = ERarity.Common,
+                Attributes = itemAttributes,
+                ModSlots = mods.Select((mod, index) => new ItemModSlot
+                {
+                    Id = index,
+                    Index = index,
+                    Type = mod.Type,
+                }).ToList(),
+                Tags = [],
+            };
+
+            var player = MakePlayer(strength, endurance, skills: skills);
+            player.UnlockItem(item);
+            player.TryEquipItem(item.Id, EEquipmentSlot.AccessorySlot);
+            for (var index = 0; index < mods.Count; index++)
+            {
+                player.UnlockMod(mods[index].Id);
+                player.TryApplyMod(item.Id, mods[index].Id, index, mods[index]);
+            }
+
+            return new Battler(player);
+        }
+
+        private static ItemMod MakeMod(int id, EItemModType type, List<AttributeModifier> attributes) => new()
+        {
+            Id = id,
+            Name = $"Mod {id}",
+            Description = string.Empty,
+            Type = type,
+            Rarity = ERarity.Common,
+            Attributes = attributes,
+            Tags = [],
+        };
+
+        private static AttributeModifier ItemAttr(EAttribute attribute, double amount) => new()
+        {
+            Attribute = attribute,
+            Amount = amount,
+            Type = EModifierType.Additive,
+            Source = EAttributeModifierSource.Item,
+        };
 
         /// <summary>
         /// Creates a player whose attributes mimic the frontend double-counting bug:

--- a/UI/src/tests/lib/battle/battle-sim-test-utils.ts
+++ b/UI/src/tests/lib/battle/battle-sim-test-utils.ts
@@ -1,5 +1,16 @@
-import { Battler } from '$lib/battle';
-import type { EAttribute, IAttributeMultiplier, ISkill } from '$lib/api';
+import { Battler, newItem } from '$lib/battle';
+import {
+	EItemCategory,
+	ERarity,
+	type EAttribute,
+	type EItemModType,
+	type IAppliedModModel,
+	type IAttributeMultiplier,
+	type IBattlerAttribute,
+	type IItem,
+	type IItemMod,
+	type ISkill
+} from '$lib/api';
 
 /**
  * Shared helpers for the battle-simulation tests. They build the **real**
@@ -30,10 +41,18 @@ export const makeSkill = (
  * Binds a `makeBattler` builder to a mock skill registry (the array a test's
  * mocked `staticData.skills` returns). `makeBattler` registers each skill spec
  * into the registry, then builds a real Battler from raw stat allocations whose
- * `selectedSkills` reference those registered ids.
+ * `selectedSkills` reference those registered ids. The optional `equipment` is
+ * passed through as the Battler's additional attributes — exactly how the live
+ * game feeds `InventoryManager.equipmentStats` to the player Battler — so a
+ * scenario can layer equipped item + applied-mod attributes on top of the raw
+ * stat allocations before derived stats are computed.
  */
 export function battlerFactory(registry: ISkill[]) {
-	return (attrs: { id: EAttribute; amount: number }[], skills: SkillSpec[]): Battler => {
+	return (
+		attrs: { id: EAttribute; amount: number }[],
+		skills: SkillSpec[],
+		equipment?: IBattlerAttribute[]
+	): Battler => {
 		const selectedSkills = skills.map((spec) => {
 			const id = registry.length;
 			registry.push({
@@ -48,11 +67,72 @@ export function battlerFactory(registry: ISkill[]) {
 			return id;
 		});
 
-		return new Battler({
-			name: 'Battler',
-			level: 1,
-			selectedSkills,
-			attributes: attrs.map((a) => ({ attributeId: a.id, amount: a.amount }))
+		return new Battler(
+			{
+				name: 'Battler',
+				level: 1,
+				selectedSkills,
+				attributes: attrs.map((a) => ({ attributeId: a.id, amount: a.amount }))
+			},
+			equipment
+		);
+	};
+}
+
+/** A single applied mod's raw definition, before it is registered and given an id. */
+export interface ModSpec {
+	type: EItemModType;
+	attributes: IBattlerAttribute[];
+}
+
+/** An equipped item's raw definition, before it (and its mods) are registered. */
+export interface ItemSpec {
+	attributes: IBattlerAttribute[];
+	mods: ModSpec[];
+}
+
+/**
+ * Binds a `makeEquipment` builder to mock item + itemMod registries (the arrays a
+ * test's mocked `staticData.items` / `staticData.itemMods` return). It registers
+ * the item and each applied mod, builds the real production `Item` via
+ * {@link newItem} — exercising the item + applied-mod attribute merge — and
+ * returns the flattened equipment stats exactly as the live
+ * `InventoryManager.equipmentStats` does (the item's own attributes followed by
+ * every applied mod's attributes), ready to feed a Battler as its equipment.
+ */
+export function equipmentFactory(itemRegistry: IItem[], itemModRegistry: IItemMod[]) {
+	return (spec: ItemSpec): IBattlerAttribute[] => {
+		const appliedMods: IAppliedModModel[] = spec.mods.map((mod, slotIndex) => {
+			const id = itemModRegistry.length;
+			itemModRegistry.push({
+				id,
+				name: `Mod ${id}`,
+				description: '',
+				itemModTypeId: mod.type,
+				rarityId: ERarity.Common,
+				attributes: mod.attributes,
+				tags: []
+			});
+			return { itemModId: id, itemModSlotId: slotIndex };
 		});
+
+		const itemId = itemRegistry.length;
+		itemRegistry.push({
+			id: itemId,
+			name: `Item ${itemId}`,
+			description: '',
+			itemCategoryId: EItemCategory.Accessory,
+			rarityId: ERarity.Common,
+			iconPath: '',
+			attributes: spec.attributes,
+			modSlots: [],
+			tags: []
+		});
+
+		const item = newItem({ itemId, equipped: true, favorite: false, appliedMods });
+
+		// Mirror InventoryManager.equipmentStats: the equipped item's own
+		// attributes followed by every applied mod's attributes.
+		return [...item.attributes, ...item.appliedMods.flatMap((mod) => mod.attributes)];
 	};
 }

--- a/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
+++ b/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
@@ -1,22 +1,31 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { EAttribute } from '$lib/api';
-import type { ISkill } from '$lib/api';
+import { EAttribute, EItemModType } from '$lib/api';
+import type { ISkill, IItem, IItemMod } from '$lib/api';
 
 // Drive the REAL production simulation. The mocked `staticData.skills` is the
 // registry `makeBattler` registers each scenario's skills into, so the Battlers
-// resolve their skills exactly as the live game does.
+// resolve their skills exactly as the live game does; `items` / `itemMods` back
+// the registries `makeEquipment` builds equipped items + applied mods from.
 const mockSkills: ISkill[] = [];
+const mockItems: IItem[] = [];
+const mockItemMods: IItemMod[] = [];
 vi.mock('$stores', () => ({
 	staticData: {
 		get skills() {
 			return mockSkills;
+		},
+		get items() {
+			return mockItems;
+		},
+		get itemMods() {
+			return mockItemMods;
 		}
 	}
 }));
 
 import { BattleSimulator, Battler } from '$lib/battle';
 import type { BattleResult } from '$lib/battle';
-import { battlerFactory, makeSkill } from './battle-sim-test-utils';
+import { battlerFactory, equipmentFactory, makeSkill } from './battle-sim-test-utils';
 
 /**
  * The parity matrix below asserts the full outcome (victory / playerDied /
@@ -27,6 +36,7 @@ import { battlerFactory, makeSkill } from './battle-sim-test-utils';
  */
 const msPerTick = 40;
 const makeBattler = battlerFactory(mockSkills);
+const makeEquipment = equipmentFactory(mockItems, mockItemMods);
 
 // ── Shared parity matrix ───────────────────────────────────────────────────────
 // Every scenario here MUST mirror — with identical inputs and identical expected
@@ -176,12 +186,66 @@ const scenarios: ParityScenario[] = [
 			),
 		maxMs: 200,
 		expected: { victory: false, playerDied: false, totalMs: 200 }
+	},
+
+	// The only scenario whose player is built through the equipped-item + applied-mod
+	// attribute-composition path (the rest build the player from raw stat allocations).
+	// An item and two mods (prefix + suffix) each contribute Strength, so dropping any
+	// one source changes the kill count; the item's Agility and the prefix's Dexterity
+	// additionally feed CooldownRecovery, so the whole merge is exercised end to end.
+	//   Allocations: Str=20, End=20.  Item: +10 Str, +20 Agi.  Prefix: +8 Str, +20 Dex.  Suffix: +7 Str.
+	//   Merged: Str=45, End=20, Agi=20, Dex=20 → MaxHealth=675, Def=32, CDR=10 → cdMult=1.10.
+	//   Player skill: 10 + 45*1.5 = 77.5 raw, after enemy def 17 → 60.5, fires every 28 ticks
+	//     (charge/tick = 40*1.10 = 44, 44*28=1232 ≥ 1200).
+	//   Enemy: MaxHealth=400, Def=17; attack 5-32 clamps to 0, so the player never dies.
+	//   7 hits reach 423.5 ≥ 400 at tick 196 → 7840ms (vs 21600ms for the same allocations
+	//   with no equipment — proof the merged attributes change the outcome).
+	{
+		name: 'equippedItemWithMods',
+		player: () =>
+			makeBattler(
+				[
+					{ id: EAttribute.Strength, amount: 20 },
+					{ id: EAttribute.Endurance, amount: 20 }
+				],
+				[makeSkill(10, 1200, [{ attributeId: EAttribute.Strength, multiplier: 1.5 }])],
+				makeEquipment({
+					attributes: [
+						{ attributeId: EAttribute.Strength, amount: 10 },
+						{ attributeId: EAttribute.Agility, amount: 20 }
+					],
+					mods: [
+						{
+							type: EItemModType.Prefix,
+							attributes: [
+								{ attributeId: EAttribute.Strength, amount: 8 },
+								{ attributeId: EAttribute.Dexterity, amount: 20 }
+							]
+						},
+						{
+							type: EItemModType.Suffix,
+							attributes: [{ attributeId: EAttribute.Strength, amount: 7 }]
+						}
+					]
+				})
+			),
+		enemy: () =>
+			makeBattler(
+				[
+					{ id: EAttribute.Strength, amount: 10 },
+					{ id: EAttribute.Endurance, amount: 15 }
+				],
+				[makeSkill(5, 2000)]
+			),
+		expected: { victory: true, playerDied: false, totalMs: 7840 }
 	}
 ];
 
 describe('Battle simulation parity with backend', () => {
 	beforeEach(() => {
 		mockSkills.length = 0;
+		mockItems.length = 0;
+		mockItemMods.length = 0;
 	});
 
 	for (const scenario of scenarios) {
@@ -205,6 +269,27 @@ describe('Battle simulation parity with backend', () => {
 
 		expect(enemy.attributes.getValue(EAttribute.MaxHealth)).toBe(400);
 		expect(enemy.attributes.getValue(EAttribute.Defense)).toBe(17);
+	});
+
+	it('composes the equippedItemWithMods stat + item + mod attributes to the expected values', () => {
+		// Pins the merged values down so a divergence in item/mod attribute merging
+		// (rather than just the battle outcome) is reported directly. Mirrors
+		// BattleSimulatorParityTests.Parity_EquippedItemWithMods_ComposesMergedAttributes.
+		const scenario = scenarios.find((s) => s.name === 'equippedItemWithMods');
+		if (!scenario) {
+			throw new Error('equippedItemWithMods scenario is missing from the matrix');
+		}
+		const player = scenario.player();
+
+		// Strength 20 (alloc) + 10 (item) + 8 (prefix) + 7 (suffix) = 45.
+		expect(player.attributes.getValue(EAttribute.Strength)).toBe(45);
+		expect(player.attributes.getValue(EAttribute.Endurance)).toBe(20);
+		expect(player.attributes.getValue(EAttribute.Agility)).toBe(20);
+		expect(player.attributes.getValue(EAttribute.Dexterity)).toBe(20);
+		expect(player.attributes.getValue(EAttribute.MaxHealth)).toBe(675);
+		expect(player.attributes.getValue(EAttribute.Defense)).toBe(32);
+		expect(player.attributes.getValue(EAttribute.CooldownRecovery)).toBe(10);
+		expect(player.cdMultiplier).toBeCloseTo(1.1, 10);
 	});
 
 	it('ends sooner if the player double-counts derived stats (the historical bug)', () => {


### PR DESCRIPTION
## Summary

The cross-implementation battle-parity suites (`Game.Core.Tests/Battle/BattleSimulatorParityTests.cs` ⇄ `UI/src/tests/lib/battle/battle-simulation-parity.test.ts`) were row-for-row aligned, but **no scenario built the player through the equipped-item + applied-mod attribute-composition path** — every scenario built the player from raw stat allocations only. As issue #256 notes, a divergence in item/mod attribute merging between the two implementations would **not** have been caught by the parity matrix (only the separate, non-mirrored `BattleSnapshotTests.cs` / `item.test.ts` exercised mod composition).

This adds a mirrored `equippedItemWithMods` scenario that runs the merge path on both sides, with identical inputs and an identical expected outcome.

## The scenario

Player allocations `Str=20, End=20`, plus an equipped accessory and two applied mods:

| Source | Attributes |
| --- | --- |
| Item | +10 Str, +20 Agi |
| Prefix mod | +8 Str, +20 Dex |
| Suffix mod | +7 Str |

Merged → `Str=45, End=20, Agi=20, Dex=20` → `MaxHealth=675, Def=32, CooldownRecovery=10` (`cdMult=1.10`). The player's `10 + 45×1.5 = 77.5` skill (after the enemy's 17 Defense → 60.5/hit) kills the 400-HP enemy in 7 hits, firing every 28 ticks → **7840ms**, victory. The same allocations with no equipment would take 21600ms, so the merged attributes demonstrably change the tick-by-tick outcome (the issue's requirement).

Each of the three sources contributes Strength, so dropping any one changes the kill count; the item's Agility and the prefix's Dexterity additionally feed CooldownRecovery, so the full merge is exercised.

## How it exercises the real composition path

- **Backend:** a new `MakeBattlerWithEquipment` helper equips a real `Item` with prefix/suffix mods on a `Player` and builds the Battler through the live `Player.GetAttributes` → `Inventory.GetEquippedAttributeModifiers` → `Item.GetAttributeModifiers` path (alongside `StatAllocation.ToModifier`).
- **Frontend:** a new `equipmentFactory` builds the production `Item` via `newItem` (exercising the item + applied-mod merge into `Item.totalAttributes`) and feeds the flattened equipment stats to the Battler exactly as the live `InventoryManager.equipmentStats` does. `makeBattler` gained an optional `equipment` argument (passed as the Battler's additional attributes, mirroring `battler.reset(playerManager, equipmentStats)`).
- Both suites additionally assert the **merged attribute values** directly (`Parity_EquippedItemWithMods_ComposesMergedAttributes` ⇄ `composes the equippedItemWithMods stat + item + mod attributes...`), so a mismerge is reported as such rather than only surfacing as a different battle outcome.

The frontend and backend simulators independently produce **7840ms** for this scenario, confirming the two item/mod merge paths agree.

## Test plan

- [x] `dotnet build` — clean (0 warnings/errors)
- [x] `dotnet test` — full solution green (Game.Core.Tests 317 passed, all projects pass)
- [x] `npm run lint` — eslint + svelte-check clean (0 errors/warnings)
- [x] `npm run test:unit:ci` — 995 passed (incl. the new parity scenario and the two other `battle-sim-test-utils` consumers, which remain backward-compatible)

Closes #256

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbL4ZDTFjRm2ZVwFgGvCGG)_