### PR TITLE
Remove now-unread Battler.maxSkills field

### DIFF
--- a/UI/src/lib/battle/battler.ts
+++ b/UI/src/lib/battle/battler.ts
@@ -20,7 +20,6 @@ export class Battler {
 	public currentHealth = 0;
 	public attributes: BattleAttributes = new BattleAttributes();
 	public skills: (Skill | undefined)[] = [];
-	public maxSkills = MAX_SELECTED_SKILLS;
 	public isDead = true;
 
 	/** Live read of the CooldownRecovery-derived multiplier (mirrors the backend), so a

--- a/UI/src/tests/lib/battle/battler.test.ts
+++ b/UI/src/tests/lib/battle/battler.test.ts
@@ -98,7 +98,7 @@ describe('Battler', () => {
 			expect(battler.isDead).toBe(false);
 		});
 
-		it('fills skill slots up to maxSkills (4)', () => {
+		it('fills skill slots up to MAX_SELECTED_SKILLS', () => {
 			const battler = new Battler(makeBattlerData({ selectedSkills: [0] }));
 			expect(battler.skills).toHaveLength(4);
 			expect(battler.skills[0]).toBeDefined();


### PR DESCRIPTION
## Summary

Removes the now-unused `maxSkills` field from the `Battler` class that was set to the generated `MAX_SELECTED_SKILLS` constant but never referenced in production code.

## Changes

- Remove the `public maxSkills` field from `Battler` class in `UI/src/lib/battle/battler.ts`
- The code already references `MAX_SELECTED_SKILLS` directly in `fillSelectedSkills` where it's needed
- Update the test name to reference the constant instead of the removed field

## Test Plan

- [x] All unit tests pass (1319 tests)
- [x] No linting errors
- [x] Type checking passes

Closes #355
https://claude.ai/code/session_012E9agRz3pnh5D5zwWtaRpJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012E9agRz3pnh5D5zwWtaRpJ)_