### PR TITLE
Integration tests for inventory HTTP, Tags reads, SetItemFavorite/GetChallenges sockets (#386)

### DIFF
--- a/Game.Api.Tests/Integration/PlayerControllerTests.cs
+++ b/Game.Api.Tests/Integration/PlayerControllerTests.cs
@@ -1,7 +1,9 @@
 using Game.Abstractions.Contracts;
 using Game.Api.Models.Attributes;
 using Game.Api.Models.Common;
+using Game.Api.Models.InventoryItems;
 using Game.Api.Models.Player;
+using Game.Core;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
@@ -112,6 +114,202 @@ namespace Game.Api.Tests.Integration
             var result = await response.Content.ReadFromJsonAsync<ApiEnumerableResponse<BattlerAttribute>>(CancellationToken);
             Assert.NotNull(result);
             Assert.NotNull(result.ErrorMessage);
+        }
+
+        // The inventory endpoints exercise the HTTP adapter path only — routing, model binding, and the
+        // success/error mapping through ApiResponse (the underlying PlayerService logic is covered in
+        // Game.Application.Tests). A false result from the service maps to a 400 via ErrorStatusFilter.
+
+        [Fact]
+        public async Task EquipItem_UnlockedItem_ReturnsSuccess()
+        {
+            var (authClient, itemId) = await CreatePlayerWithInventoryAsync("equipuser", "equippass",
+                async (context, playerId, item) =>
+                    await TestDataSeeder.LinkItemToPlayerAsync(context, playerId, item.Id));
+            using var client = authClient;
+
+            var request = new EquipRequest { ItemId = itemId, EquipmentSlotId = (int)EEquipmentSlot.WeaponSlot };
+            var response = await client.PostAsJsonAsync("/api/Player/EquipItem", request, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Null(result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task EquipItem_ItemNotUnlocked_ReturnsBadRequest()
+        {
+            // The player owns no items, so equipping any item id is rejected by the domain.
+            var (authClient, _) = await CreateAuthenticatedPlayerAsync(username: "noequip", password: "noequip");
+            using var client = authClient;
+
+            var request = new EquipRequest { ItemId = 0, EquipmentSlotId = (int)EEquipmentSlot.WeaponSlot };
+            var response = await client.PostAsJsonAsync("/api/Player/EquipItem", request, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.NotNull(result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task EquipItem_Unauthenticated_Returns401()
+        {
+            var request = new EquipRequest { ItemId = 0, EquipmentSlotId = (int)EEquipmentSlot.WeaponSlot };
+            var response = await Client.PostAsJsonAsync("/api/Player/EquipItem", request, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task UnequipItem_EquippedItem_ReturnsSuccess()
+        {
+            var (authClient, _) = await CreatePlayerWithInventoryAsync("unequipuser", "unequippass",
+                async (context, playerId, item) =>
+                    await TestDataSeeder.LinkItemToPlayerAsync(context, playerId, item.Id, EEquipmentSlot.WeaponSlot));
+            using var client = authClient;
+
+            var request = new EquipRequest { EquipmentSlotId = (int)EEquipmentSlot.WeaponSlot };
+            var response = await client.PostAsJsonAsync("/api/Player/UnequipItem", request, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Null(result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task UnequipItem_EmptySlot_ReturnsBadRequest()
+        {
+            // Nothing is equipped in the weapon slot, so there is nothing to unequip.
+            var (authClient, _) = await CreateAuthenticatedPlayerAsync(username: "emptyslot", password: "emptyslot");
+            using var client = authClient;
+
+            var request = new EquipRequest { EquipmentSlotId = (int)EEquipmentSlot.WeaponSlot };
+            var response = await client.PostAsJsonAsync("/api/Player/UnequipItem", request, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.NotNull(result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task ApplyMod_UnlockedModAndItem_ReturnsSuccess()
+        {
+            var modSlotId = 0;
+            var modId = 0;
+            var (authClient, itemId) = await CreatePlayerWithInventoryAsync("applymoduser", "applymodpass",
+                async (context, playerId, item) =>
+                {
+                    var modSlot = await TestDataSeeder.AddItemModSlotAsync(context, item.Id);
+                    await TestDataSeeder.LinkItemToPlayerAsync(context, playerId, item.Id, EEquipmentSlot.WeaponSlot);
+                    var mod = await TestDataSeeder.CreateItemModAsync(context, attributeId: EAttribute.Dexterity, attributeAmount: 7m);
+                    await TestDataSeeder.LinkModToPlayerAsync(context, playerId, mod.Id);
+                    modSlotId = modSlot.Id;
+                    modId = mod.Id;
+                });
+            using var client = authClient;
+
+            var request = new ApplyModRequest { ItemId = itemId, ItemModId = modId, ItemModSlotId = modSlotId };
+            var response = await client.PostAsJsonAsync("/api/Player/ApplyMod", request, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Null(result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task ApplyMod_NonexistentMod_ReturnsBadRequest()
+        {
+            var (authClient, _) = await CreateAuthenticatedPlayerAsync(username: "badmod", password: "badmod");
+            using var client = authClient;
+
+            // A mod id far beyond any seeded catalog entry is rejected before any application is attempted.
+            var request = new ApplyModRequest { ItemId = 0, ItemModId = 99999, ItemModSlotId = 0 };
+            var response = await client.PostAsJsonAsync("/api/Player/ApplyMod", request, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.NotNull(result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task RemoveMod_AppliedMod_ReturnsSuccess()
+        {
+            var modSlotId = 0;
+            var (authClient, itemId) = await CreatePlayerWithInventoryAsync("removemoduser", "removemodpass",
+                async (context, playerId, item) =>
+                {
+                    var modSlot = await TestDataSeeder.AddItemModSlotAsync(context, item.Id);
+                    await TestDataSeeder.LinkItemToPlayerAsync(context, playerId, item.Id, EEquipmentSlot.WeaponSlot);
+                    var mod = await TestDataSeeder.CreateItemModAsync(context, attributeId: EAttribute.Dexterity, attributeAmount: 7m);
+                    await TestDataSeeder.LinkModToPlayerAsync(context, playerId, mod.Id);
+                    await TestDataSeeder.ApplyModToItemAsync(context, playerId, item.Id, modSlot.Id, mod.Id);
+                    modSlotId = modSlot.Id;
+                });
+            using var client = authClient;
+
+            var request = new RemoveModRequest { ItemId = itemId, ItemModSlotId = modSlotId };
+            var response = await client.PostAsJsonAsync("/api/Player/RemoveMod", request, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Null(result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task RemoveMod_NoAppliedMod_ReturnsBadRequest()
+        {
+            var (authClient, itemId) = await CreatePlayerWithInventoryAsync("noremovemoduser", "noremovemodpass",
+                async (context, playerId, item) =>
+                {
+                    await TestDataSeeder.AddItemModSlotAsync(context, item.Id);
+                    await TestDataSeeder.LinkItemToPlayerAsync(context, playerId, item.Id, EEquipmentSlot.WeaponSlot);
+                });
+            using var client = authClient;
+
+            // The item is unlocked but has no mod applied in slot 0, so there is nothing to remove.
+            var request = new RemoveModRequest { ItemId = itemId, ItemModSlotId = 0 };
+            var response = await client.PostAsJsonAsync("/api/Player/RemoveMod", request, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.NotNull(result.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Seeds a user + player and a weapon item, runs the caller-provided inventory setup against the
+        /// seeded item (mod slots, unlocked/applied mods, equipped state), then reloads the reference
+        /// caches and logs in so the cached player aggregate already carries the inventory. Returns an
+        /// authenticated client and the seeded item id.
+        /// </summary>
+        private async Task<(HttpClient Client, int ItemId)> CreatePlayerWithInventoryAsync(
+            string username,
+            string password,
+            Func<GameContext, int, Game.Infrastructure.Entities.Item, Task> seedInventory)
+        {
+            int itemId;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                var user = await TestDataSeeder.CreateUserAsync(context, username, password);
+                var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+                var item = await TestDataSeeder.CreateItemAsync(context);
+                await seedInventory(context, player.Id, item);
+                itemId = item.Id;
+            }
+
+            // The caches no longer lazily refill, so reload them to resolve the seeded item on load.
+            await ReloadReferenceCachesAsync();
+
+            var (client, _) = await LoginAndBuildClientAsync(username, password);
+            return (client, itemId);
         }
     }
 }

--- a/Game.Api.Tests/Integration/ReferenceDataSocketTests.cs
+++ b/Game.Api.Tests/Integration/ReferenceDataSocketTests.cs
@@ -168,6 +168,58 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task GetChallenges_PopulatedChallenge_MapsDomainToContract()
+        {
+            int userId;
+            int challengeId;
+            int enemyId;
+            int itemId;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+                var enemy = await TestDataSeeder.CreateEnemyAsync(context, "ChallengeTarget");
+                var item = await TestDataSeeder.CreateItemAsync(context, "ChallengeReward");
+                var challenge = await TestDataSeeder.CreateChallengeAsync(context,
+                    name: "Slay 10 Goblins",
+                    challengeTypeId: EChallengeType.EnemiesKilled,
+                    progressGoal: 10m,
+                    targetEntityId: enemy.Id,
+                    rewardItemId: item.Id);
+                challengeId = challenge.Id;
+                enemyId = enemy.Id;
+                itemId = item.Id;
+
+                var user = await TestDataSeeder.CreateUserAsync(context, "challsocketuser", "challsocketpass");
+                await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+                userId = user.Id;
+            }
+
+            // Reload so the seeded challenge is resolvable, then log in to create the socket session.
+            await ReloadReferenceCachesAsync();
+            await LoginAsync("challsocketuser", "challsocketpass");
+
+            await using var socketClient = await ConnectAsync(userId);
+
+            var response = await socketClient.SendCommandAsync<List<Challenge>>("GetChallenges");
+
+            Assert.Null(response.Error);
+            Assert.NotNull(response.Data);
+
+            // The ToContract mapping flattens the domain ChallengeType to its id plus the derived
+            // statistic/entity dimensions — exercised here by a fully-populated challenge.
+            var mapped = Assert.Single(response.Data, c => c.Id == challengeId);
+            Assert.Equal("Slay 10 Goblins", mapped.Name);
+            Assert.Equal(EChallengeType.EnemiesKilled, mapped.ChallengeTypeId);
+            Assert.Equal(EStatisticType.EnemiesKilled, mapped.StatisticType);
+            Assert.Equal(EEntityType.Enemy, mapped.EntityType);
+            Assert.Equal(enemyId, mapped.TargetEntityId);
+            Assert.Equal(10m, mapped.ProgressGoal);
+            Assert.Equal(itemId, mapped.RewardItemId);
+            Assert.Null(mapped.RetiredAt);
+        }
+
+        [Fact]
         public async Task GetStatisticTypes_ReturnsIntrinsicStatisticTypes()
         {
             var userId = await SeedReferenceDataAndLoginAsync();

--- a/Game.Api.Tests/Integration/SetItemFavoriteSocketTests.cs
+++ b/Game.Api.Tests/Integration/SetItemFavoriteSocketTests.cs
@@ -1,0 +1,112 @@
+using Game.Api.Models.Common;
+using Game.Api.Models.InventoryItems;
+using Game.Api.Models.Player;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    /// <summary>
+    /// Integration tests for the <c>SetItemFavorite</c> socket command. #251 was a real persistence bug
+    /// in exactly this favorite flow, so an end-to-end socket test guards the command's write path.
+    /// </summary>
+    [Collection("Integration")]
+    public class SetItemFavoriteSocketTests : ApiIntegrationTestBase
+    {
+        private const string Username = "favoriteuser";
+        private const string Password = "favoritepass";
+
+        public SetItemFavoriteSocketTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper) : base(containers, testOutputHelper) { }
+
+        private async Task<(int UserId, int ItemId)> SeedPlayerWithUnlockedItemAsync()
+        {
+            int userId;
+            int itemId;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+                var user = await TestDataSeeder.CreateUserAsync(context, Username, Password);
+                var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+                var item = await TestDataSeeder.CreateItemAsync(context);
+                await TestDataSeeder.LinkItemToPlayerAsync(context, player.Id, item.Id);
+                userId = user.Id;
+                itemId = item.Id;
+            }
+
+            // The caches no longer lazily refill, so reload them to resolve the seeded item on load.
+            await ReloadReferenceCachesAsync();
+            return (userId, itemId);
+        }
+
+        [Fact]
+        public async Task SetItemFavorite_PersistsFavoriteFlagToCachedPlayer()
+        {
+            var (userId, itemId) = await SeedPlayerWithUnlockedItemAsync();
+            var (client, _) = await LoginAndBuildClientAsync(Username, Password);
+
+            await using var socketClient = new TestSocketClient();
+            var wsClient = Factory.Server.CreateWebSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+
+            var response = await socketClient.SendCommandRawAsync("SetItemFavorite", new { ItemId = itemId, Favorite = true });
+
+            Assert.Null(response.Error);
+
+            var items = await WaitForFavoriteAsync(client, itemId, favorite: true);
+            Assert.True(items.Single(i => i.ItemId == itemId).Favorite);
+        }
+
+        [Fact]
+        public async Task SetItemFavorite_ItemNotUnlocked_ReturnsError()
+        {
+            var (userId, _) = await SeedPlayerWithUnlockedItemAsync();
+            // Logging in creates the session the WebSocket handshake requires.
+            await LoginAsync(Username, Password);
+
+            await using var socketClient = new TestSocketClient();
+            var wsClient = Factory.Server.CreateWebSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+
+            // An item id the player has not unlocked must be rejected, not silently accepted.
+            var response = await socketClient.SendCommandRawAsync("SetItemFavorite", new { ItemId = 9999, Favorite = true });
+
+            Assert.NotNull(response.Error);
+        }
+
+        private async Task<List<InventoryItem>> GetInventoryItemsAsync(HttpClient client)
+        {
+            var response = await client.GetAsync("/api/Player", CancellationToken);
+            response.EnsureSuccessStatusCode();
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse<PlayerData>>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.NotNull(result.Data);
+            return result.Data.InventoryData.UnlockedItems;
+        }
+
+        /// <summary>
+        /// The command writes the cached player fire-and-forget, so poll the player snapshot until the
+        /// expected favorite flag lands (or fail after a short budget).
+        /// </summary>
+        private async Task<List<InventoryItem>> WaitForFavoriteAsync(HttpClient client, int itemId, bool favorite)
+        {
+            for (var attempt = 0; attempt < 20; attempt++)
+            {
+                var items = await GetInventoryItemsAsync(client);
+                if (items.Any(i => i.ItemId == itemId && i.Favorite == favorite))
+                {
+                    return items;
+                }
+
+                await Task.Delay(50, CancellationToken);
+            }
+
+            Assert.Fail($"Item {itemId} favorite flag did not reach expected value {favorite}.");
+            return [];
+        }
+    }
+}

--- a/Game.Api.Tests/Integration/TagsControllerTests.cs
+++ b/Game.Api.Tests/Integration/TagsControllerTests.cs
@@ -1,0 +1,83 @@
+using Game.Abstractions.Contracts;
+using Game.Api.Models.Common;
+using Game.Core;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    /// <summary>
+    /// Integration tests for the Tags reference reads — the only remaining HTTP-exclusive reference
+    /// endpoints (consumed by the Workbench). They are read live from the database (no in-memory cache),
+    /// so seeding a tag and reading it back exercises the controller and the IAsyncEnumerable projection.
+    /// </summary>
+    [Collection("Integration")]
+    public class TagsControllerTests : ApiIntegrationTestBase
+    {
+        private const string Username = "tagsuser";
+        private const string Password = "tagspass";
+
+        public TagsControllerTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper) : base(containers, testOutputHelper) { }
+
+        private async Task<HttpClient> SeedTagAndAuthenticateAsync(string tagName)
+        {
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                var user = await TestDataSeeder.CreateUserAsync(context, Username, Password);
+                await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+                await TestDataSeeder.CreateTagAsync(context, tagName, ETagCategory.Accessory);
+            }
+
+            var (client, _) = await LoginAndBuildClientAsync(Username, Password);
+            return client;
+        }
+
+        [Fact]
+        public async Task Tags_ReturnsSeededTag()
+        {
+            using var client = await SeedTagAndAuthenticateAsync("RefTag");
+
+            var response = await client.GetAsync("/api/Tags", CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiEnumerableResponse<Tag>>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Null(result.ErrorMessage);
+            Assert.NotNull(result.Data);
+            var tag = Assert.Single(result.Data, t => t.Name == "RefTag");
+            Assert.Equal((int)ETagCategory.Accessory, tag.TagCategoryId);
+        }
+
+        [Fact]
+        public async Task TagCategories_ReturnsIntrinsicCategories()
+        {
+            using var client = await SeedTagAndAuthenticateAsync("RefTagForCategories");
+
+            var response = await client.GetAsync("/api/Tags/TagCategories", CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiEnumerableResponse<TagCategory>>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Null(result.ErrorMessage);
+            Assert.NotNull(result.Data);
+            // Categories are intrinsic, migration-seeded reference data, so every ETagCategory is present.
+            var categories = result.Data.ToList();
+            Assert.Contains(categories, c => c.Id == (int)ETagCategory.Accessory);
+            Assert.Equal(Enum.GetValues<ETagCategory>().Length, categories.Count);
+        }
+
+        [Fact]
+        public async Task Tags_Unauthenticated_Returns401()
+        {
+            var response = await Client.GetAsync("/api/Tags", CancellationToken);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+    }
+}

--- a/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
+++ b/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
@@ -257,6 +257,68 @@ namespace Game.TestInfrastructure.Helpers
             await context.SaveChangesAsync();
         }
 
+        // Marks an item as unlocked for a player, optionally already equipped in a slot and/or favorited.
+        public static async Task LinkItemToPlayerAsync(
+            GameContext context,
+            int playerId,
+            int itemId,
+            EEquipmentSlot? equipmentSlot = null,
+            bool favorite = false)
+        {
+            context.UnlockedItems.Add(new UnlockedItem
+            {
+                PlayerId = playerId,
+                ItemId = itemId,
+                EquipmentSlotId = (int?)equipmentSlot,
+                Favorite = favorite,
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Authors a mod slot on an item and returns it so callers can resolve its store-generated Id.
+        public static async Task<ItemModSlot> AddItemModSlotAsync(
+            GameContext context,
+            int itemId,
+            EItemModType modType = EItemModType.Prefix)
+        {
+            var modSlot = new ItemModSlot
+            {
+                ItemId = itemId,
+                ItemModSlotTypeId = (int)modType,
+            };
+            context.ItemModSlots.Add(modSlot);
+            await context.SaveChangesAsync();
+            return modSlot;
+        }
+
+        public static async Task LinkModToPlayerAsync(GameContext context, int playerId, int itemModId)
+        {
+            context.UnlockedMods.Add(new UnlockedMod
+            {
+                PlayerId = playerId,
+                ItemModId = itemModId,
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Persists an applied mod as if it had been applied in a previous session.
+        public static async Task ApplyModToItemAsync(
+            GameContext context,
+            int playerId,
+            int itemId,
+            int itemModSlotId,
+            int itemModId)
+        {
+            context.AppliedMods.Add(new AppliedMod
+            {
+                PlayerId = playerId,
+                ItemId = itemId,
+                ItemModSlotId = itemModSlotId,
+                ItemModId = itemModId,
+            });
+            await context.SaveChangesAsync();
+        }
+
         public static async Task<Challenge> CreateChallengeAsync(
             GameContext context,
             string name = "Test Challenge",


### PR DESCRIPTION
## Summary

Closes #386. Fills the API-surface integration-test gaps the health review flagged. `Game.Api` is measure-only by design, but per the testing guidelines its adapters are meant to be covered by integration tests, and these surfaces had none.

- **`PlayerController` inventory endpoints** — `EquipItem` / `UnequipItem` / `ApplyMod` / `RemoveMod`. These tests deliberately cover the **HTTP adapter path only** (routing, model binding, and the `ApiResponse` success/error mapping — a `false` service result becoming a `400` via `ErrorStatusFilter` — plus a `401` auth check). The underlying `PlayerService` logic stays covered in `Game.Application.Tests`, so I didn't re-assert persistence here.
- **`TagsController`** — `Tags` and `Tags/TagCategories`, the only HTTP-exclusive reference reads (consumed by the Workbench), plus an auth check. They read live from the DB, so a seeded tag is read back and the intrinsic seeded categories are asserted.
- **`SetItemFavorite` socket command** — end-to-end favorite persistence to the cached player (read back through `/api/Player`) and rejection of an un-unlocked item id. #251 was a real persistence bug in exactly this flow.
- **`GetChallenges` socket command** — a new test seeds a fully-populated challenge so the `ToContract` domain→contract mapping actually runs (the pre-existing `GetChallenges_ReturnsWithoutError` served an empty collection, so the mapping never executed). Asserts the flattened `ChallengeTypeId` + derived `StatisticType`/`EntityType` and the reward/target ids.

### Shared helpers

Added reusable inventory-seeding helpers to `TestDataSeeder` (`LinkItemToPlayerAsync`, `AddItemModSlotAsync`, `LinkModToPlayerAsync`, `ApplyModToItemAsync`), mirroring the existing `LinkSkillToPlayerAsync` style, so the new tests don't hand-build entity graphs inline.

## Test plan

- `dotnet build` (full solution) — clean, 0 warnings / 0 errors.
- `dotnet test Game.Api.Tests` — **341 passed, 0 failed**, including the new tests across `PlayerControllerTests`, `TagsControllerTests`, `SetItemFavoriteSocketTests`, and `ReferenceDataSocketTests`. (Tests reuse the session's Postgres/Redis containers.)

## Notes / follow-ups

- The existing `PlayerServiceIntegrationTests` build the same `UnlockedItem`/`ItemModSlot`/`UnlockedMod`/`AppliedMod` graphs inline; those could be DRYed onto the new `TestDataSeeder` helpers in a follow-up, but I left them untouched here to keep the diff focused on new coverage (several carry detailed `#316`-era explanatory comments).
- Whether `Game.Api` is now healthy enough to **gate** on coverage is, as the issue notes, a separate decision and out of scope for this PR.

Closes #386


---
_Generated by [Claude Code](https://claude.ai/code/session_01E47LtrtaY6qeGtUivNnrsc)_