### PR TITLE
Display skill rewards on the challenges screen (#470)

### DIFF
--- a/UI/src/routes/game/screens/challenges/RewardIcon.svelte
+++ b/UI/src/routes/game/screens/challenges/RewardIcon.svelte
@@ -9,6 +9,8 @@
 	>
 		{#if reward.kind === 'item' && reward.item}
 			<CategoryGlyph cat={reward.item.itemCategoryId} color={accent} size={Math.round(size * 0.5)} />
+		{:else if reward.kind === 'skill' && reward.skill}
+			<img class="skill-img" src={reward.skill.iconPath} alt="" />
 		{:else}
 			<div
 				class="mod-diamond"
@@ -75,6 +77,13 @@ const revealGlow = $derived(`0 0 calc(4px + ${reward.glow} * 16px) ${tintColor(a
 
 .mod-diamond {
 	transform: rotate(45deg);
+}
+
+.skill-img {
+	width: 62%;
+	height: 62%;
+	object-fit: cover;
+	border-radius: 3px;
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/UI/src/routes/game/screens/challenges/RewardTooltip.svelte
+++ b/UI/src/routes/game/screens/challenges/RewardTooltip.svelte
@@ -4,11 +4,15 @@
 			<!-- Revealed rewards open the exact tooltip you'd see inspecting the thing in your bag. -->
 			{#if reward.kind === 'item' && reward.item}
 				<ItemTooltip item={reward.item} />
+			{:else if reward.kind === 'skill' && reward.skill}
+				<SkillRewardTooltip skill={reward.skill} />
 			{:else if reward.mod}
 				<ModTooltip mod={reward.mod} />
 			{/if}
 		{:else if reward.kind === 'item' && reward.item}
 			<SealedItemTooltip item={reward.item} />
+		{:else if reward.kind === 'skill' && reward.skill}
+			<SealedSkillTooltip skill={reward.skill} />
 		{:else if reward.mod}
 			<SealedModTooltip mod={reward.mod} />
 		{/if}
@@ -20,6 +24,8 @@ import ItemTooltip from '../inventory/ItemTooltip.svelte';
 import ModTooltip from './ModTooltip.svelte';
 import SealedItemTooltip from './SealedItemTooltip.svelte';
 import SealedModTooltip from './SealedModTooltip.svelte';
+import SealedSkillTooltip from './SealedSkillTooltip.svelte';
+import SkillRewardTooltip from './SkillRewardTooltip.svelte';
 import type { ResolvedReward } from './challenges-view.svelte';
 
 export const getBaseNode = () => container;

--- a/UI/src/routes/game/screens/challenges/SealedSkillTooltip.svelte
+++ b/UI/src/routes/game/screens/challenges/SealedSkillTooltip.svelte
@@ -1,0 +1,42 @@
+<TooltipShell {accent}>
+	{#snippet header()}
+		<SealedHeader rarityAccent={accent} catAccent="var(--accent)" typeLabel="Skill" />
+	{/snippet}
+
+	{#if skill.damageMultipliers.length}
+		<TooltipSection label="Scaling">
+			<MaskedStatsGrid {accent} rows={skill.damageMultipliers.length} barWidths={SCALING_BAR_WIDTHS} />
+		</TooltipSection>
+	{/if}
+
+	{#if skill.effects.length}
+		<TooltipSection label="On hit">
+			<MaskedStatsGrid {accent} rows={skill.effects.length} barWidths={EFFECT_BAR_WIDTHS} />
+		</TooltipSection>
+	{/if}
+
+	<TooltipSection label="Description" last>
+		<MaskedDescription {accent} lineWidths={[236, 180]} />
+	</TooltipSection>
+</TooltipShell>
+
+<script lang="ts">
+import type { ISkill } from '$lib/api';
+import SealedHeader from './SealedHeader.svelte';
+import TooltipShell from '$components/tooltip/TooltipShell.svelte';
+import TooltipSection from '$components/tooltip/TooltipSection.svelte';
+import MaskedStatsGrid from '$components/tooltip/MaskedStatsGrid.svelte';
+import MaskedDescription from '$components/tooltip/MaskedDescription.svelte';
+
+interface Props {
+	skill: ISkill;
+}
+
+const { skill }: Props = $props();
+
+// Skills have no rarity tier, so the teaser uses the neutral skill accent throughout.
+const accent = 'var(--accent-light)';
+
+const SCALING_BAR_WIDTHS = [82, 64, 92];
+const EFFECT_BAR_WIDTHS = [70, 88, 58];
+</script>

--- a/UI/src/routes/game/screens/challenges/SkillRewardTooltip.svelte
+++ b/UI/src/routes/game/screens/challenges/SkillRewardTooltip.svelte
@@ -1,0 +1,142 @@
+<!-- A lightweight, reference-data-only preview of a skill reward, composed over the shared tooltip
+	chrome. Unlike the battle `SkillTooltip` it needs no `Battler`/owner context (there is no live
+	fight when inspecting a challenge reward), so it reads the authored `ISkill` directly. -->
+<TooltipShell accent="var(--accent)" glow>
+	{#snippet header()}
+		<TooltipTitle label="Skill" name={skill.name} diamondColor="var(--accent)" labelColor="var(--accent)" />
+	{/snippet}
+
+	<TooltipSection label="Damage">
+		<div class="srt-line">
+			<span class="srt-key">Base damage</span>
+			<span class="srt-val">{formatNum(skill.baseDamage)}</span>
+		</div>
+		{#each scaling as entry (entry.attributeId)}
+			<div class="srt-line">
+				<span class="srt-key" style:color={attributeColor(entry.attributeId)}>{entry.name}</span>
+				<span class="srt-val">×{formatNum(entry.multiplier)}</span>
+			</div>
+		{/each}
+	</TooltipSection>
+
+	<TooltipSection label="Cooldown" last={effectLines.length === 0 && !skill.description}>
+		<div class="srt-line">
+			<span class="srt-key">Cooldown</span>
+			<span class="srt-val">{cooldownSeconds}s</span>
+		</div>
+	</TooltipSection>
+
+	{#if effectLines.length}
+		<TooltipSection label="On hit" last={!skill.description}>
+			{#each effectLines as effect (effect.id)}
+				<div class="srt-effect">
+					<span class="srt-mag" style:color={effectDirectionColor(effect.direction)}>{effect.magnitude}</span>
+					<span class="srt-attr">{effect.attributeName}</span>
+					<span class="srt-meta">{effect.targetLabel} · {effect.duration}</span>
+				</div>
+			{/each}
+		</TooltipSection>
+	{/if}
+
+	{#if skill.description}
+		<TooltipSection label="Description" last>
+			<div class="srt-description">{skill.description}</div>
+		</TooltipSection>
+	{/if}
+</TooltipShell>
+
+<script lang="ts">
+import { EAttribute, type ISkill } from '$lib/api';
+import { attributeColor, describeEffect, effectDirectionColor, formatNum, normalizeText } from '$lib/common';
+import { staticData } from '$stores';
+import TooltipShell from '$components/tooltip/TooltipShell.svelte';
+import TooltipSection from '$components/tooltip/TooltipSection.svelte';
+import TooltipTitle from '$components/tooltip/TooltipTitle.svelte';
+
+interface Props {
+	skill: ISkill;
+}
+
+const { skill }: Props = $props();
+
+// Reference-data attribute name (the full names live in the `Attributes` set); falls back to the
+// humanised enum key, matching the battle skill tooltip.
+const attributeName = (id: EAttribute) =>
+	staticData.attributes?.find((a) => a.id === id)?.name ?? normalizeText(EAttribute[id]);
+
+const scaling = $derived(
+	skill.damageMultipliers.map((m) => ({
+		attributeId: m.attributeId,
+		name: attributeName(m.attributeId),
+		multiplier: m.multiplier
+	}))
+);
+const cooldownSeconds = $derived(formatNum(skill.cooldownMs / 1000));
+// One display line per authored effect, reusing the shared helper so wording/direction match the
+// battle tooltip's "On hit" lines; `id` is kept for a stable each-key.
+const effectLines = $derived(
+	skill.effects.map((effect) => ({ id: effect.id, ...describeEffect(effect, attributeName(effect.attributeId)) }))
+);
+</script>
+
+<style lang="scss">
+.srt-line {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	font-size: 12px;
+
+	& + & {
+		margin-top: 4px;
+	}
+}
+
+.srt-key {
+	color: var(--text-secondary);
+}
+
+.srt-val {
+	font-family: var(--mono);
+	font-size: 11.5px;
+	color: color-mix(in srgb, var(--text-primary) 70%, transparent);
+}
+
+.srt-effect {
+	display: flex;
+	align-items: baseline;
+	gap: 10px;
+	font-size: 12px;
+
+	& + & {
+		margin-top: 4px;
+	}
+}
+
+.srt-mag {
+	min-width: 42px;
+	font-family: var(--mono);
+	font-size: 11px;
+	font-weight: 600;
+	text-align: right;
+}
+
+.srt-attr {
+	color: var(--text-secondary);
+}
+
+.srt-meta {
+	margin-left: auto;
+	font-family: var(--mono);
+	font-size: 9.5px;
+	letter-spacing: 0.4px;
+	color: var(--text-muted);
+	white-space: nowrap;
+}
+
+.srt-description {
+	font-size: 11.5px;
+	font-style: italic;
+	color: color-mix(in srgb, var(--text-primary) 60%, transparent);
+	line-height: 1.55;
+}
+</style>

--- a/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
+++ b/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
@@ -2,10 +2,11 @@ import {
 	EChallengeGoalComparison,
 	EChallengeType,
 	EEntityType,
-	type ERarity,
+	ERarity,
 	type IChallenge,
 	type IItemMod,
-	type IPlayerChallenge
+	type IPlayerChallenge,
+	type ISkill
 } from '$lib/api';
 import { BattleAttributes, type Item } from '$lib/battle';
 import {
@@ -26,24 +27,27 @@ import { challengeTypeUnit } from './challenge-meta';
 export type ChallengeState = 'locked' | 'active' | 'done';
 export type SortKey = 'progress' | 'rarity' | 'name';
 
-/** A challenge's reward, resolved against the item/mod reference pools. While
+/** A challenge's reward, resolved against the item/mod/skill reference pools. While
  *  the challenge is incomplete the reward is *sealed* (`revealed: false`) — the
  *  rarity tier and category are teased, but the name/stats stay hidden. */
 export interface ResolvedReward {
-	kind: 'item' | 'mod';
+	kind: 'item' | 'mod' | 'skill';
 	revealed: boolean;
+	/** Rarity tier (drives the rarity sort). Skills have no tier, so they resolve to `Common`. */
 	rarity: ERarity;
-	/** Themeable rarity hue (`var(--rarity-*)`). */
+	/** Themeable accent: the rarity hue for items/mods, the neutral skill accent for skills. */
 	accent: string;
-	/** Themeable rarity glow intensity (`var(--rarity-*-glow)`). */
+	/** Themeable rarity glow intensity (`var(--rarity-*-glow)`); `0` for the (rarity-less) skill. */
 	glow: string;
 	name: string;
-	/** Teaser sub-line, e.g. `Rare · Helm`. */
+	/** Teaser sub-line, e.g. `Rare · Helm`, or `Skill`. */
 	sub: string;
 	/** Item rewards: a preview battle item for the (re-used) item tooltip. */
 	item?: Item;
 	/** Mod rewards: the raw mod data for the mod tooltip. */
 	mod?: IItemMod;
+	/** Skill rewards: the raw skill data for the skill tooltip. */
+	skill?: ISkill;
 }
 
 export interface ProgressInfo {
@@ -160,6 +164,24 @@ export function resolveReward(ch: IChallenge, revealed: boolean): ResolvedReward
 			name: mod.name,
 			sub: `${rarityLabel(mod.rarityId)} · ${modTypeLabel(mod.itemModTypeId)}`,
 			mod
+		};
+	}
+	if (ch.rewardSkillId != null) {
+		const skill = staticData.skills?.[ch.rewardSkillId];
+		if (!skill) {
+			return null;
+		}
+		// Skills carry no rarity tier; sort with the lowest and use the neutral skill accent
+		// (mirroring the shared `resolveUnlockReward` so both reward surfaces agree).
+		return {
+			kind: 'skill',
+			revealed,
+			rarity: ERarity.Common,
+			accent: 'var(--accent-light)',
+			glow: '0',
+			name: skill.name,
+			sub: 'Skill',
+			skill
 		};
 	}
 	return null;

--- a/UI/src/tests/routes/game/screens/challenges/RewardAffordance.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/RewardAffordance.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
-import { ERarity, EItemModType, type IItemMod } from '$lib/api';
+import { EAttribute, ERarity, EItemModType, type IItemMod, type ISkill } from '$lib/api';
 import RewardAffordance from '$routes/game/screens/challenges/RewardAffordance.svelte';
 import type { ResolvedReward } from '$routes/game/screens/challenges/challenges-view.svelte';
 
@@ -23,6 +23,28 @@ const modReward = (revealed: boolean): ResolvedReward => ({
 	name: 'Honed',
 	sub: 'Rare · Prefix',
 	mod: sampleMod
+});
+
+const sampleSkill: ISkill = {
+	id: 5,
+	name: 'Firebolt',
+	baseDamage: 12,
+	description: 'Hurls a bolt of fire.',
+	damageMultipliers: [{ attributeId: EAttribute.Intellect, multiplier: 1.5 }],
+	effects: [],
+	cooldownMs: 3000,
+	iconPath: ''
+};
+
+const skillReward = (revealed: boolean): ResolvedReward => ({
+	kind: 'skill',
+	revealed,
+	rarity: ERarity.Common,
+	accent: 'var(--accent-light)',
+	glow: '0',
+	name: 'Firebolt',
+	sub: 'Skill',
+	skill: sampleSkill
 });
 
 afterEach(cleanup);
@@ -52,6 +74,17 @@ describe('RewardAffordance', () => {
 
 		const revealed = render(RewardAffordance, { props: { reward: modReward(true), variant: 'chip' } });
 		expect(revealed.getByText('Honed')).toBeTruthy();
+	});
+
+	it('seals then reveals a skill reward name with the "Skill" teaser sub-line', () => {
+		const sealed = render(RewardAffordance, { props: { reward: skillReward(false), variant: 'tile' } });
+		expect(sealed.getByText('???')).toBeTruthy();
+		expect(sealed.queryByText('Firebolt')).toBeNull();
+		expect(sealed.getByText('Skill')).toBeTruthy();
+		cleanup();
+
+		const revealed = render(RewardAffordance, { props: { reward: skillReward(true), variant: 'tile' } });
+		expect(revealed.getByText('Firebolt')).toBeTruthy();
 	});
 
 	it('shows a fallback when there is no reward', () => {

--- a/UI/src/tests/routes/game/screens/challenges/RewardTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/RewardTooltip.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
-import { EAttribute, EItemCategory, EItemModType, ERarity, type IItemMod } from '$lib/api';
+import { EAttribute, EItemCategory, EItemModType, ERarity, type IItemMod, type ISkill } from '$lib/api';
 import { BattleAttributes } from '$lib/battle/battle-attributes';
 import type { Item } from '$lib/battle';
 import type { ResolvedReward } from '$routes/game/screens/challenges/challenges-view.svelte';
@@ -60,6 +60,29 @@ const modReward = (revealed: boolean): ResolvedReward =>
 		mod: previewMod()
 	}) as ResolvedReward;
 
+const previewSkill = (): ISkill => ({
+	id: 5,
+	name: 'Firebolt',
+	baseDamage: 12,
+	description: 'Hurls a bolt of fire.',
+	damageMultipliers: [{ attributeId: EAttribute.Intellect, multiplier: 1.5 }],
+	effects: [],
+	cooldownMs: 3000,
+	iconPath: ''
+});
+
+const skillReward = (revealed: boolean): ResolvedReward =>
+	({
+		kind: 'skill',
+		revealed,
+		rarity: ERarity.Common,
+		accent: 'var(--accent-light)',
+		glow: '0',
+		name: 'Firebolt',
+		sub: 'Skill',
+		skill: previewSkill()
+	}) as ResolvedReward;
+
 afterEach(cleanup);
 
 describe('RewardTooltip', () => {
@@ -90,6 +113,19 @@ describe('RewardTooltip', () => {
 	it('renders the sealed mod teaser for an unrevealed mod reward', () => {
 		const { container } = render(RewardTooltip, { props: { reward: modReward(false) } });
 		expect((container.querySelector('.tt-title-name') as HTMLElement).textContent).toBe('?????????');
+		expect(container.querySelector('.tt-qmark')).toBeTruthy();
+	});
+
+	it('renders the skill preview tooltip (with the name) for a revealed skill reward', () => {
+		const { container } = render(RewardTooltip, { props: { reward: skillReward(true) } });
+		expect((container.querySelector('.tt-title-name') as HTMLElement).textContent).toBe('Firebolt');
+		expect((container.querySelector('.tt-category-label') as HTMLElement).textContent).toBe('Skill');
+	});
+
+	it('renders the sealed skill teaser (masked name) for an unrevealed skill reward', () => {
+		const { container } = render(RewardTooltip, { props: { reward: skillReward(false) } });
+		expect((container.querySelector('.tt-title-name') as HTMLElement).textContent).toBe('?????????');
+		// One masked scaling row teases the single damage multiplier.
 		expect(container.querySelector('.tt-qmark')).toBeTruthy();
 	});
 });

--- a/UI/src/tests/routes/game/screens/challenges/SealedTooltips.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/SealedTooltips.test.ts
@@ -1,10 +1,20 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
-import { EAttribute, EItemCategory, EItemModType, ERarity, type IItemMod } from '$lib/api';
+import {
+	EAttribute,
+	EItemCategory,
+	EItemModType,
+	ERarity,
+	EModifierType,
+	ESkillEffectTarget,
+	type IItemMod,
+	type ISkill
+} from '$lib/api';
 import { BattleAttributes } from '$lib/battle/battle-attributes';
 import type { Item } from '$lib/battle';
 import SealedItemTooltip from '$routes/game/screens/challenges/SealedItemTooltip.svelte';
 import SealedModTooltip from '$routes/game/screens/challenges/SealedModTooltip.svelte';
+import SealedSkillTooltip from '$routes/game/screens/challenges/SealedSkillTooltip.svelte';
 import SealedHeader from '$routes/game/screens/challenges/SealedHeader.svelte';
 
 const makeItem = (over: Partial<Item> = {}): Item =>
@@ -33,6 +43,30 @@ const makeItem = (over: Partial<Item> = {}): Item =>
 		),
 		...over
 	}) as unknown as Item;
+
+const makeSkill = (over: Partial<ISkill> = {}): ISkill => ({
+	id: 1,
+	name: 'Firebolt',
+	baseDamage: 12,
+	description: 'Hidden.',
+	damageMultipliers: [
+		{ attributeId: EAttribute.Intellect, multiplier: 1.5 },
+		{ attributeId: EAttribute.Dexterity, multiplier: 0.5 }
+	],
+	effects: [
+		{
+			id: 1,
+			target: ESkillEffectTarget.Self,
+			attributeId: EAttribute.Strength,
+			modifierTypeId: EModifierType.Additive,
+			amount: 5,
+			durationMs: 5000
+		}
+	],
+	cooldownMs: 3000,
+	iconPath: '',
+	...over
+});
 
 const makeMod = (over: Partial<IItemMod> = {}): IItemMod => ({
 	id: 1,
@@ -113,6 +147,30 @@ describe('SealedModTooltip', () => {
 
 	it('omits the effects section for a mod with no attributes', () => {
 		const { container } = render(SealedModTooltip, { props: { mod: makeMod({ attributes: [] }) } });
+		expect(container.querySelector('.tt-qmark')).toBeNull();
+	});
+});
+
+describe('SealedSkillTooltip', () => {
+	it('accents the panel with the neutral skill hue and masks the name', () => {
+		const { container } = render(SealedSkillTooltip, { props: { skill: makeSkill() } });
+		expect((container.querySelector('.tt-shell') as HTMLElement).getAttribute('style')).toContain(
+			'var(--accent-light)'
+		);
+		expect((container.querySelector('.tt-title-name') as HTMLElement).textContent).toBe('?????????');
+		expect((container.querySelector('.tt-category-label') as HTMLElement).textContent).toBe('Skill');
+	});
+
+	it('teases one masked row per scaling attribute and per effect', () => {
+		const { container } = render(SealedSkillTooltip, { props: { skill: makeSkill() } });
+		// Two damage multipliers + one effect → three masked rows.
+		expect(container.querySelectorAll('.tt-qmark')).toHaveLength(3);
+	});
+
+	it('omits the scaling and on-hit sections for a skill with neither', () => {
+		const { container } = render(SealedSkillTooltip, {
+			props: { skill: makeSkill({ damageMultipliers: [], effects: [] }) }
+		});
 		expect(container.querySelector('.tt-qmark')).toBeNull();
 	});
 });

--- a/UI/src/tests/routes/game/screens/challenges/SkillRewardTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/SkillRewardTooltip.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EAttribute, EModifierType, ESkillEffectTarget, type ISkill } from '$lib/api';
+
+// The tooltip resolves attribute display names from the reference-data store; a populated
+// fixture lets us assert the real names render (rather than the enum-key fallback).
+vi.mock('$stores', () => ({
+	staticData: {
+		attributes: [
+			{ id: EAttribute.Intellect, name: 'Intellect' },
+			{ id: EAttribute.Strength, name: 'Strength' }
+		]
+	}
+}));
+
+import SkillRewardTooltip from '$routes/game/screens/challenges/SkillRewardTooltip.svelte';
+
+const makeSkill = (over: Partial<ISkill> = {}): ISkill => ({
+	id: 1,
+	name: 'Firebolt',
+	baseDamage: 12,
+	description: 'Hurls a bolt of fire.',
+	damageMultipliers: [{ attributeId: EAttribute.Intellect, multiplier: 1.5 }],
+	effects: [],
+	cooldownMs: 3000,
+	iconPath: '',
+	...over
+});
+
+afterEach(cleanup);
+
+describe('SkillRewardTooltip', () => {
+	it('renders the skill name under a "Skill" category label', () => {
+		const { container } = render(SkillRewardTooltip, { props: { skill: makeSkill() } });
+		expect((container.querySelector('.tt-title-name') as HTMLElement).textContent).toBe('Firebolt');
+		expect((container.querySelector('.tt-category-label') as HTMLElement).textContent).toBe('Skill');
+	});
+
+	it('shows base damage, the resolved scaling attribute and the cooldown in seconds', () => {
+		const { container } = render(SkillRewardTooltip, { props: { skill: makeSkill() } });
+		const text = container.textContent ?? '';
+		expect(text).toContain('Base damage');
+		expect(text).toContain('12');
+		expect(text).toContain('Intellect');
+		expect(text).toContain('×1.5');
+		expect(text).toContain('3s');
+	});
+
+	it('renders an "On hit" line for each authored effect, omitting the section when there are none', () => {
+		const withEffect = render(SkillRewardTooltip, {
+			props: {
+				skill: makeSkill({
+					effects: [
+						{
+							id: 1,
+							target: ESkillEffectTarget.Self,
+							attributeId: EAttribute.Strength,
+							modifierTypeId: EModifierType.Additive,
+							amount: 5,
+							durationMs: 5000
+						}
+					]
+				})
+			}
+		});
+		expect(withEffect.container.textContent).toContain('On hit');
+		expect(withEffect.container.textContent).toContain('Strength');
+		cleanup();
+
+		const noEffect = render(SkillRewardTooltip, { props: { skill: makeSkill({ effects: [] }) } });
+		expect(noEffect.container.textContent).not.toContain('On hit');
+	});
+
+	it('omits the description section when the skill has none', () => {
+		const { container } = render(SkillRewardTooltip, { props: { skill: makeSkill({ description: '' }) } });
+		expect(container.textContent).not.toContain('Description');
+	});
+});

--- a/UI/src/tests/routes/game/screens/challenges/challenges-view.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/challenges-view.test.ts
@@ -135,6 +135,39 @@ describe('resolveReward', () => {
 		expect(reward?.mod?.id).toBe(213);
 	});
 
+	it('resolves a skill reward with the neutral skill accent and "Skill" sub-line', () => {
+		const ch = challenge({
+			id: 7,
+			name: 'Pyromancer',
+			challengeTypeId: EChallengeType.EnemiesKilled,
+			rewardSkillId: 2
+		});
+		const reward = resolveReward(ch, true);
+		expect(reward).toMatchObject({ kind: 'skill', revealed: true, name: 'Firebolt', sub: 'Skill' });
+		expect(reward?.accent).toBe('var(--accent-light)');
+		expect(reward?.skill?.id).toBe(2);
+	});
+
+	it('honours the revealed flag for a skill reward', () => {
+		const ch = challenge({
+			id: 8,
+			name: 'Pyromancer',
+			challengeTypeId: EChallengeType.EnemiesKilled,
+			rewardSkillId: 2
+		});
+		expect(resolveReward(ch, false)?.revealed).toBe(false);
+	});
+
+	it('returns null when the rewarded skill is missing from the pool', () => {
+		const ch = challenge({
+			id: 8,
+			name: 'Pyromancer',
+			challengeTypeId: EChallengeType.EnemiesKilled,
+			rewardSkillId: 999
+		});
+		expect(resolveReward(ch, true)).toBeNull();
+	});
+
 	it('returns null when the challenge has no reward', () => {
 		expect(
 			resolveReward(challenge({ id: 99, name: 'No Reward', challengeTypeId: EChallengeType.EnemiesKilled }), true)


### PR DESCRIPTION
## Summary

`IChallenge` can grant a `rewardSkillId`, but the challenges-screen reward resolver `resolveReward` (`challenges-view.svelte.ts`) only handled `rewardItemId`/`rewardItemModId` and returned `null` for a skill-only reward — so a challenge whose only reward is a skill rendered **"No reward"** in `RewardAffordance` even though it grants something. (The shared `resolveUnlockReward` from #429 already resolves skills, so the locked-zone tooltip was unaffected; only the challenges screen's richer affordance/tooltip path was.)

This adds a skill reward path end-to-end on the challenges screen.

## What changed

- **`challenges-view.svelte.ts`** — `ResolvedReward` gains `kind: 'skill'` and a `skill?: ISkill` field; `resolveReward` now resolves `rewardSkillId` (item > mod > skill precedence, matching the shared helper). Skills carry no rarity tier, so they resolve to the neutral `--accent-light` accent, a `Skill` sub-line, and sort with `Common` in the rarity sort.
- **`RewardIcon.svelte`** — renders the skill's icon image for a revealed skill reward (the sealed lock treatment is unchanged).
- **`RewardTooltip.svelte`** — opens a skill tooltip on the revealed/sealed paths via two new challenges-local components:
  - **`SkillRewardTooltip.svelte`** (revealed) — a lightweight, reference-data-only preview composed over the shared tooltip chrome (`TooltipShell`/`TooltipSection`/`TooltipTitle`). It reads the authored `ISkill` directly and needs no `Battler`/owner context, unlike the in-battle `SkillTooltip` (there is no live fight when inspecting a challenge reward). Shows base damage, scaling attributes, cooldown, on-hit effects (reusing `describeEffect`) and the description.
  - **`SealedSkillTooltip.svelte`** (sealed) — the masked teaser, mirroring `SealedItemTooltip`/`SealedModTooltip` but accented with the neutral skill hue.

## How it addresses the issue

- A challenge whose only reward is a skill now shows the skill (sealed until complete), not "No reward". ✅
- Skill rewards are covered by tests in the challenges-view suite. ✅

## Note on scope (resolver consolidation)

The issue's third bullet — *consider consolidating `resolveReward` and the shared `resolveUnlockReward`* — is intentionally **not** done here: the two produce genuinely different shapes (the screen needs rich preview objects — a battle `Item`, the raw `ISkill` — for full tooltips, while the shared helper returns a lightweight descriptor for the compact challenge/zone tooltip). Folding them together is a non-trivial refactor that also touches `ChallengeTooltip`, so I've opened a follow-up issue for it (**#476**) rather than expanding this PR's scope.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors.
- [x] `npm run test:unit:ci` — **1605 passed** (incl. new skill-reward cases across `challenges-view`, `RewardAffordance`, `RewardTooltip`, `SealedTooltips`, and a new `SkillRewardTooltip` suite).

Closes #470

https://claude.ai/code/session_01KJtxoQV9ruNCiZrEDRCU6y