### PR TITLE
Fix pub/sub command processor hot-loop on ExecuteCommand failure (#317)

### DIFF
--- a/Game.Api.Tests/Integration/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Integration/SocketCommandProcessorTests.cs
@@ -1,0 +1,56 @@
+using Game.Api.Services;
+using Game.Api.Sockets.Commands;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    [Collection("Integration")]
+    public class SocketCommandProcessorTests : ApiIntegrationTestBase
+    {
+        private const string Username = "cmdprocuser";
+        private const string Password = "cmdprocpass";
+
+        public SocketCommandProcessorTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        private async Task<(int UserId, int PlayerId)> SeedAndLoginAsync()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context, Username, Password);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+            await LoginAsync(Username, Password);
+            return (user.Id, player.Id);
+        }
+
+        [Fact]
+        public async Task PubSub_UnknownCommandFollowedByValidCommand_ValidCommandStillExecutes()
+        {
+            var (userId, playerId) = await SeedAndLoginAsync();
+
+            await using var socketClient = new TestSocketClient();
+            var wsClient = Factory.Server.CreateWebSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+
+            // Confirm the socket's pub/sub subscription is registered before emitting via the server path.
+            await socketClient.SendCommandAsync<object>("GetStatisticTypes");
+
+            using var scope = CreateScope();
+            var socketManager = scope.ServiceProvider.GetRequiredService<SocketManagerService>();
+
+            var validCommandId = Guid.NewGuid().ToString();
+
+            // An unknown command deterministically throws in CreateCommand / the command loop. If the
+            // processor hot-loops on failure it never processes the valid command below.
+            await socketManager.EmitSocketCommand(new SocketCommandInfo("NonExistentCommand"), playerId);
+            await socketManager.EmitSocketCommand(new SocketCommandInfo("GetStatisticTypes") { Id = validCommandId }, playerId);
+
+            var response = await socketClient.WaitForResponseAsync(validCommandId);
+            Assert.Null(response.Error);
+        }
+    }
+}

--- a/Game.Api/Services/SocketManagerService.cs
+++ b/Game.Api/Services/SocketManagerService.cs
@@ -122,12 +122,13 @@ namespace Game.Api.Services
                     {
                         _logger.LogTrace("Received command on socket: {Id}, playerId: {PlayerId}, command: {CommandInfo}.", socket.Id, socket.PlayerId, nextCommandInfo);
                         await socket.ExecuteCommand(nextCommandInfo);
-                        nextCommandInfo = await queue.GetNextAsync<SocketCommandInfo>();
                     }
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, "An error occured while executing a socket command: {CommandInfo}", nextCommandInfo);
                     }
+
+                    nextCommandInfo = await queue.GetNextAsync<SocketCommandInfo>();
                 }
             };
         }

--- a/Game.Api/Sockets/SocketHandler.cs
+++ b/Game.Api/Sockets/SocketHandler.cs
@@ -40,9 +40,9 @@ namespace Game.Api.Sockets
         {
             _logger.LogTrace("Executing command: {CommandInfo} on socket: {Id}", commandInfo, Id);
             using var scope = _scopeFactory.CreateScope();
-            var command = _commandFactory.CreateCommand(commandInfo, scope);
             try
             {
+                var command = _commandFactory.CreateCommand(commandInfo, scope);
                 var response = await command.ExecuteAsync(_context);
                 await scope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
                 await _context.SendData(response);

--- a/Game.TestInfrastructure/Helpers/TestSocketClient.cs
+++ b/Game.TestInfrastructure/Helpers/TestSocketClient.cs
@@ -73,6 +73,16 @@ namespace Game.TestInfrastructure.Helpers
             return await ReadResponseAsync(commandInfo.Id);
         }
 
+        /// <summary>
+        /// Reads from the socket until a response with the given ID arrives, without sending anything.
+        /// Use this when a command is emitted through a server-side path (e.g. pub/sub) rather than
+        /// directly from the client.
+        /// </summary>
+        public async Task<ApiSocketResponse> WaitForResponseAsync(string commandId)
+        {
+            return await ReadResponseAsync(commandId);
+        }
+
         public async Task CloseAsync()
         {
             if (_socket.State == WebSocketState.Open)


### PR DESCRIPTION
## Summary

- **`GetSocketCommandProcessor` (SocketManagerService)**: The queue-advance call was inside the `try` block but not the `catch`, so any exception from `ExecuteCommand` caused the loop to retry the same command forever — a tight, delay-free infinite loop that pegged a thread and flooded logs, permanently wedging that socket's queue processor. Fixed by moving the advance outside try/catch so it always executes regardless of outcome, matching the resilient pattern already used by `DataProviderSynchronizer`.
- **`ExecuteCommand` (SocketHandler)**: `CreateCommand` was called *before* the `try` block, so an `InvalidOperationException` for an unknown command name (or a `SetParameters` throw on malformed params) escaped the error handler and propagated to the processor loop as a deterministic failure. Fixed by moving `CreateCommand` inside the `try` so unknown/malformed commands are caught and returned as a proper `"Internal Server Error"` response.
- **Regression test** (`SocketCommandProcessorTests`): emits an unknown command name then a valid `GetStatisticTypes` command through the Redis pub/sub path and asserts the valid command's response arrives — proving the processor continues after a failure rather than spinning.

## Test plan

- [x] New integration test `PubSub_UnknownCommandFollowedByValidCommand_ValidCommandStillExecutes` passes in isolation
- [x] Full `Game.Api.Tests` suite passes (297/297)
- [x] Build clean, zero warnings

Closes #317

https://claude.ai/code/session_01LceY6ANUhThcVttRHK6AJm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LceY6ANUhThcVttRHK6AJm)_