### PR TITLE
Add integration coverage for the socket presence lifecycle (SocketManagerService)

### DIFF
--- a/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
+++ b/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
@@ -1,0 +1,247 @@
+using Game.Abstractions.Infrastructure;
+using Game.Api;
+using Game.Api.Services;
+using Game.Api.Sockets.Commands;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    /// <summary>
+    /// Integration coverage for the socket-presence lifecycle that backs the documented single-active-
+    /// connection / session-takeover model (see <c>docs/backend.md</c> → "Single active connection").
+    /// <see cref="SocketManagerService"/> is Redis-coupled and holds no unit-worthy logic, so its
+    /// presence-key contract is exercised here against the real cache fixture.
+    /// </summary>
+    [Collection("Integration")]
+    public class SocketManagerServiceTests : ApiIntegrationTestBase
+    {
+        // Field initializer runs before the base constructor so the provider is ready when
+        // CreateFactory is invoked from the base constructor (mirrors RequestLoggingTests).
+        private readonly CapturingLoggerProvider _capturingProvider = new();
+
+        private static readonly string SocketManagerCategory = typeof(SocketManagerService).FullName!;
+
+        public SocketManagerServiceTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        protected override GameServerFactory CreateFactory(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+        {
+            return new GameServerFactory(containers, testOutputHelper, [_capturingProvider]);
+        }
+
+        [Fact]
+        public async Task RegisterSocket_SecondConnection_ReplacesPresenceKeyAndNotifiesOldSocket()
+        {
+            var (userId, playerId) = await SeedAndLoginAsync();
+
+            // First connection registers and owns the presence key.
+            await using var socketA = new TestSocketClient();
+            await socketA.ConnectAsync(Factory.Server.CreateWebSocketClient(), userId);
+            await socketA.SendCommandAsync<object>("GetStatisticTypes");
+            var idA = await ReadPresenceValueAsync(playerId);
+            Assert.NotNull(idA);
+            Assert.True(await HasActiveSocketAsync(playerId));
+
+            // Second connection takes over: the old socket is told it was replaced...
+            await using var socketB = new TestSocketClient();
+            await socketB.ConnectAsync(Factory.Server.CreateWebSocketClient(), userId);
+
+            // SocketReplaced is emitted with no command Id, so it surfaces as a null-Id server push.
+            var replaced = await socketA.WaitForResponseAsync(null);
+            Assert.Equal(nameof(SocketReplaced), replaced.Name);
+
+            // ...and the presence key now points at the new socket rather than the old one.
+            await socketB.SendCommandAsync<object>("GetStatisticTypes");
+            var idB = await ReadPresenceValueAsync(playerId);
+            Assert.NotNull(idB);
+            Assert.NotEqual(idA, idB);
+        }
+
+        [Fact]
+        public async Task UnRegisterSocket_GracefulClose_ClearsPresenceKey()
+        {
+            var (userId, playerId) = await SeedAndLoginAsync();
+
+            await using var socketA = new TestSocketClient();
+            await socketA.ConnectAsync(Factory.Server.CreateWebSocketClient(), userId);
+            await socketA.SendCommandAsync<object>("GetStatisticTypes");
+            Assert.True(await HasActiveSocketAsync(playerId));
+
+            // A clean close drives the server through UnRegisterSocket, which compare-and-deletes the key.
+            await socketA.CloseAsync();
+
+            Assert.True(await WaitUntilAsync(async () => !await HasActiveSocketAsync(playerId)),
+                "Expected the presence key to be cleared after the socket closed gracefully.");
+        }
+
+        [Fact]
+        public async Task UnRegisterSocket_ReplacedSocket_DoesNotDeleteNewSocketPresenceKey()
+        {
+            var (userId, playerId) = await SeedAndLoginAsync();
+
+            await using var socketA = new TestSocketClient();
+            await socketA.ConnectAsync(Factory.Server.CreateWebSocketClient(), userId);
+            await socketA.SendCommandAsync<object>("GetStatisticTypes");
+
+            await using var socketB = new TestSocketClient();
+            await socketB.ConnectAsync(Factory.Server.CreateWebSocketClient(), userId);
+
+            // Wait for the takeover to land, then capture the new owner of the key.
+            var replaced = await socketA.WaitForResponseAsync(null);
+            Assert.Equal(nameof(SocketReplaced), replaced.Name);
+            await socketB.SendCommandAsync<object>("GetStatisticTypes");
+            var idB = await ReadPresenceValueAsync(playerId);
+            Assert.NotNull(idB);
+
+            // The replaced socket's own teardown (UnRegisterSocket) is a compare-and-delete keyed on its
+            // stale socket id, so it must not delete the key the newer connection has taken over. Give the
+            // server-side cleanup time to run, then prove the key still belongs to the surviving socket.
+            await Task.Delay(1000, CancellationToken);
+            Assert.Equal(idB, await ReadPresenceValueAsync(playerId));
+            var stillAlive = await socketB.SendCommandAsync<object>("GetStatisticTypes");
+            Assert.Null(stillAlive.Error);
+        }
+
+        [Fact]
+        public async Task RefreshSocketPresence_FromConnectionThatWasTakenOver_ProlongsCurrentKeyWithoutResurrectingOldSocketId()
+        {
+            var (userId, playerId) = await SeedAndLoginAsync();
+            var key = PresenceKey(playerId);
+
+            // Register a real socket so its inbound activity drives the refresh path.
+            await using var socketA = new TestSocketClient();
+            await socketA.ConnectAsync(Factory.Server.CreateWebSocketClient(), userId);
+            await socketA.SendCommandAsync<object>("GetStatisticTypes");
+            var idA = await ReadPresenceValueAsync(playerId);
+            Assert.NotNull(idA);
+
+            // Simulate a newer connection taking over the key (exactly what a second RegisterSocket does),
+            // but keep socket A open so it can still send the refreshing activity. A short TTL lets the
+            // subsequent extend-TTL be observed.
+            var newerSocketId = Guid.NewGuid().ToString();
+            using (var scope = CreateScope())
+            {
+                var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+                await cache.Set(key, newerSocketId, TimeSpan.FromSeconds(8));
+            }
+            await Task.Delay(500, CancellationToken);
+
+            // Inbound activity on the old connection refreshes presence via Expire (not a re-set). The
+            // read loop refreshes before handling the message, so the command's response confirms it ran.
+            await socketA.SendCommandAsync<object>("GetStatisticTypes");
+
+            // The refresh prolonged whatever key was current — it did not re-set the old socket id.
+            Assert.Equal(newerSocketId, await ReadPresenceValueAsync(playerId));
+            var refreshedTtl = await GetPresenceTtlAsync(playerId);
+            Assert.NotNull(refreshedTtl);
+            Assert.True(refreshedTtl > TimeSpan.FromSeconds(12),
+                $"Expected the TTL to be extended past its 8s ceiling but it was {refreshedTtl}.");
+        }
+
+        [Fact]
+        public async Task HasActiveSocket_AfterPresenceTtlExpires_ReturnsFalse()
+        {
+            // HasActiveSocket is a pure presence-key read, so a directly-seeded key with a short TTL
+            // exercises the expiry contract without waiting out the production 30s window.
+            const int playerId = 987654;
+            var key = PresenceKey(playerId);
+
+            using var scope = CreateScope();
+            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+            var socketManager = scope.ServiceProvider.GetRequiredService<SocketManagerService>();
+
+            await cache.Set(key, Guid.NewGuid().ToString(), TimeSpan.FromSeconds(1));
+            Assert.True(await socketManager.HasActiveSocket(playerId));
+
+            Assert.True(await WaitUntilAsync(async () => !await socketManager.HasActiveSocket(playerId)),
+                "Expected HasActiveSocket to report false once the presence key TTL expired.");
+        }
+
+        [Fact]
+        public async Task EmitSocketCommand_NoActiveSocket_LogsWarning()
+        {
+            // No presence key exists for this player, so EmitSocketCommand has no socket to publish to: it
+            // takes the warn-and-skip branch rather than publishing.
+            const int playerId = 876543;
+            var startIndex = _capturingProvider.Entries.Count;
+
+            using (var scope = CreateScope())
+            {
+                var socketManager = scope.ServiceProvider.GetRequiredService<SocketManagerService>();
+                await socketManager.EmitSocketCommand(new SocketCommandInfo("GetStatisticTypes"), playerId);
+            }
+
+            var warning = Assert.Single(
+                _capturingProvider.Entries.Skip(startIndex),
+                e => e.Category == SocketManagerCategory && e.Level == LogLevel.Warning);
+            Assert.Contains("no active socket", warning.Message);
+            Assert.Equal(playerId, warning.Properties.Single(p => p.Key == "PlayerId").Value);
+        }
+
+        /// <summary>
+        /// Seeds a user with a player and a linked skill, then logs in (creating the Redis session the
+        /// WebSocket handshake authenticates against), returning the ids needed for socket auth.
+        /// </summary>
+        private async Task<(int UserId, int PlayerId)> SeedAndLoginAsync(string username = "socketmgruser", string password = "socketmgrpass")
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context, username, password);
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
+
+            await LoginAsync(username, password);
+            return (user.Id, player.Id);
+        }
+
+        private async Task<bool> HasActiveSocketAsync(int playerId)
+        {
+            using var scope = CreateScope();
+            var socketManager = scope.ServiceProvider.GetRequiredService<SocketManagerService>();
+            return await socketManager.HasActiveSocket(playerId);
+        }
+
+        private async Task<string?> ReadPresenceValueAsync(int playerId)
+        {
+            using var scope = CreateScope();
+            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+            return await cache.Get(PresenceKey(playerId));
+        }
+
+        private async Task<TimeSpan?> GetPresenceTtlAsync(int playerId)
+        {
+            await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(Containers.CacheConnectionString);
+            return await multiplexer.GetDatabase().KeyTimeToLiveAsync(PresenceKey(playerId));
+        }
+
+        /// <summary>Polls the condition until it holds or a short timeout elapses; returns whether it held.</summary>
+        private async Task<bool> WaitUntilAsync(Func<Task<bool>> condition, int timeoutMs = 5000)
+        {
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            while (DateTime.UtcNow < deadline)
+            {
+                if (await condition())
+                {
+                    return true;
+                }
+
+                await Task.Delay(100, CancellationToken);
+            }
+
+            return await condition();
+        }
+
+        private static string PresenceKey(int playerId)
+        {
+            return $"{Constants.CACHE_PLAYER_SOCKET_PREFIX}_{playerId}";
+        }
+    }
+}

--- a/Game.TestInfrastructure/Helpers/TestSocketClient.cs
+++ b/Game.TestInfrastructure/Helpers/TestSocketClient.cs
@@ -78,7 +78,7 @@ namespace Game.TestInfrastructure.Helpers
         /// Use this when a command is emitted through a server-side path (e.g. pub/sub) rather than
         /// directly from the client.
         /// </summary>
-        public async Task<ApiSocketResponse> WaitForResponseAsync(string commandId)
+        public async Task<ApiSocketResponse> WaitForResponseAsync(string? commandId)
         {
             return await ReadResponseAsync(commandId);
         }


### PR DESCRIPTION
## Summary

`SocketManagerService` is the machinery behind the documented single-active-connection / session-takeover model (`docs/backend.md` → "Single active connection"), but no test in the solution referenced `SocketManagerService`, `HasActiveSocket`, or `SocketReplaced` directly — its presence-key guarantees were exercised only incidentally (~17% branch). Per the testing guidelines, this Redis-coupled service holds no unit-worthy logic, so it is covered here by **integration tests against the real cache fixture**.

New tests in `Game.Api.Tests/Integration/SocketManagerServiceTests.cs`:

- **Register replaces and notifies** — a second connection for the same player emits `SocketReplaced` to the *old* socket and leaves the presence key pointing at the new socket.
- **`HasActiveSocket`** — true while a socket is registered; false after a graceful close drives `UnRegisterSocket`; false after the presence TTL expires without refresh.
- **`UnRegisterSocket` is compare-and-delete** — a replaced socket's teardown does not delete the *new* socket's presence key.
- **Refresh never resurrects a replaced key** — inbound activity from a connection that was taken over prolongs the current key via `Expire` (extend-TTL) without re-setting the old socket id. (The "inbound activity extends the TTL" half of the invariant is already covered by `SocketConnectionTests.SocketActivity_RefreshesPresenceTtl`.)
- **`EmitSocketCommand(playerId)` with no active socket** — takes the warn-and-skip branch rather than publishing.

The register/replace/teardown behaviors are driven through real in-memory `TestServer` WebSocket connections (the natural way a socket registers/unregisters); the pure presence-key reads (`HasActiveSocket` expiry, the no-socket emit warning) call the DI-resolved `SocketManagerService` directly against the real cache, using short/seeded TTLs so they stay fast and deterministic.

### Supporting change

`TestSocketClient.WaitForResponseAsync` now accepts a nullable command id so it can await the id-less `SocketReplaced` server push (the method already forwarded to a `string?`-typed reader).

## Test plan

- [x] `dotnet build Game.Api.Tests` — 0 warnings, 0 errors
- [x] `dotnet test Game.Api.Tests` — 303 passed, 0 failed (6 new tests plus the existing suite, unaffected by the `TestSocketClient` signature widening)

Closes #319

https://claude.ai/code/session_017XUFoqhN763SbxMY3vtk1V

---
_Generated by [Claude Code](https://claude.ai/code/session_017XUFoqhN763SbxMY3vtk1V)_