### PR TITLE
Add interaction tests for GridSlot, EquippedRail, and InventoryGrid (#343)

### DIFF
--- a/UI/src/tests/routes/game/screens/inventory/EquippedRail.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/EquippedRail.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { EItemCategory, ERarity } from '$lib/api';
+import type { Item } from '$lib/battle';
+
+const { setTooltipPosition, showTooltip, hideTooltip } = vi.hoisted(() => ({
+	setTooltipPosition: vi.fn(),
+	showTooltip: vi.fn(),
+	hideTooltip: vi.fn()
+}));
+
+vi.mock('$lib/engine', () => ({
+	EEquipmentSlot: { HelmSlot: 0, ChestSlot: 1, LegSlot: 2, BootSlot: 3, WeaponSlot: 4, AccessorySlot: 5 },
+	getEquipmentSlotForCategory: vi.fn(),
+	inventoryManager: {
+		get unlockedItemList() {
+			return [];
+		},
+		unlockedMods: new Set<number>(),
+		equipItem: vi.fn(),
+		unequipItem: vi.fn(),
+		setFavorite: vi.fn(),
+		applyMod: vi.fn(),
+		removeMod: vi.fn()
+	}
+}));
+
+vi.mock('$stores', () => ({
+	staticData: { itemMods: [] },
+	registerTooltipComponent: vi.fn(() => ({ setTooltipPosition, showTooltip, hideTooltip }))
+}));
+
+import EquippedRail from '$routes/game/screens/inventory/EquippedRail.svelte';
+import type { InventoryView } from '$routes/game/screens/inventory/inventory-view.svelte';
+
+afterEach(cleanup);
+
+const makeItem = (overrides: Partial<Item> = {}): Item =>
+	({
+		id: 1,
+		itemId: 1,
+		name: 'Iron Sword',
+		description: '',
+		itemCategoryId: EItemCategory.Weapon,
+		rarityId: ERarity.Common,
+		iconPath: '',
+		attributes: [],
+		appliedMods: [],
+		modSlots: [],
+		tags: [],
+		equipped: true,
+		favorite: false,
+		equipmentSlotId: 4,
+		...overrides
+	}) as unknown as Item;
+
+const makeView = (overrides: Partial<InventoryView> = {}): InventoryView =>
+	({
+		equippedBySlot: {} as Record<number, Item>,
+		dragItem: null as Item | null,
+		selected: null as Item | null,
+		select: vi.fn(),
+		equip: vi.fn(),
+		unequip: vi.fn(),
+		...overrides
+	}) as unknown as InventoryView;
+
+describe('EquippedRail — rendering', () => {
+	it('renders the "Equipped" section header', () => {
+		const { getByText } = render(EquippedRail, { props: { view: makeView() } });
+		expect(getByText('Equipped')).toBeTruthy();
+	});
+
+	it('renders both equipment groups: Armor and Arms', () => {
+		const { getByText } = render(EquippedRail, { props: { view: makeView() } });
+		expect(getByText('Armor')).toBeTruthy();
+		expect(getByText('Arms')).toBeTruthy();
+	});
+
+	it('renders all six slot labels', () => {
+		const { getByText } = render(EquippedRail, { props: { view: makeView() } });
+		for (const label of ['Helm', 'Chest', 'Legs', 'Boots', 'Weapon', 'Accessory']) {
+			expect(getByText(label)).toBeTruthy();
+		}
+	});
+
+	it('shows the item name for a filled slot', () => {
+		const item = makeItem({ name: 'Blessed Blade' });
+		const view = makeView({ equippedBySlot: { 4: item } as Record<number, Item> });
+		const { getByText } = render(EquippedRail, { props: { view } });
+		expect(getByText('Blessed Blade')).toBeTruthy();
+	});
+
+	it('shows "Empty" for an unfilled slot', () => {
+		const { getAllByText } = render(EquippedRail, { props: { view: makeView() } });
+		// All 6 slots are empty on a default view.
+		expect(getAllByText('Empty').length).toBe(6);
+	});
+
+	it('shows the disabled "Save loadout" button', () => {
+		const { container } = render(EquippedRail, { props: { view: makeView() } });
+		const btn = container.querySelector('.loadout-button') as HTMLButtonElement;
+		expect(btn.disabled).toBe(true);
+	});
+});
+
+describe('EquippedRail — drop handling', () => {
+	it('calls view.equip when the dragged item category matches the target slot', async () => {
+		const dragItem = makeItem({ itemId: 99, itemCategoryId: EItemCategory.Weapon });
+		const view = makeView({ dragItem });
+		const { container } = render(EquippedRail, { props: { view } });
+		// Weapon slot is the 5th equip-tile (index 4): Helm, Chest, Leg, Boot, Weapon, Accessory.
+		const tiles = container.querySelectorAll('.equip-tile');
+		await fireEvent.drop(tiles[4]);
+		expect(view.equip).toHaveBeenCalledWith(99, 4 /* WeaponSlot id */);
+	});
+
+	it('does not call view.equip when the dragged category does not match the slot', async () => {
+		const dragItem = makeItem({ itemId: 99, itemCategoryId: EItemCategory.Helm });
+		const view = makeView({ dragItem });
+		const { container } = render(EquippedRail, { props: { view } });
+		// Drop a Helm item onto the Weapon slot — category mismatch.
+		const tiles = container.querySelectorAll('.equip-tile');
+		await fireEvent.drop(tiles[4]);
+		expect(view.equip).not.toHaveBeenCalled();
+	});
+
+	it('does not call view.equip when there is no dragged item', async () => {
+		const view = makeView({ dragItem: null });
+		const { container } = render(EquippedRail, { props: { view } });
+		const tiles = container.querySelectorAll('.equip-tile');
+		await fireEvent.drop(tiles[4]);
+		expect(view.equip).not.toHaveBeenCalled();
+	});
+
+	it('calls view.unequip with the slot id when the unequip button is clicked', async () => {
+		const item = makeItem();
+		const view = makeView({ equippedBySlot: { 4: item } as Record<number, Item> });
+		const { container } = render(EquippedRail, { props: { view } });
+		// Hover over the weapon tile to reveal the unequip button.
+		const tiles = container.querySelectorAll('.equip-tile');
+		await fireEvent.mouseEnter(tiles[4]);
+		await fireEvent.click(container.querySelector('.unequip')!);
+		expect(view.unequip).toHaveBeenCalledWith(4);
+	});
+});
+
+describe('EquippedRail — tooltip handling', () => {
+	it('shows the tooltip on hover enter when a slot is filled', async () => {
+		showTooltip.mockClear();
+		const item = makeItem();
+		const view = makeView({ equippedBySlot: { 4: item } as Record<number, Item> });
+		const { container } = render(EquippedRail, { props: { view } });
+		const tiles = container.querySelectorAll('.equip-tile');
+		await fireEvent.mouseEnter(tiles[4]);
+		expect(showTooltip).toHaveBeenCalled();
+	});
+
+	it('hides the tooltip on hover leave', async () => {
+		hideTooltip.mockClear();
+		const item = makeItem();
+		const view = makeView({ equippedBySlot: { 4: item } as Record<number, Item> });
+		const { container } = render(EquippedRail, { props: { view } });
+		const tiles = container.querySelectorAll('.equip-tile');
+		await fireEvent.mouseEnter(tiles[4]);
+		await fireEvent.mouseLeave(tiles[4]);
+		expect(hideTooltip).toHaveBeenCalled();
+	});
+
+	it('updates the tooltip position on hover move', async () => {
+		setTooltipPosition.mockClear();
+		const item = makeItem();
+		const view = makeView({ equippedBySlot: { 4: item } as Record<number, Item> });
+		const { container } = render(EquippedRail, { props: { view } });
+		const tiles = container.querySelectorAll('.equip-tile');
+		await fireEvent.mouseMove(tiles[4]);
+		expect(setTooltipPosition).toHaveBeenCalled();
+	});
+});

--- a/UI/src/tests/routes/game/screens/inventory/GridSlot.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/GridSlot.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { EItemCategory, ERarity } from '$lib/api';
+import type { Item } from '$lib/battle';
+
+import GridSlot from '$routes/game/screens/inventory/GridSlot.svelte';
+
+afterEach(cleanup);
+
+const makeItem = (overrides: Partial<Item> = {}): Item =>
+	({
+		id: 1,
+		itemId: 1,
+		name: 'Iron Sword',
+		description: '',
+		itemCategoryId: EItemCategory.Weapon,
+		rarityId: ERarity.Common,
+		iconPath: '',
+		attributes: [],
+		appliedMods: [],
+		modSlots: [],
+		tags: [],
+		equipped: false,
+		favorite: false,
+		equipmentSlotId: undefined,
+		...overrides
+	}) as unknown as Item;
+
+describe('GridSlot — rendering', () => {
+	it('renders the grid-slot element', () => {
+		const { container } = render(GridSlot, { props: { item: makeItem() } });
+		expect(container.querySelector('.grid-slot')).toBeTruthy();
+	});
+
+	it('shows the equipped-marker when the item is equipped', () => {
+		const { container } = render(GridSlot, { props: { item: makeItem({ equipped: true }) } });
+		expect(container.querySelector('.equipped-marker')).toBeTruthy();
+	});
+
+	it('does not show the equipped-marker when the item is not equipped', () => {
+		const { container } = render(GridSlot, { props: { item: makeItem({ equipped: false }) } });
+		expect(container.querySelector('.equipped-marker')).toBeNull();
+	});
+
+	it('shows the mod-count badge when the item has applied mods', () => {
+		const item = makeItem({
+			appliedMods: [{ id: 0, itemModSlotId: 0, attributes: [] } as unknown as Item['appliedMods'][0]]
+		});
+		const { container } = render(GridSlot, { props: { item } });
+		expect(container.querySelector('.mod-count')).toBeTruthy();
+	});
+
+	it('does not show the mod-count badge when the item has no mods', () => {
+		const { container } = render(GridSlot, { props: { item: makeItem({ appliedMods: [] }) } });
+		expect(container.querySelector('.mod-count')).toBeNull();
+	});
+
+	it('applies the "selected" class when selected=true', () => {
+		const { container } = render(GridSlot, { props: { item: makeItem(), selected: true } });
+		expect(container.querySelector('.grid-slot')!.classList.contains('selected')).toBe(true);
+	});
+
+	it('does not apply the "selected" class when selected=false', () => {
+		const { container } = render(GridSlot, { props: { item: makeItem(), selected: false } });
+		expect(container.querySelector('.grid-slot')!.classList.contains('selected')).toBe(false);
+	});
+
+	it('marks the fav-star as "on" when the item is a favorite', () => {
+		const { container } = render(GridSlot, { props: { item: makeItem({ favorite: true }) } });
+		expect(container.querySelector('.fav-star')!.classList.contains('on')).toBe(true);
+	});
+
+	it('does not mark the fav-star as "on" for a non-favorite item', () => {
+		const { container } = render(GridSlot, { props: { item: makeItem({ favorite: false }) } });
+		expect(container.querySelector('.fav-star')!.classList.contains('on')).toBe(false);
+	});
+});
+
+describe('GridSlot — click interactions', () => {
+	it('calls onSelect with the item on a plain click', async () => {
+		const onSelect = vi.fn();
+		const item = makeItem();
+		const { container } = render(GridSlot, { props: { item, onSelect } });
+		await fireEvent.click(container.querySelector('.grid-slot')!);
+		expect(onSelect).toHaveBeenCalledWith(item);
+	});
+
+	it('calls onToggleEquip instead of onSelect on a ctrl+click', async () => {
+		const onSelect = vi.fn();
+		const onToggleEquip = vi.fn();
+		const item = makeItem();
+		const { container } = render(GridSlot, { props: { item, onSelect, onToggleEquip } });
+		await fireEvent.click(container.querySelector('.grid-slot')!, { ctrlKey: true });
+		expect(onToggleEquip).toHaveBeenCalledWith(item);
+		expect(onSelect).not.toHaveBeenCalled();
+	});
+
+	it('calls onToggleEquip instead of onSelect on a meta+click', async () => {
+		const onSelect = vi.fn();
+		const onToggleEquip = vi.fn();
+		const item = makeItem();
+		const { container } = render(GridSlot, { props: { item, onSelect, onToggleEquip } });
+		await fireEvent.click(container.querySelector('.grid-slot')!, { metaKey: true });
+		expect(onToggleEquip).toHaveBeenCalledWith(item);
+		expect(onSelect).not.toHaveBeenCalled();
+	});
+
+	it('calls onToggleEquip on a double-click', async () => {
+		const onToggleEquip = vi.fn();
+		const item = makeItem();
+		const { container } = render(GridSlot, { props: { item, onToggleEquip } });
+		await fireEvent.dblClick(container.querySelector('.grid-slot')!);
+		expect(onToggleEquip).toHaveBeenCalledWith(item);
+	});
+
+	it('calls onToggleFav when the fav-star button is clicked', async () => {
+		const onToggleFav = vi.fn();
+		const item = makeItem();
+		const { container } = render(GridSlot, { props: { item, onToggleFav } });
+		await fireEvent.click(container.querySelector('.fav-star')!);
+		expect(onToggleFav).toHaveBeenCalledWith(item);
+	});
+});
+
+describe('GridSlot — keyboard interactions', () => {
+	it('calls onSelect on Enter key', async () => {
+		const onSelect = vi.fn();
+		const item = makeItem();
+		const { container } = render(GridSlot, { props: { item, onSelect } });
+		await fireEvent.keyDown(container.querySelector('.grid-slot')!, { key: 'Enter' });
+		expect(onSelect).toHaveBeenCalledWith(item);
+	});
+
+	it('calls onSelect on Space key', async () => {
+		const onSelect = vi.fn();
+		const item = makeItem();
+		const { container } = render(GridSlot, { props: { item, onSelect } });
+		await fireEvent.keyDown(container.querySelector('.grid-slot')!, { key: ' ' });
+		expect(onSelect).toHaveBeenCalledWith(item);
+	});
+
+	it('does not call onSelect for other keys', async () => {
+		const onSelect = vi.fn();
+		const item = makeItem();
+		const { container } = render(GridSlot, { props: { item, onSelect } });
+		await fireEvent.keyDown(container.querySelector('.grid-slot')!, { key: 'ArrowRight' });
+		expect(onSelect).not.toHaveBeenCalled();
+	});
+});
+
+describe('GridSlot — hover interactions', () => {
+	it('shows the fav-star (adds "show" class) on mouse enter', async () => {
+		const { container } = render(GridSlot, { props: { item: makeItem() } });
+		await fireEvent.mouseEnter(container.querySelector('.grid-slot')!);
+		expect(container.querySelector('.fav-star')!.classList.contains('show')).toBe(true);
+	});
+
+	it('hides the fav-star ("show" removed) on mouse leave', async () => {
+		const { container } = render(GridSlot, { props: { item: makeItem() } });
+		await fireEvent.mouseEnter(container.querySelector('.grid-slot')!);
+		await fireEvent.mouseLeave(container.querySelector('.grid-slot')!);
+		expect(container.querySelector('.fav-star')!.classList.contains('show')).toBe(false);
+	});
+
+	it('calls onHoverEnter with the item and event on mouse enter', async () => {
+		const onHoverEnter = vi.fn();
+		const item = makeItem();
+		const { container } = render(GridSlot, { props: { item, onHoverEnter } });
+		await fireEvent.mouseEnter(container.querySelector('.grid-slot')!);
+		expect(onHoverEnter).toHaveBeenCalledWith(item, expect.any(MouseEvent));
+	});
+
+	it('calls onHoverLeave on mouse leave', async () => {
+		const onHoverLeave = vi.fn();
+		const { container } = render(GridSlot, { props: { item: makeItem(), onHoverLeave } });
+		await fireEvent.mouseLeave(container.querySelector('.grid-slot')!);
+		expect(onHoverLeave).toHaveBeenCalled();
+	});
+
+	it('calls onHoverMove with the event on mouse move', async () => {
+		const onHoverMove = vi.fn();
+		const { container } = render(GridSlot, { props: { item: makeItem(), onHoverMove } });
+		await fireEvent.mouseMove(container.querySelector('.grid-slot')!);
+		expect(onHoverMove).toHaveBeenCalledWith(expect.any(MouseEvent));
+	});
+});
+
+describe('GridSlot — drag interactions', () => {
+	it('sets dataTransfer text/plain to the itemId string on drag start', async () => {
+		const item = makeItem({ itemId: 42 });
+		const { container } = render(GridSlot, { props: { item } });
+		const dt = { setData: vi.fn(), effectAllowed: '' };
+		await fireEvent.dragStart(container.querySelector('.grid-slot')!, { dataTransfer: dt });
+		expect(dt.setData).toHaveBeenCalledWith('text/plain', '42');
+	});
+
+	it('sets dataTransfer.effectAllowed to "move" on drag start', async () => {
+		const item = makeItem();
+		const { container } = render(GridSlot, { props: { item } });
+		const dt = { setData: vi.fn(), effectAllowed: '' };
+		await fireEvent.dragStart(container.querySelector('.grid-slot')!, { dataTransfer: dt });
+		expect(dt.effectAllowed).toBe('move');
+	});
+
+	it('calls onDragStart with the item on drag start', async () => {
+		const onDragStart = vi.fn();
+		const item = makeItem();
+		const { container } = render(GridSlot, { props: { item, onDragStart } });
+		await fireEvent.dragStart(container.querySelector('.grid-slot')!, {
+			dataTransfer: { setData: vi.fn(), effectAllowed: '' }
+		});
+		expect(onDragStart).toHaveBeenCalledWith(item);
+	});
+
+	it('calls onDragEnd on drag end', async () => {
+		const onDragEnd = vi.fn();
+		const { container } = render(GridSlot, { props: { item: makeItem(), onDragEnd } });
+		await fireEvent.dragEnd(container.querySelector('.grid-slot')!);
+		expect(onDragEnd).toHaveBeenCalled();
+	});
+});

--- a/UI/src/tests/routes/game/screens/inventory/GridSlot.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/GridSlot.test.ts
@@ -113,12 +113,14 @@ describe('GridSlot — click interactions', () => {
 		expect(onToggleEquip).toHaveBeenCalledWith(item);
 	});
 
-	it('calls onToggleFav when the fav-star button is clicked', async () => {
+	it('calls onToggleFav when the fav-star button is clicked and does not bubble to onSelect', async () => {
 		const onToggleFav = vi.fn();
+		const onSelect = vi.fn();
 		const item = makeItem();
-		const { container } = render(GridSlot, { props: { item, onToggleFav } });
+		const { container } = render(GridSlot, { props: { item, onToggleFav, onSelect } });
 		await fireEvent.click(container.querySelector('.fav-star')!);
 		expect(onToggleFav).toHaveBeenCalledWith(item);
+		expect(onSelect).not.toHaveBeenCalled();
 	});
 });
 

--- a/UI/src/tests/routes/game/screens/inventory/InventoryGrid.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/InventoryGrid.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { render, cleanup } from '@testing-library/svelte';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
 import { EItemCategory, ERarity } from '$lib/api';
 import { BattleAttributes, type Item } from '$lib/battle';
+
+const { setTooltipPosition, showTooltip, hideTooltip } = vi.hoisted(() => ({
+	setTooltipPosition: vi.fn(),
+	showTooltip: vi.fn(),
+	hideTooltip: vi.fn()
+}));
 
 vi.mock('$lib/engine', () => ({
 	EEquipmentSlot: { HelmSlot: 0, ChestSlot: 1, LegSlot: 2, BootSlot: 3, WeaponSlot: 4, AccessorySlot: 5 },
@@ -21,11 +27,7 @@ vi.mock('$lib/engine', () => ({
 
 vi.mock('$stores', () => ({
 	staticData: { itemMods: [] },
-	registerTooltipComponent: vi.fn(() => ({
-		setTooltipPosition: vi.fn(),
-		showTooltip: vi.fn(),
-		hideTooltip: vi.fn()
-	}))
+	registerTooltipComponent: vi.fn(() => ({ setTooltipPosition, showTooltip, hideTooltip }))
 }));
 
 import InventoryGrid from '$routes/game/screens/inventory/InventoryGrid.svelte';
@@ -103,5 +105,85 @@ describe('InventoryGrid', () => {
 		const { container } = render(InventoryGrid, { props: { view: makeView(items) } });
 		const slots = container.querySelectorAll('.grid-slot');
 		expect(slots.length).toBe(2);
+	});
+
+	it('disables the next-page button when on the last page', () => {
+		const items = Array.from({ length: 50 }, (_, i) => makeGridItem(i + 1));
+		// page: 1 puts us on the last page (pages = ceil(50/48) = 2, pageClamped = min(1, 1) = 1).
+		const { container } = render(InventoryGrid, { props: { view: makeView(items, { page: 1 }) } });
+		const pageBtns = container.querySelectorAll('.page-btn') as NodeListOf<HTMLButtonElement>;
+		const nextBtn = pageBtns[1];
+		expect(nextBtn.disabled).toBe(true);
+	});
+
+	it('enables the previous-page button when not on the first page', () => {
+		const items = Array.from({ length: 50 }, (_, i) => makeGridItem(i + 1));
+		const { container } = render(InventoryGrid, { props: { view: makeView(items, { page: 1 }) } });
+		const pageBtns = container.querySelectorAll('.page-btn') as NodeListOf<HTMLButtonElement>;
+		const prevBtn = pageBtns[0];
+		expect(prevBtn.disabled).toBe(false);
+	});
+
+	it('shows the correct page indicator text on the last page', () => {
+		const items = Array.from({ length: 50 }, (_, i) => makeGridItem(i + 1));
+		const { container } = render(InventoryGrid, { props: { view: makeView(items, { page: 1 }) } });
+		expect(container.querySelector('.page-indicator')!.textContent).toBe('2 / 2');
+	});
+});
+
+describe('InventoryGrid — tooltip suppression', () => {
+	it('shows the tooltip on hover when nothing is selected or dragged', async () => {
+		showTooltip.mockClear();
+		const items = [makeGridItem(1)];
+		const { container } = render(InventoryGrid, { props: { view: makeView(items) } });
+		await fireEvent.mouseEnter(container.querySelector('.grid-slot')!);
+		expect(showTooltip).toHaveBeenCalled();
+	});
+
+	it('suppresses the tooltip when an item is selected', async () => {
+		showTooltip.mockClear();
+		const items = [makeGridItem(1)];
+		const { container } = render(InventoryGrid, { props: { view: makeView(items, { selectedId: 1 }) } });
+		await fireEvent.mouseEnter(container.querySelector('.grid-slot')!);
+		expect(showTooltip).not.toHaveBeenCalled();
+	});
+
+	it('suppresses the tooltip when an item is being dragged', async () => {
+		showTooltip.mockClear();
+		const items = [makeGridItem(1)];
+		const { container } = render(InventoryGrid, { props: { view: makeView(items, { dragItemId: 1 }) } });
+		await fireEvent.mouseEnter(container.querySelector('.grid-slot')!);
+		expect(showTooltip).not.toHaveBeenCalled();
+	});
+});
+
+describe('InventoryGrid — drag interactions', () => {
+	it('hides the tooltip when a drag starts', async () => {
+		hideTooltip.mockClear();
+		const items = [makeGridItem(1)];
+		const view = makeView(items);
+		const { container } = render(InventoryGrid, { props: { view } });
+		await fireEvent.dragStart(container.querySelector('.grid-slot')!, {
+			dataTransfer: { setData: vi.fn(), effectAllowed: '' }
+		});
+		expect(hideTooltip).toHaveBeenCalled();
+	});
+
+	it('sets view.dragItemId on drag start', async () => {
+		const items = [makeGridItem(7)];
+		const view = makeView(items);
+		const { container } = render(InventoryGrid, { props: { view } });
+		await fireEvent.dragStart(container.querySelector('.grid-slot')!, {
+			dataTransfer: { setData: vi.fn(), effectAllowed: '' }
+		});
+		expect(view.dragItemId).toBe(7);
+	});
+
+	it('clears view.dragItemId on drag end', async () => {
+		const items = [makeGridItem(7)];
+		const view = makeView(items, { dragItemId: 7 });
+		const { container } = render(InventoryGrid, { props: { view } });
+		await fireEvent.dragEnd(container.querySelector('.grid-slot')!);
+		expect(view.dragItemId).toBeNull();
 	});
 });

--- a/UI/vite.config.ts
+++ b/UI/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
 				'src/lib/card-game/**': { lines: 94, functions: 100, branches: 81, statements: 94 },
 				'src/stores/**': { lines: 98, functions: 100, branches: 90, statements: 98 },
 				'src/components/**': { lines: 90, functions: 95, branches: 77, statements: 93 },
-				'src/routes/**': { lines: 90, functions: 88, branches: 68, statements: 89 }
+				'src/routes/**': { lines: 91, functions: 89, branches: 69, statements: 90 }
 			}
 		}
 	},


### PR DESCRIPTION
## Summary

- **`GridSlot.test.ts`** (new, 26 tests): covers all rendering branches (equipped marker, mod count badge, selected class, favorite star), click routing (plain → `onSelect`, ctrl/meta/dbl → `onToggleEquip`, fav star → `onToggleFav`), keyboard activation (Enter/Space → `onSelect`, other keys are no-ops), hover lifecycle (enter sets `.show`, leave clears it; `onHoverEnter`/`onHoverLeave`/`onHoverMove` callbacks), and drag interactions (dataTransfer text + effectAllowed set on dragstart, `onDragStart`/`onDragEnd` callbacks).

- **`EquippedRail.test.ts`** (new, 13 tests): covers rendering (all six slot labels, both group headings, filled vs empty slot states, disabled loadout button), `handleDrop` branching (category-match calls `view.equip`, category mismatch is a no-op, null `dragItem` is a no-op, `view.unequip` fires from the unequip button), and tooltip lifecycle (`showTooltip` on hover enter, `hideTooltip` on leave, `setTooltipPosition` on move).

- **`InventoryGrid.test.ts`** (deepened, +9 tests): adds pagination state (next button disabled on last page, prev button enabled away from first page, page indicator text), tooltip suppression (skipped when `selectedId` or `dragItemId` is non-null, shown when both are null), and drag interactions (`dragItemId` set on dragstart, cleared on dragend, `hideTooltip` called on dragstart).

- **`vite.config.ts`**: ratchets the `src/routes/**` coverage floors (lines 90→91, functions 88→89, branches 68→69, statements 89→90) now that the new tests raise measured coverage.

## Test plan

- [x] All 1367 existing tests continue to pass (`vitest run --reporter=minimal`)
- [x] The 48 new tests pass (26 GridSlot + 13 EquippedRail + 9 new InventoryGrid)
- [x] Coverage gates pass with the ratcheted `src/routes/**` floors (`vitest run --coverage`)
- [x] ESLint reports no issues on the new files

Closes #343

https://claude.ai/code/session_01XMRKj9EU45HMfnh4TVVAV1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMRKj9EU45HMfnh4TVVAV1)_