### PR TITLE
Deduplicate reference-cache invalidation via ICacheInvalidatable

### DIFF
--- a/Game.Abstractions/DataAccess/ICacheInvalidatable.cs
+++ b/Game.Abstractions/DataAccess/ICacheInvalidatable.cs
@@ -1,0 +1,7 @@
+namespace Game.Abstractions.DataAccess
+{
+    public interface ICacheInvalidatable
+    {
+        void InvalidateCache();
+    }
+}

--- a/Game.Abstractions/DataAccess/IChallenges.cs
+++ b/Game.Abstractions/DataAccess/IChallenges.cs
@@ -2,10 +2,9 @@ using Game.Core.Progress;
 
 namespace Game.Abstractions.DataAccess
 {
-    public interface IChallenges
+    public interface IChallenges : ICacheInvalidatable
     {
         public List<Challenge> All();
         public Challenge GetChallenge(int challengeId);
-        public void InvalidateCache();
     }
 }

--- a/Game.Abstractions/DataAccess/IEnemies.cs
+++ b/Game.Abstractions/DataAccess/IEnemies.cs
@@ -3,9 +3,8 @@ using CoreEnemy = Game.Core.Enemies.Enemy;
 
 namespace Game.Abstractions.DataAccess
 {
-    public interface IEnemies
+    public interface IEnemies : ICacheInvalidatable
     {
-        public void InvalidateCache();
         public List<Contracts.Enemy> All(bool refreshCache = false);
 
         /// <summary>Maps the entity enemy with <paramref name="level"/> to a domain

--- a/Game.Abstractions/DataAccess/IItemMods.cs
+++ b/Game.Abstractions/DataAccess/IItemMods.cs
@@ -3,9 +3,8 @@ using CoreItemMod = Game.Core.Items.ItemMod;
 
 namespace Game.Abstractions.DataAccess
 {
-    public interface IItemMods
+    public interface IItemMods : ICacheInvalidatable
     {
-        public void InvalidateCache();
         public List<Contracts.ItemMod> All(bool refreshCache = false);
         // Whether an item mod with the given id exists; lets callers validate before GetItemMod without touching the entity.
         public bool ValidateItemModId(int itemModId);

--- a/Game.Abstractions/DataAccess/IItems.cs
+++ b/Game.Abstractions/DataAccess/IItems.cs
@@ -3,9 +3,8 @@ using CoreItem = Game.Core.Items.Item;
 
 namespace Game.Abstractions.DataAccess
 {
-    public interface IItems
+    public interface IItems : ICacheInvalidatable
     {
-        public void InvalidateCache();
         public List<Contracts.Item> All(bool refreshCache = false);
         public CoreItem GetItem(int itemId);
     }

--- a/Game.Abstractions/DataAccess/ISkills.cs
+++ b/Game.Abstractions/DataAccess/ISkills.cs
@@ -3,9 +3,8 @@ using CoreSkill = Game.Core.Skills.Skill;
 
 namespace Game.Abstractions.DataAccess
 {
-    public interface ISkills
+    public interface ISkills : ICacheInvalidatable
     {
-        public void InvalidateCache();
         public List<Contracts.Skill> AllSkills(bool refreshCache = false);
         public CoreSkill GetSkill(int skillId);
     }

--- a/Game.Abstractions/DataAccess/IZones.cs
+++ b/Game.Abstractions/DataAccess/IZones.cs
@@ -3,9 +3,8 @@ using CoreZone = Game.Core.Zones.Zone;
 
 namespace Game.Abstractions.DataAccess
 {
-    public interface IZones
+    public interface IZones : ICacheInvalidatable
     {
-        public void InvalidateCache();
         public List<Contracts.Zone> All(bool refreshCache = false);
         // Returns the read contract for a single zone; throws if the id is out of range.
         public Contracts.Zone GetZone(int zoneId);

--- a/Game.Api.Tests/Integration/ApiIntegrationTestBase.cs
+++ b/Game.Api.Tests/Integration/ApiIntegrationTestBase.cs
@@ -1,4 +1,3 @@
-using Game.Abstractions.DataAccess;
 using Game.Api.Models.Auth;
 using Game.Api.Models.Common;
 using Game.Api.Services;
@@ -41,14 +40,7 @@ namespace Game.Api.Tests.Integration
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
             await DatabaseCleaner.TruncatePlayerDataAsync(context);
             await RedisCleaner.FlushAsync(Containers.CacheConnectionString);
-
-            // Invalidate static caches in repositories so stale data doesn't leak between tests
-            scope.ServiceProvider.GetRequiredService<IEnemies>().InvalidateCache();
-            scope.ServiceProvider.GetRequiredService<IZones>().InvalidateCache();
-            scope.ServiceProvider.GetRequiredService<ISkills>().InvalidateCache();
-            scope.ServiceProvider.GetRequiredService<IItems>().InvalidateCache();
-            scope.ServiceProvider.GetRequiredService<IItemMods>().InvalidateCache();
-            scope.ServiceProvider.GetRequiredService<IChallenges>().InvalidateCache();
+            ReferenceCacheCleaner.InvalidateAll(scope.ServiceProvider);
         }
 
         public async ValueTask DisposeAsync()

--- a/Game.Api/Filters/AdminCacheInvalidationFilter.cs
+++ b/Game.Api/Filters/AdminCacheInvalidationFilter.cs
@@ -3,25 +3,17 @@ using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace Game.Api.Filters
 {
-    public class AdminCacheInvalidationFilter(
-        IEnemies enemies,
-        IItems items,
-        IItemMods itemMods,
-        ISkills skills,
-        IZones zones,
-        IChallenges challenges) : IAsyncActionFilter
+    public class AdminCacheInvalidationFilter(IEnumerable<ICacheInvalidatable> caches) : IAsyncActionFilter
     {
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
             var executedContext = await next();
             if (executedContext.Exception is null || executedContext.ExceptionHandled)
             {
-                enemies.InvalidateCache();
-                items.InvalidateCache();
-                itemMods.InvalidateCache();
-                skills.InvalidateCache();
-                zones.InvalidateCache();
-                challenges.InvalidateCache();
+                foreach (var cache in caches)
+                {
+                    cache.InvalidateCache();
+                }
             }
         }
     }

--- a/Game.DataAccess/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Game.DataAccess/DependencyInjection/ServiceCollectionExtensions.cs
@@ -44,21 +44,28 @@ namespace Game.DataAccess.DependencyInjection
                 // an internal entity-cache/queries seam (used by Enemies to build domain enemies, and by
                 // the Content Authoring admin repositories for existence/diff lookups); a single scoped
                 // instance backs both so the cached entity list is shared rather than duplicated.
+                // ICacheInvalidatable registrations allow resolving all invalidatable caches as a set
+                // (e.g. IEnumerable<ICacheInvalidatable>) without a manually-maintained list.
                 .AddScoped<IChallenges, Challenges>()
+                .AddScoped<ICacheInvalidatable>(sp => sp.GetRequiredService<IChallenges>())
                 .AddScoped<Enemies>()
                 .AddScoped<IEnemies>(sp => sp.GetRequiredService<Enemies>())
                 .AddScoped<IEnemyEntityCache>(sp => sp.GetRequiredService<Enemies>())
+                .AddScoped<ICacheInvalidatable>(sp => sp.GetRequiredService<IEnemies>())
                 .AddScoped<Items>()
                 .AddScoped<IItems>(sp => sp.GetRequiredService<Items>())
                 .AddScoped<IItemEntityCache>(sp => sp.GetRequiredService<Items>())
+                .AddScoped<ICacheInvalidatable>(sp => sp.GetRequiredService<IItems>())
                 .AddScoped<ItemMods>()
                 .AddScoped<IItemMods>(sp => sp.GetRequiredService<ItemMods>())
                 .AddScoped<IItemModEntityCache>(sp => sp.GetRequiredService<ItemMods>())
+                .AddScoped<ICacheInvalidatable>(sp => sp.GetRequiredService<IItemMods>())
                 .AddScoped<IItemModTypes, ItemModTypes>()
                 .AddScoped<IItemCategories, ItemCategories>()
                 .AddScoped<Skills>()
                 .AddScoped<ISkills>(sp => sp.GetRequiredService<Skills>())
                 .AddScoped<ISkillEntityCache>(sp => sp.GetRequiredService<Skills>())
+                .AddScoped<ICacheInvalidatable>(sp => sp.GetRequiredService<ISkills>())
                 .AddScoped<Tags>()
                 .AddScoped<ITags>(sp => sp.GetRequiredService<Tags>())
                 .AddScoped<ITagEntityQueries>(sp => sp.GetRequiredService<Tags>())
@@ -66,6 +73,7 @@ namespace Game.DataAccess.DependencyInjection
                 .AddScoped<Zones>()
                 .AddScoped<IZones>(sp => sp.GetRequiredService<Zones>())
                 .AddScoped<IZoneEntityCache>(sp => sp.GetRequiredService<Zones>())
+                .AddScoped<ICacheInvalidatable>(sp => sp.GetRequiredService<IZones>())
                 .AddScoped<ISessionStore, SessionStore>()
                 .AddScoped<IRefreshTokenStore, RefreshTokenStore>()
                 .AddScoped<IUsers, Users>()

--- a/Game.TestInfrastructure/Base/ApplicationIntegrationTestBase.cs
+++ b/Game.TestInfrastructure/Base/ApplicationIntegrationTestBase.cs
@@ -1,4 +1,3 @@
-using Game.Abstractions.DataAccess;
 using Game.Application.DependencyInjection;
 using Game.Core.Events;
 using Game.DataAccess;
@@ -82,14 +81,7 @@ namespace Game.TestInfrastructure.Base
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
             await DatabaseCleaner.TruncatePlayerDataAsync(context);
             await RedisCleaner.FlushAsync(Containers.CacheConnectionString);
-
-            // Invalidate static caches in repositories so stale data doesn't leak between tests
-            scope.ServiceProvider.GetRequiredService<IEnemies>().InvalidateCache();
-            scope.ServiceProvider.GetRequiredService<IZones>().InvalidateCache();
-            scope.ServiceProvider.GetRequiredService<ISkills>().InvalidateCache();
-            scope.ServiceProvider.GetRequiredService<IItems>().InvalidateCache();
-            scope.ServiceProvider.GetRequiredService<IItemMods>().InvalidateCache();
-            scope.ServiceProvider.GetRequiredService<IChallenges>().InvalidateCache();
+            ReferenceCacheCleaner.InvalidateAll(scope.ServiceProvider);
         }
     }
 }

--- a/Game.TestInfrastructure/Helpers/ReferenceCacheCleaner.cs
+++ b/Game.TestInfrastructure/Helpers/ReferenceCacheCleaner.cs
@@ -1,0 +1,16 @@
+using Game.Abstractions.DataAccess;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Game.TestInfrastructure.Helpers
+{
+    public static class ReferenceCacheCleaner
+    {
+        public static void InvalidateAll(IServiceProvider provider)
+        {
+            foreach (var cache in provider.GetServices<ICacheInvalidatable>())
+            {
+                cache.InvalidateCache();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `ICacheInvalidatable` in `Game.Abstractions/DataAccess/` — the six reference-data interfaces (`IEnemies`, `IItems`, `IItemMods`, `ISkills`, `IZones`, `IChallenges`) now extend it instead of each declaring `void InvalidateCache()` independently.
- Registers each reference-data repo as `ICacheInvalidatable` in `ServiceCollectionExtensions`, so the full set resolves via `IEnumerable<ICacheInvalidatable>` without a hand-maintained list. Adding a new reference cache only requires wiring its `ICacheInvalidatable` registration — no test-infra files need to change.
- Adds `ReferenceCacheCleaner.InvalidateAll(IServiceProvider)` in `Game.TestInfrastructure/Helpers/`, which resolves and invalidates the whole set. Both `ApplicationIntegrationTestBase.CleanupAsync` and `ApiIntegrationTestBase.InitializeAsync` call it instead of their former six-line blocks — the two lists can no longer drift.
- Cleans up `AdminCacheInvalidationFilter` the same way: it now takes `IEnumerable<ICacheInvalidatable>` instead of six individual constructor parameters, fixing the identical drift risk in production code at the same time.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 785 tests pass across all projects (Infrastructure: 26, Core: 346, Application: 118, Api: 295)
- [x] Both two previously-failing tests (`StartBattle_AbandoningAnUnresolvedBattle_RecordsAbandonedNotLost`, `StartBossBattle_ChallengingBossInDifferentZone_RecordsClearForChallengedZone`) remain covered by the shared invalidation path

Closes #300

https://claude.ai/code/session_01Pi293mnmRCGZVro4hTqtnC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pi293mnmRCGZVro4hTqtnC)_