### PR TITLE
Add SkillEffect reference data + admin authoring end-to-end (#332)

### DIFF
--- a/Game.Abstractions/Contracts/Admin/SetSkillEffectsData.cs
+++ b/Game.Abstractions/Contracts/Admin/SetSkillEffectsData.cs
@@ -1,0 +1,11 @@
+namespace Game.Abstractions.Contracts.Admin
+{
+    /// <summary>
+    /// A change set against the effects collection of a single skill, keyed by the skill's <see cref="Id"/>.
+    /// </summary>
+    public class SetSkillEffectsData
+    {
+        public int Id { get; set; }
+        public required List<Change<SkillEffect>> Changes { get; set; }
+    }
+}

--- a/Game.Abstractions/Contracts/Skill.cs
+++ b/Game.Abstractions/Contracts/Skill.cs
@@ -7,6 +7,7 @@ namespace Game.Abstractions.Contracts
         public required string Name { get; set; }
         public decimal BaseDamage { get; set; }
         public required IEnumerable<AttributeMultiplier> DamageMultipliers { get; set; }
+        public required IEnumerable<SkillEffect> Effects { get; set; }
         public required string Description { get; set; }
         public int CooldownMs { get; set; }
         public required string IconPath { get; set; }

--- a/Game.Abstractions/Contracts/SkillEffect.cs
+++ b/Game.Abstractions/Contracts/SkillEffect.cs
@@ -1,0 +1,15 @@
+using Game.Core;
+
+namespace Game.Abstractions.Contracts
+{
+    /// <summary>Read contract for a skill effect in the reference-data catalogue.</summary>
+    public class SkillEffect : IModel
+    {
+        public int Id { get; set; }
+        public ESkillEffectTarget Target { get; set; }
+        public EAttribute AttributeId { get; set; }
+        public EModifierType ModifierTypeId { get; set; }
+        public decimal Amount { get; set; }
+        public int DurationMs { get; set; }
+    }
+}

--- a/Game.Abstractions/DataAccess/Admin/IAdminSkills.cs
+++ b/Game.Abstractions/DataAccess/Admin/IAdminSkills.cs
@@ -4,8 +4,8 @@ using Game.Abstractions.Contracts.Admin;
 namespace Game.Abstractions.DataAccess.Admin
 {
     /// <summary>
-    /// Content Authoring persistence for skills and their damage multipliers. Encapsulates the EF
-    /// specifics behind an entity-free admin contract surface.
+    /// Content Authoring persistence for skills, their damage multipliers, and their effects.
+    /// Encapsulates the EF specifics behind an entity-free admin contract surface.
     /// </summary>
     public interface IAdminSkills
     {
@@ -14,5 +14,8 @@ namespace Game.Abstractions.DataAccess.Admin
 
         /// <summary>Applies a change set to a skill's damage multipliers. Returns <c>false</c> if the skill does not exist.</summary>
         bool SetMultipliers(AddEditAttributesData data);
+
+        /// <summary>Applies a change set to a skill's effects. Returns <c>false</c> if the skill does not exist.</summary>
+        bool SetEffects(SetSkillEffectsData data);
     }
 }

--- a/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
@@ -570,6 +570,142 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task SetSkillEffects_AddEditDelete_RoundTripsThroughTheDatabase()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var skill = await TestDataSeeder.CreateSkillAsync(context, "Poison Sting"); // Id 0
+
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            // Add two effects: a self Strength buff and an opponent Defense debuff.
+            var addData = new
+            {
+                Id = skill.Id,
+                Changes = new[]
+                {
+                    new
+                    {
+                        Item = new
+                        {
+                            Id = 0,
+                            Target = (int)ESkillEffectTarget.Self,
+                            AttributeId = (int)EAttribute.Strength,
+                            ModifierTypeId = (int)EModifierType.Additive,
+                            Amount = 15m,
+                            DurationMs = 5000
+                        },
+                        ChangeType = 0 // Add
+                    },
+                    new
+                    {
+                        Item = new
+                        {
+                            Id = 0,
+                            Target = (int)ESkillEffectTarget.Opponent,
+                            AttributeId = (int)EAttribute.Defense,
+                            ModifierTypeId = (int)EModifierType.Multiplicative,
+                            Amount = 0.5m,
+                            DurationMs = 3000
+                        },
+                        ChangeType = 0 // Add
+                    }
+                }
+            };
+
+            var addResponse = await authClient.PostAsJsonAsync("/api/AdminTools/SetSkillEffects", addData, CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, addResponse.StatusCode);
+
+            var afterAdd = Assert.Single(GetSkills(), s => s.Id == skill.Id);
+            Assert.Equal(2, afterAdd.Effects.Count());
+            var selfBuff = Assert.Single(afterAdd.Effects, e => e.Target == ESkillEffectTarget.Self);
+            Assert.Equal(EAttribute.Strength, selfBuff.AttributeId);
+            Assert.Equal(EModifierType.Additive, selfBuff.ModifierTypeId);
+            Assert.Equal(15m, selfBuff.Amount);
+            Assert.Equal(5000, selfBuff.DurationMs);
+            var debuff = Assert.Single(afterAdd.Effects, e => e.Target == ESkillEffectTarget.Opponent);
+            Assert.Equal(EAttribute.Defense, debuff.AttributeId);
+
+            // Edit the self buff's amount and delete the opponent debuff.
+            var editData = new
+            {
+                Id = skill.Id,
+                Changes = new[]
+                {
+                    new
+                    {
+                        Item = new
+                        {
+                            selfBuff.Id,
+                            Target = (int)ESkillEffectTarget.Self,
+                            AttributeId = (int)EAttribute.Strength,
+                            ModifierTypeId = (int)EModifierType.Additive,
+                            Amount = 25m,
+                            DurationMs = 5000
+                        },
+                        ChangeType = 1 // Edit
+                    },
+                    new
+                    {
+                        Item = new
+                        {
+                            debuff.Id,
+                            Target = (int)ESkillEffectTarget.Opponent,
+                            AttributeId = (int)EAttribute.Defense,
+                            ModifierTypeId = (int)EModifierType.Multiplicative,
+                            Amount = 0.5m,
+                            DurationMs = 3000
+                        },
+                        ChangeType = 2 // Delete
+                    }
+                }
+            };
+
+            var editResponse = await authClient.PostAsJsonAsync("/api/AdminTools/SetSkillEffects", editData, CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, editResponse.StatusCode);
+
+            var afterEdit = Assert.Single(GetSkills(), s => s.Id == skill.Id);
+            var remaining = Assert.Single(afterEdit.Effects);
+            Assert.Equal(selfBuff.Id, remaining.Id);
+            Assert.Equal(ESkillEffectTarget.Self, remaining.Target);
+            Assert.Equal(25m, remaining.Amount);
+        }
+
+        [Fact]
+        public async Task SetSkillEffects_MissingSkill_ReturnsError()
+        {
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            var data = new
+            {
+                Id = 999,
+                Changes = new[]
+                {
+                    new
+                    {
+                        Item = new
+                        {
+                            Id = 0,
+                            Target = (int)ESkillEffectTarget.Self,
+                            AttributeId = (int)EAttribute.Strength,
+                            ModifierTypeId = (int)EModifierType.Additive,
+                            Amount = 5m,
+                            DurationMs = 1000
+                        },
+                        ChangeType = 0 // Add
+                    }
+                }
+            };
+
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/SetSkillEffects", data, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Equal("Skill does not exist.", result.ErrorMessage);
+        }
+
+        [Fact]
         public async Task AddEditSkills_EditZeroIdSkill_UpdatesInPlaceWithoutCreatingDuplicate()
         {
             using var scope = CreateScope();
@@ -591,7 +727,8 @@ namespace Game.Api.Tests.Integration
                         CooldownMs = 1500,
                         Description = "Updated",
                         IconPath = "skills/new.png",
-                        DamageMultipliers = Array.Empty<object>()
+                        DamageMultipliers = Array.Empty<object>(),
+                        Effects = Array.Empty<object>()
                     },
                     ChangeType = 1 // Edit
                 }

--- a/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
@@ -669,6 +669,17 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(selfBuff.Id, remaining.Id);
             Assert.Equal(ESkillEffectTarget.Self, remaining.Target);
             Assert.Equal(25m, remaining.Amount);
+
+            // The domain projection (SkillMapper.ToCore, which #333's battle runtime consumes)
+            // resolves the same effect: decimal→double amount, enum casts, surrogate id.
+            var domainSkill = GetDomainSkill(skill.Id);
+            var domainEffect = Assert.Single(domainSkill.Effects);
+            Assert.Equal(selfBuff.Id, domainEffect.Id);
+            Assert.Equal(ESkillEffectTarget.Self, domainEffect.Target);
+            Assert.Equal(EAttribute.Strength, domainEffect.AttributeId);
+            Assert.Equal(EModifierType.Additive, domainEffect.ModifierType);
+            Assert.Equal(25.0, domainEffect.Amount);
+            Assert.Equal(5000, domainEffect.DurationMs);
         }
 
         [Fact]
@@ -835,6 +846,12 @@ namespace Game.Api.Tests.Integration
         {
             using var scope = CreateScope();
             return scope.ServiceProvider.GetRequiredService<ISkills>().AllSkills().ToList();
+        }
+
+        private Game.Core.Skills.Skill GetDomainSkill(int skillId)
+        {
+            using var scope = CreateScope();
+            return scope.ServiceProvider.GetRequiredService<ISkills>().GetSkill(skillId);
         }
 
         private List<Enemy> GetEnemies()

--- a/Game.Api.Tests/Unit/PlayerDataMappingTests.cs
+++ b/Game.Api.Tests/Unit/PlayerDataMappingTests.cs
@@ -76,6 +76,7 @@ namespace Game.Api.Tests.Unit
             Description = string.Empty,
             CooldownMs = 1000,
             DamageMultipliers = [],
+            Effects = [],
         };
     }
 }

--- a/Game.Api/Controllers/Admin/AdminSkillsController.cs
+++ b/Game.Api/Controllers/Admin/AdminSkillsController.cs
@@ -8,9 +8,9 @@ using Microsoft.AspNetCore.Mvc;
 namespace Game.Api.Controllers.Admin
 {
     /// <summary>
-    /// Admin Workbench endpoints for persisting skills and their damage multipliers. A thin HTTP
-    /// adapter over <see cref="IAdminSkills"/>. The route prefix is shared across every admin
-    /// controller so the existing <c>/api/AdminTools/*</c> contract is preserved.
+    /// Admin Workbench endpoints for persisting skills, their damage multipliers, and their effects.
+    /// A thin HTTP adapter over <see cref="IAdminSkills"/>. The route prefix is shared across every
+    /// admin controller so the existing <c>/api/AdminTools/*</c> contract is preserved.
     /// </summary>
     [Route("/api/AdminTools/[action]")]
     [ApiController]
@@ -31,6 +31,14 @@ namespace Game.Api.Controllers.Admin
         public ApiResponse SetSkillMultipliers([FromBody] AddEditAttributesData changeData)
         {
             return _adminSkills.SetMultipliers(changeData)
+                ? ApiResponse.Success()
+                : ApiResponse.Error("Skill does not exist.");
+        }
+
+        [HttpPost]
+        public ApiResponse SetSkillEffects([FromBody] SetSkillEffectsData changeData)
+        {
+            return _adminSkills.SetEffects(changeData)
                 ? ApiResponse.Success()
                 : ApiResponse.Error("Skill does not exist.");
         }

--- a/Game.Core.Tests/Battle/BattleFactoryTests.cs
+++ b/Game.Core.Tests/Battle/BattleFactoryTests.cs
@@ -136,6 +136,7 @@ namespace Game.Core.Tests.Battle
             BaseDamage = 1,
             CooldownMs = 1000,
             DamageMultipliers = [],
+            Effects = [],
         };
     }
 }

--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -261,6 +261,7 @@ namespace Game.Core.Tests.Battle
                             Source = EAttributeModifierSource.Derived,
                         }
                     ],
+                Effects = [],
             };
 
         private static Battler MakeBattler(

--- a/Game.Core.Tests/Battle/BattleSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorTests.cs
@@ -130,6 +130,7 @@ namespace Game.Core.Tests.Battle
                             Source = EAttributeModifierSource.Derived,
                         }
                     ],
+                    Effects = [],
                 }
             ];
 
@@ -160,6 +161,7 @@ namespace Game.Core.Tests.Battle
                     CooldownMs = 1500,
                     BaseDamage = 5,
                     DamageMultipliers = [],
+                    Effects = [],
                 }
             ];
 

--- a/Game.Core.Tests/Battle/BattleSkillTests.cs
+++ b/Game.Core.Tests/Battle/BattleSkillTests.cs
@@ -142,6 +142,7 @@ namespace Game.Core.Tests.Battle
             CooldownMs = cooldownMs,
             BaseDamage = baseDamage,
             DamageMultipliers = multipliers ?? [],
+            Effects = [],
         };
 
         /// <summary>

--- a/Game.Core.Tests/Battle/BattleSnapshotTests.cs
+++ b/Game.Core.Tests/Battle/BattleSnapshotTests.cs
@@ -325,6 +325,7 @@ namespace Game.Core.Tests.Battle
             Description = string.Empty,
             CooldownMs = 1000,
             DamageMultipliers = [],
+            Effects = [],
         };
 
         private static AttributeModifier MakeModifier(EAttribute attribute, double amount) => new()

--- a/Game.Core.Tests/Battle/Performance/BattlePerformanceTests.cs
+++ b/Game.Core.Tests/Battle/Performance/BattlePerformanceTests.cs
@@ -241,6 +241,7 @@ namespace Game.Core.Tests.Battle.Performance
                 CooldownMs = 80, // fires every couple of ticks, so the damage path runs heavily
                 BaseDamage = 10,
                 DamageMultipliers = multipliers,
+                Effects = [],
             };
         }
 

--- a/Game.Core.Tests/Enemies/EnemyTests.cs
+++ b/Game.Core.Tests/Enemies/EnemyTests.cs
@@ -124,6 +124,7 @@ namespace Game.Core.Tests.Enemies
             BaseDamage = 1,
             CooldownMs = 1000,
             DamageMultipliers = [],
+            Effects = [],
         };
 
         private static Enemy MakeEnemy(List<Skill> skills) => new()

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -618,6 +618,7 @@ namespace Game.Core.Tests.Players
             Description = string.Empty,
             CooldownMs = 1000,
             DamageMultipliers = [],
+            Effects = [],
         };
     }
 }

--- a/Game.Core/Enums.cs
+++ b/Game.Core/Enums.cs
@@ -375,7 +375,29 @@ namespace Game.Core
         /// <summary>
         /// The modifier came from an item mod.
         /// </summary>
-        ItemMod = 6
+        ItemMod = 6,
+
+        /// <summary>
+        /// The modifier came from an active skill effect (a timed buff/debuff).
+        /// </summary>
+        SkillEffect = 7,
+    }
+
+    /// <summary>
+    /// Determines which battler a <see cref="SkillEffect"/> is applied to when its skill fires.
+    /// </summary>
+    [ClientMirrored]
+    public enum ESkillEffectTarget
+    {
+        /// <summary>
+        /// The effect is applied to the battler that used the skill.
+        /// </summary>
+        Self = 1,
+
+        /// <summary>
+        /// The effect is applied to the opposing battler.
+        /// </summary>
+        Opponent = 2,
     }
 
     /// <summary>

--- a/Game.Core/Enums.cs
+++ b/Game.Core/Enums.cs
@@ -384,7 +384,7 @@ namespace Game.Core
     }
 
     /// <summary>
-    /// Determines which battler a <see cref="SkillEffect"/> is applied to when its skill fires.
+    /// Determines which battler a <see cref="Skills.SkillEffect"/> is applied to when its skill fires.
     /// </summary>
     [ClientMirrored]
     public enum ESkillEffectTarget

--- a/Game.Core/Skills/Skill.cs
+++ b/Game.Core/Skills/Skill.cs
@@ -18,5 +18,7 @@ namespace Game.Core.Skills
         public required int CooldownMs { get; set; }
 
         public required List<AttributeModifier> DamageMultipliers { get; set; }
+
+        public required List<SkillEffect> Effects { get; set; }
     }
 }

--- a/Game.Core/Skills/SkillEffect.cs
+++ b/Game.Core/Skills/SkillEffect.cs
@@ -1,0 +1,16 @@
+namespace Game.Core.Skills
+{
+    /// <summary>
+    /// An authored effect that a skill applies when it fires — a timed attribute modifier on a target battler.
+    /// Not consumed by battle until the runtime issue (#333).
+    /// </summary>
+    public class SkillEffect
+    {
+        public required int Id { get; set; }
+        public required ESkillEffectTarget Target { get; set; }
+        public required EAttribute AttributeId { get; set; }
+        public required EModifierType ModifierType { get; set; }
+        public required double Amount { get; set; }
+        public required int DurationMs { get; set; }
+    }
+}

--- a/Game.DataAccess/Mapping/SkillMapper.cs
+++ b/Game.DataAccess/Mapping/SkillMapper.cs
@@ -4,6 +4,7 @@ using Game.Core.Attributes.Modifiers;
 using Game.Core.Skills;
 using Contracts = Game.Abstractions.Contracts;
 using EntitySkill = Game.Infrastructure.Entities.Skill;
+using CoreSkillEffect = Game.Core.Skills.SkillEffect;
 
 namespace Game.DataAccess.Mapping
 {
@@ -26,6 +27,16 @@ namespace Game.DataAccess.Mapping
                     {
                         AttributeId = (EAttribute)sdm.AttributeId,
                         Multiplier = sdm.Multiplier,
+                    }).ToList(),
+                Effects = entity.SkillEffects
+                    .Select(se => new Contracts.SkillEffect
+                    {
+                        Id = se.Id,
+                        Target = (ESkillEffectTarget)se.Target,
+                        AttributeId = (EAttribute)se.AttributeId,
+                        ModifierTypeId = (EModifierType)se.ModifierType,
+                        Amount = se.Amount,
+                        DurationMs = se.DurationMs,
                     }).ToList(),
                 RetiredAt = entity.RetiredAt,
             };
@@ -51,6 +62,16 @@ namespace Game.DataAccess.Mapping
                         Amount = (double)sdm.Multiplier,
                         Type = EModifierType.Multiplicative,
                         Source = EAttributeModifierSource.Derived,
+                    }).ToList(),
+                Effects = (entity.SkillEffects ?? [])
+                    .Select(se => new CoreSkillEffect
+                    {
+                        Id = se.Id,
+                        Target = (ESkillEffectTarget)se.Target,
+                        AttributeId = (EAttribute)se.AttributeId,
+                        ModifierType = (EModifierType)se.ModifierType,
+                        Amount = (double)se.Amount,
+                        DurationMs = se.DurationMs,
                     }).ToList(),
             };
         }

--- a/Game.DataAccess/Mapping/SkillMapper.cs
+++ b/Game.DataAccess/Mapping/SkillMapper.cs
@@ -10,8 +10,8 @@ namespace Game.DataAccess.Mapping
 {
     internal static class SkillMapper
     {
-        /// <summary>Maps an entity <see cref="EntitySkill"/> (with its damage multipliers loaded) to the
-        /// reference-data read <see cref="Contracts.Skill"/> contract.</summary>
+        /// <summary>Maps an entity <see cref="EntitySkill"/> (with its damage multipliers and effects loaded)
+        /// to the reference-data read <see cref="Contracts.Skill"/> contract.</summary>
         public static Contracts.Skill ToContract(EntitySkill entity)
         {
             return new Contracts.Skill
@@ -43,7 +43,7 @@ namespace Game.DataAccess.Mapping
         }
 
         /// <summary>
-        /// Maps an entity <see cref="EntitySkill"/> (with its damage multipliers loaded) to a
+        /// Maps an entity <see cref="EntitySkill"/> (with its damage multipliers and effects loaded) to a
         /// domain <see cref="Skill"/>.
         /// </summary>
         public static Skill ToCore(EntitySkill entity)
@@ -63,7 +63,7 @@ namespace Game.DataAccess.Mapping
                         Type = EModifierType.Multiplicative,
                         Source = EAttributeModifierSource.Derived,
                     }).ToList(),
-                Effects = (entity.SkillEffects ?? [])
+                Effects = entity.SkillEffects
                     .Select(se => new CoreSkillEffect
                     {
                         Id = se.Id,

--- a/Game.DataAccess/Repositories/Admin/AdminSkills.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminSkills.cs
@@ -1,5 +1,6 @@
 using Game.Abstractions.Contracts.Admin;
 using Game.Abstractions.DataAccess.Admin;
+using Game.Core;
 using Contracts = Game.Abstractions.Contracts;
 using Entities = Game.Infrastructure.Entities;
 
@@ -75,6 +76,56 @@ namespace Game.DataAccess.Repositories.Admin
                         {
                             SkillId = skill.Id,
                             AttributeId = (int)attribute.AttributeId,
+                        });
+                    }
+                });
+
+            return true;
+        }
+
+        public bool SetEffects(SetSkillEffectsData data)
+        {
+            var skill = _skills.LookupSkill(data.Id);
+            if (skill is null)
+            {
+                return false;
+            }
+
+            ChangeSetProcessor.Apply(data.Changes,
+                add: effect => _entityStore.Insert(new Entities.SkillEffect
+                {
+                    SkillId = skill.Id,
+                    Target = (int)effect.Target,
+                    AttributeId = (int)effect.AttributeId,
+                    ModifierType = (int)effect.ModifierTypeId,
+                    Amount = effect.Amount,
+                    DurationMs = effect.DurationMs,
+                }),
+                // Build fresh, navigation-free entities so cached back-references don't drag
+                // the whole graph into the change tracker.
+                edit: effect =>
+                {
+                    if (skill.SkillEffects.Any(se => se.Id == effect.Id))
+                    {
+                        _entityStore.Update(new Entities.SkillEffect
+                        {
+                            Id = effect.Id,
+                            SkillId = skill.Id,
+                            Target = (int)effect.Target,
+                            AttributeId = (int)effect.AttributeId,
+                            ModifierType = (int)effect.ModifierTypeId,
+                            Amount = effect.Amount,
+                            DurationMs = effect.DurationMs,
+                        });
+                    }
+                },
+                delete: effect =>
+                {
+                    if (skill.SkillEffects.Any(se => se.Id == effect.Id))
+                    {
+                        _entityStore.Delete(new Entities.SkillEffect
+                        {
+                            Id = effect.Id,
                         });
                     }
                 });

--- a/Game.DataAccess/Repositories/Caching/SkillsCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/SkillsCacheHolder.cs
@@ -14,6 +14,7 @@ namespace Game.DataAccess.Repositories.Caching
             return await context.Skills
                 .AsNoTracking()
                 .Include(s => s.SkillDamageMultipliers)
+                .Include(s => s.SkillEffects)
                 .OrderBy(s => s.Id)
                 .ToListAsync(cancellationToken);
         }

--- a/Game.Infrastructure/Database/GameContext.cs
+++ b/Game.Infrastructure/Database/GameContext.cs
@@ -43,6 +43,7 @@ namespace Game.Infrastructure.Database
         public DbSet<Role> Roles { get; set; }
         public DbSet<Skill> Skills { get; set; }
         public DbSet<SkillDamageMultiplier> SkillDamageMultipliers { get; set; }
+        public DbSet<SkillEffect> SkillEffects { get; set; }
         public DbSet<StatisticType> StatisticTypes { get; set; }
         public DbSet<ItemModType> ItemModTypes { get; set; }
         public DbSet<TagCategory> TagCategories { get; set; }
@@ -342,6 +343,12 @@ namespace Game.Infrastructure.Database
                 entity.HasKey(sdm => new { sdm.SkillId, sdm.AttributeId });
 
                 entity.Property(sdm => sdm.Multiplier)
+                    .HasPrecision(18, 3);
+            });
+
+            modelBuilder.Entity<SkillEffect>(entity =>
+            {
+                entity.Property(se => se.Amount)
                     .HasPrecision(18, 3);
             });
 

--- a/Game.Infrastructure/Entities/Skill.cs
+++ b/Game.Infrastructure/Entities/Skill.cs
@@ -13,6 +13,7 @@
         public DateTime? RetiredAt { get; set; }
 
         public virtual List<SkillDamageMultiplier> SkillDamageMultipliers { get => field ?? throw new NotLoadedException(nameof(SkillDamageMultipliers)); set; }
+        public virtual List<SkillEffect> SkillEffects { get => field ?? throw new NotLoadedException(nameof(SkillEffects)); set; }
         public virtual List<EnemySkill> EnemySkills { get => field ?? throw new NotLoadedException(nameof(EnemySkills)); set; }
         public virtual List<PlayerSkill> PlayerSkills { get => field ?? throw new NotLoadedException(nameof(PlayerSkills)); set; }
     }

--- a/Game.Infrastructure/Entities/SkillEffect.cs
+++ b/Game.Infrastructure/Entities/SkillEffect.cs
@@ -1,0 +1,16 @@
+namespace Game.Infrastructure.Entities
+{
+    public class SkillEffect
+    {
+        public int Id { get; set; }
+        public int SkillId { get; set; }
+        public int Target { get; set; }
+        public int AttributeId { get; set; }
+        public int ModifierType { get; set; }
+        public decimal Amount { get; set; }
+        public int DurationMs { get; set; }
+
+        public virtual Skill Skill { get => field ?? throw new NotLoadedException(nameof(Skill)); set; }
+        public virtual Attribute Attribute { get => field ?? throw new NotLoadedException(nameof(Attribute)); set; }
+    }
+}

--- a/Game.Infrastructure/Migrations/20260611001345_AddSkillEffects.Designer.cs
+++ b/Game.Infrastructure/Migrations/20260611001345_AddSkillEffects.Designer.cs
@@ -4,6 +4,7 @@ using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Game.Infrastructure.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20260611001345_AddSkillEffects")]
+    partial class AddSkillEffects
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Game.Infrastructure/Migrations/20260611001345_AddSkillEffects.cs
+++ b/Game.Infrastructure/Migrations/20260611001345_AddSkillEffects.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Game.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSkillEffects : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SkillEffects",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SkillId = table.Column<int>(type: "integer", nullable: false),
+                    Target = table.Column<int>(type: "integer", nullable: false),
+                    AttributeId = table.Column<int>(type: "integer", nullable: false),
+                    ModifierType = table.Column<int>(type: "integer", nullable: false),
+                    Amount = table.Column<decimal>(type: "numeric(18,3)", precision: 18, scale: 3, nullable: false),
+                    DurationMs = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SkillEffects", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SkillEffects_Attributes_AttributeId",
+                        column: x => x.AttributeId,
+                        principalTable: "Attributes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_SkillEffects_Skills_SkillId",
+                        column: x => x.SkillId,
+                        principalTable: "Skills",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SkillEffects_AttributeId",
+                table: "SkillEffects",
+                column: "AttributeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SkillEffects_SkillId",
+                table: "SkillEffects",
+                column: "SkillId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SkillEffects");
+        }
+    }
+}

--- a/UI/src/lib/api/types/api-type-map.ts
+++ b/UI/src/lib/api/types/api-type-map.ts
@@ -28,6 +28,7 @@ import type {
 	ISetEnemyAttributeDistributions,
 	ISetEnemySkillsData,
 	ISetEnemySpawnsData,
+	ISetSkillEffectsData,
 	ISetTagsData,
 	ISetUserRolesData,
 	ISetZoneEnemiesData,
@@ -57,6 +58,7 @@ export type ApiResponseTypes = {
 	'AdminTools/SetEnemyAttributeDistributions': undefined;
 	'AdminTools/SetEnemySkills': undefined;
 	'AdminTools/SetEnemySpawns': undefined;
+	'AdminTools/SetSkillEffects': undefined;
 	'AdminTools/SetSkillMultipliers': undefined;
 	'AdminTools/SetTagsForItem': undefined;
 	'AdminTools/SetTagsForItemMod': undefined;
@@ -99,6 +101,7 @@ export type ApiRequestTypes = {
 	'AdminTools/SetEnemyAttributeDistributions': ISetEnemyAttributeDistributions;
 	'AdminTools/SetEnemySkills': ISetEnemySkillsData;
 	'AdminTools/SetEnemySpawns': ISetEnemySpawnsData;
+	'AdminTools/SetSkillEffects': ISetSkillEffectsData;
 	'AdminTools/SetSkillMultipliers': IAddEditAttributesData;
 	'AdminTools/SetTagsForItem': ISetTagsData;
 	'AdminTools/SetTagsForItemMod': ISetTagsData;

--- a/UI/src/lib/api/types/enums.ts
+++ b/UI/src/lib/api/types/enums.ts
@@ -27,6 +27,7 @@ export enum EAttributeModifierSource {
 	Derived = 4,
 	Item = 5,
 	ItemMod = 6,
+	SkillEffect = 7,
 }
 
 export enum EChallengeGoalComparison {
@@ -103,6 +104,11 @@ export enum ERarity {
 	Epic = 4,
 	Legendary = 5,
 	Mythic = 6,
+}
+
+export enum ESkillEffectTarget {
+	Self = 1,
+	Opponent = 2,
 }
 
 export enum EStatisticType {

--- a/UI/src/lib/api/types/interfaces/admin.ts
+++ b/UI/src/lib/api/types/interfaces/admin.ts
@@ -6,6 +6,7 @@ import type {
 	IAttributeDistribution,
 	IBattlerAttribute,
 	IEnemySpawn,
+	ISkillEffect,
 	IZoneEnemy
 } from '../';
 
@@ -32,6 +33,11 @@ export interface ISetEnemySkillsData {
 export interface ISetEnemySpawnsData {
 	enemyId: number;
 	spawns: IEnemySpawn[];
+}
+
+export interface ISetSkillEffectsData {
+	id: number;
+	changes: IChange<ISkillEffect>[];
 }
 
 export interface ISetTagsData {

--- a/UI/src/lib/api/types/interfaces/contracts.ts
+++ b/UI/src/lib/api/types/interfaces/contracts.ts
@@ -7,7 +7,9 @@ import type {
 	EEntityType,
 	EItemCategory,
 	EItemModType,
+	EModifierType,
 	ERarity,
+	ESkillEffectTarget,
 	EStatisticType
 } from '../';
 
@@ -92,10 +94,20 @@ export interface ISkill {
 	name: string;
 	baseDamage: number;
 	damageMultipliers: IAttributeMultiplier[];
+	effects: ISkillEffect[];
 	description: string;
 	cooldownMs: number;
 	iconPath: string;
 	retiredAt?: string;
+}
+
+export interface ISkillEffect {
+	id: number;
+	target: ESkillEffectTarget;
+	attributeId: EAttribute;
+	modifierTypeId: EModifierType;
+	amount: number;
+	durationMs: number;
 }
 
 export interface ITag {

--- a/UI/src/lib/battle/skill.ts
+++ b/UI/src/lib/battle/skill.ts
@@ -1,4 +1,4 @@
-﻿import { IAttributeMultiplier, ISkill } from '$lib/api';
+﻿import { IAttributeMultiplier, ISkill, ISkillEffect } from '$lib/api';
 import { Battler } from './battler';
 
 export class Skill implements ISkill {
@@ -6,6 +6,7 @@ export class Skill implements ISkill {
 	name: string;
 	baseDamage: number;
 	damageMultipliers: IAttributeMultiplier[];
+	effects: ISkillEffect[];
 	description: string;
 	cooldownMs: number;
 	iconPath: string;
@@ -18,6 +19,7 @@ export class Skill implements ISkill {
 		this.name = data.name;
 		this.baseDamage = data.baseDamage;
 		this.damageMultipliers = data.damageMultipliers;
+		this.effects = data.effects;
 		this.description = data.description;
 		this.cooldownMs = data.cooldownMs;
 		this.iconPath = data.iconPath;

--- a/UI/src/routes/admin/workbench/entities/skill.ts
+++ b/UI/src/routes/admin/workbench/entities/skill.ts
@@ -1,7 +1,7 @@
 import { ApiRequest, fetchSocketData, type ISkill } from '$lib/api';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
-import { attributeChanges, persistEntity } from '../save-helpers';
+import { attributeChanges, persistEntity, skillEffectChanges } from '../save-helpers';
 import { firstFree } from './helpers';
 import type { EntityConfig } from './types';
 
@@ -25,11 +25,13 @@ export const skillEntity: EntityConfig<ISkill> = {
 		cooldownMs: 2000,
 		iconPath: '',
 		description: '',
-		damageMultipliers: []
+		damageMultipliers: [],
+		effects: []
 	}),
 	meta: (s) => [
 		['dmg', s.baseDamage],
 		['×mult', s.damageMultipliers.length],
+		['fx', s.effects.length],
 		['cd', `${(s.cooldownMs / 1000).toFixed(1)}s`]
 	],
 	sections: [
@@ -94,13 +96,59 @@ export const skillEntity: EntityConfig<ISkill> = {
 				},
 				{ key: 'multiplier', label: 'Multiplier ×', type: 'number', align: 'r', width: 120, allowNegative: true }
 			]
+		},
+		{
+			key: 'effects',
+			label: 'Effects',
+			glyph: 'bolt',
+			desc: 'Timed attribute buffs/debuffs applied when the skill fires',
+			count: (s) => s.effects.length,
+			kind: 'table',
+			itemsKey: 'effects',
+			addLabel: 'Add effect',
+			emptyIcon: 'bolt',
+			emptyTitle: 'No effects',
+			emptySub: 'This skill applies no timed attribute modifiers.',
+			newRow: () => ({
+				id: 0,
+				target: 2,
+				attributeId: 0,
+				modifierTypeId: 1,
+				amount: 0,
+				durationMs: 3000
+			}),
+			columns: [
+				{
+					key: 'target',
+					label: 'Target',
+					type: 'select',
+					options: reference.skillEffectTargetOptions,
+					width: 130
+				},
+				{
+					key: 'attributeId',
+					label: 'Attribute',
+					type: 'select',
+					options: reference.attributeOptions,
+					min: 170
+				},
+				{
+					key: 'modifierTypeId',
+					label: 'Modifier',
+					type: 'select',
+					options: reference.modifierTypeOptions,
+					width: 140
+				},
+				{ key: 'amount', label: 'Amount', type: 'number', align: 'r', width: 100, allowNegative: true },
+				{ key: 'durationMs', label: 'Duration (ms)', type: 'number', align: 'r', width: 130 }
+			]
 		}
 	],
 	refresh,
 	persist: (diff) =>
 		persistEntity({
 			diff,
-			toPrimaryDto: (s) => ({ ...s, damageMultipliers: [] }),
+			toPrimaryDto: (s) => ({ ...s, damageMultipliers: [], effects: [] }),
 			postPrimary: (changes) => ApiRequest.post('AdminTools/AddEditSkills', changes),
 			refresh,
 			childSavers: [
@@ -108,6 +156,12 @@ export const skillEntity: EntityConfig<ISkill> = {
 					const changes = attributeChanges(record.damageMultipliers, baseline?.damageMultipliers, 'multiplier');
 					if (changes.length) {
 						await ApiRequest.post('AdminTools/SetSkillMultipliers', { id, changes });
+					}
+				},
+				async (id, record, baseline) => {
+					const changes = skillEffectChanges(record.effects, baseline?.effects);
+					if (changes.length) {
+						await ApiRequest.post('AdminTools/SetSkillEffects', { id, changes });
 					}
 				}
 			]

--- a/UI/src/routes/admin/workbench/entities/skill.ts
+++ b/UI/src/routes/admin/workbench/entities/skill.ts
@@ -1,4 +1,4 @@
-import { ApiRequest, fetchSocketData, type ISkill } from '$lib/api';
+import { ApiRequest, EAttribute, EModifierType, ESkillEffectTarget, fetchSocketData, type ISkill } from '$lib/api';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import { attributeChanges, persistEntity, skillEffectChanges } from '../save-helpers';
@@ -111,9 +111,9 @@ export const skillEntity: EntityConfig<ISkill> = {
 			emptySub: 'This skill applies no timed attribute modifiers.',
 			newRow: () => ({
 				id: 0,
-				target: 2,
-				attributeId: 0,
-				modifierTypeId: 1,
+				target: ESkillEffectTarget.Opponent,
+				attributeId: EAttribute.Strength,
+				modifierTypeId: EModifierType.Additive,
 				amount: 0,
 				durationMs: 3000
 			}),

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -4,7 +4,9 @@ import {
 	EEntityType,
 	EItemCategory,
 	EItemModType,
+	EModifierType,
 	ERarity,
+	ESkillEffectTarget,
 	fetchSocketData,
 	type IChallengeType,
 	type IItem,
@@ -92,6 +94,8 @@ class WorkbenchReference {
 	itemCategoryOptions = (): SelectOption[] => toOptions(enumPairs(EItemCategory));
 	rarityOptions = (): SelectOption[] => toOptions(enumPairs(ERarity));
 	modTypeOptions = (): SelectOption[] => toOptions(enumPairs(EItemModType));
+	skillEffectTargetOptions = (): SelectOption[] => toOptions(enumPairs(ESkillEffectTarget));
+	modifierTypeOptions = (): SelectOption[] => toOptions(enumPairs(EModifierType));
 	tagCategoryOptions = (): SelectOption[] => this.tagCategories.map((c) => ({ value: c.id, text: c.name }));
 	zoneOptions = (keep?: number): SelectOption[] =>
 		this.retireableOptions(staticData.zones ?? [], keep, (z) => `${z.name} · L${z.levelMin}–${z.levelMax}`);

--- a/UI/src/routes/admin/workbench/save-helpers.ts
+++ b/UI/src/routes/admin/workbench/save-helpers.ts
@@ -1,4 +1,4 @@
-import { EChangeType, type IChange, type IItemModSlot } from '$lib/api';
+import { EChangeType, type IChange, type IItemModSlot, type ISkillEffect } from '$lib/api';
 import type { Identified, SaveDiff } from './entities/types';
 
 export const listsEqual = (a: unknown, b: unknown): boolean => JSON.stringify(a) === JSON.stringify(b);
@@ -111,6 +111,44 @@ export function attributeChanges<K extends string, T extends AttributeRow & Reco
 	for (const row of base) {
 		if (!currentIds.has(row.attributeId)) {
 			changes.push({ changeType: EChangeType.Delete, item: { attributeId: row.attributeId, amount: row[valueKey] } });
+		}
+	}
+	return changes;
+}
+
+/**
+ * Diffs a skill's effects into Add/Edit/Delete changes. Effects carry their own
+ * id (≤ 0 marks a new, unsaved effect).
+ */
+export function skillEffectChanges(
+	current: ISkillEffect[],
+	baseline: ISkillEffect[] | undefined
+): IChange<ISkillEffect>[] {
+	const base = baseline ?? [];
+	const baseById = new Map(base.filter((e) => e.id > 0).map((e) => [e.id, e]));
+	const currentIds = new Set(current.filter((e) => e.id > 0).map((e) => e.id));
+	const changes: IChange<ISkillEffect>[] = [];
+
+	for (const effect of current) {
+		if (effect.id <= 0) {
+			changes.push({ changeType: EChangeType.Add, item: effect });
+		} else {
+			const previous = baseById.get(effect.id);
+			if (
+				previous &&
+				(previous.target !== effect.target ||
+					previous.attributeId !== effect.attributeId ||
+					previous.modifierTypeId !== effect.modifierTypeId ||
+					previous.amount !== effect.amount ||
+					previous.durationMs !== effect.durationMs)
+			) {
+				changes.push({ changeType: EChangeType.Edit, item: effect });
+			}
+		}
+	}
+	for (const effect of base) {
+		if (!currentIds.has(effect.id)) {
+			changes.push({ changeType: EChangeType.Delete, item: effect });
 		}
 	}
 	return changes;

--- a/UI/src/routes/admin/workbench/save-helpers.ts
+++ b/UI/src/routes/admin/workbench/save-helpers.ts
@@ -116,6 +116,48 @@ export function attributeChanges<K extends string, T extends AttributeRow & Reco
 	return changes;
 }
 
+interface SurrogateId {
+	id: number;
+}
+
+/**
+ * Diffs a surrogate-id child collection into Add/Edit/Delete changes: a row with
+ * `id <= 0` is a new, unsaved record (Add), an existing row whose fields differ
+ * from its baseline is an Edit (per `equals`), and a baseline row absent from the
+ * current set is a Delete. `toItem` maps a row to the persisted change payload
+ * (default: the row itself); it lets a caller normalise the new-record id or inject
+ * a parent key. Shared by every surrogate-id child collection (skill effects, item
+ * mod slots, …).
+ */
+function surrogateIdChanges<T extends SurrogateId>(
+	current: T[],
+	baseline: T[] | undefined,
+	equals: (a: T, b: T) => boolean,
+	toItem: (row: T) => T = (row) => row
+): IChange<T>[] {
+	const base = baseline ?? [];
+	const baseById = new Map(base.filter((row) => row.id > 0).map((row) => [row.id, row]));
+	const currentIds = new Set(current.filter((row) => row.id > 0).map((row) => row.id));
+	const changes: IChange<T>[] = [];
+
+	for (const row of current) {
+		if (row.id <= 0) {
+			changes.push({ changeType: EChangeType.Add, item: toItem(row) });
+		} else {
+			const previous = baseById.get(row.id);
+			if (previous && !equals(row, previous)) {
+				changes.push({ changeType: EChangeType.Edit, item: toItem(row) });
+			}
+		}
+	}
+	for (const row of base) {
+		if (!currentIds.has(row.id)) {
+			changes.push({ changeType: EChangeType.Delete, item: toItem(row) });
+		}
+	}
+	return changes;
+}
+
 /**
  * Diffs a skill's effects into Add/Edit/Delete changes. Effects carry their own
  * id (≤ 0 marks a new, unsaved effect).
@@ -124,34 +166,16 @@ export function skillEffectChanges(
 	current: ISkillEffect[],
 	baseline: ISkillEffect[] | undefined
 ): IChange<ISkillEffect>[] {
-	const base = baseline ?? [];
-	const baseById = new Map(base.filter((e) => e.id > 0).map((e) => [e.id, e]));
-	const currentIds = new Set(current.filter((e) => e.id > 0).map((e) => e.id));
-	const changes: IChange<ISkillEffect>[] = [];
-
-	for (const effect of current) {
-		if (effect.id <= 0) {
-			changes.push({ changeType: EChangeType.Add, item: effect });
-		} else {
-			const previous = baseById.get(effect.id);
-			if (
-				previous &&
-				(previous.target !== effect.target ||
-					previous.attributeId !== effect.attributeId ||
-					previous.modifierTypeId !== effect.modifierTypeId ||
-					previous.amount !== effect.amount ||
-					previous.durationMs !== effect.durationMs)
-			) {
-				changes.push({ changeType: EChangeType.Edit, item: effect });
-			}
-		}
-	}
-	for (const effect of base) {
-		if (!currentIds.has(effect.id)) {
-			changes.push({ changeType: EChangeType.Delete, item: effect });
-		}
-	}
-	return changes;
+	return surrogateIdChanges(
+		current,
+		baseline,
+		(a, b) =>
+			a.target === b.target &&
+			a.attributeId === b.attributeId &&
+			a.modifierTypeId === b.modifierTypeId &&
+			a.amount === b.amount &&
+			a.durationMs === b.durationMs
+	);
 }
 
 /**
@@ -163,31 +187,10 @@ export function modSlotChanges(
 	baseline: IItemModSlot[] | undefined,
 	itemId: number
 ): IChange<IItemModSlot>[] {
-	const base = baseline ?? [];
-	const baseById = new Map(base.filter((slot) => slot.id > 0).map((slot) => [slot.id, slot]));
-	const currentIds = new Set(current.filter((slot) => slot.id > 0).map((slot) => slot.id));
-	const changes: IChange<IItemModSlot>[] = [];
-
-	for (const slot of current) {
-		if (slot.id <= 0) {
-			changes.push({ changeType: EChangeType.Add, item: { id: 0, itemId, itemModSlotTypeId: slot.itemModSlotTypeId } });
-		} else {
-			const previous = baseById.get(slot.id);
-			if (previous && previous.itemModSlotTypeId !== slot.itemModSlotTypeId) {
-				changes.push({
-					changeType: EChangeType.Edit,
-					item: { id: slot.id, itemId, itemModSlotTypeId: slot.itemModSlotTypeId }
-				});
-			}
-		}
-	}
-	for (const slot of base) {
-		if (!currentIds.has(slot.id)) {
-			changes.push({
-				changeType: EChangeType.Delete,
-				item: { id: slot.id, itemId, itemModSlotTypeId: slot.itemModSlotTypeId }
-			});
-		}
-	}
-	return changes;
+	return surrogateIdChanges(
+		current,
+		baseline,
+		(a, b) => a.itemModSlotTypeId === b.itemModSlotTypeId,
+		(slot) => ({ id: slot.id <= 0 ? 0 : slot.id, itemId, itemModSlotTypeId: slot.itemModSlotTypeId })
+	);
 }

--- a/UI/src/routes/game/screens/attribute-breakdown/source-display.ts
+++ b/UI/src/routes/game/screens/attribute-breakdown/source-display.ts
@@ -19,7 +19,9 @@ const SOURCE_KEY: Record<EAttributeModifierSource, string> = {
 	[EAttributeModifierSource.Derived]: 'derived',
 	// AttributeDistribution is an enemy/NPC source that never appears in a
 	// player's breakdown; it falls back to the neutral base hue if ever shown.
-	[EAttributeModifierSource.AttributeDistribution]: 'base'
+	[EAttributeModifierSource.AttributeDistribution]: 'base',
+	// SkillEffect is a timed battle modifier; it falls back to the derived hue.
+	[EAttributeModifierSource.SkillEffect]: 'derived'
 };
 
 const SOURCE_LABEL: Record<EAttributeModifierSource, string> = {
@@ -28,7 +30,8 @@ const SOURCE_LABEL: Record<EAttributeModifierSource, string> = {
 	[EAttributeModifierSource.Item]: 'Equipment',
 	[EAttributeModifierSource.ItemMod]: 'Item mods',
 	[EAttributeModifierSource.Derived]: 'Derived',
-	[EAttributeModifierSource.AttributeDistribution]: 'Distribution'
+	[EAttributeModifierSource.AttributeDistribution]: 'Distribution',
+	[EAttributeModifierSource.SkillEffect]: 'Skill effect'
 };
 
 /** Themeable source accent hue, e.g. `var(--source-points)`. */

--- a/UI/src/tests/lib/battle/battle-sim-test-utils.ts
+++ b/UI/src/tests/lib/battle/battle-sim-test-utils.ts
@@ -61,6 +61,7 @@ export function battlerFactory(registry: ISkill[]) {
 				baseDamage: spec.baseDamage,
 				cooldownMs: spec.cooldownMs,
 				damageMultipliers: spec.multipliers,
+				effects: [],
 				description: '',
 				iconPath: ''
 			});

--- a/UI/src/tests/lib/battle/battler.test.ts
+++ b/UI/src/tests/lib/battle/battler.test.ts
@@ -20,6 +20,7 @@ const makeSkillData = (id: number, baseDamage: number, cooldownMs: number): ISki
 	name: `Skill ${id}`,
 	baseDamage,
 	damageMultipliers: [],
+	effects: [],
 	description: '',
 	cooldownMs,
 	iconPath: ''

--- a/UI/src/tests/lib/battle/skill.test.ts
+++ b/UI/src/tests/lib/battle/skill.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { EAttribute } from '$lib/api';
+import { EAttribute, EModifierType, ESkillEffectTarget } from '$lib/api';
 import type { ISkill, IAttributeMultiplier } from '$lib/api';
 import { BattleAttributes } from '$lib/battle/battle-attributes';
 import { Skill } from '$lib/battle/skill';
@@ -28,7 +28,17 @@ const makeMockOwner = (attrs: [EAttribute, number][] = []) => {
 describe('Skill', () => {
 	describe('constructor', () => {
 		it('copies all properties from skill data', () => {
-			const data = makeSkillData({ id: 5, name: 'Fireball', baseDamage: 25, cooldownMs: 2000 });
+			const effects = [
+				{
+					id: 1,
+					target: ESkillEffectTarget.Self,
+					attributeId: EAttribute.Strength,
+					modifierTypeId: EModifierType.Additive,
+					amount: 5,
+					durationMs: 3000
+				}
+			];
+			const data = makeSkillData({ id: 5, name: 'Fireball', baseDamage: 25, cooldownMs: 2000, effects });
 			const owner = makeMockOwner();
 			const skill = new Skill(data, owner);
 
@@ -36,6 +46,7 @@ describe('Skill', () => {
 			expect(skill.name).toBe('Fireball');
 			expect(skill.baseDamage).toBe(25);
 			expect(skill.cooldownMs).toBe(2000);
+			expect(skill.effects).toEqual(effects);
 		});
 
 		it('initializes chargeTime and renderChargeTime to 0', () => {

--- a/UI/src/tests/lib/battle/skill.test.ts
+++ b/UI/src/tests/lib/battle/skill.test.ts
@@ -10,6 +10,7 @@ const makeSkillData = (overrides: Partial<ISkill> = {}): ISkill => ({
 	name: 'Slash',
 	baseDamage: 10,
 	damageMultipliers: [],
+	effects: [],
 	description: 'A basic slash',
 	cooldownMs: 1000,
 	iconPath: '/icons/slash.png',

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -117,6 +117,7 @@ describe('BattleEngine', () => {
 			name: 'Slash',
 			baseDamage: 100,
 			damageMultipliers: [],
+			effects: [],
 			description: '',
 			cooldownMs: 500,
 			iconPath: ''

--- a/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EAttribute, EChangeType, EModifierType, ESkillEffectTarget, type ISkill } from '$lib/api';
+import type { TableSectionConfig } from '$routes/admin/workbench/entities/types';
+
+/* Skill config transforms: `newItem` defaults, the derived meta line, the effects
+   `newRow` defaults, and the persist path — a child-only change (effects or
+   multipliers) must NOT hit the identity Add/Edit endpoint, and an untouched
+   child collection is skipped. `fetchSocketData`/`ApiRequest` are stubbed; the
+   real `persistEntity` orchestration runs unmocked. */
+
+const { staticData, socket, mockPost, mockFetch } = vi.hoisted(() => {
+	const socket = { skills: [] as unknown[] };
+	return {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		staticData: {} as any,
+		socket,
+		mockPost: vi.fn(),
+		mockFetch: vi.fn(async (command: string) => (command === 'GetSkills' ? socket.skills : []))
+	};
+});
+
+vi.mock('$stores', () => ({ staticData }));
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	class ApiRequest {
+		static post = mockPost;
+		static get = vi.fn();
+	}
+	return { ...actual, ApiRequest, fetchSocketData: mockFetch };
+});
+
+import { skillEntity } from '$routes/admin/workbench/entities/skill';
+
+/** Finds the body posted to a given AdminTools endpoint (or undefined if never called). */
+const postBodyTo = (endpoint: string) => mockPost.mock.calls.find((c) => c[0] === endpoint)?.[1];
+
+/** A table section's config by key (for exercising its `newRow` factory). */
+const tableSection = (key: string) => skillEntity.sections.find((s) => s.key === key) as TableSectionConfig<ISkill>;
+
+const effect = (over: Partial<ISkill['effects'][number]> = {}): ISkill['effects'][number] => ({
+	id: 1,
+	target: ESkillEffectTarget.Opponent,
+	attributeId: EAttribute.Defense,
+	modifierTypeId: EModifierType.Multiplicative,
+	amount: 0.5,
+	durationMs: 3000,
+	...over
+});
+
+beforeEach(() => {
+	mockPost.mockReset().mockResolvedValue(undefined);
+	mockFetch.mockClear();
+	socket.skills = [];
+	for (const key of Object.keys(staticData)) {
+		delete staticData[key];
+	}
+});
+
+describe('skillEntity', () => {
+	it('newItem defaults to a 10-damage, 2s-cooldown skill with empty collections', () => {
+		expect(skillEntity.newItem(4)).toEqual({
+			id: 4,
+			name: '',
+			baseDamage: 10,
+			cooldownMs: 2000,
+			iconPath: '',
+			description: '',
+			damageMultipliers: [],
+			effects: []
+		});
+	});
+
+	it('meta shows the damage, multiplier count, effect count and cooldown', () => {
+		const skill: ISkill = {
+			...skillEntity.newItem(1),
+			baseDamage: 25,
+			cooldownMs: 1500,
+			damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 1 }],
+			effects: [effect()]
+		};
+		expect(skillEntity.meta(skill)).toEqual([
+			['dmg', 25],
+			['×mult', 1],
+			['fx', 1],
+			['cd', '1.5s']
+		]);
+	});
+
+	it('effects newRow defaults to an opponent Strength additive over 3s', () => {
+		expect(tableSection('effects').newRow(skillEntity.newItem(1))).toEqual({
+			id: 0,
+			target: ESkillEffectTarget.Opponent,
+			attributeId: EAttribute.Strength,
+			modifierTypeId: EModifierType.Additive,
+			amount: 0,
+			durationMs: 3000
+		});
+	});
+
+	it('persist saves the effects when only effects change, without an identity Edit or a multipliers call', async () => {
+		const baseline: ISkill = {
+			id: 0,
+			name: 'Poison Sting',
+			baseDamage: 10,
+			cooldownMs: 2000,
+			iconPath: '',
+			description: 'desc',
+			damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 1 }],
+			effects: [effect({ id: 1, amount: 0.5 })]
+		};
+		const record: ISkill = { ...baseline, effects: [effect({ id: 1, amount: 0.75 })] }; // only the effect amount changed
+		socket.skills = [record];
+
+		await skillEntity.persist({ added: [], modified: [{ record, baseline }], deleted: [], existingIds: [0] });
+
+		// Identity + multipliers unchanged → only the effects endpoint is hit, as an Edit.
+		expect(postBodyTo('AdminTools/AddEditSkills')).toBeUndefined();
+		expect(postBodyTo('AdminTools/SetSkillMultipliers')).toBeUndefined();
+		expect(postBodyTo('AdminTools/SetSkillEffects')).toMatchObject({
+			id: 0,
+			changes: [{ changeType: EChangeType.Edit, item: { id: 1, amount: 0.75 } }]
+		});
+	});
+
+	it('persist saves the multipliers when only multipliers change, skipping the effects endpoint', async () => {
+		const baseline: ISkill = {
+			id: 0,
+			name: 'Slash',
+			baseDamage: 10,
+			cooldownMs: 2000,
+			iconPath: '',
+			description: 'desc',
+			damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 1 }],
+			effects: [effect({ id: 1 })]
+		};
+		const record: ISkill = { ...baseline, damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 2 }] };
+		socket.skills = [record];
+
+		await skillEntity.persist({ added: [], modified: [{ record, baseline }], deleted: [], existingIds: [0] });
+
+		expect(postBodyTo('AdminTools/AddEditSkills')).toBeUndefined();
+		expect(postBodyTo('AdminTools/SetSkillMultipliers')).toMatchObject({
+			id: 0,
+			changes: [{ changeType: EChangeType.Edit, item: { attributeId: EAttribute.Strength, amount: 2 } }]
+		});
+		// Effects were untouched, so their endpoint is skipped.
+		expect(postBodyTo('AdminTools/SetSkillEffects')).toBeUndefined();
+	});
+
+	it('persist Adds a new skill and saves its effects against the resolved id', async () => {
+		// A freshly-added record has a temporary negative id; persistEntity resolves the real
+		// id from the post-save refetch before running the effects child saver.
+		const added: ISkill = {
+			id: -1,
+			name: 'Venom',
+			baseDamage: 5,
+			cooldownMs: 1000,
+			iconPath: '',
+			description: 'Poisons the foe',
+			damageMultipliers: [],
+			effects: [effect({ id: 0, target: ESkillEffectTarget.Opponent })] // new effect, id 0
+		};
+		socket.skills = [{ ...added, id: 7 }]; // the persisted record at its real id
+
+		await skillEntity.persist({ added: [added], modified: [], deleted: [], existingIds: [] });
+
+		// Identity Add posted with the child collections stripped.
+		const addCall = postBodyTo('AdminTools/AddEditSkills');
+		expect(addCall[0].changeType).toBe(EChangeType.Add);
+		expect(addCall[0].item).toMatchObject({ id: -1, name: 'Venom', damageMultipliers: [], effects: [] });
+		// The new effect is an Add against the resolved id (7).
+		expect(postBodyTo('AdminTools/SetSkillEffects')).toMatchObject({
+			id: 7,
+			changes: [{ changeType: EChangeType.Add, item: { id: 0, target: ESkillEffectTarget.Opponent } }]
+		});
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
@@ -97,6 +97,34 @@ describe('skillEntity', () => {
 		});
 	});
 
+	it('multipliers newRow picks the first free attribute with a default multiplier of 1', () => {
+		// Strength (id 0) is already taken, so the first free attribute (id 1) is chosen.
+		const skill: ISkill = {
+			...skillEntity.newItem(1),
+			damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 2 }]
+		};
+		expect(tableSection('multipliers').newRow(skill)).toEqual({ attributeId: EAttribute.Endurance, multiplier: 1 });
+	});
+
+	it('section count/warn badges reflect the multiplier and effect collections', () => {
+		const multipliers = tableSection('multipliers');
+		const effects = tableSection('effects');
+		const empty = skillEntity.newItem(1);
+
+		expect(multipliers.count?.(empty)).toBe(0);
+		expect(multipliers.warn?.(empty)).toBe('No damage multipliers');
+		expect(effects.count?.(empty)).toBe(0);
+
+		const filled: ISkill = {
+			...empty,
+			damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 1 }],
+			effects: [effect(), effect({ id: 2 })]
+		};
+		expect(multipliers.count?.(filled)).toBe(1);
+		expect(multipliers.warn?.(filled)).toBeNull();
+		expect(effects.count?.(filled)).toBe(2);
+	});
+
 	it('persist saves the effects when only effects change, without an identity Edit or a multipliers call', async () => {
 		const baseline: ISkill = {
 			id: 0,

--- a/UI/src/tests/routes/admin/workbench/reference.test.ts
+++ b/UI/src/tests/routes/admin/workbench/reference.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { EChallengeGoalComparison, EEntityType, EItemCategory, EItemModType, ERarity } from '$lib/api';
+import {
+	EChallengeGoalComparison,
+	EEntityType,
+	EItemCategory,
+	EItemModType,
+	EModifierType,
+	ERarity,
+	ESkillEffectTarget
+} from '$lib/api';
 
 // WorkbenchReference reads its catalogues from the in-memory staticData store, so
 // it is mocked here (mirrors statistics-view.test.ts). The tags/categories/challenge-types
@@ -73,6 +81,17 @@ describe('enum-backed select options', () => {
 		expect(reference.itemCategoryOptions().find((o) => o.value === EItemCategory.Weapon)?.text).toBe('Weapon');
 		expect(reference.rarityOptions().find((o) => o.value === ERarity.Legendary)?.text).toBe('Legendary');
 		expect(reference.modTypeOptions().find((o) => o.value === EItemModType.Prefix)?.text).toBe('Prefix');
+	});
+
+	it('builds skill-effect-target and modifier-type options from their enums', () => {
+		expect(reference.skillEffectTargetOptions().find((o) => o.value === ESkillEffectTarget.Self)?.text).toBe('Self');
+		expect(reference.skillEffectTargetOptions().find((o) => o.value === ESkillEffectTarget.Opponent)?.text).toBe(
+			'Opponent'
+		);
+		expect(reference.modifierTypeOptions().find((o) => o.value === EModifierType.Additive)?.text).toBe('Additive');
+		expect(reference.modifierTypeOptions().find((o) => o.value === EModifierType.Multiplicative)?.text).toBe(
+			'Multiplicative'
+		);
 	});
 });
 

--- a/UI/src/tests/routes/admin/workbench/save-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/save-helpers.test.ts
@@ -1,6 +1,19 @@
 import { describe, it, expect, vi } from 'vitest';
-import { EChangeType, type IChange, type IItemModSlot } from '$lib/api';
-import { attributeChanges, modSlotChanges, persistEntity } from '../../../../routes/admin/workbench/save-helpers';
+import {
+	EAttribute,
+	EChangeType,
+	EModifierType,
+	ESkillEffectTarget,
+	type IChange,
+	type IItemModSlot,
+	type ISkillEffect
+} from '$lib/api';
+import {
+	attributeChanges,
+	modSlotChanges,
+	persistEntity,
+	skillEffectChanges
+} from '../../../../routes/admin/workbench/save-helpers';
 import type { Identified, SaveDiff } from '../../../../routes/admin/workbench/entities/types';
 
 describe('attributeChanges', () => {
@@ -43,6 +56,48 @@ describe('modSlotChanges', () => {
 			{ changeType: EChangeType.Add, item: { id: 0, itemId: 5, itemModSlotTypeId: 3 } },
 			{ changeType: EChangeType.Delete, item: { id: 2, itemId: 5, itemModSlotTypeId: 1 } }
 		]);
+	});
+});
+
+const makeEffect = (id: number, overrides: Partial<ISkillEffect> = {}): ISkillEffect => ({
+	id,
+	target: ESkillEffectTarget.Opponent,
+	attributeId: EAttribute.Strength,
+	modifierTypeId: EModifierType.Additive,
+	amount: 10,
+	durationMs: 3000,
+	...overrides
+});
+
+describe('skillEffectChanges', () => {
+	it('adds new effects (id <= 0), edits changed effects, and deletes removed effects', () => {
+		const current: ISkillEffect[] = [makeEffect(1, { amount: 15 }), makeEffect(0, { attributeId: EAttribute.Defense })];
+		const baseline: ISkillEffect[] = [makeEffect(1), makeEffect(2, { attributeId: EAttribute.Intellect })];
+		const changes = skillEffectChanges(current, baseline);
+		expect(changes).toEqual([
+			{ changeType: EChangeType.Edit, item: makeEffect(1, { amount: 15 }) },
+			{ changeType: EChangeType.Add, item: makeEffect(0, { attributeId: EAttribute.Defense }) },
+			{ changeType: EChangeType.Delete, item: makeEffect(2, { attributeId: EAttribute.Intellect }) }
+		]);
+	});
+
+	it('treats a missing baseline as all-added', () => {
+		const current: ISkillEffect[] = [makeEffect(0)];
+		const changes = skillEffectChanges(current, undefined);
+		expect(changes).toEqual([{ changeType: EChangeType.Add, item: makeEffect(0) }]);
+	});
+
+	it('emits no changes when current and baseline are identical', () => {
+		const effects = [makeEffect(1), makeEffect(2, { amount: 5 })];
+		expect(skillEffectChanges(effects, effects)).toEqual([]);
+	});
+
+	it('emits an Edit when any field changes', () => {
+		expect(skillEffectChanges([makeEffect(1, { target: ESkillEffectTarget.Self })], [makeEffect(1)])).toHaveLength(1);
+		expect(
+			skillEffectChanges([makeEffect(1, { modifierTypeId: EModifierType.Multiplicative })], [makeEffect(1)])
+		).toHaveLength(1);
+		expect(skillEffectChanges([makeEffect(1, { durationMs: 5000 })], [makeEffect(1)])).toHaveLength(1);
 	});
 });
 

--- a/UI/src/tests/routes/game/screens/fight/fight-fixtures.ts
+++ b/UI/src/tests/routes/game/screens/fight/fight-fixtures.ts
@@ -12,6 +12,7 @@ export const makeSkill = (owner: Battler, over: Partial<ISkill> = {}): Skill =>
 			name: 'Slash',
 			baseDamage: 10,
 			damageMultipliers: [],
+			effects: [],
 			description: 'A basic slash.',
 			cooldownMs: 1000,
 			iconPath: '/icons/slash.png',

--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -51,6 +51,7 @@ const skill = (over: Partial<ISkill> & { id: number }): ISkill => ({
 	name: `Skill ${over.id}`,
 	baseDamage: 10,
 	damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 1 }],
+	effects: [],
 	description: 'A skill.',
 	cooldownMs: 1000,
 	iconPath: '',

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -65,6 +65,7 @@ const skill = (over: Partial<ISkill> & { id: number }): ISkill => ({
 	name: `Skill ${over.id}`,
 	baseDamage: 0,
 	damageMultipliers: [],
+	effects: [],
 	description: '',
 	cooldownMs: 1000,
 	iconPath: '',


### PR DESCRIPTION
## Summary

Introduces the authored `SkillEffect` child reference data on `Skill`, shaped like `SkillDamageMultiplier`, carried end-to-end (entity → contract → domain → codegen → admin authoring) with **no battle behavior yet**. This is **area B** of the skill-effects spike ([#180](https://github.com/ginderjeremiah/GameServer/issues/180)); the battle runtime that consumes these effects is tracked separately in #333. This issue is independent of the attribute foundation (#331).

An authored `SkillEffect` is a timed attribute modifier a skill will (eventually) apply when it fires:
- `Target` — new enum `ESkillEffectTarget { Self = 1, Opponent = 2 }`
- `AttributeId` (`EAttribute`), `ModifierTypeId` (`EModifierType`), `Amount` (decimal entity / double domain), `DurationMs` (int)

## How it addresses the issue

**Backend**
- New `ESkillEffectTarget` enum and `EAttributeModifierSource.SkillEffect` value (both `[ClientMirrored]`, flow to the client via domain-enum codegen).
- `Game.Infrastructure.Entities.SkillEffect` (surrogate `Id`, FKs to `Skill` + `Attribute`), `GameContext` config, **EF migration** (`AddSkillEffects`), and a `SkillEffects` nav on the `Skill` entity.
- Read contract `Game.Abstractions.Contracts.SkillEffect`, carried as `Effects` on the `Skill` contract; projected in both `SkillMapper.ToContract` and `ToCore`, and eager-loaded in `SkillsCacheHolder`.
- `Game.Core.Skills.SkillEffect` list on the domain `Skill` (forward-scaffolding; unused by battle until the runtime issue).
- `AdminTools/SetSkillEffects` endpoint + `IAdminSkills.SetEffects`, mirroring `SetSkillMultipliers`/`AdminSkills`. Keyed by the effect's **own surrogate id** (rather than a composite `(SkillId, Attribute)` key like multipliers) so a skill can carry multiple effects on the same attribute — the `ItemModSlot` precedent.

**Frontend**
- Regenerated TS codegen: `ISkill.effects`, `ISkillEffect`, `ESkillEffectTarget`, `ISetSkillEffectsData`, and the endpoint type map.
- Workbench skill-editor **Effects** table section (columns: target, attribute, modifier type, amount, duration ms) with add/remove rows, mirroring the Multipliers section; `skillEffectChanges` diff helper and a `SetSkillEffects` child saver in the skill entity's `persist`.
- Threaded the new `EAttributeModifierSource.SkillEffect` source through the attribute-breakdown source-display map.

## Test plan
- [x] **Integration** (`AdminToolsControllerTests`): `SetSkillEffects` add/edit/delete round-trip through the DB (verifies the repo projection), and missing-skill → error. Updated the existing `AddEditSkills` test for the now-required `Effects` member.
- [x] **Frontend unit**: `skillEffectChanges` add/edit/delete + no-op cases; new `skillEffectTargetOptions`/`modifierTypeOptions` reference helpers.
- [x] Backend suites green: Core 358, Api 326, Application 142, Infrastructure 26.
- [x] Frontend green: 1324 tests, `npm run lint` clean.

## Notes
- Per the spike's "Documentation to update on landing", the game-design/backend doc updates are tied to the battle-runtime areas (C/D), not this authored-data area (B), so no doc changes are included here.

Closes #332


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ta71yCjjFFBayZXf3uMxdB)_