### PR TITLE
Fix skill effect badge duration text jitter

### DIFF
--- a/UI/src/routes/game/screens/fight/ActiveEffectChips.svelte
+++ b/UI/src/routes/game/screens/fight/ActiveEffectChips.svelte
@@ -20,7 +20,7 @@
 
 <script lang="ts">
 import { EAttribute } from '$lib/api';
-import { effectDirection, effectDirectionColor, formatEffectMagnitude, formatNum, normalizeText } from '$lib/common';
+import { effectDirection, effectDirectionColor, formatEffectMagnitude, normalizeText } from '$lib/common';
 import { staticData } from '$stores';
 import type { ActiveEffectView, Battler } from '$lib/battle';
 
@@ -35,7 +35,7 @@ const { battler, reversed = false }: Props = $props();
 const attributeName = (id: EAttribute) =>
 	staticData.attributes?.find((attr) => attr.id === id)?.name ?? normalizeText(EAttribute[id]);
 
-const remainingSeconds = (effect: ActiveEffectView) => formatNum(effect.renderRemainingMs / 1000);
+const remainingSeconds = (effect: ActiveEffectView) => (effect.renderRemainingMs / 1000).toFixed(2);
 const remainingPercent = (effect: ActiveEffectView) =>
 	effect.durationMs > 0 ? Math.max(0, Math.min(100, (effect.renderRemainingMs / effect.durationMs) * 100)) : 0;
 const chipTitle = (effect: ActiveEffectView) =>

--- a/UI/src/tests/routes/game/screens/fight/ActiveEffectChips.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/ActiveEffectChips.test.ts
@@ -63,7 +63,7 @@ describe('ActiveEffectChips', () => {
 
 		const fill = container.querySelector('.chip-fill') as HTMLElement;
 		expect(fill.style.width).toBe('50%');
-		expect((container.querySelector('.chip-time') as HTMLElement).textContent).toContain('0.5s');
+		expect((container.querySelector('.chip-time') as HTMLElement).textContent).toContain('0.50s');
 	});
 
 	it('right-aligns the row when reversed (enemy/boss layout)', () => {

--- a/UI/src/tests/routes/game/screens/fight/ActiveEffectChips.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/ActiveEffectChips.test.ts
@@ -66,6 +66,14 @@ describe('ActiveEffectChips', () => {
 		expect((container.querySelector('.chip-time') as HTMLElement).textContent).toContain('0.50s');
 	});
 
+	it('formats integer seconds with two decimal places to prevent width jitter', () => {
+		battler.applyEffect(effect({ id: 1, durationMs: 2000 }));
+		battler.activeEffects[0].renderRemainingMs = 2000;
+		const { container } = render(ActiveEffectChips, { props: { battler } });
+
+		expect((container.querySelector('.chip-time') as HTMLElement).textContent).toContain('2.00s');
+	});
+
 	it('right-aligns the row when reversed (enemy/boss layout)', () => {
 		battler.applyEffect(effect());
 		const { getByTestId } = render(ActiveEffectChips, { props: { battler, reversed: true } });


### PR DESCRIPTION
## Summary

- The active effect chip's duration countdown used `formatNum`, which strips trailing zeros from the two-decimal-place string (e.g. `2.50` → `2.5`, `2.00` → `2`), causing the text width — and the badge size — to jitter as the timer counts down.
- Replaced `formatNum` with `.toFixed(2)` directly, matching the formatting already used for the skill tooltip charge time (`remainingCd.toFixed(2)` in `SkillTooltip.svelte`).
- Removed the now-unused `formatNum` import and updated the affected test assertion to expect the fixed two-decimal format (`0.50s`).

## Test plan

- [x] Existing `ActiveEffectChips` unit tests pass with updated assertion
- [x] All 1548 frontend unit tests pass (`npm run test:unit:ci`)
- [x] Lint clean (`npm run lint` — 0 errors, 0 warnings)

Closes #431

https://claude.ai/code/session_01TA2RpVgVsz8fWy52m7Ukyr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA2RpVgVsz8fWy52m7Ukyr)_