### PR TITLE
Unify InventoryManager optimistic-rollback snapshotting (#403)

### DIFF
--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -15,6 +15,31 @@ import { logMessage } from '$lib/engine/log';
 // it here while the single source of truth is the codegen'd enum.
 export { EEquipmentSlot };
 
+type RestoreSnapshot = () => void;
+
+/**
+ * Captures the current values of the named fields on `target`, returning a closure that restores
+ * them — the single snapshot/restore primitive behind every optimistic mutation's rollback. Captured
+ * fields must be reassigned (not mutated in place) for the snapshot to stay a valid baseline.
+ */
+const snapshotFields = <T extends object, K extends keyof T>(target: T, ...keys: K[]): RestoreSnapshot => {
+	const saved = keys.map((key) => ({ key, value: target[key] }));
+	return () => {
+		for (const { key, value } of saved) {
+			target[key] = value;
+		}
+	};
+};
+
+/** Combines several field snapshots into a single restore closure. */
+const combineSnapshots = (...restores: RestoreSnapshot[]): RestoreSnapshot => {
+	return () => {
+		for (const restore of restores) {
+			restore();
+		}
+	};
+};
+
 export class InventoryManager {
 	/** All items the player has unlocked, keyed by itemId. */
 	public unlockedItems: Map<number, Item> = new Map();
@@ -84,7 +109,11 @@ export class InventoryManager {
 
 		// Apply optimistically (instant UI), then persist; a failed persist rolls the change back so
 		// the authoritative state can never diverge from what was actually saved.
-		const rollback = this.snapshotEquipped(item, this.equippedSlots[slotId]);
+		const affected = [item, this.equippedSlots[slotId]].filter((it): it is Item => it != null);
+		const rollback = combineSnapshots(
+			snapshotFields(this, 'equippedSlots'),
+			...affected.map((it) => snapshotFields(it, 'equipped', 'equipmentSlotId'))
+		);
 		this.applyEquip(item, slotId);
 		this.publish();
 
@@ -105,10 +134,15 @@ export class InventoryManager {
 			return false;
 		}
 
-		const rollback = this.snapshotEquipped(item);
+		const rollback = combineSnapshots(
+			snapshotFields(this, 'equippedSlots'),
+			snapshotFields(item, 'equipped', 'equipmentSlotId')
+		);
 		item.equipped = false;
 		item.equipmentSlotId = undefined;
-		this.equippedSlots[slotId] = undefined;
+		const slots = [...this.equippedSlots];
+		slots[slotId] = undefined;
+		this.equippedSlots = slots;
 		this.publish();
 
 		const req = new ApiRequest('Player/UnequipItem');
@@ -128,8 +162,7 @@ export class InventoryManager {
 			return false;
 		}
 
-		const prevMods = item.appliedMods;
-		const prevTotal = item.totalAttributes;
+		const rollback = snapshotFields(item, 'appliedMods', 'totalAttributes');
 		item.appliedMods = [
 			...item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId),
 			newItemMod({ itemModId, itemModSlotId })
@@ -140,8 +173,7 @@ export class InventoryManager {
 		const req = new ApiRequest('Player/ApplyMod');
 		const response = await req.post({ itemId, itemModId, itemModSlotId });
 		if (!response.ok) {
-			item.appliedMods = prevMods;
-			item.totalAttributes = prevTotal;
+			rollback();
 			this.publish();
 			return false;
 		}
@@ -156,8 +188,7 @@ export class InventoryManager {
 			return false;
 		}
 
-		const prevMods = item.appliedMods;
-		const prevTotal = item.totalAttributes;
+		const rollback = snapshotFields(item, 'appliedMods', 'totalAttributes');
 		item.appliedMods = item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId);
 		this.refreshItemAttributes(item);
 		this.publish();
@@ -165,8 +196,7 @@ export class InventoryManager {
 		const req = new ApiRequest('Player/RemoveMod');
 		const response = await req.post({ itemId, itemModSlotId });
 		if (!response.ok) {
-			item.appliedMods = prevMods;
-			item.totalAttributes = prevTotal;
+			rollback();
 			this.publish();
 			return false;
 		}
@@ -218,20 +248,22 @@ export class InventoryManager {
 		logMessage(ELogType.ItemFound, 'New modifier unlocked!');
 	}
 
-	/** The equip mutation, applied directly to the authoritative items + slot array. */
+	/** The equip mutation, reassigning a fresh slot array so a captured snapshot stays a valid baseline. */
 	private applyEquip(item: Item, slotId: EEquipmentSlot) {
+		const slots = [...this.equippedSlots];
+
 		// Unequip from any current slot
-		for (let i = 0; i < this.equippedSlots.length; i++) {
-			const old = this.equippedSlots[i];
+		for (let i = 0; i < slots.length; i++) {
+			const old = slots[i];
 			if (old?.itemId === item.itemId) {
 				old.equipped = false;
 				old.equipmentSlotId = undefined;
-				this.equippedSlots[i] = undefined;
+				slots[i] = undefined;
 			}
 		}
 
 		// Unequip whatever is in the target slot
-		const displaced = this.equippedSlots[slotId];
+		const displaced = slots[slotId];
 		if (displaced) {
 			displaced.equipped = false;
 			displaced.equipmentSlotId = undefined;
@@ -240,25 +272,9 @@ export class InventoryManager {
 		// Equip the new item
 		item.equipped = true;
 		item.equipmentSlotId = slotId;
-		this.equippedSlots[slotId] = item;
-	}
+		slots[slotId] = item;
 
-	/**
-	 * Captures the slot array plus the equip/slot fields of the given items, returning a closure that
-	 * restores them — the rollback for a failed equip/unequip persist.
-	 */
-	private snapshotEquipped(...items: (Item | undefined)[]): () => void {
-		const prevSlots = [...this.equippedSlots];
-		const snaps = items
-			.filter((it): it is Item => it != null)
-			.map((it) => ({ item: it, equipped: it.equipped, slot: it.equipmentSlotId }));
-		return () => {
-			this.equippedSlots = prevSlots;
-			for (const snap of snaps) {
-				snap.item.equipped = snap.equipped;
-				snap.item.equipmentSlotId = snap.slot;
-			}
-		};
+		this.equippedSlots = slots;
 	}
 
 	/** Rebuilds an item's cached totalAttributes after its applied mods change. */

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -309,6 +309,28 @@ describe('InventoryManager', () => {
 			expect(manager.unlockedItems.get(1)?.equipped).toBe(false);
 		});
 
+		it('restores both the displaced item and its slot when the persist fails', async () => {
+			mockItems[1] = makeItem(1);
+			mockItems[2] = makeItem(2);
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({ itemId: 1, equipped: true, equipmentSlotId: EEquipmentSlot.WeaponSlot }),
+				makeInventoryItem({ itemId: 2 })
+			];
+			manager.initialize();
+			mockPost.mockResolvedValue({ ok: false, error: 'nope' });
+
+			const result = await manager.equipItem(2, EEquipmentSlot.WeaponSlot);
+
+			// The displaced incumbent (item 1) is fully restored to its slot, and the new item (item 2)
+			// is rolled back to unequipped — the single snapshot covers every object the equip touched.
+			expect(result).toBe(false);
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]?.itemId).toBe(1);
+			expect(manager.unlockedItems.get(1)?.equipped).toBe(true);
+			expect(manager.unlockedItems.get(1)?.equipmentSlotId).toBe(EEquipmentSlot.WeaponSlot);
+			expect(manager.unlockedItems.get(2)?.equipped).toBe(false);
+			expect(manager.unlockedItems.get(2)?.equipmentSlotId).toBeUndefined();
+		});
+
 		it('applies the change optimistically before the persist resolves, then rolls back on error', async () => {
 			mockItems[1] = makeItem(1);
 			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];


### PR DESCRIPTION
## Summary

Follow-up from PR #394. `InventoryManager`'s four optimistic mutations rolled back in two slightly-divergent ways:

- `equipItem` / `unequipItem` used a bespoke `snapshotEquipped(...items)` helper (captured the slot array + each item's `equipped`/`equipmentSlotId`).
- `applyMod` / `removeMod` captured `prevMods` / `prevTotal` inline and restored them by hand in the error branch.

Both were correct, but the two hand-synced patterns are the same kind of duplication #352 set out to remove, just smaller. This routes all four through a single generic snapshot/restore primitive:

```ts
const rollback = snapshotFields(item, 'appliedMods', 'totalAttributes');
// …optimistic mutation…
if (!response.ok) { rollback(); this.publish(); return false; }
```

`snapshotFields(target, ...keys)` captures the named fields' current values and returns a restore closure; `combineSnapshots(...)` composes several for the multi-object equip case (the manager's `equippedSlots` plus each affected item).

## Correctness note

The old `snapshotEquipped` deep-copied `equippedSlots` because `applyEquip`/`unequipItem` mutated the slot array **in place**, whereas the mod path captured by reference because it **reassigns**. To make one generic capture-by-reference helper valid for all four, `applyEquip` (and `unequipItem`) now build and assign a **fresh** slot array instead of mutating in place — the same immutable-reassign contract the mod path already followed (and `publish()` already reassigned a fresh copy on every change, so the live array identity changed regardless). The captured baseline is therefore never corrupted by the optimistic mutation. No user-facing behavior change.

## How it addresses the issue

Closes #403 — consolidates the rollback logic onto a single helper so the four mutations can't drift apart, exactly the "unify optimistic-rollback snapshotting" the issue asked for.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npx vitest run inventory-manager.test.ts` — 41/41 green
- [x] Inventory screen suites (`screens/inventory`) — 133/133 green
- [x] Added a regression test pinning the **multi-object** equip rollback: a failed persist now restores both the displaced incumbent (back into its slot) and the new item (to unequipped) via the single combined snapshot

Closes #403

---
_Generated by [Claude Code](https://claude.ai/code/session_015X6dqLCoXysyDEnVhPCNCz)_