### PR TITLE
Fix inventory optimistic updates reverting on successful save

### DIFF
--- a/UI/src/lib/api/api-response.ts
+++ b/UI/src/lib/api/api-response.ts
@@ -28,6 +28,16 @@ export class ApiResponse<T extends ApiResponseType> {
 		return this.#raw.status;
 	}
 
+	/**
+	 * Whether the request succeeded: a 2xx status with no error message in the body (the backend signals
+	 * business failures via an `errorMessage` on an otherwise-200 response). Use this for control flow —
+	 * `error` is a display-message accessor that always returns a non-empty string (it falls back to the
+	 * status text or a generic message), so it must never be used as a boolean success check.
+	 */
+	public get ok(): boolean {
+		return this.status >= 200 && this.status < 300 && !this.responseJson.errorMessage;
+	}
+
 	public get data(): T {
 		if (!this.responseJson.data && this.responseJson.errorMessage) {
 			throw new Error(this.error);

--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -90,7 +90,7 @@ export class InventoryManager {
 
 		const req = new ApiRequest('Player/EquipItem');
 		const response = await req.post({ itemId, equipmentSlotId: slotId });
-		if (response.error) {
+		if (!response.ok) {
 			rollback();
 			this.publish();
 			return false;
@@ -113,7 +113,7 @@ export class InventoryManager {
 
 		const req = new ApiRequest('Player/UnequipItem');
 		const response = await req.post({ itemId: item.itemId, equipmentSlotId: slotId });
-		if (response.error) {
+		if (!response.ok) {
 			rollback();
 			this.publish();
 			return false;
@@ -139,7 +139,7 @@ export class InventoryManager {
 
 		const req = new ApiRequest('Player/ApplyMod');
 		const response = await req.post({ itemId, itemModId, itemModSlotId });
-		if (response.error) {
+		if (!response.ok) {
 			item.appliedMods = prevMods;
 			item.totalAttributes = prevTotal;
 			this.publish();
@@ -164,7 +164,7 @@ export class InventoryManager {
 
 		const req = new ApiRequest('Player/RemoveMod');
 		const response = await req.post({ itemId, itemModSlotId });
-		if (response.error) {
+		if (!response.ok) {
 			item.appliedMods = prevMods;
 			item.totalAttributes = prevTotal;
 			this.publish();

--- a/UI/src/tests/lib/api/api-response.test.ts
+++ b/UI/src/tests/lib/api/api-response.test.ts
@@ -80,6 +80,35 @@ describe('ApiResponse', () => {
 		});
 	});
 
+	describe('ok', () => {
+		it('is true for a 2xx response with no error message', () => {
+			const response = new ApiResponse(makeRaw({ responseText: JSON.stringify({ data: null }) }));
+			expect(response.ok).toBe(true);
+		});
+
+		it('is true for a bodyless 2xx success (ApiResponse.Success())', () => {
+			const response = new ApiResponse(makeRaw({ responseText: '' }));
+			expect(response.ok).toBe(true);
+		});
+
+		it('is false for a 2xx response that carries an error message (a business failure)', () => {
+			const raw = makeRaw({
+				responseText: JSON.stringify({ data: null, errorMessage: 'Failed to equip item.' })
+			});
+			expect(new ApiResponse(raw).ok).toBe(false);
+		});
+
+		it('is false for a non-2xx status', () => {
+			const response = new ApiResponse(makeRaw({ status: 500, statusText: 'Internal Server Error' }));
+			expect(response.ok).toBe(false);
+		});
+
+		it('is false for a network error (status 0, empty body)', () => {
+			const response = new ApiResponse(makeRaw({ status: 0, statusText: '', responseText: '' }));
+			expect(response.ok).toBe(false);
+		});
+	});
+
 	describe('status', () => {
 		it('returns HTTP status code', () => {
 			const response = new ApiResponse(makeRaw({ status: 404 }));

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -30,8 +30,9 @@ vi.mock('$stores', () => ({
 }));
 
 // Controllable stubs for the network boundary the inventory mutations cross. `mockPost` resolves
-// the `{ error }` an `ApiRequest` would return, so a test can flip an endpoint to the
-// error/early-return path; `mockSendSocketCommand` backs `setFavorite`'s websocket persistence.
+// the `{ ok }` an `ApiRequest` response exposes (mirroring `ApiResponse.ok` — a success boolean,
+// since `ApiResponse.error` is an always-truthy message accessor), so a test can flip an endpoint to
+// the error/rollback path; `mockSendSocketCommand` backs `setFavorite`'s websocket persistence.
 const { mockPost, mockSendSocketCommand } = vi.hoisted(() => {
 	const mockPost = vi.fn();
 	const mockSendSocketCommand = vi.fn();
@@ -102,7 +103,7 @@ describe('InventoryManager', () => {
 		vi.mocked(ApiRequest).mockClear();
 
 		// Default the network boundary to success; error-path tests override per case.
-		mockPost.mockReset().mockResolvedValue({ error: undefined });
+		mockPost.mockReset().mockResolvedValue({ ok: true });
 		mockSendSocketCommand.mockReset().mockResolvedValue(undefined);
 
 		mockItems.length = 0;
@@ -299,7 +300,7 @@ describe('InventoryManager', () => {
 			mockItems[1] = makeItem(1);
 			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
 			manager.initialize();
-			mockPost.mockResolvedValue({ error: 'nope' });
+			mockPost.mockResolvedValue({ ok: false, error: 'nope' });
 
 			const result = await manager.equipItem(1, EEquipmentSlot.WeaponSlot);
 
@@ -313,7 +314,7 @@ describe('InventoryManager', () => {
 			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
 			manager.initialize();
 
-			let resolvePost: (value: { error?: string }) => void = () => {};
+			let resolvePost: (value: { ok: boolean; error?: string }) => void = () => {};
 			mockPost.mockReturnValue(new Promise((resolve) => (resolvePost = resolve)));
 
 			const pending = manager.equipItem(1, EEquipmentSlot.WeaponSlot);
@@ -321,7 +322,7 @@ describe('InventoryManager', () => {
 			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]?.itemId).toBe(1);
 			expect(manager.unlockedItems.get(1)?.equipped).toBe(true);
 
-			resolvePost({ error: 'nope' });
+			resolvePost({ ok: false, error: 'nope' });
 			await pending;
 
 			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]).toBeUndefined();
@@ -363,7 +364,7 @@ describe('InventoryManager', () => {
 				makeInventoryItem({ itemId: 1, equipped: true, equipmentSlotId: EEquipmentSlot.WeaponSlot })
 			];
 			manager.initialize();
-			mockPost.mockResolvedValue({ error: 'nope' });
+			mockPost.mockResolvedValue({ ok: false, error: 'nope' });
 
 			const result = await manager.unequipItem(EEquipmentSlot.WeaponSlot);
 
@@ -443,7 +444,7 @@ describe('InventoryManager', () => {
 			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
 			mockInventoryData.unlockedMods = [10];
 			manager.initialize();
-			mockPost.mockResolvedValue({ error: 'nope' });
+			mockPost.mockResolvedValue({ ok: false, error: 'nope' });
 
 			const result = await manager.applyMod(1, 10, 0);
 
@@ -479,7 +480,7 @@ describe('InventoryManager', () => {
 			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
 			mockInventoryData.unlockedMods = [10];
 			manager.initialize();
-			mockPost.mockResolvedValue({ error: 'nope' });
+			mockPost.mockResolvedValue({ ok: false, error: 'nope' });
 
 			const result = await manager.applyMod(1, 10, 0);
 
@@ -537,7 +538,7 @@ describe('InventoryManager', () => {
 			mockItems[1] = makeItem(1);
 			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
 			manager.initialize();
-			mockPost.mockResolvedValue({ error: 'nope' });
+			mockPost.mockResolvedValue({ ok: false, error: 'nope' });
 
 			const result = await manager.removeMod(1, 0);
 
@@ -553,7 +554,7 @@ describe('InventoryManager', () => {
 			];
 			mockInventoryData.unlockedMods = [10];
 			manager.initialize();
-			mockPost.mockResolvedValue({ error: 'nope' });
+			mockPost.mockResolvedValue({ ok: false, error: 'nope' });
 
 			const result = await manager.removeMod(1, 0);
 


### PR DESCRIPTION
## Problem

Inventory actions flickered: equipping an item (or unequipping / applying / removing a mod) showed the optimistic change for a frame, then reverted to the old state — yet a page refresh showed the change *had* persisted server-side.

## Root cause

Every mutation in `InventoryManager` checks failure with `if (response.error)`. But the HTTP `ApiResponse.error` getter is a **display-message accessor**, not a boolean:

```ts
get error() {
  return this.responseJson?.errorMessage || this.#raw.statusText || 'Failed to communicate with server.';
}
```

It can never be falsy — on a successful equip it returns `"OK"` (the status text) or the generic fallback. So `if (response.error)` was **always true**, and every successful POST hit the rollback path, reverting the optimistic update the moment the request resolved. The server had already persisted the change (the controller returned `ApiResponse.Success()`), which is why a refresh showed it.

Scope is contained to inventory: the socket callers (`enemy-manager`, `skills-view`, `options-view`) check `.error` on `IApiSocketResponse`, whose `error?: string` *is* genuinely `undefined` on success. `InventoryManager` was the only consumer using the always-truthy HTTP `ApiResponse.error` as a boolean.

## Fix

- Add an `ApiResponse.ok` getter — `2xx status && no errorMessage` (the backend signals business failures via an `errorMessage` on an otherwise-200 body) — with a doc comment warning that `error` is display-only and must not be used as a boolean.
- Switch all four `InventoryManager` mutations from `if (response.error)` to `if (!response.ok)`.

## Why it slipped past the tests

The `inventory-manager` test mocks resolved `{ error: undefined }` for success — a value the real `ApiResponse.error` getter can never return, so the mock was more forgiving than reality. Fixed the mocks to honor the real `ok` contract and added direct `ok` coverage (success, bodyless success, 200-business-error, non-2xx, network error).

## Verification

- `api-response` + `inventory-manager` suites: **57 passed**
- `svelte-check`: **0 errors** across 882 files

No live browser check: exercising this path needs the full stack (API + Postgres + Redis + an authenticated player with items); without a backend the POST would fail and legitimately roll back, proving nothing. The unit tests drive the exact code path through the faithful `ApiResponse.ok` contract instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)