### PR TITLE
Fix exp reward unit mismatch in DefeatRewards.GetExpReward (#480)

### DIFF
--- a/Game.Core.Tests/Battle/DefeatRewardsTests.cs
+++ b/Game.Core.Tests/Battle/DefeatRewardsTests.cs
@@ -1,90 +1,191 @@
+using Game.Core;
 using Game.Core.Attributes;
+using Game.Core.Attributes.Modifiers;
 using Game.Core.Battle;
 using Game.Core.Enemies;
+using Game.Core.Items;
 using Game.Core.Players;
 using Game.Core.Players.Inventories;
 using Xunit;
+using static Game.Core.EAttribute;
 
 namespace Game.Core.Tests.Battle
 {
     public class DefeatRewardsTests
     {
         [Fact]
-        public void ExpReward_ZeroPlayerStats_ReturnsFlooredEnemyTotal()
+        public void ExpReward_EqualCoreAttributeTotals_MultiplierIsOne()
         {
-            var player = MakePlayer(statPointsGained: 0);
+            var player = MakePlayer(allocations: [(Strength, 10), (Endurance, 5)]);
             var enemy = MakeEnemy(strength: 10, endurance: 5);
 
             var rewards = new DefeatRewards(player, enemy);
 
-            // Enemy attribute total = 10 + 5 = 15. Player stat total = 0 → floor(15) = 15.
-            Assert.Equal(15, rewards.ExpReward);
-        }
-
-        [Fact]
-        public void ExpReward_EqualStrength_MultiplierIsOne()
-        {
-            var player = MakePlayer(statPointsGained: 15);
-            var enemy = MakeEnemy(strength: 10, endurance: 5);
-
-            var rewards = new DefeatRewards(player, enemy);
-
-            // ratio = 15/15 = 1.0; within [0.8, 1.2] → multiplier = 1.0 → exp = floor(15*1) = 15
+            // enemy total = 15, player core total = 15; ratio 1.0 ∈ [0.8, 1.2] → exp = floor(15 * 1) = 15
             Assert.Equal(15, rewards.ExpReward);
         }
 
         [Fact]
         public void ExpReward_RatioNearOne_MultiplierIsOne()
         {
-            var player = MakePlayer(statPointsGained: 16);
+            var player = MakePlayer(allocations: [(Strength, 11), (Endurance, 5)]);
             var enemy = MakeEnemy(strength: 10, endurance: 5);
 
             var rewards = new DefeatRewards(player, enemy);
 
-            // ratio = 15/16 ≈ 0.9375; within [0.8, 1.2] → multiplier = 1.0 → exp = floor(15) = 15
+            // ratio = 15/16 ≈ 0.9375 ∈ [0.8, 1.2] → multiplier 1.0 → exp = floor(15) = 15
             Assert.Equal(15, rewards.ExpReward);
         }
 
         [Fact]
         public void ExpReward_WeakEnemy_ReducedExp()
         {
-            var player = MakePlayer(statPointsGained: 100);
+            var player = MakePlayer(allocations: [(Strength, 60), (Endurance, 40)]);
             var enemy = MakeEnemy(strength: 5, endurance: 5);
 
             var rewards = new DefeatRewards(player, enemy);
 
-            // ratio = 10/100 = 0.1; < 0.8 → multiplier = 0.1^2 = 0.01 → exp = floor(10 * 0.01) = 0
+            // ratio = 10/100 = 0.1 < 0.8 → multiplier 0.1^2 = 0.01 → exp = floor(10 * 0.01) = 0
             Assert.Equal(0, rewards.ExpReward);
         }
 
         [Fact]
         public void ExpReward_StrongEnemy_IncreasedExp()
         {
-            var player = MakePlayer(statPointsGained: 10);
+            var player = MakePlayer(allocations: [(Strength, 10)]);
             var enemy = MakeEnemy(strength: 50, endurance: 50);
 
             var rewards = new DefeatRewards(player, enemy);
 
-            // ratio = 100/10 = 10; > 1.2 → multiplier = 10^2 = 100 → exp = floor(100 * 100) = 10000
+            // ratio = 100/10 = 10 > 1.2 → multiplier 10^2 = 100 → exp = floor(100 * 100) = 10000
             Assert.Equal(10000, rewards.ExpReward);
         }
 
-        private static Player MakePlayer(int statPointsGained) => new()
+        [Fact]
+        public void ExpReward_ZeroPlayerAttributes_ReturnsFlooredEnemyTotal()
         {
-            Id = 1,
-            Name = "Test",
-            Level = 1,
-            Exp = 0,
-            CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints([])
-            { StatPointsGained = statPointsGained, StatPointsUsed = 0 },
-            Inventory = new Inventory(),
-            SelectedSkills = [],
-            Skills = [],
-            LogPreferences = [],
+            var player = MakePlayer(allocations: []);
+            var enemy = MakeEnemy(strength: 10, endurance: 5);
+
+            var rewards = new DefeatRewards(player, enemy);
+
+            // No player attribute investment → guard returns floor(enemy total) = floor(15) = 15
+            Assert.Equal(15, rewards.ExpReward);
+        }
+
+        [Fact]
+        public void ExpReward_NewPlayer_UsesAllocatedAttributesNotStatPointsGainedCount()
+        {
+            // A new player has a starter spread allocated (sum 30) but StatPointsGained == 0 — the
+            // starter spread is not counted as "gained". The denominator must be the allocated total.
+            var player = MakePlayer(
+                allocations: [(Strength, 5), (Endurance, 5), (Intellect, 5), (Agility, 5), (Dexterity, 5), (Luck, 5)],
+                statPointsGained: 0);
+            var enemy = MakeEnemy(strength: 15);
+
+            var rewards = new DefeatRewards(player, enemy);
+
+            // ratio = 15/30 = 0.5 < 0.8 → multiplier 0.25 → exp = floor(15 * 0.25) = 3.
+            // The old formula divided by StatPointsGained (0) and returned the full floor(15) = 15.
+            Assert.Equal(3, rewards.ExpReward);
+        }
+
+        [Fact]
+        public void ExpReward_DoesNotDependOnStatPointsGained()
+        {
+            // Two identical players that differ only in StatPointsGained must earn identical exp,
+            // proving the reward no longer keys off the stat-point count.
+            var enemy = MakeEnemy(strength: 30);
+            var lowGained = MakePlayer(allocations: [(Strength, 15), (Endurance, 15)], statPointsGained: 0);
+            var highGained = MakePlayer(allocations: [(Strength, 15), (Endurance, 15)], statPointsGained: 999);
+
+            var lowReward = new DefeatRewards(lowGained, enemy);
+            var highReward = new DefeatRewards(highGained, enemy);
+
+            // ratio = 30/30 = 1.0 → exp = floor(30) = 30 for both
+            Assert.Equal(30, lowReward.ExpReward);
+            Assert.Equal(30, highReward.ExpReward);
+        }
+
+        [Fact]
+        public void ExpReward_IncludesEquippedItemCoreAttributes()
+        {
+            var player = MakePlayer(allocations: [(Strength, 10)]);
+            EquipAccessory(player, [Modifier(Strength, 5, EModifierType.Additive)]);
+            var enemy = MakeEnemy(strength: 15);
+
+            var rewards = new DefeatRewards(player, enemy);
+
+            // Player core total = 10 (allocation) + 5 (gear) = 15; ratio 1.0 → exp = floor(15) = 15
+            Assert.Equal(15, rewards.ExpReward);
+        }
+
+        [Fact]
+        public void ExpReward_ExcludesDerivedAndMultiplicativeModifiers()
+        {
+            var player = MakePlayer(allocations: [(Strength, 15)]);
+            EquipAccessory(player,
+            [
+                Modifier(MaxHealth, 100, EModifierType.Additive),   // derived attribute → excluded
+                Modifier(Strength, 1.5, EModifierType.Multiplicative), // scaling factor → excluded
+            ]);
+            var enemy = MakeEnemy(strength: 15);
+
+            var rewards = new DefeatRewards(player, enemy);
+
+            // Only the additive core Strength (15) counts; ratio 15/15 = 1.0 → exp = floor(15) = 15.
+            // Were the derived/multiplicative modifiers summed, the denominator would balloon and the
+            // reward would collapse.
+            Assert.Equal(15, rewards.ExpReward);
+        }
+
+        private static Player MakePlayer(
+            (EAttribute Attribute, double Amount)[] allocations,
+            int statPointsGained = 0) => new()
+            {
+                Id = 1,
+                Name = "Test",
+                Level = 1,
+                Exp = 0,
+                CurrentZoneId = 0,
+                StatPoints = new PlayerStatPoints(
+                    allocations.Select(a => new StatAllocation { Attribute = a.Attribute, Amount = a.Amount }).ToList())
+                {
+                    StatPointsGained = statPointsGained,
+                    StatPointsUsed = (int)allocations.Sum(a => a.Amount),
+                },
+                Inventory = new Inventory(),
+                SelectedSkills = [],
+                Skills = [],
+                LogPreferences = [],
+            };
+
+        private static void EquipAccessory(Player player, List<AttributeModifier> attributes)
+        {
+            var item = new Item
+            {
+                Id = 10,
+                Name = "Accessory",
+                Description = string.Empty,
+                Category = EItemCategory.Accessory,
+                Rarity = ERarity.Common,
+                Attributes = attributes,
+                ModSlots = [],
+                Tags = [],
+            };
+            player.Inventory.UnlockItem(item);
+            player.TryEquipItem(item.Id, EEquipmentSlot.AccessorySlot);
+        }
+
+        private static AttributeModifier Modifier(EAttribute attribute, double amount, EModifierType type) => new()
+        {
+            Attribute = attribute,
+            Amount = amount,
+            Type = type,
+            Source = EAttributeModifierSource.Item,
         };
 
-        private static Enemy MakeEnemy(double strength, double endurance) => new()
+        private static Enemy MakeEnemy(double strength = 0, double endurance = 0) => new()
         {
             Id = 1,
             Name = "Test Enemy",
@@ -94,13 +195,13 @@ namespace Game.Core.Tests.Battle
             [
                 new AttributeDistribution
                 {
-                    AttributeId = EAttribute.Strength,
+                    AttributeId = Strength,
                     BaseAmount = (decimal)strength,
                     AmountPerLevel = 0,
                 },
                 new AttributeDistribution
                 {
-                    AttributeId = EAttribute.Endurance,
+                    AttributeId = Endurance,
                     BaseAmount = (decimal)endurance,
                     AmountPerLevel = 0,
                 },

--- a/Game.Core/Attributes/Attribute.cs
+++ b/Game.Core/Attributes/Attribute.cs
@@ -62,5 +62,27 @@ namespace Game.Core.Attributes
         {
             return Enum.GetValues<EAttribute>().Select(a => new Attribute(a));
         }
+
+        /// <summary>
+        /// The core attributes a player directly invests stat points into. Every other attribute is
+        /// "derived" — computed from these via <see cref="Modifiers.StaticAttributeModifiers"/> — so the
+        /// core set is the meaningful measure of raw attribute investment.
+        /// </summary>
+        private static readonly HashSet<EAttribute> CoreAttributeSet =
+        [
+            Strength, Endurance, Intellect, Agility, Dexterity, Luck,
+        ];
+
+        /// <inheritdoc cref="CoreAttributeSet"/>
+        public static IReadOnlySet<EAttribute> CoreAttributes => CoreAttributeSet;
+
+        /// <summary>
+        /// Whether the given <paramref name="attribute"/> is a core (directly-allocatable) attribute
+        /// rather than a derived one.
+        /// </summary>
+        public static bool IsCore(EAttribute attribute)
+        {
+            return CoreAttributeSet.Contains(attribute);
+        }
     }
 }

--- a/Game.Core/Battle/DefeatRewards.cs
+++ b/Game.Core/Battle/DefeatRewards.cs
@@ -1,3 +1,4 @@
+using Game.Core.Attributes.Modifiers;
 using Game.Core.Enemies;
 using Game.Core.Players;
 
@@ -17,17 +18,31 @@ namespace Game.Core.Battle
 
         private static int GetExpReward(Player player, Enemy enemy)
         {
-            var enemyAttTotal = enemy.GetAttributeModifiers().Sum(att => att.Amount);
-            var playerAttTotal = player.StatPoints.StatPointsGained;
-            if (playerAttTotal == 0)
+            var enemyAttTotal = SumCoreAttributes(enemy.GetAttributeModifiers());
+            var playerAttTotal = SumCoreAttributes(player.GetAllModifiers());
+            if (playerAttTotal <= 0)
             {
                 return (int)Math.Floor(enemyAttTotal);
-
             }
 
             var attRatio = enemyAttTotal / playerAttTotal;
             var expMulti = attRatio is < 0.8 or > 1.2 ? Math.Pow(attRatio, 2) : 1.0;
             return (int)Math.Floor(enemyAttTotal * expMulti);
+        }
+
+        /// <summary>
+        /// Sums the additive amounts of the core attributes in <paramref name="modifiers"/>. Both
+        /// combatants' power is measured the same way so the difficulty ratio compares like with like:
+        /// derived attributes (e.g. MaxHealth) are excluded because they are computed from the core
+        /// attributes and never appear in a player's <see cref="Player.GetAllModifiers"/>, and
+        /// multiplicative modifiers are excluded because their amount is a scaling factor, not a flat
+        /// point total that can be meaningfully summed.
+        /// </summary>
+        private static double SumCoreAttributes(IEnumerable<AttributeModifier> modifiers)
+        {
+            return modifiers
+                .Where(mod => mod.Type == EModifierType.Additive && Attribute.IsCore(mod.Attribute))
+                .Sum(mod => mod.Amount);
         }
     }
 }

--- a/docs/game-design.md
+++ b/docs/game-design.md
@@ -18,6 +18,12 @@ Attributes are somewhat of a work-in-progress feature, but the general idea is t
 
 The attribute system is the substrate for timed skill effects (see [Skills](#skills)): applying an effect adds a real attribute modifier to the target mid-battle and expiry removes it, so derived attributes cascade naturally (a temporary Strength buff also raises MaxHealth, exactly like a permanent one). Damage-over-time and heal-over-time are realized the same way, through two **per-second** attributes — `DamageTakenPerSecond` and `HealthRegenPerSecond` — that an end-of-tick simulator phase consumes (a poison is then pure data: a debuff that adds `DamageTakenPerSecond` to the opponent for a duration). See [Skill Effects](#skill-effects) for the DoT/HoT runtime rules.
 
+## Experience Rewards
+
+The XP a victory awards scales with how well the enemy is matched to the player's power, so fighting something around (or above) your level pays off and grinding trivial enemies does not. The reward (`DefeatRewards`, computed server-side and sent to the client) is the enemy's attribute power times a difficulty multiplier derived from the ratio of the enemy's power to the player's: within a ±20% band the multiplier is `1`, and outside it the reward scales quadratically with the ratio (over-level enemies pay out more, under-level enemies far less).
+
+"Power" on both sides is measured the same way — **the sum of the additive *core* attribute amounts** (Strength, Endurance, Intellect, Agility, Dexterity, Luck). Comparing like with like is the key invariant: derived attributes (e.g. MaxHealth) are excluded because they are computed *from* the core attributes (counting both double-counts the same investment, and a player's derived attributes are not part of their raw modifier set), and multiplicative modifiers are excluded because their amount is a scaling factor rather than a flat point total. Notably the player's measure is their **allocated** attribute total (allocations plus equipment), **not** the count of stat points they have been granted — a new player's starter allocation counts even though it was never "gained" from a level-up.
+
 # Skills
 
 Skills are a fairly underdeveloped feature in the game, but the general idea is that they will provide active abilities for players that are automatically used during battles. Beyond dealing damage, a skill can carry **timed effects** — buffs/debuffs that raise or lower an attribute on the caster or the opponent for a duration (see [Skill Effects](#skill-effects)).


### PR DESCRIPTION
## Summary

`DefeatRewards.GetExpReward` scaled exp by a ratio computed from two **different units**: it divided the enemy's summed attribute *amounts* by `player.StatPoints.StatPointsGained`, which is a *count of stat points granted by level-ups*, not an attribute total. A new player starts with a 30-point starter allocation but `StatPointsGained == 0`, so the denominator ignored the player's entire starting investment, and the quadratic multiplier (`Math.Pow(attRatio, 2)`) amplified the distortion — worst for low-level players.

## How it's fixed

Both combatants' "power" is now measured the same way so the difficulty ratio compares like with like: **the sum of the additive *core*-attribute amounts** (Strength, Endurance, Intellect, Agility, Dexterity, Luck).

- The player side comes from `GetAllModifiers()` (stat allocations **+ equipment**), not `StatPointsGained`.
- **Derived attributes** (e.g. `MaxHealth`) are excluded — they are computed *from* the core attributes, so counting both double-counts the same investment, and a player's derived attributes never appear in `GetAllModifiers()` anyway (they'd be an asymmetry against the enemy).
- **Multiplicative modifiers** are excluded — their amount is a scaling factor, not a flat point total that can be meaningfully summed.

The scaling shape itself (±20% deadzone, quadratic outside it) is unchanged — there is no exp formula authored in `docs/game-design.md`, so only the unit mismatch was corrected.

A small domain addition models the core-vs-derived distinction that previously lived only in `EAttribute` XML comments: `Attribute.IsCore(EAttribute)` and `Attribute.CoreAttributes`.

## Tests

`DefeatRewardsTests` previously set `StatPointsGained` directly, which **passed while masking the bug**. The suite is rewritten to build realistic attribute spreads via `StatAllocation`s and equipped items, and adds regression cases:

- `ExpReward_NewPlayer_UsesAllocatedAttributesNotStatPointsGainedCount` — starter spread (sum 30, `StatPointsGained == 0`) is the denominator; the old code returned the full enemy total.
- `ExpReward_DoesNotDependOnStatPointsGained` — two players differing only in `StatPointsGained` earn identical exp.
- `ExpReward_IncludesEquippedItemCoreAttributes` — gear-granted core attributes count toward player power.
- `ExpReward_ExcludesDerivedAndMultiplicativeModifiers` — a flat `MaxHealth` bonus and a multiplicative Strength modifier are both ignored.
- Plus the equal/near/weak/strong-enemy and zero-attribute edge cases, now driven by real allocations.

## Notes

- Exp reward is computed **server-side** in `DefeatRewards` and sent to the client (`rewards.expReward`); the frontend only consumes it and does not re-derive it. It is therefore **not** part of the battle-simulation parity surface, so no frontend mirror test is required (the frontend has no exp-reward logic of its own).
- Documented the scaling in `docs/game-design.md` (new "Experience Rewards" subsection) since exp is a core progression lever.

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings / 0 errors
- [x] `dotnet test` — all 952 tests pass (Core 401, Application 159, Api 366, Infrastructure 26), including the rewritten/added DefeatRewards cases
- [x] Verified the existing `BattleServiceIntegrationTests` exp assertion is unaffected (the seeded player's allocations sum to the same 100 as its `StatPointsGained`)

Closes #480

https://claude.ai/code/session_012KDYfckEzpvKZV2qkZCSwD

---
_Generated by [Claude Code](https://claude.ai/code/session_012KDYfckEzpvKZV2qkZCSwD)_