### PR TITLE
Fix SkillEffectBadge clipping on loadout skill cards (#421)

### DIFF
--- a/UI/src/routes/game/screens/skills/SkillIcon.svelte
+++ b/UI/src/routes/game/screens/skills/SkillIcon.svelte
@@ -1,9 +1,11 @@
 <div class="skill-icon" class:locked style:--icon-accent={accent} style:width="{size}px" style:height="{size}px">
-	{#if locked}
-		<span class="lock-glyph" aria-hidden="true">🔒</span>
-	{:else}
-		<img src={skill.iconPath} alt={skill.name} />
-	{/if}
+	<div class="icon-clip">
+		{#if locked}
+			<span class="lock-glyph" aria-hidden="true">🔒</span>
+		{:else}
+			<img src={skill.iconPath} alt={skill.name} />
+		{/if}
+	</div>
 	{#if skill.effects.length > 0}
 		<div class="effect-badge-anchor"><SkillEffectBadge /></div>
 	{/if}
@@ -33,14 +35,26 @@ const accent = $derived(
 <style lang="scss">
 .skill-icon {
 	position: relative;
-	display: flex;
-	align-items: center;
-	justify-content: center;
 	flex-shrink: 0;
-	overflow: hidden;
 	border: 1px solid var(--border-light);
 	border-radius: 3px;
 	background: color-mix(in srgb, var(--white) 4%, transparent);
+
+	&.locked {
+		opacity: 0.8;
+	}
+}
+
+// Clips the rounded icon image; kept separate from `.skill-icon` so the effect badge
+// (anchored to the non-clipped outer tile) and its glow aren't cut off (#421).
+.icon-clip {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	overflow: hidden;
+	border-radius: 3px;
 
 	&::before {
 		content: '';
@@ -51,10 +65,6 @@ const accent = $derived(
 			color-mix(in srgb, var(--icon-accent) 34%, transparent),
 			transparent 72%
 		);
-	}
-
-	&.locked {
-		opacity: 0.8;
 	}
 
 	img {

--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -260,6 +260,12 @@ describe('Skills screen', () => {
 		// Alpha (equipped, has effects) shows the badge; Bravo (effect-free) does not.
 		expect(rowByName(container, 'Alpha')?.querySelector('.effect-badge')).toBeTruthy();
 		expect(rowByName(container, 'Bravo')?.querySelector('.effect-badge')).toBeNull();
+
+		// The badge must anchor to the non-clipped outer tile, not the `overflow: hidden`
+		// `.icon-clip`, so its glow isn't cut off (#421).
+		const anchor = rowByName(container, 'Alpha')?.querySelector('.effect-badge-anchor');
+		expect(anchor?.parentElement?.classList.contains('skill-icon')).toBe(true);
+		expect(anchor?.closest('.icon-clip')).toBeNull();
 	});
 
 	it('renders an Effects section in the inspector for an effect-bearing skill', async () => {


### PR DESCRIPTION
## Summary

`SkillIcon.svelte` sets `overflow: hidden` to clip the rounded icon image, but the shared `SkillEffectBadge` (anchored inside `SkillIcon` via `.effect-badge-anchor` in #415) sat under that same clip — so the badge's `box-shadow` glow, and at the 30px `SkillRow` size the rotated diamond's top-right corner, got cut off at the tile boundary. This diverged from the battle-side rendering in `fight/Skills.svelte`, where the badge sits in a non-clipped slot and renders in full.

## How it addresses the issue

Per the issue's preferred option (keep the badge in `SkillIcon`, just give it a non-clipped anchor), the icon image/lock glyph and the accent gradient are now wrapped in an inner `.icon-clip` element that carries the `overflow: hidden` + `border-radius`. The outer `.skill-icon` keeps the border/background/sizing and `position: relative`, but no longer clips — so the `.effect-badge-anchor` (still a direct child of `.skill-icon`, at `top: 3px; right: 3px`) and its glow render fully. Presentation-only; no logic change, and the visual treatment of the icon itself is unchanged.

This benefits both consumers of `SkillIcon`: the 30px `SkillRow` cards and the 78px `SkillInspector` large icon.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit` for the skills/fight Skills suites — green
- [x] Added a regression guard asserting `.effect-badge-anchor` anchors to the outer `.skill-icon` and is **not** a descendant of the clipped `.icon-clip`, so a future refactor can't reintroduce the clip
- [x] Existing badge presence/absence assertions still pass

Closes #421

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTstxcG6XL9HaWhCppE1ob)_