### PR TITLE
Resolve ItemModSlot Index/Id conflation in apply-mod path (#316)

### DIFF
--- a/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
@@ -118,12 +118,12 @@ namespace Game.Application.Tests.Services
 
             // A weapon (base Strength +5) with one Prefix mod slot, equipped in the weapon slot.
             var item = await TestDataSeeder.CreateItemAsync(context);
-            context.ItemModSlots.Add(new Infrastructure.Entities.ItemModSlot
+            var modSlot = new Infrastructure.Entities.ItemModSlot
             {
                 ItemId = item.Id,
                 ItemModSlotTypeId = (int)EItemModType.Prefix,
-                Index = 0,
-            });
+            };
+            context.ItemModSlots.Add(modSlot);
             context.UnlockedItems.Add(new Infrastructure.Entities.UnlockedItem
             {
                 PlayerId = playerEntity.Id,
@@ -144,11 +144,68 @@ namespace Game.Application.Tests.Services
             var player = await playerService.LoadPlayer(playerEntity.Id);
             Assert.NotNull(player);
 
-            var applied = await playerService.ApplyMod(player, item.Id, mod.Id, itemModSlotId: 0);
+            // The client speaks the slot's DB Id, so apply resolves the target by Id (not ordinal).
+            var applied = await playerService.ApplyMod(player, item.Id, mod.Id, modSlot.Id);
 
             Assert.True(applied);
             var modifiers = player.Inventory.GetEquippedAttributeModifiers().ToList();
             Assert.Contains(modifiers, m => m.Attribute == EAttribute.Strength && m.Amount == 5.0 && m.Source == EAttributeModifierSource.Item);
+            Assert.Contains(modifiers, m => m.Attribute == EAttribute.Dexterity && m.Amount == 7.0 && m.Source == EAttributeModifierSource.ItemMod);
+        }
+
+        [Fact]
+        public async Task ApplyMod_SecondItemSlotIdNotZero_ResolvesById()
+        {
+            // Regression for #316: the apply path used to match the slot by its per-item Index, which
+            // only equals the slot's DB Id for the first authored slot (Id 0). A second item's slot has
+            // Id != 0, so a client request carrying that Id silently found no slot. Authoring a throwaway
+            // slotted item first pushes the real item's slot to Id 1, exercising the masked case.
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+
+            // First authored slotted item consumes slot Id 0.
+            var decoyItem = await TestDataSeeder.CreateItemAsync(context);
+            context.ItemModSlots.Add(new Infrastructure.Entities.ItemModSlot
+            {
+                ItemId = decoyItem.Id,
+                ItemModSlotTypeId = (int)EItemModType.Prefix,
+            });
+
+            // The item under test: its only slot is authored second, so it gets a non-zero Id.
+            var item = await TestDataSeeder.CreateItemAsync(context);
+            var modSlot = new Infrastructure.Entities.ItemModSlot
+            {
+                ItemId = item.Id,
+                ItemModSlotTypeId = (int)EItemModType.Prefix,
+            };
+            context.ItemModSlots.Add(modSlot);
+            context.UnlockedItems.Add(new Infrastructure.Entities.UnlockedItem
+            {
+                PlayerId = playerEntity.Id,
+                ItemId = item.Id,
+                EquipmentSlotId = (int)EEquipmentSlot.WeaponSlot,
+            });
+
+            var mod = await TestDataSeeder.CreateItemModAsync(context, attributeId: EAttribute.Dexterity, attributeAmount: 7m);
+            context.UnlockedMods.Add(new Infrastructure.Entities.UnlockedMod
+            {
+                PlayerId = playerEntity.Id,
+                ItemModId = mod.Id,
+            });
+            await context.SaveChangesAsync(CancellationToken);
+            Assert.NotEqual(0, modSlot.Id);
+
+            var playerService = scope.ServiceProvider.GetRequiredService<PlayerService>();
+            var player = await playerService.LoadPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var applied = await playerService.ApplyMod(player, item.Id, mod.Id, modSlot.Id);
+
+            Assert.True(applied);
+            var modifiers = player.Inventory.GetEquippedAttributeModifiers().ToList();
             Assert.Contains(modifiers, m => m.Attribute == EAttribute.Dexterity && m.Amount == 7.0 && m.Source == EAttributeModifierSource.ItemMod);
         }
 
@@ -187,7 +244,6 @@ namespace Game.Application.Tests.Services
             {
                 ItemId = item.Id,
                 ItemModSlotTypeId = (int)EItemModType.Prefix,
-                Index = 0,
             };
             context.ItemModSlots.Add(modSlot);
             context.UnlockedItems.Add(new Infrastructure.Entities.UnlockedItem
@@ -240,7 +296,6 @@ namespace Game.Application.Tests.Services
             {
                 ItemId = item.Id,
                 ItemModSlotTypeId = (int)EItemModType.Prefix,
-                Index = 0,
             };
             context.ItemModSlots.Add(modSlot);
             var mod = await TestDataSeeder.CreateItemModAsync(context, attributeId: EAttribute.Dexterity, attributeAmount: 7m);
@@ -565,7 +620,6 @@ namespace Game.Application.Tests.Services
             {
                 ItemId = item.Id,
                 ItemModSlotTypeId = (int)EItemModType.Prefix,
-                Index = 0,
             };
             context.ItemModSlots.Add(modSlot);
             context.UnlockedItems.Add(new Infrastructure.Entities.UnlockedItem
@@ -588,8 +642,7 @@ namespace Game.Application.Tests.Services
             // the LoadPlayer_PersistedAppliedMod scenario).
             // AppliedMod.ItemModSlotId is a FK to ItemModSlot.Id, so the persisted row, the RemoveMod
             // argument (matched against the loaded AppliedModSlot.ItemModSlotId), and the verify query
-            // all key off modSlot.Id — the same value the symmetric LoadPlayer_PersistedAppliedMod test
-            // persists. (The domain's Index-vs-Id mismatch on the apply path is tracked separately.)
+            // all key off modSlot.Id — the single identifier the apply/remove path resolves by (#316).
             context.AppliedMods.Add(new Infrastructure.Entities.AppliedMod
             {
                 PlayerId = playerEntity.Id,

--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -328,7 +328,6 @@ namespace Game.Core.Tests.Battle
                 ModSlots = mods.Select((mod, index) => new ItemModSlot
                 {
                     Id = index,
-                    Index = index,
                     Type = mod.Type,
                 }).ToList(),
                 Tags = [],

--- a/Game.Core.Tests/Battle/BattleSnapshotTests.cs
+++ b/Game.Core.Tests/Battle/BattleSnapshotTests.cs
@@ -16,7 +16,7 @@ namespace Game.Core.Tests.Battle
         public void FromPlayer_CapturesLevelStatsEquipmentAndSkills()
         {
             var item = MakeItem(1, attributes: [MakeModifier(EAttribute.Strength, 5)],
-                modSlots: [new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix }]);
+                modSlots: [new ItemModSlot { Id = 0, Type = EItemModType.Prefix }]);
             var mod = MakeMod(10, EItemModType.Prefix, [MakeModifier(EAttribute.Dexterity, 7)]);
 
             var player = MakePlayer(
@@ -165,7 +165,7 @@ namespace Game.Core.Tests.Battle
         {
             var item = MakeItem(1,
                 attributes: [MakeModifier(EAttribute.Strength, 5), MakeModifier(EAttribute.Endurance, 2)],
-                modSlots: [new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix }]);
+                modSlots: [new ItemModSlot { Id = 0, Type = EItemModType.Prefix }]);
             var mod = MakeMod(10, EItemModType.Prefix, [MakeModifier(EAttribute.Dexterity, 7)]);
             var skillA = MakeSkill(2);
             var skillB = MakeSkill(3);
@@ -198,8 +198,8 @@ namespace Game.Core.Tests.Battle
                 attributes: [MakeModifier(EAttribute.Strength, 5)],
                 modSlots:
                 [
-                    new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
-                    new ItemModSlot { Id = 1, Index = 1, Type = EItemModType.Suffix },
+                    new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
+                    new ItemModSlot { Id = 1, Type = EItemModType.Suffix },
                 ]);
             var prefix = MakeMod(10, EItemModType.Prefix, [MakeModifier(EAttribute.Strength, 3)]);
             var suffix = MakeMod(11, EItemModType.Suffix, [MakeModifier(EAttribute.Dexterity, 4)]);

--- a/Game.Core.Tests/Players/InventoryTests.cs
+++ b/Game.Core.Tests/Players/InventoryTests.cs
@@ -166,7 +166,7 @@ namespace Game.Core.Tests.Players
             var inventory = new Inventory();
             var item = MakeItem(1, modSlots:
             [
-                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
             ]);
             AddUnlockedItem(inventory, item);
             inventory.UnlockMod(10);
@@ -196,7 +196,7 @@ namespace Game.Core.Tests.Players
             var inventory = new Inventory();
             var item = MakeItem(1, modSlots:
             [
-                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
             ]);
             AddUnlockedItem(inventory, item);
             // Don't unlock mod 10
@@ -223,7 +223,7 @@ namespace Game.Core.Tests.Players
             var inventory = new Inventory();
             var item = MakeItem(1, modSlots:
             [
-                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
             ]);
             AddUnlockedItem(inventory, item);
             inventory.UnlockMod(10);
@@ -250,7 +250,7 @@ namespace Game.Core.Tests.Players
             var inventory = new Inventory();
             var item = MakeItem(1, modSlots:
             [
-                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
             ]);
             AddUnlockedItem(inventory, item);
             inventory.UnlockMod(10);
@@ -277,20 +277,63 @@ namespace Game.Core.Tests.Players
         }
 
         [Fact]
-        public void TryApplyMod_ModSlotIndexNotFound_ReturnsFalse()
+        public void TryApplyMod_ModSlotIdNotFound_ReturnsFalse()
         {
             var inventory = new Inventory();
             var item = MakeItem(1, modSlots:
             [
-                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
             ]);
             AddUnlockedItem(inventory, item);
             inventory.UnlockMod(10);
 
-            // The item has only slot index 0; index 5 does not exist.
+            // The item has only slot Id 0; slot Id 5 does not exist.
             var result = inventory.TryApplyMod(1, 10, 5, MakeMod(10, EItemModType.Prefix));
 
             Assert.False(result);
+        }
+
+        [Fact]
+        public void TryApplyMod_SlotIdDiffersFromOrdinal_ResolvesById()
+        {
+            // Regression for the Index/Id conflation (#316): a slot whose DB Id (3) is not its
+            // 0-based position in the item's slot list. The client speaks the slot's Id, so apply
+            // must resolve by Id — matching by ordinal would target the wrong slot or none at all.
+            var inventory = new Inventory();
+            var item = MakeItem(1, modSlots:
+            [
+                new ItemModSlot { Id = 3, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 4, Type = EItemModType.Suffix },
+            ]);
+            AddUnlockedItem(inventory, item);
+            inventory.UnlockMod(10);
+
+            var result = inventory.TryApplyMod(1, 10, 4, MakeMod(10, EItemModType.Suffix));
+
+            Assert.True(result);
+            var applied = Assert.Single(inventory.UnlockedItems[0].AppliedMods);
+            Assert.Equal(4, applied.ItemModSlotId);
+            Assert.Equal(10, applied.ItemModId);
+        }
+
+        [Fact]
+        public void TryRemoveMod_SlotIdDiffersFromOrdinal_ResolvesById()
+        {
+            // Regression for #316: removal must key off the slot's Id, consistent with apply/persistence.
+            var inventory = new Inventory();
+            var item = MakeItem(1, modSlots:
+            [
+                new ItemModSlot { Id = 3, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 4, Type = EItemModType.Suffix },
+            ]);
+            AddUnlockedItem(inventory, item);
+            inventory.UnlockMod(10);
+            inventory.TryApplyMod(1, 10, 4, MakeMod(10, EItemModType.Suffix));
+
+            var result = inventory.TryRemoveMod(1, 4);
+
+            Assert.True(result);
+            Assert.Empty(inventory.UnlockedItems[0].AppliedMods);
         }
 
         // ── TryRemoveMod ────────────────────────────────────────────────────
@@ -301,7 +344,7 @@ namespace Game.Core.Tests.Players
             var inventory = new Inventory();
             var item = MakeItem(1, modSlots:
             [
-                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
             ]);
             AddUnlockedItem(inventory, item);
             inventory.UnlockMod(10);
@@ -424,7 +467,7 @@ namespace Game.Core.Tests.Players
             var inventory = new Inventory();
             var item = MakeItem(1, EItemCategory.Accessory, modSlots:
             [
-                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
             ]);
             AddUnlockedItem(inventory, item);
             inventory.TryEquipItem(1, EEquipmentSlot.AccessorySlot);
@@ -450,7 +493,7 @@ namespace Game.Core.Tests.Players
                 attributes: [MakeModifier(EAttribute.Strength, 5.0, EAttributeModifierSource.Item)],
                 modSlots:
                 [
-                    new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+                    new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
                 ]);
             AddUnlockedItem(inventory, item);
             inventory.TryEquipItem(1, EEquipmentSlot.AccessorySlot);
@@ -473,7 +516,7 @@ namespace Game.Core.Tests.Players
             var inventory = new Inventory();
             var item = MakeItem(1, EItemCategory.Accessory, modSlots:
             [
-                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
             ]);
             AddUnlockedItem(inventory, item);
             inventory.UnlockMod(10);
@@ -494,8 +537,8 @@ namespace Game.Core.Tests.Players
             var inventory = new Inventory();
             var item = MakeItem(1, EItemCategory.Accessory, modSlots:
             [
-                new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
-                new ItemModSlot { Id = 1, Index = 1, Type = EItemModType.Suffix },
+                new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 1, Type = EItemModType.Suffix },
             ]);
             AddUnlockedItem(inventory, item);
             inventory.TryEquipItem(1, EEquipmentSlot.AccessorySlot);

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -593,10 +593,10 @@ namespace Game.Core.Tests.Players
                 Tags = [],
             };
 
-        /// <summary>An accessory carrying a single Prefix mod slot at index 0, for the apply/remove-mod paths.</summary>
+        /// <summary>An accessory carrying a single Prefix mod slot (Id 0), for the apply/remove-mod paths.</summary>
         private static Item MakeItemWithPrefixSlot(int id) => MakeItem(id, modSlots:
         [
-            new ItemModSlot { Id = 0, Index = 0, Type = EItemModType.Prefix },
+            new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
         ]);
 
         private static ItemMod MakeMod(int id, EItemModType type) => new()

--- a/Game.Core/Items/ItemModSlot.cs
+++ b/Game.Core/Items/ItemModSlot.cs
@@ -16,11 +16,6 @@ namespace Game.Core.Items
         public required EItemModType Type { get; set; }
 
         /// <summary>
-        /// The index of this slot on the item.
-        /// </summary>
-        public required int Index { get; set; }
-
-        /// <summary>
         /// The item mod currently applied in this slot (if any).
         /// </summary>
         public ItemMod? ItemMod { get; set; }

--- a/Game.Core/Players/Inventories/Inventory.cs
+++ b/Game.Core/Players/Inventories/Inventory.cs
@@ -102,7 +102,7 @@ namespace Game.Core.Players.Inventories
                 return false;
             }
 
-            var modSlot = unlocked.Item.ModSlots.FirstOrDefault(s => s.Index == itemModSlotId);
+            var modSlot = unlocked.Item.ModSlots.FirstOrDefault(s => s.Id == itemModSlotId);
             if (modSlot is null)
             {
                 return false;

--- a/Game.DataAccess/Mapping/ItemMapper.cs
+++ b/Game.DataAccess/Mapping/ItemMapper.cs
@@ -31,7 +31,6 @@ namespace Game.DataAccess.Mapping
                     {
                         Id = ims.Id,
                         Type = (EItemModType)ims.ItemModSlotTypeId,
-                        Index = ims.Index,
                         ItemMod = null,
                     }).ToList(),
                 Tags = [],

--- a/Game.Infrastructure/Entities/ItemModSlot.cs
+++ b/Game.Infrastructure/Entities/ItemModSlot.cs
@@ -5,7 +5,6 @@
         public int Id { get; set; }
         public int ItemId { get; set; }
         public int ItemModSlotTypeId { get; set; }
-        public int Index { get; set; }
 
         public virtual Item Item { get => field ?? throw new NotLoadedException(nameof(Item)); set; }
         public virtual ItemModType ItemModSlotType { get => field ?? throw new NotLoadedException(nameof(ItemModSlotType)); set; }

--- a/Game.Infrastructure/Migrations/20260610041445_RemoveItemModSlotIndex.Designer.cs
+++ b/Game.Infrastructure/Migrations/20260610041445_RemoveItemModSlotIndex.Designer.cs
@@ -4,6 +4,7 @@ using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Game.Infrastructure.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20260610041445_RemoveItemModSlotIndex")]
+    partial class RemoveItemModSlotIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Game.Infrastructure/Migrations/20260610041445_RemoveItemModSlotIndex.cs
+++ b/Game.Infrastructure/Migrations/20260610041445_RemoveItemModSlotIndex.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Game.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveItemModSlotIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Index",
+                table: "ItemModSlots");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Index",
+                table: "ItemModSlots",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the apply/remove-mod path conflating `ItemModSlot.Index` and the DB `Id` (#316).

`Inventory.TryApplyMod` resolved the target slot by **`Index`**:

```csharp
var modSlot = unlocked.Item.ModSlots.FirstOrDefault(s => s.Index == itemModSlotId);
```

…while every other hop in the round-trip keys off **`Id`**:

- `AppliedMod.ItemModSlotId` is a FK to `ItemModSlot.Id`
- `PlayerMapper` loads it back as an `Id`
- `PlayerData.FromPlayer` projects it to the client as `AppliedModModel.ItemModSlotId` (the `Id`)
- the reference contract `ItemModSlot` exposes `Id`/`ItemId` but **not** `Index`, so an `ApplyModRequest`/`RemoveModRequest` carries the slot's `Id`

The two only coincide for the **first** authored slot (`Id == Index == 0`), which is why every single-item fixture masked the bug. For any item whose slot `Id` differs from its index, a client `ApplyMod` sent the `Id`, `TryApplyMod` matched against `Index`, found nothing, and **silently returned `false`** — the mod could not be applied at all.

## How it's fixed

Settle the whole wire + domain + persistence contract on **`Id`** (the issue's recommended direction — it's already what the client receives and what the FK references): resolve the slot by `Id`.

While investigating I found the per-item `Index` was **never authored** — `AdminItems.SaveModSlots` never sets it on insert/update, so it always defaulted to `0` — and it is **never sent to the client** (the read contract omits it). With the apply path no longer reading it, the concept is fully dead, so per the project's dead-code guidance I removed it end-to-end:

- `Inventory.TryApplyMod` → resolves by `Id`
- removed `Index` from the domain `Game.Core.Items.ItemModSlot`, the entity `Game.Infrastructure.Entities.ItemModSlot`, and `ItemMapper`
- EF migration `RemoveItemModSlotIndex` drops the column (the project has no backwards-compat constraints)

No wire contract or codegen'd type changed, so there's no codegen drift and **no frontend impact** — the client side was already `Id`-based (it never had an `Index` concept).

## Test plan

- **New unit regressions** (`InventoryTests`): apply **and** remove against a slot whose `Id` (3/4) differs from its ordinal, asserting resolution by `Id`.
- **New end-to-end regression** (`PlayerServiceIntegrationTests.ApplyMod_SecondItemSlotIdNotZero_ResolvesById`): a second authored slotted item gets a non-zero slot `Id`; `ApplyMod` with that `Id` succeeds and the mod's attribute lands in the equipped modifiers — the exact case the old code failed.
- Existing apply/remove integration tests updated to resolve by the actual `modSlot.Id` rather than a hardcoded `0`.
- Full backend suite green: Infrastructure 26, Core 353, Application 123, Api 300.

Closes #316


---
_Generated by [Claude Code](https://claude.ai/code/session_011jsheYVUxs9QwnC65sj1jM)_