### PR TITLE
Move --panel/--panel-2 colors into _colors.scss tokens (#419)

### DIFF
--- a/UI/src/routes/+layout.svelte
+++ b/UI/src/routes/+layout.svelte
@@ -116,8 +116,8 @@ $effect(() => {
 	// theme overrides. Paired with the container's backdrop blur for legibility.
 	--tooltip-bg: color-mix(in srgb, var(--surface) 92%, transparent);
 	--page: #{colors.$page};
-	--panel: #16171e;
-	--panel-2: #1b1c24;
+	--panel: #{colors.$panel};
+	--panel-2: #{colors.$panel-2};
 	--mono: 'Geist Mono', ui-monospace, monospace;
 	--sans: Geist, system-ui, sans-serif;
 	--enemy: #{colors.$enemy-accent};

--- a/UI/src/styles/_colors.scss
+++ b/UI/src/styles/_colors.scss
@@ -15,6 +15,11 @@ $accent: #a1c2f7;
 $accent-light: #c0d8ff;
 $surface: #14151b;
 $surface-alpha: rgba(20, 21, 27, 0.96);
+// Raised panel surfaces sitting just above the page/surface base — the slightly
+// lighter card/well backgrounds (challenge cards/overview panels, workbench list,
+// card-game loom face). Consumed via the --panel / --panel-2 tokens.
+$panel: #16171e;
+$panel-2: #1b1c24;
 $text-primary: #f0f0f0;
 $text-secondary: rgba(240, 240, 240, 0.78);
 $text-tertiary: rgba(240, 240, 240, 0.55);


### PR DESCRIPTION
## Summary

`--panel` and `--panel-2` in `UI/src/routes/+layout.svelte` were the lone raw hex literals (`#16171e` / `#1b1c24`) in a block where every sibling token interpolates a SCSS variable from `_colors.scss`. That bypassed the palette's single source of truth, so these two surface colours couldn't be retheme'd alongside the rest (the theming convention documented in `docs/frontend.md` → Styling).

This moves them into the palette:

- Add `$panel: #16171e;` / `$panel-2: #1b1c24;` to `UI/src/styles/_colors.scss`, placed with the surface/neutral tokens (after `$surface-alpha`) with a short comment matching the neighbours.
- Replace the literals in `+layout.svelte` with `--panel: #{colors.$panel};` / `--panel-2: #{colors.$panel-2};`, matching the `--page` sibling's interpolation form.

## No visual change

The hex values are unchanged — this purely sources the same values through the palette so they're consistent with every sibling token. The four consumers read the CSS vars and need no edits (confirmed):

- `UI/src/routes/admin/workbench/workbench.scss`
- `UI/src/routes/game/screens/challenges/OverviewPane.svelte`
- `UI/src/routes/game/screens/challenges/ChallengeDetailCard.svelte`
- `UI/src/routes/game/screens/card-game/loom/CardFace.svelte`

## Test plan

- `npm ci`
- `npm run lint` — eslint clean + `svelte-check` 0 errors / 0 warnings across 890 files (compiles the SCSS interpolation)
- `npm run test:unit:ci` — 1605/1605 tests pass across 579 suites

No new test added: this is a no-op colour refactor (no JS/logic change), so green lint + unit run + visual SCSS sanity is sufficient.

Closes #419

https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6)_