### PR TITLE
Format challenge completion time as local date/time

### DIFF
--- a/UI/src/routes/game/screens/challenges/ChallengeDetailCard.svelte
+++ b/UI/src/routes/game/screens/challenges/ChallengeDetailCard.svelte
@@ -16,8 +16,8 @@
 				>
 			{/if}
 			<div class="card-spacer"></div>
-			{#if done && c.completedAt}
-				<span class="card-completed">{c.completedAt}</span>
+			{#if done && completedAtDisplay}
+				<span class="card-completed">{completedAtDisplay}</span>
 			{/if}
 		</div>
 		<div class="card-desc">{c.description}</div>
@@ -40,6 +40,9 @@ interface Props {
 const { c }: Props = $props();
 
 const done = $derived(c.state === 'done');
+const completedAtDisplay = $derived(
+	c.completedAt ? new Date(c.completedAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' }) : null
+);
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
## Summary

- The `completedAt` field on challenge detail cards was displayed as a raw UTC ISO string (e.g. `2026-06-11T23:43:37.240757Z`) instead of a human-readable local time.
- Added a `completedAtDisplay` derived value in `ChallengeDetailCard.svelte` that converts the UTC string via `Date.toLocaleString()` with `dateStyle: 'medium'` and `timeStyle: 'short'`, rendering something like `Jun 11, 2026, 11:43 PM` in the user's local timezone.

## Test plan

- [ ] All 1548 existing unit tests pass (`npm run test:unit:ci`)
- [ ] ESLint + `svelte-check` pass clean (`npm run lint`)
- [ ] Manually verify a completed challenge card shows a readable local date/time instead of the raw ISO string

Closes #430

https://claude.ai/code/session_01FRhrL9wsjpsuie4vygz2qR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRhrL9wsjpsuie4vygz2qR)_