### PR TITLE
Cover deferred Workbench/reference test gaps (#330)

### DIFF
--- a/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
@@ -144,4 +144,42 @@ describe('ChallengeRewardSection', () => {
 		const retiredRow = container.querySelector('.ch-picker-nm.retired') as HTMLElement;
 		expect(retiredRow?.textContent).toContain('Rusty Relic');
 	});
+
+	it('opens the mod picker and assigns the chosen mod', async () => {
+		const { store, record, baseline } = setup();
+		const { container } = render(ChallengeRewardSection, { props: { record, baseline, store } });
+		await fireEvent.click(screen.getByText('Choose mod…'));
+		expect(container.querySelector('.ch-picker')).toBeTruthy();
+		await fireEvent.click(screen.getByText('Sharp'));
+		expect((store.items[0] as unknown as IChallenge).rewardItemModId).toBe(0);
+		expect(container.querySelector('.ch-picker')).toBeNull();
+	});
+
+	it('opens the skill picker and assigns the chosen skill', async () => {
+		const { store, record, baseline } = setup();
+		const { container } = render(ChallengeRewardSection, { props: { record, baseline, store } });
+		await fireEvent.click(screen.getByText('Choose skill…'));
+		expect(container.querySelector('.ch-picker')).toBeTruthy();
+		await fireEvent.click(screen.getByText('Cleave'));
+		expect((store.items[0] as unknown as IChallenge).rewardSkillId).toBe(0);
+		expect(container.querySelector('.ch-picker')).toBeNull();
+	});
+
+	it('collapses an open picker when the rendered record switches to a different challenge', async () => {
+		// Two sibling challenges in the same store; the section is reused as the detail
+		// pane switches between them, and its $effect must reset the open picker on switch.
+		const first = { id: 1, name: 'One', challengeTypeId: 1, entityType: 0, progressGoal: 5 } as IChallenge;
+		const second = { id: 2, name: 'Two', challengeTypeId: 1, entityType: 0, progressGoal: 5 } as IChallenge;
+		const store = new EntityStore(config(), [first, second] as unknown as Identified[]);
+
+		const { container, rerender } = render(ChallengeRewardSection, {
+			props: { record: store.items[0], baseline: store.baselineOf(1), store }
+		});
+		await fireEvent.click(screen.getByText('Choose item…'));
+		expect(container.querySelector('.ch-picker')).toBeTruthy();
+
+		// Switch the detail pane to the other record: the picker collapses.
+		await rerender({ record: store.items[1], baseline: store.baselineOf(2), store });
+		expect(container.querySelector('.ch-picker')).toBeNull();
+	});
 });

--- a/UI/src/tests/routes/admin/workbench/entities/enemy.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/enemy.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type { IEnemy } from '$lib/api';
+import { EChangeType, type IEnemy } from '$lib/api';
+import type { TableSectionConfig } from '$routes/admin/workbench/entities/types';
 
 /* Enemy config transforms: `newItem` defaults, the boss list badge, and the
    persist path — the identity DTO strips the child collections, and only the
@@ -31,6 +32,9 @@ import { enemyEntity } from '$routes/admin/workbench/entities/enemy';
 
 /** Finds the body posted to a given AdminTools endpoint (or undefined if never called). */
 const postBodyTo = (endpoint: string) => mockPost.mock.calls.find((c) => c[0] === endpoint)?.[1];
+
+/** A table section's config by key (for exercising its `newRow` factory). */
+const tableSection = (key: string) => enemyEntity.sections.find((s) => s.key === key) as TableSectionConfig<IEnemy>;
 
 beforeEach(() => {
 	mockPost.mockReset().mockResolvedValue(undefined);
@@ -117,5 +121,61 @@ describe('enemyEntity', () => {
 		expect(postBodyTo('AdminTools/SetEnemySkills')).toEqual({ enemyId: 0, skillIds: [1, 2] });
 		expect(postBodyTo('AdminTools/SetEnemyAttributeDistributions')).toBeUndefined();
 		expect(postBodyTo('AdminTools/SetEnemySpawns')).toBeUndefined();
+	});
+
+	it('persist Adds a new enemy and saves its children against the resolved id', async () => {
+		// A freshly-added record carries a temporary negative id; after the identity Add the
+		// backend appends it at a real id, which persistEntity resolves before the child savers run.
+		const added: IEnemy = {
+			id: -1,
+			name: 'New Enemy',
+			isBoss: true,
+			attributeDistribution: [{ attributeId: 0, baseAmount: 3, amountPerLevel: 1 }],
+			skillPool: [2],
+			spawns: [{ zoneId: 1, weight: 8 }]
+		};
+		socket.enemies = [{ ...added, id: 7 }]; // the persisted record at its real id
+
+		await enemyEntity.persist({ added: [added], modified: [], deleted: [], existingIds: [] });
+
+		// Identity Add posted with the child collections stripped.
+		const addCall = postBodyTo('AdminTools/AddEditEnemies');
+		expect(addCall[0].changeType).toBe(EChangeType.Add);
+		expect(addCall[0].item).toEqual({
+			id: -1,
+			name: 'New Enemy',
+			isBoss: true,
+			attributeDistribution: [],
+			skillPool: [],
+			spawns: []
+		});
+		// Every child saver runs against the RESOLVED id (7), not the temporary -1.
+		expect(postBodyTo('AdminTools/SetEnemyAttributeDistributions')).toEqual({
+			enemyId: 7,
+			attributeDistributions: [{ attributeId: 0, baseAmount: 3, amountPerLevel: 1 }]
+		});
+		expect(postBodyTo('AdminTools/SetEnemySkills')).toEqual({ enemyId: 7, skillIds: [2] });
+		expect(postBodyTo('AdminTools/SetEnemySpawns')).toEqual({ enemyId: 7, spawns: [{ zoneId: 1, weight: 8 }] });
+	});
+
+	describe('newRow factories', () => {
+		it('attribute newRow picks the first free attribute and zeroes the amounts', () => {
+			// Strength (id 0) is already taken, so the first free attribute (id 1) is chosen.
+			const enemy: IEnemy = {
+				...baseline,
+				attributeDistribution: [{ attributeId: 0, baseAmount: 1, amountPerLevel: 0 }]
+			};
+			expect(tableSection('attrs').newRow(enemy)).toEqual({ attributeId: 1, baseAmount: 0, amountPerLevel: 0 });
+		});
+
+		it('spawn newRow picks the first unused zone with the default weight', () => {
+			staticData.zones = [
+				{ id: 0, name: 'Verdant Hollow', levelMin: 1, levelMax: 5 },
+				{ id: 1, name: 'Frost Cavern', levelMin: 6, levelMax: 10 }
+			];
+			// Zone 0 is already assigned, so zone 1 is the first free option.
+			const enemy: IEnemy = { ...baseline, spawns: [{ zoneId: 0, weight: 5 }] };
+			expect(tableSection('spawns').newRow(enemy)).toEqual({ zoneId: 1, weight: 5 });
+		});
 	});
 });

--- a/UI/src/tests/routes/admin/workbench/entities/item-mod.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/item-mod.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { EItemModType, ERarity, type IItemMod } from '$lib/api';
+import { EChangeType, EItemModType, ERarity, type IItemMod } from '$lib/api';
+import type { TableSectionConfig } from '$routes/admin/workbench/entities/types';
 
 /* Item-mod config transforms: `newItem` defaults, the derived meta line, and the
    persist path — a child-only attribute edit must NOT hit the identity Add/Edit
@@ -31,6 +32,9 @@ import { itemModEntity } from '$routes/admin/workbench/entities/item-mod';
 
 /** Finds the body posted to a given AdminTools endpoint (or undefined if never called). */
 const postBodyTo = (endpoint: string) => mockPost.mock.calls.find((c) => c[0] === endpoint)?.[1];
+
+/** A table section's config by key (for exercising its `newRow` factory). */
+const tableSection = (key: string) => itemModEntity.sections.find((s) => s.key === key) as TableSectionConfig<IItemMod>;
 
 beforeEach(() => {
 	mockPost.mockReset().mockResolvedValue(undefined);
@@ -113,5 +117,47 @@ describe('itemModEntity', () => {
 		});
 		// Tags were untouched, so their endpoint is skipped.
 		expect(postBodyTo('AdminTools/SetTagsForItemMod')).toBeUndefined();
+	});
+
+	it('persist Adds a new mod and saves its attributes/tags against the resolved id', async () => {
+		// A freshly-added record has a temporary negative id; persistEntity resolves the real
+		// id from the post-save refetch before running the attribute/tag child savers.
+		const added: IItemMod = {
+			id: -1,
+			name: 'Keen',
+			description: 'Sharper edge',
+			itemModTypeId: EItemModType.Prefix,
+			rarityId: ERarity.Rare,
+			attributes: [{ attributeId: 0, amount: 3 }],
+			tags: [5]
+		};
+		socket.itemMods = [{ ...added, id: 9 }]; // the persisted record at its real id
+
+		await itemModEntity.persist({ added: [added], modified: [], deleted: [], existingIds: [] });
+
+		// Identity Add posted with the child collections stripped.
+		const addCall = postBodyTo('AdminTools/AddEditItemMods');
+		expect(addCall[0].changeType).toBe(EChangeType.Add);
+		expect(addCall[0].item).toEqual({
+			id: -1,
+			name: 'Keen',
+			description: 'Sharper edge',
+			itemModTypeId: EItemModType.Prefix,
+			rarityId: ERarity.Rare,
+			attributes: [],
+			tags: []
+		});
+		// An added record has no baseline, so every attribute is an Add against the resolved id (9).
+		expect(postBodyTo('AdminTools/AddEditItemModAttributes')).toMatchObject({
+			id: 9,
+			changes: [{ changeType: EChangeType.Add, item: { attributeId: 0, amount: 3 } }]
+		});
+		expect(postBodyTo('AdminTools/SetTagsForItemMod')).toEqual({ id: 9, tagIds: [5] });
+	});
+
+	it('attribute newRow picks the first free attribute with a default amount', () => {
+		// Strength (id 0) is already taken, so the first free attribute (id 1) is chosen.
+		const mod: IItemMod = { ...itemModEntity.newItem(1), attributes: [{ attributeId: 0, amount: 5 }] };
+		expect(tableSection('attributes').newRow(mod)).toEqual({ attributeId: 1, amount: 1 });
 	});
 });

--- a/UI/src/tests/routes/admin/workbench/reference-load.test.ts
+++ b/UI/src/tests/routes/admin/workbench/reference-load.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/*
+ * Integration-style coverage of WorkbenchReference.load() — the out-of-process
+ * orchestration #320 deferred. Rather than mock load() into a tautology, the real
+ * method runs against stubbed transports so the assertions verify the documented
+ * socket-vs-HTTP split (reference catalogues over the `Get*` socket commands; only
+ * tags/categories over HTTP, since they have no socket command yet) and that the
+ * results land where the workbench reads them, with `loaded` flipping true.
+ */
+
+const { staticData, mockFetchSocket, mockGet } = vi.hoisted(() => ({
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	staticData: {} as any,
+	mockFetchSocket: vi.fn(),
+	mockGet: vi.fn()
+}));
+vi.mock('$stores', () => ({ staticData }));
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	class ApiRequest {
+		static get = mockGet;
+		static post = vi.fn();
+	}
+	return { ...actual, ApiRequest, fetchSocketData: mockFetchSocket };
+});
+
+import { reference } from '$routes/admin/workbench/reference.svelte';
+
+// One distinct payload per socket command, so a mis-wired assignment is caught.
+const SOCKET_SETS: Record<string, { id: number; name: string }[]> = {
+	GetEnemies: [{ id: 0, name: 'Cave Bat' }],
+	GetSkills: [{ id: 0, name: 'Cleave' }],
+	GetZones: [{ id: 0, name: 'Verdant Hollow' }],
+	GetItems: [{ id: 0, name: 'Iron Helm' }],
+	GetItemMods: [{ id: 0, name: 'Sharp' }],
+	GetChallengeTypes: [{ id: 1, name: 'Enemies Killed' }],
+	GetChallenges: [{ id: 0, name: 'First Blood' }]
+};
+const TAGS = [{ id: 10, name: 'Fire', tagCategoryId: 100 }];
+const TAG_CATEGORIES = [{ id: 100, name: 'Element' }];
+
+beforeEach(() => {
+	mockFetchSocket.mockReset().mockImplementation(async (command: string) => SOCKET_SETS[command]);
+	mockGet
+		.mockReset()
+		.mockImplementation(async (path: string) =>
+			path === 'Tags' ? TAGS : path === 'Tags/TagCategories' ? TAG_CATEGORIES : []
+		);
+	for (const key of Object.keys(staticData)) {
+		delete staticData[key];
+	}
+});
+
+describe('WorkbenchReference.load', () => {
+	it('reads each set over its correct transport, populates the stores, and flips loaded', async () => {
+		expect(reference.loaded).toBe(false);
+
+		await reference.load();
+
+		// The six zero-based-id catalogues plus challenge types load over the socket.
+		for (const command of [
+			'GetEnemies',
+			'GetSkills',
+			'GetZones',
+			'GetItems',
+			'GetItemMods',
+			'GetChallengeTypes',
+			'GetChallenges'
+		]) {
+			expect(mockFetchSocket).toHaveBeenCalledWith(command);
+		}
+		// Only tags + categories use HTTP — the transport split is exactly 7 socket / 2 HTTP.
+		expect(mockFetchSocket).toHaveBeenCalledTimes(7);
+		expect(mockGet).toHaveBeenCalledTimes(2);
+		expect(mockGet).toHaveBeenCalledWith('Tags');
+		expect(mockGet).toHaveBeenCalledWith('Tags/TagCategories');
+
+		// The socket catalogues land in the shared staticData store…
+		expect(staticData.enemies).toBe(SOCKET_SETS.GetEnemies);
+		expect(staticData.skills).toBe(SOCKET_SETS.GetSkills);
+		expect(staticData.zones).toBe(SOCKET_SETS.GetZones);
+		expect(staticData.items).toBe(SOCKET_SETS.GetItems);
+		expect(staticData.itemMods).toBe(SOCKET_SETS.GetItemMods);
+		expect(staticData.challenges).toBe(SOCKET_SETS.GetChallenges);
+		// …and the tags/categories/challenge-types the singleton owns onto its own fields
+		// (these are $state-wrapped reactive proxies, so compare by value, not identity).
+		expect(reference.tags).toEqual(TAGS);
+		expect(reference.tagCategories).toEqual(TAG_CATEGORIES);
+		expect(reference.challengeTypes).toEqual(SOCKET_SETS.GetChallengeTypes);
+
+		expect(reference.loaded).toBe(true);
+	});
+
+	it('propagates a socket failure so a load error surfaces (fetchSocketData throws on socket error)', async () => {
+		mockFetchSocket.mockImplementation(async (command: string) => {
+			if (command === 'GetItems') {
+				throw new Error('socket down');
+			}
+			return SOCKET_SETS[command];
+		});
+
+		await expect(reference.load()).rejects.toThrow('socket down');
+	});
+});


### PR DESCRIPTION
## Summary

Closes the test headroom #320 (PR #327) intentionally deferred — three areas of genuine logic that had uncovered branches. No production code changes; tests only.

`Closes #330`

## How it addresses the issue

### 1. `reference.svelte.ts` — async `load()` (was the main uncovered block, ~86%)
New `reference-load.test.ts` runs the **real** `load()` against stubbed transports (not mocked into a tautology). It asserts the documented socket-vs-HTTP transport split: the six zero-based-id catalogues + challenge types each load over their `Get*` **socket** command (7 socket reads), while **only** `Tags`/`TagCategories` use HTTP (exactly 2 `ApiRequest.get`s). It then verifies the results land where the Workbench reads them — the socket catalogues into `staticData`, the tags/categories/challenge-types onto the singleton's own reactive fields — and that `loaded` flips `true`. A second case asserts a socket failure propagates (since `fetchSocketData` throws on a socket error, so load failures surface as toasts).

### 2. `ChallengeRewardSection.svelte` — mod/skill picker paths (~71%)
#327 covered the item slot end-to-end. Added:
- **mod** picker open → assign → `rewardItemModId` set + picker closes,
- **skill** picker open → assign → `rewardSkillId` set + picker closes,
- the **`$effect`** that collapses an open picker when the detail pane switches to a different challenge record (rendered via two sibling challenges in one store + `rerender`).

### 3. `entities/enemy.ts` & `entities/item-mod.ts` — `newRow` + add-persist
- **`newRow` factories**: enemy's attribute + spawn rows and item-mod's attribute row, verifying `firstFree` picks the first unused option against live reference options (and the row defaults).
- **`added`-record persist branch** (previously only `modified` was tested): the identity `Add` strips child collections, and after the post-save refetch resolves the backend-assigned id (send order), every child saver runs against that **resolved** id, not the temporary negative one.

## Test plan

- `npx vitest run` on the four files: all green.
- Full frontend suite: **1263 passing** (147 files), `npm run lint` (eslint + svelte-check) clean, the `src/routes/**` / `src/lib/api/**` coverage thresholds satisfied (`test:unit:ci` exit 0).

## Notes

- Pure-display markup exempt under the testing guidelines (`TypeHero`, `StatusNode`, …) was left out of scope, as the issue specifies.
- Left the coverage **floors** un-ratcheted: #330 is about closing branch headroom with tests (which these do), and the new coverage only raises the area numbers — re-seeding the whole-area floor is the kind of ratchet #343 calls for on the inventory drag/drop work, and tightening it here for unrelated future PRs felt like scope creep. Happy to ratchet if preferred.

https://claude.ai/code/session_01LJm8bBDKuBgM3aULfrpjzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJm8bBDKuBgM3aULfrpjzL)_