### PR TITLE
Routine health review: ratchet frontend coverage floors

### DIFF
--- a/UI/vite.config.ts
+++ b/UI/vite.config.ts
@@ -33,12 +33,12 @@ export default defineConfig({
 			// for pure-display markup. Re-seed with `node scripts/coverage-floors.mjs` to ratchet up.
 			thresholds: {
 				'src/lib/battle/**': { lines: 99, functions: 100, branches: 90, statements: 99 },
-				'src/lib/engine/**': { lines: 96, functions: 95, branches: 90, statements: 96 },
-				'src/lib/common/**': { lines: 96, functions: 92, branches: 82, statements: 96 },
+				'src/lib/engine/**': { lines: 97, functions: 96, branches: 90, statements: 96 },
+				'src/lib/common/**': { lines: 97, functions: 93, branches: 85, statements: 97 },
 				'src/lib/api/**': { lines: 96, functions: 98, branches: 91, statements: 96 },
 				'src/lib/card-game/**': { lines: 94, functions: 100, branches: 81, statements: 94 },
 				'src/stores/**': { lines: 98, functions: 100, branches: 90, statements: 98 },
-				'src/components/**': { lines: 92, functions: 95, branches: 79, statements: 94 },
+				'src/components/**': { lines: 93, functions: 96, branches: 79, statements: 94 },
 				'src/routes/**': { lines: 93, functions: 91, branches: 72, statements: 92 }
 			}
 		}


### PR DESCRIPTION
## Routine codebase health review

Periodic health pass over the codebase. The actionable code change is a coverage-floor ratchet; the rest of the review is summarized below and filed as a tracking issue.

### Frontend coverage ratchet

Re-seeded the per-area Vitest thresholds (`UI/vite.config.ts`) from the current measured levels via `node scripts/coverage-floors.mjs`:

| Area | Change |
| --- | --- |
| `src/lib/engine` | lines 96→97, functions 95→96 |
| `src/lib/common` | lines 96→97, functions 92→93, branches 82→85, statements 96→97 |
| `src/components` | lines 92→93, functions 95→96 |

All other areas were already at their measured floor. Verified green by re-running `npm run test:unit:coverage` with the new floors.

### Backend coverage — left unchanged (intentionally)

Ran the full merged backend coverage (`dotnet-coverage` across all four test projects + ReportGenerator). The gated assemblies sit right at their floors with sub-1% headroom, so raising them would risk CI flakiness:

- `Game.Core`: line 97.1% (floor 97), branch 92.8% (floor 92)
- `Game.Application`: line 95.5% (floor 95), branch 85.9% (floor 85)

### Review findings

- **Docs (`backend.md`, `game-design.md`):** already current — the recently-merged skill-effects and DoT/HoT runtime are accurately documented. No updates needed.
- **Frontend/backend guideline sweep:** clean. No new layering violations, missing braces, dead code, or hardcoded-theme issues beyond what is already tracked (#402).
- **Untested admin-repository branches:** the one genuine untracked gap surfaced by the coverage run — the Content Authoring admin repositories have notably low (measure-only) coverage. Filed as a follow-up issue.

https://claude.ai/code/session_01Mkto3592aLm85qDhtYsMN8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkto3592aLm85qDhtYsMN8)_