### PR TITLE
Resolve SkillTooltip attribute names via .find per #297 lookup convention (#402)

### DIFF
--- a/UI/src/routes/game/screens/fight/SkillTooltip.svelte
+++ b/UI/src/routes/game/screens/fight/SkillTooltip.svelte
@@ -25,7 +25,7 @@
 <script lang="ts">
 import { EAttribute } from '$lib/api';
 import { applyDefense, skillContributions, type Skill } from '$lib/battle';
-import { describeEffect } from '$lib/common';
+import { describeEffect, normalizeText } from '$lib/common';
 import { battleEngine } from '$lib/engine';
 import { staticData } from '$stores';
 import TooltipShell from '$components/tooltip/TooltipShell.svelte';
@@ -72,7 +72,6 @@ const effectLines = $derived(
 	(skill?.effects ?? []).map((effect) => describeEffect(effect, attributeName(effect.attributeId)))
 );
 
-const attributeName = (attrId: number) => {
-	return staticData.attributes?.[attrId]?.name ?? EAttribute[attrId] ?? 'Unknown';
-};
+const attributeName = (attrId: number) =>
+	staticData.attributes?.find((a) => a.id === attrId)?.name ?? normalizeText(EAttribute[attrId]);
 </script>

--- a/UI/src/tests/routes/game/screens/fight/SkillTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/SkillTooltip.test.ts
@@ -48,7 +48,7 @@ describe('SkillTooltip', () => {
 	});
 
 	it('shows the damage breakdown: base, per-attribute multiplier, enemy defense and total', () => {
-		staticData.attributes[EAttribute.Strength] = { id: EAttribute.Strength, name: 'Strength', description: '' };
+		staticData.attributes = [{ id: EAttribute.Strength, name: 'Strength', description: '' }];
 		const skill = makeSkill(owner, {
 			name: 'Cleave',
 			baseDamage: 10,
@@ -109,8 +109,10 @@ describe('SkillTooltip', () => {
 
 	it('renders an "On hit" effect line per authored effect, tinted by buff/debuff direction', async () => {
 		const { EModifierType, ESkillEffectTarget } = await import('$lib/api');
-		staticData.attributes[EAttribute.Strength] = { id: EAttribute.Strength, name: 'Strength', description: '' };
-		staticData.attributes[EAttribute.Defense] = { id: EAttribute.Defense, name: 'Defense', description: '' };
+		staticData.attributes = [
+			{ id: EAttribute.Strength, name: 'Strength', description: '' },
+			{ id: EAttribute.Defense, name: 'Defense', description: '' }
+		];
 		const skill = makeSkill(owner, {
 			name: 'Warcry',
 			effects: [


### PR DESCRIPTION
## Summary

`SkillTooltip.svelte` was the lone holdout resolving an attribute's display name by **array index**:

```ts
staticData.attributes?.[attrId]?.name ?? EAttribute[attrId] ?? 'Unknown';
```

Per the lookup convention documented in `docs/frontend.md` (Reference Data, #297), the `attributes` set is one of the **intrinsic, enum-keyed** sets that must be resolved via `.find(e => e.id === id)` — array index addressing is reserved for the six zero-based-id catalogues (items, itemMods, skills, enemies, zones, challenges). This PR aligns `attributeName` with the shared `.find` + `normalizeText` form already used by `ActiveEffectChips`, `SkillInspector`, and `SortFilterModal`:

```ts
const attributeName = (attrId: number) =>
	staticData.attributes?.find((a) => a.id === attrId)?.name ?? normalizeText(EAttribute[attrId]);
```

This also fixes the inconsistent fallback — the old code used the raw `EAttribute[attrId]` enum string, while the siblings run it through `normalizeText` (e.g. `CooldownRecovery` → `Cooldown Recovery`).

## How it addresses the issue

Pre-existing inconsistency surfaced during review of PR #393. The fix is presentation-only with no behavioral change for the populated case; the only observable difference is correctly spacing a multi-word enum name in the (rare) reference-data-missing fallback.

## Test setup note

The existing `SkillTooltip` tests populated `staticData.attributes` **sparsely by index** (`attributes[EAttribute.Defense] = …`, where `Defense = 7`), which leaves holes that `.find` visits as `undefined`. Updated those two setups to dense arrays, matching the `ActiveEffectChips` test convention, so the `.find` lookup resolves cleanly.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npx vitest run` for `SkillTooltip.test.ts` — 9/9 green

Closes #402

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEfFuFXnUNHyXiGXEuhEEe)_