### PR TITLE
Fix RedisQueue add-path log messages to say "Added" instead of "Retrieved" (#441)

### DIFF
--- a/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
@@ -54,7 +54,7 @@ namespace Game.Infrastructure.PubSub.Redis
 
         public void AddToQueue(string value)
         {
-            _logger.LogTrace("Retrieved value from RedisQueue: {QueueName}, value: {Value}", QueueName, value);
+            _logger.LogTrace("Added value to RedisQueue: {QueueName}, value: {Value}", QueueName, value);
             _redis.ListRightPush(QueueName, value);
         }
 
@@ -65,7 +65,7 @@ namespace Game.Infrastructure.PubSub.Redis
 
         public Task AddToQueueAsync(string value)
         {
-            _logger.LogTrace("Retrieved value from RedisQueue: {QueueName}, value: {Value}", QueueName, value);
+            _logger.LogTrace("Added value to RedisQueue: {QueueName}, value: {Value}", QueueName, value);
             return _redis.ListRightPushAsync(QueueName, value);
         }
 


### PR DESCRIPTION
## Summary

`RedisQueue.AddToQueue` and `RedisQueue.AddToQueueAsync` logged `"Retrieved value from RedisQueue: {QueueName}, value: {Value}"` — a message copied from the `GetNext`/`GetNextAsync` pop/retrieve path — even though these methods *push* onto the queue. Anyone tracing the write-behind pipeline at `Trace` level saw every enqueue mislabelled as a dequeue.

This rewords both add-path messages to `"Added value to RedisQueue: {QueueName}, value: {Value}"`, keeping the existing structured-logging placeholder style. The pop-path messages (lines 27 and 43) are correct and left untouched.

## How it addresses the issue

Resolves the copy-paste slip described in #441: the two PUSH log statements now describe the operation they actually perform.

## Test plan

- Log-message-only change with no behavioral impact, so no new assertions were added (per the project's testing guidance, brittle log-text assertions are avoided).
- Verified nothing in the test suite asserts on the message text (grep across the repo found the string only in `RedisQueue.cs`).
- `dotnet build` — succeeded, 0 warnings / 0 errors.
- `dotnet test --no-build --no-restore` — all suites green: Infrastructure 26, Core 401, Application 164, Api 370 (integration tests included), 0 failed / 0 skipped.

Closes #441

https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6)_