### PR TITLE
Surface skill effects on the Skills loadout inspector (badge + effect lines)

### DIFF
--- a/UI/src/routes/game/screens/skills/SkillIcon.svelte
+++ b/UI/src/routes/game/screens/skills/SkillIcon.svelte
@@ -4,11 +4,15 @@
 	{:else}
 		<img src={skill.iconPath} alt={skill.name} />
 	{/if}
+	{#if skill.effects.length > 0}
+		<div class="effect-badge-anchor"><SkillEffectBadge /></div>
+	{/if}
 </div>
 
 <script lang="ts">
 import type { ISkill } from '$lib/api';
 import { attributeColor } from '$lib/common';
+import SkillEffectBadge from '$components/SkillEffectBadge.svelte';
 
 type Props = {
 	skill: ISkill;
@@ -66,5 +70,12 @@ const accent = $derived(
 	position: relative;
 	font-size: 0.9em;
 	color: var(--text-muted);
+}
+
+.effect-badge-anchor {
+	position: absolute;
+	top: 3px;
+	right: 3px;
+	pointer-events: none;
 }
 </style>

--- a/UI/src/routes/game/screens/skills/SkillInspector.svelte
+++ b/UI/src/routes/game/screens/skills/SkillInspector.svelte
@@ -71,6 +71,19 @@
 			</div>
 		</div>
 
+		{#if effects.length}
+			<div class="d-sec">
+				<div class="label">Effects</div>
+				{#each effects as effect (effect.id)}
+					<div class="effect-row">
+						<span class="emag" style:color={effectDirectionColor(effect.direction)}>{effect.magnitude}</span>
+						<span class="eattr">{effect.attributeName}</span>
+						<span class="emeta">{effect.targetLabel} · {effect.duration}</span>
+					</div>
+				{/each}
+			</div>
+		{/if}
+
 		<div class="d-foot">
 			<div class="foot-item">
 				<div class="fl">Scaling</div>
@@ -90,7 +103,14 @@
 
 <script lang="ts">
 import { EAttribute } from '$lib/api';
-import { attributeCode, attributeColor, formatNum, normalizeText } from '$lib/common';
+import {
+	attributeCode,
+	attributeColor,
+	describeEffect,
+	effectDirectionColor,
+	formatNum,
+	normalizeText
+} from '$lib/common';
 import { staticData } from '$stores';
 import SkillIcon from './SkillIcon.svelte';
 import type { SkillMetrics, SkillsView } from './skills-view.svelte';
@@ -110,6 +130,15 @@ const fmt = (n: number) => formatNum(Math.round(n));
 
 const attributeName = (id: EAttribute) =>
 	staticData.attributes?.find((a) => a.id === id)?.name ?? normalizeText(EAttribute[id]);
+
+// One display description per authored effect, reusing the shared helper so wording/direction
+// match the battle tooltip's "On hit" lines; `id` is kept for a stable each-key.
+const effects = $derived(
+	(metrics?.skill.effects ?? []).map((effect) => ({
+		id: effect.id,
+		...describeEffect(effect, attributeName(effect.attributeId))
+	}))
+);
 
 const scalesEyebrow = $derived(
 	metrics?.skill.damageMultipliers.length
@@ -409,6 +438,35 @@ const rawNote = $derived.by(() => {
 			font-size: 13px;
 		}
 	}
+}
+
+.effect-row {
+	display: flex;
+	align-items: baseline;
+	gap: 11px;
+	margin-top: 8px;
+	font-size: 12px;
+}
+
+.emag {
+	min-width: 46px;
+	font-family: var(--mono);
+	font-size: 11px;
+	font-weight: 600;
+	text-align: right;
+}
+
+.eattr {
+	color: var(--text-secondary);
+}
+
+.emeta {
+	margin-left: auto;
+	font-family: var(--mono);
+	font-size: 9.5px;
+	letter-spacing: 0.4px;
+	color: var(--text-muted);
+	white-space: nowrap;
 }
 
 .d-foot {

--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, fireEvent } from '@testing-library/svelte';
-import { EAttribute, type IChallenge, type IEnemy, type ISkill, type IZone } from '$lib/api';
+import {
+	EAttribute,
+	EModifierType,
+	ESkillEffectTarget,
+	type IChallenge,
+	type IEnemy,
+	type ISkill,
+	type ISkillEffect,
+	type IZone
+} from '$lib/api';
 
 // Same engine/stores/api mocks as the view-model test: the rendered screen builds
 // its own SkillsView from these at mount.
@@ -235,6 +244,47 @@ describe('Skills screen', () => {
 		await fireEvent.input(slider, { target: { value: '3' } });
 		expect(pills[0].classList.contains('on')).toBe(false);
 		expect(container.querySelector('.vs-defval b')?.textContent).toBe('3');
+	});
+
+	it('marks effect-bearing skills with a badge and leaves effect-free skills unmarked', () => {
+		const effect: ISkillEffect = {
+			id: 7,
+			target: ESkillEffectTarget.Opponent,
+			attributeId: EAttribute.Defense,
+			modifierTypeId: EModifierType.Additive,
+			amount: -10,
+			durationMs: 5000
+		};
+		staticData.skills = [skill({ id: 0, name: 'Alpha', effects: [effect] }), ...SKILLS.slice(1)];
+		const { container } = render(Skills);
+		// Alpha (equipped, has effects) shows the badge; Bravo (effect-free) does not.
+		expect(rowByName(container, 'Alpha')?.querySelector('.effect-badge')).toBeTruthy();
+		expect(rowByName(container, 'Bravo')?.querySelector('.effect-badge')).toBeNull();
+	});
+
+	it('renders an Effects section in the inspector for an effect-bearing skill', async () => {
+		const effect: ISkillEffect = {
+			id: 7,
+			target: ESkillEffectTarget.Opponent,
+			attributeId: EAttribute.Defense,
+			modifierTypeId: EModifierType.Additive,
+			amount: -10,
+			durationMs: 5000
+		};
+		staticData.skills = [skill({ id: 0, name: 'Alpha', effects: [effect] }), ...SKILLS.slice(1)];
+		const { container } = render(Skills);
+		await fireEvent.click(rowByName(container, 'Alpha')!);
+		const row = container.querySelector<HTMLElement>('.effect-row');
+		expect(row).toBeTruthy();
+		expect(row?.querySelector('.emag')?.textContent).toBe('-10');
+		expect(row?.querySelector('.eattr')?.textContent).toBe('Defense');
+		expect(row?.querySelector('.emeta')?.textContent).toContain('5s');
+	});
+
+	it('omits the inspector Effects section for an effect-free skill', async () => {
+		const { container } = render(Skills);
+		await fireEvent.click(rowByName(container, 'Delta')!);
+		expect(container.querySelector('.effect-row')).toBeNull();
 	});
 
 	it('filters the rail by search term', async () => {


### PR DESCRIPTION
Closes #392.

Follow-up to #335 (area **E** of #180). The battle arena already indicates skill effects (badge on battle skill buttons, "On hit" tooltip lines, active-effect chips), but the **Skills loadout screen** (`src/routes/game/screens/skills`) showed a skill's damage breakdown and nothing about the buffs/debuffs it applies. This closes that consistency gap. Presentation-only — the `--effect-*` theme tokens and the `describeEffect`/`effectDirection` helpers already exist from #335, so no new derivation logic.

## What changed

- **Effect badge on skill cards** — `SkillIcon.svelte` now renders the shared `components/SkillEffectBadge` (anchored top-right) whenever the skill's `effects` list is non-empty. Because both `SkillRow` and the inspector's large icon compose `SkillIcon`, the marker shows up everywhere a skill card appears, mirroring how the battle skill slots anchor the same badge.
- **"Effects" section in `SkillInspector.svelte`** — a new section mirroring the existing Damage-breakdown section, listing each authored effect (magnitude tinted by `effectDirection`, attribute name, target, duration) via the shared `$lib/common/skill-effect-display` `describeEffect` helper — the same wording the battle tooltip's "On hit" lines use.

## Notes / scope

- Per the issue, when the dedicated loadout/selection page (#264) lands it should reuse the same badge + helper.
- I left the lone-holdout `SkillTooltip` array-index attribute lookup alone — it's already tracked separately as #402.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — 1530 tests pass, coverage thresholds met.
- [x] New unit tests (in `Skills.test.ts`): badge present for an effect-bearing skill and absent for an effect-free one; inspector renders the Effects section with the expected magnitude/attribute/duration for an effect-bearing skill and omits it otherwise.

The effect-bearing skill *content* that would make these surfaces appear in actual play is still deferred (tracked in #336 → Content authoring), so this is exercised entirely by synthetic effects in tests today.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5guxJJNVGY38At4nL56ji)_