### PR TITLE
Cover skills list re-sort when compare-vs defense changes (#428)

### DIFF
--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -246,6 +246,44 @@ describe('Skills screen', () => {
 		expect(container.querySelector('.vs-defval b')?.textContent).toBe('3');
 	});
 
+	it('resorts the available rail when a compare-vs preset is clicked', async () => {
+		// Two available skills whose DPS ranking flips when Ogre King's defense (12) is applied.
+		// FastLow:  baseDmg=20, cd=1s  → DPS 20 at def=0, DPS  8.0 at def=12 (effective=8)
+		// SlowHigh: baseDmg=100, cd=10s → DPS 10 at def=0, DPS  8.8 at def=12 (effective=88)
+		staticData.skills = [
+			...SKILLS.slice(0, 3),
+			skill({ id: 3, name: 'FastLow', baseDamage: 20, damageMultipliers: [], cooldownMs: 1000 }),
+			skill({ id: 4, name: 'SlowHigh', baseDamage: 100, damageMultipliers: [], cooldownMs: 10000 })
+		];
+		mockPlayerManager.unlockedSkills = [
+			{ skillId: 0, selected: true, order: 0 },
+			{ skillId: 1, selected: true, order: 1 },
+			{ skillId: 2, selected: true, order: 2 },
+			{ skillId: 3, selected: false, order: 0 },
+			{ skillId: 4, selected: false, order: 0 }
+		];
+		const { container } = render(Skills);
+
+		// `.row` elements: first 3 are equipped (slot-ordered), then available (DPS-ordered).
+		const availableRowNames = () =>
+			Array.from(container.querySelectorAll<HTMLElement>('.row'))
+				.slice(3)
+				.map((r) => r.querySelector('.rowname')?.textContent ?? '');
+
+		// Initial DPS order: FastLow (20) > SlowHigh (10) → FastLow first.
+		expect(availableRowNames()[0]).toBe('FastLow');
+		expect(availableRowNames()[1]).toBe('SlowHigh');
+
+		// Ogre King pill: defense=12. SlowHigh (8.8 DPS) overtakes FastLow (8.0 DPS).
+		const ogreKing = Array.from(container.querySelectorAll<HTMLButtonElement>('.epill')).find((p) =>
+			p.textContent?.includes('Ogre King')
+		)!;
+		await fireEvent.click(ogreKing);
+
+		expect(availableRowNames()[0]).toBe('SlowHigh');
+		expect(availableRowNames()[1]).toBe('FastLow');
+	});
+
 	it('marks effect-bearing skills with a badge and leaves effect-free skills unmarked', () => {
 		const effect: ISkillEffect = {
 			id: 7,

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -406,4 +406,16 @@ describe('SkillsView — compare-vs enemy presets', () => {
 		expect(view.defense).toBe(7);
 		expect(view.selectedPresetKey).toBeNull();
 	});
+
+	it('resorts railList by effective dps when a preset is selected', () => {
+		view.setSort('dps');
+		// At 0 defense: Delta(50/1=50) > Bravo(40/2=20) > Alpha(12/1=12) > Charlie(5/0.5=10).
+		expect(view.railList.map((m) => m.skill.id)).toEqual([3, 1, 0, 2]);
+
+		// Imp (defense=12): Delta=(50-12)/1=38, Bravo=(40-12)/2=14, Alpha=Charlie=0.
+		const [spawn] = view.comparePresets;
+		view.selectPreset(spawn);
+		expect(view.defense).toBe(spawn.defense);
+		expect(view.railList.map((m) => m.skill.id).slice(0, 2)).toEqual([3, 1]);
+	});
 });


### PR DESCRIPTION
## Summary

- The existing `Skills.test.ts` fixture used skills with identical DPS values (`baseDamage: 10`, same cooldown), making it impossible to observe a sort-order flip when defense changed — so the behavior described in #428 was never actually exercised by tests.
- Added a **view-model test** in `skills-view.test.ts` that calls `selectPreset()` and asserts `railList` re-sorts by effective DPS with the preset's defense applied.
- Added an **integration test** in `Skills.test.ts` with two available skills whose DPS ranking inverts under the Ogre King's defense (12): `FastLow` (20 DPS → 8 at def=12) is overtaken by `SlowHigh` (10 DPS → 8.8 at def=12). The test verifies the rendered available rail reorders after the preset pill is clicked.

The reactive chain (`$state defense` → `$derived.by railList` → `$derived availableRail` → `{#each}`) works correctly — both new tests pass, confirming the sort does update when the compare-vs enemy changes.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx vitest run` — all 1550 tests pass (2 new tests added)

Closes #428

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1TbZy9dKZsaMYeQ5GFAPk)_