### PR TITLE
Fix zone cleared overlay not covering full fight screen

### DIFF
--- a/UI/src/routes/game/screens/fight/Fight.svelte
+++ b/UI/src/routes/game/screens/fight/Fight.svelte
@@ -30,16 +30,16 @@
 		{:else}
 			<BattlerCard battler={battleEngine.enemy} side="enemy" />
 		{/if}
-
-		{#if boss.victory}
-			<ZoneClearedOverlay
-				bossName={boss.bossName}
-				zoneName={boss.zoneName}
-				autoFight={boss.autoFight}
-				unlockedNextZone={boss.unlockedNextZone}
-			/>
-		{/if}
 	</div>
+
+	{#if boss.victory}
+		<ZoneClearedOverlay
+			bossName={boss.bossName}
+			zoneName={boss.zoneName}
+			autoFight={boss.autoFight}
+			unlockedNextZone={boss.unlockedNextZone}
+		/>
+	{/if}
 </div>
 
 <script lang="ts">


### PR DESCRIPTION
## Summary

- The `ZoneClearedOverlay` was nested inside the `.combatants` div, so its `position: absolute; inset: 0` only covered that element — leaving the zone nav and boss affordance controls at the top of the screen uncovered.
- Moved the overlay to be a direct child of `.fight-screen` (which has `position: relative`), so it now spans the full fight screen with its existing `z-index: 20` ensuring it renders above the zone nav (`z-index: 1`) and boss affordance (`z-index: 2`).

## Test plan

- [ ] Defeat a zone boss and confirm the dimmed overlay covers the entire fight screen, including the zone nav and boss controls at the top.
- [ ] Verify the "Zone Cleared" content is still centered and the animation plays correctly.
- [ ] Confirm all unit tests pass (`npm run test:unit:ci` — 1548 tests, all green).

Closes #427

---
_Generated by [Claude Code](https://claude.ai/code/session_019gmZLSCQ18gyweaeuSdhua)_