### PR TITLE
Fix inconsistent locking on _pubsubInstance in RedisMultiplexerFactory

### DIFF
--- a/Game.Infrastructure/Redis/RedisMultiplexerFactory.cs
+++ b/Game.Infrastructure/Redis/RedisMultiplexerFactory.cs
@@ -9,7 +9,6 @@ namespace Game.Infrastructure.Redis
         private static ConnectionMultiplexer? _cacheInstance;
         private static ConnectionMultiplexer? _pubsubInstance;
         private static readonly object _cacheLock = new();
-        private static readonly object _pubsubLock = new();
 
         // Minimum size to grow the thread pool to before connecting (see ConnectMultiplexer).
         private const int MinThreadPoolThreads = 32;
@@ -76,9 +75,6 @@ namespace Game.Infrastructure.Redis
             {
                 _cacheInstance?.Dispose();
                 _cacheInstance = null;
-            }
-            lock (_pubsubLock)
-            {
                 _pubsubInstance?.Dispose();
                 _pubsubInstance = null;
             }


### PR DESCRIPTION
## Summary

- Removes the dead `_pubsubLock` field — it was only ever acquired in `ResetForTesting`, while all create paths for `_pubsubInstance` used `_cacheLock`, making the two lock objects non-mutually-exclusive.
- Consolidates `ResetForTesting` to reset both `_cacheInstance` and `_pubsubInstance` inside a single `lock (_cacheLock)` block, matching the create paths for both multiplexers.
- Since the two fields can alias each other (each can be assigned the other's connection), a single shared lock is the correct and simplest choice.

## Test plan

- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] `dotnet test` — all 850 tests pass across all four test projects

Closes #365

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjJtruDWuz5mtrGtTJWmYM)_