### PR TITLE
Route BattleStatisticsEventHandlerTests cache invalidation through ReferenceCacheCleaner.InvalidateAll (#315)

### DIFF
--- a/Game.Application.Tests/Events/BattleStatisticsEventHandlerTests.cs
+++ b/Game.Application.Tests/Events/BattleStatisticsEventHandlerTests.cs
@@ -145,10 +145,7 @@ namespace Game.Application.Tests.Events
 
             // Reference caches are static and not reset between tests, so refresh them to pick up the
             // rows just seeded before the handler reads through its providers.
-            scope.ServiceProvider.GetRequiredService<IChallenges>().InvalidateCache();
-            scope.ServiceProvider.GetRequiredService<IItems>().InvalidateCache();
-            scope.ServiceProvider.GetRequiredService<ISkills>().InvalidateCache();
-            scope.ServiceProvider.GetRequiredService<IEnemies>().InvalidateCache();
+            ReferenceCacheCleaner.InvalidateAll(scope.ServiceProvider);
 
             return new Setup(player.Id, enemy.Id, item.Id, mod.Id, rewardSkill.Id);
         }


### PR DESCRIPTION
## Summary

- Replaces the four hand-maintained inline `InvalidateCache()` calls in `BattleStatisticsEventHandlerTests.SeedScenarioAsync` (lines 148-151) with a single `ReferenceCacheCleaner.InvalidateAll(scope.ServiceProvider)` call.
- This eliminates the exact drift risk #300 warned about: a partial list of caches that would silently miss any newly registered `ICacheInvalidatable` in the future.
- The two single-cache invalidations in `ChallengesControllerTests` and `PlayerProgressRepositoryIntegrationTests` are intentionally scoped (only challenge data is seeded in those tests) and already carry explanatory comments — left unchanged per the issue.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] All 5 `BattleStatisticsEventHandlerTests` pass
- [x] All 125 `Game.Application.Tests` pass (0 failures)
- [x] All 296 `Game.Api.Tests` pass (0 failures)

Closes #315

https://claude.ai/code/session_01Dqnf1FYB2S22Gm3efWqy2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dqnf1FYB2S22Gm3efWqy2d)_