### PR TITLE
Observe socket errors in setFavorite instead of swallowing them (#481)

### DIFF
--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -219,7 +219,8 @@ export class InventoryManager {
 	/**
 	 * Toggles whether an item is favorited and persists it via a websocket command. The local flag is
 	 * updated optimistically; a failed send keeps the local state (it re-syncs on the next toggle or
-	 * on reload) rather than rolling back, since a favourite flag is low-stakes.
+	 * on reload) rather than rolling back, since a favourite flag is low-stakes. The transport resolves
+	 * every failure with `response.error` (it never rejects), so the failure is observed and logged.
 	 */
 	public async setFavorite(itemId: number, favorite: boolean) {
 		const item = this.unlockedItems.get(itemId);
@@ -229,10 +230,9 @@ export class InventoryManager {
 
 		item.favorite = favorite;
 		this.publish();
-		try {
-			await apiSocket.sendSocketCommand('SetItemFavorite', { itemId, favorite });
-		} catch {
-			// Keep the optimistic local state; it re-syncs on the next toggle/reload.
+		const response = await apiSocket.sendSocketCommand('SetItemFavorite', { itemId, favorite });
+		if (response.error) {
+			logMessage(ELogType.Debug, 'There was an error setting the item favorite: ' + response.error);
 		}
 		return true;
 	}

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -105,9 +105,11 @@ describe('InventoryManager', () => {
 		vi.mocked(logMessage).mockClear();
 		vi.mocked(ApiRequest).mockClear();
 
-		// Default the network boundary to success; error-path tests override per case.
+		// Default the network boundary to success; error-path tests override per case. The socket
+		// transport always resolves an `IApiSocketResponse` (never rejects), so a success resolves an
+		// object with no `error` field rather than `undefined`.
 		mockPost.mockReset().mockResolvedValue({ ok: true });
-		mockSendSocketCommand.mockReset().mockResolvedValue(undefined);
+		mockSendSocketCommand.mockReset().mockResolvedValue({});
 
 		mockItems.length = 0;
 		mockItemMods.length = 0;
@@ -733,16 +735,19 @@ describe('InventoryManager', () => {
 			expect(mockSendSocketCommand).not.toHaveBeenCalled();
 		});
 
-		it('keeps the optimistic local flag when the socket send fails', async () => {
+		it('keeps the optimistic local flag and logs when the socket reports an error', async () => {
 			mockItems[1] = makeItem(1);
 			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
 			manager.initialize();
-			mockSendSocketCommand.mockRejectedValue(new Error('socket down'));
+			// The transport never rejects — it resolves every failure with an `error` field — so the
+			// failure must be observed via `response.error` and logged rather than swallowed by a catch.
+			mockSendSocketCommand.mockResolvedValue({ error: 'socket down' });
 
 			const result = await manager.setFavorite(1, true);
 
 			expect(result).toBe(true);
 			expect(manager.unlockedItems.get(1)?.favorite).toBe(true);
+			expect(logMessage).toHaveBeenCalledWith(ELogType.Debug, expect.stringContaining('socket down'));
 		});
 	});
 


### PR DESCRIPTION
## Summary

`InventoryManager.setFavorite` wrapped its `SetItemFavorite` socket command in a `try/catch`, but per the documented transport contract (`docs/frontend.md` → "Socket request lifecycle", implemented in `api-socket.ts`) `sendSocketCommand` **always resolves** with an `IApiSocketResponse` carrying an `error` field and **never rejects** — even on a dropped connection. The `catch` was therefore dead code: a failed persist resolved with `.error` set, the result was ignored, and (unlike every other socket caller, e.g. `enemy-manager.ts`) nothing was logged.

## How this fixes the bug

- Drops the dead `try/catch` and instead inspects `response.error`, logging it via `logMessage(ELogType.Debug, …)` — mirroring the established `enemy-manager` error-observation pattern (`getNewEnemy`, `claimVictory`, `resolveBossLoss`).
- Keeps the deliberate "optimistic state, no rollback" behaviour for this low-stakes favourite flag; the failure is now *observed and logged* rather than silently swallowed.
- Fixes the test that gave false confidence: it used `mockRejectedValue(...)`, asserting an impossible rejection the real transport never produces. It now resolves with `{ error: '...' }` and asserts the failure is logged, matching the actual transport contract. The shared default socket mock was also corrected to resolve `{}` (a no-error `IApiSocketResponse`) instead of `undefined`, so the mock faithfully models a transport that never returns `undefined`.

## Test plan

- `npm run lint` — clean (eslint + svelte-check: 0 errors, 0 warnings).
- `npm run test:unit:ci` — all 1605 tests pass across 579 suites, including both `setFavorite` socket cases (success-path and error-logged-path).

Closes #481

https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6)_