### PR TITLE
Eliminate per-fire LINQ allocations in BattleSkill.CalculateDamage (#286)

### DIFF
--- a/Game.Core.Tests/Battle/BattleSkillTests.cs
+++ b/Game.Core.Tests/Battle/BattleSkillTests.cs
@@ -95,6 +95,43 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(25.0, damage, 0.001);
         }
 
+        [Fact]
+        public void CalculateDamage_OnHotPath_DoesNotAllocate()
+        {
+            // CalculateDamage runs on every skill fire, the hottest sub-path of the simulation, so it
+            // must stay allocation-free (the prior LINQ `.Sum(lambda)` boxed a list enumerator and
+            // captured a closure on every call — #286). Measure managed allocations on this thread
+            // across a batch of calls and assert none, locking the optimization in against regression.
+            var multipliers = new List<AttributeModifier>
+            {
+                new() { Attribute = EAttribute.Strength,  Amount = 2.0, Type = EModifierType.Additive, Source = EAttributeModifierSource.Item },
+                new() { Attribute = EAttribute.Endurance, Amount = 1.5, Type = EModifierType.Additive, Source = EAttributeModifierSource.Item },
+                new() { Attribute = EAttribute.Agility,   Amount = 0.5, Type = EModifierType.Additive, Source = EAttributeModifierSource.Item },
+            };
+            var skill = MakeSkill(cooldownMs: 1000, baseDamage: 5, multipliers: multipliers);
+            var battleSkill = new BattleSkill(skill);
+
+            var attacker = MakeBattler(strength: 10);
+            var defender = MakeBattler(strength: 0);
+            var context = new BattleContext(attacker, defender, timeDelta: 0);
+
+            // Warm up so JIT compilation and the AttributeCollection's first-access value caching
+            // happen before measuring — otherwise their one-off allocations would be counted.
+            for (var i = 0; i < 200; i++)
+            {
+                _ = battleSkill.CalculateDamage(context);
+            }
+
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (var i = 0; i < 1000; i++)
+            {
+                _ = battleSkill.CalculateDamage(context);
+            }
+            var allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.Equal(0, allocatedBytes);
+        }
+
         // ── Helpers ──────────────────────────────────────────────────────────
 
         private static Skill MakeSkill(int cooldownMs, double baseDamage, List<AttributeModifier>? multipliers = null) => new()

--- a/Game.Core/Battle/BattleSkill.cs
+++ b/Game.Core/Battle/BattleSkill.cs
@@ -31,7 +31,19 @@ namespace Game.Core.Battle
 
         public double CalculateDamage(BattleContext context)
         {
-            return Skill.BaseDamage + Skill.DamageMultipliers.Sum(mult => context.GetActiveBattlerAttribute(mult.Attribute) * mult.Amount);
+            // Accumulate the multiplier bonus separately and add BaseDamage last, exactly mirroring the
+            // previous `BaseDamage + DamageMultipliers.Sum(...)`. Floating-point addition is not
+            // associative, so preserving this order keeps the result bit-for-bit identical — required
+            // for frontend/backend battle parity. The manual loop avoids the per-fire allocations the
+            // LINQ Sum incurred on this hot path (a boxed list enumerator plus a closure capturing
+            // `context`, allocated on every skill fire) — see #286.
+            var multiplierBonus = 0.0;
+            foreach (var multiplier in Skill.DamageMultipliers)
+            {
+                multiplierBonus += context.GetActiveBattlerAttribute(multiplier.Attribute) * multiplier.Amount;
+            }
+
+            return Skill.BaseDamage + multiplierBonus;
         }
     }
 }


### PR DESCRIPTION
Closes #286. Follow-up from the battle-simulation performance work (#283 / #288).

## Why

`BattleSkill.CalculateDamage` runs on **every skill fire** — the hottest sub-path of the battle simulation the backend re-runs for every completed battle (the anti-cheat replay). The previous implementation used LINQ:

```csharp
return Skill.BaseDamage + Skill.DamageMultipliers.Sum(mult => context.GetActiveBattlerAttribute(mult.Attribute) * mult.Amount);
```

That allocates twice per call: the `List<AttributeModifier>` is passed to `Sum` as `IEnumerable<T>`, so its struct enumerator is **boxed**, and the selector captures `context` into a **closure**. Across a worst-case battle (~80k fires over both combatants) that is ~160k short-lived allocations of avoidable GC pressure.

## What changed

Replaced the LINQ with a manual loop:

```csharp
var multiplierBonus = 0.0;
foreach (var multiplier in Skill.DamageMultipliers)
{
    multiplierBonus += context.GetActiveBattlerAttribute(multiplier.Attribute) * multiplier.Amount;
}
return Skill.BaseDamage + multiplierBonus;
```

- **Zero allocation** — `foreach` over the concrete `List<T>` uses its struct enumerator by value (no boxing), and there's no closure.
- **Bit-for-bit identical result.** Floating-point addition is not associative, so the order is preserved *exactly*: the multiplier bonus accumulates from `0.0` in list order and `BaseDamage` is added last — the same sequence `BaseDamage + Sum(...)` produced. This matters because the result must stay identical for **frontend/backend battle parity**; the parity matrix passes unchanged, confirming no behaviour drift.

The frontend simulator isn't on the anti-cheat critical path, so a matching JS micro-optimization is intentionally out of scope (as noted in #286).

## Test plan
- [x] Added `CalculateDamage_OnHotPath_DoesNotAllocate` — asserts **0 bytes** allocated across a warmed-up batch of calls (via `GC.GetAllocatedBytesForCurrentThread`), locking the win in against regression.
- [x] `BattleSimulatorParityTests` (the shared parity matrix) and the rest of the battle suite pass unchanged — proof the numeric result is identical.
- [x] Full backend suite green: **755 passed, 0 failed** (Game.Core.Tests 337, Game.Api.Tests 288, Game.Application.Tests 104, Game.Infrastructure.Tests 26).
- [x] `dotnet build` and `dotnet format --verify-no-changes` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbAmjvMuSygjsZ1jx6shsK)_