### PR TITLE
Sync client battle stats when applying/removing an item mod (#342)

### DIFF
--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -1,6 +1,6 @@
 import { IInventoryItem, IBattlerAttribute, ELogType, EItemCategory, ApiRequest, apiSocket } from '$lib/api';
 import { playerManager } from '$lib/engine';
-import { Item, newItem } from '$lib/battle';
+import { BattleAttributes, Item, newItem, newItemMod } from '$lib/battle';
 import { logMessage } from '$lib/engine/log';
 
 //Manually putting this here until codegen gets updated to load this
@@ -133,10 +133,8 @@ export class InventoryManager {
 	}
 
 	public async applyMod(itemId: number, itemModId: number, itemModSlotId: number) {
-		if (!this.unlockedMods.has(itemModId)) {
-			return false;
-		}
-		if (!this.unlockedItems.has(itemId)) {
+		const item = this.unlockedItems.get(itemId);
+		if (!this.unlockedMods.has(itemModId) || !item) {
 			return false;
 		}
 
@@ -146,15 +144,21 @@ export class InventoryManager {
 			return false;
 		}
 
-		// Re-fetch player data to get updated item state
-		// (or update locally — for now just log success)
+		// Mirror the change onto the authoritative item (the equip/favorite precedent) so
+		// equipmentStats (battle) and any view re-seed reflect it without a page reload.
+		item.appliedMods = [
+			...item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId),
+			newItemMod({ itemModId, itemModSlotId })
+		];
+		this.refreshItemAttributes(item);
 		logMessage(ELogType.ItemFound, 'Modifier applied.');
 
 		return true;
 	}
 
 	public async removeMod(itemId: number, itemModSlotId: number) {
-		if (!this.unlockedItems.has(itemId)) {
+		const item = this.unlockedItems.get(itemId);
+		if (!item) {
 			return false;
 		}
 
@@ -164,9 +168,17 @@ export class InventoryManager {
 			return false;
 		}
 
+		item.appliedMods = item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId);
+		this.refreshItemAttributes(item);
 		logMessage(ELogType.ItemFound, 'Modifier removed.');
 
 		return true;
+	}
+
+	/** Rebuilds an item's cached totalAttributes after its applied mods change. */
+	private refreshItemAttributes(item: Item) {
+		const allAttributes = [...item.attributes, ...item.appliedMods.flatMap((mod) => mod.attributes)];
+		item.totalAttributes = new BattleAttributes(allAttributes, false);
 	}
 
 	/**

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -372,6 +372,69 @@ describe('InventoryManager', () => {
 			expect(logMessage).toHaveBeenCalledWith(ELogType.ItemFound, 'Modifier applied.');
 		});
 
+		it('mirrors the mod onto the authoritative item and its totalAttributes on success', async () => {
+			mockItems[1] = makeItem(1);
+			mockItemMods[10] = makeItemMod(10);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			mockInventoryData.unlockedMods = [10];
+			manager.initialize();
+
+			await manager.applyMod(1, 10, 0);
+
+			const item = manager.unlockedItems.get(1);
+			expect(item?.appliedMods.map((m) => m.id)).toEqual([10]);
+			expect(item?.appliedMods[0].itemModSlotId).toBe(0);
+			// totalAttributes recomputes to include the mod's attributes (Agility 3).
+			expect(item?.totalAttributes.getValue(EAttribute.Agility)).toBe(3);
+		});
+
+		it('replaces an existing mod occupying the same slot', async () => {
+			mockItems[1] = makeItem(1);
+			mockItemMods[10] = makeItemMod(10);
+			mockItemMods[11] = makeItemMod(11);
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({ itemId: 1, appliedMods: [{ itemModId: 10, itemModSlotId: 0 }] })
+			];
+			mockInventoryData.unlockedMods = [10, 11];
+			manager.initialize();
+
+			await manager.applyMod(1, 11, 0);
+
+			const item = manager.unlockedItems.get(1);
+			expect(item?.appliedMods.map((m) => m.id)).toEqual([11]);
+		});
+
+		it('reflects an applied mod in equipmentStats for an equipped item', async () => {
+			mockItems[1] = makeItem(1);
+			mockItemMods[10] = makeItemMod(10);
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({ itemId: 1, equipped: true, equipmentSlotId: EEquipmentSlot.WeaponSlot })
+			];
+			mockInventoryData.unlockedMods = [10];
+			manager.initialize();
+
+			await manager.applyMod(1, 10, 0);
+
+			expect(manager.equipmentStats).toEqual([
+				{ attributeId: EAttribute.Strength, amount: 5 },
+				{ attributeId: EAttribute.Agility, amount: 3 }
+			]);
+		});
+
+		it('leaves the authoritative item unchanged when the API returns an error', async () => {
+			mockItems[1] = makeItem(1);
+			mockItemMods[10] = makeItemMod(10);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			mockInventoryData.unlockedMods = [10];
+			manager.initialize();
+			mockPost.mockResolvedValue({ error: 'nope' });
+
+			const result = await manager.applyMod(1, 10, 0);
+
+			expect(result).toBe(false);
+			expect(manager.unlockedItems.get(1)?.appliedMods).toEqual([]);
+		});
+
 		it('returns false and makes no API call when the mod is not unlocked', async () => {
 			mockItems[1] = makeItem(1);
 			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
@@ -423,6 +486,28 @@ describe('InventoryManager', () => {
 			expect(logMessage).toHaveBeenCalledWith(ELogType.ItemFound, 'Modifier removed.');
 		});
 
+		it('removes the mod from the authoritative item and equipmentStats on success', async () => {
+			mockItems[1] = makeItem(1);
+			mockItemMods[10] = makeItemMod(10);
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({
+					itemId: 1,
+					equipped: true,
+					equipmentSlotId: EEquipmentSlot.WeaponSlot,
+					appliedMods: [{ itemModId: 10, itemModSlotId: 0 }]
+				})
+			];
+			mockInventoryData.unlockedMods = [10];
+			manager.initialize();
+
+			await manager.removeMod(1, 0);
+
+			const item = manager.unlockedItems.get(1);
+			expect(item?.appliedMods).toEqual([]);
+			expect(item?.totalAttributes.getValue(EAttribute.Agility)).toBe(0);
+			expect(manager.equipmentStats).toEqual([{ attributeId: EAttribute.Strength, amount: 5 }]);
+		});
+
 		it('returns false and makes no API call when the item is not unlocked', async () => {
 			manager.initialize();
 
@@ -442,6 +527,22 @@ describe('InventoryManager', () => {
 
 			expect(result).toBe(false);
 			expect(logMessage).not.toHaveBeenCalled();
+		});
+
+		it('leaves the applied mod in place when the API returns an error', async () => {
+			mockItems[1] = makeItem(1);
+			mockItemMods[10] = makeItemMod(10);
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({ itemId: 1, appliedMods: [{ itemModId: 10, itemModSlotId: 0 }] })
+			];
+			mockInventoryData.unlockedMods = [10];
+			manager.initialize();
+			mockPost.mockResolvedValue({ error: 'nope' });
+
+			const result = await manager.removeMod(1, 0);
+
+			expect(result).toBe(false);
+			expect(manager.unlockedItems.get(1)?.appliedMods.map((m) => m.id)).toEqual([10]);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fixes the frontend state-sync gap from #342: applying or removing an item mod didn't affect the player's battle stats (or survive an inventory re-seed) until a full page reload.

`InventoryManager.applyMod`/`removeMod` POSTed to the API and logged success but never touched the **authoritative** item's `appliedMods`. Two consequences:

1. **Stale battle stats.** `equipmentStats` (consumed at battle start by `battle-engine.ts`) iterates the manager's equipped items, whose `appliedMods` were never updated — so a freshly applied mod's attributes didn't reach combat until reload.
2. **Optimistic display silently reverted.** `InventoryView.reload()` re-seeds from the manager's (un-updated) items, so navigating away and back dropped the change.

## How it addresses the issue

- On a successful `applyMod`, mirror `{ ...modData, itemModSlotId }` onto the manager's `unlockedItems[itemId].appliedMods` (replacing any mod in the same slot); on `removeMod`, filter it out — following the existing `equipItem`/`unequipItem`/`setFavorite` precedent that already updates the manager's item objects.
- Reuse `newItemMod({ itemModId, itemModSlotId })` to build the applied-mod entry rather than re-deriving it, keeping a single construction path.
- Rebuild the item's cached `totalAttributes` (a new private `refreshItemAttributes` helper) so the item tooltip's merged stats stay current too, not just `equipmentStats`.
- Removed the now-obsolete "re-fetch player data / for now just log" placeholder comment and dead `.has()` guards (replaced by a single `.get()` lookup).

`InventoryView` keeps its own optimistic mutation on its shallow display copy (consistent with how `equip` already works) — the manager is now the source of truth that `reload()` re-seeds from.

## Test plan

Extended `inventory-manager.test.ts`:
- `applyMod`: mirrors mod onto the item + recomputes `totalAttributes`; replaces a same-slot mod; reflects in `equipmentStats` for an equipped item; leaves the item unchanged on API error.
- `removeMod`: removes from the item + `equipmentStats` on success; leaves the mod in place on API error.

- `inventory-manager.test.ts`: 37 passing.
- Full frontend unit suite green (1259 tests); `npm run lint` (eslint + svelte-check) clean.

## Follow-up note

The issue flags a broader question — whether `InventoryView`'s shallow-copy-and-manually-mirror pattern should instead read through the manager to eliminate this class of divergence. That's an architectural change beyond this bug fix; happy to file a tech-debt follow-up if desired.

Closes #342

https://claude.ai/code/session_01TFk6YsGftvkgGG97cCw1xf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFk6YsGftvkgGG97cCw1xf)_