### PR TITLE
Remove unreachable ?? [] coalesces in reference-data mappers

### DIFF
--- a/Game.DataAccess/Mapping/EnemyMapper.cs
+++ b/Game.DataAccess/Mapping/EnemyMapper.cs
@@ -49,14 +49,14 @@ namespace Game.DataAccess.Mapping
                 Name = entity.Name,
                 IsBoss = entity.IsBoss,
                 Level = level,
-                AttributeDistributions = (entity.AttributeDistributions ?? [])
+                AttributeDistributions = entity.AttributeDistributions
                     .Select(ad => new AttributeDistribution
                     {
                         AttributeId = (EAttribute)ad.AttributeId,
                         BaseAmount = ad.BaseAmount,
                         AmountPerLevel = ad.AmountPerLevel,
                     }).ToList(),
-                AvailableSkills = (entity.EnemySkills ?? [])
+                AvailableSkills = entity.EnemySkills
                     .Where(es => skillLookup.ContainsKey(es.SkillId))
                     .Select(es => SkillMapper.ToCore(skillLookup[es.SkillId]))
                     .ToList(),

--- a/Game.DataAccess/Mapping/ItemMapper.cs
+++ b/Game.DataAccess/Mapping/ItemMapper.cs
@@ -18,7 +18,7 @@ namespace Game.DataAccess.Mapping
                 Description = entity.Description ?? string.Empty,
                 Category = (EItemCategory)entity.ItemCategoryId,
                 Rarity = (ERarity)entity.RarityId,
-                Attributes = (entity.ItemAttributes ?? [])
+                Attributes = entity.ItemAttributes
                     .Select(ia => new AttributeModifier
                     {
                         Attribute = (EAttribute)ia.AttributeId,
@@ -26,7 +26,7 @@ namespace Game.DataAccess.Mapping
                         Type = EModifierType.Additive,
                         Source = EAttributeModifierSource.Item,
                     }).ToList(),
-                ModSlots = (entity.ItemModSlots ?? [])
+                ModSlots = entity.ItemModSlots
                     .Select(ims => new ItemModSlot
                     {
                         Id = ims.Id,
@@ -46,7 +46,7 @@ namespace Game.DataAccess.Mapping
                 Description = entity.Description ?? string.Empty,
                 Type = (EItemModType)entity.ItemModTypeId,
                 Rarity = (ERarity)entity.RarityId,
-                Attributes = (entity.ItemModAttributes ?? [])
+                Attributes = entity.ItemModAttributes
                     .Select(ima => new AttributeModifier
                     {
                         Attribute = (EAttribute)ima.AttributeId,

--- a/Game.DataAccess/Mapping/SkillMapper.cs
+++ b/Game.DataAccess/Mapping/SkillMapper.cs
@@ -55,7 +55,7 @@ namespace Game.DataAccess.Mapping
                 BaseDamage = (double)entity.BaseDamage,
                 Description = entity.Description,
                 CooldownMs = entity.CooldownMs,
-                DamageMultipliers = (entity.SkillDamageMultipliers ?? [])
+                DamageMultipliers = entity.SkillDamageMultipliers
                     .Select(sdm => new AttributeModifier
                     {
                         Attribute = (EAttribute)sdm.AttributeId,


### PR DESCRIPTION
## Summary

Removes unreachable `?? []` coalesces from reference-data mappers. The entity nav properties use the `field ?? throw` pattern, making the coalesces dead code that misleadingly suggests unloaded navs are tolerated when they actually throw.

## Changes

- `SkillMapper.ToCore`: Remove `?? []` from `SkillDamageMultipliers`
- `EnemyMapper.ToCore`: Remove `?? []` from `AttributeDistributions` and `EnemySkills`
- `ItemMapper.ToCore`: Remove `?? []` from `ItemAttributes`, `ItemModSlots`, and `ItemModAttributes`

Now consistent with `ToContract` mappers which already access navs directly. No behavior change — all navs are included in cache holders and guaranteed loaded.

## Test Plan

- [x] All tests pass (358 Core, 26 Infrastructure, 144 Application)
- [x] Builds without warnings

Closes #381

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3ETwu1fpG3EaqygDvgU5M)_