### PR TITLE
Ratchet coverage floors after a full health-review run

### DIFF
--- a/UI/vite.config.ts
+++ b/UI/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
 			// for pure-display markup. Re-seed with `node scripts/coverage-floors.mjs` to ratchet up.
 			thresholds: {
 				'src/lib/battle/**': { lines: 99, functions: 100, branches: 90, statements: 99 },
-				'src/lib/engine/**': { lines: 97, functions: 96, branches: 90, statements: 96 },
+				'src/lib/engine/**': { lines: 97, functions: 96, branches: 91, statements: 97 },
 				'src/lib/common/**': { lines: 97, functions: 93, branches: 85, statements: 97 },
 				'src/lib/api/**': { lines: 96, functions: 98, branches: 91, statements: 96 },
 				'src/lib/card-game/**': { lines: 94, functions: 100, branches: 81, statements: 94 },

--- a/build/coverage-floors.json
+++ b/build/coverage-floors.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Backend coverage gate floors. Assemblies under 'gated' fail the build when below their line/branch floor; every other measured assembly is reported but never fails (measure-only). Floors are a ratchet: seeded at the current level and only ever raised. Re-seed after a full run by reading coverage/backend-report/Summary.json. See docs/infrastructure.md (Code coverage).",
   "gated": {
-    "Game.Core": { "line": 97, "branch": 92 },
+    "Game.Core": { "line": 97, "branch": 93 },
     "Game.Application": { "line": 95, "branch": 85 }
   },
   "measureOnly": [


### PR DESCRIPTION
## What

Part of a routine codebase-health review. A full backend (`dotnet-coverage` + ReportGenerator) and frontend (Vitest v8) coverage run showed three gated metrics had risen above their current floors, so this re-seeds them per the documented ratchet process.

| Gate | Metric | Floor was | Measured | New floor |
|---|---|---|---|---|
| `Game.Core` (backend) | branch | 92 | 93.10% | **93** |
| `src/lib/engine/**` (frontend) | branch | 90 | 91.03% | **91** |
| `src/lib/engine/**` (frontend) | statements | 96 | 97.04% | **97** |

No other gated assembly/area had integer headroom (e.g. `Game.Application` sits at 95.4% line / 85.7% branch against 95/85 floors — no room for an integer bump).

## Verification

- Frontend: `npm run test:unit:ci` → exit 0, 1527 tests pass, all area thresholds met with the new floors.
- Backend: confirmed `Game.Core` branch = 445/478 = 93.10% ≥ 93 from the merged Cobertura summary; line floor and `Game.Application` floors unchanged.

The margins are intentionally tight (the ratchet locks in measured gains); a future change that legitimately drops coverage re-seeds via `node scripts/coverage-floors.mjs` / `build/coverage-floors.json`.

https://claude.ai/code/session_015RjBja3qwAXzz6Hy9wCWPm

---
_Generated by [Claude Code](https://claude.ai/code/session_015RjBja3qwAXzz6Hy9wCWPm)_