### PR TITLE
Reject server-initiated socket commands on the inbound client path (#411)

### DIFF
--- a/Game.Api.Tests/Integration/ServerInitiatedCommandRejectionTests.cs
+++ b/Game.Api.Tests/Integration/ServerInitiatedCommandRejectionTests.cs
@@ -1,0 +1,66 @@
+using Game.Api.Sockets.Commands;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net.WebSockets;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    /// <summary>
+    /// Verifies the inbound client path rejects server-initiated-only commands
+    /// (<see cref="IServerInitiatedCommand"/>) rather than executing them — the hardening from #411.
+    /// The backplane-delivered path for these commands stays covered by
+    /// <see cref="ChallengeCompletedSocketTests"/> and <see cref="SocketManagerServiceTests"/>.
+    /// </summary>
+    [Collection("Integration")]
+    public class ServerInitiatedCommandRejectionTests : ApiIntegrationTestBase
+    {
+        private const string Username = "serverinituser";
+        private const string Password = "serverinitpass";
+
+        public ServerInitiatedCommandRejectionTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        private async Task<int> SeedAndLoginAsync()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context, Username, Password);
+            await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+            await LoginAsync(Username, Password);
+            return user.Id;
+        }
+
+        [Fact]
+        public async Task ClientInvoking_ChallengeCompleted_IsRejectedWithError()
+        {
+            var userId = await SeedAndLoginAsync();
+
+            await using var socketClient = new TestSocketClient();
+            await socketClient.ConnectAsync(Factory.Server.CreateWebSocketClient(), userId);
+
+            var response = await socketClient.SendCommandRawAsync(
+                nameof(ChallengeCompleted),
+                new { ChallengeId = 0, RewardItemId = (int?)null, RewardItemModId = (int?)null, RewardSkillId = (int?)null });
+
+            Assert.Equal("Command cannot be invoked by the client.", response.Error);
+        }
+
+        [Fact]
+        public async Task ClientInvoking_SocketReplaced_IsRejectedAndSocketStaysOpen()
+        {
+            var userId = await SeedAndLoginAsync();
+
+            await using var socketClient = new TestSocketClient();
+            await socketClient.ConnectAsync(Factory.Server.CreateWebSocketClient(), userId);
+
+            // SocketReplaced would close the socket if it executed; rejection must leave it open.
+            var response = await socketClient.SendCommandRawAsync(nameof(SocketReplaced));
+
+            Assert.Equal("Command cannot be invoked by the client.", response.Error);
+            Assert.Equal(WebSocketState.Open, socketClient.State);
+        }
+    }
+}

--- a/Game.Api.Tests/Unit/SocketCommandFactoryTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandFactoryTests.cs
@@ -1,0 +1,36 @@
+using Game.Api.Services;
+using Xunit;
+
+namespace Game.Api.Tests.Unit
+{
+    public class SocketCommandFactoryTests
+    {
+        public SocketCommandFactoryTests()
+        {
+            // Populates the static command registry from the assembly; idempotent across tests.
+            SocketCommandFactory.RegisterSocketCommandGenerators();
+        }
+
+        [Theory]
+        [InlineData("ChallengeCompleted")]
+        [InlineData("SocketReplaced")]
+        public void IsServerInitiatedOnly_ReturnsTrue_ForServerInitiatedCommands(string commandName)
+        {
+            var factory = new SocketCommandFactory();
+
+            Assert.True(factory.IsServerInitiatedOnly(commandName));
+        }
+
+        [Theory]
+        [InlineData("GetZones")]
+        [InlineData("SetSelectedSkills")]
+        [InlineData("DefeatEnemy")]
+        [InlineData("NonExistentCommand")]
+        public void IsServerInitiatedOnly_ReturnsFalse_ForClientInvokableOrUnknownCommands(string commandName)
+        {
+            var factory = new SocketCommandFactory();
+
+            Assert.False(factory.IsServerInitiatedOnly(commandName));
+        }
+    }
+}

--- a/Game.Api/Services/SocketCommandFactory.cs
+++ b/Game.Api/Services/SocketCommandFactory.cs
@@ -7,6 +7,17 @@ namespace Game.Api.Services
     public class SocketCommandFactory
     {
         private static readonly ConcurrentDictionary<string, Func<IServiceProvider, AbstractSocketCommand>> _socketCommandGenerators = [];
+        private static readonly ConcurrentDictionary<string, byte> _serverInitiatedCommandNames = [];
+
+        /// <summary>
+        /// Whether the named command is server-initiated only (<see cref="IServerInitiatedCommand"/>) and
+        /// must therefore be rejected on the inbound client path. An O(1) lookup against the set built once
+        /// at registration, so the inbound path pays no per-message reflection.
+        /// </summary>
+        public bool IsServerInitiatedOnly(string commandName)
+        {
+            return _serverInitiatedCommandNames.ContainsKey(commandName);
+        }
 
         /// <summary>
         /// Creates the requested socket command inside a fresh DI scope.
@@ -43,6 +54,11 @@ namespace Game.Api.Services
                 var compiledGenerator = commandGenerator.Compile();
 
                 _socketCommandGenerators.TryAdd(type.Name, compiledGenerator);
+
+                if (type.IsAssignableTo(typeof(IServerInitiatedCommand)))
+                {
+                    _serverInitiatedCommandNames.TryAdd(type.Name, 0);
+                }
             }
         }
     }

--- a/Game.Api/Sockets/Commands/ChallengeCompleted.cs
+++ b/Game.Api/Sockets/Commands/ChallengeCompleted.cs
@@ -12,7 +12,7 @@ namespace Game.Api.Sockets.Commands
     /// request type (the parameters are not a typed <c>Parameters</c> property) since the client only
     /// listens for it.
     /// </summary>
-    public class ChallengeCompleted : AbstractSocketCommandWithResponseData<ChallengeCompletedModel>
+    public class ChallengeCompleted : AbstractSocketCommandWithResponseData<ChallengeCompletedModel>, IServerInitiatedCommand
     {
         private ChallengeCompletedModel? _model;
 

--- a/Game.Api/Sockets/Commands/IServerInitiatedCommand.cs
+++ b/Game.Api/Sockets/Commands/IServerInitiatedCommand.cs
@@ -1,0 +1,12 @@
+namespace Game.Api.Sockets.Commands
+{
+    /// <summary>
+    /// Marks a socket command as server-initiated only: it is dispatched solely through the Redis
+    /// backplane (<see cref="Game.Api.Services.SocketManagerService"/> → the pub/sub command processor)
+    /// and must never be invoked by an inbound client message. The inbound path
+    /// (<see cref="Sockets.SocketHandler"/>) rejects any command carrying this marker, closing off the
+    /// foot-gun where a client could trigger a push command by sending its name — while the
+    /// backplane-delivered path, which calls the command directly, still dispatches it.
+    /// </summary>
+    public interface IServerInitiatedCommand { }
+}

--- a/Game.Api/Sockets/Commands/SocketReplaced.cs
+++ b/Game.Api/Sockets/Commands/SocketReplaced.cs
@@ -2,7 +2,7 @@
 
 namespace Game.Api.Sockets.Commands
 {
-    public class SocketReplaced : AbstractSocketCommand
+    public class SocketReplaced : AbstractSocketCommand, IServerInitiatedCommand
     {
         public override string Name { get; set; } = nameof(SocketReplaced);
 

--- a/Game.Api/Sockets/SocketHandler.cs
+++ b/Game.Api/Sockets/SocketHandler.cs
@@ -122,6 +122,20 @@ namespace Game.Api.Sockets
                 var commandInfo = message.Deserialize<SocketCommandInfo>();
                 if (commandInfo is not null)
                 {
+                    if (_commandFactory.IsServerInitiatedOnly(commandInfo.Name))
+                    {
+                        // Server-initiated commands (e.g. ChallengeCompleted, SocketReplaced) are only valid
+                        // when dispatched via the backplane; a client sending one is rejected, not executed.
+                        _logger.LogWarning("Client attempted to invoke server-initiated command: {CommandInfo} on socket: {Id}", commandInfo, Id);
+                        await _context.SendData(new ApiSocketResponse
+                        {
+                            Id = commandInfo.Id,
+                            Name = commandInfo.Name,
+                            Error = "Command cannot be invoked by the client."
+                        });
+                        return;
+                    }
+
                     await ExecuteCommand(commandInfo);
                 }
             }


### PR DESCRIPTION
## Summary

Inbound client messages and Redis-backplane pushes both flow through `SocketHandler.ExecuteCommand` → `SocketCommandFactory.CreateCommand`, so **any** registered command can be invoked by a client sending its name — including the server-initiated-only push commands `ChallengeCompleted` and `SocketReplaced`. This closes that off structurally, as #411 requested, so a future push command that does more than echo its payload can't be triggered out-of-band by a client.

## What changed

- **`IServerInitiatedCommand`** (new marker interface) — tags a command as dispatched solely through the backplane.
- **`SocketCommandFactory`** — the same one-time reflection pass that builds the command-generator registry now also records the marked command names into a set, and a new `IsServerInitiatedOnly(name)` exposes an **O(1)** lookup (no per-message reflection, per the issue's "avoid repeated reflection" note).
- **`SocketHandler.HandleMessage`** (the inbound path) — rejects a server-initiated command before execution: logs a warning and returns an error response (`"Command cannot be invoked by the client."`) carrying the request id. The backplane path (`SocketManagerService.GetSocketCommandProcessor` → `socket.ExecuteCommand`) calls `ExecuteCommand` directly and is unaffected, so pushes still dispatch.
- **`ChallengeCompleted`** and **`SocketReplaced`** now implement the marker.

## How it addresses the issue

- Introduces a structural marker for server-initiated-only commands. ✅
- Rejects them on the inbound path while keeping the pub/sub path dispatching. ✅
- Avoids repeated reflection (set built once at registration; runtime lookup is a dictionary hit). ✅
- Applies the marker to `ChallengeCompleted` and `SocketReplaced`. ✅

No user-facing change — this is robustness/hardening only.

## Test plan

- [x] `dotnet build` — clean (0 warnings, 0 errors).
- [x] `dotnet test Game.Api.Tests` — **351 passed, 0 failed** (run against the session's Postgres/Redis containers).

New tests:
- `SocketCommandFactoryTests` (unit) — `IsServerInitiatedOnly` is true for the two push commands and false for client-invokable/unknown commands.
- `ServerInitiatedCommandRejectionTests` (integration) — a client invoking `ChallengeCompleted` gets the rejection error; a client invoking `SocketReplaced` is rejected **and the socket stays open** (proving it wasn't executed — it would otherwise close the socket). The backplane-delivered path for these commands stays covered by the existing `ChallengeCompletedSocketTests` / `SocketManagerServiceTests`.

Closes #411

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKQufRtuywM8JVe7VMybJd)_