### PR TITLE
Keep frontend Battler.isDead in sync in applyHealOverTime (#404)

### DIFF
--- a/Game.Core.Tests/Battle/BattleDamageOverTimeTests.cs
+++ b/Game.Core.Tests/Battle/BattleDamageOverTimeTests.cs
@@ -67,6 +67,18 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(100, battler.CurrentHealth);
         }
 
+        [Fact]
+        public void ApplyHealOverTime_KeepsIsDeadInSync()
+        {
+            var battler = MakeBattler(Stat(Strength, 10), Stat(HealthRegenPerSecond, 75)); // MaxHealth 100
+            battler.TakeDamage(52); // CurrentHealth 50
+
+            battler.ApplyHealOverTime(40); // heals 3 → CurrentHealth 53
+
+            Assert.Equal(battler.CurrentHealth <= 0, battler.IsDead);
+            Assert.False(battler.IsDead);
+        }
+
         // ── Statistics attribution (backend-only) ────────────────────────────
 
         [Fact]

--- a/UI/src/lib/battle/battler.ts
+++ b/UI/src/lib/battle/battler.ts
@@ -119,6 +119,9 @@ export class Battler {
 		const healed = Math.min(heal, this.attributes.getValue(EAttribute.MaxHealth) - this.currentHealth);
 		if (healed > 0) {
 			this.currentHealth += healed;
+			// Keep the cached flag in sync with currentHealth, mirroring takeDamage/applyDamageOverTime and
+			// the backend's always-live IsDead, so isDead is correct regardless of mutation ordering.
+			this.isDead = this.currentHealth <= 0;
 			return healed;
 		}
 

--- a/UI/src/tests/lib/battle/battler-dot.test.ts
+++ b/UI/src/tests/lib/battle/battler-dot.test.ts
@@ -77,4 +77,17 @@ describe('Battler damage/heal-over-time', () => {
 		expect(healed).toBe(2);
 		expect(battler.currentHealth).toBe(100);
 	});
+
+	it('keeps isDead in sync after a heal (matches the backend always-live IsDead)', () => {
+		const battler = makeBattler([
+			{ id: EAttribute.Strength, amount: 10 }, // MaxHealth 100
+			{ id: EAttribute.HealthRegenPerSecond, amount: 75 }
+		]);
+		battler.takeDamage(52); // currentHealth 50
+
+		battler.applyHealOverTime(40); // heals 3 → currentHealth 53
+
+		expect(battler.isDead).toBe(battler.currentHealth <= 0);
+		expect(battler.isDead).toBe(false);
+	});
 });


### PR DESCRIPTION
## Summary

Follow-up from PR #390 (DoT/HoT battle runtime, #334). On the frontend `Battler` (`UI/src/lib/battle/battler.ts`), `applyDamageOverTime` and `takeDamage` both update the cached `isDead` flag, but `applyHealOverTime` did **not** — so the frontend relied on `applyDamageOverTime` always being the last thing to write the flag before it's read. The backend's `IsDead` is a live computed property (`CurrentHealth <= 0`) and is correct regardless of call ordering.

This sets `this.isDead = this.currentHealth <= 0;` at the end of `applyHealOverTime` (in the `healed > 0` branch — a no-op heal can't change the flag), mirroring the two existing mutators and the backend's always-live `IsDead`. No behavior change in any current code path; this removes the latent parity asymmetry the replay anti-cheat must avoid.

I took the smaller, mirror-the-siblings fix rather than converting `isDead` to a getter: the field is deliberately a plain property consumed by the rest of the battle code, and the issue itself flags the getter conversion as the larger, evaluate-first option.

## How it addresses the issue

Closes #404 — the frontend cached flag now matches the backend's always-live `IsDead` after a heal, so a future edit (regen lowering health, reading `isDead` right after a heal, reusing `applyHealOverTime` outside the DoT phase) can't silently desync the two simulators.

## Test plan

- [x] Added a parity test on **both** suites pinning the `isDead`/`IsDead` invariant after a heal (`battler-dot.test.ts` and `BattleDamageOverTimeTests.cs`), per the battle-logic mirroring rule.
- [x] Frontend: `node_modules/.bin/vitest run battler-dot.test.ts` — 5/5 green
- [x] Frontend: `npm run lint` (eslint + svelte-check) — clean
- [x] Backend: `dotnet test Game.Core.Tests --filter BattleDamageOverTimeTests` — green (397 total in the project)

Closes #404

---
_Generated by [Claude Code](https://claude.ai/code/session_012oYRABYYyjH5KUZk82RuRh)_