### PR TITLE
Reusable challenge tooltip + accurate locked-zone hint (#429)

### DIFF
--- a/UI/.gitignore
+++ b/UI/.gitignore
@@ -4,6 +4,9 @@ node_modules
 .output
 .vercel
 /.svelte-kit
+# Vitest runs with `src` as its Vite root, so SvelteKit syncs a second, generated
+# .svelte-kit there during unit tests; it is build output and must not be committed.
+/src/.svelte-kit
 /build
 
 # OS

--- a/UI/.gitignore
+++ b/UI/.gitignore
@@ -4,9 +4,6 @@ node_modules
 .output
 .vercel
 /.svelte-kit
-# Vitest runs with `src` as its Vite root, so SvelteKit syncs a second, generated
-# .svelte-kit there during unit tests; it is build output and must not be committed.
-/src/.svelte-kit
 /build
 
 # OS

--- a/UI/src/components/index.ts
+++ b/UI/src/components/index.ts
@@ -1,8 +1,8 @@
+export { default as ChallengeTooltip } from './tooltip/ChallengeTooltip.svelte';
 export { default as DiamondMark } from './DiamondMark.svelte';
 export { default as Loading } from './Loading.svelte';
 export { default as Modal } from './Modal.svelte';
 export { default as ModalHost } from './ModalHost.svelte';
-export { default as ChallengeTooltip } from './tooltip/ChallengeTooltip.svelte';
 export { default as StatusGlyph } from './StatusGlyph.svelte';
 export { default as Toast } from './Toast.svelte';
 export { default as ToastContainer } from './ToastContainer.svelte';

--- a/UI/src/components/index.ts
+++ b/UI/src/components/index.ts
@@ -2,6 +2,7 @@ export { default as DiamondMark } from './DiamondMark.svelte';
 export { default as Loading } from './Loading.svelte';
 export { default as Modal } from './Modal.svelte';
 export { default as ModalHost } from './ModalHost.svelte';
+export { default as ChallengeTooltip } from './tooltip/ChallengeTooltip.svelte';
 export { default as StatusGlyph } from './StatusGlyph.svelte';
 export { default as Toast } from './Toast.svelte';
 export { default as ToastContainer } from './ToastContainer.svelte';

--- a/UI/src/components/tooltip/ChallengeTooltip.svelte
+++ b/UI/src/components/tooltip/ChallengeTooltip.svelte
@@ -30,8 +30,7 @@
 </TooltipShell>
 
 <script lang="ts">
-import { EChallengeType } from '$lib/api';
-import { challengeTypeColor, normalizeText, resolveUnlockReward, tintColor, zonesUnlockedBy } from '$lib/common';
+import { challengeTypeColor, challengeTypeName, resolveUnlockReward, tintColor, zonesUnlockedBy } from '$lib/common';
 import { playerChallenges, staticData } from '$stores';
 import TooltipSection from '$components/tooltip/TooltipSection.svelte';
 import TooltipShell from '$components/tooltip/TooltipShell.svelte';
@@ -53,12 +52,7 @@ let container = $state<HTMLDivElement>();
 const challenge = $derived(challengeId != null ? staticData.challenges?.[challengeId] : undefined);
 const completed = $derived(challenge != null && playerChallenges.isChallengeCompleted(challenge.id));
 const accent = $derived(challenge ? challengeTypeColor(challenge.challengeTypeId) : 'var(--accent)');
-const typeName = $derived(
-	challenge
-		? (staticData.challengeTypes?.find((t) => t.id === challenge.challengeTypeId)?.name ??
-				normalizeText(EChallengeType[challenge.challengeTypeId] ?? ''))
-		: ''
-);
+const typeName = $derived(challenge ? challengeTypeName(challenge.challengeTypeId, staticData.challengeTypes) : '');
 const unlockedZones = $derived(challenge ? zonesUnlockedBy(challenge.id, staticData.zones ?? []) : []);
 const reward = $derived(
 	challenge

--- a/UI/src/components/tooltip/ChallengeTooltip.svelte
+++ b/UI/src/components/tooltip/ChallengeTooltip.svelte
@@ -1,0 +1,115 @@
+<TooltipShell {accent} hidden={!challenge} bind:base={container}>
+	{#snippet header()}
+		<TooltipTitle label={typeName} name={challenge?.name ?? ''} diamondColor={accent} labelColor={accent} />
+	{/snippet}
+
+	{#if challenge?.description}
+		<TooltipSection label="Requirement" last={!hasUnlocks}>
+			<p class="ct-desc">{challenge.description}</p>
+		</TooltipSection>
+	{/if}
+
+	{#if hasUnlocks}
+		<TooltipSection label="Unlocks" last>
+			{#each unlockedZones as zone (zone.id)}
+				<div class="ct-row">
+					<span class="ct-kind" style:color={tintColor(accent, 0.85)}>Zone</span>
+					<span class="ct-name">{zone.name}</span>
+				</div>
+			{/each}
+			{#if reward}
+				<div class="ct-row">
+					<span class="ct-kind" style:color={tintColor(reward.accent, 0.85)}>{reward.sub}</span>
+					<span class="ct-name" class:sealed={!completed} style:color={reward.accent}>
+						{completed ? reward.name : '???'}
+					</span>
+				</div>
+			{/if}
+		</TooltipSection>
+	{/if}
+</TooltipShell>
+
+<script lang="ts">
+import { EChallengeType } from '$lib/api';
+import { challengeTypeColor, normalizeText, resolveUnlockReward, tintColor, zonesUnlockedBy } from '$lib/common';
+import { playerChallenges, staticData } from '$stores';
+import TooltipSection from '$components/tooltip/TooltipSection.svelte';
+import TooltipShell from '$components/tooltip/TooltipShell.svelte';
+import TooltipTitle from '$components/tooltip/TooltipTitle.svelte';
+
+export const getBaseNode = () => container;
+
+interface Props {
+	/** The challenge whose requirement + unlocks to show, or undefined for the empty/hidden panel. */
+	challengeId: number | undefined;
+}
+
+const { challengeId }: Props = $props();
+
+// Bound to the shell's root element and relocated into the global tooltip container by
+// getBaseNode(); reactive so the relocation runs once the shell has mounted.
+let container = $state<HTMLDivElement>();
+
+const challenge = $derived(challengeId != null ? staticData.challenges?.[challengeId] : undefined);
+const completed = $derived(challenge != null && playerChallenges.isChallengeCompleted(challenge.id));
+const accent = $derived(challenge ? challengeTypeColor(challenge.challengeTypeId) : 'var(--accent)');
+const typeName = $derived(
+	challenge
+		? (staticData.challengeTypes?.find((t) => t.id === challenge.challengeTypeId)?.name ??
+				normalizeText(EChallengeType[challenge.challengeTypeId] ?? ''))
+		: ''
+);
+const unlockedZones = $derived(challenge ? zonesUnlockedBy(challenge.id, staticData.zones ?? []) : []);
+const reward = $derived(
+	challenge
+		? resolveUnlockReward(challenge, {
+				items: staticData.items,
+				itemMods: staticData.itemMods,
+				skills: staticData.skills
+			})
+		: null
+);
+const hasUnlocks = $derived(unlockedZones.length > 0 || reward != null);
+</script>
+
+<style lang="scss">
+.ct-desc {
+	margin: 0;
+	font-size: 12px;
+	line-height: 1.5;
+	color: var(--text-tertiary);
+}
+
+.ct-row {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+
+	& + & {
+		margin-top: 6px;
+	}
+}
+
+.ct-kind {
+	font-family: var(--mono);
+	font-size: 8px;
+	letter-spacing: 1.6px;
+	text-transform: uppercase;
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
+.ct-name {
+	font-size: 13px;
+	color: var(--text-primary);
+	letter-spacing: -0.1px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+
+	&.sealed {
+		letter-spacing: 1px;
+		color: color-mix(in srgb, var(--text-primary) 45%, transparent);
+	}
+}
+</style>

--- a/UI/src/lib/common/challenge-type.ts
+++ b/UI/src/lib/common/challenge-type.ts
@@ -1,5 +1,5 @@
-import { EChallengeType } from '$lib/api';
-import { tintColor } from './functions';
+import { EChallengeType, type IChallengeType } from '$lib/api';
+import { normalizeText, tintColor } from './functions';
 
 /*
  * Single source of truth for challenge-type accent visuals. The hues are
@@ -30,3 +30,12 @@ export const challengeTypeColor = (id: EChallengeType): string =>
 /** The challenge-type accent at a given opacity (themeable via `color-mix`). */
 export const challengeTypeTint = (id: EChallengeType, alpha: number): string =>
 	tintColor(challengeTypeColor(id), alpha);
+
+/**
+ * The challenge type's display name — the authored name from the `ChallengeTypes` reference set
+ * when available, falling back to the normalized enum name. The reference set is passed in (rather
+ * than read from `$stores`) so this module stays free of a store dependency, mirroring the other
+ * param-based `$lib/common` helpers.
+ */
+export const challengeTypeName = (id: EChallengeType, challengeTypes?: IChallengeType[]): string =>
+	challengeTypes?.find((t) => t.id === id)?.name ?? normalizeText(EChallengeType[id] ?? '');

--- a/UI/src/lib/common/challenge-unlocks.ts
+++ b/UI/src/lib/common/challenge-unlocks.ts
@@ -1,0 +1,81 @@
+import type { IChallenge, IItem, IItemMod, ISkill, IZone } from '$lib/api';
+import { itemCategoryName, modTypeLabel } from './item-display';
+import { rarityColor, rarityLabel } from './rarity';
+
+/* What completing a challenge grants. A challenge can unlock zones (those gated on it via
+   `unlockChallengeId`) and award a single reward (an item, a mod, or a skill). These pure helpers
+   resolve that "what does this unlock" view from the reference data so it can be surfaced wherever
+   a challenge appears — the locked-zone tooltip, the challenges screen, etc. — without each call
+   site re-deriving the relationship. */
+
+export type UnlockRewardKind = 'item' | 'mod' | 'skill';
+
+export interface UnlockReward {
+	kind: UnlockRewardKind;
+	/** The reward's real name. Callers mask it themselves (e.g. `???`) while the challenge is sealed. */
+	name: string;
+	/** Themeable accent: the rarity hue for items/mods, a neutral skill accent for skills. */
+	accent: string;
+	/** Teaser sub-label, e.g. `Rare · Helm`, `Epic · Prefix`, or `Skill`. */
+	sub: string;
+}
+
+/** The zero-based-id reference pools the reward resolver reads (any may be undefined before load). */
+export interface RewardRefs {
+	items?: (IItem | undefined)[];
+	itemMods?: (IItemMod | undefined)[];
+	skills?: (ISkill | undefined)[];
+}
+
+/**
+ * Zones whose unlock gate is this challenge — i.e. completing it unlocks them. Returned in authored
+ * order, with retired zones excluded (a retired zone is out of circulation, so it is not advertised
+ * as a reward). The gate is the reverse of the zone→challenge relationship (`zone.unlockChallengeId`).
+ */
+export function zonesUnlockedBy(challengeId: number, zones: (IZone | undefined)[]): IZone[] {
+	return zones
+		.filter((z): z is IZone => z != null && z.unlockChallengeId === challengeId && z.retiredAt == null)
+		.sort((a, b) => a.order - b.order);
+}
+
+/**
+ * Resolve a challenge's single reward (item, mod, or skill) from the reference pools. Item > mod >
+ * skill precedence mirrors the challenges-screen reward resolution. Returns null when the challenge
+ * grants no reward (or the referenced record is missing/unloaded).
+ */
+export function resolveUnlockReward(challenge: IChallenge, refs: RewardRefs): UnlockReward | null {
+	if (challenge.rewardItemId != null) {
+		const item = refs.items?.[challenge.rewardItemId];
+		if (item) {
+			return {
+				kind: 'item',
+				name: item.name,
+				accent: rarityColor(item.rarityId),
+				sub: `${rarityLabel(item.rarityId)} · ${itemCategoryName(item.itemCategoryId)}`
+			};
+		}
+	}
+	if (challenge.rewardItemModId != null) {
+		const mod = refs.itemMods?.[challenge.rewardItemModId];
+		if (mod) {
+			return {
+				kind: 'mod',
+				name: mod.name,
+				accent: rarityColor(mod.rarityId),
+				sub: `${rarityLabel(mod.rarityId)} · ${modTypeLabel(mod.itemModTypeId)}`
+			};
+		}
+	}
+	if (challenge.rewardSkillId != null) {
+		const skill = refs.skills?.[challenge.rewardSkillId];
+		if (skill) {
+			return {
+				kind: 'skill',
+				name: skill.name,
+				accent: 'var(--accent-light)',
+				sub: 'Skill'
+			};
+		}
+	}
+	return null;
+}

--- a/UI/src/lib/common/index.ts
+++ b/UI/src/lib/common/index.ts
@@ -1,6 +1,7 @@
 export * from './functions';
 export * from './rarity';
 export * from './challenge-type';
+export * from './challenge-unlocks';
 export * from './zone-progression';
 export * from './attribute-display';
 export * from './skill-effect-display';

--- a/UI/src/routes/game/screens/challenges/ChallengeDetailCard.svelte
+++ b/UI/src/routes/game/screens/challenges/ChallengeDetailCard.svelte
@@ -24,6 +24,18 @@
 	</div>
 	<ProgressReadout {c} />
 	<RewardAffordance reward={c.reward} variant="tile" />
+	{#if c.unlocksZones.length > 0}
+		<div class="card-unlocks">
+			<span class="unlocks-label">Unlocks</span>
+			{#each c.unlocksZones as zoneName (zoneName)}
+				<span
+					class="unlocks-zone"
+					style:color={tintColor(c.typeAccent, 0.85)}
+					style:border="1px solid {tintColor(c.typeAccent, 0.3)}">Zone · {zoneName}</span
+				>
+			{/each}
+		</div>
+	{/if}
 </div>
 
 <script lang="ts">
@@ -95,5 +107,28 @@ const completedAtDisplay = $derived(
 	color: var(--text-tertiary);
 	margin-top: 6px;
 	line-height: 1.5;
+}
+
+.card-unlocks {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 7px;
+}
+
+.unlocks-label {
+	font-family: var(--mono);
+	font-size: 8.5px;
+	letter-spacing: 1.6px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+}
+
+.unlocks-zone {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 0.5px;
+	border-radius: 2px;
+	padding: 1px 6px;
 }
 </style>

--- a/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
+++ b/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
@@ -10,9 +10,9 @@ import {
 import { BattleAttributes, type Item } from '$lib/battle';
 import {
 	challengeTypeColor,
+	challengeTypeName,
 	itemCategoryName,
 	modTypeLabel,
-	normalizeText,
 	rarityColor,
 	rarityGlow,
 	rarityLabel,
@@ -93,10 +93,6 @@ export interface TypeGroup {
 /** Goal-comparison direction is intrinsic to the type; sourced from reference data. */
 function comparisonFor(typeId: EChallengeType): EChallengeGoalComparison {
 	return staticData.challengeTypes?.find((t) => t.id === typeId)?.goalComparison ?? EChallengeGoalComparison.AtLeast;
-}
-
-function typeNameFor(typeId: EChallengeType): string {
-	return staticData.challengeTypes?.find((t) => t.id === typeId)?.name ?? normalizeText(EChallengeType[typeId] ?? '');
 }
 
 /** Resolve a scoped challenge's target entity name from the relevant reference pool. */
@@ -216,7 +212,7 @@ const CHALLENGE_TYPE_IDS = Object.values(EChallengeType).filter((v): v is EChall
 export function groupByType(list: ChallengeVM[]): TypeGroup[] {
 	return CHALLENGE_TYPE_IDS.map((typeId) => ({
 		typeId,
-		label: typeNameFor(typeId),
+		label: challengeTypeName(typeId, staticData.challengeTypes),
 		accent: challengeTypeColor(typeId),
 		items: list.filter((c) => c.typeId === typeId)
 	})).filter((g) => g.items.length > 0);

--- a/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
+++ b/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
@@ -16,7 +16,8 @@ import {
 	rarityColor,
 	rarityGlow,
 	rarityLabel,
-	rarityLevel
+	rarityLevel,
+	zonesUnlockedBy
 } from '$lib/common';
 import { staticData } from '$stores';
 import { challengeTypeUnit } from './challenge-meta';
@@ -77,6 +78,8 @@ export interface ChallengeVM {
 	/** Target entity name for scoped challenges ("Goblin", "Frostspire"), else null. */
 	target: string | null;
 	reward: ResolvedReward | null;
+	/** Names of zones this challenge unlocks (gated on it via `unlockChallengeId`), in authored order. */
+	unlocksZones: string[];
 }
 
 export interface TypeGroup {
@@ -202,7 +205,8 @@ export function buildChallengeVM(ch: IChallenge, player?: IPlayerChallenge): Cha
 		typeAccent: challengeTypeColor(ch.challengeTypeId),
 		target: targetName(ch),
 		// A reward is only revealed (and inspectable) once its challenge completes.
-		reward: resolveReward(ch, completed)
+		reward: resolveReward(ch, completed),
+		unlocksZones: zonesUnlockedBy(ch.id, staticData.zones ?? []).map((z) => z.name)
 	};
 }
 

--- a/UI/src/routes/game/screens/fight/ZoneNav.svelte
+++ b/UI/src/routes/game/screens/fight/ZoneNav.svelte
@@ -1,38 +1,74 @@
 <div class="zone-nav" data-testid="zone-nav">
-	<button
-		class="zone-btn"
-		class:locked={leftLocked}
-		disabled={leftDisabled}
-		aria-label={leftLocked ? 'Previous zone locked' : 'Previous zone'}
-		title={leftLocked ? LOCK_HINT : undefined}
-		onclick={handleClickLeft}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<span
+		class="zone-btn-wrap"
+		onmouseenter={(e) => showLock(leftLocked, prevZone?.unlockChallengeId, e)}
+		onmousemove={moveLock}
+		onmouseleave={hideLock}
 	>
-		{#if leftLocked}<LockGlyph />{:else}&#8249;{/if}
-	</button>
+		<button
+			class="zone-btn"
+			class:locked={leftLocked}
+			disabled={leftDisabled}
+			aria-label={leftLocked ? 'Previous zone locked' : 'Previous zone'}
+			onclick={handleClickLeft}
+		>
+			{#if leftLocked}<LockGlyph />{:else}&#8249;{/if}
+		</button>
+	</span>
 	<div class="zone-info">
 		<span class="zone-num">Zone · {String(zoneNum).padStart(2, '0')}</span>
 		<span class="zone-name">{current?.name}</span>
 	</div>
-	<button
-		class="zone-btn"
-		class:locked={rightLocked}
-		disabled={rightDisabled}
-		aria-label={rightLocked ? 'Next zone locked' : 'Next zone'}
-		title={rightLocked ? LOCK_HINT : undefined}
-		onclick={handleClickRight}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<span
+		class="zone-btn-wrap"
+		onmouseenter={(e) => showLock(rightLocked, nextZone?.unlockChallengeId, e)}
+		onmousemove={moveLock}
+		onmouseleave={hideLock}
 	>
-		{#if rightLocked}<LockGlyph />{:else}&#8250;{/if}
-	</button>
+		<button
+			class="zone-btn"
+			class:locked={rightLocked}
+			disabled={rightDisabled}
+			aria-label={rightLocked ? 'Next zone locked' : 'Next zone'}
+			onclick={handleClickRight}
+		>
+			{#if rightLocked}<LockGlyph />{:else}&#8250;{/if}
+		</button>
+	</span>
 </div>
+
+<ChallengeTooltip bind:this={tooltip} {challengeId} />
 
 <script lang="ts">
 import type { IZone } from '$lib/api';
-import { staticData, playerChallenges } from '$stores';
+import { staticData, playerChallenges, registerTooltipComponent, type TooltipComponent } from '$stores';
 import { playerManager } from '$lib/engine';
 import { isZoneUnlocked, zonesByOrder } from '$lib/common';
+import { ChallengeTooltip } from '$components';
 import LockGlyph from './LockGlyph.svelte';
 
-const LOCK_HINT = "Clear this zone's boss to unlock";
+// A locked zone is always gated on a challenge (an ungated zone is never locked), so the lock
+// affordance shows that gating challenge — what it requires and what completing it unlocks —
+// rather than a static hint that wrongly assumed every gate was the zone's boss.
+let tooltip = $state<TooltipComponent>();
+let challengeId = $state<number | undefined>();
+const { setTooltipPosition, showTooltip, hideTooltip } = registerTooltipComponent(() => tooltip);
+
+const showLock = (locked: boolean, gateChallengeId: number | undefined, ev: MouseEvent) => {
+	if (!locked) {
+		return;
+	}
+	challengeId = gateChallengeId;
+	setTooltipPosition({ x: ev.clientX, y: ev.clientY });
+	showTooltip();
+};
+const moveLock = (ev: MouseEvent) => setTooltipPosition({ x: ev.clientX, y: ev.clientY });
+const hideLock = () => {
+	hideTooltip();
+	challengeId = undefined;
+};
 
 const orderedZones = $derived(zonesByOrder(staticData.zones ?? []));
 const currentIndex = $derived(orderedZones.findIndex((z) => z.id === playerManager.currentZone));
@@ -73,6 +109,10 @@ const handleClickRight = () => goToZone(nextZone);
 	padding: 6px 10px 6px 6px;
 }
 
+.zone-btn-wrap {
+	display: inline-flex;
+}
+
 .zone-btn {
 	width: 24px;
 	height: 24px;
@@ -97,11 +137,13 @@ const handleClickRight = () => goToZone(nextZone);
 		cursor: not-allowed;
 	}
 
-	// A locked neighbour (boss not yet cleared) reads more clearly than a plain end-of-list disabled
-	// arrow, so the lock glyph stays legible.
+	// A locked neighbour (gating challenge not yet completed) reads more clearly than a plain
+	// end-of-list disabled arrow, so the lock glyph stays legible. Disabling the button suppresses
+	// its own pointer events, so the wrapping span receives the hover that drives the lock tooltip.
 	&.locked:disabled {
 		opacity: 0.6;
 		color: color-mix(in srgb, var(--text-primary) 65%, transparent);
+		pointer-events: none;
 	}
 }
 

--- a/UI/src/tests/components/tooltip/ChallengeTooltip.test.ts
+++ b/UI/src/tests/components/tooltip/ChallengeTooltip.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EChallengeType, EItemCategory, ERarity, type IChallenge, type IItem, type IZone } from '$lib/api';
+
+// The tooltip resolves the challenge, its gating-zone relationship and reward from the reference
+// store, and reads completion from the player-challenge store; both are mocked with small fixtures.
+const { staticData, playerChallenges } = vi.hoisted(() => ({
+	staticData: {
+		challenges: [] as IChallenge[],
+		challengeTypes: [] as { id: number; name: string }[],
+		zones: [] as IZone[],
+		items: [] as (IItem | undefined)[],
+		itemMods: [] as unknown[],
+		skills: [] as unknown[]
+	},
+	playerChallenges: { isChallengeCompleted: vi.fn(() => false) }
+}));
+
+vi.mock('$stores', () => ({ staticData, playerChallenges }));
+
+import ChallengeTooltip from '$components/tooltip/ChallengeTooltip.svelte';
+
+const zone = (id: number, order: number, name: string, unlockChallengeId?: number): IZone =>
+	({ id, name, description: '', order, levelMin: 1, levelMax: 10, bossLevel: 1, unlockChallengeId }) as IZone;
+
+const setup = (over: Partial<IChallenge> = {}) => {
+	staticData.challenges = [];
+	staticData.challenges[5] = {
+		id: 5,
+		name: 'Cull the Swarm',
+		description: 'Defeat 10 enemies',
+		challengeTypeId: EChallengeType.EnemiesKilled,
+		progressGoal: 10,
+		...over
+	} as IChallenge;
+	staticData.challengeTypes = [{ id: EChallengeType.EnemiesKilled, name: 'Enemies Killed' }];
+	staticData.zones = [zone(20, 2, 'Beta', 5)];
+};
+
+afterEach(() => {
+	cleanup();
+	playerChallenges.isChallengeCompleted.mockReset();
+	playerChallenges.isChallengeCompleted.mockReturnValue(false);
+});
+
+describe('ChallengeTooltip', () => {
+	it('renders nothing for an undefined challenge (the empty/hidden panel)', () => {
+		setup();
+		const { container } = render(ChallengeTooltip, { props: { challengeId: undefined } });
+		expect(container.querySelector('.tt-title-name')).toBeNull();
+	});
+
+	it('shows the challenge type, name and requirement description', () => {
+		setup();
+		const { container } = render(ChallengeTooltip, { props: { challengeId: 5 } });
+		expect((container.querySelector('.tt-category-label') as HTMLElement).textContent).toBe('Enemies Killed');
+		expect((container.querySelector('.tt-title-name') as HTMLElement).textContent).toBe('Cull the Swarm');
+		expect((container.querySelector('.ct-desc') as HTMLElement).textContent).toBe('Defeat 10 enemies');
+	});
+
+	it('accents the panel border by the challenge type', () => {
+		setup();
+		const { container } = render(ChallengeTooltip, { props: { challengeId: 5 } });
+		expect((container.querySelector('.tt-shell') as HTMLElement).getAttribute('style')).toContain(
+			'var(--challenge-enemies-killed)'
+		);
+	});
+
+	it('lists the zone the challenge unlocks', () => {
+		setup();
+		const { container } = render(ChallengeTooltip, { props: { challengeId: 5 } });
+		const names = Array.from(container.querySelectorAll('.ct-name')).map((n) => n.textContent?.trim());
+		expect(names).toContain('Beta');
+	});
+
+	it('seals a reward name while the challenge is incomplete, then reveals it once complete', () => {
+		setup({ rewardItemId: 3 });
+		staticData.items = [];
+		staticData.items[3] = {
+			id: 3,
+			name: 'Iron Helm',
+			itemCategoryId: EItemCategory.Helm,
+			rarityId: ERarity.Rare
+		} as IItem;
+
+		const { container, unmount } = render(ChallengeTooltip, { props: { challengeId: 5 } });
+		const sealed = container.querySelector('.ct-name.sealed') as HTMLElement;
+		expect(sealed.textContent?.trim()).toBe('???');
+		// The teaser sub-label is still shown even while sealed.
+		expect(container.textContent).toContain('Rare · Helm');
+		unmount();
+
+		playerChallenges.isChallengeCompleted.mockReturnValue(true);
+		const { container: done } = render(ChallengeTooltip, { props: { challengeId: 5 } });
+		expect(done.querySelector('.ct-name.sealed')).toBeNull();
+		expect(done.textContent).toContain('Iron Helm');
+	});
+});

--- a/UI/src/tests/lib/common/challenge-type.test.ts
+++ b/UI/src/tests/lib/common/challenge-type.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { EChallengeType, type IChallengeType } from '$lib/api';
+import { challengeTypeColor, challengeTypeName } from '$lib/common';
+
+describe('challengeTypeColor', () => {
+	it('maps each type to its themeable --challenge-* accent variable', () => {
+		expect(challengeTypeColor(EChallengeType.EnemiesKilled)).toBe('var(--challenge-enemies-killed)');
+		expect(challengeTypeColor(EChallengeType.TimeTrial)).toBe('var(--challenge-time-trial)');
+	});
+});
+
+describe('challengeTypeName', () => {
+	const types = [{ id: EChallengeType.EnemiesKilled, name: 'Slayer' }] as IChallengeType[];
+
+	it('prefers the authored name from the reference set', () => {
+		expect(challengeTypeName(EChallengeType.EnemiesKilled, types)).toBe('Slayer');
+	});
+
+	it('falls back to the normalized enum name when the type is absent or no set is given', () => {
+		expect(challengeTypeName(EChallengeType.TimeTrial, types)).toBe('Time Trial');
+		expect(challengeTypeName(EChallengeType.BossesDefeated)).toBe('Bosses Defeated');
+	});
+});

--- a/UI/src/tests/lib/common/challenge-unlocks.test.ts
+++ b/UI/src/tests/lib/common/challenge-unlocks.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+	EItemCategory,
+	EItemModType,
+	ERarity,
+	type IChallenge,
+	type IItem,
+	type IItemMod,
+	type ISkill,
+	type IZone
+} from '$lib/api';
+import { resolveUnlockReward, zonesUnlockedBy } from '$lib/common';
+
+const zone = (id: number, order: number, name: string, unlockChallengeId?: number, retiredAt?: string): IZone =>
+	({
+		id,
+		name,
+		description: '',
+		order,
+		levelMin: 1,
+		levelMax: 10,
+		bossLevel: 1,
+		unlockChallengeId,
+		retiredAt
+	}) as IZone;
+
+const challenge = (over: Partial<IChallenge> = {}): IChallenge =>
+	({ id: 1, name: 'C', description: '', challengeTypeId: 0, entityType: 0, progressGoal: 10, ...over }) as IChallenge;
+
+describe('zonesUnlockedBy', () => {
+	it('returns the zones gated on the challenge, in authored order', () => {
+		const zones = [zone(30, 3, 'Gamma', 7), zone(10, 1, 'Alpha', 7), zone(20, 2, 'Beta')];
+		expect(zonesUnlockedBy(7, zones).map((z) => z.name)).toEqual(['Alpha', 'Gamma']);
+	});
+
+	it('returns an empty list when no zone is gated on the challenge', () => {
+		const zones = [zone(10, 1, 'Alpha', 7), zone(20, 2, 'Beta')];
+		expect(zonesUnlockedBy(99, zones)).toEqual([]);
+	});
+
+	it('excludes retired zones (out of circulation, not advertised as a reward)', () => {
+		const zones = [zone(10, 1, 'Alpha', 7), zone(20, 2, 'Beta', 7, '2026-01-01T00:00:00Z')];
+		expect(zonesUnlockedBy(7, zones).map((z) => z.name)).toEqual(['Alpha']);
+	});
+
+	it('tolerates holes in the sparse (id-indexed) zone array', () => {
+		const zones: (IZone | undefined)[] = [];
+		zones[10] = zone(10, 1, 'Alpha', 7);
+		expect(zonesUnlockedBy(7, zones).map((z) => z.name)).toEqual(['Alpha']);
+	});
+});
+
+describe('resolveUnlockReward', () => {
+	const items: (IItem | undefined)[] = [];
+	items[3] = { id: 3, name: 'Iron Helm', itemCategoryId: EItemCategory.Helm, rarityId: ERarity.Rare } as IItem;
+	const itemMods: (IItemMod | undefined)[] = [];
+	itemMods[4] = { id: 4, name: 'of Fury', itemModTypeId: EItemModType.Suffix, rarityId: ERarity.Epic } as IItemMod;
+	const skills: (ISkill | undefined)[] = [];
+	skills[5] = { id: 5, name: 'Cleave' } as ISkill;
+	const refs = { items, itemMods, skills };
+
+	it('resolves an item reward with rarity accent and a "rarity · category" sub-label', () => {
+		const reward = resolveUnlockReward(challenge({ rewardItemId: 3 }), refs);
+		expect(reward).toMatchObject({ kind: 'item', name: 'Iron Helm', sub: 'Rare · Helm' });
+		expect(reward?.accent).toContain('--rarity-');
+	});
+
+	it('resolves a mod reward with rarity accent and a "rarity · modtype" sub-label', () => {
+		const reward = resolveUnlockReward(challenge({ rewardItemModId: 4 }), refs);
+		expect(reward).toMatchObject({ kind: 'mod', name: 'of Fury', sub: 'Epic · Suffix' });
+	});
+
+	it('resolves a skill reward (no rarity) with a neutral accent and "Skill" sub-label', () => {
+		const reward = resolveUnlockReward(challenge({ rewardSkillId: 5 }), refs);
+		expect(reward).toMatchObject({ kind: 'skill', name: 'Cleave', sub: 'Skill' });
+	});
+
+	it('returns null when the challenge grants no reward', () => {
+		expect(resolveUnlockReward(challenge(), refs)).toBeNull();
+	});
+
+	it('returns null when the referenced reward record is missing/unloaded', () => {
+		expect(resolveUnlockReward(challenge({ rewardItemId: 999 }), refs)).toBeNull();
+	});
+
+	it('prefers an item over a mod/skill when more than one reward field is set', () => {
+		const reward = resolveUnlockReward(challenge({ rewardItemId: 3, rewardItemModId: 4, rewardSkillId: 5 }), refs);
+		expect(reward?.kind).toBe('item');
+	});
+});

--- a/UI/src/tests/routes/game/screens/challenges/challenges-view.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/challenges-view.test.ts
@@ -24,7 +24,7 @@ const { staticData } = vi.hoisted(() => ({
 		items: [] as IItem[],
 		itemMods: [] as IItemMod[],
 		enemies: [] as { id: number; name: string }[],
-		zones: [] as { id: number; name: string }[],
+		zones: [] as { id: number; name: string; order?: number; unlockChallengeId?: number }[],
 		skills: [] as { id: number; name: string }[]
 	}
 }));
@@ -204,6 +204,17 @@ describe('buildChallengeVM', () => {
 		const vm = buildChallengeVM(staticData.challenges[2], { challengeId: 9, progress: 52, completed: false });
 		expect(vm.prog.atMost).toBe(true);
 		expect(vm.prog.target).toBe(60);
+	});
+
+	it('lists the zones the challenge unlocks (gated on it), in authored order', () => {
+		staticData.zones = [];
+		staticData.zones[40] = { id: 40, name: 'Sunken Vault', order: 4, unlockChallengeId: 1 };
+		staticData.zones[30] = { id: 30, name: 'Ashen Pass', order: 3, unlockChallengeId: 1 };
+		staticData.zones[20] = { id: 20, name: 'Other', order: 2, unlockChallengeId: 2 };
+
+		expect(buildChallengeVM(staticData.challenges[0]).unlocksZones).toEqual(['Ashen Pass', 'Sunken Vault']);
+		// A challenge that gates no zone reports none.
+		expect(buildChallengeVM(staticData.challenges[2]).unlocksZones).toEqual([]);
 	});
 });
 

--- a/UI/src/tests/routes/game/screens/fight/Fight.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/Fight.test.ts
@@ -13,29 +13,27 @@ const {
 	statistics,
 	playerChallenges,
 	registerTooltipComponent
-} = vi.hoisted(
-	() => ({
-		mockBattleEngine: { player: undefined as unknown, enemy: undefined as unknown, getOpponent: vi.fn() },
-		mockPlayerManager: { currentZone: 0 },
-		mockEnemyManager: {
-			mode: 'idle' as 'idle' | 'boss',
-			autoFight: false,
-			bossOutcome: undefined as 'victory' | undefined,
-			bossUnlockedNextZone: false,
-			challengeBoss: vi.fn(),
-			retreatFromBoss: vi.fn(),
-			setAutoFight: vi.fn()
-		},
-		staticData: { attributes: [] as IAttribute[], zones: [] as IZone[], enemies: [] as IEnemy[] },
-		statistics: { isZoneCleared: vi.fn(() => false) },
-		playerChallenges: { isChallengeCompleted: vi.fn(() => false) },
-		registerTooltipComponent: vi.fn(() => ({
-			setTooltipPosition: vi.fn(),
-			showTooltip: vi.fn(),
-			hideTooltip: vi.fn()
-		}))
-	})
-);
+} = vi.hoisted(() => ({
+	mockBattleEngine: { player: undefined as unknown, enemy: undefined as unknown, getOpponent: vi.fn() },
+	mockPlayerManager: { currentZone: 0 },
+	mockEnemyManager: {
+		mode: 'idle' as 'idle' | 'boss',
+		autoFight: false,
+		bossOutcome: undefined as 'victory' | undefined,
+		bossUnlockedNextZone: false,
+		challengeBoss: vi.fn(),
+		retreatFromBoss: vi.fn(),
+		setAutoFight: vi.fn()
+	},
+	staticData: { attributes: [] as IAttribute[], zones: [] as IZone[], enemies: [] as IEnemy[] },
+	statistics: { isZoneCleared: vi.fn(() => false) },
+	playerChallenges: { isChallengeCompleted: vi.fn(() => false) },
+	registerTooltipComponent: vi.fn(() => ({
+		setTooltipPosition: vi.fn(),
+		showTooltip: vi.fn(),
+		hideTooltip: vi.fn()
+	}))
+}));
 
 vi.mock('$lib/engine', () => ({
 	battleEngine: mockBattleEngine,

--- a/UI/src/tests/routes/game/screens/fight/Fight.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/Fight.test.ts
@@ -5,7 +5,15 @@ import type { IAttribute, IEnemy, IZone } from '$lib/api';
 // Fight composes the screen from the live battle engine (the two battlers), the zone nav
 // (player manager + reference data) and the boss affordance (engine boss mode + the per-zone
 // cleared statistic); all data sources are mocked.
-const { mockBattleEngine, mockPlayerManager, mockEnemyManager, staticData, statistics, playerChallenges } = vi.hoisted(
+const {
+	mockBattleEngine,
+	mockPlayerManager,
+	mockEnemyManager,
+	staticData,
+	statistics,
+	playerChallenges,
+	registerTooltipComponent
+} = vi.hoisted(
 	() => ({
 		mockBattleEngine: { player: undefined as unknown, enemy: undefined as unknown, getOpponent: vi.fn() },
 		mockPlayerManager: { currentZone: 0 },
@@ -20,7 +28,12 @@ const { mockBattleEngine, mockPlayerManager, mockEnemyManager, staticData, stati
 		},
 		staticData: { attributes: [] as IAttribute[], zones: [] as IZone[], enemies: [] as IEnemy[] },
 		statistics: { isZoneCleared: vi.fn(() => false) },
-		playerChallenges: { isChallengeCompleted: vi.fn(() => false) }
+		playerChallenges: { isChallengeCompleted: vi.fn(() => false) },
+		registerTooltipComponent: vi.fn(() => ({
+			setTooltipPosition: vi.fn(),
+			showTooltip: vi.fn(),
+			hideTooltip: vi.fn()
+		}))
 	})
 );
 
@@ -29,7 +42,7 @@ vi.mock('$lib/engine', () => ({
 	playerManager: mockPlayerManager,
 	enemyManager: mockEnemyManager
 }));
-vi.mock('$stores', () => ({ staticData, statistics, playerChallenges }));
+vi.mock('$stores', () => ({ staticData, statistics, playerChallenges, registerTooltipComponent }));
 
 import Fight from '$routes/game/screens/fight/Fight.svelte';
 import { makeBattler } from './fight-fixtures';

--- a/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
@@ -1,20 +1,37 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
-import type { IZone } from '$lib/api';
+import { EChallengeType, type IChallenge, type IZone } from '$lib/api';
 
 // ZoneNav reads the zone list from the reference-data store, the active zone from the player
 // manager, and challenge completion from the shared store; all are mocked so the test controls
 // the navigation + lock state directly. The real `$lib/common` zone-progression helpers are used.
-const { mockPlayerManager, staticData, playerChallenges } = vi.hoisted(() => ({
+// The lock tooltip is registered through the store; the registration is stubbed and the child
+// ChallengeTooltip resolves the gating challenge from the same mocked reference data.
+const { mockPlayerManager, staticData, playerChallenges, registerTooltipComponent } = vi.hoisted(() => ({
 	mockPlayerManager: { currentZone: 0 },
-	staticData: { zones: [] as IZone[] },
-	playerChallenges: { isChallengeCompleted: vi.fn(() => false) }
+	staticData: {
+		zones: [] as IZone[],
+		challenges: [] as IChallenge[],
+		challengeTypes: [] as unknown[],
+		items: [] as unknown[],
+		itemMods: [] as unknown[],
+		skills: [] as unknown[]
+	},
+	playerChallenges: { isChallengeCompleted: vi.fn(() => false) },
+	registerTooltipComponent: vi.fn(() => ({
+		setTooltipPosition: vi.fn(),
+		showTooltip: vi.fn(),
+		hideTooltip: vi.fn()
+	}))
 }));
 
 vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager }));
-vi.mock('$stores', () => ({ staticData, playerChallenges }));
+vi.mock('$stores', () => ({ staticData, playerChallenges, registerTooltipComponent }));
 
 import ZoneNav from '$routes/game/screens/fight/ZoneNav.svelte';
+
+const challenge = (id: number, name: string, description: string): IChallenge =>
+	({ id, name, description, challengeTypeId: EChallengeType.EnemiesKilled, progressGoal: 10 }) as IChallenge;
 
 const zone = (id: number, order: number, name: string, unlockChallengeId?: number): IZone => ({
 	id,
@@ -30,6 +47,7 @@ const zone = (id: number, order: number, name: string, unlockChallengeId?: numbe
 beforeEach(() => {
 	playerChallenges.isChallengeCompleted.mockReset();
 	playerChallenges.isChallengeCompleted.mockReturnValue(false);
+	staticData.challenges = [];
 	// Deliberately out of array order to prove the component orders by `order`, not index.
 	staticData.zones = [zone(30, 3, 'Frozen Summit'), zone(10, 1, 'Verdant Hollow'), zone(20, 2, 'Ashen Wastes')];
 	mockPlayerManager.currentZone = 20;
@@ -132,5 +150,44 @@ describe('ZoneNav', () => {
 		expect(left.disabled).toBe(true);
 		expect(left.getAttribute('aria-label')).toBe('Previous zone locked');
 		expect(left.querySelector('svg')).not.toBeNull();
+	});
+
+	it('shows the actual gating challenge (not a boss assumption) when hovering a locked arrow', async () => {
+		// Beta (order 2) is gated behind a non-boss challenge; hovering the locked arrow surfaces it.
+		staticData.zones = [zone(10, 1, 'Alpha'), zone(20, 2, 'Beta', 5)];
+		// Challenges are id-indexed (zero-based-id catalogue), so the gate (id 5) sits at index 5.
+		staticData.challenges = [];
+		staticData.challenges[5] = challenge(5, 'Cull the Swarm', 'Defeat 10 enemies');
+		mockPlayerManager.currentZone = 10;
+		playerChallenges.isChallengeCompleted.mockReturnValue(false);
+
+		const { container } = render(ZoneNav);
+		const wraps = container.querySelectorAll('.zone-btn-wrap');
+		await fireEvent.mouseEnter(wraps[1], { clientX: 5, clientY: 5 });
+
+		// The gating challenge's name + requirement appear, and what it unlocks (Beta).
+		expect(screen.getByText('Cull the Swarm')).toBeTruthy();
+		expect(screen.getByText('Defeat 10 enemies')).toBeTruthy();
+		expect(screen.getByText('Beta')).toBeTruthy();
+		// The old, inaccurate boss-only hint is gone.
+		expect(container.textContent).not.toContain("Clear this zone's boss");
+
+		// Leaving clears the tooltip's challenge so it no longer renders the gate.
+		await fireEvent.mouseLeave(wraps[1]);
+		expect(screen.queryByText('Cull the Swarm')).toBeNull();
+	});
+
+	it('does not surface a tooltip when hovering an unlocked (navigable) arrow', async () => {
+		staticData.zones = [zone(10, 1, 'Alpha'), zone(20, 2, 'Beta')];
+		staticData.challenges = [];
+		staticData.challenges[5] = challenge(5, 'Cull the Swarm', 'Defeat 10 enemies');
+		mockPlayerManager.currentZone = 10;
+
+		const { container } = render(ZoneNav);
+		const wraps = container.querySelectorAll('.zone-btn-wrap');
+		await fireEvent.mouseEnter(wraps[1], { clientX: 5, clientY: 5 });
+
+		// The right arrow is open (no gate), so hovering it shows nothing.
+		expect(screen.queryByText('Cull the Swarm')).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the inaccurate locked-zone navigation hint and introduces a reusable challenge tooltip, per #429.

The locked-zone nav arrow showed a hardcoded **"Clear this zone's boss to unlock"** title — wrong for any zone gated by a non-boss challenge (zones are gated on an arbitrary `unlockChallengeId`, not necessarily their boss). It now shows a rich, accurate `ChallengeTooltip` describing the **actual** gating challenge: its requirement and everything completing it unlocks.

## What's included

- **`$lib/common/challenge-unlocks.ts`** (pure, fully unit-tested): `zonesUnlockedBy(challengeId, zones)` (zones gated on a challenge, retired excluded, authored order) and `resolveUnlockReward(challenge, refs)` (resolves the item / mod / **skill** reward into a compact, sealed-aware descriptor).
- **`components/tooltip/ChallengeTooltip.svelte`**: a reusable tooltip built on the shared `TooltipShell` primitive (per the "extend the shared primitive" frontend guideline). Shows the challenge type + name, its requirement (the authored description), and an **Unlocks** section listing the gated zone(s) and the reward — sealed (`???` + teaser sub-label) until the challenge is complete, mirroring the challenges screen.
- **`ZoneNav.svelte`**: the locked arrows now drive that tooltip on hover; the static, inaccurate hint is removed.
- **Challenges screen** (`ChallengeDetailCard` + view-model): now shows that a challenge **unlocks a zone**, via the same shared `zonesUnlockedBy` lookup.

## Notes / decisions (flagging the not-totally-obvious bits)

- **Sealed rewards stay sealed.** For an incomplete challenge the reward name is masked (`???`) with only its rarity/category teaser shown — consistent with the challenges screen. The requirement and unlocked zones are always shown, since "what do I need to do to unlock this?" is the point of the locked-zone tooltip.
- **Hovering a disabled button.** A locked arrow stays `disabled` (preserving its semantics and the existing tests), which suppresses its own pointer events, so the hover that drives the tooltip is carried by a thin wrapping `<span>` (the button gets `pointer-events: none`). This keeps the lock affordance non-interactive while still being inspectable.
- **Follow-ups discovered while implementing:**
  - #470 — the challenges-screen reward affordance (`resolveReward`) ignores `rewardSkillId`, so a skill-only reward renders "No reward". The new shared helper handles skills, so the locked-zone tooltip already shows them; consolidating the two resolvers is the natural fix.
  - #471 — the issue's "could also use [it] on the skills page" suggestion, deferred: wire `ChallengeTooltip` onto challenge-gated skills on the skills page.

## Test plan

- [x] New `tests/lib/common/challenge-unlocks.test.ts` — `zonesUnlockedBy` (match/empty/retired/sparse-array) and `resolveUnlockReward` (item/mod/skill/none/missing/precedence).
- [x] New `tests/components/tooltip/ChallengeTooltip.test.ts` — type/name/requirement render, type-accent border, unlocked-zone listing, sealed→revealed reward.
- [x] `ZoneNav.test.ts` — hovering a locked arrow surfaces the actual gating challenge + what it unlocks (and no longer the boss-only hint); hovering an unlocked arrow shows nothing.
- [x] `challenges-view.test.ts` — `unlocksZones` populated in authored order.
- [x] `Fight.test.ts` mock updated for the new tooltip registration.
- [x] `npm run check` — 0 errors. `eslint` clean on all changed source files. Full unit suite: **1570 passed**, coverage gates satisfied.

Frontend-only change (the backend is the authoritative gate and is unaffected), so there is no battle-parity-style backend mirror to keep in sync.

Closes #429

https://claude.ai/code/session_01BcZmbqLTx6vQiYUEKD477a

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcZmbqLTx6vQiYUEKD477a)_