### PR TITLE
Add unit tests for RenderEngine and log-kind.ts; ratchet coverage floors (#369)

### DIFF
--- a/UI/src/tests/components/log-panel/log-kind.test.ts
+++ b/UI/src/tests/components/log-panel/log-kind.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { ELogType } from '$lib/api';
+import { logKind, formatLogTime, logColors } from '../../../components/log-panel/log-kind';
+
+type LogMessage = { id: number; logType: ELogType; message: string };
+
+function makeLog(logType: ELogType, message: string): LogMessage {
+	return { id: 1, logType, message };
+}
+
+describe('logKind', () => {
+	describe('ELogType.Damage', () => {
+		it('returns the player-hit treatment when the message starts with "You"', () => {
+			const result = logKind(makeLog(ELogType.Damage, 'You used Slash for 42 damage.'));
+			expect(result.color).toBe(logColors.player);
+			expect(result.glyph).toBe('hit');
+			expect(result.label).toBe('Hit');
+		});
+
+		it('returns the enemy-hit treatment when the message does not start with "You"', () => {
+			const result = logKind(makeLog(ELogType.Damage, 'Goblin hit you for 15 damage.'));
+			expect(result.color).toBe(logColors.enemy);
+			expect(result.glyph).toBe('enemy');
+			expect(result.label).toBe('Hurt');
+		});
+	});
+
+	describe('ELogType.EnemyDefeated', () => {
+		it('returns the player-kill treatment when the message starts with "You"', () => {
+			const result = logKind(makeLog(ELogType.EnemyDefeated, "You've defeated the Goblin!"));
+			expect(result.color).toBe(logColors.enemy);
+			expect(result.glyph).toBe('kill');
+			expect(result.label).toBe('Defeat');
+		});
+
+		it('returns the enemy-victory treatment when the message does not start with "You"', () => {
+			const result = logKind(makeLog(ELogType.EnemyDefeated, 'Goblin has defeated you!'));
+			expect(result.color).toBe(logColors.loot);
+			expect(result.glyph).toBe('kill');
+			expect(result.label).toBe('Victory');
+		});
+	});
+
+	it('returns the loot treatment for ELogType.ItemFound', () => {
+		const result = logKind(makeLog(ELogType.ItemFound, 'Found Iron Sword!'));
+		expect(result.color).toBe(logColors.loot);
+		expect(result.glyph).toBe('loot');
+		expect(result.label).toBe('Loot');
+	});
+
+	it('returns the exp reward treatment for ELogType.Exp', () => {
+		const result = logKind(makeLog(ELogType.Exp, 'Gained 120 exp.'));
+		expect(result.color).toBe(logColors.reward);
+		expect(result.glyph).toBe('crit');
+		expect(result.label).toBe('Exp');
+	});
+
+	it('returns the level reward treatment for ELogType.LevelUp', () => {
+		const result = logKind(makeLog(ELogType.LevelUp, 'Level up! You are now level 5.'));
+		expect(result.color).toBe(logColors.reward);
+		expect(result.glyph).toBe('crit');
+		expect(result.label).toBe('Level');
+	});
+
+	it('returns the system treatment for ELogType.Debug', () => {
+		const result = logKind(makeLog(ELogType.Debug, 'Debug info.'));
+		expect(result.color).toBe(logColors.system);
+		expect(result.glyph).toBe('system');
+		expect(result.label).toBe('Info');
+	});
+
+	it('falls back to the system treatment for unknown log types', () => {
+		const result = logKind(makeLog(999 as ELogType, 'Unknown event.'));
+		expect(result.color).toBe(logColors.system);
+		expect(result.glyph).toBe('system');
+		expect(result.label).toBe('Info');
+	});
+});
+
+describe('formatLogTime', () => {
+	it('formats id 0 as 00:00', () => {
+		expect(formatLogTime(0)).toBe('00:00');
+	});
+
+	it('ids below 60 still show 00:00 (sub-second resolution rounds down)', () => {
+		expect(formatLogTime(30)).toBe('00:00');
+		expect(formatLogTime(59)).toBe('00:00');
+	});
+
+	it('formats exactly one second', () => {
+		expect(formatLogTime(60)).toBe('00:01');
+	});
+
+	it('formats one minute boundary', () => {
+		expect(formatLogTime(3600)).toBe('01:00');
+	});
+
+	it('formats a value with both minutes and seconds', () => {
+		// 90 seconds = 1 min 30 sec → id = 90 * 60 = 5400
+		expect(formatLogTime(5400)).toBe('01:30');
+	});
+
+	it('pads single-digit minutes and seconds with a leading zero', () => {
+		// 5 min 9 sec → id = 309 * 60 = 18540
+		expect(formatLogTime(18540)).toBe('05:09');
+	});
+
+	it('wraps minutes at 100 (minutes % 100)', () => {
+		// 100 minutes → id = 6000 * 60 = 360000
+		expect(formatLogTime(360000)).toBe('00:00');
+	});
+
+	it('handles large ids correctly', () => {
+		// 99 min 59 sec → id = (99*60 + 59) * 60 = 359940
+		expect(formatLogTime(359940)).toBe('99:59');
+	});
+});

--- a/UI/src/tests/lib/engine/render-engine.test.ts
+++ b/UI/src/tests/lib/engine/render-engine.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('svelte', async (importOriginal) => ({
+	...((await importOriginal()) as Record<string, unknown>),
+	onDestroy: vi.fn()
+}));
+
+const logicEngineStub = vi.hoisted(() => ({ time: 0 }));
+vi.mock('$lib/engine/engine', () => ({ logicEngine: logicEngineStub }));
+
+const rafCallbacks: (() => void)[] = [];
+vi.stubGlobal('window', {
+	requestAnimationFrame: vi.fn((cb: () => void) => {
+		rafCallbacks.push(cb);
+		return rafCallbacks.length;
+	})
+});
+
+import { RenderEngine, onRenderUpdate } from '$lib/engine/render-engine';
+
+describe('RenderEngine', () => {
+	let engine: RenderEngine;
+	let performanceNow: number;
+	/** Accumulates [delta, logicalDelta] pairs from each onRenderUpdate notification. */
+	let renderUpdates: [number, number][];
+	let unhook: () => void;
+
+	beforeEach(() => {
+		rafCallbacks.length = 0;
+		logicEngineStub.time = 0;
+		performanceNow = 0;
+		renderUpdates = [];
+		vi.spyOn(performance, 'now').mockImplementation(() => performanceNow);
+		unhook = onRenderUpdate((delta, logicalDelta) => renderUpdates.push([delta, logicalDelta]), false);
+		engine = new RenderEngine();
+	});
+
+	afterEach(() => {
+		engine.stop();
+		unhook();
+		vi.restoreAllMocks();
+	});
+
+	describe('start / stop guard', () => {
+		it('schedules a requestAnimationFrame callback on start', () => {
+			engine.start();
+			expect(rafCallbacks.length).toBe(1);
+		});
+
+		it('is idempotent — a second start call does not double-schedule', () => {
+			engine.start();
+			engine.start();
+			expect(rafCallbacks.length).toBe(1);
+		});
+
+		it('stop prevents the pending RAF callback from scheduling another', () => {
+			engine.start();
+			engine.stop();
+			rafCallbacks.shift()?.(); // renderLoop checks running → false, schedules nothing
+			expect(rafCallbacks.length).toBe(0);
+		});
+
+		it('can be restarted after stop', () => {
+			engine.start();
+			engine.stop();
+			renderUpdates.length = 0;
+
+			engine.start();
+			expect(renderUpdates.length).toBe(1);
+		});
+	});
+
+	describe('update notifications', () => {
+		it('notifies onRenderUpdate immediately on the first frame', () => {
+			engine.start();
+			expect(renderUpdates.length).toBe(1);
+		});
+
+		it('passes delta as the elapsed time since the previous frame', () => {
+			performanceNow = 1000;
+			engine.start(); // delta = 1000 − 0 (initial time)
+
+			expect(renderUpdates[0][0]).toBe(1000);
+
+			performanceNow = 1016;
+			rafCallbacks.shift()?.(); // second frame: delta = 1016 − 1000 = 16
+
+			expect(renderUpdates[1][0]).toBe(16);
+		});
+
+		it('passes logicalDelta as the difference from logicEngine.time', () => {
+			performanceNow = 2000;
+			logicEngineStub.time = 1960;
+			engine.start();
+
+			expect(renderUpdates[0][1]).toBe(40); // 2000 − 1960
+		});
+
+		it('updates the time property to the current performance timestamp each frame', () => {
+			performanceNow = 500;
+			engine.start();
+			expect(engine.time).toBe(500);
+
+			performanceNow = 516;
+			rafCallbacks.shift()?.();
+			expect(engine.time).toBe(516);
+		});
+
+		it('fires a notification on every rendered frame', () => {
+			engine.start();
+			rafCallbacks.shift()?.(); // second frame
+			rafCallbacks.shift()?.(); // third frame
+
+			expect(renderUpdates.length).toBe(3);
+		});
+	});
+
+	describe('tickRate', () => {
+		it('is 0 before the first report interval elapses', () => {
+			engine.start(); // only 1 countTick call — well below the 10-event threshold
+			expect(engine.tickRate).toBe(0);
+		});
+
+		it('is updated after 10 frames (getEventCounter default report interval)', () => {
+			engine.start(); // frame 1
+
+			for (let i = 1; i <= 9; i++) {
+				performanceNow = i * 16; // 16 ms per frame
+				rafCallbacks.shift()?.(); // frames 2–10
+			}
+
+			expect(engine.tickRate).toBeGreaterThan(0);
+		});
+	});
+});

--- a/UI/vite.config.ts
+++ b/UI/vite.config.ts
@@ -33,12 +33,12 @@ export default defineConfig({
 			// for pure-display markup. Re-seed with `node scripts/coverage-floors.mjs` to ratchet up.
 			thresholds: {
 				'src/lib/battle/**': { lines: 99, functions: 100, branches: 89, statements: 99 },
-				'src/lib/engine/**': { lines: 91, functions: 87, branches: 85, statements: 90 },
-				'src/lib/common/**': { lines: 90, functions: 89, branches: 80, statements: 90 },
+				'src/lib/engine/**': { lines: 94, functions: 92, branches: 87, statements: 93 },
+				'src/lib/common/**': { lines: 94, functions: 89, branches: 82, statements: 94 },
 				'src/lib/api/**': { lines: 89, functions: 90, branches: 82, statements: 89 },
 				'src/lib/card-game/**': { lines: 94, functions: 100, branches: 81, statements: 94 },
 				'src/stores/**': { lines: 98, functions: 100, branches: 90, statements: 98 },
-				'src/components/**': { lines: 89, functions: 95, branches: 74, statements: 92 },
+				'src/components/**': { lines: 90, functions: 95, branches: 77, statements: 93 },
 				'src/routes/**': { lines: 90, functions: 88, branches: 68, statements: 89 }
 			}
 		}


### PR DESCRIPTION
## Summary

- Adds unit tests for `RenderEngine` (`src/lib/engine/render-engine.ts`) — previously at 0% function/branch coverage — covering start/stop guard (idempotency, restart-after-stop), per-frame `delta`/`logicalDelta` notifications via `onRenderUpdate`, `time` property updates, and the `tickRate` ratchet after 10 frames.
- Adds unit tests for `logKind` and `formatLogTime` in `src/components/log-panel/log-kind.ts` — previously at ~27% branch coverage — covering every `ELogType` switch arm, both sides of the player-vs-enemy `message.startsWith('You')` disambiguation for `Damage` and `EnemyDefeated`, and a full range of `formatLogTime` formatting cases including minute wrapping.
- Re-seeds the `vite.config.ts` coverage floors for `src/lib/engine/**` and `src/components/**` after the measured gains (`node UI/scripts/coverage-floors.mjs`).

## Test plan

- [x] `npx vitest run src/tests/lib/engine/render-engine.test.ts` — 11 tests, all pass
- [x] `npx vitest run src/tests/components/log-panel/log-kind.test.ts` — 17 tests, all pass
- [x] Full test suite (`npx vitest run`) — 152 files, 1346 tests, all pass
- [x] `npm run lint` — 0 errors, 0 warnings

Closes #369

https://claude.ai/code/session_01MarP4pHwWCBNs7YXKm7iNr

---
_Generated by [Claude Code](https://claude.ai/code/session_01MarP4pHwWCBNs7YXKm7iNr)_