### PR TITLE
Dead-letter unknown event types in DataProviderSynchronizer (#364)

### DIFF
--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -171,6 +171,33 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task ProcessQueue_UnknownEventType_DeadLettersWithoutRetrying()
+        {
+            using var scope = CreateScope();
+            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
+            var logger = new CapturingLogger<DataProviderSynchronizer>();
+            var synchronizer = new DataProviderSynchronizer(scope.ServiceProvider, pubsub, logger, TestRetryPolicy);
+
+            // A well-formed envelope whose Type matches no registered handler case — e.g. a new event
+            // added to PlayerPersistencePublisher without a corresponding case in HandleEvent.
+            var envelope = new DomainEventEnvelope
+            {
+                Type = "UnregisteredEventType",
+                Payload = "{}",
+            };
+            var message = envelope.Serialize();
+            var queue = new InMemoryPubSubQueue(message);
+
+            await synchronizer.ProcessQueue(queue);
+
+            // An unknown type is a poison message — no retry can fix it — so it is dead-lettered
+            // immediately with a warning and without escalating to an error.
+            Assert.Equal(1, logger.Entries.Count(e => e.Level == LogLevel.Warning));
+            Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+            Assert.Equal([message], await DrainDeadLetterQueue(pubsub));
+        }
+
+        [Fact]
         public async Task ProcessQueue_SkillUnlockedEvent_InsertsUnselectedPlayerSkillIdempotently()
         {
             using var scope = CreateScope();

--- a/Game.DataAccess/DataProviderSynchronizer.cs
+++ b/Game.DataAccess/DataProviderSynchronizer.cs
@@ -187,8 +187,8 @@ namespace Game.DataAccess
                     await HandleLogPreferenceChanged(context, logEvt);
                     break;
 
-                    // PlayerLeveledUpEvent is handled in-process only — it has no persistence
-                    // handler registered, so it is never published to this queue.
+                // PlayerLeveledUpEvent is handled in-process only — it has no persistence
+                // handler registered, so it is never published to this queue.
 
                 default:
                     throw new UnknownEventTypeException(envelope.Type);

--- a/Game.DataAccess/DataProviderSynchronizer.cs
+++ b/Game.DataAccess/DataProviderSynchronizer.cs
@@ -97,6 +97,13 @@ namespace Game.DataAccess
                     await deadLetterQueue.AddToQueueAsync(message);
                     return;
                 }
+                catch (UnknownEventTypeException ex)
+                {
+                    // An unrecognized event type is a poison message — no retry can fix it — so it is dead-lettered immediately.
+                    _logger.LogWarning(ex, "Dead-lettering player data event with unrecognized type '{EventType}' from queue '{Queue}'. Raw message: {Message}", envelope.Type, Constants.PUBSUB_PLAYER_QUEUE, message);
+                    await deadLetterQueue.AddToQueueAsync(message);
+                    return;
+                }
                 catch (Exception ex) when (attempt < _retryPolicy.MaxAttempts)
                 {
                     // An unexpected failure (e.g. a transient database error) may succeed on a retry.
@@ -182,6 +189,9 @@ namespace Game.DataAccess
 
                     // PlayerLeveledUpEvent is handled in-process only — it has no persistence
                     // handler registered, so it is never published to this queue.
+
+                default:
+                    throw new UnknownEventTypeException(envelope.Type);
             }
         }
 
@@ -386,5 +396,8 @@ namespace Game.DataAccess
 
         private static T Deserialize<T>(string json)
             => json.Deserialize<T>() ?? throw new JsonException($"Deserialized '{typeof(T).Name}' payload was null.");
+
+        private sealed class UnknownEventTypeException(string eventType)
+            : Exception($"Unrecognized player event type '{eventType}'.");
     }
 }


### PR DESCRIPTION
## Summary

- `DataProviderSynchronizer.HandleEvent` had no `default:` arm in its `switch (envelope.Type)`, so any envelope whose type matched no registered case was silently dropped — counted as successfully processed with no log, no retry, and no dead-letter entry.
- This violated the documented invariant in `docs/backend.md`: *"Queue processing in `DataProviderSynchronizer` is resilient and **never silently drops an event**."*
- Fix: add a `default:` arm that throws a new private `UnknownEventTypeException`, and a matching catch in `ProcessMessage` that dead-letters immediately — same no-retry path as an inner `JsonException`, since no retry can fix an unrecognized type.

## Changes

- **`Game.DataAccess/DataProviderSynchronizer.cs`**
  - Added `default: throw new UnknownEventTypeException(envelope.Type)` arm to the `HandleEvent` switch
  - Added `catch (UnknownEventTypeException)` block in `ProcessMessage` that logs a warning and dead-letters immediately (no retry)
  - Added private nested `UnknownEventTypeException` class

- **`Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs`**
  - Added `ProcessQueue_UnknownEventType_DeadLettersWithoutRetrying` integration test asserting that an envelope with an unrecognized `Type` lands in `PlayerUpdateDeadLetterQueue` with exactly one warning and no errors

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test` — all 143 application tests pass including the new one

Closes #364

https://claude.ai/code/session_01D4M1tRsd3oMj2zA1321ckp

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4M1tRsd3oMj2zA1321ckp)_