### PR TITLE
Format BattlerCard max health to avoid fractional display (#482)

### DIFF
--- a/UI/src/routes/game/screens/fight/BattlerCard.svelte
+++ b/UI/src/routes/game/screens/fight/BattlerCard.svelte
@@ -38,7 +38,7 @@ const { battler, side }: Props = $props();
 
 const accent = $derived(side === 'player' ? 'var(--accent)' : 'var(--enemy-accent)');
 const maxHealth = $derived(battler.attributes.getValue(EAttribute.MaxHealth));
-const healthText = $derived(`${formatNum(battler.currentHealth)} / ${maxHealth}`);
+const healthText = $derived(`${formatNum(battler.currentHealth)} / ${formatNum(maxHealth)}`);
 const healthPerc = $derived(maxHealth ? formatNum(Math.max((battler.currentHealth * 100) / maxHealth, 0)) : 100);
 </script>
 

--- a/UI/src/tests/routes/game/screens/fight/BattlerCard.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/BattlerCard.test.ts
@@ -33,6 +33,16 @@ describe('BattlerCard', () => {
 		expect(card.querySelector('.hp-text')?.textContent).toContain('80 / 100');
 	});
 
+	it('formats a fractional max health instead of rendering floating-point noise', () => {
+		const battler = makeBattler({
+			attributes: [{ attributeId: EAttribute.MaxHealth, amount: 412.50000000001 }],
+			currentHealth: 73.4
+		});
+		const { getByTestId } = render(BattlerCard, { props: { battler, side: 'player' } });
+
+		expect(getByTestId('player-card').querySelector('.hp-text')?.textContent).toContain('73.4 / 412.5');
+	});
+
 	it('sizes the health bar to the remaining health percentage', () => {
 		const battler = makeBattler({
 			attributes: [{ attributeId: EAttribute.MaxHealth, amount: 200 }],


### PR DESCRIPTION
## Summary

The fight-screen `BattlerCard` health readout passed `currentHealth` through `formatNum` (2-dp clamp) but interpolated `maxHealth` **raw**. Because derived `MaxHealth` can be fractional (multiplicative modifiers, per-attribute scaling from Strength, etc.), the readout could render floating-point noise such as `73.4 / 412.50000000001`.

## How it fixes the bug

`UI/src/routes/game/screens/fight/BattlerCard.svelte` now wraps `maxHealth` in the same `formatNum` helper already imported and used for `currentHealth`, so both sides of the `current / max` readout are formatted consistently:

```ts
const healthText = $derived(`${formatNum(battler.currentHealth)} / ${formatNum(maxHealth)}`);
```

No other behaviour changes — `healthPerc` already used `maxHealth` numerically and is untouched.

## Test plan

- Added a focused unit test to `BattlerCard.test.ts` that renders a battler with a fractional `MaxHealth` of `412.50000000001` and asserts the readout shows `73.4 / 412.5` (formatted), guarding against the floating-point noise regressing.
- `npm run lint` — clean (0 errors, 0 warnings).
- `npm run test:unit:ci` — all 1606 unit tests pass; coverage thresholds hold.

Closes #482

https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6)_