### PR TITLE
Add removable modifiers + frontend modifier-graph battle attributes (#331)

### DIFF
--- a/Game.Core.Tests/Attributes/AttributeCollectionTests.cs
+++ b/Game.Core.Tests/Attributes/AttributeCollectionTests.cs
@@ -126,6 +126,114 @@ namespace Game.Core.Tests.Attributes
         }
 
         [Fact]
+        public void RemoveModifier_RevertsTheValue()
+        {
+            var added = Additive(EAttribute.Strength, 5);
+            var collection = new AttributeCollection([Additive(EAttribute.Strength, 10)]);
+            collection.AddModifier(added);
+
+            var before = collection[EAttribute.Strength];
+            var removed = collection.RemoveModifier(added);
+            var after = collection[EAttribute.Strength];
+
+            Assert.True(removed);
+            Assert.Equal(15, before);
+            Assert.Equal(10, after);
+        }
+
+        [Fact]
+        public void RemoveModifier_CascadesInvalidationToDerivedAttributes()
+        {
+            var strength = Additive(EAttribute.Strength, 10);
+            var collection = new AttributeCollection([strength]);
+
+            // MaxHealth derives from Strength (×5): 50 + 5*10 = 100 while the modifier is present.
+            var before = collection[EAttribute.MaxHealth];
+            collection.RemoveModifier(strength);
+            var after = collection[EAttribute.MaxHealth];
+
+            Assert.Equal(100, before);
+            Assert.Equal(50, after);
+        }
+
+        [Fact]
+        public void RemoveModifier_ThenReAdd_RestoresTheValue()
+        {
+            var modifier = Additive(EAttribute.Strength, 7);
+            var collection = new AttributeCollection([modifier]);
+
+            collection.RemoveModifier(modifier);
+            Assert.Equal(0, collection[EAttribute.Strength]);
+
+            collection.AddModifier(modifier);
+            Assert.Equal(7, collection[EAttribute.Strength]);
+        }
+
+        [Fact]
+        public void RemoveModifier_RemovesTheExactInstanceAmongSameTypeModifiers()
+        {
+            // Two additive Strength modifiers share a sort key (Type); only the targeted
+            // instance must be removed, not whichever sorts equal first.
+            var first = Additive(EAttribute.Strength, 10);
+            var second = Additive(EAttribute.Strength, 3);
+            var collection = new AttributeCollection([first, second]);
+
+            collection.RemoveModifier(second);
+
+            Assert.Equal(10, collection[EAttribute.Strength]);
+        }
+
+        [Fact]
+        public void RemoveModifier_RemovesDerivedModifierAndUpdatesValue()
+        {
+            // Endurance contributes to MaxHealth (×20) both via the static derived modifier and
+            // this extra one; removing the extra leaves the static contribution intact.
+            var extraEndurance = new AttributeModifier
+            {
+                Attribute = EAttribute.MaxHealth,
+                Amount = 3.0,
+                Type = EModifierType.Additive,
+                Source = EAttributeModifierSource.Derived,
+                DerivedSource = EAttribute.Endurance,
+            };
+            var collection = new AttributeCollection([Additive(EAttribute.Endurance, 10)]);
+            collection.AddModifier(extraEndurance);
+
+            // 50 + (20 + 3)*10 = 280 with the extra derived modifier present.
+            Assert.Equal(280, collection[EAttribute.MaxHealth]);
+
+            collection.RemoveModifier(extraEndurance);
+
+            // Back to the static-only derivation: 50 + 20*10 = 250.
+            Assert.Equal(250, collection[EAttribute.MaxHealth]);
+
+            // The cascade link from Endurance still works for the remaining static modifier.
+            collection.AddModifier(Additive(EAttribute.Endurance, 5));
+            Assert.Equal(50 + 20 * 15, collection[EAttribute.MaxHealth]);
+        }
+
+        [Fact]
+        public void RemoveModifier_NotPresent_ReturnsFalse()
+        {
+            var collection = new AttributeCollection([Additive(EAttribute.Strength, 10)]);
+
+            var removed = collection.RemoveModifier(Additive(EAttribute.Strength, 10));
+
+            Assert.False(removed);
+            Assert.Equal(10, collection[EAttribute.Strength]);
+        }
+
+        [Fact]
+        public void RemoveModifier_AttributeWithNoModifiers_ReturnsFalse()
+        {
+            var collection = new AttributeCollection([]);
+
+            var removed = collection.RemoveModifier(Additive(EAttribute.Intellect, 1));
+
+            Assert.False(removed);
+        }
+
+        [Fact]
         public void AllModifiers_ReturnsAllAddedModifiers()
         {
             var modifiers = new List<AttributeModifier>

--- a/Game.Core.Tests/Collections/SortedLinkedListTests.cs
+++ b/Game.Core.Tests/Collections/SortedLinkedListTests.cs
@@ -318,5 +318,44 @@ namespace Game.Core.Tests.Collections
                     $"Order violated at index {i}: {result[i - 1]} > {result[i]}");
             }
         }
+
+        // ── Remove(value, equalityComparer): identity-aware removal ──
+        // The ordering comparer here sorts by Key only, so two distinct boxes can share a sort
+        // key; the equality overload must remove the targeted instance, not whichever sorts equal.
+
+        private sealed class Box(int key)
+        {
+            public int Key { get; } = key;
+        }
+
+        [Fact]
+        public void RemoveWithEqualityComparer_RemovesTargetedInstanceAmongSortEqualEntries()
+        {
+            var list = new SortedLinkedList<Box>((a, b) => a.Key.CompareTo(b.Key));
+            var first = new Box(1);
+            var second = new Box(1);
+            var third = new Box(1);
+            list.Add(first);
+            list.Add(second);
+            list.Add(third);
+
+            var removed = list.Remove(second, EqualityComparer<Box>.Default);
+
+            Assert.True(removed);
+            Assert.Equal(2, list.Count);
+            Assert.Equal(new[] { first, third }, list.ToList());
+        }
+
+        [Fact]
+        public void RemoveWithEqualityComparer_NotPresent_ReturnsFalse()
+        {
+            var list = new SortedLinkedList<Box>((a, b) => a.Key.CompareTo(b.Key));
+            list.Add(new Box(1));
+
+            var removed = list.Remove(new Box(1), EqualityComparer<Box>.Default);
+
+            Assert.False(removed);
+            Assert.Equal(1, list.Count);
+        }
     }
 }

--- a/Game.Core/Attributes/AttributeCollection.cs
+++ b/Game.Core/Attributes/AttributeCollection.cs
@@ -38,6 +38,33 @@ namespace Game.Core.Attributes
         }
 
         /// <summary>
+        /// Removes the <paramref name="modifier"/> instance from the store, invalidating the
+        /// affected node's cached value with the same cascading derived-node invalidation
+        /// <see cref="AddModifier"/> performs. Returns whether the modifier was present.
+        /// </summary>
+        /// <param name="modifier"></param>
+        public bool RemoveModifier(AttributeModifier modifier)
+        {
+            var node = _attributeNodeList[(int)modifier.Attribute];
+
+            // Identity removal: a node can hold several modifiers with the same Type (the
+            // collection's sort key), so the exact instance must be matched, not a sort-equal one.
+            // AttributeModifier does not override Equals, so the default comparer is reference equality.
+            if (node.Modifiers is null || !node.Modifiers.Remove(modifier, EqualityComparer<AttributeModifier>.Default))
+            {
+                return false;
+            }
+
+            if (modifier.Source is EAttributeModifierSource.Derived)
+            {
+                UnhookDerivedLink(node, modifier.DerivedSource);
+            }
+
+            node.SetCachedValue(null);
+            return true;
+        }
+
+        /// <summary>
         /// Gets the final value of the <see cref="EAttribute"/> based on each <see cref="AttributeModifier"/>.
         /// </summary>
         /// <param name="attribute"></param>
@@ -89,6 +116,24 @@ namespace Game.Core.Attributes
 
                 sourceNode.DerivedNodes.Add(node);
             }
+        }
+
+        /// <summary>
+        /// Unhooks the cascade link from <paramref name="derivedSource"/> to <paramref name="node"/>,
+        /// but only when no remaining modifier on the node still derives from that source — so the
+        /// source's cache-invalidation cascade stays correct rather than dropping a still-needed link.
+        /// </summary>
+        private void UnhookDerivedLink(AttributeCollectionNode node, EAttribute derivedSource)
+        {
+            foreach (var modifier in node.GetModifiersOrNew())
+            {
+                if (modifier.Source is EAttributeModifierSource.Derived && modifier.DerivedSource == derivedSource)
+                {
+                    return;
+                }
+            }
+
+            _attributeNodeList[(int)derivedSource].DerivedNodes.Remove(node);
         }
 
         private void AddStaticModifiers()

--- a/Game.Core/Collections/SortedLinkedList.cs
+++ b/Game.Core/Collections/SortedLinkedList.cs
@@ -73,6 +73,42 @@ namespace Game.Core.Collections
             return false;
         }
 
+        /// <summary>
+        /// Removes the first node matching <paramref name="value"/> per
+        /// <paramref name="equalityComparer"/> rather than the ordering comparer. Use this to
+        /// remove a specific instance when several entries can share the same sort key (the
+        /// ordering comparer would otherwise remove whichever entry sorts equal first).
+        /// </summary>
+        public bool Remove(T value, IEqualityComparer<T> equalityComparer)
+        {
+            if (_head is null)
+            {
+                return false;
+            }
+
+            if (equalityComparer.Equals(_head.Value, value))
+            {
+                _head = _head.Next;
+                Count--;
+                return true;
+            }
+
+            var current = _head;
+            while (current.Next is not null)
+            {
+                if (equalityComparer.Equals(current.Next.Value, value))
+                {
+                    current.Next = current.Next.Next;
+                    Count--;
+                    return true;
+                }
+
+                current = current.Next;
+            }
+
+            return false;
+        }
+
         public void Clear()
         {
             _head = null;

--- a/UI/src/lib/battle/battle-attributes.ts
+++ b/UI/src/lib/battle/battle-attributes.ts
@@ -12,25 +12,36 @@ import { computeAttributes } from './attribute-collection';
 const attributesMaxId = Object.values(EAttribute)[Object.values(EAttribute).length - 1] as number;
 
 /**
- * The frontend's battle attribute set, mirroring the backend `AttributeCollection`. It retains
- * its modifier list (rather than flattening to a `number[]` up front) so effects can add/remove
- * modifiers mid-battle; the per-attribute totals are memoised and recomputed only when a modifier
- * changes, through the same {@link computeAttributes} path the breakdown screen uses.
+ * The frontend's battle attribute set, mirroring the backend `AttributeCollection`. It retains its
+ * modifier list (rather than discarding it after battle start) so effects can add/remove modifiers
+ * mid-battle; the per-attribute totals are recomputed — through the same {@link computeAttributes}
+ * path the breakdown screen uses — only when the modifier set changes, and memoised between changes.
+ *
+ * Two reactivity rules make this safe once an instance is made reactive (`statify`):
+ * - The recompute is **eager** (on each `setData`/`addModifier`/`removeModifier`), so
+ *   {@link getValue}/{@link getAttributeMap} are pure reads. Those reads happen inside Svelte
+ *   `$derived` (e.g. a battler card's MaxHealth bar); a lazy recompute would be an illegal
+ *   mid-derivation `$state` write (`state_unsafe_mutation`).
+ * - The modifier list and the `calcDerived` flag are **private (`#`) fields**, invisible to
+ *   `statify`, so they stay non-reactive. That keeps `removeModifier`'s reference identity intact
+ *   (a reactive array would deep-proxy its elements, so the stored modifier would no longer be
+ *   `===` the reference the caller holds). Only {@link attributeValues} — what the UI reads — is
+ *   reactive, reassigned on each recompute.
  */
 export class BattleAttributes {
 	/** Every modifier composing this set, in the order the backend applies them. */
-	private modifiers: AttributeModifier[] = [];
+	#modifiers: AttributeModifier[] = [];
 	/** When false the derived/static pass is skipped — raw additive sums, for display only. */
-	private calcDerived = true;
-	/** Memoised per-attribute totals; null marks them stale after a modifier change. */
-	private cachedValues: number[] | null = null;
+	#calcDerived = true;
+	/** The memoised per-attribute totals, recomputed only when the modifier set changes. */
+	private attributeValues: number[] = new Array<number>(attributesMaxId + 1).fill(0);
 
 	constructor(attList: IBattlerAttribute[] = [], calcDerivedStats: boolean = true) {
 		this.setData(attList, calcDerivedStats);
 	}
 
 	public setData(attList: IBattlerAttribute[] = [], calcDerivedStats: boolean = true) {
-		this.calcDerived = calcDerivedStats;
+		this.#calcDerived = calcDerivedStats;
 		const base = attList.map(
 			(att): BaseAttributeModifier => ({
 				attribute: att.attributeId,
@@ -39,55 +50,51 @@ export class BattleAttributes {
 				source: EAttributeModifierSource.AttributeDistribution
 			})
 		);
-		this.modifiers = calcDerivedStats ? [...base, ...STATIC_ATTRIBUTE_MODIFIERS] : base;
-		this.cachedValues = null;
+		this.#modifiers = calcDerivedStats ? [...base, ...STATIC_ATTRIBUTE_MODIFIERS] : base;
+		this.recompute();
 	}
 
-	/** Adds a modifier and invalidates the memoised totals (recomputed lazily on next read). */
+	/** Adds a modifier and recomputes the totals. */
 	public addModifier(modifier: AttributeModifier) {
-		this.modifiers.push(modifier);
-		this.cachedValues = null;
+		this.#modifiers.push(modifier);
+		this.recompute();
 	}
 
-	/** Removes a previously-added modifier instance (by reference). Returns whether it was present. */
+	/** Removes a previously-added modifier instance (by reference) and recomputes the totals.
+	 *  Returns whether it was present. */
 	public removeModifier(modifier: AttributeModifier): boolean {
-		const index = this.modifiers.indexOf(modifier);
+		const index = this.#modifiers.indexOf(modifier);
 		if (index < 0) {
 			return false;
 		}
-		this.modifiers.splice(index, 1);
-		this.cachedValues = null;
+		this.#modifiers.splice(index, 1);
+		this.recompute();
 		return true;
 	}
 
 	public getValue(attId: EAttribute) {
-		return this.values()[attId];
+		return this.attributeValues[attId];
 	}
 
 	public getAttributeMap = (includeZeroes: boolean = false) => {
-		return this.values()
+		return this.attributeValues
 			.map((att, i) => ({ name: normalizeText(EAttribute[i]), value: att }))
 			.filter((att) => att.value != 0 || includeZeroes);
 	};
 
-	/** Lazily (re)computes and memoises the per-attribute totals from the current modifiers. */
-	private values(): number[] {
-		if (this.cachedValues) {
-			return this.cachedValues;
-		}
-
+	/** Recomputes the per-attribute totals from the current modifiers. Called only when the
+	 *  modifier set changes; reads then return the memoised result without recomputing. */
+	private recompute() {
 		const values = new Array<number>(attributesMaxId + 1).fill(0);
-		if (this.calcDerived) {
-			for (const [attr, result] of computeAttributes(this.modifiers)) {
+		if (this.#calcDerived) {
+			for (const [attr, result] of computeAttributes(this.#modifiers)) {
 				values[attr] = result.total;
 			}
 		} else {
-			for (const modifier of this.modifiers) {
+			for (const modifier of this.#modifiers) {
 				values[modifier.attribute] += modifier.amount;
 			}
 		}
-
-		this.cachedValues = values;
-		return values;
+		this.attributeValues = values;
 	}
 }

--- a/UI/src/lib/battle/battle-attributes.ts
+++ b/UI/src/lib/battle/battle-attributes.ts
@@ -11,47 +11,83 @@ import { computeAttributes } from './attribute-collection';
 
 const attributesMaxId = Object.values(EAttribute)[Object.values(EAttribute).length - 1] as number;
 
+/**
+ * The frontend's battle attribute set, mirroring the backend `AttributeCollection`. It retains
+ * its modifier list (rather than flattening to a `number[]` up front) so effects can add/remove
+ * modifiers mid-battle; the per-attribute totals are memoised and recomputed only when a modifier
+ * changes, through the same {@link computeAttributes} path the breakdown screen uses.
+ */
 export class BattleAttributes {
-	public attributes: number[];
+	/** Every modifier composing this set, in the order the backend applies them. */
+	private modifiers: AttributeModifier[] = [];
+	/** When false the derived/static pass is skipped — raw additive sums, for display only. */
+	private calcDerived = true;
+	/** Memoised per-attribute totals; null marks them stale after a modifier change. */
+	private cachedValues: number[] | null = null;
 
 	constructor(attList: IBattlerAttribute[] = [], calcDerivedStats: boolean = true) {
-		this.attributes = new Array<number>(attributesMaxId + 1);
 		this.setData(attList, calcDerivedStats);
 	}
 
 	public setData(attList: IBattlerAttribute[] = [], calcDerivedStats: boolean = true) {
-		this.attributes.fill(0, 0, attributesMaxId + 1);
+		this.calcDerived = calcDerivedStats;
+		const base = attList.map(
+			(att): BaseAttributeModifier => ({
+				attribute: att.attributeId,
+				amount: att.amount,
+				type: EModifierType.Additive,
+				source: EAttributeModifierSource.AttributeDistribution
+			})
+		);
+		this.modifiers = calcDerivedStats ? [...base, ...STATIC_ATTRIBUTE_MODIFIERS] : base;
+		this.cachedValues = null;
+	}
 
-		if (calcDerivedStats) {
-			const modifiers: AttributeModifier[] = [
-				...attList.map(
-					(att): BaseAttributeModifier => ({
-						attribute: att.attributeId,
-						amount: att.amount,
-						type: EModifierType.Additive,
-						source: EAttributeModifierSource.AttributeDistribution
-					})
-				),
-				...STATIC_ATTRIBUTE_MODIFIERS
-			];
-			const computed = computeAttributes(modifiers);
-			for (const [attr, result] of computed) {
-				this.attributes[attr] = result.total;
-			}
-		} else {
-			for (const att of attList) {
-				this.attributes[att.attributeId] += att.amount;
-			}
+	/** Adds a modifier and invalidates the memoised totals (recomputed lazily on next read). */
+	public addModifier(modifier: AttributeModifier) {
+		this.modifiers.push(modifier);
+		this.cachedValues = null;
+	}
+
+	/** Removes a previously-added modifier instance (by reference). Returns whether it was present. */
+	public removeModifier(modifier: AttributeModifier): boolean {
+		const index = this.modifiers.indexOf(modifier);
+		if (index < 0) {
+			return false;
 		}
+		this.modifiers.splice(index, 1);
+		this.cachedValues = null;
+		return true;
 	}
 
 	public getValue(attId: EAttribute) {
-		return this.attributes[attId];
+		return this.values()[attId];
 	}
 
 	public getAttributeMap = (includeZeroes: boolean = false) => {
-		return this.attributes
+		return this.values()
 			.map((att, i) => ({ name: normalizeText(EAttribute[i]), value: att }))
 			.filter((att) => att.value != 0 || includeZeroes);
 	};
+
+	/** Lazily (re)computes and memoises the per-attribute totals from the current modifiers. */
+	private values(): number[] {
+		if (this.cachedValues) {
+			return this.cachedValues;
+		}
+
+		const values = new Array<number>(attributesMaxId + 1).fill(0);
+		if (this.calcDerived) {
+			for (const [attr, result] of computeAttributes(this.modifiers)) {
+				values[attr] = result.total;
+			}
+		} else {
+			for (const modifier of this.modifiers) {
+				values[modifier.attribute] += modifier.amount;
+			}
+		}
+
+		this.cachedValues = values;
+		return values;
+	}
 }

--- a/UI/src/lib/battle/battler.ts
+++ b/UI/src/lib/battle/battler.ts
@@ -21,8 +21,13 @@ export class Battler {
 	public attributes: BattleAttributes = new BattleAttributes();
 	public skills: (Skill | undefined)[] = [];
 	public maxSkills: typeof maxSkills = maxSkills;
-	public cdMultiplier = 1;
 	public isDead = true;
+
+	/** Live read of the CooldownRecovery-derived multiplier (mirrors the backend), so a
+	 *  mid-battle CDR change takes effect on the next tick rather than being frozen at reset. */
+	public get cdMultiplier(): number {
+		return 1 + this.attributes.getValue(EAttribute.CooldownRecovery) / 100;
+	}
 
 	constructor(battlerData?: BattlerData, additionalAtttributes?: IBattlerAttribute[]) {
 		this.reset(battlerData, additionalAtttributes);
@@ -73,7 +78,6 @@ export class Battler {
 		}
 
 		this.currentHealth = this.attributes.getValue(EAttribute.MaxHealth);
-		this.cdMultiplier = 1 + this.attributes.getValue(EAttribute.CooldownRecovery) / 100;
 		this.isDead = false;
 	}
 

--- a/UI/src/tests/lib/battle/battle-attributes.svelte.test.ts
+++ b/UI/src/tests/lib/battle/battle-attributes.svelte.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { flushSync } from 'svelte';
+import { EAttribute } from '$lib/api';
+import { statify } from '$lib/common';
+import { BattleAttributes } from '$lib/battle/battle-attributes';
+import { EModifierType, EAttributeModifierSource, type AttributeModifier } from '$lib/battle/attribute-modifier';
+
+// In the running app battlers are made reactive with `statify`, so their attribute values are read
+// inside Svelte `$derived` (e.g. BattlerCard's MaxHealth bar). A `getValue` that recomputed lazily
+// would perform a `$state` write mid-derivation — the illegal `state_unsafe_mutation` that broke the
+// real-time fight in e2e while the (non-reactive) unit suites stayed green. These guard that reading
+// the memoised values inside a derivation is a pure read.
+describe('BattleAttributes under statify (reactive reads)', () => {
+	it('reads getValue inside a $derived without an unsafe-mutation, and reacts to changes', () => {
+		const attrs = statify(new BattleAttributes([{ attributeId: EAttribute.Endurance, amount: 10 }]));
+
+		let derivedMaxHealth = 0;
+		const cleanup = $effect.root(() => {
+			const maxHealth = $derived(attrs.getValue(EAttribute.MaxHealth));
+			$effect(() => {
+				derivedMaxHealth = maxHealth;
+			});
+		});
+
+		flushSync();
+		// 50 + 20*Endurance(10) = 250.
+		expect(derivedMaxHealth).toBe(250);
+
+		const enduranceBuff: AttributeModifier = {
+			attribute: EAttribute.Endurance,
+			amount: 5,
+			type: EModifierType.Additive,
+			source: EAttributeModifierSource.PlayerStatPoints
+		};
+		attrs.addModifier(enduranceBuff);
+		flushSync();
+		// 50 + 20*15 = 350 — the derived recomputes off the new modifier set.
+		expect(derivedMaxHealth).toBe(350);
+
+		attrs.removeModifier(enduranceBuff);
+		flushSync();
+		expect(derivedMaxHealth).toBe(250);
+
+		cleanup();
+	});
+});

--- a/UI/src/tests/lib/battle/battle-attributes.test.ts
+++ b/UI/src/tests/lib/battle/battle-attributes.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { EAttribute } from '$lib/api';
 import { BattleAttributes } from '$lib/battle/battle-attributes';
+import { EModifierType, EAttributeModifierSource, type AttributeModifier } from '$lib/battle/attribute-modifier';
 
 const makeAttrs = (...pairs: [EAttribute, number][]) => pairs.map(([attributeId, amount]) => ({ attributeId, amount }));
+
+const additive = (attribute: EAttribute, amount: number): AttributeModifier => ({
+	attribute,
+	amount,
+	type: EModifierType.Additive,
+	source: EAttributeModifierSource.PlayerStatPoints
+});
 
 describe('BattleAttributes', () => {
 	describe('constructor', () => {
@@ -83,6 +91,71 @@ describe('BattleAttributes', () => {
 
 			expect(map.length).toBeGreaterThan(0);
 			expect(map.some((a) => a.value === 0)).toBe(true);
+		});
+	});
+
+	// Mirrors Game.Core.Tests AttributeCollectionTests.RemoveModifier_* so the two attribute
+	// implementations stay aligned on add/remove and the derived-cascade behaviour.
+	describe('addModifier / removeModifier', () => {
+		it('recomputes the value when a modifier is added', () => {
+			const ba = new BattleAttributes([]);
+			expect(ba.getValue(EAttribute.Strength)).toBe(0);
+
+			ba.addModifier(additive(EAttribute.Strength, 10));
+			expect(ba.getValue(EAttribute.Strength)).toBe(10);
+		});
+
+		it('reverts the value when a modifier is removed', () => {
+			const ba = new BattleAttributes([]);
+			const modifier = additive(EAttribute.Strength, 5);
+			ba.addModifier(additive(EAttribute.Strength, 10));
+			ba.addModifier(modifier);
+			expect(ba.getValue(EAttribute.Strength)).toBe(15);
+
+			expect(ba.removeModifier(modifier)).toBe(true);
+			expect(ba.getValue(EAttribute.Strength)).toBe(10);
+		});
+
+		it('cascades a removal to derived attributes (Strength → MaxHealth)', () => {
+			const ba = new BattleAttributes([]);
+			const strength = additive(EAttribute.Strength, 10);
+			ba.addModifier(strength);
+			// MaxHealth derives from Strength (×5): 50 + 5*10 = 100.
+			expect(ba.getValue(EAttribute.MaxHealth)).toBe(100);
+
+			ba.removeModifier(strength);
+			expect(ba.getValue(EAttribute.MaxHealth)).toBe(50);
+		});
+
+		it('restores the value when a removed modifier is re-added', () => {
+			const ba = new BattleAttributes([]);
+			const modifier = additive(EAttribute.Strength, 7);
+			ba.addModifier(modifier);
+
+			ba.removeModifier(modifier);
+			expect(ba.getValue(EAttribute.Strength)).toBe(0);
+
+			ba.addModifier(modifier);
+			expect(ba.getValue(EAttribute.Strength)).toBe(7);
+		});
+
+		it('removes the exact instance among modifiers of the same type', () => {
+			const ba = new BattleAttributes([]);
+			const first = additive(EAttribute.Strength, 10);
+			const second = additive(EAttribute.Strength, 3);
+			ba.addModifier(first);
+			ba.addModifier(second);
+
+			ba.removeModifier(second);
+			expect(ba.getValue(EAttribute.Strength)).toBe(10);
+		});
+
+		it('returns false when removing a modifier that was never added', () => {
+			const ba = new BattleAttributes([]);
+			ba.addModifier(additive(EAttribute.Strength, 10));
+
+			expect(ba.removeModifier(additive(EAttribute.Strength, 10))).toBe(false);
+			expect(ba.getValue(EAttribute.Strength)).toBe(10);
 		});
 	});
 });

--- a/UI/src/tests/lib/battle/battler.test.ts
+++ b/UI/src/tests/lib/battle/battler.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EAttribute } from '$lib/api';
 import type { ISkill } from '$lib/api';
+import { EModifierType, EAttributeModifierSource } from '$lib/battle/attribute-modifier';
 
 const mockSkills: ISkill[] = [];
 
@@ -76,6 +77,20 @@ describe('Battler', () => {
 
 			const cdRecovery = 0.4 * 20 + 0.1 * 10;
 			expect(battler.cdMultiplier).toBeCloseTo(1 + cdRecovery / 100, 10);
+		});
+
+		it('reads cdMultiplier live, reflecting a mid-battle CooldownRecovery change', () => {
+			const battler = new Battler(makeBattlerData({ attributes: [] }));
+			expect(battler.cdMultiplier).toBe(1);
+
+			battler.attributes.addModifier({
+				attribute: EAttribute.CooldownRecovery,
+				amount: 100,
+				type: EModifierType.Additive,
+				source: EAttributeModifierSource.PlayerStatPoints
+			});
+
+			expect(battler.cdMultiplier).toBe(2);
 		});
 
 		it('sets isDead to false', () => {

--- a/UI/src/tests/routes/game/screens/fight/SkillTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/SkillTooltip.test.ts
@@ -87,8 +87,14 @@ describe('SkillTooltip', () => {
 	});
 
 	it('derives cooldown and DPS, shortening the cooldown for a faster battler', () => {
-		const fast = makeBattler({ attributes: [{ attributeId: EAttribute.Strength, amount: 20 }] });
-		fast.cdMultiplier = 2;
+		// cdMultiplier is a live read of CooldownRecovery: 1 + 100/100 = 2 (fixtures skip the
+		// derived pass, so CooldownRecovery is taken verbatim from the supplied attributes).
+		const fast = makeBattler({
+			attributes: [
+				{ attributeId: EAttribute.Strength, amount: 20 },
+				{ attributeId: EAttribute.CooldownRecovery, amount: 100 }
+			]
+		});
 		const skill = makeSkill(fast, {
 			baseDamage: 10,
 			damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 2 }],

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -39,6 +39,8 @@ The frontend simulates battles in real time as an anti-cheat measure: the backen
 
 The cross-implementation parity suite (`battle-simulation-parity.test.ts`) drives the production `BattleSimulator` (not a hand-rolled copy), so a change to `Battler.advanceCooldowns`, `Skill.calculateDamage` or `Battler.takeDamage` that diverged from the backend would fail parity rather than silently weaken the replay. Keep its scenario matrix row-for-row aligned with the backend's `BattleSimulatorParityTests`.
 
+**Mid-battle attributes are a modifier graph, not a frozen snapshot.** `BattleAttributes` (`$lib/battle/battle-attributes.ts`) retains its modifier list instead of flattening to a `number[]` at battle start, and composes the per-attribute totals through the same `computeAttributes` path the breakdown screen uses — memoised, recomputed only when a modifier is added (`addModifier`) or removed (`removeModifier`, by reference). This mirrors the backend `AttributeCollection` (whose `RemoveModifier` performs the same cascading derived-node cache invalidation as `AddModifier`), so both sides resolve derived attributes through one composition path even as values change mid-fight — the parity surface skill effects build on. Consequently `Battler.cdMultiplier` is a **live read** of `CooldownRecovery` (matching the backend's per-tick read) rather than a value cached at `reset`.
+
 ## Authentication (JWT bearer + rotating refresh tokens)
 
 The frontend authenticates against the backend's JWT scheme (see the backend doc for the server side). All of the token handling lives in the API client layer (`lib/api`) so the rest of the app never touches tokens directly:


### PR DESCRIPTION
## Summary

Implements #331 (spike #180, **area A**) — the **foundation** for the skill-effect battle runtime. Temporary effects need attribute values that can change and revert mid-battle, on **both** sides of the battle-parity boundary. This lands that capability with **no behaviour change to current battles** (the existing parity matrices stay green); the runtime issues (#333+) build on it.

## How it addresses the issue

### Backend
- **`AttributeCollection.RemoveModifier(modifier)`** removes a modifier instance and invalidates the affected node's cached value with the **same cascading derived-node invalidation** `AddModifier` performs (`SetCachedValue(null)` already cascades to derived nodes). When the removed modifier is `Derived`, the cascade link from its source attribute is unhooked **only when no remaining modifier on the node still derives from that source** (decided per the issue's note — keeps the source's invalidation cascade correct rather than dropping a still-needed link). Returns whether the modifier was present.
- **`SortedLinkedList<T>.Remove(value, equalityComparer)`** — an identity-aware overload. The node's list is ordered by modifier `Type`, so several entries can share a sort key; removing the exact instance needs equality, not the ordering comparer (which would drop whichever sorts equal first). `RemoveModifier` passes `EqualityComparer<AttributeModifier>.Default` (reference identity, since `AttributeModifier` doesn't override `Equals`). The existing comparer-based `Remove(value)` is untouched.

### Frontend
- **`BattleAttributes` retains its modifier list** instead of flattening to a `number[]` at battle start, exposing `addModifier` / `removeModifier` (by reference) with **memoised** per-attribute totals recomputed only on a modifier change — through the existing `computeAttributes`, the **same composition path** the Attribute Breakdown screen uses (additive-then-multiplicative, derived resolution, circular guard). So both sides now compose attributes through one path, including mid-battle recompute. The public API (`getValue` / `getAttributeMap` / `setData`) is unchanged; the previously-public flattened array became the private memoised cache (no external reader).
- **`Battler.cdMultiplier` is now a live read** of `CooldownRecovery` (matching the backend's per-tick `GetCooldownMultiplier`) rather than a value cached at `reset`, so a later CDR buff takes effect on the next tick.

### Docs
- `docs/frontend.md` battle-parity section gains a concise note on the modifier-graph rework + live `cdMultiplier` read (the parity surface skill effects build on).

## Test plan

Mirrored on both sides (`AttributeCollectionTests` ↔ `battle-attributes.test.ts`): value reverts on remove, derived cascade (Strength removal updates MaxHealth), remove-then-re-add, **identity** removal among same-type modifiers, removing a derived modifier leaves the static cascade intact, and not-present → `false`. Plus `SortedLinkedList` identity-removal tests and a frontend `Battler` live-`cdMultiplier` test. The `SkillTooltip` test that set `cdMultiplier` directly now drives it via `CooldownRecovery` (it's a getter now).

- **Backend:** `dotnet build` clean (full solution); `Game.Core.Tests` — **358 passing**.
- **Frontend:** `npm run lint` (eslint + svelte-check) clean; `npm run test:unit:ci` — **1260 passing**, coverage gate satisfied.

## Notes

- During selection I confirmed two other open issues are already implemented but weren't auto-closed: **#268** (legacy password hash removed — migration `ConsolidateUserSaltIntoPassHash`) and **#295** (`retireableOptions` already excludes retired records from the Workbench pickers). Both look ready to close.

Closes #331

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXwVM1xZyiyLnk9KdA6Eme)_