### PR TITLE
Fix biased battle RNG seed fold in CreateBattleSeed (#479)

### DIFF
--- a/Game.Application.Tests/Services/CreateBattleSeedTests.cs
+++ b/Game.Application.Tests/Services/CreateBattleSeedTests.cs
@@ -1,0 +1,33 @@
+using Game.Application.Services;
+using Xunit;
+
+namespace Game.Application.Tests.Services
+{
+    /// <summary>
+    /// Unit tests pinning the battle RNG seed derivation (<see cref="BattleService.CreateBattleSeed"/>).
+    /// The seed is the shared starting point for the seeded crit/dodge/block work (#178) and must fold the
+    /// 64-bit tick count into uint32 by plain truncation (its low 32 bits), not a biased modulo by
+    /// <c>uint.MaxValue</c> (2^32 - 1), which can never yield <c>uint.MaxValue</c> and does not cleanly
+    /// truncate. The cross-port RNG parity itself lives in
+    /// <c>Game.Core.Tests/Battle/Mulberry32ParityTests.cs</c>; the seed is server-derived and transmitted to
+    /// the client, so there is no frontend seed-derivation to mirror — the client consumes the seed it receives.
+    /// </summary>
+    public class CreateBattleSeedTests
+    {
+        // ticks => expected seed (the low 32 bits of the 64-bit tick count). The chosen vectors expose the
+        // old biased fold: under "% uint.MaxValue" the uint.MaxValue case yielded 0 and the 2^32 case yielded
+        // 1 — both wrong.
+        [Theory]
+        [InlineData(0L, 0u)]
+        [InlineData(4294967295L, 4294967295u)]          // uint.MaxValue ticks: a value "% uint.MaxValue" can never produce
+        [InlineData(4294967296L, 0u)]                   // 2^32 ticks folds cleanly to 0, not 1
+        [InlineData(639169488000000000L, 1266819072u)]  // 2026-06-13T12:00:00Z — a realistic battle-start time
+        [InlineData(773437014593704226L, 4009693474u)]  // high-bit arbitrary tick count
+        public void CreateBattleSeed_TruncatesTicksToLow32Bits(long ticks, uint expectedSeed)
+        {
+            var seed = BattleService.CreateBattleSeed(new DateTime(ticks, DateTimeKind.Utc));
+
+            Assert.Equal(expectedSeed, seed);
+        }
+    }
+}

--- a/Game.Application/Game.Application.csproj
+++ b/Game.Application/Game.Application.csproj
@@ -10,6 +10,10 @@
     <ProjectReference Include="..\Game.Abstractions\Game.Abstractions.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Game.Application.Tests" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -264,9 +264,11 @@ namespace Game.Application.Services
             return zone.IsUnlocked(completedChallengeIds);
         }
 
-        // Derives the simulation RNG seed from the battle-start timestamp. Shared by both start paths so
-        // seed generation stays in one place if it ever changes.
-        private static uint CreateBattleSeed(DateTime now) => (uint)(now.Ticks % uint.MaxValue);
+        // Derives the simulation RNG seed from the battle-start timestamp by truncating the 64-bit tick
+        // count to its low 32 bits. A modulo by uint.MaxValue (2^32 - 1) biases the fold — it can never
+        // produce uint.MaxValue and does not cleanly truncate — and this seed must reproduce identically
+        // under the frontend Mulberry32 port for battle-replay parity (#178). Shared by both start paths.
+        internal static uint CreateBattleSeed(DateTime now) => unchecked((uint)now.Ticks);
 
         private BattleResult SimulateBattle(CoreEnemy enemy, IReadOnlyList<int> enemySkillIds, BattleSnapshot snapshot, int? maxMs = null)
         {


### PR DESCRIPTION
## Summary

`BattleService.CreateBattleSeed` folded the 64-bit tick count into the 32-bit seed range with `now.Ticks % uint.MaxValue`. `uint.MaxValue` is `2^32 - 1`, not `2^32`, so the reduction is biased: it can **never** produce `uint.MaxValue` and does not cleanly truncate a 64-bit value into the 32-bit range. This seed is the documented shared RNG starting point for the seeded crit/dodge/block parity work (#178), so a wrong reduction is exactly the kind of silent server/client drift the parity vectors exist to prevent — even though the seed currently has no live consumer.

## How it's fixed

Truncate to the low 32 bits instead:

```csharp
internal static uint CreateBattleSeed(DateTime now) => unchecked((uint)now.Ticks);
```

The helper is now `internal` (with `InternalsVisibleTo` for `Game.Application.Tests`) so the pure fold can be unit-tested directly with pinned `Ticks → seed` vectors — there is currently no test exercising it.

## On the "mirror on the frontend" note in the issue

The issue suggested mirroring the test on the frontend alongside `Mulberry32ParityTests ↔ mulberry32-parity.test.ts`. I deliberately did **not** add a frontend test, because there is nothing to mirror: the seed is derived **server-side from `DateTime.Ticks`** and transmitted to the client (`BattleStartResult.Seed`; the client receives it as `enemies.ts`'s `seed` field). The frontend has no seed-derivation code of its own — it consumes the seed it's given. The genuine cross-port parity surface (the Mulberry32 stream produced *from* a given seed) is already locked by the existing parity vectors, which this change does not touch. Happy to revisit if you'd rather the client eventually derive its own seed, but that would be new behavior beyond this bug.

## Tests

Added `Game.Application.Tests/Services/CreateBattleSeedTests.cs` — a theory pinning known `Ticks → seed` vectors, including the two cases the old modulo got wrong:

- `uint.MaxValue` ticks → `uint.MaxValue` (old code yielded `0`)
- `2^32` ticks → `0` (old code yielded `1`)
- plus `0`, a realistic `2026-06-13T12:00:00Z` timestamp, and a high-bit arbitrary tick count

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings / 0 errors
- [x] `dotnet test Game.Application.Tests` — all 164 tests pass (including the 5 new vector cases)

Closes #479

https://claude.ai/code/session_01BLYdjsoGGuqjievqWPE3se

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLYdjsoGGuqjievqWPE3se)_