### PR TITLE
Avoid full Player aggregate load on id-only reads (#448)

### DIFF
--- a/Game.Api.Tests/Unit/PlayerDataMappingTests.cs
+++ b/Game.Api.Tests/Unit/PlayerDataMappingTests.cs
@@ -1,3 +1,5 @@
+using Game.Core;
+using Game.Core.Items;
 using Game.Core.Players;
 using Game.Core.Players.Inventories;
 using Game.Core.Skills;
@@ -54,7 +56,33 @@ namespace Game.Api.Tests.Unit
             Assert.Empty(data.UnlockedSkills);
         }
 
-        private static CorePlayer MakePlayer(List<Skill> skills, List<Skill> selectedSkills) => new()
+        [Fact]
+        public void FromPlayer_ProjectsUnlockedItems_WithEquippedStateAndSlot()
+        {
+            var weapon = MakeItem(10, EItemCategory.Weapon);
+            var helm = MakeItem(11, EItemCategory.Helm);
+
+            var inventory = new Inventory();
+            inventory.UnlockItem(weapon);
+            inventory.UnlockItem(helm);
+            inventory.TryEquipItem(weapon.Id, EEquipmentSlot.WeaponSlot);
+
+            var player = MakePlayer(skills: [], selectedSkills: [], inventory: inventory);
+
+            var data = PlayerDataModel.FromPlayer(player);
+
+            Assert.Equal(2, data.InventoryData.UnlockedItems.Count);
+
+            var equippedWeapon = data.InventoryData.UnlockedItems.Single(i => i.ItemId == weapon.Id);
+            Assert.True(equippedWeapon.Equipped);
+            Assert.Equal((int)EEquipmentSlot.WeaponSlot, equippedWeapon.EquipmentSlotId);
+
+            var unequippedHelm = data.InventoryData.UnlockedItems.Single(i => i.ItemId == helm.Id);
+            Assert.False(unequippedHelm.Equipped);
+            Assert.Null(unequippedHelm.EquipmentSlotId);
+        }
+
+        private static CorePlayer MakePlayer(List<Skill> skills, List<Skill> selectedSkills, Inventory? inventory = null) => new()
         {
             Id = 1,
             Name = "Test",
@@ -62,7 +90,7 @@ namespace Game.Api.Tests.Unit
             Exp = 0,
             CurrentZoneId = 0,
             StatPoints = new PlayerStatPoints([]) { StatPointsGained = 0, StatPointsUsed = 0 },
-            Inventory = new Inventory(),
+            Inventory = inventory ?? new Inventory(),
             Skills = skills,
             SelectedSkills = selectedSkills,
             LogPreferences = [],
@@ -77,6 +105,18 @@ namespace Game.Api.Tests.Unit
             CooldownMs = 1000,
             DamageMultipliers = [],
             Effects = [],
+        };
+
+        private static Item MakeItem(int id, EItemCategory category) => new()
+        {
+            Id = id,
+            Name = $"Item {id}",
+            Description = string.Empty,
+            Category = category,
+            Rarity = ERarity.Common,
+            Attributes = [],
+            ModSlots = [],
+            Tags = [],
         };
     }
 }

--- a/Game.Api/Auth/JwtTokenService.cs
+++ b/Game.Api/Auth/JwtTokenService.cs
@@ -23,6 +23,9 @@ namespace Game.Api.Auth
 
         private readonly JwtOptions _options;
         private readonly SymmetricSecurityKey _signingKey;
+        // JsonWebTokenHandler is thread-safe and caches signing material internally, so a single
+        // instance is reused across all token issuance rather than allocated per call.
+        private readonly JsonWebTokenHandler _handler = new();
 
         public JwtTokenService(IOptions<JwtOptions> options)
         {
@@ -50,7 +53,7 @@ namespace Game.Api.Auth
                 SigningCredentials = new SigningCredentials(_signingKey, SecurityAlgorithms.HmacSha256),
             };
 
-            return new JsonWebTokenHandler().CreateToken(descriptor);
+            return _handler.CreateToken(descriptor);
         }
     }
 }

--- a/Game.Api/Controllers/ChallengesController.cs
+++ b/Game.Api/Controllers/ChallengesController.cs
@@ -16,8 +16,7 @@ namespace Game.Api.Controllers
         [HttpGet]
         public async Task<ApiEnumerableResponse<PlayerChallenge>> Player()
         {
-            var player = await _sessionService.LoadPlayer();
-            var progress = await _playerProgress.GetChallenges(player.Id);
+            var progress = await _playerProgress.GetChallenges(_sessionService.SelectedPlayerId);
             return ApiResponse.Success(progress.To().Model<PlayerChallenge>());
         }
     }

--- a/Game.Api/Controllers/StatisticsController.cs
+++ b/Game.Api/Controllers/StatisticsController.cs
@@ -16,8 +16,7 @@ namespace Game.Api.Controllers
         [HttpGet("/api/[controller]")]
         public async Task<ApiEnumerableResponse<PlayerStatistic>> Statistics()
         {
-            var player = await _sessionService.LoadPlayer();
-            var stats = await _playerProgress.GetStatistics(player.Id);
+            var stats = await _playerProgress.GetStatistics(_sessionService.SelectedPlayerId);
             return ApiResponse.Success(stats.To().Model<PlayerStatistic>());
         }
 

--- a/Game.Api/Models/Player/PlayerData.cs
+++ b/Game.Api/Models/Player/PlayerData.cs
@@ -21,6 +21,16 @@ namespace Game.Api.Models.Player
         {
             var inventory = player.Inventory;
 
+            // Precompute the loadout-order and equipped-slot lookups once, so the per-skill and
+            // per-item projections below index them instead of rescanning SelectedSkills/EquipmentSlots
+            // for every unlocked entry.
+            var skillOrderById = player.SelectedSkills
+                .Select((skill, order) => (skill.Id, order))
+                .ToDictionary(entry => entry.Id, entry => entry.order);
+            var equipSlotByItemId = inventory.EquipmentSlots
+                .Where(slot => slot.ItemId.HasValue)
+                .ToDictionary(slot => slot.ItemId.GetValueOrDefault());
+
             return new PlayerData
             {
                 Name = player.Name,
@@ -36,12 +46,12 @@ namespace Game.Api.Models.Player
                 UnlockedSkills = player.Skills
                     .Select(skill =>
                     {
-                        var order = player.SelectedSkills.FindIndex(s => s.Id == skill.Id);
+                        var selected = skillOrderById.TryGetValue(skill.Id, out var order);
                         return new UnlockedSkill
                         {
                             SkillId = skill.Id,
-                            Selected = order >= 0,
-                            Order = order >= 0 ? order : null,
+                            Selected = selected,
+                            Order = selected ? order : null,
                         };
                     })
                     .ToList(),
@@ -64,8 +74,7 @@ namespace Game.Api.Models.Player
                     UnlockedItems = inventory.UnlockedItems
                         .Select(slot =>
                         {
-                            var equipSlot = inventory.EquipmentSlots
-                                .FirstOrDefault(es => es.ItemId == slot.ItemId);
+                            equipSlotByItemId.TryGetValue(slot.ItemId, out var equipSlot);
 
                             return new InventoryItem
                             {


### PR DESCRIPTION
## Summary

Addresses the three independent read-path inefficiencies surfaced in #448. All three preserve existing behaviour — they are tidy-ups / per-request cost reductions, not functional changes.

### 1. Full-aggregate load for an id-only operation (the meaty one)
`ChallengesController` and `StatisticsController` called `await _sessionService.LoadPlayer()` solely to read `player.Id`, which deserializes the **entire** `Player` aggregate (inventory, skills, attributes, mod slots, log prefs) from the Redis session cache on every request. The id is already available with no I/O via `SessionService.SelectedPlayerId` (populated by `SessionLoaderMiddleware` from the validated token's session state). Both controllers now pass `_sessionService.SelectedPlayerId` straight into `GetChallenges`/`GetStatistics`.

### 2. `JwtTokenService` allocated a `JsonWebTokenHandler` per token issuance
`CreateAccessToken` did `new JsonWebTokenHandler().CreateToken(...)` on every login and refresh, even though the service is a singleton and `JsonWebTokenHandler` is thread-safe and caches signing material internally. Promoted to a reused `private readonly JsonWebTokenHandler _handler = new();` field.

### 3. `PlayerData.FromPlayer` nested O(n·m) scans
The projection ran `player.SelectedSkills.FindIndex(...)` per unlocked skill and `inventory.EquipmentSlots.FirstOrDefault(...)` per unlocked item — two nested linear scans per projection, run at login and on every `Player`/`Status` read. Now precomputes a `skillId → order` dictionary and an `itemId → slot` dictionary once, then indexes them. The equipped-item dictionary keys only on slots that hold an item (each item can occupy at most one slot, so keys stay unique).

## How it addresses the issue
Each of the three directions in #448 is implemented exactly as described. Counts are small today (so #2/#3 are tidy-ups), but #1 removes a real per-request Redis deserialization of the full aggregate on two player-facing read endpoints.

## Test plan
- [x] `dotnet build` — clean, 0 warnings.
- [x] `Game.Api.Tests` full suite — **343 passed, 0 failed** (covers `ChallengesControllerTests`, `StatisticsControllerTests`, `LoginControllerTests`, `PlayerControllerTests`, and the `PlayerDataMappingTests`).
- [x] Added `FromPlayer_ProjectsUnlockedItems_WithEquippedStateAndSlot`, a unit test pinning the inventory equipped/unequipped projection that the dictionary refactor touches (the skill-ordering path was already covered).

No frontend changes and no battle-logic changes, so no parity-matrix updates are needed.

Closes #448

https://claude.ai/code/session_01T3bqaujML2dXWSB19JFPPc

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3bqaujML2dXWSB19JFPPc)_