### PR TITLE
Routine health review: ratchet FE battle-branch and backend Core line coverage floors

### DIFF
--- a/UI/vite.config.ts
+++ b/UI/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
 			// route/component layers are gated at-current to block backsliding without demanding tests
 			// for pure-display markup. Re-seed with `node scripts/coverage-floors.mjs` to ratchet up.
 			thresholds: {
-				'src/lib/battle/**': { lines: 99, functions: 100, branches: 89, statements: 99 },
+				'src/lib/battle/**': { lines: 99, functions: 100, branches: 90, statements: 99 },
 				'src/lib/engine/**': { lines: 94, functions: 92, branches: 87, statements: 93 },
 				'src/lib/common/**': { lines: 94, functions: 89, branches: 82, statements: 94 },
 				'src/lib/api/**': { lines: 89, functions: 90, branches: 82, statements: 89 },

--- a/build/coverage-floors.json
+++ b/build/coverage-floors.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Backend coverage gate floors. Assemblies under 'gated' fail the build when below their line/branch floor; every other measured assembly is reported but never fails (measure-only). Floors are a ratchet: seeded at the current level and only ever raised. Re-seed after a full run by reading coverage/backend-report/Summary.json. See docs/infrastructure.md (Code coverage).",
   "gated": {
-    "Game.Core": { "line": 96, "branch": 92 },
+    "Game.Core": { "line": 97, "branch": 92 },
     "Game.Application": { "line": 95, "branch": 85 }
   },
   "measureOnly": [


### PR DESCRIPTION
## What this is

A routine codebase-health review. The headline finding is that the project is in good shape: the previous same-day sweep already filed the live coverage/dead-code gaps (#386–#389), and the skill-effects work is moving through PRs #390/#393/#394. So this PR is small — just the two coverage-floor ratchets the sweep turned up — and the rest of the review is reported below for the record.

## Changes

Ran the full coverage tooling on a green suite — the merged backend `dotnet-coverage` run (whole-solution, matching CI) and the frontend `test:unit:coverage`. The backend gate and every frontend area floor hold. Two floors had real headroom above their current setting and are ratcheted to lock it in:

- **`UI/vite.config.ts`** — `src/lib/battle/**` branches `89 → 90` (measured **90.8%**, ~0.8pp headroom). Confirmed green by re-running `test:unit:coverage` with the new floor.
- **`build/coverage-floors.json`** — `Game.Core` line `96 → 97` (measured **97.1%**). This is the documented re-seed convention (`Math.floor` of the measured %); headroom is thin (~2 lines) but still wider than an already-accepted floor on `main` (routes-branches sits at 70 against 70.02%). Verified the gate still passes against the new floors.

No other area moved — all the rest already sit at the `Math.floor` of their measured value.

## Review notes (no new issues filed — already tracked)

- **Frontend coverage hotspots** (Challenges shell, global Tooltip, api-socket error paths, BattleEngine stage flow, `+page.svelte`) → **#389**.
- **Backend API integration gaps** (PlayerController inventory endpoints, TagsController, SetItemFavorite/GetChallenges socket commands) → **#386**.
- **Untested write-behind handlers + Redis primitive error paths** (DataProviderSynchronizer, RedisQueue/Factory) → **#387**.
- **Dead code** (AsyncModelMapper + async `To`/`Select` extensions) → **#388**.

Other things checked and found clean, so explicitly *not* filed: no `TODO`/`FIXME`/skipped tests; no hardcoded colors in `.svelte` (theme tokens only); no sync-over-async / `async void` / empty catches in production code; DDD layering intact (Game.Core depends only on DI/Options abstractions); the admin Workbench is well covered overall (93.7% line) despite a couple of low per-file outliers; and `docs/game-design.md` is accurate for `main` (the DoT/HoT-phase and skill-selection-page "remaining" notes still hold until #390/#393 merge, which carry their own doc updates).

https://claude.ai/code/session_017gMfhmezMJz5cNvVZD4pUV

---
_Generated by [Claude Code](https://claude.ai/code/session_017gMfhmezMJz5cNvVZD4pUV)_