### PR TITLE
Release resolved dedupedFetch entries so a forced reload re-fetches

### DIFF
--- a/UI/src/lib/engine/reference-data.ts
+++ b/UI/src/lib/engine/reference-data.ts
@@ -193,12 +193,11 @@ export const dedupedFetch = (key: string, run: () => Promise<void>): Promise<num
 	let pending = pendingFetches.get(key);
 	if (!pending) {
 		const start = performance.now();
+		// Clear the entry once it settles (success or failure) so concurrent callers share the in-flight
+		// promise, but a later call — e.g. the forced reload on session resume — re-invokes `run`.
 		pending = run()
 			.then(() => Math.round(performance.now() - start))
-			.catch((e) => {
-				pendingFetches.delete(key);
-				throw e;
-			});
+			.finally(() => pendingFetches.delete(key));
 		pendingFetches.set(key, pending);
 	}
 	return pending;

--- a/UI/src/tests/lib/engine/reference-data.test.ts
+++ b/UI/src/tests/lib/engine/reference-data.test.ts
@@ -241,6 +241,17 @@ describe('dedupedFetch', () => {
 		expect(run).toHaveBeenCalledTimes(1);
 	});
 
+	it('clears the in-flight entry on success so a later call re-runs', async () => {
+		const { dedupedFetch } = await loadModule();
+		const run = vi.fn().mockResolvedValue(undefined);
+
+		// First load resolves and clears the entry...
+		await expect(dedupedFetch('zones', run)).resolves.toBeTypeOf('number');
+		// ...so a forced reload re-invokes `run` rather than returning the stale resolved promise.
+		await expect(dedupedFetch('zones', run)).resolves.toBeTypeOf('number');
+		expect(run).toHaveBeenCalledTimes(2);
+	});
+
 	it('clears the in-flight entry on failure so a later call can retry', async () => {
 		const { dedupedFetch } = await loadModule();
 		const run = vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce(undefined);


### PR DESCRIPTION
## Summary

`dedupedFetch` (`UI/src/lib/engine/reference-data.ts`) collapses concurrent fetches of the same reference-data set onto one in-flight promise, but it only removed the entry from `pendingFetches` on the **error** path. On **success** the resolved promise lingered in the map for the whole page session, so the intended "dedupe concurrent callers within one load sequence" scope leaked to "fetch at most once, ever."

The consequence shows up on the forced-reload paths (the silent session-resume / re-login path that forces a fresh reference reload): `dedupedFetch` returned the already-resolved promise from the first load instead of re-invoking `run()`, so the actual re-download was skipped and the caller got back stale timing metadata. The common case was masked when the in-memory store was already warm, but the forced reload is exactly where re-fetching is expected.

## How it addresses the issue

- Clear the entry on **settle** (success or failure) via `.finally(() => pendingFetches.delete(key))`, so concurrent callers still share the single in-flight promise but a later call re-runs `run()`.
- This replaces — and removes — the now-redundant re-throwing `.catch`, keeping the failure-path clearing while adding the success-path clearing in one place (DRY).

## Test plan

- Added a unit test asserting a second `dedupedFetch(key, run)` after the first resolved re-invokes `run` (previously it would not). The existing test that concurrent calls share a single `run` still passes, confirming in-flight deduping is preserved; the existing failure-retry test is unchanged.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors / 0 warnings
- [x] `npx vitest run src/tests/lib/engine/reference-data.test.ts` — 18 passed

Closes #446

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbaPg6pxELhjJPFHBUKFDV)_