### PR TITLE
Await InitSubscriber in StartAsync so boot-time subscribe failure surfaces as startup failure (#366)

### DIFF
--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -322,6 +322,17 @@ namespace Game.Application.Tests.DataAccess
             AssertSkillState(rows, skill1.Id, selected: false, order: 0);
         }
 
+        [Fact]
+        public async Task StartAsync_SubscribeThrows_PropagatesException()
+        {
+            using var scope = CreateScope();
+            var logger = new CapturingLogger<DataProviderSynchronizer>();
+            var throwingPubSub = new ThrowingPubSubService();
+            var synchronizer = new DataProviderSynchronizer(scope.ServiceProvider, throwingPubSub, logger, TestRetryPolicy);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => synchronizer.StartAsync(CancellationToken.None));
+        }
+
         private static void AssertSkillState(IEnumerable<Infrastructure.Entities.PlayerSkill> rows, int skillId, bool selected, int order)
         {
             var row = Assert.Single(rows, ps => ps.SkillId == skillId);
@@ -413,6 +424,23 @@ namespace Game.Application.Tests.DataAccess
 
                 return inner.GetRequiredService<IServiceScopeFactory>().CreateScope();
             }
+        }
+
+        /// <summary>
+        /// A minimal <see cref="IPubSubService"/> stub whose <c>Subscribe</c> overloads always throw, used to verify
+        /// that <see cref="DataProviderSynchronizer.StartAsync"/> propagates a subscribe failure rather than swallowing it.
+        /// </summary>
+        private sealed class ThrowingPubSubService : IPubSubService
+        {
+            public Task Publish(string channel, string message) => Task.CompletedTask;
+            public Task Publish(string channel, string queueName, string queueData) => Task.CompletedTask;
+            public Task Publish<T>(string channel, string queueName, T queueData) => Task.CompletedTask;
+            public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => throw new InvalidOperationException("Simulated subscribe failure.");
+            public Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string? id = null) => throw new InvalidOperationException("Simulated subscribe failure.");
+            public Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string? id = null) => throw new InvalidOperationException("Simulated subscribe failure.");
+            public Task UnSubscribe(string channel) => Task.CompletedTask;
+            public Task UnSubscribe(string channel, string id) => Task.CompletedTask;
+            public IPubSubQueue GetQueue(string queueName) => throw new NotSupportedException();
         }
 
         private sealed class CapturingLogger<T> : ILogger<T>

--- a/Game.DataAccess/DataProviderSynchronizer.cs
+++ b/Game.DataAccess/DataProviderSynchronizer.cs
@@ -26,10 +26,9 @@ namespace Game.DataAccess
             _retryPolicy = retryPolicy;
         }
 
-        public Task StartAsync(CancellationToken cancellationToken)
+        public async Task StartAsync(CancellationToken cancellationToken)
         {
-            _ = InitSubscriber();
-            return Task.CompletedTask;
+            await InitSubscriber();
         }
 
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;


### PR DESCRIPTION
## Summary

- `DataProviderSynchronizer.StartAsync` was fire-and-forgetting `InitSubscriber()` (`_ = InitSubscriber()`). Any Redis connectivity error at boot landed on an unobserved `Task` and was silently swallowed — the hosted service reported a clean start while the player write-behind pipeline was never wired up and player state was never persisted.
- Changed `StartAsync` to `async Task` and `await InitSubscriber()` directly, so a subscribe failure propagates through the hosted-service startup pipeline and the host does not claim ready when persistence isn't wired.
- This is consistent with the project's fail-fast startup philosophy (reference caches are eagerly loaded at boot for the same reason — a DB problem surfaces at startup rather than on the first player request).
- Added `StartAsync_SubscribeThrows_PropagatesException` to `DataProviderSynchronizerTests` with a minimal `ThrowingPubSubService` stub to verify the exception escapes `StartAsync` rather than being swallowed.

## Test plan

- [x] New test `StartAsync_SubscribeThrows_PropagatesException` passes
- [x] All existing `DataProviderSynchronizerTests` continue to pass (143 total in `Game.Application.Tests`)
- [x] `Game.Core.Tests` — 358 tests pass
- [x] `Game.Infrastructure.Tests` — 26 tests pass
- [x] `dotnet build` — 0 errors, 0 warnings

Closes #366

https://claude.ai/code/session_01TvaLMx4ti4QvQiv6ZUmH8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvaLMx4ti4QvQiv6ZUmH8C)_