### PR TITLE
Make skills unlockable via challenge rewards (RewardSkillId) (#261)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "10.0.8",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/Game.Abstractions/Contracts/Challenge.cs
+++ b/Game.Abstractions/Contracts/Challenge.cs
@@ -20,5 +20,6 @@ namespace Game.Abstractions.Contracts
         public decimal ProgressGoal { get; set; }
         public int? RewardItemId { get; set; }
         public int? RewardItemModId { get; set; }
+        public int? RewardSkillId { get; set; }
     }
 }

--- a/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
@@ -571,6 +571,46 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(10m, created.ProgressGoal);
         }
 
+        [Fact]
+        public async Task AddEditChallenges_AddChallengeWithSkillReward_RoundTripsRewardSkillId()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var skill = await TestDataSeeder.CreateSkillAsync(context, "Fireball"); // Id 0
+
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            var changes = new[]
+            {
+                new
+                {
+                    Item = new
+                    {
+                        Id = 0,
+                        Name = "Pyromancer",
+                        Description = "Defeat enough foes to learn Fireball.",
+                        ChallengeTypeId = (int)EChallengeType.EnemiesKilled,
+                        TargetEntityId = (int?)null,
+                        ProgressGoal = 25m,
+                        RewardItemId = (int?)null,
+                        RewardItemModId = (int?)null,
+                        RewardSkillId = (int?)skill.Id
+                    },
+                    ChangeType = 0 // Add
+                }
+            };
+
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/AddEditChallenges", changes, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Null(result.ErrorMessage);
+
+            var created = Assert.Single(GetChallenges(), c => c.Name == "Pyromancer");
+            Assert.Equal(skill.Id, created.RewardSkillId);
+        }
+
         // The reference-data HTTP GET endpoints were removed (#64); reads now go over the socket, which
         // serves the same in-memory caches these repositories expose. The admin write filter invalidates
         // those caches, so reading through the repository after a write returns the freshly-persisted data

--- a/Game.Api/Sockets/Commands/GetChallenges.cs
+++ b/Game.Api/Sockets/Commands/GetChallenges.cs
@@ -42,6 +42,7 @@ namespace Game.Api.Sockets.Commands
                 ProgressGoal = challenge.ProgressGoal,
                 RewardItemId = challenge.RewardItemId,
                 RewardItemModId = challenge.RewardItemModId,
+                RewardSkillId = challenge.RewardSkillId,
             };
         }
     }

--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -1,11 +1,13 @@
 using Game.Abstractions.Infrastructure;
 using Game.Core;
+using Game.Core.Events;
 using Game.Core.Players.Events;
 using Game.DataAccess;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -168,6 +170,41 @@ namespace Game.Application.Tests.DataAccess
             Assert.Equal([message], await DrainDeadLetterQueue(pubsub));
         }
 
+        [Fact]
+        public async Task ProcessQueue_SkillUnlockedEvent_InsertsUnselectedPlayerSkillIdempotently()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id, level: 5, zoneId: 0);
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+
+            var evt = new SkillUnlockedEvent(player.Id, skill.Id);
+
+            var logger = new CapturingLogger<DataProviderSynchronizer>();
+            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
+            var synchronizer = new DataProviderSynchronizer(scope.ServiceProvider, pubsub, logger, TestRetryPolicy);
+
+            // The same unlock is delivered twice (e.g. a retry, or two challenges granting the same skill);
+            // the idempotent insert must leave exactly one row, unselected and at order 0.
+            var queue = new InMemoryPubSubQueue(Serialize(evt), Serialize(evt));
+
+            await synchronizer.ProcessQueue(queue);
+
+            Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+            Assert.Empty(await DrainDeadLetterQueue(pubsub));
+
+            using var verifyScope = CreateScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
+            var rows = await verifyContext.PlayerSkills
+                .Where(ps => ps.PlayerId == player.Id && ps.SkillId == skill.Id)
+                .ToListAsync(CancellationToken);
+            var row = Assert.Single(rows);
+            Assert.False(row.Selected);
+            Assert.Equal(0, row.Order);
+        }
+
         private static async Task<List<string>> DrainDeadLetterQueue(IPubSubService pubsub)
         {
             var deadLetterQueue = pubsub.GetQueue(Constants.PUBSUB_PLAYER_DEAD_LETTER_QUEUE);
@@ -182,11 +219,11 @@ namespace Game.Application.Tests.DataAccess
             return drained;
         }
 
-        private static string Serialize(PlayerCoreUpdatedEvent evt)
+        private static string Serialize<T>(T evt) where T : IDomainEvent
         {
             var envelope = new DomainEventEnvelope
             {
-                Type = nameof(PlayerCoreUpdatedEvent),
+                Type = typeof(T).Name,
                 Payload = evt.Serialize(),
             };
 

--- a/Game.Application/Events/BattleStatisticsEventHandler.cs
+++ b/Game.Application/Events/BattleStatisticsEventHandler.cs
@@ -7,12 +7,14 @@ namespace Game.Application.Events
     public class BattleStatisticsEventHandler(
         IPlayerProgressRepository progressRepo,
         IChallenges challengeRepo,
-        IItems items
+        IItems items,
+        ISkills skills
     ) : IDomainEventHandler<BattleCompletedEvent>
     {
         private readonly IPlayerProgressRepository _progressRepo = progressRepo;
         private readonly IChallenges _challengeRepo = challengeRepo;
         private readonly IItems _items = items;
+        private readonly ISkills _skills = skills;
 
         public async Task HandleAsync(BattleCompletedEvent domainEvent, CancellationToken cancellationToken = default)
         {
@@ -37,6 +39,11 @@ namespace Game.Application.Events
                     if (c.RewardItemModId.HasValue)
                     {
                         player.UnlockMod(c.RewardItemModId.Value);
+                    }
+                    if (c.RewardSkillId.HasValue)
+                    {
+                        var skill = _skills.GetSkill(c.RewardSkillId.Value);
+                        player.UnlockSkill(skill);
                     }
                 }
             }

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -6,6 +6,7 @@ using Game.Core.Items;
 using Game.Core.Players;
 using Game.Core.Players.Events;
 using Game.Core.Players.Inventories;
+using Game.Core.Skills;
 using Xunit;
 
 namespace Game.Core.Tests.Players
@@ -169,6 +170,46 @@ namespace Game.Core.Tests.Players
             Assert.NotNull(evt);
             Assert.Equal(player.Id, evt.PlayerId);
             Assert.Equal(5, evt.ItemModId);
+        }
+
+        // ── UnlockSkill ──────────────────────────────────────────────────────
+
+        [Fact]
+        public void UnlockSkill_AddsSkillToUnlockedSetUnselected()
+        {
+            var player = MakePlayer();
+            var skill = MakeSkill(id: 7);
+
+            player.UnlockSkill(skill);
+
+            Assert.Equal(skill, Assert.Single(player.Skills));
+            // Earning a skill does not equip it.
+            Assert.Empty(player.SelectedSkills);
+        }
+
+        [Fact]
+        public void UnlockSkill_RaisesSkillUnlockedEvent()
+        {
+            var player = MakePlayer();
+            var skill = MakeSkill(id: 7);
+
+            player.UnlockSkill(skill);
+
+            var evt = player.DomainEvents.OfType<SkillUnlockedEvent>().SingleOrDefault();
+            Assert.NotNull(evt);
+            Assert.Equal(player.Id, evt.PlayerId);
+            Assert.Equal(7, evt.SkillId);
+        }
+
+        [Fact]
+        public void UnlockSkill_AlreadyUnlocked_DoesNotDuplicateInUnlockedSet()
+        {
+            var player = MakePlayer();
+            player.UnlockSkill(MakeSkill(id: 7));
+
+            player.UnlockSkill(MakeSkill(id: 7));
+
+            Assert.Single(player.Skills);
         }
 
         // ── TrySetFavorite ───────────────────────────────────────────────────
@@ -335,5 +376,15 @@ namespace Game.Core.Tests.Players
                 ModSlots = modSlots ?? [],
                 Tags = [],
             };
+
+        private static Skill MakeSkill(int id) => new()
+        {
+            Id = id,
+            Name = $"Skill {id}",
+            BaseDamage = 10,
+            Description = string.Empty,
+            CooldownMs = 1000,
+            DamageMultipliers = [],
+        };
     }
 }

--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -345,7 +345,7 @@ namespace Game.Core.Tests.Progress
         [Fact]
         public void EvaluateChallenges_StatisticMeetsGoal_CompletesAndReturnsReward()
         {
-            var challenge = MakeChallenge(id: 0, EChallengeType.EnemiesKilled, goal: 5, rewardItemId: 42, rewardItemModId: 7);
+            var challenge = MakeChallenge(id: 0, EChallengeType.EnemiesKilled, goal: 5, rewardItemId: 42, rewardItemModId: 7, rewardSkillId: 3);
             var progress = MakeProgress(statistics:
             [
                 Stat(EStatisticType.EnemiesKilled, null, 5m),
@@ -357,6 +357,7 @@ namespace Game.Core.Tests.Progress
             Assert.Equal(0, result.ChallengeId);
             Assert.Equal(42, result.RewardItemId);
             Assert.Equal(7, result.RewardItemModId);
+            Assert.Equal(3, result.RewardSkillId);
 
             var playerChallenge = Assert.Single(progress.ChallengeProgress);
             Assert.True(playerChallenge.Completed);
@@ -542,7 +543,8 @@ namespace Game.Core.Tests.Progress
             decimal goal,
             int? targetEntityId = null,
             int? rewardItemId = null,
-            int? rewardItemModId = null) => new()
+            int? rewardItemModId = null,
+            int? rewardSkillId = null) => new()
             {
                 Id = id,
                 Name = "Test Challenge",
@@ -552,6 +554,7 @@ namespace Game.Core.Tests.Progress
                 ProgressGoal = goal,
                 RewardItemId = rewardItemId,
                 RewardItemModId = rewardItemModId,
+                RewardSkillId = rewardSkillId,
             };
 
         // Boss-ness is now driven by the explicit isBossBattle marker passed to RecordBattleCompleted,

--- a/Game.Core/Players/Events/SkillUnlockedEvent.cs
+++ b/Game.Core/Players/Events/SkillUnlockedEvent.cs
@@ -1,0 +1,12 @@
+using Game.Core.Events;
+
+namespace Game.Core.Players.Events
+{
+    /// <summary>
+    /// Raised when a player unlocks a new skill (e.g. as a challenge reward). The skill is added
+    /// to the player's unlocked set but is not equipped — earning a skill does not auto-select it.
+    /// </summary>
+    public record SkillUnlockedEvent(
+        int PlayerId,
+        int SkillId) : IDomainEvent;
+}

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -96,6 +96,22 @@ namespace Game.Core.Players
             RaiseEvent(new ModUnlockedEvent(Id, itemModId));
         }
 
+        /// <summary>
+        /// Unlocks a skill for the player and raises a <see cref="SkillUnlockedEvent"/>. The skill is
+        /// added to <see cref="Skills"/> unselected — earning a skill does not equip it (the player
+        /// chooses their loadout via the selection flow). Mirrors <see cref="UnlockItem"/>: the in-memory
+        /// set is de-duplicated and the event is raised for the idempotent write-behind insert to apply.
+        /// </summary>
+        public void UnlockSkill(Skill skill)
+        {
+            if (!Skills.Any(s => s.Id == skill.Id))
+            {
+                Skills.Add(skill);
+            }
+
+            RaiseEvent(new SkillUnlockedEvent(Id, skill.Id));
+        }
+
         public bool TryEquipItem(int itemId, EEquipmentSlot slot)
         {
             if (!Inventory.TryEquipItem(itemId, slot))

--- a/Game.Core/Progress/Challenge.cs
+++ b/Game.Core/Progress/Challenge.cs
@@ -1,7 +1,7 @@
 namespace Game.Core.Progress
 {
     /// <summary>
-    /// Represents a challenge that can be completed to unlock an item or modifier.
+    /// Represents a challenge that can be completed to unlock an item, modifier, and/or skill.
     /// </summary>
     public class Challenge
     {
@@ -13,6 +13,7 @@ namespace Game.Core.Progress
         public required decimal ProgressGoal { get; set; }
         public int? RewardItemId { get; set; }
         public int? RewardItemModId { get; set; }
+        public int? RewardSkillId { get; set; }
 
         public void UpdateChallengeProgress(PlayerChallenge playerChallenge, PlayerProgress playerProgress)
         {

--- a/Game.Core/Progress/PlayerProgress.cs
+++ b/Game.Core/Progress/PlayerProgress.cs
@@ -119,6 +119,7 @@ namespace Game.Core.Progress
                         ChallengeId = challenge.Id,
                         RewardItemId = challenge.RewardItemId,
                         RewardItemModId = challenge.RewardItemModId,
+                        RewardSkillId = challenge.RewardSkillId,
                     });
                 }
             }
@@ -179,5 +180,6 @@ namespace Game.Core.Progress
         public required int ChallengeId { get; set; }
         public int? RewardItemId { get; set; }
         public int? RewardItemModId { get; set; }
+        public int? RewardSkillId { get; set; }
     }
 }

--- a/Game.DataAccess/DataProviderSynchronizer.cs
+++ b/Game.DataAccess/DataProviderSynchronizer.cs
@@ -160,6 +160,11 @@ namespace Game.DataAccess
                     await HandleModRemoved(context, modRemoveEvt);
                     break;
 
+                case nameof(SkillUnlockedEvent):
+                    var skillUnlockEvt = Deserialize<SkillUnlockedEvent>(envelope.Payload);
+                    await HandleSkillUnlocked(context, skillUnlockEvt);
+                    break;
+
                 case nameof(ItemFavoriteChangedEvent):
                     var favoriteEvt = Deserialize<ItemFavoriteChangedEvent>(envelope.Payload);
                     await HandleItemFavoriteChanged(context, favoriteEvt);
@@ -271,6 +276,27 @@ namespace Game.DataAccess
                 {
                     PlayerId = evt.PlayerId,
                     ItemModId = evt.ItemModId,
+                });
+                await context.SaveChangesAsync();
+            }
+        }
+
+        private static async Task HandleSkillUnlocked(GameContext context, SkillUnlockedEvent evt)
+        {
+            var exists = await context.PlayerSkills
+                .AnyAsync(ps => ps.PlayerId == evt.PlayerId && ps.SkillId == evt.SkillId);
+
+            if (!exists)
+            {
+                // Earning a skill unlocks it without equipping it: Selected = false, Order = 0
+                // (the player chooses their loadout separately). Idempotent insert mirrors the
+                // item/mod unlock handlers so re-applying the event never duplicates the row.
+                context.PlayerSkills.Add(new PlayerSkill
+                {
+                    PlayerId = evt.PlayerId,
+                    SkillId = evt.SkillId,
+                    Selected = false,
+                    Order = 0,
                 });
                 await context.SaveChangesAsync();
             }

--- a/Game.DataAccess/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Game.DataAccess/DependencyInjection/ServiceCollectionExtensions.cs
@@ -97,6 +97,7 @@ namespace Game.DataAccess.DependencyInjection
             DomainEventDispatcher.RegisterDomainEventHandler<ModUnlockedEvent, PlayerPersistencePublisher>();
             DomainEventDispatcher.RegisterDomainEventHandler<ModAppliedEvent, PlayerPersistencePublisher>();
             DomainEventDispatcher.RegisterDomainEventHandler<ModRemovedEvent, PlayerPersistencePublisher>();
+            DomainEventDispatcher.RegisterDomainEventHandler<SkillUnlockedEvent, PlayerPersistencePublisher>();
             DomainEventDispatcher.RegisterDomainEventHandler<ItemFavoriteChangedEvent, PlayerPersistencePublisher>();
             DomainEventDispatcher.RegisterDomainEventHandler<LogPreferenceChangedEvent, PlayerPersistencePublisher>();
         }

--- a/Game.DataAccess/PlayerPersistencePublisher.cs
+++ b/Game.DataAccess/PlayerPersistencePublisher.cs
@@ -20,6 +20,7 @@ namespace Game.DataAccess
         IDomainEventHandler<ModUnlockedEvent>,
         IDomainEventHandler<ModAppliedEvent>,
         IDomainEventHandler<ModRemovedEvent>,
+        IDomainEventHandler<SkillUnlockedEvent>,
         IDomainEventHandler<ItemFavoriteChangedEvent>,
         IDomainEventHandler<LogPreferenceChangedEvent>
     {
@@ -33,6 +34,7 @@ namespace Game.DataAccess
         public Task HandleAsync(ModUnlockedEvent domainEvent, CancellationToken cancellationToken = default) => PublishAsync(domainEvent);
         public Task HandleAsync(ModAppliedEvent domainEvent, CancellationToken cancellationToken = default) => PublishAsync(domainEvent);
         public Task HandleAsync(ModRemovedEvent domainEvent, CancellationToken cancellationToken = default) => PublishAsync(domainEvent);
+        public Task HandleAsync(SkillUnlockedEvent domainEvent, CancellationToken cancellationToken = default) => PublishAsync(domainEvent);
         public Task HandleAsync(ItemFavoriteChangedEvent domainEvent, CancellationToken cancellationToken = default) => PublishAsync(domainEvent);
         public Task HandleAsync(LogPreferenceChangedEvent domainEvent, CancellationToken cancellationToken = default) => PublishAsync(domainEvent);
 

--- a/Game.DataAccess/Repositories/Admin/AdminChallenges.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminChallenges.cs
@@ -27,6 +27,7 @@ namespace Game.DataAccess.Repositories.Admin
                     ProgressGoal = item.ProgressGoal,
                     RewardItemId = item.RewardItemId,
                     RewardItemModId = item.RewardItemModId,
+                    RewardSkillId = item.RewardSkillId,
                 }),
                 edit: item => _entityStore.Update(new Entities.Challenge
                 {
@@ -38,6 +39,7 @@ namespace Game.DataAccess.Repositories.Admin
                     ProgressGoal = item.ProgressGoal,
                     RewardItemId = item.RewardItemId,
                     RewardItemModId = item.RewardItemModId,
+                    RewardSkillId = item.RewardSkillId,
                 }),
                 delete: item => _entityStore.Delete(new Entities.Challenge
                 {

--- a/Game.DataAccess/Repositories/Challenges.cs
+++ b/Game.DataAccess/Repositories/Challenges.cs
@@ -26,6 +26,7 @@ namespace Game.DataAccess.Repositories
                     ProgressGoal = c.ProgressGoal,
                     RewardItemId = c.RewardItemId,
                     RewardItemModId = c.RewardItemModId,
+                    RewardSkillId = c.RewardSkillId,
                 })];
 
             return _challengeList;

--- a/Game.Infrastructure/Entities/Challenge.cs
+++ b/Game.Infrastructure/Entities/Challenge.cs
@@ -10,9 +10,11 @@ namespace Game.Infrastructure.Entities
         public decimal ProgressGoal { get; set; }
         public int? RewardItemId { get; set; }
         public int? RewardItemModId { get; set; }
+        public int? RewardSkillId { get; set; }
 
         public virtual Item? RewardItem { get; set; }
         public virtual ItemMod? RewardItemMod { get; set; }
+        public virtual Skill? RewardSkill { get; set; }
         public virtual ChallengeType ChallengeType { get => field ?? throw new NotLoadedException(nameof(ChallengeType)); set; }
     }
 }

--- a/Game.Infrastructure/Migrations/20260609184114_AddChallengeRewardSkill.Designer.cs
+++ b/Game.Infrastructure/Migrations/20260609184114_AddChallengeRewardSkill.Designer.cs
@@ -4,6 +4,7 @@ using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Game.Infrastructure.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20260609184114_AddChallengeRewardSkill")]
+    partial class AddChallengeRewardSkill
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Game.Infrastructure/Migrations/20260609184114_AddChallengeRewardSkill.cs
+++ b/Game.Infrastructure/Migrations/20260609184114_AddChallengeRewardSkill.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Game.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChallengeRewardSkill : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "RewardSkillId",
+                table: "Challenges",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Challenges_RewardSkillId",
+                table: "Challenges",
+                column: "RewardSkillId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Challenges_Skills_RewardSkillId",
+                table: "Challenges",
+                column: "RewardSkillId",
+                principalTable: "Skills",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Challenges_Skills_RewardSkillId",
+                table: "Challenges");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Challenges_RewardSkillId",
+                table: "Challenges");
+
+            migrationBuilder.DropColumn(
+                name: "RewardSkillId",
+                table: "Challenges");
+        }
+    }
+}

--- a/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
+++ b/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
@@ -260,7 +260,8 @@ namespace Game.TestInfrastructure.Helpers
             decimal progressGoal = 10m,
             int? targetEntityId = null,
             int? rewardItemId = null,
-            int? rewardItemModId = null)
+            int? rewardItemModId = null,
+            int? rewardSkillId = null)
         {
             var challenge = new Challenge
             {
@@ -271,6 +272,7 @@ namespace Game.TestInfrastructure.Helpers
                 TargetEntityId = targetEntityId,
                 RewardItemId = rewardItemId,
                 RewardItemModId = rewardItemModId,
+                RewardSkillId = rewardSkillId,
             };
 
             context.Challenges.Add(challenge);

--- a/UI/src/lib/api/types/interfaces/contracts.ts
+++ b/UI/src/lib/api/types/interfaces/contracts.ts
@@ -38,6 +38,7 @@ export interface IChallenge {
 	progressGoal: number;
 	rewardItemId?: number;
 	rewardItemModId?: number;
+	rewardSkillId?: number;
 }
 
 export interface IEnemy {

--- a/UI/src/routes/admin/workbench/components/challenge/ChallengeRewardSection.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/ChallengeRewardSection.svelte
@@ -1,6 +1,6 @@
 <!--
-	Reward section: grant an item and/or a mod, with hard exclusivity across every
-	challenge in the catalogue (a reward unlocked elsewhere can't be re-assigned).
+	Reward section: grant an item, a mod, and/or a skill, with hard exclusivity across
+	every challenge in the catalogue (a reward unlocked elsewhere can't be re-assigned).
 	The current sibling challenges are read live from the store so exclusivity
 	reflects unsaved edits too.
 -->
@@ -8,8 +8,8 @@
 	<div class="ch-reward-intro">
 		<WorkbenchIcon kind="gift" size={13} stroke="var(--text-tertiary)" />
 		<span>
-			Grant an item, a mod, or both. Each unlock belongs to exactly one challenge — already-claimed rewards are disabled
-			below.
+			Grant an item, a mod, and/or a skill. Each unlock belongs to exactly one challenge — already-claimed rewards are
+			disabled below.
 		</span>
 	</div>
 
@@ -42,6 +42,18 @@
 			onClear={() => setMod(undefined)}
 			onOpen={() => (open = open === 'mod' ? null : 'mod')}
 		/>
+		<RewardSlot
+			kind="skill"
+			label="Skill Reward"
+			valueId={challenge.rewardSkillId}
+			name={challenge.rewardSkillId != null ? reference.skillName(challenge.rewardSkillId) : undefined}
+			sub={challenge.rewardSkillId != null ? `${reference.skillBaseDamage(challenge.rewardSkillId) ?? 0} dmg` : ''}
+			color={challenge.rewardSkillId != null ? 'var(--accent)' : null}
+			dirty={skillDirty}
+			open={open === 'skill'}
+			onClear={() => setSkill(undefined)}
+			onOpen={() => (open = open === 'skill' ? null : 'skill')}
+		/>
 	</div>
 
 	{#if open === 'item'}
@@ -62,6 +74,15 @@
 			onPick={setMod}
 			onClose={() => (open = null)}
 		/>
+	{:else if open === 'skill'}
+		<RewardPicker
+			kind="skill"
+			records={skillPickRecords}
+			currentId={challenge.rewardSkillId}
+			claimed={claimedSkills}
+			onPick={setSkill}
+			onClose={() => (open = null)}
+		/>
 	{/if}
 
 	{#if none}
@@ -77,7 +98,7 @@ import { ERarity, type IChallenge } from '$lib/api';
 import { reference } from '../../reference.svelte';
 import type { EntityStore } from '../../entity-store.svelte';
 import type { Identified } from '../../entities/types';
-import { claimedItemMap, claimedModMap } from '../../entities/challenge-helpers';
+import { claimedItemMap, claimedModMap, claimedSkillMap } from '../../entities/challenge-helpers';
 import WorkbenchIcon from '../../WorkbenchIcon.svelte';
 import RewardSlot from './RewardSlot.svelte';
 import RewardPicker from './RewardPicker.svelte';
@@ -93,7 +114,7 @@ const { record, baseline, store }: Props = $props();
 const challenge = $derived(record as unknown as IChallenge);
 const base = $derived(baseline as unknown as IChallenge | undefined);
 
-let open = $state<'item' | 'mod' | null>(null);
+let open = $state<'item' | 'mod' | 'skill' | null>(null);
 // Collapse any open picker when switching to a different record.
 let openForId = $state<number>();
 $effect(() => {
@@ -106,10 +127,14 @@ $effect(() => {
 const liveChallenges = $derived(store.items.filter((it) => store.status(it) !== 'deleted') as unknown as IChallenge[]);
 const claimedItems = $derived(claimedItemMap(liveChallenges, challenge.id));
 const claimedMods = $derived(claimedModMap(liveChallenges, challenge.id));
+const claimedSkills = $derived(claimedSkillMap(liveChallenges, challenge.id));
 
 const itemDirty = $derived(base ? challenge.rewardItemId !== base.rewardItemId : false);
 const modDirty = $derived(base ? challenge.rewardItemModId !== base.rewardItemModId : false);
-const none = $derived(challenge.rewardItemId == null && challenge.rewardItemModId == null);
+const skillDirty = $derived(base ? challenge.rewardSkillId !== base.rewardSkillId : false);
+const none = $derived(
+	challenge.rewardItemId == null && challenge.rewardItemModId == null && challenge.rewardSkillId == null
+);
 
 const itemPickRecords = $derived(
 	reference.itemRecords().map((i) => ({
@@ -127,6 +152,14 @@ const modPickRecords = $derived(
 		tag: reference.modTypeName(m.itemModTypeId)
 	}))
 );
+const skillPickRecords = $derived(
+	reference.skillRecords().map((s) => ({
+		id: s.id,
+		name: s.name,
+		color: 'var(--accent)',
+		tag: `${s.baseDamage} dmg`
+	}))
+);
 
 const setItem = (id: number | undefined) => {
 	store.patch(challenge.id, (d) => ((d as unknown as IChallenge).rewardItemId = id));
@@ -134,6 +167,10 @@ const setItem = (id: number | undefined) => {
 };
 const setMod = (id: number | undefined) => {
 	store.patch(challenge.id, (d) => ((d as unknown as IChallenge).rewardItemModId = id));
+	open = null;
+};
+const setSkill = (id: number | undefined) => {
+	store.patch(challenge.id, (d) => ((d as unknown as IChallenge).rewardSkillId = id));
 	open = null;
 };
 </script>

--- a/UI/src/routes/admin/workbench/components/challenge/RewardPicker.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/RewardPicker.svelte
@@ -11,7 +11,7 @@
 			<input
 				class="inp"
 				autofocus
-				placeholder={`Search ${kind === 'item' ? 'items' : 'item mods'}…`}
+				placeholder={`Search ${kind === 'item' ? 'items' : kind === 'mod' ? 'item mods' : 'skills'}…`}
 				bind:value={query}
 			/>
 		</div>
@@ -56,7 +56,7 @@ export interface PickerRecord {
 }
 
 interface Props {
-	kind: 'item' | 'mod';
+	kind: 'item' | 'mod' | 'skill';
 	records: PickerRecord[];
 	currentId: number | undefined;
 	claimed: Map<number, IChallenge>;

--- a/UI/src/routes/admin/workbench/components/challenge/RewardSlot.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/RewardSlot.svelte
@@ -2,7 +2,7 @@
 <div class="ch-reward-slot" class:filled={valueId != null} class:open>
 	<div class="ch-reward-head">
 		<span class="ch-reward-ic" style={valueId != null && color ? `color:${color};border-color:${color}` : ''}>
-			<WorkbenchIcon kind={kind === 'item' ? 'box' : 'rune'} size={15} />
+			<WorkbenchIcon kind={kind === 'item' ? 'box' : kind === 'mod' ? 'rune' : 'bolt'} size={15} />
 		</span>
 		<div class="ch-reward-body">
 			<div class="ch-reward-label">
@@ -23,9 +23,7 @@
 		{/if}
 	</div>
 	<button type="button" class="btn sm reward-cta" class:primary={valueId == null} onclick={onOpen}>
-		<WorkbenchIcon kind={open ? 'chevD' : 'plus'} size={12} />{valueId != null
-			? 'Change…'
-			: `Choose ${kind === 'item' ? 'item' : 'mod'}…`}
+		<WorkbenchIcon kind={open ? 'chevD' : 'plus'} size={12} />{valueId != null ? 'Change…' : `Choose ${kind}…`}
 	</button>
 </div>
 
@@ -33,7 +31,7 @@
 import WorkbenchIcon from '../../WorkbenchIcon.svelte';
 
 interface Props {
-	kind: 'item' | 'mod';
+	kind: 'item' | 'mod' | 'skill';
 	label: string;
 	valueId: number | undefined;
 	name: string | undefined;

--- a/UI/src/routes/admin/workbench/entities/challenge-helpers.ts
+++ b/UI/src/routes/admin/workbench/entities/challenge-helpers.ts
@@ -148,6 +148,16 @@ export function claimedModMap(challenges: IChallenge[], exceptId: number): Map<n
 	return map;
 }
 
+export function claimedSkillMap(challenges: IChallenge[], exceptId: number): Map<number, IChallenge> {
+	const map = new Map<number, IChallenge>();
+	for (const c of challenges) {
+		if (c.id !== exceptId && c.rewardSkillId != null) {
+			map.set(c.rewardSkillId, c);
+		}
+	}
+	return map;
+}
+
 /** Re-derive the statistic + entity a challenge tracks from a (possibly new) type. */
 export function deriveFromType(c: IChallenge, types: IChallengeType[], typeId: EChallengeType): void {
 	const stat = typeStatistic(types, typeId);

--- a/UI/src/routes/admin/workbench/entities/challenge.ts
+++ b/UI/src/routes/admin/workbench/entities/challenge.ts
@@ -13,7 +13,8 @@ const refresh = async (): Promise<IChallenge[]> => {
 	return challenges;
 };
 
-const rewardCount = (c: IChallenge): number => (c.rewardItemId != null ? 1 : 0) + (c.rewardItemModId != null ? 1 : 0);
+const rewardCount = (c: IChallenge): number =>
+	(c.rewardItemId != null ? 1 : 0) + (c.rewardItemModId != null ? 1 : 0) + (c.rewardSkillId != null ? 1 : 0);
 
 export const challengeEntity: EntityConfig<IChallenge> = {
 	key: 'challenges',
@@ -88,8 +89,11 @@ export const challengeEntity: EntityConfig<IChallenge> = {
 			desc: 'What the player unlocks on completion',
 			kind: 'challenge-reward',
 			count: rewardCount,
-			dirtyKeys: ['rewardItemId', 'rewardItemModId'],
-			warn: (c) => (c.rewardItemId == null && c.rewardItemModId == null ? 'No reward — unlocks nothing' : null)
+			dirtyKeys: ['rewardItemId', 'rewardItemModId', 'rewardSkillId'],
+			warn: (c) =>
+				c.rewardItemId == null && c.rewardItemModId == null && c.rewardSkillId == null
+					? 'No reward — unlocks nothing'
+					: null
 		}
 	],
 	refresh,

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -123,6 +123,9 @@ class WorkbenchReference {
 		const mod = (staticData.itemMods ?? []).find((m) => m.id === id);
 		return mod ? this.modTypeName(mod.itemModTypeId) : undefined;
 	};
+	skillRecords = () => staticData.skills ?? [];
+	skillName = (id: number) => (staticData.skills ?? []).find((s) => s.id === id)?.name;
+	skillBaseDamage = (id: number) => (staticData.skills ?? []).find((s) => s.id === id)?.baseDamage;
 
 	// ── Name lookups ──
 	itemCategoryName = (id: number) => EItemCategory[id] ?? '';

--- a/UI/src/tests/routes/admin/workbench/challenge-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge-helpers.test.ts
@@ -11,6 +11,7 @@ import {
 	challengeSentence,
 	claimedItemMap,
 	claimedModMap,
+	claimedSkillMap,
 	deriveFromType,
 	fmtMs,
 	fmtNum,
@@ -209,9 +210,9 @@ describe('challengeSentence', () => {
 
 describe('reward exclusivity maps', () => {
 	const challenges: IChallenge[] = [
-		make({ id: 1, rewardItemId: 10, rewardItemModId: 100 }),
-		make({ id: 2, rewardItemId: 20, rewardItemModId: undefined }),
-		make({ id: 3, rewardItemId: undefined, rewardItemModId: 300 })
+		make({ id: 1, rewardItemId: 10, rewardItemModId: 100, rewardSkillId: 1000 }),
+		make({ id: 2, rewardItemId: 20, rewardItemModId: undefined, rewardSkillId: 2000 }),
+		make({ id: 3, rewardItemId: undefined, rewardItemModId: 300, rewardSkillId: undefined })
 	];
 
 	it('maps every claimed reward to its owning challenge, excluding the edited one', () => {
@@ -221,6 +222,9 @@ describe('reward exclusivity maps', () => {
 		const mods = claimedModMap(challenges, 1);
 		expect(mods.get(300)?.id).toBe(3);
 		expect(mods.has(100)).toBe(false);
+		const skills = claimedSkillMap(challenges, 1);
+		expect(skills.get(2000)?.id).toBe(2);
+		expect(skills.has(1000)).toBe(false); // challenge 1 is excluded so its own skill reward stays selectable
 	});
 });
 

--- a/UI/src/tests/routes/admin/workbench/entities/challenge.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/challenge.test.ts
@@ -97,11 +97,11 @@ describe('challengeEntity', () => {
 			['', 'global'],
 			['reward', 0]
 		]);
-		const scoped = { ...base, targetEntityId: 2, rewardItemId: 5, rewardItemModId: 9 };
+		const scoped = { ...base, targetEntityId: 2, rewardItemId: 5, rewardItemModId: 9, rewardSkillId: 3 };
 		expect(challengeEntity.meta(scoped)).toEqual([
 			['goal', '1,500'],
 			['', 'scoped'],
-			['reward', 2]
+			['reward', 3]
 		]);
 	});
 

--- a/docs/game-design.md
+++ b/docs/game-design.md
@@ -18,9 +18,11 @@ Attributes are somewhat of a work-in-progress feature, but the general idea is t
 
 # Skills
 
-Skills are a fairly underdeveloped feature in the game, but the general idea is that they will provide active abilities for players that are automatically used during battles. Skills currently only deal damage and are not unlockable or (un)equippable.
+Skills are a fairly underdeveloped feature in the game, but the general idea is that they will provide active abilities for players that are automatically used during battles. Skills currently only deal damage.
 
-In the future, Skills will be expanded to include a wider variety of effects, such as buffs, debuffs, healing, and utility effects. They will also be unlockable through Challenges and potentially other means, and players will be able to equip a certain number of Skills to use in battle.
+Skills are **unlockable through Challenges**, mirroring the item/mod reward path: a challenge may carry an optional `RewardSkillId`, and completing it unlocks that skill via `Player.UnlockSkill`. An earned skill is added to the player's unlocked set **unselected** — unlocking a skill does not auto-equip it. New players still start with their fixed starter skills. Choosing which unlocked skills are equipped (a selection page with a fixed loadout cap and a meaningful order) is upcoming work; until it lands, only the starter skills are equipped.
+
+In the future, Skills will be expanded to include a wider variety of effects, such as buffs, debuffs, healing, and utility effects, and skills may become unlockable through means beyond Challenges.
 
 # Items, Item Mods, and Tags
 

--- a/docs/spikes/179-skill-unlock-and-selection.md
+++ b/docs/spikes/179-skill-unlock-and-selection.md
@@ -81,7 +81,7 @@ Settled with the project owner during the spike:
 
 Tracked as sub-issues of #179:
 
-1. **[#261](https://github.com/ginderjeremiah/GameServer/issues/261) — Skills unlockable via challenge rewards (`RewardSkillId`)** *(independent)*: area **A** above, end to end (entity/contract/domain, repo + admin authoring + Workbench picker, `Player.UnlockSkill` + event + write-behind handler, migration, tests).
+1. **[#261](https://github.com/ginderjeremiah/GameServer/issues/261) — Skills unlockable via challenge rewards (`RewardSkillId`)** *(independent — ✅ landed)*: area **A** above, end to end (entity/contract/domain, repo + admin authoring + Workbench picker, `Player.UnlockSkill` + `SkillUnlockedEvent` + write-behind handler, migration, tests).
 2. **[#260](https://github.com/ginderjeremiah/GameServer/issues/260) — Persist skill loadout order + loadout-cap foundation** *(foundation)*: area **B** (`PlayerSkill.Order` + migration, ordered mapping, starter-skill order, cap constant).
 3. **[#262](https://github.com/ginderjeremiah/GameServer/issues/262) — Expose unlocked skills to the client via `PlayerData`** *(depends on #260)*: area **C** (contract + codegen + `player-manager`).
 4. **[#263](https://github.com/ginderjeremiah/GameServer/issues/263) — `SetSelectedSkills` socket command + loadout orchestration** *(depends on #260)*: area **D** (domain mutation + validation/cap, `PlayerService`, socket command, write-behind handler, tests).


### PR DESCRIPTION
## Summary

Implements **#261** (area **A** of spike #179): skills become earnable as a **challenge reward**, mirroring the existing item/mod challenge-reward unlock path end to end. A challenge may now carry an optional `RewardSkillId` (additive — a challenge can grant any combination of item/mod/skill), and completing it unlocks that skill for the player.

This is the independent unlock half of the skills feature; the loadout-selection page and write path (#262/#263/#264) are tracked separately and are not in scope here.

## How it addresses the issue

**Challenge model (all layers carry `RewardSkillId`):**
- `Game.Infrastructure.Entities.Challenge` (+ `RewardSkill` nav), the `Game.Abstractions.Contracts.Challenge` read/write contract, and the `Game.Core.Progress.Challenge` domain model.
- Projected through `Challenges.All()`, `GetChallenges.ToContract`, and `AdminChallenges` add/edit.
- **EF migration** `AddChallengeRewardSkill` adds the nullable column + an optional FK to `Skills` (matching the existing `RewardItem`/`RewardItemMod` FKs).

**Reward application:**
- `CompletedChallenge` + `PlayerProgress.EvaluateChallenges` carry `RewardSkillId`.
- `BattleStatisticsEventHandler` injects `ISkills`, resolves the skill, and calls `Player.UnlockSkill`.
- `Player.UnlockSkill(Skill)` adds the skill to the unlocked set **unselected** (earning a skill does not auto-equip it) and raises a new `SkillUnlockedEvent` — mirroring `UnlockItem` (in-memory de-dup, event always raised for the idempotent write-behind insert).
- `SkillUnlockedEvent` is registered with `PlayerPersistencePublisher`; `DataProviderSynchronizer.HandleSkillUnlocked` does an idempotent `PlayerSkill` insert (`Selected = false`, `Order = 0`).

**Admin Workbench challenge editor:**
- New skill-reward picker (`RewardSlot`/`RewardPicker` gain a `skill` kind, with a `claimedSkillMap` for cross-challenge exclusivity).
- Regenerated the `IChallenge` TS client (adds `rewardSkillId`).

**Docs:** updated the game-design Skills section (skills are unlockable via challenges) and marked #261 landed in the spike doc.

## Test plan

- [x] **Backend** — `dotnet build` (0 warnings) + full suite green: Core 331, Application 104, Api 284, Infrastructure 26.
  - `Player.UnlockSkill` domain unit tests (adds unselected, raises event, no duplicate).
  - `PlayerProgress.EvaluateChallenges` returns `RewardSkillId`.
  - `DataProviderSynchronizer` integration test: re-applying `SkillUnlockedEvent` inserts exactly one unselected `PlayerSkill` (idempotent).
  - Admin `AddEditChallenges` round-trips `RewardSkillId`.
- [x] **Frontend** — `npm run lint` clean; `npm run test:unit:ci` 1048/1048 pass, including `claimedSkillMap` exclusivity and the reward-count update.

## Notes

- Seeding existing challenges with skill rewards is a separate small content follow-up (per the spike), not part of this issue.
- Added a pinned `dotnet-ef` local tool manifest (`.config/dotnet-tools.json`) so the EF migration in this PR is reproducible in clean environments (the repo had none).

Closes #261

https://claude.ai/code/session_01FmoY8n1h4bVT2zpdTCSpEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmoY8n1h4bVT2zpdTCSpEh)_