### PR TITLE
Make InventoryManager the single source of truth for inventory state (#352)

### DIFF
--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -25,8 +25,12 @@ export class InventoryManager {
 	/** The 6 equipment slots — index matches EEquipmentSlot. */
 	public equippedSlots: (Item | undefined)[] = new Array(6).fill(undefined);
 
-	/** Currently selected item (for mod customization panel). */
-	public selectedItemId: number | undefined;
+	/**
+	 * Reactive published view of `unlockedItems`. The manager is the single owner of the item
+	 * objects and the only place they are mutated; this snapshot is republished (`publish`) on every
+	 * change so reactive consumers (the inventory screen) re-derive without keeping their own copies.
+	 */
+	public items: Item[] = [];
 
 	public initialize() {
 		this.unlockedItems.clear();
@@ -50,10 +54,12 @@ export class InventoryManager {
 				this.equippedSlots[invItem.equipmentSlotId] = item;
 			}
 		}
+
+		this.publish();
 	}
 
 	public get unlockedItemList(): Item[] {
-		return [...this.unlockedItems.values()];
+		return this.items;
 	}
 
 	/** Computes combined attributes from all equipped items and their applied mods. */
@@ -70,30 +76,146 @@ export class InventoryManager {
 		return stats;
 	}
 
-	public get selectedItem(): Item | undefined {
-		return this.selectedItemId != null ? this.unlockedItems.get(this.selectedItemId) : undefined;
-	}
-
-	public selectItem(itemId: number) {
-		this.selectedItemId = itemId;
-	}
-
 	public async equipItem(itemId: number, slotId: EEquipmentSlot) {
 		const item = this.unlockedItems.get(itemId);
 		if (!item) {
 			return false;
 		}
 
+		// Apply optimistically (instant UI), then persist; a failed persist rolls the change back so
+		// the authoritative state can never diverge from what was actually saved.
+		const rollback = this.snapshotEquipped(item, this.equippedSlots[slotId]);
+		this.applyEquip(item, slotId);
+		this.publish();
+
 		const req = new ApiRequest('Player/EquipItem');
 		const response = await req.post({ itemId, equipmentSlotId: slotId });
 		if (response.error) {
+			rollback();
+			this.publish();
 			return false;
 		}
 
+		return true;
+	}
+
+	public async unequipItem(slotId: EEquipmentSlot) {
+		const item = this.equippedSlots[slotId];
+		if (!item) {
+			return false;
+		}
+
+		const rollback = this.snapshotEquipped(item);
+		item.equipped = false;
+		item.equipmentSlotId = undefined;
+		this.equippedSlots[slotId] = undefined;
+		this.publish();
+
+		const req = new ApiRequest('Player/UnequipItem');
+		const response = await req.post({ itemId: item.itemId, equipmentSlotId: slotId });
+		if (response.error) {
+			rollback();
+			this.publish();
+			return false;
+		}
+
+		return true;
+	}
+
+	public async applyMod(itemId: number, itemModId: number, itemModSlotId: number) {
+		const item = this.unlockedItems.get(itemId);
+		if (!this.unlockedMods.has(itemModId) || !item) {
+			return false;
+		}
+
+		const prevMods = item.appliedMods;
+		const prevTotal = item.totalAttributes;
+		item.appliedMods = [
+			...item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId),
+			newItemMod({ itemModId, itemModSlotId })
+		];
+		this.refreshItemAttributes(item);
+		this.publish();
+
+		const req = new ApiRequest('Player/ApplyMod');
+		const response = await req.post({ itemId, itemModId, itemModSlotId });
+		if (response.error) {
+			item.appliedMods = prevMods;
+			item.totalAttributes = prevTotal;
+			this.publish();
+			return false;
+		}
+
+		logMessage(ELogType.ItemFound, 'Modifier applied.');
+		return true;
+	}
+
+	public async removeMod(itemId: number, itemModSlotId: number) {
+		const item = this.unlockedItems.get(itemId);
+		if (!item) {
+			return false;
+		}
+
+		const prevMods = item.appliedMods;
+		const prevTotal = item.totalAttributes;
+		item.appliedMods = item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId);
+		this.refreshItemAttributes(item);
+		this.publish();
+
+		const req = new ApiRequest('Player/RemoveMod');
+		const response = await req.post({ itemId, itemModSlotId });
+		if (response.error) {
+			item.appliedMods = prevMods;
+			item.totalAttributes = prevTotal;
+			this.publish();
+			return false;
+		}
+
+		logMessage(ELogType.ItemFound, 'Modifier removed.');
+		return true;
+	}
+
+	/**
+	 * Toggles whether an item is favorited and persists it via a websocket command. The local flag is
+	 * updated optimistically; a failed send keeps the local state (it re-syncs on the next toggle or
+	 * on reload) rather than rolling back, since a favourite flag is low-stakes.
+	 */
+	public async setFavorite(itemId: number, favorite: boolean) {
+		const item = this.unlockedItems.get(itemId);
+		if (!item) {
+			return false;
+		}
+
+		item.favorite = favorite;
+		this.publish();
+		try {
+			await apiSocket.sendSocketCommand('SetItemFavorite', { itemId, favorite });
+		} catch {
+			// Keep the optimistic local state; it re-syncs on the next toggle/reload.
+		}
+		return true;
+	}
+
+	/** Called when the player unlocks a new item from a challenge reward. */
+	public addUnlockedItem(invItem: IInventoryItem) {
+		const item = newItem(invItem);
+		this.unlockedItems.set(invItem.itemId, item);
+		this.publish();
+		logMessage(ELogType.ItemFound, `Unlocked: ${item.name}!`);
+	}
+
+	/** Called when the player unlocks a new mod from a challenge reward. */
+	public addUnlockedMod(modId: number) {
+		this.unlockedMods.add(modId);
+		logMessage(ELogType.ItemFound, 'New modifier unlocked!');
+	}
+
+	/** The equip mutation, applied directly to the authoritative items + slot array. */
+	private applyEquip(item: Item, slotId: EEquipmentSlot) {
 		// Unequip from any current slot
 		for (let i = 0; i < this.equippedSlots.length; i++) {
 			const old = this.equippedSlots[i];
-			if (old?.itemId === itemId) {
+			if (old?.itemId === item.itemId) {
 				old.equipped = false;
 				old.equipmentSlotId = undefined;
 				this.equippedSlots[i] = undefined;
@@ -111,70 +233,24 @@ export class InventoryManager {
 		item.equipped = true;
 		item.equipmentSlotId = slotId;
 		this.equippedSlots[slotId] = item;
-
-		return true;
 	}
 
-	public async unequipItem(slotId: EEquipmentSlot) {
-		const item = this.equippedSlots[slotId];
-		if (!item) {
-			return false;
-		}
-
-		const req = new ApiRequest('Player/UnequipItem');
-		const response = await req.post({ itemId: item.itemId, equipmentSlotId: slotId });
-		if (response.error) {
-			return false;
-		}
-
-		item.equipped = false;
-		item.equipmentSlotId = undefined;
-		this.equippedSlots[slotId] = undefined;
-
-		return true;
-	}
-
-	public async applyMod(itemId: number, itemModId: number, itemModSlotId: number) {
-		const item = this.unlockedItems.get(itemId);
-		if (!this.unlockedMods.has(itemModId) || !item) {
-			return false;
-		}
-
-		const req = new ApiRequest('Player/ApplyMod');
-		const response = await req.post({ itemId, itemModId, itemModSlotId });
-		if (response.error) {
-			return false;
-		}
-
-		// Mirror the change onto the authoritative item (the equip/favorite precedent) so
-		// equipmentStats (battle) and any view re-seed reflect it without a page reload.
-		item.appliedMods = [
-			...item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId),
-			newItemMod({ itemModId, itemModSlotId })
-		];
-		this.refreshItemAttributes(item);
-		logMessage(ELogType.ItemFound, 'Modifier applied.');
-
-		return true;
-	}
-
-	public async removeMod(itemId: number, itemModSlotId: number) {
-		const item = this.unlockedItems.get(itemId);
-		if (!item) {
-			return false;
-		}
-
-		const req = new ApiRequest('Player/RemoveMod');
-		const response = await req.post({ itemId, itemModSlotId });
-		if (response.error) {
-			return false;
-		}
-
-		item.appliedMods = item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId);
-		this.refreshItemAttributes(item);
-		logMessage(ELogType.ItemFound, 'Modifier removed.');
-
-		return true;
+	/**
+	 * Captures the slot array plus the equip/slot fields of the given items, returning a closure that
+	 * restores them — the rollback for a failed equip/unequip persist.
+	 */
+	private snapshotEquipped(...items: (Item | undefined)[]): () => void {
+		const prevSlots = [...this.equippedSlots];
+		const snaps = items
+			.filter((it): it is Item => it != null)
+			.map((it) => ({ item: it, equipped: it.equipped, slot: it.equipmentSlotId }));
+		return () => {
+			this.equippedSlots = prevSlots;
+			for (const snap of snaps) {
+				snap.item.equipped = snap.equipped;
+				snap.item.equipmentSlotId = snap.slot;
+			}
+		};
 	}
 
 	/** Rebuilds an item's cached totalAttributes after its applied mods change. */
@@ -183,37 +259,10 @@ export class InventoryManager {
 		item.totalAttributes = new BattleAttributes(allAttributes, false);
 	}
 
-	/**
-	 * Toggles whether an item is favorited and persists it via a websocket
-	 * command. The local flag is updated optimistically; a failed send keeps
-	 * the local state (it re-syncs on the next toggle or on reload).
-	 */
-	public async setFavorite(itemId: number, favorite: boolean) {
-		const item = this.unlockedItems.get(itemId);
-		if (!item) {
-			return false;
-		}
-
-		item.favorite = favorite;
-		try {
-			await apiSocket.sendSocketCommand('SetItemFavorite', { itemId, favorite });
-		} catch {
-			// Keep the optimistic local state; it re-syncs on the next toggle/reload.
-		}
-		return true;
-	}
-
-	/** Called when the player unlocks a new item from a challenge reward. */
-	public addUnlockedItem(invItem: IInventoryItem) {
-		const item = newItem(invItem);
-		this.unlockedItems.set(invItem.itemId, item);
-		logMessage(ELogType.ItemFound, `Unlocked: ${item.name}!`);
-	}
-
-	/** Called when the player unlocks a new mod from a challenge reward. */
-	public addUnlockedMod(modId: number) {
-		this.unlockedMods.add(modId);
-		logMessage(ELogType.ItemFound, 'New modifier unlocked!');
+	/** Republishes the reactive item snapshot so consumers re-derive after a mutation. */
+	private publish() {
+		this.items = [...this.unlockedItems.values()];
+		this.equippedSlots = [...this.equippedSlots];
 	}
 }
 

--- a/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
+++ b/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
@@ -48,11 +48,11 @@ export interface StatEntry {
 }
 
 /* ─── Reactive view-model ────────────────────────────────────────────────
-   Holds the UI state for the inventory screen. Item edits (equip, favorite,
-   mods) update the local reactive copies immediately and delegate to the
-   inventoryManager for persistence. */
+   Holds only the UI state for the inventory screen (sort/filter/selection).
+   The item data and every mutation live on the authoritative `inventoryManager`;
+   the view reads through its reactive `items`/`equippedSlots` and delegates
+   actions, so there is a single source of truth and a single mutation path. */
 export class InventoryView {
-	items = $state<Item[]>([]);
 	sort = $state<SortKey>('category');
 	filterCat = $state<EItemCategory | null>(null);
 	favOnly = $state(false);
@@ -60,25 +60,18 @@ export class InventoryView {
 	dragItemId = $state<number | null>(null);
 	page = $state(0);
 
-	constructor() {
-		this.reload();
-	}
-
-	/** Seed the reactive copies from the manager's unlocked items. */
-	reload() {
-		this.items = inventoryManager.unlockedItemList.map((i) => ({
-			...i,
-			appliedMods: [...i.appliedMods]
-		}));
+	/** The authoritative unlocked items, read reactively through the manager. */
+	get items(): Item[] {
+		return inventoryManager.unlockedItemList;
 	}
 
 	readonly equippedBySlot = $derived.by(() => {
 		const map: Partial<Record<EEquipmentSlot, Item>> = {};
-		for (const it of this.items) {
-			if (it.equipmentSlotId != null) {
-				map[it.equipmentSlotId as EEquipmentSlot] = it;
+		inventoryManager.equippedSlots.forEach((item, slot) => {
+			if (item) {
+				map[slot as EEquipmentSlot] = item;
 			}
-		}
+		});
 		return map;
 	});
 
@@ -113,14 +106,13 @@ export class InventoryView {
 		return list.sort(SORTS[this.sort].cmp);
 	});
 
-	readonly equippedTotals = $derived.by<StatEntry[]>(() => {
-		const allAttrs = this.items
-			.filter((i) => i.equipmentSlotId != null)
-			.flatMap((i) => [...i.attributes, ...i.appliedMods.flatMap((m) => m.attributes)]);
-		return new BattleAttributes(allAttrs, false).getAttributeMap();
-	});
+	// Display totals reuse the manager's single equipmentStats derivation rather than re-flattening
+	// equipped items, projecting it to a named stat list for the UI.
+	readonly equippedTotals = $derived.by<StatEntry[]>(() =>
+		new BattleAttributes(inventoryManager.equipmentStats, false).getAttributeMap()
+	);
 
-	readonly slotsFilled = $derived(this.items.filter((i) => i.equipmentSlotId != null).length);
+	readonly slotsFilled = $derived(inventoryManager.equippedSlots.filter((s) => s != null).length);
 
 	/* ── actions ─────────────────────────────────────────────────────── */
 
@@ -129,25 +121,10 @@ export class InventoryView {
 	}
 
 	equip(itemId: number, slotId: EEquipmentSlot) {
-		for (const it of this.items) {
-			if (it.itemId === itemId) {
-				it.equipmentSlotId = slotId;
-				it.equipped = true;
-			} else if (it.equipmentSlotId === slotId) {
-				it.equipmentSlotId = undefined;
-				it.equipped = false;
-			}
-		}
 		inventoryManager.equipItem(itemId, slotId);
 	}
 
 	unequip(slotId: EEquipmentSlot) {
-		for (const it of this.items) {
-			if (it.equipmentSlotId === slotId) {
-				it.equipmentSlotId = undefined;
-				it.equipped = false;
-			}
-		}
 		inventoryManager.unequipItem(slotId);
 	}
 
@@ -164,9 +141,7 @@ export class InventoryView {
 		if (!item) {
 			return;
 		}
-
-		item.favorite = !item.favorite;
-		inventoryManager.setFavorite(itemId, item.favorite);
+		inventoryManager.setFavorite(itemId, !item.favorite);
 	}
 
 	/** Unlocked mods compatible with a slot type, minus ones already on the item. */
@@ -179,26 +154,10 @@ export class InventoryView {
 	}
 
 	applyMod(itemId: number, slotId: number, modId: number) {
-		const item = this.items.find((i) => i.itemId === itemId);
-		const modData = staticData.itemMods?.[modId];
-		if (!item || !modData) {
-			return;
-		}
-
-		item.appliedMods = [
-			...item.appliedMods.filter((m) => m.itemModSlotId !== slotId),
-			{ ...modData, itemModSlotId: slotId }
-		];
 		inventoryManager.applyMod(itemId, modId, slotId);
 	}
 
 	removeMod(itemId: number, slotId: number) {
-		const item = this.items.find((i) => i.itemId === itemId);
-		if (!item) {
-			return;
-		}
-
-		item.appliedMods = item.appliedMods.filter((m) => m.itemModSlotId !== slotId);
 		inventoryManager.removeMod(itemId, slotId);
 	}
 }

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -210,32 +210,28 @@ describe('InventoryManager', () => {
 		});
 	});
 
-	describe('selectItem', () => {
-		it('updates the selected item id', () => {
+	describe('items (reactive published list)', () => {
+		it('mirrors unlockedItemList and republishes a new array reference on mutation', async () => {
 			mockItems[1] = makeItem(1);
 			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
 			manager.initialize();
 
-			manager.selectItem(1);
+			expect(manager.items).toBe(manager.unlockedItemList);
+			expect(manager.items.map((i) => i.itemId)).toEqual([1]);
 
-			expect(manager.selectedItemId).toBe(1);
-			expect(manager.selectedItem?.itemId).toBe(1);
-		});
-	});
-
-	describe('selectedItem', () => {
-		it('returns undefined when no item selected', () => {
-			expect(manager.selectedItem).toBeUndefined();
+			const before = manager.items;
+			await manager.equipItem(1, EEquipmentSlot.WeaponSlot);
+			// A mutation publishes a fresh array reference so reactive consumers re-derive.
+			expect(manager.items).not.toBe(before);
 		});
 
-		it('returns the selected item', () => {
-			mockItems[1] = makeItem(1);
-			mockInventoryData.unlockedItems = [{ itemId: 1, equipped: false, appliedMods: [], favorite: false }];
+		it('publishes a newly unlocked item into the list', () => {
+			mockItems[3] = makeItem(3);
 			manager.initialize();
 
-			manager.selectItem(1);
-			expect(manager.selectedItem).toBeDefined();
-			expect(manager.selectedItem?.itemId).toBe(1);
+			manager.addUnlockedItem(makeInventoryItem({ itemId: 3 }));
+
+			expect(manager.items.map((i) => i.itemId)).toEqual([3]);
 		});
 	});
 
@@ -308,6 +304,26 @@ describe('InventoryManager', () => {
 			const result = await manager.equipItem(1, EEquipmentSlot.WeaponSlot);
 
 			expect(result).toBe(false);
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]).toBeUndefined();
+			expect(manager.unlockedItems.get(1)?.equipped).toBe(false);
+		});
+
+		it('applies the change optimistically before the persist resolves, then rolls back on error', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+
+			let resolvePost: (value: { error?: string }) => void = () => {};
+			mockPost.mockReturnValue(new Promise((resolve) => (resolvePost = resolve)));
+
+			const pending = manager.equipItem(1, EEquipmentSlot.WeaponSlot);
+			// Optimistically equipped while the persist is still in flight.
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]?.itemId).toBe(1);
+			expect(manager.unlockedItems.get(1)?.equipped).toBe(true);
+
+			resolvePost({ error: 'nope' });
+			await pending;
+
 			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]).toBeUndefined();
 			expect(manager.unlockedItems.get(1)?.equipped).toBe(false);
 		});

--- a/UI/src/tests/routes/game/screens/inventory/Inventory.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/Inventory.test.ts
@@ -10,6 +10,7 @@ vi.mock('$lib/engine', () => ({
 			return [];
 		},
 		equippedSlots: [],
+		equipmentStats: [],
 		unlockedMods: new Set<number>(),
 		equipItem: vi.fn(),
 		unequipItem: vi.fn(),

--- a/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
@@ -1,23 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EAttribute, EItemCategory, ERarity } from '$lib/api';
 import type { Item } from '$lib/battle';
+import type { IBattlerAttribute } from '$lib/api';
 
 // Light mock of the engine so importing the view-model doesn't pull the real
 // game engine. EEquipmentSlot mirrors the real enum's indices. `vi.hoisted`
-// keeps these initialized before the hoisted vi.mock factory runs.
-const { equipItem, unequipItem, setFavorite, applyMod, removeMod, unlockedMods, sampleItems, staticData } = vi.hoisted(
-	() => ({
-		equipItem: vi.fn(),
-		unequipItem: vi.fn(),
-		setFavorite: vi.fn(),
-		applyMod: vi.fn(),
-		removeMod: vi.fn(),
-		unlockedMods: new Set<number>(),
-		sampleItems: [] as Item[],
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		staticData: { itemMods: [] as any[] }
-	})
-);
+// keeps these initialized before the hoisted vi.mock factory runs. The view now
+// reads the manager's authoritative `unlockedItemList`/`equippedSlots`/`equipmentStats`
+// and delegates every mutation, so the mock exposes that surface.
+const {
+	equipItem,
+	unequipItem,
+	setFavorite,
+	applyMod,
+	removeMod,
+	unlockedMods,
+	sampleItems,
+	sampleSlots,
+	sampleStats,
+	staticData
+} = vi.hoisted(() => ({
+	equipItem: vi.fn(),
+	unequipItem: vi.fn(),
+	setFavorite: vi.fn(),
+	applyMod: vi.fn(),
+	removeMod: vi.fn(),
+	unlockedMods: new Set<number>(),
+	sampleItems: [] as Item[],
+	sampleSlots: new Array(6).fill(undefined) as (Item | undefined)[],
+	sampleStats: [] as IBattlerAttribute[],
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	staticData: { itemMods: [] as any[] | undefined }
+}));
 
 vi.mock('$lib/engine', () => ({
 	EEquipmentSlot: {
@@ -32,6 +46,12 @@ vi.mock('$lib/engine', () => ({
 	inventoryManager: {
 		get unlockedItemList() {
 			return sampleItems;
+		},
+		get equippedSlots() {
+			return sampleSlots;
+		},
+		get equipmentStats() {
+			return sampleStats;
 		},
 		unlockedMods,
 		equipItem,
@@ -65,15 +85,6 @@ const makeItem = (itemId: number, name: string, cat: EItemCategory, rarity: ERar
 		...extra
 	}) as unknown as Item;
 
-// Locate a seeded item, narrowing it to a defined Item (avoids a null-forgiving `!`).
-const itemOf = (view: InventoryView, itemId: number): Item => {
-	const item = view.items.find((i) => i.itemId === itemId);
-	if (!item) {
-		throw new Error(`expected inventory item ${itemId} to exist`);
-	}
-	return item;
-};
-
 beforeEach(() => {
 	equipItem.mockClear();
 	unequipItem.mockClear();
@@ -82,6 +93,8 @@ beforeEach(() => {
 	removeMod.mockClear();
 	unlockedMods.clear();
 	staticData.itemMods = [];
+	sampleSlots.fill(undefined);
+	sampleStats.length = 0;
 	sampleItems.length = 0;
 	sampleItems.push(
 		makeItem(1, 'Zeta Helm', EItemCategory.Helm, ERarity.Rare, { favorite: true }),
@@ -107,18 +120,27 @@ describe('inventory-view helpers', () => {
 		expect(EQUIP_SLOTS).toHaveLength(6);
 		expect(SORTS.name.cmp(makeItem(9, 'Aaa', 1, 1), makeItem(8, 'Bbb', 1, 1))).toBeLessThan(0);
 	});
+
+	it('breaks a category-sort tie by name', () => {
+		// Same category falls through to the localeCompare tiebreak.
+		expect(SORTS.category.cmp(makeItem(9, 'Bbb', 2, 1), makeItem(8, 'Aaa', 2, 1))).toBeGreaterThan(0);
+	});
 });
 
-describe('InventoryView', () => {
-	it('seeds reactive copies from the manager', () => {
-		const view = new InventoryView();
-		expect(view.items).toHaveLength(3);
+describe('InventoryView derivations', () => {
+	it('reads the unlocked items through the manager', () => {
+		expect(new InventoryView().items).toHaveLength(3);
 	});
 
 	it('sorts visible items by name', () => {
 		const view = new InventoryView();
 		view.sort = 'name';
 		expect(view.visible.map((i) => i.name)).toEqual(['Alpha Blade', 'Mid Ring', 'Zeta Helm']);
+	});
+
+	it('sorts visible items by category then name by default', () => {
+		// Helm(1) < Weapon(5) < Accessory(6) by category id.
+		expect(new InventoryView().visible.map((i) => i.name)).toEqual(['Zeta Helm', 'Alpha Blade', 'Mid Ring']);
 	});
 
 	it('filters by favorites and by category', () => {
@@ -129,29 +151,6 @@ describe('InventoryView', () => {
 		view.favOnly = false;
 		view.filterCat = EItemCategory.Weapon;
 		expect(view.visible.map((i) => i.itemId)).toEqual([2]);
-	});
-
-	it('toggles favorite and delegates to the manager', () => {
-		const view = new InventoryView();
-		view.toggleFavorite(2);
-		expect(view.items.find((i) => i.itemId === 2)?.favorite).toBe(true);
-		expect(setFavorite).toHaveBeenCalledWith(2, true);
-	});
-
-	it('equips an item into a slot and reflects it in equippedBySlot + totals', () => {
-		const view = new InventoryView();
-		view.equip(2, 4 /* WeaponSlot */);
-		expect(view.equippedBySlot[4]?.itemId).toBe(2);
-		expect(equipItem).toHaveBeenCalledWith(2, 4);
-		expect(view.slotsFilled).toBe(1);
-		// the equipped weapon contributes +5 Strength
-		expect(view.equippedTotals).toEqual([{ name: 'Strength', value: 5 }]);
-	});
-
-	it('sorts visible items by category then name by default', () => {
-		const view = new InventoryView();
-		// Helm(1) < Weapon(5) < Accessory(6) by category id.
-		expect(view.visible.map((i) => i.name)).toEqual(['Zeta Helm', 'Alpha Blade', 'Mid Ring']);
 	});
 
 	it('tallies overall, favorite and per-category counts', () => {
@@ -178,49 +177,78 @@ describe('InventoryView', () => {
 		expect(view.dragItem?.name).toBe('Mid Ring');
 	});
 
-	it('reload re-seeds the reactive copies from the manager', () => {
+	it('yields null when the selected/drag id no longer matches an item', () => {
 		const view = new InventoryView();
-		sampleItems.push(makeItem(4, 'New Boots', EItemCategory.Boot, ERarity.Common));
-		expect(view.items).toHaveLength(3);
-		view.reload();
-		expect(view.items).toHaveLength(4);
+		view.select(999);
+		expect(view.selected).toBeNull();
+		view.dragItemId = 999;
+		expect(view.dragItem).toBeNull();
 	});
 
-	it('swaps the occupant when equipping into an already-filled slot', () => {
+	it('derives equippedBySlot and slotsFilled from the manager slots', () => {
+		sampleSlots[4] = sampleItems[1]; // Alpha Blade in the weapon slot
 		const view = new InventoryView();
-		view.equip(2, 4);
-		view.equip(3, 4); // re-use the same weapon slot
-		expect(view.equippedBySlot[4]?.itemId).toBe(3);
-		expect(view.items.find((i) => i.itemId === 2)?.equipped).toBe(false);
-		expect(view.items.find((i) => i.itemId === 2)?.equipmentSlotId).toBeUndefined();
+		expect(view.equippedBySlot[4]?.itemId).toBe(2);
+		expect(view.equippedBySlot[0]).toBeUndefined();
 		expect(view.slotsFilled).toBe(1);
 	});
 
-	it('unequips a slot and delegates to the manager', () => {
-		const view = new InventoryView();
-		view.equip(2, 4);
-		view.unequip(4);
-		expect(view.equippedBySlot[4]).toBeUndefined();
-		expect(view.items.find((i) => i.itemId === 2)?.equipped).toBe(false);
+	it('projects equippedTotals from the manager equipmentStats', () => {
+		sampleStats.push({ attributeId: EAttribute.Strength, amount: 5 });
+		expect(new InventoryView().equippedTotals).toEqual([{ name: 'Strength', value: 5 }]);
+	});
+});
+
+describe('InventoryView delegation', () => {
+	it('equip delegates to the manager', () => {
+		new InventoryView().equip(2, 4);
+		expect(equipItem).toHaveBeenCalledWith(2, 4);
+	});
+
+	it('unequip delegates to the manager', () => {
+		new InventoryView().unequip(4);
 		expect(unequipItem).toHaveBeenCalledWith(4);
 	});
 
-	it('toggleEquip equips an unequipped item and unequips an equipped one', () => {
-		const view = new InventoryView();
-		view.toggleEquip(itemOf(view, 2)); // Weapon category (5) → slot 4
-		expect(view.equippedBySlot[4]?.itemId).toBe(2);
+	it('toggleEquip equips an unequipped item into its category slot', () => {
+		const item = sampleItems[1]; // Weapon category (5) → slot 4
+		new InventoryView().toggleEquip(item);
+		expect(equipItem).toHaveBeenCalledWith(2, 4);
+		expect(unequipItem).not.toHaveBeenCalled();
+	});
 
-		view.toggleEquip(itemOf(view, 2));
-		expect(view.equippedBySlot[4]).toBeUndefined();
+	it('toggleEquip unequips an item already in a slot', () => {
+		const item = makeItem(2, 'Alpha Blade', EItemCategory.Weapon, ERarity.Legendary, {
+			equipped: true,
+			equipmentSlotId: 4
+		});
+		new InventoryView().toggleEquip(item);
 		expect(unequipItem).toHaveBeenCalledWith(4);
+		expect(equipItem).not.toHaveBeenCalled();
+	});
+
+	it('toggleFavorite delegates the flipped flag to the manager', () => {
+		new InventoryView().toggleFavorite(2); // currently false → true
+		expect(setFavorite).toHaveBeenCalledWith(2, true);
 	});
 
 	it('toggleFavorite is a no-op for an unknown item', () => {
-		const view = new InventoryView();
-		view.toggleFavorite(999);
+		new InventoryView().toggleFavorite(999);
 		expect(setFavorite).not.toHaveBeenCalled();
 	});
 
+	it('applyMod delegates with the manager argument order (itemId, modId, slotId)', () => {
+		new InventoryView().applyMod(2, 0 /* slotId */, 7 /* modId */);
+		expect(applyMod).toHaveBeenCalledWith(2, 7, 0);
+	});
+
+	it('removeMod delegates to the manager', () => {
+		new InventoryView().removeMod(2, 0);
+		expect(removeMod).toHaveBeenCalledWith(2, 0);
+	});
+});
+
+describe('InventoryView.compatibleMods', () => {
 	it('lists only unlocked, type-matching mods not already applied', () => {
 		staticData.itemMods = [
 			{ id: 0, name: 'Sharp', itemModTypeId: 2, attributes: [] },
@@ -238,36 +266,22 @@ describe('InventoryView', () => {
 		expect(compatible[0].itemModSlotId).toBe(-1);
 	});
 
-	it('applies a mod into a slot, replacing any existing mod there, and delegates', () => {
-		staticData.itemMods = [{ id: 0, name: 'Sharp', itemModTypeId: 2, attributes: [] }];
-		const view = new InventoryView();
-		view.applyMod(2, 0 /* slotId */, 0 /* modId */);
-		const item = itemOf(view, 2);
-		expect(item.appliedMods.map((m) => m.id)).toEqual([0]);
-		expect(item.appliedMods[0].itemModSlotId).toBe(0);
-		expect(applyMod).toHaveBeenCalledWith(2, 0, 0);
+	it('skips sparse catalogue gaps and not-yet-unlocked mods', () => {
+		// A gap in the itemMods catalogue must be filtered out rather than throw, and a
+		// type-matching mod the player has not unlocked is excluded.
+		staticData.itemMods = [
+			undefined,
+			{ id: 1, name: 'Heavy', itemModTypeId: 2, attributes: [] },
+			{ id: 2, name: 'Locked', itemModTypeId: 2, attributes: [] }
+		];
+		unlockedMods.add(1); // id 2 stays locked
+		const item = makeItem(2, 'Alpha Blade', EItemCategory.Weapon, ERarity.Legendary);
+		expect(new InventoryView().compatibleMods(2, item).map((m) => m.id)).toEqual([1]);
 	});
 
-	it('applyMod is a no-op when the item or mod data is missing', () => {
-		staticData.itemMods = [];
-		const view = new InventoryView();
-		view.applyMod(2, 0, 99); // no such mod
-		view.applyMod(999, 0, 0); // no such item
-		expect(applyMod).not.toHaveBeenCalled();
-	});
-
-	it('removes a mod from a slot and delegates', () => {
-		staticData.itemMods = [{ id: 0, name: 'Sharp', itemModTypeId: 2, attributes: [] }];
-		const view = new InventoryView();
-		view.applyMod(2, 0, 0);
-		view.removeMod(2, 0);
-		expect(view.items.find((i) => i.itemId === 2)?.appliedMods).toEqual([]);
-		expect(removeMod).toHaveBeenCalledWith(2, 0);
-	});
-
-	it('removeMod is a no-op for an unknown item', () => {
-		const view = new InventoryView();
-		view.removeMod(999, 0);
-		expect(removeMod).not.toHaveBeenCalled();
+	it('returns nothing when the mod catalogue is unavailable', () => {
+		staticData.itemMods = undefined;
+		const item = makeItem(2, 'Alpha Blade', EItemCategory.Weapon, ERarity.Legendary);
+		expect(new InventoryView().compatibleMods(2, item)).toEqual([]);
 	});
 });

--- a/docs/frontend-screens.md
+++ b/docs/frontend-screens.md
@@ -2,6 +2,16 @@
 
 This document collects the per-screen design decisions for the in-game screens and the boot flow. It is split out from [frontend.md](./frontend.md) (which covers the cross-cutting frontend architecture — auth, reference data, the Workbench, theming, toasts) so that the main doc stays focused. The decisions below are feature-specific; the cross-cutting patterns they build on (the reactive view-model pattern, themeable accent variables, the empty-vs-error/toast rule) are documented in `frontend.md`.
 
+## Inventory screen (gear & mods)
+
+The in-game Inventory screen (`src/routes/game/screens/inventory`) is the gear/mod loadout: an equipped rail, a filterable/sortable item grid, an equipped-totals panel, and a detail drawer for inspecting/modding an item.
+
+Key decisions and rationale:
+
+- **The `InventoryManager` is the single source of truth and the single mutation path.** `InventoryView` (`inventory-view.svelte.ts`) holds only UI state (sort/filter/selection/drag/page) and reads the authoritative item data **through** the manager's reactive `items` / `equippedSlots` / `equipmentStats`, delegating every action (equip, unequip, apply/remove mod, favorite) to it. It does **not** keep its own shallow copies or re-implement the manager's mutation logic — the earlier copy-and-mirror approach (#352) was two parallel sources kept in hand-sync, which is exactly the divergence #342 hit. The manager owns the item objects; the view is a pure projection.
+- **Optimistic apply with rollback.** Each manager mutation applies to the authoritative item/slot state synchronously (so the UI updates instantly), then persists; a failed persist rolls the change back to the captured prior state so the local state can never diverge from what was saved. (Favorite is the one exception — a low-stakes flag kept optimistically and re-synced on the next toggle/reload rather than rolled back.)
+- **Reactivity without making the items reactive.** `Item`s stay plain objects (they carry a display-only `BattleAttributes`, which must not become a reactive proxy — see [frontend.md](./frontend.md) → _Battle simulation & parity_). Instead the `statify`-reactive manager **republishes** a fresh `items` array (and re-references `equippedSlots`) on every mutation; that reassignment is the reactivity signal the view's `$derived` getters depend on, so in-place item-field edits surface without deep item reactivity and without touching the battle hot path (which still reads `equipmentStats` only).
+
 ## Challenge screen (the Type Rail)
 
 The in-game Challenges screen (`src/routes/game/screens/challenges`) is a **type-driven master/detail** view: a left rail lists each `ChallengeType` (ring meter + done/total) plus an "Overview" entry; selecting a type swaps the right pane to a hero banner + that type's challenge cards with an in-page Progress/Rarity/Name sort, while "Overview" shows overall progress, a pulsing "next up" reward, and a per-type grid. It reuses the existing screen chrome (dark frame, diamond mark, Geist/Geist Mono) and is decomposed into many small components per the component-size guideline.


### PR DESCRIPTION
## Summary

Closes #352. `InventoryView` kept its own shallow copies of the manager's items and re-implemented the manager's equip/unequip/apply-mod/remove-mod/favorite mutation logic, plus recomputed equipped totals from the copy. That was two parallel sources of truth kept in hand-sync — exactly the divergence #342/PR #348 fixed and left flagged as tech debt.

This makes `InventoryManager` the single source of truth **and** the single mutation path:

- **`InventoryView` is now a pure projection.** It holds only UI state (sort / filter / selection / drag / page), reads item data **through** the manager's reactive `items` / `equippedSlots` / `equipmentStats`, and delegates every action to the manager. Its duplicated optimistic-mutation methods and shallow-copy `reload()` are gone. Equipped totals now reuse the manager's single `equipmentStats` derivation instead of re-flattening equipped items.
- **The manager applies optimistically and rolls back on a failed persist.** Each mutation applies to the authoritative item/slot state synchronously (so the UI stays instant), then persists; a failed persist restores the captured prior state. This also fixes a latent bug: previously the view mutated optimistically while the manager only mutated on success, so a server error left the two diverged. `setFavorite` keeps its existing optimistic-no-rollback behaviour (a low-stakes flag, re-synced on the next toggle/reload).
- **Reactivity without making items reactive.** `Item`s stay plain objects — they carry a display-only `BattleAttributes`, which must not become a reactive proxy (`BattleAttributes.removeModifier` matches modifiers by reference; see `frontend.md` → _Battle simulation & parity_). Instead the `statify`-reactive manager **republishes** a fresh `items` array (and re-references `equippedSlots`) on every mutation; that reassignment is the reactivity signal the view's `$derived` getters depend on. The battle hot path is untouched — it still reads `equipmentStats` only, never the item objects.

Also removed the manager's unused `selectItem` / `selectedItem` / `selectedItemId` (no production consumers — the view owns selection) per the dead-code guideline.

## Design notes / judgment calls

Since this is an unattended pickup, flagging the two decisions for review:

1. **Optimistic-with-rollback** (vs. keeping the manager pessimistic and accepting a server-round-trip delay before the UI updates). I chose rollback because it preserves the instant-UI behaviour the view's optimism gave today and fixes the divergence; post-`await` observable state is identical to the old pessimistic manager, so the existing manager error-path tests stayed green.
2. **Republish-snapshot reactivity** (vs. making `Item` a reactive class). The latter would drag `Item.totalAttributes` (a `BattleAttributes`) into a reactive proxy, which the parity docs explicitly warn against. The snapshot approach keeps items plain and the battle path clean.

No battle arithmetic changed, so no backend changes and no new parity vectors.

## Test plan

- `inventory-manager.test.ts`: added coverage for the reactive `items` publishing and the optimistic-then-rollback intermediate state (deferred `post` promise observed mid-flight); removed the deleted `selectItem`/`selectedItem` tests. Existing equip/unequip/mod error-path tests pass unchanged (rollback restores the same post-`await` state).
- `inventory-view.test.ts`: rewritten around the new contract — derivation (visible/counts/selected/dragItem/equippedBySlot/slotsFilled/equippedTotals read through the manager) + delegation (each action calls the right manager method with the right args) + `compatibleMods`. `inventory-view.svelte.ts` is at 100% branch coverage.
- `Inventory.test.ts`: manager mock gains `equipmentStats` (the real view now reads it for totals).
- `npm run lint` clean; full `npm run test:unit:ci` green (1440 tests), all coverage floors holding.

## Docs

- `docs/frontend-screens.md` — new **Inventory screen** section documenting the single-source-of-truth model, optimistic+rollback, and the republish-snapshot reactivity choice.

Closes #352

https://claude.ai/code/session_01DmAWjRoLkf2hudaT1cUsB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmAWjRoLkf2hudaT1cUsB1)_