### PR TITLE
Fix admin SetTags removing a tag from every item/mod, not just the target (#477)

### DIFF
--- a/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
@@ -1306,6 +1306,64 @@ namespace Game.Api.Tests.Integration
             Assert.Equal("Item mod not found.", result.ErrorMessage);
         }
 
+        [Fact]
+        public async Task SetTagsForItem_RemovesUnlistedTag_LeavesOtherItemsTagged()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var itemA = await TestDataSeeder.CreateItemAsync(context, "Item A");
+            var itemB = await TestDataSeeder.CreateItemAsync(context, "Item B");
+            var tag = await TestDataSeeder.CreateTagAsync(context, "Shared");
+
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            // Both items carry the shared tag.
+            await authClient.PostAsJsonAsync("/api/AdminTools/SetTagsForItem",
+                new { Id = itemA.Id, TagIds = new[] { tag.Id } }, CancellationToken);
+            await authClient.PostAsJsonAsync("/api/AdminTools/SetTagsForItem",
+                new { Id = itemB.Id, TagIds = new[] { tag.Id } }, CancellationToken);
+
+            // Re-set item A to drop the tag.
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/SetTagsForItem",
+                new { Id = itemA.Id, TagIds = Array.Empty<int>() }, CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // Item A lost the tag; item B must keep it.
+            Assert.Empty(await GetTagsForItem(itemA.Id));
+            var bTags = await GetTagsForItem(itemB.Id);
+            var remaining = Assert.Single(bTags);
+            Assert.Equal(tag.Id, remaining.Id);
+        }
+
+        [Fact]
+        public async Task SetTagsForItemMod_RemovesUnlistedTag_LeavesOtherModsTagged()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var modA = await TestDataSeeder.CreateItemModAsync(context, "Mod A");
+            var modB = await TestDataSeeder.CreateItemModAsync(context, "Mod B");
+            var tag = await TestDataSeeder.CreateTagAsync(context, "SharedMod");
+
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            // Both mods carry the shared tag.
+            await authClient.PostAsJsonAsync("/api/AdminTools/SetTagsForItemMod",
+                new { Id = modA.Id, TagIds = new[] { tag.Id } }, CancellationToken);
+            await authClient.PostAsJsonAsync("/api/AdminTools/SetTagsForItemMod",
+                new { Id = modB.Id, TagIds = new[] { tag.Id } }, CancellationToken);
+
+            // Re-set mod A to drop the tag.
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/SetTagsForItemMod",
+                new { Id = modA.Id, TagIds = Array.Empty<int>() }, CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // Mod A lost the tag; mod B must keep it.
+            Assert.Empty(await GetTagsForItemMod(modA.Id));
+            var bTags = await GetTagsForItemMod(modB.Id);
+            var remaining = Assert.Single(bTags);
+            Assert.Equal(tag.Id, remaining.Id);
+        }
+
         private async Task<List<Tag>> GetTagsForItem(int itemId)
         {
             using var scope = CreateScope();

--- a/Game.DataAccess/Repositories/Admin/AdminItemMods.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminItemMods.cs
@@ -100,7 +100,9 @@ namespace Game.DataAccess.Repositories.Admin
             {
                 if (!data.TagIds.Contains(currentTag.Id))
                 {
-                    currentTag.ItemMods.Clear();
+                    // Remove only this mod's join row; Clear() would delete the rows for every
+                    // mod carrying the tag, since the navigation eager-loads the full membership.
+                    currentTag.ItemMods.RemoveAll(im => im.Id == data.Id);
                 }
             }
 

--- a/Game.DataAccess/Repositories/Admin/AdminItems.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminItems.cs
@@ -123,7 +123,9 @@ namespace Game.DataAccess.Repositories.Admin
             {
                 if (!data.TagIds.Contains(currentTag.Id))
                 {
-                    currentTag.Items.Clear();
+                    // Remove only this item's join row; Clear() would delete the rows for every
+                    // item carrying the tag, since the navigation eager-loads the full membership.
+                    currentTag.Items.RemoveAll(i => i.Id == data.Id);
                 }
             }
 


### PR DESCRIPTION
## Summary

`AdminItems.SetTags` and `AdminItemMods.SetTags` corrupted tag assignments across **unrelated** records when removing a tag. Removing a tag from one item/mod silently stripped it from **every** item/mod that carried it.

The root cause: `GetTagEntitiesForItem`/`GetTagEntitiesForItemMod` (`Game.DataAccess/Repositories/Tags.cs`) eager-load the tag's *entire* membership (`.Include(t => t.Items)`), and the setters unassigned a tag by calling `currentTag.Items.Clear()` (and `currentTag.ItemMods.Clear()`). Because the navigation held every item/mod with that tag, `Clear()` deleted the `ItemTags`/`ItemModTags` join rows for all of them, not just the target.

## How it's fixed

Remove only the target record's join row instead of clearing the whole collection:

```csharp
currentTag.Items.RemoveAll(i => i.Id == data.Id);      // AdminItems
currentTag.ItemMods.RemoveAll(im => im.Id == data.Id); // AdminItemMods
```

This is the minimal, targeted fix that keeps the existing eager-loaded structure intact. I kept the current `GetTagEntitiesFor*` shape rather than reworking it to avoid the full-membership load, since `RemoveAll` already makes the operation correct and the alternative (constructing/deleting join rows directly without loading the navigation) is a larger change for no functional gain here.

## Tests

Added two regression integration tests in `Game.Api.Tests/Integration/AdminToolsControllerTests.cs`, mirroring the `DropsUnlisted*` pattern the other relationship setters already have:

- `SetTagsForItem_RemovesUnlistedTag_LeavesOtherItemsTagged` — two items share a tag; re-set item A to drop it; assert item A loses it and item B keeps it.
- `SetTagsForItemMod_RemovesUnlistedTag_LeavesOtherModsTagged` — the item-mod equivalent.

Both fail against the old `Clear()` behavior and pass with the fix.

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings/errors
- [x] `dotnet test Game.Api.Tests` — all 368 tests pass (including the two new ones)

Closes #477

---
_Generated by [Claude Code](https://claude.ai/code/session_019q4ky2ZhSVtgQqvEF4iVtE)_