### PR TITLE
Factor out retired-record filter in ChallengeRewardSection pick lists

### DIFF
--- a/UI/src/routes/admin/workbench/components/challenge/ChallengeRewardSection.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/ChallengeRewardSection.svelte
@@ -141,41 +141,35 @@ const none = $derived(
 
 // Retired records drop out of the pick list (can't be newly granted) unless they're the
 // challenge's current reward, which stays visible (marked retired) so it isn't silently lost.
+const keepActive = <T extends { id: number; retiredAt?: string | null }>(records: T[], currentId: number | undefined) =>
+	records.filter((r) => !r.retiredAt || r.id === currentId);
+
 const itemPickRecords = $derived(
-	reference
-		.itemRecords()
-		.filter((i) => !i.retiredAt || i.id === challenge.rewardItemId)
-		.map((i) => ({
-			id: i.id,
-			name: i.name,
-			color: reference.rarityColor(i.rarityId),
-			tag: reference.rarityName(i.rarityId),
-			retired: !!i.retiredAt
-		}))
+	keepActive(reference.itemRecords(), challenge.rewardItemId).map((i) => ({
+		id: i.id,
+		name: i.name,
+		color: reference.rarityColor(i.rarityId),
+		tag: reference.rarityName(i.rarityId),
+		retired: !!i.retiredAt
+	}))
 );
 const modPickRecords = $derived(
-	reference
-		.itemModRecords()
-		.filter((m) => !m.retiredAt || m.id === challenge.rewardItemModId)
-		.map((m) => ({
-			id: m.id,
-			name: m.name,
-			color: 'var(--accent)',
-			tag: reference.modTypeName(m.itemModTypeId),
-			retired: !!m.retiredAt
-		}))
+	keepActive(reference.itemModRecords(), challenge.rewardItemModId).map((m) => ({
+		id: m.id,
+		name: m.name,
+		color: 'var(--accent)',
+		tag: reference.modTypeName(m.itemModTypeId),
+		retired: !!m.retiredAt
+	}))
 );
 const skillPickRecords = $derived(
-	reference
-		.skillRecords()
-		.filter((s) => !s.retiredAt || s.id === challenge.rewardSkillId)
-		.map((s) => ({
-			id: s.id,
-			name: s.name,
-			color: 'var(--accent)',
-			tag: `${s.baseDamage} dmg`,
-			retired: !!s.retiredAt
-		}))
+	keepActive(reference.skillRecords(), challenge.rewardSkillId).map((s) => ({
+		id: s.id,
+		name: s.name,
+		color: 'var(--accent)',
+		tag: `${s.baseDamage} dmg`,
+		retired: !!s.retiredAt
+	}))
 );
 
 const setItem = (id: number | undefined) => {


### PR DESCRIPTION
## Summary

Refactors `ChallengeRewardSection.svelte` to eliminate repeated `!retiredAt || id === current` filter logic by introducing a local `keepActive` helper function.

## Changes

- Extracted the common filter pattern into a generic `keepActive<T>` helper that accepts records and a currentId
- Applied the helper to all three pick-record lists (item, mod, skill)
- Preserved per-type `.map()` projections since they have different field mappings

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run test:unit:ci` — 1319 tests pass, coverage maintained

Closes #346

---
_Generated by [Claude Code](https://claude.ai/code/session_01MM7M88GtiTd5y8VokRXM8r)_