### PR TITLE
Materialize SaveChangesAsync temporary-id query to avoid deferred re-evaluation hazard (#452)

### DIFF
--- a/Game.Infrastructure/Database/GameContext.cs
+++ b/Game.Infrastructure/Database/GameContext.cs
@@ -520,7 +520,9 @@ namespace Game.Infrastructure.Database
         {
             foreach (var entry in ChangeTracker.Entries())
             {
-                var tempProps = entry.Properties.Where(p => p.IsTemporary);
+                // Materialize once so the PK and FK branches share a single pre-mutation snapshot;
+                // the PK branch clears IsTemporary, which the deferred predicate would otherwise re-filter on.
+                var tempProps = entry.Properties.Where(p => p.IsTemporary).ToList();
                 if (entry.State is not EntityState.Added)
                 {
                     var idProp = tempProps.FirstOrDefault(p => p.Metadata.IsPrimaryKey());


### PR DESCRIPTION
## Summary

`GameContext.SaveChangesAsync` performs a zero-based-identity temporary-id fixup over each tracked entry. It assigned the candidate set as a **deferred** LINQ query:

```csharp
var tempProps = entry.Properties.Where(p => p.IsTemporary);
```

The PK branch then clears `IsTemporary` on the id property (`idProp.IsTemporary = false`), and the FK branch later re-enumerates the **same** deferred predicate — now against the mutated state. This change materializes the query once with `.ToList()` so both the PK and FK branches operate on a single, stable pre-mutation snapshot. A short comment documents why.

## How it addresses #452

The deferred re-evaluation is correct today only because no current entity has a primary-key column that is simultaneously a foreign key. If such a dependent (PK == FK) were ever modeled, the PK branch would clear its `IsTemporary` flag and the FK branch would then silently exclude it from the fixup scan — a save-time correctness bug that would be very hard to trace. Materializing once removes that latent trap. The change is **behavior-preserving** for the current model, where the PK and FK property sets are disjoint, so the FK branch sees the identical set whether the predicate is deferred or snapshotted.

## Test plan

- `dotnet build` — succeeded, 0 warnings / 0 errors.
- `dotnet test` — all suites green: Game.Infrastructure.Tests 26/26, Game.Core.Tests 401/401, Game.Api.Tests 370/370, Game.Application.Tests 164/164. (When run together, `Game.Application.Tests` initially reported failures purely from waiting on the serialized integration-test lock held by the concurrent `Game.Api.Tests` run; re-running it in isolation passes 164/164.)
- The existing admin-write and player insert/save integration paths (`AdminToolsControllerTests`, `PlayerControllerTests`, write-behind/synchronizer tests) round-trip zero-based-identity entities with FK relationships through this loop, exercising both the PK and FK branches. No artificial regression test was added for a structurally-identical refactor, per the project's "test what's worth testing" guidance.

Closes #452

https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6)_