### PR TITLE
Add frontend tests for inventory-manager equip/unequip/apply-mod client logic

### DIFF
--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -29,13 +29,29 @@ vi.mock('$stores', () => ({
 	}
 }));
 
+// Controllable stubs for the network boundary the inventory mutations cross. `mockPost` resolves
+// the `{ error }` an `ApiRequest` would return, so a test can flip an endpoint to the
+// error/early-return path; `mockSendSocketCommand` backs `setFavorite`'s websocket persistence.
+const { mockPost, mockSendSocketCommand } = vi.hoisted(() => {
+	const mockPost = vi.fn();
+	const mockSendSocketCommand = vi.fn();
+	return { mockPost, mockSendSocketCommand };
+});
+
 vi.mock('$lib/api', async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, unknown>;
 	return {
 		...actual,
-		ApiRequest: vi.fn().mockImplementation(() => ({
-			post: vi.fn().mockResolvedValue({ error: undefined })
-		}))
+		ApiRequest: vi.fn().mockImplementation(function (
+			this: { endpoint: string; post: typeof mockPost },
+			endpoint: string
+		) {
+			this.endpoint = endpoint;
+			this.post = mockPost;
+		}),
+		apiSocket: {
+			sendSocketCommand: mockSendSocketCommand
+		}
 	};
 });
 
@@ -44,7 +60,9 @@ vi.mock('$lib/engine/log', () => ({
 }));
 
 import { InventoryManager, EEquipmentSlot, getEquipmentSlotForCategory } from '$lib/engine/player/inventory-manager';
+import { ApiRequest } from '$lib/api';
 import { logMessage } from '$lib/engine/log';
+import type { IInventoryItem } from '$lib/api';
 
 const makeItem = (id: number, category: EItemCategory = EItemCategory.Weapon): IItem => ({
 	id,
@@ -68,12 +86,24 @@ const makeItemMod = (id: number): IItemMod => ({
 	tags: []
 });
 
+const makeInventoryItem = (overrides: Partial<IInventoryItem> & { itemId: number }): IInventoryItem => ({
+	equipped: false,
+	favorite: false,
+	appliedMods: [],
+	...overrides
+});
+
 describe('InventoryManager', () => {
 	let manager: InventoryManager;
 
 	beforeEach(() => {
 		manager = new InventoryManager();
 		vi.mocked(logMessage).mockClear();
+		vi.mocked(ApiRequest).mockClear();
+
+		// Default the network boundary to success; error-path tests override per case.
+		mockPost.mockReset().mockResolvedValue({ error: undefined });
+		mockSendSocketCommand.mockReset().mockResolvedValue(undefined);
 
 		mockItems.length = 0;
 		mockItemMods.length = 0;
@@ -153,6 +183,44 @@ describe('InventoryManager', () => {
 
 			expect(stats.length).toBeGreaterThan(0);
 		});
+
+		it('merges equipped item attributes with their applied mods across slots', () => {
+			mockItems[1] = makeItem(1, EItemCategory.Weapon);
+			mockItems[2] = makeItem(2, EItemCategory.Helm);
+			mockItemMods[10] = makeItemMod(10);
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({
+					itemId: 1,
+					equipped: true,
+					equipmentSlotId: EEquipmentSlot.WeaponSlot,
+					appliedMods: [{ itemModId: 10, itemModSlotId: 0 }]
+				}),
+				makeInventoryItem({ itemId: 2, equipped: true, equipmentSlotId: EEquipmentSlot.HelmSlot })
+			];
+
+			manager.initialize();
+			const stats = manager.equipmentStats;
+
+			// Slots aggregate in index order: Helm (item 2) before Weapon (item 1 + its mod).
+			expect(stats).toEqual([
+				{ attributeId: EAttribute.Strength, amount: 5 },
+				{ attributeId: EAttribute.Strength, amount: 5 },
+				{ attributeId: EAttribute.Agility, amount: 3 }
+			]);
+		});
+	});
+
+	describe('selectItem', () => {
+		it('updates the selected item id', () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+
+			manager.selectItem(1);
+
+			expect(manager.selectedItemId).toBe(1);
+			expect(manager.selectedItem?.itemId).toBe(1);
+		});
 	});
 
 	describe('selectedItem', () => {
@@ -168,6 +236,247 @@ describe('InventoryManager', () => {
 			manager.selectItem(1);
 			expect(manager.selectedItem).toBeDefined();
 			expect(manager.selectedItem?.itemId).toBe(1);
+		});
+	});
+
+	describe('equipItem', () => {
+		it('equips an item into an empty slot and posts to the API', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+
+			const result = await manager.equipItem(1, EEquipmentSlot.WeaponSlot);
+
+			expect(result).toBe(true);
+			expect(ApiRequest).toHaveBeenCalledWith('Player/EquipItem');
+			expect(mockPost).toHaveBeenCalledWith({ itemId: 1, equipmentSlotId: EEquipmentSlot.WeaponSlot });
+			const equipped = manager.equippedSlots[EEquipmentSlot.WeaponSlot];
+			expect(equipped?.itemId).toBe(1);
+			expect(equipped?.equipped).toBe(true);
+			expect(equipped?.equipmentSlotId).toBe(EEquipmentSlot.WeaponSlot);
+		});
+
+		it('displaces the item already occupying the target slot', async () => {
+			mockItems[1] = makeItem(1);
+			mockItems[2] = makeItem(2);
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({ itemId: 1, equipped: true, equipmentSlotId: EEquipmentSlot.WeaponSlot }),
+				makeInventoryItem({ itemId: 2 })
+			];
+			manager.initialize();
+			const displaced = manager.unlockedItems.get(1);
+
+			const result = await manager.equipItem(2, EEquipmentSlot.WeaponSlot);
+
+			expect(result).toBe(true);
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]?.itemId).toBe(2);
+			expect(displaced?.equipped).toBe(false);
+			expect(displaced?.equipmentSlotId).toBeUndefined();
+		});
+
+		it('moves an item already equipped in another slot', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({ itemId: 1, equipped: true, equipmentSlotId: EEquipmentSlot.HelmSlot })
+			];
+			manager.initialize();
+
+			const result = await manager.equipItem(1, EEquipmentSlot.ChestSlot);
+
+			expect(result).toBe(true);
+			expect(manager.equippedSlots[EEquipmentSlot.HelmSlot]).toBeUndefined();
+			expect(manager.equippedSlots[EEquipmentSlot.ChestSlot]?.itemId).toBe(1);
+			expect(manager.equippedSlots[EEquipmentSlot.ChestSlot]?.equipmentSlotId).toBe(EEquipmentSlot.ChestSlot);
+		});
+
+		it('returns false and makes no API call for an unknown item', async () => {
+			manager.initialize();
+
+			const result = await manager.equipItem(99, EEquipmentSlot.WeaponSlot);
+
+			expect(result).toBe(false);
+			expect(ApiRequest).not.toHaveBeenCalled();
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]).toBeUndefined();
+		});
+
+		it('leaves state unchanged when the API returns an error', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+			mockPost.mockResolvedValue({ error: 'nope' });
+
+			const result = await manager.equipItem(1, EEquipmentSlot.WeaponSlot);
+
+			expect(result).toBe(false);
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]).toBeUndefined();
+			expect(manager.unlockedItems.get(1)?.equipped).toBe(false);
+		});
+	});
+
+	describe('unequipItem', () => {
+		it('unequips the item in a slot and posts to the API', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({ itemId: 1, equipped: true, equipmentSlotId: EEquipmentSlot.WeaponSlot })
+			];
+			manager.initialize();
+			const item = manager.unlockedItems.get(1);
+
+			const result = await manager.unequipItem(EEquipmentSlot.WeaponSlot);
+
+			expect(result).toBe(true);
+			expect(ApiRequest).toHaveBeenCalledWith('Player/UnequipItem');
+			expect(mockPost).toHaveBeenCalledWith({ itemId: 1, equipmentSlotId: EEquipmentSlot.WeaponSlot });
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]).toBeUndefined();
+			expect(item?.equipped).toBe(false);
+			expect(item?.equipmentSlotId).toBeUndefined();
+		});
+
+		it('returns false and makes no API call for an empty slot', async () => {
+			manager.initialize();
+
+			const result = await manager.unequipItem(EEquipmentSlot.WeaponSlot);
+
+			expect(result).toBe(false);
+			expect(ApiRequest).not.toHaveBeenCalled();
+		});
+
+		it('leaves the item equipped when the API returns an error', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({ itemId: 1, equipped: true, equipmentSlotId: EEquipmentSlot.WeaponSlot })
+			];
+			manager.initialize();
+			mockPost.mockResolvedValue({ error: 'nope' });
+
+			const result = await manager.unequipItem(EEquipmentSlot.WeaponSlot);
+
+			expect(result).toBe(false);
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]?.itemId).toBe(1);
+		});
+	});
+
+	describe('applyMod', () => {
+		it('posts to the API and logs on success', async () => {
+			mockItems[1] = makeItem(1);
+			mockItemMods[10] = makeItemMod(10);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			mockInventoryData.unlockedMods = [10];
+			manager.initialize();
+
+			const result = await manager.applyMod(1, 10, 0);
+
+			expect(result).toBe(true);
+			expect(ApiRequest).toHaveBeenCalledWith('Player/ApplyMod');
+			expect(mockPost).toHaveBeenCalledWith({ itemId: 1, itemModId: 10, itemModSlotId: 0 });
+			expect(logMessage).toHaveBeenCalledWith(ELogType.ItemFound, 'Modifier applied.');
+		});
+
+		it('returns false and makes no API call when the mod is not unlocked', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+
+			const result = await manager.applyMod(1, 10, 0);
+
+			expect(result).toBe(false);
+			expect(ApiRequest).not.toHaveBeenCalled();
+		});
+
+		it('returns false and makes no API call when the item is not unlocked', async () => {
+			mockItemMods[10] = makeItemMod(10);
+			mockInventoryData.unlockedMods = [10];
+			manager.initialize();
+
+			const result = await manager.applyMod(1, 10, 0);
+
+			expect(result).toBe(false);
+			expect(ApiRequest).not.toHaveBeenCalled();
+		});
+
+		it('returns false and does not log when the API returns an error', async () => {
+			mockItems[1] = makeItem(1);
+			mockItemMods[10] = makeItemMod(10);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			mockInventoryData.unlockedMods = [10];
+			manager.initialize();
+			mockPost.mockResolvedValue({ error: 'nope' });
+
+			const result = await manager.applyMod(1, 10, 0);
+
+			expect(result).toBe(false);
+			expect(logMessage).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('removeMod', () => {
+		it('posts to the API and logs on success', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+
+			const result = await manager.removeMod(1, 0);
+
+			expect(result).toBe(true);
+			expect(ApiRequest).toHaveBeenCalledWith('Player/RemoveMod');
+			expect(mockPost).toHaveBeenCalledWith({ itemId: 1, itemModSlotId: 0 });
+			expect(logMessage).toHaveBeenCalledWith(ELogType.ItemFound, 'Modifier removed.');
+		});
+
+		it('returns false and makes no API call when the item is not unlocked', async () => {
+			manager.initialize();
+
+			const result = await manager.removeMod(1, 0);
+
+			expect(result).toBe(false);
+			expect(ApiRequest).not.toHaveBeenCalled();
+		});
+
+		it('returns false and does not log when the API returns an error', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+			mockPost.mockResolvedValue({ error: 'nope' });
+
+			const result = await manager.removeMod(1, 0);
+
+			expect(result).toBe(false);
+			expect(logMessage).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('setFavorite', () => {
+		it('sets the flag and persists it over the socket', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+
+			const result = await manager.setFavorite(1, true);
+
+			expect(result).toBe(true);
+			expect(manager.unlockedItems.get(1)?.favorite).toBe(true);
+			expect(mockSendSocketCommand).toHaveBeenCalledWith('SetItemFavorite', { itemId: 1, favorite: true });
+		});
+
+		it('returns false for an unknown item', async () => {
+			manager.initialize();
+
+			const result = await manager.setFavorite(99, true);
+
+			expect(result).toBe(false);
+			expect(mockSendSocketCommand).not.toHaveBeenCalled();
+		});
+
+		it('keeps the optimistic local flag when the socket send fails', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+			mockSendSocketCommand.mockRejectedValue(new Error('socket down'));
+
+			const result = await manager.setFavorite(1, true);
+
+			expect(result).toBe(true);
+			expect(manager.unlockedItems.get(1)?.favorite).toBe(true);
 		});
 	});
 

--- a/UI/vite.config.ts
+++ b/UI/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
 			// for pure-display markup. Re-seed with `node scripts/coverage-floors.mjs` to ratchet up.
 			thresholds: {
 				'src/lib/battle/**': { lines: 99, functions: 100, branches: 88, statements: 99 },
-				'src/lib/engine/**': { lines: 80, functions: 83, branches: 73, statements: 80 },
+				'src/lib/engine/**': { lines: 91, functions: 87, branches: 85, statements: 90 },
 				'src/lib/common/**': { lines: 90, functions: 89, branches: 80, statements: 90 },
 				'src/lib/api/**': { lines: 89, functions: 90, branches: 82, statements: 89 },
 				'src/lib/card-game/**': { lines: 94, functions: 100, branches: 81, statements: 94 },


### PR DESCRIPTION
## Summary

Closes #303.

`UI/src/lib/engine/player/inventory-manager.ts` sat at ~42% statements / 38% branches — the optimistic-update inventory mutations (lines 80–189) were entirely untested. This adds tests for that client-side state logic, bringing the file to **100% coverage** and lifting the `src/lib/engine/**` area floor.

## What's covered

Extended `UI/src/tests/lib/engine/player/inventory-manager.test.ts` with the previously-uncovered methods:

- **`equipItem`** — equip into an empty slot, equip that **displaces** an occupied slot, equip of an item already equipped elsewhere (moves it), plus the error/early-return branches (unknown item → no API call, API `response.error` → state unchanged).
- **`unequipItem`** — success, empty-slot no-op, and the API-error branch (item stays equipped).
- **`applyMod`** — success + log, the two unlocked-guard early returns (mod not unlocked, item not unlocked), and the API-error branch (no log).
- **`removeMod`** — success + log, item-not-unlocked early return, and the API-error branch.
- **`setFavorite`** — optimistic flag set + socket persistence, unknown-item early return, and the socket-failure path keeping the optimistic local flag.
- **`selectItem`** and a richer **`equipmentStats`** test exercising merged item + applied-mod attributes across multiple slots (covers the previously-uncovered mod-attribute line).

The `ApiRequest` / `apiSocket` boundary is mocked (via `vi.hoisted` controllable stubs) so no real network or socket call is made, and error paths can be driven by flipping the resolved `{ error }`.

## Coverage floor

Re-seeded the `src/lib/engine/**` thresholds in `UI/vite.config.ts` via `node scripts/coverage-floors.mjs` now that the area cleared integer boundaries: `lines 80→91, functions 83→87, branches 73→85, statements 80→90`.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run test:unit:ci` — 1077 tests pass, all coverage thresholds (including the raised engine floor) met.
- [x] Targeted coverage of `inventory-manager.ts` confirms 100% statements/branches/functions/lines.

## Note

This is the frontend counterpart to the backend equip/mod coverage gap tracked in #302.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUtdSAkkkg5kR1RUjDJSPW)_