### PR TITLE
Fix inventory drawer backdrop: use &lt;button&gt; instead of &lt;div&gt; (a11y)

### DIFF
--- a/UI/src/routes/game/screens/inventory/Inventory.svelte
+++ b/UI/src/routes/game/screens/inventory/Inventory.svelte
@@ -19,7 +19,14 @@
 
 	<!-- Detail drawer: right-side slide-over with dimmed backdrop + click-outside close -->
 	<div class="drawer-layer" style:pointer-events={view.selected ? 'auto' : 'none'}>
-		<div class="backdrop" class:open={!!view.selected} role="presentation" onclick={() => view.select(null)}></div>
+		<button
+			class="backdrop"
+			type="button"
+			tabindex="-1"
+			aria-label="Close item drawer"
+			class:open={!!view.selected}
+			onclick={() => view.select(null)}
+		></button>
 		<div class="drawer" class:open={!!view.selected}>
 			{#if view.selected}
 				<ItemDrawer item={view.selected} {view} />
@@ -114,6 +121,9 @@ const view = new InventoryView();
 .backdrop {
 	position: absolute;
 	inset: 0;
+	padding: 0;
+	border: none;
+	cursor: default;
 	background: color-mix(in srgb, var(--black) 50%, transparent);
 	opacity: 0;
 	transition: opacity 200ms;

--- a/UI/src/tests/routes/game/screens/inventory/Inventory.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/Inventory.test.ts
@@ -54,4 +54,12 @@ describe('Inventory screen', () => {
 		const { container } = render(Inventory);
 		expect(container.querySelector('.rail')).toBeTruthy();
 	});
+
+	it('renders the drawer backdrop as a <button> (not a <div>) for a11y', () => {
+		const { container } = render(Inventory);
+		const backdrop = container.querySelector('.backdrop');
+		expect(backdrop?.tagName.toLowerCase()).toBe('button');
+		expect(backdrop?.getAttribute('type')).toBe('button');
+		expect(backdrop?.getAttribute('aria-label')).toBe('Close item drawer');
+	});
 });


### PR DESCRIPTION
## Summary

- Replaces the `<div role="presentation" onclick={...}>` backdrop in `Inventory.svelte` with a proper `<button type="button" tabindex="-1" aria-label="Close item drawer">`, matching the `ModalHost` backdrop pattern documented in `frontend.md`.
- Adds `padding: 0; border: none; cursor: default;` CSS resets to `.backdrop` to neutralise default button browser styling.
- Adds a unit test asserting the backdrop element is a `<button>` with the correct `type` and `aria-label`.

## How it addresses the issue

The project's a11y convention (documented in `frontend.md` → _Modal dialogs_) requires dim backdrops to be real `<button>` elements. The inventory drawer was the only backdrop using a clickable `<div>` with `role="presentation"`, which contradicted both the documented pattern and the sibling `ModalHost` implementation. This PR brings it into line.

## Test plan

- [x] `npm run test:unit:ci` — all 1319 tests pass (including the new backdrop assertion)
- [x] `npm run lint` — no ESLint or Svelte type-check errors
- [x] Backdrop is still visually and functionally identical (opacity transition, click-outside-to-close); only the element tag changes

Closes #368

https://claude.ai/code/session_0188o1KUZ7WmS7uBA6LjzeVr

---
_Generated by [Claude Code](https://claude.ai/code/session_0188o1KUZ7WmS7uBA6LjzeVr)_