### PR TITLE
Add frontend tests for challenges-screen logic and admin Workbench section components

### DIFF
--- a/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+
+vi.mock('$stores', () => ({ toastError: vi.fn() }));
+
+import ChipsSection from '$routes/admin/workbench/components/ChipsSection.svelte';
+import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
+import type { ChipsSectionConfig, EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+
+interface Row extends Identified {
+	skillPool: number[];
+}
+
+const CATALOGUE = [
+	{ id: 1, name: 'Cleave', baseDamage: 12 },
+	{ id: 2, name: 'Fireball', baseDamage: 25 },
+	{ id: 3, name: 'Heal', baseDamage: 0 }
+];
+
+const section: ChipsSectionConfig<Row> = {
+	key: 'skills',
+	label: 'Skills',
+	glyph: 'rune',
+	kind: 'chips',
+	itemsKey: 'skillPool',
+	catalogue: () => CATALOGUE,
+	labelOf: (e) => e.name,
+	metaOf: (e) => `${(e as unknown as { baseDamage: number }).baseDamage} dmg`,
+	emptyIcon: 'rune',
+	emptyTitle: 'No skills in pool',
+	emptySub: "Enemies with no skills can't act.",
+	addLabel: 'Add skill…'
+};
+
+const config = (): EntityConfig<Row> =>
+	({
+		key: 'rows',
+		label: 'Rows',
+		singular: 'Row',
+		glyph: 'box',
+		blankName: 'Unnamed',
+		newItem: (id: number) => ({ id, skillPool: [] }),
+		meta: () => [],
+		sections: [section],
+		refresh: async () => [],
+		persist: async () => []
+	}) as unknown as EntityConfig<Row>;
+
+const setup = (skillPool: number[]) => {
+	const store = new EntityStore(config(), [{ id: 1, skillPool }]);
+	return { store, record: store.items[0], baseline: store.baselineOf(1) };
+};
+
+// The workbench section components are entity-agnostic (typed against `Identified`);
+// cast the concrete-Row store/section to that shape at the single render boundary.
+const renderChips = (store: EntityStore<Row>, record: Row | undefined, baseline: Row | undefined) =>
+	render(ChipsSection, {
+		props: {
+			section: section as unknown as ChipsSectionConfig<Identified>,
+			record: record as Identified,
+			baseline,
+			store: store as unknown as EntityStore<Identified>
+		}
+	});
+
+afterEach(cleanup);
+
+describe('ChipsSection', () => {
+	it('shows the empty state when no chips are assigned', () => {
+		const { store, record, baseline } = setup([]);
+		renderChips(store, record, baseline);
+		expect(screen.getByText('No skills in pool')).toBeTruthy();
+	});
+
+	it('renders a chip with the catalogue label and meta for each assigned id', () => {
+		const { store, record, baseline } = setup([1, 2]);
+		const { container } = renderChips(store, record, baseline);
+		expect(container.querySelectorAll('.skill-chip')).toHaveLength(2);
+		expect(screen.getByText('Cleave')).toBeTruthy();
+		expect(screen.getByText('25 dmg')).toBeTruthy();
+	});
+
+	it('offers only the not-yet-assigned catalogue entries in the add select', () => {
+		const { store, record, baseline } = setup([1]);
+		const { container } = renderChips(store, record, baseline);
+		const addSelect = container.querySelector('.add-select select') as HTMLSelectElement;
+		// One placeholder option + the two remaining (Fireball, Heal).
+		expect(addSelect.querySelectorAll('option')).toHaveLength(3);
+	});
+
+	it('adds a chip when an option is chosen', async () => {
+		const { store, record, baseline } = setup([1]);
+		const { container } = renderChips(store, record, baseline);
+		const addSelect = container.querySelector('.add-select select') as HTMLSelectElement;
+		await fireEvent.change(addSelect, { target: { value: '2' } });
+		expect(store.items[0].skillPool).toEqual([1, 2]);
+	});
+
+	it('removes a chip when its remove control is activated', async () => {
+		const { store, record, baseline } = setup([1, 2]);
+		const { container } = renderChips(store, record, baseline);
+		const removeFirst = container.querySelector('.skill-chip .x') as HTMLElement;
+		await fireEvent.click(removeFirst);
+		expect(store.items[0].skillPool).toEqual([2]);
+	});
+
+	it('flags a chip added since the baseline', () => {
+		const store = new EntityStore(config(), [{ id: 1, skillPool: [1] }]);
+		store.patch(1, (d) => d.skillPool.push(2));
+		const { container } = renderChips(store, store.items[0], store.baselineOf(1));
+		// The second chip (id 2) is not in the baseline → flagged "added".
+		const chips = container.querySelectorAll('.skill-chip');
+		expect(chips[1].classList.contains('added')).toBe(true);
+		expect(chips[0].classList.contains('added')).toBe(false);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/FieldControl.test.ts
+++ b/UI/src/tests/routes/admin/workbench/FieldControl.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+
+// EntityStore imports toastError from $stores.
+vi.mock('$stores', () => ({ toastError: vi.fn() }));
+
+import FieldControl from '$routes/admin/workbench/components/FieldControl.svelte';
+import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
+import type { EntityConfig, FieldConfig, Identified } from '$routes/admin/workbench/entities/types';
+
+interface Row extends Identified {
+	name: string;
+	count: number;
+	enabled: boolean;
+	notes: string;
+	choice: number;
+}
+
+const config = (): EntityConfig<Row> =>
+	({
+		key: 'rows',
+		label: 'Rows',
+		singular: 'Row',
+		glyph: 'box',
+		blankName: 'Unnamed',
+		newItem: (id: number) => ({ id, name: '', count: 0, enabled: false, notes: '', choice: 1 }),
+		meta: () => [],
+		sections: [],
+		refresh: async () => [],
+		persist: async () => []
+	}) as unknown as EntityConfig<Row>;
+
+const seed = (): Row[] => [{ id: 1, name: 'Alpha', count: 5, enabled: false, notes: 'hi', choice: 1 }];
+
+const field = (over: Partial<FieldConfig<Row>> & Pick<FieldConfig<Row>, 'key' | 'label' | 'type'>): FieldConfig<Row> =>
+	over as FieldConfig<Row>;
+
+const setup = () => {
+	const store = new EntityStore(config(), seed());
+	return { store, record: store.items[0], baseline: store.baselineOf(1) };
+};
+
+// FieldControl is entity-agnostic (typed against `Identified`); cast the concrete-Row
+// field/store to that shape at the single render boundary.
+const renderField = (f: FieldConfig<Row>, store: EntityStore<Row>, record: Row, baseline: Row | undefined) =>
+	render(FieldControl, {
+		props: {
+			field: f as unknown as FieldConfig<Identified>,
+			record: record as Identified,
+			baseline,
+			store: store as unknown as EntityStore<Identified>
+		}
+	});
+
+afterEach(cleanup);
+
+describe('FieldControl — text field', () => {
+	it('renders the value and patches the store on input', async () => {
+		const { store, record, baseline } = setup();
+		const { container } = renderField(field({ key: 'name', label: 'Name', type: 'text' }), store, record, baseline);
+		const input = container.querySelector('input.inp') as HTMLInputElement;
+		expect(input.value).toBe('Alpha');
+		await fireEvent.input(input, { target: { value: 'Beta' } });
+		expect(store.items[0].name).toBe('Beta');
+	});
+
+	it('shows a required warning when the value is empty', () => {
+		const store = new EntityStore(config(), [{ id: 1, name: '', count: 0, enabled: false, notes: '', choice: 1 }]);
+		const { container } = renderField(
+			field({ key: 'name', label: 'Name', type: 'text', required: true, reqMsg: 'Missing name' }),
+			store,
+			store.items[0],
+			store.baselineOf(1)
+		);
+		expect((container.querySelector('.lbl') as HTMLElement).classList.contains('warn')).toBe(true);
+	});
+});
+
+describe('FieldControl — number field', () => {
+	it('renders a numeric input and marks dirty against a differing baseline', () => {
+		const { store, record } = setup();
+		const baseline = { ...record, count: 99 }; // differs → dirty
+		const { container } = renderField(
+			field({ key: 'count', label: 'Count', type: 'number', suffix: 'pts' }),
+			store,
+			record,
+			baseline
+		);
+		expect(container.querySelector('.num-unit')).toBeTruthy();
+		expect(container.querySelector('.suffix')?.textContent).toBe('pts');
+		expect(container.querySelector('.dirty-dot')).toBeTruthy();
+	});
+});
+
+describe('FieldControl — toggle field', () => {
+	it('renders a switch and flips the value on click', async () => {
+		const { store, record, baseline } = setup();
+		const { container } = renderField(
+			field({ key: 'enabled', label: 'On', type: 'toggle', onLabel: 'Yes', offLabel: 'No' }),
+			store,
+			record,
+			baseline
+		);
+		const toggle = container.querySelector('.toggle') as HTMLElement;
+		expect(toggle.getAttribute('aria-checked')).toBe('false');
+		await fireEvent.click(toggle);
+		expect(store.items[0].enabled).toBe(true);
+	});
+
+	it('toggles via the keyboard (Enter)', async () => {
+		const { store, record, baseline } = setup();
+		const { container } = renderField(
+			field({ key: 'enabled', label: 'On', type: 'toggle', onLabel: 'Yes', offLabel: 'No' }),
+			store,
+			record,
+			baseline
+		);
+		await fireEvent.keyDown(container.querySelector('.toggle') as HTMLElement, { key: 'Enter' });
+		expect(store.items[0].enabled).toBe(true);
+	});
+});
+
+describe('FieldControl — textarea field', () => {
+	it('renders a textarea bound to the value and patches on input', async () => {
+		const { store, record, baseline } = setup();
+		const { container } = renderField(
+			field({ key: 'notes', label: 'Notes', type: 'textarea' }),
+			store,
+			record,
+			baseline
+		);
+		const area = container.querySelector('textarea.txtarea') as HTMLTextAreaElement;
+		expect(area.value).toBe('hi');
+		await fireEvent.input(area, { target: { value: 'changed' } });
+		expect(store.items[0].notes).toBe('changed');
+	});
+});
+
+describe('FieldControl — select field', () => {
+	it('renders the provided options and patches the numeric value on change', async () => {
+		const { store, record, baseline } = setup();
+		const { container } = renderField(
+			field({
+				key: 'choice',
+				label: 'Choice',
+				type: 'select',
+				options: () => [
+					{ value: 1, text: 'One' },
+					{ value: 2, text: 'Two' }
+				]
+			}),
+			store,
+			record,
+			baseline
+		);
+		const select = container.querySelector('select.sel') as HTMLSelectElement;
+		expect(select.querySelectorAll('option')).toHaveLength(2);
+		await fireEvent.change(select, { target: { value: '2' } });
+		expect(store.items[0].choice).toBe(2);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/SectionRenderer.test.ts
+++ b/UI/src/tests/routes/admin/workbench/SectionRenderer.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/svelte';
+
+// SectionRenderer dispatches to one child per section kind; several children read
+// the workbench reference singleton, so it is stubbed with everything they touch.
+const { mockReference } = vi.hoisted(() => ({
+	mockReference: {
+		tags: [],
+		tagCategories: [],
+		tagColor: vi.fn(() => ({ fg: '#aaa', bd: '#888', bg: '#222' })),
+		tagsByCategory: vi.fn(() => []),
+		tagById: vi.fn(() => undefined),
+		rarityColor: vi.fn(() => 'var(--rarity-common)'),
+		tagUsage: vi.fn(() => ({ items: 0, mods: 0, itemList: [], modList: [] })),
+		challengeTypes: [{ id: 1, name: 'Enemies Killed', goalComparison: 1, statisticType: null }],
+		entityOptions: vi.fn(() => []),
+		entityName: vi.fn(() => null),
+		itemRecords: vi.fn(() => []),
+		itemModRecords: vi.fn(() => []),
+		skillRecords: vi.fn(() => [])
+	}
+}));
+vi.mock('$routes/admin/workbench/reference.svelte', () => ({ reference: mockReference }));
+vi.mock('$stores', () => ({ toastError: vi.fn() }));
+
+import SectionRenderer from '$routes/admin/workbench/components/SectionRenderer.svelte';
+import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
+import type { EntityConfig, Identified, SectionConfig } from '$routes/admin/workbench/entities/types';
+
+// A record carrying every field the various section kinds read.
+const RECORD = {
+	id: 1,
+	name: 'Rec',
+	tagCategoryId: 5,
+	rows: [] as unknown[],
+	chipIds: [] as number[],
+	tags: [] as number[],
+	challengeTypeId: 1,
+	entityType: 0,
+	statisticType: undefined,
+	targetEntityId: undefined,
+	progressGoal: 10
+};
+
+const config = (): EntityConfig<Identified> =>
+	({
+		key: 'rows',
+		label: 'Rows',
+		singular: 'Row',
+		glyph: 'box',
+		blankName: 'Unnamed',
+		newItem: (id: number) => ({ ...RECORD, id }),
+		meta: () => [],
+		sections: [],
+		refresh: async () => [],
+		persist: async () => []
+	}) as unknown as EntityConfig<Identified>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const renderKind = (section: SectionConfig<any>) => {
+	const store = new EntityStore(config(), [{ ...RECORD } as unknown as Identified]);
+	const record = store.items[0];
+	return render(SectionRenderer, { props: { section, record, baseline: store.baselineOf(1), store } });
+};
+
+afterEach(cleanup);
+
+describe('SectionRenderer dispatch', () => {
+	it('renders a fields section', () => {
+		const { container } = renderKind({
+			key: 'identity',
+			label: 'Identity',
+			glyph: 'tag',
+			kind: 'fields',
+			fields: [{ key: 'name', label: 'Name', type: 'text' }]
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
+		expect(container.querySelector('input.inp')).toBeTruthy();
+	});
+
+	it('renders a table section', () => {
+		renderKind({
+			key: 'rows',
+			label: 'Rows',
+			glyph: 'bars',
+			kind: 'table',
+			itemsKey: 'rows',
+			addLabel: 'Add row',
+			emptyIcon: 'bars',
+			emptyTitle: 'TABLE EMPTY MARKER',
+			emptySub: '',
+			newRow: () => ({ a: 0 }),
+			columns: [{ key: 'a', label: 'A', type: 'number' }]
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
+		expect(screen.getByText('TABLE EMPTY MARKER')).toBeTruthy();
+	});
+
+	it('renders a chips section', () => {
+		renderKind({
+			key: 'chips',
+			label: 'Chips',
+			glyph: 'rune',
+			kind: 'chips',
+			itemsKey: 'chipIds',
+			catalogue: () => [],
+			labelOf: (e: { name: string }) => e.name,
+			metaOf: () => '',
+			emptyIcon: 'rune',
+			emptyTitle: 'CHIPS EMPTY MARKER',
+			emptySub: '',
+			addLabel: 'Add'
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
+		expect(screen.getByText('CHIPS EMPTY MARKER')).toBeTruthy();
+	});
+
+	it('renders a tags section', () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		renderKind({ key: 'tags', label: 'Tags', glyph: 'tag', kind: 'tags', itemsKey: 'tags' } as any);
+		expect(screen.getByText('Applied · 0')).toBeTruthy();
+	});
+
+	it('renders a usage section', () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const { container } = renderKind({ key: 'usage', label: 'Usage', glyph: 'tag', kind: 'usage' } as any);
+		expect(container.querySelector('.usage-count')).toBeTruthy();
+	});
+
+	it('renders a challenge-condition section', () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		renderKind({ key: 'cond', label: 'Condition', glyph: 'target', kind: 'challenge-condition' } as any);
+		expect(screen.getByText('Players see')).toBeTruthy();
+	});
+
+	it('renders a challenge-reward section', () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		renderKind({ key: 'reward', label: 'Reward', glyph: 'gift', kind: 'challenge-reward' } as any);
+		expect(screen.getByText('Item Reward')).toBeTruthy();
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/SectionTable.test.ts
+++ b/UI/src/tests/routes/admin/workbench/SectionTable.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+
+vi.mock('$stores', () => ({ toastError: vi.fn() }));
+
+import SectionTable from '$routes/admin/workbench/components/SectionTable.svelte';
+import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
+import type { EntityConfig, Identified, TableSectionConfig } from '$routes/admin/workbench/entities/types';
+
+interface Spawn {
+	zoneId: number;
+	weight: number;
+}
+interface Row extends Identified {
+	spawns: Spawn[];
+}
+
+const ZONE_OPTS = [
+	{ value: 0, text: 'Verdant Hollow' },
+	{ value: 1, text: 'Frost Cavern' }
+];
+
+const section: TableSectionConfig<Row> = {
+	key: 'spawns',
+	label: 'Spawns',
+	glyph: 'pin',
+	kind: 'table',
+	itemsKey: 'spawns',
+	addLabel: 'Assign zone',
+	emptyIcon: 'pin',
+	emptyTitle: 'Not assigned to any zone',
+	emptySub: 'This enemy will never spawn.',
+	newRow: (rec) => ({ zoneId: rec.spawns.some((s) => s.zoneId === 0) ? 1 : 0, weight: 5 }),
+	columns: [
+		{ key: 'zoneId', label: 'Zone', type: 'select', options: () => ZONE_OPTS, unique: true },
+		{ key: 'weight', label: 'Weight', type: 'number', align: 'r' },
+		{ key: '__share', label: 'Share', type: 'share', weightKey: 'weight' }
+	]
+};
+
+const config = (): EntityConfig<Row> =>
+	({
+		key: 'rows',
+		label: 'Rows',
+		singular: 'Row',
+		glyph: 'box',
+		blankName: 'Unnamed',
+		newItem: (id: number) => ({ id, spawns: [] }),
+		meta: () => [],
+		sections: [section],
+		refresh: async () => [],
+		persist: async () => []
+	}) as unknown as EntityConfig<Row>;
+
+const setup = (spawns: Spawn[]) => {
+	const store = new EntityStore(config(), [{ id: 1, spawns }]);
+	return { store, record: store.items[0], baseline: store.baselineOf(1) };
+};
+
+// SectionTable is entity-agnostic (typed against `Identified`); cast the concrete-Row
+// section/store to that shape at the single render boundary.
+const renderTable = (store: EntityStore<Row>, record: Row | undefined, baseline: Row | undefined) =>
+	render(SectionTable, {
+		props: {
+			section: section as unknown as TableSectionConfig<Identified>,
+			record: record as Identified,
+			baseline,
+			store: store as unknown as EntityStore<Identified>
+		}
+	});
+
+afterEach(cleanup);
+
+describe('SectionTable', () => {
+	it('renders the empty state with an add control when there are no rows', async () => {
+		const { store, record, baseline } = setup([]);
+		renderTable(store, record, baseline);
+		expect(screen.getByText('Not assigned to any zone')).toBeTruthy();
+		await fireEvent.click(screen.getByText('Assign zone'));
+		expect(store.items[0].spawns).toHaveLength(1);
+	});
+
+	it('renders a row per entry with its cells', () => {
+		const { store, record, baseline } = setup([{ zoneId: 0, weight: 5 }]);
+		const { container } = renderTable(store, record, baseline);
+		expect(container.querySelectorAll('tbody tr')).toHaveLength(1);
+		expect((container.querySelector('select.sel') as HTMLSelectElement).value).toBe('0');
+		// The share column renders a percentage cell.
+		expect(container.querySelector('.share-pct')?.textContent).toContain('%');
+	});
+
+	it('appends a row via the Add button', async () => {
+		const { store, record, baseline } = setup([{ zoneId: 0, weight: 5 }]);
+		renderTable(store, record, baseline);
+		await fireEvent.click(screen.getByText('Assign zone'));
+		expect(store.items[0].spawns).toHaveLength(2);
+	});
+
+	it('removes a row via its remove control', async () => {
+		const { store, record, baseline } = setup([
+			{ zoneId: 0, weight: 5 },
+			{ zoneId: 1, weight: 3 }
+		]);
+		const { container } = renderTable(store, record, baseline);
+		await fireEvent.click(container.querySelector('.row-x') as HTMLElement);
+		expect(store.items[0].spawns).toEqual([{ zoneId: 1, weight: 3 }]);
+	});
+
+	it('edits a cell value through the number input', async () => {
+		const { store, record, baseline } = setup([{ zoneId: 0, weight: 5 }]);
+		const { container } = renderTable(store, record, baseline);
+		const weightInput = container.querySelector('input.num') as HTMLInputElement;
+		await fireEvent.input(weightInput, { target: { value: '12' } });
+		expect(store.items[0].spawns[0].weight).toBe(12);
+	});
+
+	it('disables Add once every unique option is assigned', () => {
+		const { store, record, baseline } = setup([
+			{ zoneId: 0, weight: 5 },
+			{ zoneId: 1, weight: 3 }
+		]);
+		renderTable(store, record, baseline);
+		expect((screen.getByText('Assign zone').closest('button') as HTMLButtonElement).disabled).toBe(true);
+	});
+
+	it('marks a newly added row with the added edge', () => {
+		const store = new EntityStore(config(), [{ id: 1, spawns: [{ zoneId: 0, weight: 5 }] }]);
+		store.patch(1, (d) => d.spawns.push({ zoneId: 1, weight: 2 }));
+		const { container } = renderTable(store, store.items[0], store.baselineOf(1));
+		const edges = container.querySelectorAll('.row-edge');
+		expect((edges[1] as HTMLElement).getAttribute('style')).toContain('var(--change-added)');
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/TagBrowse.test.ts
+++ b/UI/src/tests/routes/admin/workbench/TagBrowse.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+
+interface Tag {
+	id: number;
+	name: string;
+	tagCategoryId: number;
+}
+
+const { mockReference } = vi.hoisted(() => ({
+	mockReference: {
+		tags: [] as Tag[],
+		tagCategories: [] as { id: number; name: string }[],
+		tagColor: vi.fn(() => ({ fg: '#aaa', bd: '#888', bg: '#222' })),
+		tagsByCategory: vi.fn<(catId: number) => Tag[]>()
+	}
+}));
+vi.mock('$routes/admin/workbench/reference.svelte', () => ({ reference: mockReference }));
+
+import TagBrowse from '$routes/admin/workbench/components/TagBrowse.svelte';
+
+const TAGS: Tag[] = [
+	{ id: 1, name: 'Fire', tagCategoryId: 10 },
+	{ id: 2, name: 'Ice', tagCategoryId: 10 },
+	{ id: 3, name: 'Holy', tagCategoryId: 20 }
+];
+
+beforeEach(() => {
+	mockReference.tags = TAGS;
+	mockReference.tagCategories = [
+		{ id: 10, name: 'Element' },
+		{ id: 20, name: 'School' }
+	];
+	mockReference.tagColor.mockClear();
+	mockReference.tagsByCategory.mockImplementation((catId: number) => TAGS.filter((t) => t.tagCategoryId === catId));
+});
+
+afterEach(cleanup);
+
+describe('TagBrowse', () => {
+	it('lists every category with its total count', () => {
+		render(TagBrowse, { props: { ids: [], onToggle: vi.fn() } });
+		expect(screen.getByText('Element')).toBeTruthy();
+		expect(screen.getByText('School')).toBeTruthy();
+	});
+
+	it('shows the first category tags by default', () => {
+		render(TagBrowse, { props: { ids: [], onToggle: vi.fn() } });
+		expect(screen.getByText('Fire')).toBeTruthy();
+		expect(screen.getByText('Ice')).toBeTruthy();
+		// Holy belongs to the unselected School category.
+		expect(screen.queryByText('Holy')).toBeNull();
+	});
+
+	it('switches the shown tags when another category is selected', async () => {
+		render(TagBrowse, { props: { ids: [], onToggle: vi.fn() } });
+		await fireEvent.click(screen.getByText('School'));
+		expect(screen.getByText('Holy')).toBeTruthy();
+		expect(screen.queryByText('Fire')).toBeNull();
+	});
+
+	it('filters across all categories when searching', async () => {
+		const { container } = render(TagBrowse, { props: { ids: [], onToggle: vi.fn() } });
+		const input = container.querySelector('input.inp') as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: 'ho' } });
+		expect(screen.getByText('Holy')).toBeTruthy();
+		expect(screen.queryByText('Fire')).toBeNull();
+	});
+
+	it('shows the applied count for a category that has selected tags', () => {
+		const { container } = render(TagBrowse, { props: { ids: [1], onToggle: vi.fn() } });
+		// Element category has one applied tag (Fire).
+		expect(container.querySelector('.cat-count')?.textContent).toBe('1');
+	});
+
+	it('marks an applied tag as on', () => {
+		const { container } = render(TagBrowse, { props: { ids: [1], onToggle: vi.fn() } });
+		const on = container.querySelector('.tag-toggle.on') as HTMLElement;
+		expect(on.textContent).toContain('Fire');
+	});
+
+	it('calls onToggle with the clicked tag id', async () => {
+		const onToggle = vi.fn();
+		render(TagBrowse, { props: { ids: [], onToggle } });
+		await fireEvent.click(screen.getByText('Ice'));
+		expect(onToggle).toHaveBeenCalledWith(2);
+	});
+
+	it('shows an empty message when a category has no tags', async () => {
+		mockReference.tagsByCategory.mockReturnValue([]);
+		render(TagBrowse, { props: { ids: [], onToggle: vi.fn() } });
+		expect(screen.getByText('No tags here.')).toBeTruthy();
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/TagPill.test.ts
+++ b/UI/src/tests/routes/admin/workbench/TagPill.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+
+const { mockReference } = vi.hoisted(() => ({
+	mockReference: {
+		tagColor: vi.fn(() => ({ fg: '#aaa', bd: '#888', bg: '#222' }))
+	}
+}));
+vi.mock('$routes/admin/workbench/reference.svelte', () => ({ reference: mockReference }));
+
+import TagPill from '$routes/admin/workbench/components/TagPill.svelte';
+
+const tag = { id: 1, name: 'Fire', tagCategoryId: 10 };
+
+afterEach(cleanup);
+
+describe('TagPill', () => {
+	it('renders the tag name', () => {
+		render(TagPill, { props: { tag } });
+		expect(screen.getByText('Fire')).toBeTruthy();
+	});
+
+	it('omits the remove control when no onRemove is given', () => {
+		const { container } = render(TagPill, { props: { tag } });
+		expect(container.querySelector('.x')).toBeNull();
+	});
+
+	it('calls onRemove when the remove control is clicked', async () => {
+		const onRemove = vi.fn();
+		const { container } = render(TagPill, { props: { tag, onRemove } });
+		await fireEvent.click(container.querySelector('.x') as HTMLElement);
+		expect(onRemove).toHaveBeenCalledOnce();
+	});
+
+	it('adds the new-pill inset ring only when isNew is set', () => {
+		const { container, rerender } = render(TagPill, { props: { tag, isNew: true } });
+		expect((container.querySelector('.tag-pill') as HTMLElement).getAttribute('style')).toContain('inset');
+
+		rerender({ tag, isNew: false });
+		expect((container.querySelector('.tag-pill') as HTMLElement).getAttribute('style')).toContain('none');
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/TagsSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/TagsSection.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+
+interface Tag {
+	id: number;
+	name: string;
+	tagCategoryId: number;
+}
+
+const { mockReference } = vi.hoisted(() => ({
+	mockReference: {
+		tags: [] as Tag[],
+		tagCategories: [] as { id: number; name: string }[],
+		tagColor: vi.fn(() => ({ fg: '#aaa', bd: '#888', bg: '#222' })),
+		tagsByCategory: vi.fn<(catId: number) => Tag[]>(),
+		tagById: vi.fn<(id: number) => Tag | undefined>()
+	}
+}));
+vi.mock('$routes/admin/workbench/reference.svelte', () => ({ reference: mockReference }));
+vi.mock('$stores', () => ({ toastError: vi.fn() }));
+
+import TagsSection from '$routes/admin/workbench/components/TagsSection.svelte';
+import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
+import type { EntityConfig, Identified, TagsSectionConfig } from '$routes/admin/workbench/entities/types';
+
+interface Row extends Identified {
+	tags: number[];
+}
+
+const TAGS: Tag[] = [
+	{ id: 1, name: 'Fire', tagCategoryId: 10 },
+	{ id: 2, name: 'Ice', tagCategoryId: 10 }
+];
+
+const section: TagsSectionConfig<Row> = {
+	key: 'tags',
+	label: 'Tags',
+	glyph: 'tag',
+	kind: 'tags',
+	itemsKey: 'tags'
+};
+
+const config = (): EntityConfig<Row> =>
+	({
+		key: 'rows',
+		label: 'Rows',
+		singular: 'Row',
+		glyph: 'box',
+		blankName: 'Unnamed',
+		newItem: (id: number) => ({ id, tags: [] }),
+		meta: () => [],
+		sections: [section],
+		refresh: async () => [],
+		persist: async () => []
+	}) as unknown as EntityConfig<Row>;
+
+const setup = (tags: number[]) => {
+	const store = new EntityStore(config(), [{ id: 1, tags }]);
+	return { store, record: store.items[0], baseline: store.baselineOf(1) };
+};
+
+// TagsSection is entity-agnostic (typed against `Identified`); cast the concrete-Row
+// section/store to that shape at the single render boundary.
+const renderTags = (store: EntityStore<Row>, record: Row | undefined, baseline: Row | undefined) =>
+	render(TagsSection, {
+		props: {
+			section: section as unknown as TagsSectionConfig<Identified>,
+			record: record as Identified,
+			baseline,
+			store: store as unknown as EntityStore<Identified>
+		}
+	});
+
+beforeEach(() => {
+	mockReference.tags = TAGS;
+	mockReference.tagCategories = [{ id: 10, name: 'Element' }];
+	mockReference.tagColor.mockClear();
+	mockReference.tagsByCategory.mockImplementation((catId: number) => TAGS.filter((t) => t.tagCategoryId === catId));
+	mockReference.tagById.mockImplementation((id: number) => TAGS.find((t) => t.id === id));
+});
+
+afterEach(cleanup);
+
+describe('TagsSection', () => {
+	it('shows the applied count and a pill per applied tag', () => {
+		const { store, record, baseline } = setup([1]);
+		const { container } = renderTags(store, record, baseline);
+		expect(screen.getByText('Applied · 1')).toBeTruthy();
+		expect(container.querySelectorAll('.tag-pill')).toHaveLength(1);
+	});
+
+	it('shows the empty hint when no tags are applied', () => {
+		const { store, record, baseline } = setup([]);
+		renderTags(store, record, baseline);
+		expect(screen.getByText(/No tags yet/)).toBeTruthy();
+	});
+
+	it('defaults to browse mode and switches to search mode', async () => {
+		const { store, record, baseline } = setup([]);
+		const { container } = renderTags(store, record, baseline);
+		// Browse mode renders the category rail.
+		expect(container.querySelector('.tag-browse')).toBeTruthy();
+		await fireEvent.click(screen.getByText('Search'));
+		// Search mode swaps in the TagSearch input summary; the browse rail is gone.
+		expect(container.querySelector('.tag-browse')).toBeNull();
+	});
+
+	it('adds a tag when toggled on in browse mode', async () => {
+		const { store, record, baseline } = setup([]);
+		renderTags(store, record, baseline);
+		await fireEvent.click(screen.getByText('Fire'));
+		expect(store.items[0].tags).toEqual([1]);
+	});
+
+	it('removes an applied tag via its pill remove control', async () => {
+		const { store, record, baseline } = setup([1]);
+		const { container } = renderTags(store, record, baseline);
+		await fireEvent.click(container.querySelector('.tag-pill .x') as HTMLElement);
+		expect(store.items[0].tags).toEqual([]);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/UsageSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/UsageSection.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/svelte';
+import type { ITag } from '$lib/api';
+
+interface UsageRecord {
+	id: number;
+	name: string;
+	rarityId?: number;
+}
+
+const { mockReference } = vi.hoisted(() => ({
+	mockReference: {
+		tagColor: vi.fn(() => ({ fg: '#aaa', bd: '#888', bg: '#222' })),
+		rarityColor: vi.fn(() => 'var(--rarity-rare)'),
+		tagUsage: vi.fn(() => ({ items: 0, mods: 0, itemList: [], modList: [] }) as ReturnType<typeof mockUsage>)
+	}
+}));
+vi.mock('$routes/admin/workbench/reference.svelte', () => ({ reference: mockReference }));
+
+import UsageSection from '$routes/admin/workbench/components/UsageSection.svelte';
+
+const mockUsage = (items: UsageRecord[], mods: UsageRecord[]) => ({
+	items: items.length,
+	mods: mods.length,
+	itemList: items,
+	modList: mods
+});
+
+const tag: ITag = { id: 5, name: 'Fire', tagCategoryId: 10 } as ITag;
+
+beforeEach(() => {
+	mockReference.tagColor.mockClear();
+	mockReference.rarityColor.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('UsageSection', () => {
+	it('summarises total usage with correct pluralisation (singular)', () => {
+		mockReference.tagUsage.mockReturnValue(mockUsage([{ id: 1, name: 'Helm', rarityId: 3 }], []));
+		const { container } = render(UsageSection, { props: { record: tag } });
+		const text = (container.querySelector('.usage-count') as HTMLElement).textContent ?? '';
+		expect(text).toContain('Applied to');
+		expect(text).toContain('1 record');
+		expect(text).not.toContain('records');
+	});
+
+	it('pluralises the summary for multiple records', () => {
+		mockReference.tagUsage.mockReturnValue(
+			mockUsage(
+				[
+					{ id: 1, name: 'Helm', rarityId: 3 },
+					{ id: 2, name: 'Blade', rarityId: 5 }
+				],
+				[{ id: 3, name: 'Sharp', rarityId: 4 }]
+			)
+		);
+		const { container } = render(UsageSection, { props: { record: tag } });
+		expect((container.querySelector('.usage-count') as HTMLElement).textContent).toContain('3 records');
+	});
+
+	it('lists the items and mods that use the tag', () => {
+		mockReference.tagUsage.mockReturnValue(
+			mockUsage([{ id: 1, name: 'Helm', rarityId: 3 }], [{ id: 3, name: 'Sharp', rarityId: 4 }])
+		);
+		render(UsageSection, { props: { record: tag } });
+		expect(screen.getByText('Helm')).toBeTruthy();
+		expect(screen.getByText('Sharp')).toBeTruthy();
+	});
+
+	it('shows empty-group messages when nothing uses the tag', () => {
+		mockReference.tagUsage.mockReturnValue(mockUsage([], []));
+		render(UsageSection, { props: { record: tag } });
+		expect(screen.getByText('No items use this tag.')).toBeTruthy();
+		expect(screen.getByText('No mods use this tag.')).toBeTruthy();
+	});
+
+	it('caps the rendered list at 40 and shows a +N overflow chip', () => {
+		const many = Array.from({ length: 45 }, (_, i) => ({ id: i, name: `Item ${i}`, rarityId: 3 }));
+		mockReference.tagUsage.mockReturnValue(mockUsage(many, []));
+		render(UsageSection, { props: { record: tag } });
+		expect(screen.getByText('+5')).toBeTruthy();
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/challenge/ChallengeConditionSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ChallengeConditionSection.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+import { EChallengeType, EEntityType, EStatisticType, type IChallenge } from '$lib/api';
+
+const { mockReference } = vi.hoisted(() => ({
+	mockReference: {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		challengeTypes: [] as any[],
+		entityOptions: vi.fn(() => [
+			{ value: 0, text: 'Cave Bat' },
+			{ value: 1, text: 'Catacomb Lich' }
+		]),
+		entityName: vi.fn(() => 'Cave Bat')
+	}
+}));
+vi.mock('$routes/admin/workbench/reference.svelte', () => ({ reference: mockReference }));
+vi.mock('$stores', () => ({ toastError: vi.fn() }));
+
+import ChallengeConditionSection from '$routes/admin/workbench/components/challenge/ChallengeConditionSection.svelte';
+import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
+import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+
+const CHALLENGE_TYPES = [
+	{
+		id: EChallengeType.EnemiesKilled,
+		name: 'Enemies Killed',
+		goalComparison: 1,
+		statisticType: { id: EStatisticType.EnemiesKilled, entityType: EEntityType.Enemy, bossOnly: false }
+	},
+	{ id: EChallengeType.LevelReached, name: 'Level Reached', goalComparison: 1, statisticType: null }
+];
+
+const config = (): EntityConfig<Identified> =>
+	({
+		key: 'challenges',
+		label: 'Challenges',
+		singular: 'Challenge',
+		glyph: 'box',
+		blankName: 'Unnamed',
+		newItem: (id: number) => ({ id }),
+		meta: () => [],
+		sections: [],
+		refresh: async () => [],
+		persist: async () => []
+	}) as unknown as EntityConfig<Identified>;
+
+const setup = (over: Partial<IChallenge> = {}) => {
+	const challenge: IChallenge = {
+		id: 1,
+		name: 'Test',
+		description: '',
+		challengeTypeId: EChallengeType.EnemiesKilled,
+		statisticType: EStatisticType.EnemiesKilled,
+		entityType: EEntityType.Enemy,
+		targetEntityId: 0,
+		progressGoal: 10,
+		...over
+	} as IChallenge;
+	const store = new EntityStore(config(), [challenge as unknown as Identified]);
+	const record = store.items[0];
+	return { store, record, baseline: store.baselineOf(1) };
+};
+
+beforeEach(() => {
+	mockReference.challengeTypes = CHALLENGE_TYPES;
+	mockReference.entityOptions.mockClear();
+	mockReference.entityName.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('ChallengeConditionSection', () => {
+	it('renders the objective-type select with an option per challenge type', () => {
+		const { store, record, baseline } = setup();
+		const { container } = render(ChallengeConditionSection, { props: { record, baseline, store } });
+		const select = container.querySelector('.type-select select') as HTMLSelectElement;
+		expect(select.querySelectorAll('option')).toHaveLength(2);
+		expect(select.value).toBe(String(EChallengeType.EnemiesKilled));
+	});
+
+	it('renders the plain-language objective preview', () => {
+		const { store, record, baseline } = setup();
+		render(ChallengeConditionSection, { props: { record, baseline, store } });
+		expect(screen.getByText('Players see')).toBeTruthy();
+	});
+
+	it('re-derives the tracked statistic and entity when the type changes', async () => {
+		const { store, record, baseline } = setup();
+		const { container } = render(ChallengeConditionSection, { props: { record, baseline, store } });
+		const select = container.querySelector('.type-select select') as HTMLSelectElement;
+		await fireEvent.change(select, { target: { value: String(EChallengeType.LevelReached) } });
+		const updated = store.items[0] as unknown as IChallenge;
+		expect(updated.challengeTypeId).toBe(EChallengeType.LevelReached);
+		// Level Reached has no statistic → entity dimension collapses to None and the target clears.
+		expect(updated.statisticType).toBeUndefined();
+		expect(updated.entityType).toBe(EEntityType.None);
+		expect(updated.targetEntityId).toBeUndefined();
+	});
+
+	it('flags the type select dirty against a differing baseline', () => {
+		const { store } = setup();
+		store.patch(1, (d) => ((d as unknown as IChallenge).challengeTypeId = EChallengeType.LevelReached));
+		const { container } = render(ChallengeConditionSection, {
+			props: { record: store.items[0], baseline: store.baselineOf(1), store }
+		});
+		expect(container.querySelector('.type-select .dirty-dot')).toBeTruthy();
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+import { ERarity, type IChallenge } from '$lib/api';
+
+const ITEMS = [
+	{ id: 0, name: 'Iron Helm', rarityId: ERarity.Common },
+	{ id: 1, name: 'Dragon Blade', rarityId: ERarity.Legendary }
+];
+const MODS = [{ id: 0, name: 'Sharp', itemModTypeId: 2 }];
+const SKILLS = [{ id: 0, name: 'Cleave', baseDamage: 12 }];
+
+const { mockReference } = vi.hoisted(() => ({
+	mockReference: {
+		itemRecords: vi.fn(() => ITEMS),
+		itemModRecords: vi.fn(() => MODS),
+		skillRecords: vi.fn(() => SKILLS),
+		itemRecName: vi.fn((id: number) => ITEMS.find((i) => i.id === id)?.name),
+		itemRarityId: vi.fn((id: number) => ITEMS.find((i) => i.id === id)?.rarityId),
+		rarityName: vi.fn(() => 'Legendary'),
+		rarityColor: vi.fn(() => 'var(--rarity-legendary)'),
+		itemModName: vi.fn((id: number) => MODS.find((m) => m.id === id)?.name),
+		itemModTypeName: vi.fn(() => 'Prefix'),
+		modTypeName: vi.fn(() => 'Prefix'),
+		skillName: vi.fn((id: number) => SKILLS.find((s) => s.id === id)?.name),
+		skillBaseDamage: vi.fn((id: number) => SKILLS.find((s) => s.id === id)?.baseDamage)
+	}
+}));
+vi.mock('$routes/admin/workbench/reference.svelte', () => ({ reference: mockReference }));
+vi.mock('$stores', () => ({ toastError: vi.fn() }));
+
+import ChallengeRewardSection from '$routes/admin/workbench/components/challenge/ChallengeRewardSection.svelte';
+import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
+import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+
+const config = (): EntityConfig<Identified> =>
+	({
+		key: 'challenges',
+		label: 'Challenges',
+		singular: 'Challenge',
+		glyph: 'box',
+		blankName: 'Unnamed',
+		newItem: (id: number) => ({ id }),
+		meta: () => [],
+		sections: [],
+		refresh: async () => [],
+		persist: async () => []
+	}) as unknown as EntityConfig<Identified>;
+
+const setup = (over: Partial<IChallenge> = {}) => {
+	const challenge: IChallenge = {
+		id: 1,
+		name: 'Test',
+		description: '',
+		challengeTypeId: 1,
+		entityType: 0,
+		progressGoal: 10,
+		...over
+	} as IChallenge;
+	const store = new EntityStore(config(), [challenge as unknown as Identified]);
+	const record = store.items[0];
+	return { store, record, baseline: store.baselineOf(1) };
+};
+
+beforeEach(() => {
+	for (const fn of Object.values(mockReference)) {
+		fn.mockClear();
+	}
+});
+
+afterEach(cleanup);
+
+describe('ChallengeRewardSection', () => {
+	it('renders the three reward slots', () => {
+		const { store, record, baseline } = setup();
+		render(ChallengeRewardSection, { props: { record, baseline, store } });
+		expect(screen.getByText('Item Reward')).toBeTruthy();
+		expect(screen.getByText('Item Mod Reward')).toBeTruthy();
+		expect(screen.getByText('Skill Reward')).toBeTruthy();
+	});
+
+	it('warns when the challenge unlocks nothing', () => {
+		const { store, record, baseline } = setup();
+		render(ChallengeRewardSection, { props: { record, baseline, store } });
+		expect(screen.getByText(/unlocks nothing/)).toBeTruthy();
+	});
+
+	it('shows the assigned item name and drops the empty warning', () => {
+		const { store, record, baseline } = setup({ rewardItemId: 1 });
+		const { container } = render(ChallengeRewardSection, { props: { record, baseline, store } });
+		expect((container.querySelector('.ch-reward-name') as HTMLElement).textContent).toContain('Dragon Blade');
+		expect(screen.queryByText(/unlocks nothing/)).toBeNull();
+	});
+
+	it('opens the item picker and assigns the chosen item', async () => {
+		const { store, record, baseline } = setup();
+		const { container } = render(ChallengeRewardSection, { props: { record, baseline, store } });
+		await fireEvent.click(screen.getByText('Choose item…'));
+		// Picker is open: pick "Iron Helm" (id 0).
+		expect(container.querySelector('.ch-picker')).toBeTruthy();
+		await fireEvent.click(screen.getByText('Iron Helm'));
+		expect((store.items[0] as unknown as IChallenge).rewardItemId).toBe(0);
+		// Picker closes after a pick.
+		expect(container.querySelector('.ch-picker')).toBeNull();
+	});
+
+	it('clears an assigned reward', async () => {
+		const { store, record, baseline } = setup({ rewardItemId: 1 });
+		const { container } = render(ChallengeRewardSection, { props: { record, baseline, store } });
+		await fireEvent.click(container.querySelector('.row-x[title="Clear reward"]') as HTMLElement);
+		expect((store.items[0] as unknown as IChallenge).rewardItemId).toBeUndefined();
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/challenge/GoalField.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/GoalField.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { EChallengeGoalComparison, EChallengeType, EStatisticType, type IChallenge } from '$lib/api';
+
+const { mockReference } = vi.hoisted(() => ({
+	mockReference: {
+		challengeTypes: [] as { id: number; goalComparison?: number }[]
+	}
+}));
+vi.mock('$routes/admin/workbench/reference.svelte', () => ({ reference: mockReference }));
+vi.mock('$stores', () => ({ toastError: vi.fn() }));
+
+import GoalField from '$routes/admin/workbench/components/challenge/GoalField.svelte';
+import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
+import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+
+const config = (): EntityConfig<Identified> =>
+	({
+		key: 'challenges',
+		label: 'Challenges',
+		singular: 'Challenge',
+		glyph: 'box',
+		blankName: 'Unnamed',
+		newItem: (id: number) => ({ id }),
+		meta: () => [],
+		sections: [],
+		refresh: async () => [],
+		persist: async () => []
+	}) as unknown as EntityConfig<Identified>;
+
+const setup = (over: Partial<IChallenge>) => {
+	const challenge: IChallenge = {
+		id: 1,
+		name: 'Test',
+		description: '',
+		challengeTypeId: EChallengeType.EnemiesKilled,
+		progressGoal: 25,
+		...over
+	} as IChallenge;
+	const store = new EntityStore(config(), [challenge as unknown as Identified]);
+	const record = store.items[0] as unknown as IChallenge;
+	return { store, challenge: record, baseline: store.baselineOf(1) as unknown as IChallenge };
+};
+
+beforeEach(() => {
+	mockReference.challengeTypes = [];
+});
+
+afterEach(cleanup);
+
+describe('GoalField', () => {
+	it('labels an accumulating count goal with the statistic unit', () => {
+		const { store, challenge, baseline } = setup({ statisticType: EStatisticType.EnemiesKilled });
+		const { container } = render(GoalField, { props: { challenge, baseline, store } });
+		expect((container.querySelector('.lbl') as HTMLElement).textContent).toContain('Goal amount');
+		expect((container.querySelector('.suffix') as HTMLElement).textContent).toBe('kills');
+	});
+
+	it('labels a time goal with an "at most" hint and ms unit', () => {
+		mockReference.challengeTypes = [{ id: EChallengeType.TimeTrial, goalComparison: EChallengeGoalComparison.AtMost }];
+		const { store, challenge, baseline } = setup({
+			challengeTypeId: EChallengeType.TimeTrial,
+			statisticType: EStatisticType.FastestVictory
+		});
+		const { container } = render(GoalField, { props: { challenge, baseline, store } });
+		const label = (container.querySelector('.lbl') as HTMLElement).textContent ?? '';
+		expect(label).toContain('Goal (time)');
+		expect(label).toContain('at most');
+		expect((container.querySelector('.suffix') as HTMLElement).textContent).toBe('ms');
+	});
+
+	it('marks dirty against a differing baseline', () => {
+		const { store, challenge } = setup({ statisticType: EStatisticType.EnemiesKilled });
+		const baseline = { ...challenge, progressGoal: 99 } as IChallenge;
+		const { container } = render(GoalField, { props: { challenge, baseline, store } });
+		expect(container.querySelector('.dirty-dot')).toBeTruthy();
+	});
+
+	it('patches the goal when the number input changes', async () => {
+		const { store, challenge, baseline } = setup({ statisticType: EStatisticType.EnemiesKilled });
+		const { container } = render(GoalField, { props: { challenge, baseline, store } });
+		await fireEvent.input(container.querySelector('input.num') as HTMLInputElement, { target: { value: '40' } });
+		expect((store.items[0] as unknown as IChallenge).progressGoal).toBe(40);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/challenge/RewardPicker.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/RewardPicker.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+import type { IChallenge } from '$lib/api';
+
+import RewardPicker, { type PickerRecord } from '$routes/admin/workbench/components/challenge/RewardPicker.svelte';
+
+const RECORDS: PickerRecord[] = [
+	{ id: 1, name: 'Iron Helm', color: 'var(--rarity-common)', tag: 'Common' },
+	{ id: 2, name: 'Dragon Blade', color: 'var(--rarity-legendary)', tag: 'Legendary' },
+	{ id: 3, name: 'Leather Boots', color: 'var(--rarity-common)', tag: 'Common' }
+];
+
+const claimedBy = (id: number, name: string): Map<number, IChallenge> =>
+	new Map([[id, { id: 99, name } as IChallenge]]);
+
+afterEach(cleanup);
+
+describe('RewardPicker', () => {
+	it('renders a row per record', () => {
+		const { container } = render(RewardPicker, {
+			props: {
+				kind: 'item',
+				records: RECORDS,
+				currentId: undefined,
+				claimed: new Map(),
+				onPick: vi.fn(),
+				onClose: vi.fn()
+			}
+		});
+		expect(container.querySelectorAll('.ch-picker-row')).toHaveLength(3);
+	});
+
+	it('reports the unclaimed-of-total count', () => {
+		render(RewardPicker, {
+			props: {
+				kind: 'item',
+				records: RECORDS,
+				currentId: undefined,
+				claimed: claimedBy(2, 'Boss Slayer'),
+				onPick: vi.fn(),
+				onClose: vi.fn()
+			}
+		});
+		expect(screen.getByText('2 of 3 unclaimed')).toBeTruthy();
+	});
+
+	it('filters records by the search query', async () => {
+		const { container } = render(RewardPicker, {
+			props: {
+				kind: 'item',
+				records: RECORDS,
+				currentId: undefined,
+				claimed: new Map(),
+				onPick: vi.fn(),
+				onClose: vi.fn()
+			}
+		});
+		await fireEvent.input(container.querySelector('input.inp') as HTMLInputElement, { target: { value: 'blade' } });
+		expect(container.querySelectorAll('.ch-picker-row')).toHaveLength(1);
+		expect(screen.getByText('Dragon Blade')).toBeTruthy();
+	});
+
+	it('shows "No matches." when the query matches nothing', async () => {
+		const { container } = render(RewardPicker, {
+			props: {
+				kind: 'item',
+				records: RECORDS,
+				currentId: undefined,
+				claimed: new Map(),
+				onPick: vi.fn(),
+				onClose: vi.fn()
+			}
+		});
+		await fireEvent.input(container.querySelector('input.inp') as HTMLInputElement, { target: { value: 'zzz' } });
+		expect(screen.getByText('No matches.')).toBeTruthy();
+	});
+
+	it('disables a claimed record and surfaces the owning challenge', () => {
+		const { container } = render(RewardPicker, {
+			props: {
+				kind: 'item',
+				records: RECORDS,
+				currentId: undefined,
+				claimed: claimedBy(2, 'Boss Slayer'),
+				onPick: vi.fn(),
+				onClose: vi.fn()
+			}
+		});
+		const claimedRow = container.querySelector('.ch-picker-row.claimed') as HTMLButtonElement;
+		expect(claimedRow.disabled).toBe(true);
+		expect(claimedRow.textContent).toContain('Boss Slayer');
+	});
+
+	it('does not pick a claimed record', async () => {
+		const onPick = vi.fn();
+		render(RewardPicker, {
+			props: {
+				kind: 'item',
+				records: RECORDS,
+				currentId: undefined,
+				claimed: claimedBy(2, 'Boss Slayer'),
+				onPick,
+				onClose: vi.fn()
+			}
+		});
+		await fireEvent.click(screen.getByText('Dragon Blade'));
+		expect(onPick).not.toHaveBeenCalled();
+	});
+
+	it('marks the current selection', () => {
+		render(RewardPicker, {
+			props: { kind: 'item', records: RECORDS, currentId: 1, claimed: new Map(), onPick: vi.fn(), onClose: vi.fn() }
+		});
+		expect(screen.getByText('selected')).toBeTruthy();
+	});
+
+	it('picks an unclaimed record on click', async () => {
+		const onPick = vi.fn();
+		render(RewardPicker, {
+			props: { kind: 'item', records: RECORDS, currentId: undefined, claimed: new Map(), onPick, onClose: vi.fn() }
+		});
+		await fireEvent.click(screen.getByText('Iron Helm'));
+		expect(onPick).toHaveBeenCalledWith(1);
+	});
+
+	it('closes via the close control', async () => {
+		const onClose = vi.fn();
+		const { container } = render(RewardPicker, {
+			props: { kind: 'item', records: RECORDS, currentId: undefined, claimed: new Map(), onPick: vi.fn(), onClose }
+		});
+		await fireEvent.click(container.querySelector('.row-x') as HTMLElement);
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/challenge/ScopeField.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ScopeField.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+import { EChallengeType, EEntityType, type IChallenge } from '$lib/api';
+
+const { mockReference } = vi.hoisted(() => ({
+	mockReference: {
+		challengeTypes: [] as { id: number; statisticType?: { bossOnly?: boolean } }[],
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		entityOptions: vi.fn((entityType: number, bossOnly = false) => [
+			{ value: 0, text: 'Cave Bat' },
+			{ value: 1, text: 'Catacomb Lich' }
+		])
+	}
+}));
+vi.mock('$routes/admin/workbench/reference.svelte', () => ({ reference: mockReference }));
+vi.mock('$stores', () => ({ toastError: vi.fn() }));
+
+import ScopeField from '$routes/admin/workbench/components/challenge/ScopeField.svelte';
+import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
+import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+
+const config = (): EntityConfig<Identified> =>
+	({
+		key: 'challenges',
+		label: 'Challenges',
+		singular: 'Challenge',
+		glyph: 'box',
+		blankName: 'Unnamed',
+		newItem: (id: number) => ({ id }),
+		meta: () => [],
+		sections: [],
+		refresh: async () => [],
+		persist: async () => []
+	}) as unknown as EntityConfig<Identified>;
+
+const setup = (over: Partial<IChallenge>) => {
+	const challenge: IChallenge = {
+		id: 1,
+		name: 'Test',
+		description: '',
+		challengeTypeId: EChallengeType.EnemiesKilled,
+		entityType: EEntityType.Enemy,
+		progressGoal: 10,
+		...over
+	} as IChallenge;
+	const store = new EntityStore(config(), [challenge as unknown as Identified]);
+	const record = store.items[0] as unknown as IChallenge;
+	return { store, challenge: record, baseline: store.baselineOf(1) as unknown as IChallenge };
+};
+
+beforeEach(() => {
+	mockReference.challengeTypes = [];
+	mockReference.entityOptions.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('ScopeField — global / stat-less statistic', () => {
+	it('collapses to a "tracked globally" read-out when the type has no entity dimension', () => {
+		const { store, challenge, baseline } = setup({ entityType: EEntityType.None });
+		render(ScopeField, { props: { challenge, baseline, store } });
+		expect(screen.getByText(/Tracked globally/)).toBeTruthy();
+	});
+
+	it('reads "tracked from player level" for Level Reached', () => {
+		const { store, challenge, baseline } = setup({
+			entityType: EEntityType.None,
+			challengeTypeId: EChallengeType.LevelReached
+		});
+		render(ScopeField, { props: { challenge, baseline, store } });
+		expect(screen.getByText(/Tracked from player level/)).toBeTruthy();
+	});
+});
+
+describe('ScopeField — entity-scoped statistic', () => {
+	it('defaults to Global with no target select', () => {
+		const { store, challenge, baseline } = setup({ entityType: EEntityType.Enemy, targetEntityId: undefined });
+		const { container } = render(ScopeField, { props: { challenge, baseline, store } });
+		const [global, specific] = Array.from(container.querySelectorAll('.eswitch button'));
+		expect(global.classList.contains('active')).toBe(true);
+		expect(specific.classList.contains('active')).toBe(false);
+		expect(container.querySelector('.scope-select')).toBeNull();
+	});
+
+	it('shows the target select when a specific entity is chosen', () => {
+		const { store, challenge, baseline } = setup({ entityType: EEntityType.Enemy, targetEntityId: 1 });
+		const { container } = render(ScopeField, { props: { challenge, baseline, store } });
+		expect(screen.getByText('Scope · Enemy')).toBeTruthy();
+		const select = container.querySelector('.scope-select select') as HTMLSelectElement;
+		expect(select.value).toBe('1');
+	});
+
+	it('switching to Specific sets the target to the first option', async () => {
+		const { store, challenge, baseline } = setup({ entityType: EEntityType.Enemy, targetEntityId: undefined });
+		render(ScopeField, { props: { challenge, baseline, store } });
+		await fireEvent.click(screen.getByText('Specific'));
+		expect((store.items[0] as unknown as IChallenge).targetEntityId).toBe(0);
+	});
+
+	it('switching to Global clears the target', async () => {
+		const { store, challenge, baseline } = setup({ entityType: EEntityType.Enemy, targetEntityId: 1 });
+		render(ScopeField, { props: { challenge, baseline, store } });
+		await fireEvent.click(screen.getByText('Global'));
+		expect((store.items[0] as unknown as IChallenge).targetEntityId).toBeUndefined();
+	});
+
+	it('changing the select patches the target id', async () => {
+		const { store, challenge, baseline } = setup({ entityType: EEntityType.Enemy, targetEntityId: 0 });
+		const { container } = render(ScopeField, { props: { challenge, baseline, store } });
+		await fireEvent.change(container.querySelector('.scope-select select') as HTMLSelectElement, {
+			target: { value: '1' }
+		});
+		expect((store.items[0] as unknown as IChallenge).targetEntityId).toBe(1);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/entities/enemy.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/enemy.test.ts
@@ -67,6 +67,37 @@ describe('enemyEntity', () => {
 		expect(enemyEntity.listBadge?.(baseline)).toBeNull();
 	});
 
+	it('surfaces the attribute, skill and zone counts in the list meta', () => {
+		expect(enemyEntity.meta(baseline)).toEqual([
+			['attr', 1],
+			['skill', 1],
+			['zone', 1]
+		]);
+	});
+
+	it('colours the list badge with the enemy accent', () => {
+		expect(enemyEntity.badgeColor?.(baseline)).toBe('var(--enemy-accent)');
+	});
+
+	it('persist saves the attribute distribution and spawns when they change', async () => {
+		const record: IEnemy = {
+			...baseline,
+			attributeDistribution: [{ attributeId: 0, baseAmount: 2, amountPerLevel: 1 }], // changed
+			spawns: [{ zoneId: 0, weight: 9 }] // changed
+		};
+		socket.enemies = [record];
+
+		await enemyEntity.persist({ added: [], modified: [{ record, baseline }], deleted: [], existingIds: [0] });
+
+		expect(postBodyTo('AdminTools/SetEnemyAttributeDistributions')).toEqual({
+			enemyId: 0,
+			attributeDistributions: [{ attributeId: 0, baseAmount: 2, amountPerLevel: 1 }]
+		});
+		expect(postBodyTo('AdminTools/SetEnemySpawns')).toEqual({ enemyId: 0, spawns: [{ zoneId: 0, weight: 9 }] });
+		// The skill pool was untouched, so its endpoint is skipped.
+		expect(postBodyTo('AdminTools/SetEnemySkills')).toBeUndefined();
+	});
+
 	it('persist strips the child collections off the identity DTO and saves only the changed child', async () => {
 		const record: IEnemy = { ...baseline, name: 'Cave Bat', skillPool: [1, 2] }; // identity + skills changed
 		socket.enemies = [record];

--- a/UI/src/tests/routes/admin/workbench/entities/helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/helpers.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { firstFree } from '$routes/admin/workbench/entities/helpers';
+import type { SelectOption } from '$routes/admin/workbench/entities/types';
+
+const opts: SelectOption[] = [
+	{ value: 0, text: 'Strength' },
+	{ value: 1, text: 'Agility' },
+	{ value: 2, text: 'Luck' }
+];
+
+describe('firstFree', () => {
+	it('returns the first option not already taken', () => {
+		expect(firstFree([0], opts)).toBe(1);
+		expect(firstFree([0, 1], opts)).toBe(2);
+	});
+
+	it('returns the first option when nothing is taken', () => {
+		expect(firstFree([], opts)).toBe(0);
+	});
+
+	it('falls back to the first option when every option is taken', () => {
+		expect(firstFree([0, 1, 2], opts)).toBe(0);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/entities/item-mod.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/item-mod.test.ts
@@ -68,6 +68,27 @@ describe('itemModEntity', () => {
 		]);
 	});
 
+	it('persist saves the tag set when tags change without re-sending an identity Edit', async () => {
+		const baseline: IItemMod = {
+			id: 0,
+			name: 'Sharp',
+			description: 'desc',
+			itemModTypeId: EItemModType.Prefix,
+			rarityId: ERarity.Rare,
+			attributes: [{ attributeId: 0, amount: 1 }],
+			tags: [1]
+		};
+		const record: IItemMod = { ...baseline, tags: [1, 2] }; // only the tag set changed
+		socket.itemMods = [record];
+
+		await itemModEntity.persist({ added: [], modified: [{ record, baseline }], deleted: [], existingIds: [0] });
+
+		// Identity + attributes are unchanged → only the tag endpoint is hit.
+		expect(postBodyTo('AdminTools/AddEditItemMods')).toBeUndefined();
+		expect(postBodyTo('AdminTools/AddEditItemModAttributes')).toBeUndefined();
+		expect(postBodyTo('AdminTools/SetTagsForItemMod')).toEqual({ id: 0, tagIds: [1, 2] });
+	});
+
 	it('persist diffs attribute changes without sending an identity Edit when identity is unchanged', async () => {
 		const baseline: IItemMod = {
 			id: 0,

--- a/UI/src/tests/routes/admin/workbench/reference.test.ts
+++ b/UI/src/tests/routes/admin/workbench/reference.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { EEntityType } from '$lib/api';
+import { EChallengeGoalComparison, EEntityType, EItemCategory, EItemModType, ERarity } from '$lib/api';
 
 // WorkbenchReference reads its catalogues from the in-memory staticData store, so
-// it is mocked here (mirrors statistics-view.test.ts).
+// it is mocked here (mirrors statistics-view.test.ts). The tags/categories/challenge-types
+// it owns are set directly on the singleton's reactive fields.
 const { staticData } = vi.hoisted(() => ({
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	staticData: {} as any
@@ -13,13 +14,130 @@ import { reference } from '$routes/admin/workbench/reference.svelte';
 
 beforeEach(() => {
 	staticData.enemies = [
-		{ id: 0, name: 'Cave Bat', isBoss: false },
-		{ id: 1, name: 'Catacomb Lich', isBoss: true },
-		{ id: 2, name: 'Goblin', isBoss: false },
-		{ id: 3, name: 'Ancient Wyrm', isBoss: true }
+		{ id: 0, name: 'Cave Bat', isBoss: false, spawns: [{ zoneId: 0, weight: 5 }] },
+		{ id: 1, name: 'Catacomb Lich', isBoss: true, spawns: [{ zoneId: 0, weight: 15 }] },
+		{
+			id: 2,
+			name: 'Goblin',
+			isBoss: false,
+			spawns: [
+				{ zoneId: 0, weight: 30 },
+				{ zoneId: 1, weight: 5 }
+			]
+		},
+		{ id: 3, name: 'Ancient Wyrm', isBoss: true, spawns: [] }
 	];
-	staticData.zones = [{ id: 0, name: 'Verdant Hollow' }];
-	staticData.skills = [{ id: 0, name: 'Cleave' }];
+	staticData.zones = [
+		{ id: 0, name: 'Verdant Hollow', levelMin: 1, levelMax: 5 },
+		{ id: 1, name: 'Frost Cavern', levelMin: 6, levelMax: 10 }
+	];
+	staticData.skills = [
+		{ id: 0, name: 'Cleave', baseDamage: 12 },
+		{ id: 1, name: 'Fireball', baseDamage: 25 }
+	];
+	staticData.items = [
+		{ id: 0, name: 'Iron Helm', itemCategoryId: EItemCategory.Helm, rarityId: ERarity.Common, tags: [10, 20] },
+		{ id: 1, name: 'Dragon Blade', itemCategoryId: EItemCategory.Weapon, rarityId: ERarity.Legendary, tags: [10] }
+	];
+	staticData.itemMods = [
+		{ id: 0, name: 'Sharp', itemModTypeId: EItemModType.Prefix, rarityId: ERarity.Rare, tags: [10] },
+		{ id: 1, name: 'of Power', itemModTypeId: EItemModType.Suffix, rarityId: ERarity.Epic, tags: [30] }
+	];
+	staticData.challenges = [
+		{ id: 0, name: 'First Blood' },
+		{ id: 1, name: 'Boss Slayer' }
+	];
+	reference.tags = [
+		{ id: 10, name: 'Fire', tagCategoryId: 100 },
+		{ id: 20, name: 'Metal', tagCategoryId: 100 },
+		{ id: 30, name: 'Holy', tagCategoryId: 200 }
+	];
+	reference.tagCategories = [
+		{ id: 100, name: 'Element' },
+		{ id: 200, name: 'School' }
+	];
+	reference.challengeTypes = [
+		{ id: 1, name: 'Enemies Killed', goalComparison: EChallengeGoalComparison.AtLeast },
+		{ id: 2, name: 'Bosses Defeated', goalComparison: EChallengeGoalComparison.AtLeast }
+	];
+});
+
+describe('enum-backed select options', () => {
+	it('builds attribute options from the EAttribute enum', () => {
+		const opts = reference.attributeOptions();
+		expect(opts.find((o) => o.value === 0)?.text).toBe('Strength');
+		expect(opts.find((o) => o.value === 6)?.text).toBe('Max Health');
+	});
+
+	it('builds item-category, rarity and mod-type options', () => {
+		expect(reference.itemCategoryOptions().find((o) => o.value === EItemCategory.Weapon)?.text).toBe('Weapon');
+		expect(reference.rarityOptions().find((o) => o.value === ERarity.Legendary)?.text).toBe('Legendary');
+		expect(reference.modTypeOptions().find((o) => o.value === EItemModType.Prefix)?.text).toBe('Prefix');
+	});
+});
+
+describe('reference-data-backed select options', () => {
+	it('labels zone options with their level range', () => {
+		expect(reference.zoneOptions()).toEqual([
+			{ value: 0, text: 'Verdant Hollow · L1–5' },
+			{ value: 1, text: 'Frost Cavern · L6–10' }
+		]);
+	});
+
+	it('lists every enemy as an enemy option', () => {
+		expect(reference.enemyOptions().map((o) => o.text)).toEqual([
+			'Cave Bat',
+			'Catacomb Lich',
+			'Goblin',
+			'Ancient Wyrm'
+		]);
+	});
+
+	it('prefixes the boss picker with a None sentinel and lists only bosses', () => {
+		expect(reference.bossEnemyOptions()).toEqual([
+			{ value: -1, text: 'None' },
+			{ value: 1, text: 'Catacomb Lich' },
+			{ value: 3, text: 'Ancient Wyrm' }
+		]);
+	});
+
+	it('prefixes the unlock-gate picker with an always-open sentinel and lists every challenge', () => {
+		expect(reference.unlockChallengeOptions()).toEqual([
+			{ value: -1, text: 'None (always open)' },
+			{ value: 0, text: 'First Blood' },
+			{ value: 1, text: 'Boss Slayer' }
+		]);
+	});
+
+	it('exposes the skill catalogue with base damage', () => {
+		expect(reference.skillCatalogue()).toEqual([
+			{ id: 0, name: 'Cleave', baseDamage: 12 },
+			{ id: 1, name: 'Fireball', baseDamage: 25 }
+		]);
+	});
+
+	it('falls back to empty lists when a catalogue is absent', () => {
+		staticData.zones = undefined;
+		staticData.enemies = undefined;
+		staticData.challenges = undefined;
+		staticData.skills = undefined;
+		expect(reference.zoneOptions()).toEqual([]);
+		expect(reference.enemyOptions()).toEqual([]);
+		expect(reference.bossEnemyOptions()).toEqual([{ value: -1, text: 'None' }]);
+		expect(reference.unlockChallengeOptions()).toEqual([{ value: -1, text: 'None (always open)' }]);
+		expect(reference.skillCatalogue()).toEqual([]);
+	});
+});
+
+describe('challenge-type lookups', () => {
+	it('lists challenge-type options and resolves one by id', () => {
+		expect(reference.challengeTypeOptions()).toEqual([
+			{ value: 1, text: 'Enemies Killed' },
+			{ value: 2, text: 'Bosses Defeated' }
+		]);
+		expect(reference.challengeTypeById(2)?.name).toBe('Bosses Defeated');
+		expect(reference.challengeTypeById(99)).toBeUndefined();
+	});
 });
 
 describe('entityOptions / entityCatalog target-entity picker', () => {
@@ -33,8 +151,12 @@ describe('entityOptions / entityCatalog target-entity picker', () => {
 	});
 
 	it('ignores the boss-only flag for non-enemy dimensions', () => {
-		expect(reference.entityOptions(EEntityType.Zone, true).map((o) => o.value)).toEqual([0]);
-		expect(reference.entityOptions(EEntityType.Skill, true).map((o) => o.value)).toEqual([0]);
+		expect(reference.entityOptions(EEntityType.Zone, true).map((o) => o.value)).toEqual([0, 1]);
+		expect(reference.entityOptions(EEntityType.Skill, true).map((o) => o.value)).toEqual([0, 1]);
+	});
+
+	it('returns an empty catalogue for the None / unknown dimension', () => {
+		expect(reference.entityCatalog(EEntityType.None)).toEqual([]);
 	});
 
 	it('resolves a target name across all enemies regardless of the boss filter', () => {
@@ -42,5 +164,114 @@ describe('entityOptions / entityCatalog target-entity picker', () => {
 		// still renders in the objective sentence.
 		expect(reference.entityName(EEntityType.Enemy, 0)).toBe('Cave Bat');
 		expect(reference.entityName(EEntityType.Enemy, 1)).toBe('Catacomb Lich');
+		expect(reference.entityName(EEntityType.Zone, 1)).toBe('Frost Cavern');
+		expect(reference.entityName(EEntityType.Skill, 0)).toBe('Cleave');
+	});
+
+	it('returns null when the target id or dimension does not resolve', () => {
+		expect(reference.entityName(EEntityType.Enemy, 99)).toBeNull();
+		expect(reference.entityName(EEntityType.None, 0)).toBeNull();
+	});
+});
+
+describe('reward record lookups', () => {
+	it('exposes the raw item / mod / skill record lists', () => {
+		expect(reference.itemRecords()).toHaveLength(2);
+		expect(reference.itemModRecords()).toHaveLength(2);
+		expect(reference.skillRecords()).toHaveLength(2);
+	});
+
+	it('resolves item name, rarity and skill name/damage by id', () => {
+		expect(reference.itemRecName(1)).toBe('Dragon Blade');
+		expect(reference.itemRarityId(1)).toBe(ERarity.Legendary);
+		expect(reference.skillName(1)).toBe('Fireball');
+		expect(reference.skillBaseDamage(1)).toBe(25);
+	});
+
+	it('resolves item-mod name and its type name', () => {
+		expect(reference.itemModName(0)).toBe('Sharp');
+		expect(reference.itemModTypeName(0)).toBe('Prefix');
+		expect(reference.itemModTypeName(1)).toBe('Suffix');
+	});
+
+	it('returns undefined for a mod-type lookup on a missing mod', () => {
+		expect(reference.itemModTypeName(99)).toBeUndefined();
+	});
+});
+
+describe('name and colour lookups', () => {
+	it('names item categories, rarities and mod types', () => {
+		expect(reference.itemCategoryName(EItemCategory.Helm)).toBe('Helm');
+		expect(reference.rarityName(ERarity.Rare)).toBe('Rare');
+		expect(reference.modTypeName(EItemModType.Suffix)).toBe('Suffix');
+	});
+
+	it('maps a rarity id to its themeable colour var', () => {
+		expect(reference.rarityColor(ERarity.Legendary)).toBe('var(--rarity-legendary)');
+	});
+
+	it('returns an empty string for an unknown category or mod type', () => {
+		expect(reference.itemCategoryName(99)).toBe('');
+		expect(reference.modTypeName(99)).toBe('');
+	});
+});
+
+describe('tag lookups and colour', () => {
+	it('resolves a tag by id and lists tags within a category', () => {
+		expect(reference.tagById(20)?.name).toBe('Metal');
+		expect(reference.tagsByCategory(100).map((t) => t.name)).toEqual(['Fire', 'Metal']);
+		expect(reference.tagsByCategory(200).map((t) => t.name)).toEqual(['Holy']);
+	});
+
+	it('builds the category option list from the loaded categories', () => {
+		expect(reference.tagCategoryOptions()).toEqual([
+			{ value: 100, text: 'Element' },
+			{ value: 200, text: 'School' }
+		]);
+	});
+
+	it('derives a deterministic low-chroma colour per category', () => {
+		const a = reference.tagColor(100);
+		const b = reference.tagColor(100);
+		expect(a).toEqual(b); // deterministic
+		expect(a.fg).toMatch(/^oklch\(/);
+		expect(a.bd).toContain('/ 0.45');
+		expect(a.bg).toContain('/ 0.12');
+		// Different categories yield different hues.
+		expect(reference.tagColor(200).fg).not.toBe(a.fg);
+	});
+});
+
+describe('tagUsage', () => {
+	it('counts and lists the items and mods that reference a tag', () => {
+		const fire = reference.tagUsage(10);
+		expect(fire.items).toBe(2);
+		expect(fire.mods).toBe(1);
+		expect(fire.itemList.map((i) => i.name)).toEqual(['Iron Helm', 'Dragon Blade']);
+		expect(fire.modList.map((m) => m.name)).toEqual(['Sharp']);
+	});
+
+	it('reports zero usage for an unreferenced tag', () => {
+		const usage = reference.tagUsage(999);
+		expect(usage).toEqual({ items: 0, mods: 0, itemList: [], modList: [] });
+	});
+});
+
+describe('enemySpawnShareTotal', () => {
+	it('sums this row plus every OTHER enemy competing in the same zone', () => {
+		// Zone 0: Goblin's own weight (30) + Cave Bat (5) + Catacomb Lich (15) = 50.
+		const total = reference.enemySpawnShareTotal({ zoneId: 0, weight: 30 }, [], { id: 2 });
+		expect(total).toBe(50);
+	});
+
+	it('excludes the row owner so its own weight is not double-counted', () => {
+		// Zone 1: only Goblin (id 2) spawns; competing against itself contributes nothing extra.
+		const total = reference.enemySpawnShareTotal({ zoneId: 1, weight: 5 }, [], { id: 2 });
+		expect(total).toBe(5);
+	});
+
+	it('never returns 0 so a share denominator stays safe', () => {
+		const total = reference.enemySpawnShareTotal({ zoneId: 99, weight: 0 }, [], { id: 2 });
+		expect(total).toBe(1);
 	});
 });

--- a/UI/src/tests/routes/game/screens/challenges/ProgressReadout.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/ProgressReadout.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/svelte';
+import type { ChallengeVM, ProgressInfo } from '$routes/game/screens/challenges/challenges-view.svelte';
+
+vi.mock('$stores', () => ({ staticData: {} }));
+
+import ProgressReadout from '$routes/game/screens/challenges/ProgressReadout.svelte';
+
+const makeVM = (prog: Partial<ProgressInfo>, over: Partial<ChallengeVM> = {}): ChallengeVM =>
+	({
+		state: 'active',
+		unit: 'kills',
+		typeAccent: 'var(--challenge-enemies-killed)',
+		prog: { atMost: false, percent: 50, value: 5, goal: 10, best: 0, target: 0, hasData: true, ...prog },
+		...over
+	}) as unknown as ChallengeVM;
+
+afterEach(cleanup);
+
+describe('ProgressReadout — accumulating (atLeast) goal', () => {
+	it('shows the count, goal, unit and percent for an in-progress challenge', () => {
+		const { container } = render(ProgressReadout, { props: { c: makeVM({ percent: 50, value: 5, goal: 10 }) } });
+		const text = (container.querySelector('.count') as HTMLElement).textContent ?? '';
+		expect(text).toContain('5');
+		expect(text).toContain('/ 10');
+		expect(text).toContain('kills');
+		expect(screen.getByText('50%')).toBeTruthy();
+	});
+
+	it('omits the percent once the challenge is done', () => {
+		const { container } = render(ProgressReadout, {
+			props: { c: makeVM({ percent: 100, value: 10, goal: 10 }, { state: 'done' }) }
+		});
+		expect(container.querySelector('.pct')).toBeNull();
+		// The done value carries the success accent class.
+		expect(container.querySelector('.count .done')).toBeTruthy();
+	});
+});
+
+describe('ProgressReadout — minimisation (atMost) goal', () => {
+	it('shows the best time and the beat target when a qualifying value exists', () => {
+		const { container } = render(ProgressReadout, {
+			props: { c: makeVM({ atMost: true, percent: 80, best: 90, target: 75, hasData: true }, { unit: 'time' }) }
+		});
+		expect((container.querySelector('.best-value') as HTMLElement).textContent?.trim()).toBe('1:30');
+		expect(screen.getByText('best')).toBeTruthy();
+		expect((container.querySelector('.beat-target') as HTMLElement).textContent).toContain('≤ 1:15');
+	});
+
+	it('reads "no time yet" and hides the best label when no value is recorded', () => {
+		const { container } = render(ProgressReadout, {
+			props: { c: makeVM({ atMost: true, percent: 0, best: 0, target: 75, hasData: false }, { unit: 'time' }) }
+		});
+		expect((container.querySelector('.best-value') as HTMLElement).textContent?.trim()).toBe('no time yet');
+		expect(screen.queryByText('best')).toBeNull();
+	});
+});
+
+describe('ProgressReadout — bar toggle', () => {
+	it('renders the progress bar by default', () => {
+		const { container } = render(ProgressReadout, { props: { c: makeVM({}) } });
+		expect(container.querySelector('.bar-track')).toBeTruthy();
+	});
+
+	it('omits the bar when showBar is false', () => {
+		const { container } = render(ProgressReadout, { props: { c: makeVM({}), showBar: false } });
+		expect(container.querySelector('.bar-track')).toBeNull();
+	});
+});

--- a/UI/src/tests/routes/game/screens/challenges/RewardTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/RewardTooltip.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EAttribute, EItemCategory, EItemModType, ERarity, type IItemMod } from '$lib/api';
+import { BattleAttributes } from '$lib/battle/battle-attributes';
+import type { Item } from '$lib/battle';
+import type { ResolvedReward } from '$routes/game/screens/challenges/challenges-view.svelte';
+
+vi.mock('$stores', () => ({ staticData: {} }));
+
+import RewardTooltip from '$routes/game/screens/challenges/RewardTooltip.svelte';
+
+const previewItem = (): Item =>
+	({
+		id: 1,
+		itemId: 1,
+		name: 'Sunblade',
+		description: 'Bright.',
+		itemCategoryId: EItemCategory.Weapon,
+		rarityId: ERarity.Legendary,
+		iconPath: '',
+		tags: [],
+		modSlots: [{ id: 10, itemId: 1, itemModSlotTypeId: EItemModType.Prefix }],
+		appliedMods: [],
+		equipped: false,
+		favorite: false,
+		totalAttributes: new BattleAttributes([{ attributeId: EAttribute.Strength, amount: 5 }], false)
+	}) as unknown as Item;
+
+const previewMod = (): IItemMod => ({
+	id: 1,
+	name: 'Blazing',
+	description: 'Hot.',
+	itemModTypeId: EItemModType.Prefix,
+	rarityId: ERarity.Epic,
+	attributes: [{ attributeId: EAttribute.Strength, amount: 4 }],
+	tags: []
+});
+
+const itemReward = (revealed: boolean): ResolvedReward =>
+	({
+		kind: 'item',
+		revealed,
+		rarity: ERarity.Legendary,
+		accent: 'var(--rarity-legendary)',
+		glow: 'var(--rarity-legendary-glow)',
+		name: 'Sunblade',
+		sub: 'Legendary · Weapon',
+		item: previewItem()
+	}) as ResolvedReward;
+
+const modReward = (revealed: boolean): ResolvedReward =>
+	({
+		kind: 'mod',
+		revealed,
+		rarity: ERarity.Epic,
+		accent: 'var(--rarity-epic)',
+		glow: 'var(--rarity-epic-glow)',
+		name: 'Blazing',
+		sub: 'Epic · Prefix',
+		mod: previewMod()
+	}) as ResolvedReward;
+
+afterEach(cleanup);
+
+describe('RewardTooltip', () => {
+	it('hides the container and renders nothing when there is no reward', () => {
+		const { container } = render(RewardTooltip, { props: { reward: undefined } });
+		const wrap = container.querySelector('.reward-tooltip') as HTMLElement;
+		expect(wrap.getAttribute('style')).toContain('display: none');
+		expect(container.querySelector('.tt-shell')).toBeNull();
+	});
+
+	it('renders the real item tooltip (with the name) for a revealed item reward', () => {
+		const { container } = render(RewardTooltip, { props: { reward: itemReward(true) } });
+		expect((container.querySelector('.tt-title-name') as HTMLElement).textContent).toBe('Sunblade');
+	});
+
+	it('renders the real mod tooltip for a revealed mod reward', () => {
+		const { container } = render(RewardTooltip, { props: { reward: modReward(true) } });
+		expect((container.querySelector('.tt-title-name') as HTMLElement).textContent).toBe('Blazing');
+	});
+
+	it('renders the sealed item teaser (masked name) for an unrevealed item reward', () => {
+		const { container } = render(RewardTooltip, { props: { reward: itemReward(false) } });
+		const name = container.querySelector('.tt-title-name') as HTMLElement;
+		expect(name.textContent).toBe('?????????');
+		expect(container.querySelector('.sealed-slot')).toBeTruthy();
+	});
+
+	it('renders the sealed mod teaser for an unrevealed mod reward', () => {
+		const { container } = render(RewardTooltip, { props: { reward: modReward(false) } });
+		expect((container.querySelector('.tt-title-name') as HTMLElement).textContent).toBe('?????????');
+		expect(container.querySelector('.tt-qmark')).toBeTruthy();
+	});
+});

--- a/UI/src/tests/routes/game/screens/challenges/SealedTooltips.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/SealedTooltips.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EAttribute, EItemCategory, EItemModType, ERarity, type IItemMod } from '$lib/api';
+import { BattleAttributes } from '$lib/battle/battle-attributes';
+import type { Item } from '$lib/battle';
+import SealedItemTooltip from '$routes/game/screens/challenges/SealedItemTooltip.svelte';
+import SealedModTooltip from '$routes/game/screens/challenges/SealedModTooltip.svelte';
+import SealedHeader from '$routes/game/screens/challenges/SealedHeader.svelte';
+
+const makeItem = (over: Partial<Item> = {}): Item =>
+	({
+		id: 1,
+		itemId: 1,
+		name: 'Mystery Helm',
+		description: 'Hidden.',
+		itemCategoryId: EItemCategory.Helm,
+		rarityId: ERarity.Epic,
+		iconPath: '',
+		tags: [],
+		modSlots: [
+			{ id: 10, itemId: 1, itemModSlotTypeId: EItemModType.Prefix },
+			{ id: 11, itemId: 1, itemModSlotTypeId: EItemModType.Suffix }
+		],
+		appliedMods: [],
+		equipped: false,
+		favorite: false,
+		totalAttributes: new BattleAttributes(
+			[
+				{ attributeId: EAttribute.Strength, amount: 5 },
+				{ attributeId: EAttribute.Agility, amount: 2 }
+			],
+			false
+		),
+		...over
+	}) as unknown as Item;
+
+const makeMod = (over: Partial<IItemMod> = {}): IItemMod => ({
+	id: 1,
+	name: 'Hidden Mod',
+	description: 'Secret.',
+	itemModTypeId: EItemModType.Prefix,
+	rarityId: ERarity.Legendary,
+	attributes: [
+		{ attributeId: EAttribute.Strength, amount: 5 },
+		{ attributeId: EAttribute.Defense, amount: 3 }
+	],
+	tags: [],
+	...over
+});
+
+afterEach(cleanup);
+
+describe('SealedHeader', () => {
+	it('shows the visible category/type label but masks the name', () => {
+		const { container } = render(SealedHeader, {
+			props: { rarityAccent: 'var(--rarity-epic)', catAccent: 'var(--category-armor)', typeLabel: 'Helm' }
+		});
+		expect((container.querySelector('.tt-category-label') as HTMLElement).textContent).toBe('Helm');
+		const name = container.querySelector('.tt-title-name') as HTMLElement;
+		expect(name.textContent).toBe('?????????');
+		expect(name.classList.contains('masked')).toBe(true);
+	});
+
+	it('renders the Sealed badge accented by the rarity hue', () => {
+		const { container } = render(SealedHeader, {
+			props: { rarityAccent: 'var(--rarity-epic)', catAccent: 'var(--category-armor)', typeLabel: 'Helm' }
+		});
+		const badge = container.querySelector('.sealed-badge') as HTMLElement;
+		expect(badge.textContent?.trim()).toBe('Sealed');
+		expect(badge.querySelector('span')?.getAttribute('style')).toContain('var(--rarity-epic)');
+	});
+});
+
+describe('SealedItemTooltip', () => {
+	it('accents the panel border by the item rarity', () => {
+		const { container } = render(SealedItemTooltip, { props: { item: makeItem() } });
+		expect((container.querySelector('.tt-shell') as HTMLElement).getAttribute('style')).toContain('var(--rarity-epic)');
+	});
+
+	it('teases the correct number of masked stat rows without revealing values', () => {
+		const { container } = render(SealedItemTooltip, { props: { item: makeItem() } });
+		// Two non-zero stats → two masked rows of "???".
+		expect(container.querySelectorAll('.tt-qmark')).toHaveLength(2);
+		expect(container.textContent).not.toContain('Strength');
+	});
+
+	it('shows one sealed-slot row per mod slot with a 0/N count', () => {
+		const { container } = render(SealedItemTooltip, { props: { item: makeItem() } });
+		expect(container.querySelectorAll('.sealed-slot')).toHaveLength(2);
+		expect(container.textContent).toContain('Mods · 0/2');
+	});
+
+	it('omits the stats and mods sections for a statless, slotless item', () => {
+		const item = makeItem({ totalAttributes: new BattleAttributes([], false), modSlots: [] });
+		const { container } = render(SealedItemTooltip, { props: { item } });
+		expect(container.querySelector('.tt-qmark')).toBeNull();
+		expect(container.querySelector('.sealed-slot')).toBeNull();
+	});
+});
+
+describe('SealedModTooltip', () => {
+	it('accents the panel border by the mod rarity', () => {
+		const { container } = render(SealedModTooltip, { props: { mod: makeMod() } });
+		expect((container.querySelector('.tt-shell') as HTMLElement).getAttribute('style')).toContain(
+			'var(--rarity-legendary)'
+		);
+	});
+
+	it('teases one masked effect row per attribute', () => {
+		const { container } = render(SealedModTooltip, { props: { mod: makeMod() } });
+		expect(container.querySelectorAll('.tt-qmark')).toHaveLength(2);
+	});
+
+	it('omits the effects section for a mod with no attributes', () => {
+		const { container } = render(SealedModTooltip, { props: { mod: makeMod({ attributes: [] }) } });
+		expect(container.querySelector('.tt-qmark')).toBeNull();
+	});
+});

--- a/UI/src/tests/routes/game/screens/challenges/SortControl.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/SortControl.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+
+// SortControl only needs the SORT_OPTIONS const from the view module; stub the
+// store so importing the view-model doesn't pull the real game stores.
+vi.mock('$stores', () => ({ staticData: {} }));
+
+import SortControl from '$routes/game/screens/challenges/SortControl.svelte';
+
+afterEach(cleanup);
+
+describe('SortControl', () => {
+	it('renders a button for every sort option', () => {
+		render(SortControl, { props: { value: 'progress', onChange: vi.fn() } });
+		expect(screen.getByText('Progress')).toBeTruthy();
+		expect(screen.getByText('Rarity')).toBeTruthy();
+		expect(screen.getByText('Name')).toBeTruthy();
+	});
+
+	it('marks the active option', () => {
+		const { container } = render(SortControl, { props: { value: 'rarity', onChange: vi.fn() } });
+		const active = container.querySelector('.sort-option.active') as HTMLElement;
+		expect(active.textContent?.trim()).toBe('Rarity');
+	});
+
+	it('divides every option after the first', () => {
+		const { container } = render(SortControl, { props: { value: 'progress', onChange: vi.fn() } });
+		// Three options → two dividers (all but the first).
+		expect(container.querySelectorAll('.sort-option.divided')).toHaveLength(2);
+	});
+
+	it('calls onChange with the clicked option key', async () => {
+		const onChange = vi.fn();
+		render(SortControl, { props: { value: 'progress', onChange } });
+		await fireEvent.click(screen.getByText('Name'));
+		expect(onChange).toHaveBeenCalledWith('name');
+	});
+});

--- a/UI/src/tests/routes/game/screens/challenges/challenge-meta.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/challenge-meta.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { EChallengeType } from '$lib/api';
+import {
+	CHALLENGE_TYPE_META,
+	challengeTypeUnit,
+	challengeTypeBlurb,
+	formatTime,
+	formatCount
+} from '$routes/game/screens/challenges/challenge-meta';
+
+describe('CHALLENGE_TYPE_META', () => {
+	it('declares a unit and blurb for every challenge type', () => {
+		const typeIds = Object.values(EChallengeType).filter((v): v is EChallengeType => typeof v === 'number');
+		for (const id of typeIds) {
+			expect(CHALLENGE_TYPE_META[id]).toBeDefined();
+			expect(CHALLENGE_TYPE_META[id].unit).toBeTruthy();
+			expect(CHALLENGE_TYPE_META[id].blurb).toBeTruthy();
+		}
+	});
+});
+
+describe('challengeTypeUnit', () => {
+	it("returns the type's progress noun", () => {
+		expect(challengeTypeUnit(EChallengeType.EnemiesKilled)).toBe('kills');
+		expect(challengeTypeUnit(EChallengeType.BossesDefeated)).toBe('bosses');
+		expect(challengeTypeUnit(EChallengeType.SkillsUsed)).toBe('casts');
+	});
+
+	it('falls back to an empty string for an unknown type', () => {
+		expect(challengeTypeUnit(999 as EChallengeType)).toBe('');
+	});
+});
+
+describe('challengeTypeBlurb', () => {
+	it("returns the type's hero-banner blurb", () => {
+		expect(challengeTypeBlurb(EChallengeType.EnemiesKilled)).toBe('Cut down foes in the field.');
+		expect(challengeTypeBlurb(EChallengeType.LevelReached)).toBe('Grow in power.');
+	});
+
+	it('falls back to an empty string for an unknown type', () => {
+		expect(challengeTypeBlurb(999 as EChallengeType)).toBe('');
+	});
+});
+
+describe('formatTime', () => {
+	it('renders sub-minute durations in seconds', () => {
+		expect(formatTime(45)).toBe('45s');
+		expect(formatTime(9)).toBe('9s');
+	});
+
+	it('renders minute-spanning durations as m:ss with a zero-padded seconds field', () => {
+		expect(formatTime(90)).toBe('1:30');
+		expect(formatTime(125)).toBe('2:05');
+		expect(formatTime(60)).toBe('1:00');
+	});
+
+	it('rounds fractional seconds', () => {
+		expect(formatTime(45.4)).toBe('45s');
+		expect(formatTime(89.6)).toBe('1:30');
+	});
+
+	it('renders a dash for zero, negative, or missing input', () => {
+		expect(formatTime(0)).toBe('—');
+		expect(formatTime(-5)).toBe('—');
+		expect(formatTime(NaN)).toBe('—');
+	});
+});
+
+describe('formatCount', () => {
+	it('renders small counts plainly', () => {
+		expect(formatCount(0)).toBe('0');
+		expect(formatCount(999)).toBe('999');
+	});
+
+	it('thousands-separates large counts', () => {
+		expect(formatCount(1000)).toBe('1,000');
+		expect(formatCount(1234567)).toBe('1,234,567');
+	});
+});

--- a/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
@@ -65,6 +65,15 @@ const makeItem = (itemId: number, name: string, cat: EItemCategory, rarity: ERar
 		...extra
 	}) as unknown as Item;
 
+// Locate a seeded item, narrowing it to a defined Item (avoids a null-forgiving `!`).
+const itemOf = (view: InventoryView, itemId: number): Item => {
+	const item = view.items.find((i) => i.itemId === itemId);
+	if (!item) {
+		throw new Error(`expected inventory item ${itemId} to exist`);
+	}
+	return item;
+};
+
 beforeEach(() => {
 	equipItem.mockClear();
 	unequipItem.mockClear();
@@ -198,11 +207,10 @@ describe('InventoryView', () => {
 
 	it('toggleEquip equips an unequipped item and unequips an equipped one', () => {
 		const view = new InventoryView();
-		const blade = view.items.find((i) => i.itemId === 2)!;
-		view.toggleEquip(blade); // Weapon category (5) → slot 4
+		view.toggleEquip(itemOf(view, 2)); // Weapon category (5) → slot 4
 		expect(view.equippedBySlot[4]?.itemId).toBe(2);
 
-		view.toggleEquip(view.items.find((i) => i.itemId === 2)!);
+		view.toggleEquip(itemOf(view, 2));
 		expect(view.equippedBySlot[4]).toBeUndefined();
 		expect(unequipItem).toHaveBeenCalledWith(4);
 	});
@@ -234,7 +242,7 @@ describe('InventoryView', () => {
 		staticData.itemMods = [{ id: 0, name: 'Sharp', itemModTypeId: 2, attributes: [] }];
 		const view = new InventoryView();
 		view.applyMod(2, 0 /* slotId */, 0 /* modId */);
-		const item = view.items.find((i) => i.itemId === 2)!;
+		const item = itemOf(view, 2);
 		expect(item.appliedMods.map((m) => m.id)).toEqual([0]);
 		expect(item.appliedMods[0].itemModSlotId).toBe(0);
 		expect(applyMod).toHaveBeenCalledWith(2, 0, 0);

--- a/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
@@ -5,12 +5,19 @@ import type { Item } from '$lib/battle';
 // Light mock of the engine so importing the view-model doesn't pull the real
 // game engine. EEquipmentSlot mirrors the real enum's indices. `vi.hoisted`
 // keeps these initialized before the hoisted vi.mock factory runs.
-const { equipItem, unequipItem, setFavorite, sampleItems } = vi.hoisted(() => ({
-	equipItem: vi.fn(),
-	unequipItem: vi.fn(),
-	setFavorite: vi.fn(),
-	sampleItems: [] as Item[]
-}));
+const { equipItem, unequipItem, setFavorite, applyMod, removeMod, unlockedMods, sampleItems, staticData } = vi.hoisted(
+	() => ({
+		equipItem: vi.fn(),
+		unequipItem: vi.fn(),
+		setFavorite: vi.fn(),
+		applyMod: vi.fn(),
+		removeMod: vi.fn(),
+		unlockedMods: new Set<number>(),
+		sampleItems: [] as Item[],
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		staticData: { itemMods: [] as any[] }
+	})
+);
 
 vi.mock('$lib/engine', () => ({
 	EEquipmentSlot: {
@@ -26,18 +33,16 @@ vi.mock('$lib/engine', () => ({
 		get unlockedItemList() {
 			return sampleItems;
 		},
-		unlockedMods: new Set<number>(),
+		unlockedMods,
 		equipItem,
 		unequipItem,
 		setFavorite,
-		applyMod: vi.fn(),
-		removeMod: vi.fn()
+		applyMod,
+		removeMod
 	}
 }));
 
-vi.mock('$stores', () => ({
-	staticData: { itemMods: [] }
-}));
+vi.mock('$stores', () => ({ staticData }));
 
 import { itemCategoryColor, itemCategoryName } from '$lib/common';
 import { InventoryView, SORTS, EQUIP_SLOTS } from '$routes/game/screens/inventory/inventory-view.svelte';
@@ -64,6 +69,10 @@ beforeEach(() => {
 	equipItem.mockClear();
 	unequipItem.mockClear();
 	setFavorite.mockClear();
+	applyMod.mockClear();
+	removeMod.mockClear();
+	unlockedMods.clear();
+	staticData.itemMods = [];
 	sampleItems.length = 0;
 	sampleItems.push(
 		makeItem(1, 'Zeta Helm', EItemCategory.Helm, ERarity.Rare, { favorite: true }),
@@ -128,5 +137,129 @@ describe('InventoryView', () => {
 		expect(view.slotsFilled).toBe(1);
 		// the equipped weapon contributes +5 Strength
 		expect(view.equippedTotals).toEqual([{ name: 'Strength', value: 5 }]);
+	});
+
+	it('sorts visible items by category then name by default', () => {
+		const view = new InventoryView();
+		// Helm(1) < Weapon(5) < Accessory(6) by category id.
+		expect(view.visible.map((i) => i.name)).toEqual(['Zeta Helm', 'Alpha Blade', 'Mid Ring']);
+	});
+
+	it('tallies overall, favorite and per-category counts', () => {
+		const view = new InventoryView();
+		expect(view.counts.all).toBe(3);
+		expect(view.counts.fav).toBe(1);
+		expect(view.counts.cats[EItemCategory.Helm]).toBe(1);
+		expect(view.counts.cats[EItemCategory.Weapon]).toBe(1);
+	});
+
+	it('tracks the selected item via select()', () => {
+		const view = new InventoryView();
+		expect(view.selected).toBeNull();
+		view.select(2);
+		expect(view.selected?.name).toBe('Alpha Blade');
+		view.select(null);
+		expect(view.selected).toBeNull();
+	});
+
+	it('resolves the drag item from dragItemId', () => {
+		const view = new InventoryView();
+		expect(view.dragItem).toBeNull();
+		view.dragItemId = 3;
+		expect(view.dragItem?.name).toBe('Mid Ring');
+	});
+
+	it('reload re-seeds the reactive copies from the manager', () => {
+		const view = new InventoryView();
+		sampleItems.push(makeItem(4, 'New Boots', EItemCategory.Boot, ERarity.Common));
+		expect(view.items).toHaveLength(3);
+		view.reload();
+		expect(view.items).toHaveLength(4);
+	});
+
+	it('swaps the occupant when equipping into an already-filled slot', () => {
+		const view = new InventoryView();
+		view.equip(2, 4);
+		view.equip(3, 4); // re-use the same weapon slot
+		expect(view.equippedBySlot[4]?.itemId).toBe(3);
+		expect(view.items.find((i) => i.itemId === 2)?.equipped).toBe(false);
+		expect(view.items.find((i) => i.itemId === 2)?.equipmentSlotId).toBeUndefined();
+		expect(view.slotsFilled).toBe(1);
+	});
+
+	it('unequips a slot and delegates to the manager', () => {
+		const view = new InventoryView();
+		view.equip(2, 4);
+		view.unequip(4);
+		expect(view.equippedBySlot[4]).toBeUndefined();
+		expect(view.items.find((i) => i.itemId === 2)?.equipped).toBe(false);
+		expect(unequipItem).toHaveBeenCalledWith(4);
+	});
+
+	it('toggleEquip equips an unequipped item and unequips an equipped one', () => {
+		const view = new InventoryView();
+		const blade = view.items.find((i) => i.itemId === 2)!;
+		view.toggleEquip(blade); // Weapon category (5) → slot 4
+		expect(view.equippedBySlot[4]?.itemId).toBe(2);
+
+		view.toggleEquip(view.items.find((i) => i.itemId === 2)!);
+		expect(view.equippedBySlot[4]).toBeUndefined();
+		expect(unequipItem).toHaveBeenCalledWith(4);
+	});
+
+	it('toggleFavorite is a no-op for an unknown item', () => {
+		const view = new InventoryView();
+		view.toggleFavorite(999);
+		expect(setFavorite).not.toHaveBeenCalled();
+	});
+
+	it('lists only unlocked, type-matching mods not already applied', () => {
+		staticData.itemMods = [
+			{ id: 0, name: 'Sharp', itemModTypeId: 2, attributes: [] },
+			{ id: 1, name: 'Heavy', itemModTypeId: 2, attributes: [] },
+			{ id: 2, name: 'Quick', itemModTypeId: 3, attributes: [] }
+		];
+		unlockedMods.add(0);
+		unlockedMods.add(1);
+		// id 2 is a different type; id 1 is already on the item.
+		const item = makeItem(2, 'Alpha Blade', EItemCategory.Weapon, ERarity.Legendary, {
+			appliedMods: [{ id: 1, itemModSlotId: 0, attributes: [] } as unknown as Item['appliedMods'][number]]
+		});
+		const compatible = new InventoryView().compatibleMods(2, item);
+		expect(compatible.map((m) => m.id)).toEqual([0]);
+		expect(compatible[0].itemModSlotId).toBe(-1);
+	});
+
+	it('applies a mod into a slot, replacing any existing mod there, and delegates', () => {
+		staticData.itemMods = [{ id: 0, name: 'Sharp', itemModTypeId: 2, attributes: [] }];
+		const view = new InventoryView();
+		view.applyMod(2, 0 /* slotId */, 0 /* modId */);
+		const item = view.items.find((i) => i.itemId === 2)!;
+		expect(item.appliedMods.map((m) => m.id)).toEqual([0]);
+		expect(item.appliedMods[0].itemModSlotId).toBe(0);
+		expect(applyMod).toHaveBeenCalledWith(2, 0, 0);
+	});
+
+	it('applyMod is a no-op when the item or mod data is missing', () => {
+		staticData.itemMods = [];
+		const view = new InventoryView();
+		view.applyMod(2, 0, 99); // no such mod
+		view.applyMod(999, 0, 0); // no such item
+		expect(applyMod).not.toHaveBeenCalled();
+	});
+
+	it('removes a mod from a slot and delegates', () => {
+		staticData.itemMods = [{ id: 0, name: 'Sharp', itemModTypeId: 2, attributes: [] }];
+		const view = new InventoryView();
+		view.applyMod(2, 0, 0);
+		view.removeMod(2, 0);
+		expect(view.items.find((i) => i.itemId === 2)?.appliedMods).toEqual([]);
+		expect(removeMod).toHaveBeenCalledWith(2, 0);
+	});
+
+	it('removeMod is a no-op for an unknown item', () => {
+		const view = new InventoryView();
+		view.removeMod(999, 0);
+		expect(removeMod).not.toHaveBeenCalled();
 	});
 });

--- a/UI/vite.config.ts
+++ b/UI/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
 				'src/lib/card-game/**': { lines: 94, functions: 100, branches: 81, statements: 94 },
 				'src/stores/**': { lines: 98, functions: 100, branches: 90, statements: 98 },
 				'src/components/**': { lines: 89, functions: 95, branches: 74, statements: 92 },
-				'src/routes/**': { lines: 73, functions: 68, branches: 53, statements: 71 }
+				'src/routes/**': { lines: 88, functions: 87, branches: 67, statements: 88 }
 			}
 		}
 	},


### PR DESCRIPTION
## Summary

Closes #320.

The `src/routes/**` coverage floor was stuck (73% lines / 53% branches) largely because of two clusters of untested **interactive/logic-bearing** code in the challenges screen and the admin Workbench. This adds focused unit/component tests for those clusters and re-seeds the per-area threshold floors so the gate ratchets up.

Per the issue's guidance, the pure-logic modules were prioritized and the interactive/conditional components covered; genuinely non-interactive display markup (`TypeHero`, `StatusNode`, `TypeGlyph`, …) was left to the existing smoke coverage.

### Challenges screen (`game/screens/challenges`)
- **`challenge-meta.ts`** — 33% → **100%** lines (unit/blurb lookups + fallbacks, `formatTime` minute/second/round/dash branches, `formatCount` thousands separator)
- **`SortControl`** (interactive sort toggle), **`ProgressReadout`** (atMost-with/without-data, atLeast, done, bar toggle), **`RewardTooltip`** (revealed-vs-sealed item/mod dispatch + hidden empty state), **`SealedHeader` / `SealedItemTooltip` / `SealedModTooltip`** (masked teaser rows, sealed slots, accents)

### Admin Workbench (`admin/workbench`)
- **`reference.svelte.ts`** — 26% → **86%** lines / 85% branches: select-option builders, the boss-only `entityCatalog` restriction, reward/name lookups, deterministic `tagColor`, `tagUsage`, `enemySpawnShareTotal`
- **`SectionRenderer`** (dispatch for all seven section kinds), **`FieldControl`** (text/number/toggle/textarea/select + dirty/required), **`ChipsSection`**, **`SectionTable`**, **`TagsSection`**, **`TagBrowse`**, **`TagPill`**, **`UsageSection`**
- Challenge builders: **`ChallengeConditionSection`** (type-change re-derivation), **`ChallengeRewardSection`**, **`RewardPicker`** (exclusivity/claimed), **`ScopeField`** (global/specific), **`GoalField`** (unit + at-most)
- **`entities/helpers` `firstFree`** (full); extended **`enemy`/`item-mod`** for the remaining child-saver + meta/badge paths

### Inventory
- **`inventory-view.svelte.ts`** — 59% → **99%** lines / 90% branches: equip-swap, unequip, `toggleEquip`, `applyMod`/`removeMod` (+ no-op guards), `compatibleMods`, counts/select/drag/reload

### Gate re-seed
`src/routes/**` area moved 73→**88.6** L / 53→**67.6** B; floors re-seeded via `node UI/scripts/coverage-floors.mjs` to `{ lines: 88, functions: 87, branches: 67, statements: 88 }`.

## Test plan
- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — **1237 passed (145 files)**, coverage gate green with the ratcheted floor
- No production code changed; this is test + threshold-config only.

## Follow-ups (out of scope)
- `reference.svelte.ts`'s async `load()` (socket/HTTP fetch orchestration) is still uncovered — better suited to an integration test than a unit test.
- `ChallengeRewardSection` mod/skill picker-open paths and the `enemy`/`item-mod` `newRow`/add persist paths remain partially covered.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SR8kAdphNWLMoWLa8p9DQz)_