### PR TITLE
Fix enemy authoring workbench issues (#426)

### DIFF
--- a/UI/src/routes/admin/workbench/components/ChipsSection.svelte
+++ b/UI/src/routes/admin/workbench/components/ChipsSection.svelte
@@ -26,7 +26,18 @@
 
 	{#if available.length > 0}
 		<div class="fld add-select">
-			<select class="sel" value="" onchange={(e) => add(+e.currentTarget.value)}>
+			<select
+				class="sel"
+				value=""
+				onchange={(e) => {
+					const { value } = e.currentTarget;
+					// The placeholder's empty value coerces to 0 — the same as the zero-based id of
+					// the first catalogue entry — so guard on the raw string before adding.
+					if (value !== '') {
+						add(+value);
+					}
+				}}
+			>
 				<option value="">＋ {section.addLabel}</option>
 				{#each available as entry (entry.id)}
 					<option value={entry.id}>{section.labelOf(entry)} · {section.metaOf(entry)}</option>
@@ -62,7 +73,8 @@ const catalogue = $derived(section.catalogue());
 const available = $derived(catalogue.filter((c) => !ids.includes(c.id) && !c.retired));
 
 const add = (id: number) => {
-	if (id && !ids.includes(id)) {
+	// No truthiness guard on `id`: ids are zero-based, so id 0 is a valid first entry.
+	if (!ids.includes(id)) {
 		store.patch(record.id, (draft) => {
 			(fieldsOf(draft)[itemsKey] as number[]).push(id);
 		});

--- a/UI/src/routes/admin/workbench/entities/enemy.ts
+++ b/UI/src/routes/admin/workbench/entities/enemy.ts
@@ -5,20 +5,41 @@ import { childChanged, persistEntity } from '../save-helpers';
 import { firstFree } from './helpers';
 import type { EntityConfig } from './types';
 
-const refresh = async (): Promise<IEnemy[]> => {
-	const enemies = await fetchSocketData('GetEnemies');
+/** An enemy plus the zones it is the dedicated boss of, derived from the zones' boss FK. */
+export interface WorkbenchEnemy extends IEnemy {
+	/**
+	 * Zone ids this enemy is the dedicated boss of (derived from each zone's `bossEnemyId`).
+	 * Read-only here — the assignment is authored on the zone side; this is the inverse view.
+	 */
+	bossZones: number[];
+}
+
+const refresh = async (): Promise<WorkbenchEnemy[]> => {
+	const [enemies, zones] = await Promise.all([fetchSocketData('GetEnemies'), fetchSocketData('GetZones')]);
 	staticData.enemies = enemies;
-	return enemies;
+	staticData.zones = zones;
+	return enemies.map((enemy) => ({
+		...enemy,
+		bossZones: zones.flatMap((zone) => (zone.bossEnemyId === enemy.id ? [zone.id] : []))
+	}));
 };
 
-export const enemyEntity: EntityConfig<IEnemy> = {
+export const enemyEntity: EntityConfig<WorkbenchEnemy> = {
 	key: 'enemies',
 	label: 'Enemies',
 	singular: 'Enemy',
 	glyph: 'skull',
 	blankName: 'Unnamed enemy',
 	retireable: true,
-	newItem: (id) => ({ id, name: '', isBoss: false, attributeDistribution: [], skillPool: [], spawns: [] }),
+	newItem: (id) => ({
+		id,
+		name: '',
+		isBoss: false,
+		attributeDistribution: [],
+		skillPool: [],
+		spawns: [],
+		bossZones: []
+	}),
 	listBadge: (e) => (e.isBoss ? 'Boss' : null),
 	badgeColor: () => 'var(--enemy-accent)',
 	meta: (e) => [
@@ -26,6 +47,15 @@ export const enemyEntity: EntityConfig<IEnemy> = {
 		['skill', e.skillPool.length],
 		['zone', e.spawns.length]
 	],
+	// Surface the dedicated-boss assignment (the inverse of the zone's boss FK) so it's
+	// visible here too; blank for an enemy that isn't any zone's dedicated boss.
+	headline: (e) => {
+		if (!e.bossZones.length) {
+			return '';
+		}
+		const names = e.bossZones.map((id) => staticData.zones?.[id]?.name ?? `#${id}`).join(', ');
+		return `Dedicated boss of ${names}`;
+	},
 	sections: [
 		{
 			key: 'identity',
@@ -103,7 +133,9 @@ export const enemyEntity: EntityConfig<IEnemy> = {
 			glyph: 'pin',
 			desc: 'Zones this enemy appears in',
 			count: (e) => e.spawns.length,
-			warn: (e) => (e.spawns.length ? null : 'Not assigned to any zone'),
+			// A boss appears in the world via a zone's dedicated-boss FK, not its random spawn
+			// table, so an assigned boss with no random spawns is valid — only warn when neither holds.
+			warn: (e) => (e.spawns.length || e.bossZones.length ? null : 'Not assigned to any zone'),
 			kind: 'table',
 			itemsKey: 'spawns',
 			addLabel: 'Assign zone',
@@ -135,7 +167,16 @@ export const enemyEntity: EntityConfig<IEnemy> = {
 	persist: (diff) =>
 		persistEntity({
 			diff,
-			toPrimaryDto: (e) => ({ ...e, attributeDistribution: [], skillPool: [], spawns: [] }),
+			// Strip the child collections and the derived (read-only) bossZones off the identity DTO.
+			toPrimaryDto: ({ id, name, isBoss, retiredAt }) => ({
+				id,
+				name,
+				isBoss,
+				attributeDistribution: [],
+				skillPool: [],
+				spawns: [],
+				retiredAt
+			}),
 			postPrimary: (changes) => ApiRequest.post('AdminTools/AddEditEnemies', changes),
 			refresh,
 			childSavers: [

--- a/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
@@ -97,6 +97,34 @@ describe('ChipsSection', () => {
 		expect(store.items[0].skillPool).toEqual([1, 2]);
 	});
 
+	it('adds the zero-id (first) catalogue entry — id 0 is a real selection, not "no choice"', async () => {
+		// Ids are zero-based, so the first catalogue entry is id 0; a truthiness guard would drop it.
+		const zeroSection: ChipsSectionConfig<Identified> = {
+			...(section as unknown as ChipsSectionConfig<Identified>),
+			catalogue: () => [{ id: 0, name: 'Strike', baseDamage: 5 }, ...CATALOGUE]
+		};
+		const store = new EntityStore(config(), [{ id: 1, skillPool: [] }]);
+		const { container } = render(ChipsSection, {
+			props: {
+				section: zeroSection,
+				record: store.items[0] as Identified,
+				baseline: store.baselineOf(1),
+				store: store as unknown as EntityStore<Identified>
+			}
+		});
+		const addSelect = container.querySelector('.add-select select') as HTMLSelectElement;
+		await fireEvent.change(addSelect, { target: { value: '0' } });
+		expect(store.items[0].skillPool).toEqual([0]);
+	});
+
+	it('ignores the empty placeholder selection (does not add id 0)', async () => {
+		const { store, record, baseline } = setup([1]);
+		const { container } = renderChips(store, record, baseline);
+		const addSelect = container.querySelector('.add-select select') as HTMLSelectElement;
+		await fireEvent.change(addSelect, { target: { value: '' } });
+		expect(store.items[0].skillPool).toEqual([1]);
+	});
+
 	it('removes a chip when its remove control is activated', async () => {
 		const { store, record, baseline } = setup([1, 2]);
 		const { container } = renderChips(store, record, baseline);

--- a/UI/src/tests/routes/admin/workbench/entities/enemy.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/enemy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { EChangeType, type IEnemy } from '$lib/api';
+import { EChangeType } from '$lib/api';
 import type { TableSectionConfig } from '$routes/admin/workbench/entities/types';
 
 /* Enemy config transforms: `newItem` defaults, the boss list badge, and the
@@ -8,13 +8,22 @@ import type { TableSectionConfig } from '$routes/admin/workbench/entities/types'
    are stubbed; the real `persistEntity` orchestration runs unmocked. */
 
 const { staticData, socket, mockPost, mockFetch } = vi.hoisted(() => {
-	const socket = { enemies: [] as unknown[] };
+	const socket = { enemies: [] as unknown[], zones: [] as unknown[] };
 	return {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		staticData: {} as any,
 		socket,
 		mockPost: vi.fn(),
-		mockFetch: vi.fn(async (command: string) => (command === 'GetEnemies' ? socket.enemies : []))
+		mockFetch: vi.fn(async (command: string) => {
+			switch (command) {
+				case 'GetEnemies':
+					return socket.enemies;
+				case 'GetZones':
+					return socket.zones;
+				default:
+					return [];
+			}
+		})
 	};
 });
 
@@ -28,31 +37,37 @@ vi.mock('$lib/api', async (importOriginal) => {
 	return { ...actual, ApiRequest, fetchSocketData: mockFetch };
 });
 
-import { enemyEntity } from '$routes/admin/workbench/entities/enemy';
+import { enemyEntity, type WorkbenchEnemy } from '$routes/admin/workbench/entities/enemy';
 
 /** Finds the body posted to a given AdminTools endpoint (or undefined if never called). */
 const postBodyTo = (endpoint: string) => mockPost.mock.calls.find((c) => c[0] === endpoint)?.[1];
 
 /** A table section's config by key (for exercising its `newRow` factory). */
-const tableSection = (key: string) => enemyEntity.sections.find((s) => s.key === key) as TableSectionConfig<IEnemy>;
+const tableSection = (key: string) =>
+	enemyEntity.sections.find((s) => s.key === key) as TableSectionConfig<WorkbenchEnemy>;
+
+/** The spawns section, used to exercise its boss-aware `warn` predicate. */
+const spawnsWarn = () => enemyEntity.sections.find((s) => s.key === 'spawns')?.warn;
 
 beforeEach(() => {
 	mockPost.mockReset().mockResolvedValue(undefined);
 	mockFetch.mockClear();
 	socket.enemies = [];
+	socket.zones = [];
 	for (const key of Object.keys(staticData)) {
 		delete staticData[key];
 	}
 });
 
 describe('enemyEntity', () => {
-	const baseline: IEnemy = {
+	const baseline: WorkbenchEnemy = {
 		id: 0,
 		name: 'Bat',
 		isBoss: false,
 		attributeDistribution: [{ attributeId: 0, baseAmount: 1, amountPerLevel: 0 }],
 		skillPool: [1],
-		spawns: [{ zoneId: 0, weight: 5 }]
+		spawns: [{ zoneId: 0, weight: 5 }],
+		bossZones: []
 	};
 
 	it('newItem starts with empty child collections', () => {
@@ -62,7 +77,8 @@ describe('enemyEntity', () => {
 			isBoss: false,
 			attributeDistribution: [],
 			skillPool: [],
-			spawns: []
+			spawns: [],
+			bossZones: []
 		});
 	});
 
@@ -84,7 +100,7 @@ describe('enemyEntity', () => {
 	});
 
 	it('persist saves the attribute distribution and spawns when they change', async () => {
-		const record: IEnemy = {
+		const record: WorkbenchEnemy = {
 			...baseline,
 			attributeDistribution: [{ attributeId: 0, baseAmount: 2, amountPerLevel: 1 }], // changed
 			spawns: [{ zoneId: 0, weight: 9 }] // changed
@@ -103,7 +119,7 @@ describe('enemyEntity', () => {
 	});
 
 	it('persist strips the child collections off the identity DTO and saves only the changed child', async () => {
-		const record: IEnemy = { ...baseline, name: 'Cave Bat', skillPool: [1, 2] }; // identity + skills changed
+		const record: WorkbenchEnemy = { ...baseline, name: 'Cave Bat', skillPool: [1, 2] }; // identity + skills changed
 		socket.enemies = [record];
 
 		await enemyEntity.persist({ added: [], modified: [{ record, baseline }], deleted: [], existingIds: [0] });
@@ -126,13 +142,14 @@ describe('enemyEntity', () => {
 	it('persist Adds a new enemy and saves its children against the resolved id', async () => {
 		// A freshly-added record carries a temporary negative id; after the identity Add the
 		// backend appends it at a real id, which persistEntity resolves before the child savers run.
-		const added: IEnemy = {
+		const added: WorkbenchEnemy = {
 			id: -1,
 			name: 'New Enemy',
 			isBoss: true,
 			attributeDistribution: [{ attributeId: 0, baseAmount: 3, amountPerLevel: 1 }],
 			skillPool: [2],
-			spawns: [{ zoneId: 1, weight: 8 }]
+			spawns: [{ zoneId: 1, weight: 8 }],
+			bossZones: []
 		};
 		socket.enemies = [{ ...added, id: 7 }]; // the persisted record at its real id
 
@@ -158,10 +175,53 @@ describe('enemyEntity', () => {
 		expect(postBodyTo('AdminTools/SetEnemySpawns')).toEqual({ enemyId: 7, spawns: [{ zoneId: 1, weight: 8 }] });
 	});
 
+	it('refresh derives bossZones from the zones whose dedicated boss is this enemy', async () => {
+		socket.enemies = [
+			{ id: 0, name: 'Bat', isBoss: false, attributeDistribution: [], skillPool: [], spawns: [] },
+			{ id: 7, name: 'Warden', isBoss: true, attributeDistribution: [], skillPool: [], spawns: [] }
+		];
+		socket.zones = [
+			{ id: 0, name: 'Hollow', description: '', order: 0, levelMin: 1, levelMax: 5, bossLevel: 1 },
+			{ id: 1, name: 'Cavern', description: '', order: 1, levelMin: 5, levelMax: 10, bossEnemyId: 7, bossLevel: 3 },
+			{ id: 2, name: 'Grotto', description: '', order: 2, levelMin: 8, levelMax: 12, bossEnemyId: 7, bossLevel: 4 }
+		];
+
+		const rows = await enemyEntity.refresh();
+
+		// The standard enemy is no zone's dedicated boss; the boss is assigned to two zones.
+		expect(rows[0].bossZones).toEqual([]);
+		expect(rows[1].bossZones).toEqual([1, 2]);
+		// The raw catalogues are cached for the rest of the workbench.
+		expect(staticData.enemies).toBe(socket.enemies);
+		expect(staticData.zones).toBe(socket.zones);
+	});
+
+	it('headline names the zones this enemy is the dedicated boss of, or is blank otherwise', () => {
+		// Zones are indexed by id (Id-as-index), so the names resolve from their slots.
+		const zones: unknown[] = [];
+		zones[1] = { id: 1, name: 'Cavern' };
+		zones[2] = { id: 2, name: 'Grotto' };
+		staticData.zones = zones;
+		expect(enemyEntity.headline?.({ ...baseline, isBoss: true, bossZones: [1, 2] })).toBe(
+			'Dedicated boss of Cavern, Grotto'
+		);
+		expect(enemyEntity.headline?.(baseline)).toBe('');
+	});
+
+	it('spawns warn clears for a boss assigned to a zone but still flags an unassigned enemy', () => {
+		const warn = spawnsWarn();
+		// A dedicated boss with no random spawns is valid — it appears via the zone's boss FK.
+		expect(warn?.({ ...baseline, isBoss: true, spawns: [], bossZones: [1] })).toBeNull();
+		// A random spawn alone is still valid.
+		expect(warn?.({ ...baseline, spawns: [{ zoneId: 0, weight: 5 }], bossZones: [] })).toBeNull();
+		// Neither a spawn nor a boss assignment → it never appears, so warn.
+		expect(warn?.({ ...baseline, spawns: [], bossZones: [] })).toBe('Not assigned to any zone');
+	});
+
 	describe('newRow factories', () => {
 		it('attribute newRow picks the first free attribute and zeroes the amounts', () => {
 			// Strength (id 0) is already taken, so the first free attribute (id 1) is chosen.
-			const enemy: IEnemy = {
+			const enemy: WorkbenchEnemy = {
 				...baseline,
 				attributeDistribution: [{ attributeId: 0, baseAmount: 1, amountPerLevel: 0 }]
 			};
@@ -174,7 +234,7 @@ describe('enemyEntity', () => {
 				{ id: 1, name: 'Frost Cavern', levelMin: 6, levelMax: 10 }
 			];
 			// Zone 0 is already assigned, so zone 1 is the first free option.
-			const enemy: IEnemy = { ...baseline, spawns: [{ zoneId: 0, weight: 5 }] };
+			const enemy: WorkbenchEnemy = { ...baseline, spawns: [{ zoneId: 0, weight: 5 }] };
 			expect(tableSection('spawns').newRow(enemy)).toEqual({ zoneId: 1, weight: 5 });
 		});
 	});


### PR DESCRIPTION
## Summary

Fixes the three enemy-authoring inconsistencies reported in #426, all in the admin Workbench UI:

1. **Boss spawns showed as invalid even when the boss was assigned to a zone.** A boss "appears" in a zone through the zone's dedicated-boss FK (`zone.bossEnemyId`), not its random spawn table — but the Spawns section only checked `spawns.length`, so a dedicated boss with no random spawns was wrongly flagged "Not assigned to any zone".

2. **The dedicated-boss assignment didn't appear anywhere in the enemy workbench.** The zone workbench shows its boss (and derives its spawn table from the enemies), but there was no inverse view on the enemy side.

3. **Adding the *first* skill did nothing.** Skill ids are zero-based, and `ChipsSection.add` guarded with `if (id && …)`, so id `0` (the literal first skill) was silently rejected. The placeholder option (`value=""`) also coerces to `0`, conflating "no selection" with "skill 0".

## How it's addressed

- **Derive `bossZones` on the enemy record** (`entities/enemy.ts`): `refresh` now also fetches `GetZones` and maps each enemy to the zone ids whose `bossEnemyId` is that enemy — the same inverse-derivation pattern the zone entity already uses for `zoneEnemies`. It's read-only here (the assignment is authored on the zone side) and is stripped off the identity DTO on save.
- **Spawns warning is boss-aware**: it now clears when the enemy appears via a random spawn **or** a dedicated-boss assignment, and only warns when neither holds.
- **Headline on the enemy detail**: surfaces `Dedicated boss of …` (the mirror of the zone's `Boss: …` headline), blank for enemies that aren't any zone's boss.
- **`ChipsSection` first-skill fix**: dropped the `id &&` truthiness guard (id 0 is a valid selection) and guard the empty placeholder string in the `onchange` so re-selecting the placeholder can't accidentally add skill 0.

## Test plan

- [x] `entities/enemy.test.ts`: `newItem` seeds `bossZones`; `refresh` derives `bossZones` from the zones' boss FK; the headline names the boss zones (blank otherwise); the Spawns `warn` clears for an assigned boss but still flags a truly-unassigned enemy. Persist tests updated to the `WorkbenchEnemy` shape.
- [x] `ChipsSection.test.ts`: adding the zero-id (first) entry works; the empty placeholder selection is ignored (doesn't add id 0).
- [x] `npm run lint` (eslint + svelte-check) clean.
- [x] `npm run test:unit:ci` — 1556 tests pass.

Backend is unchanged: the existing zone boss validation (`bossEnemyId` must reference an `isBoss` enemy) is correct; the "invalid" in the issue was the frontend validation triangle.

Closes #426


---
_Generated by [Claude Code](https://claude.ai/code/session_01NA2dstVJA1JPRMn28UMX7w)_