### PR TITLE
Guard capitalize/normalizeText against empty or undefined input (#493)

### DIFF
--- a/UI/src/lib/battle/battle-attributes.ts
+++ b/UI/src/lib/battle/battle-attributes.ts
@@ -1,5 +1,5 @@
 import { IBattlerAttribute, EAttribute } from '$lib/api';
-import { normalizeText } from '$lib/common';
+import { attributeEnumName } from '$lib/common';
 import {
 	STATIC_ATTRIBUTE_MODIFIERS,
 	EModifierType,
@@ -78,7 +78,7 @@ export class BattleAttributes {
 
 	public getAttributeMap = (includeZeroes: boolean = false) => {
 		return this.attributeValues
-			.map((att, i) => ({ name: normalizeText(EAttribute[i]), value: att }))
+			.map((att, i) => ({ name: attributeEnumName(i), value: att }))
 			.filter((att) => att.value != 0 || includeZeroes);
 	};
 

--- a/UI/src/lib/common/attribute-display.ts
+++ b/UI/src/lib/common/attribute-display.ts
@@ -1,4 +1,5 @@
 import { EAttribute } from '$lib/api';
+import { normalizeText } from './functions';
 
 /*
  * Single source of truth for core-attribute accent visuals and short codes. The
@@ -38,3 +39,8 @@ export const attributeColor = (id: EAttribute): string => {
 
 /** The three-letter code for a core attribute (empty for derived attributes). */
 export const attributeCode = (id: EAttribute): string => ATTRIBUTE_CODE[id] ?? '';
+
+/** The humanised enum-key fallback name for an attribute (e.g. `MaxHealth` → `Max Health`),
+ *  used when the live `Attributes` reference data is unavailable. An unknown/out-of-range id
+ *  has no enum key, so it degrades to a readable `Unknown` rather than a blank label. */
+export const attributeEnumName = (id: EAttribute): string => normalizeText(EAttribute[id]) || 'Unknown';

--- a/UI/src/lib/common/functions.ts
+++ b/UI/src/lib/common/functions.ts
@@ -25,11 +25,14 @@ export function enumPairs(obj: Record<string | number, string | number>) {
 		.map((key) => ({ id: Number(key), name: normalizeText(obj[key] as string) }));
 }
 
-export function capitalize(str: string) {
+export function capitalize(str?: string) {
+	if (!str) {
+		return '';
+	}
 	return str[0].toUpperCase() + str.slice(1);
 }
 
-export function normalizeText(str: string) {
+export function normalizeText(str?: string) {
 	return capitalize(str).replaceAll(/([a-z])([A-Z])/g, '$1 $2');
 }
 

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -1,8 +1,8 @@
 import { Battler, battleStep, type BattleStepLog } from '$lib/battle';
 import { staticData } from '$stores';
-import { EAttribute, ELogType, IEnemyInstance } from '$lib/api';
+import { ELogType, IEnemyInstance } from '$lib/api';
 import { logMessage } from '../log';
-import { formatNum, createHook, Action, effectLogMessage, normalizeText } from '$lib/common';
+import { formatNum, createHook, Action, effectLogMessage, attributeEnumName } from '$lib/common';
 import { onLogicalUpdate } from '../logical-engine';
 import { onRenderUpdate } from '../render-engine';
 import { inventoryManager } from '../engine';
@@ -140,7 +140,7 @@ export class BattleEngine {
 		for (const { effect, onPlayer } of this.stepLog.appliedEffects) {
 			const name =
 				staticData.attributes?.find((attr) => attr.id === effect.attributeId)?.name ??
-				normalizeText(EAttribute[effect.attributeId]);
+				attributeEnumName(effect.attributeId);
 			logMessage(ELogType.SkillEffect, effectLogMessage(effect, name, onPlayer, this.enemy.name));
 		}
 	}

--- a/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
+++ b/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
@@ -28,7 +28,7 @@ import {
 	type AppliedModifier,
 	type ComputedAttribute
 } from '$lib/battle';
-import { normalizeText } from '$lib/common';
+import { attributeEnumName } from '$lib/common';
 import { playerManager, inventoryManager, type EEquipmentSlot } from '$lib/engine';
 import { staticData } from '$stores';
 
@@ -80,7 +80,7 @@ export const ATTRIBUTE_GROUPS: { key: AttributeGroup; label: string }[] = [
 /** Display name for an attribute, preferring the live reference data and falling
  *  back to a normalised enum key (e.g. `MaxHealth` → `Max Health`). */
 export function attributeName(id: EAttribute): string {
-	return staticData.attributes?.find((a) => a.id === id)?.name ?? normalizeText(EAttribute[id]);
+	return staticData.attributes?.find((a) => a.id === id)?.name ?? attributeEnumName(id);
 }
 
 /** Reference-data description for an attribute (empty when not yet loaded). */

--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -23,7 +23,7 @@
 
 import { apiSocket, EAttribute, type IAttributeUpdate, type IBattlerAttribute } from '$lib/api';
 import { BattleAttributes } from '$lib/battle';
-import { normalizeText } from '$lib/common';
+import { attributeEnumName } from '$lib/common';
 import { playerManager } from '$lib/engine';
 import { staticData, toastError } from '$stores';
 
@@ -140,7 +140,7 @@ export function radarValueAtPointer(
 /** The display name for an attribute, preferring the live reference data and
  *  falling back to a normalised enum key (e.g. `MaxHealth` → `Max Health`). */
 export function attributeName(id: EAttribute): string {
-	return staticData.attributes?.find((a) => a.id === id)?.name ?? normalizeText(EAttribute[id]);
+	return staticData.attributes?.find((a) => a.id === id)?.name ?? attributeEnumName(id);
 }
 
 /** Compact labels for the dense theorycraft "per point" line. Falls back to the

--- a/UI/src/routes/game/screens/challenges/ModTooltip.svelte
+++ b/UI/src/routes/game/screens/challenges/ModTooltip.svelte
@@ -22,8 +22,8 @@
 </TooltipShell>
 
 <script lang="ts">
-import { EAttribute, type IItemMod } from '$lib/api';
-import { modTypeColor, modTypeLabel, normalizeText, rarityColor } from '$lib/common';
+import { type IItemMod } from '$lib/api';
+import { attributeEnumName, modTypeColor, modTypeLabel, rarityColor } from '$lib/common';
 import TooltipShell from '$components/tooltip/TooltipShell.svelte';
 import TooltipSection from '$components/tooltip/TooltipSection.svelte';
 import TooltipStatsGrid from '$components/tooltip/TooltipStatsGrid.svelte';
@@ -37,7 +37,7 @@ const { mod }: Props = $props();
 
 const typeColor = $derived(modTypeColor(mod.itemModTypeId));
 const effects = $derived(
-	(mod.attributes ?? []).map((a) => ({ name: normalizeText(EAttribute[a.attributeId]), value: a.amount }))
+	(mod.attributes ?? []).map((a) => ({ name: attributeEnumName(a.attributeId), value: a.amount }))
 );
 </script>
 

--- a/UI/src/routes/game/screens/challenges/SkillRewardTooltip.svelte
+++ b/UI/src/routes/game/screens/challenges/SkillRewardTooltip.svelte
@@ -47,7 +47,7 @@
 
 <script lang="ts">
 import { EAttribute, type ISkill } from '$lib/api';
-import { attributeColor, describeEffect, effectDirectionColor, formatNum, normalizeText } from '$lib/common';
+import { attributeColor, attributeEnumName, describeEffect, effectDirectionColor, formatNum } from '$lib/common';
 import { staticData } from '$stores';
 import TooltipShell from '$components/tooltip/TooltipShell.svelte';
 import TooltipSection from '$components/tooltip/TooltipSection.svelte';
@@ -62,7 +62,7 @@ const { skill }: Props = $props();
 // Reference-data attribute name (the full names live in the `Attributes` set); falls back to the
 // humanised enum key, matching the battle skill tooltip.
 const attributeName = (id: EAttribute) =>
-	staticData.attributes?.find((a) => a.id === id)?.name ?? normalizeText(EAttribute[id]);
+	staticData.attributes?.find((a) => a.id === id)?.name ?? attributeEnumName(id);
 
 const scaling = $derived(
 	skill.damageMultipliers.map((m) => ({

--- a/UI/src/routes/game/screens/fight/ActiveEffectChips.svelte
+++ b/UI/src/routes/game/screens/fight/ActiveEffectChips.svelte
@@ -20,7 +20,7 @@
 
 <script lang="ts">
 import { EAttribute } from '$lib/api';
-import { effectDirection, effectDirectionColor, formatEffectMagnitude, normalizeText } from '$lib/common';
+import { attributeEnumName, effectDirection, effectDirectionColor, formatEffectMagnitude } from '$lib/common';
 import { staticData } from '$stores';
 import type { ActiveEffectView, Battler } from '$lib/battle';
 
@@ -33,7 +33,7 @@ type Props = {
 const { battler, reversed = false }: Props = $props();
 
 const attributeName = (id: EAttribute) =>
-	staticData.attributes?.find((attr) => attr.id === id)?.name ?? normalizeText(EAttribute[id]);
+	staticData.attributes?.find((attr) => attr.id === id)?.name ?? attributeEnumName(id);
 
 const remainingSeconds = (effect: ActiveEffectView) => (effect.renderRemainingMs / 1000).toFixed(2);
 const remainingPercent = (effect: ActiveEffectView) =>

--- a/UI/src/routes/game/screens/fight/SkillTooltip.svelte
+++ b/UI/src/routes/game/screens/fight/SkillTooltip.svelte
@@ -25,7 +25,7 @@
 <script lang="ts">
 import { EAttribute } from '$lib/api';
 import { applyDefense, skillContributions, type Skill } from '$lib/battle';
-import { describeEffect, normalizeText } from '$lib/common';
+import { attributeEnumName, describeEffect } from '$lib/common';
 import { battleEngine } from '$lib/engine';
 import { staticData } from '$stores';
 import TooltipShell from '$components/tooltip/TooltipShell.svelte';
@@ -73,5 +73,5 @@ const effectLines = $derived(
 );
 
 const attributeName = (attrId: number) =>
-	staticData.attributes?.find((a) => a.id === attrId)?.name ?? normalizeText(EAttribute[attrId]);
+	staticData.attributes?.find((a) => a.id === attrId)?.name ?? attributeEnumName(attrId);
 </script>

--- a/UI/src/routes/game/screens/skills/SkillInspector.svelte
+++ b/UI/src/routes/game/screens/skills/SkillInspector.svelte
@@ -106,10 +106,10 @@ import { EAttribute } from '$lib/api';
 import {
 	attributeCode,
 	attributeColor,
+	attributeEnumName,
 	describeEffect,
 	effectDirectionColor,
-	formatNum,
-	normalizeText
+	formatNum
 } from '$lib/common';
 import { staticData } from '$stores';
 import SkillIcon from './SkillIcon.svelte';
@@ -129,7 +129,7 @@ const full = $derived(view.equipped.length >= view.cap);
 const fmt = (n: number) => formatNum(Math.round(n));
 
 const attributeName = (id: EAttribute) =>
-	staticData.attributes?.find((a) => a.id === id)?.name ?? normalizeText(EAttribute[id]);
+	staticData.attributes?.find((a) => a.id === id)?.name ?? attributeEnumName(id);
 
 // One display description per authored effect, reusing the shared helper so wording/direction
 // match the battle tooltip's "On hit" lines; `id` is kept for a stable each-key.

--- a/UI/src/routes/game/screens/skills/SortFilterModal.svelte
+++ b/UI/src/routes/game/screens/skills/SortFilterModal.svelte
@@ -67,7 +67,7 @@
 
 <script lang="ts">
 import { EAttribute } from '$lib/api';
-import { attributeColor, normalizeText } from '$lib/common';
+import { attributeColor, attributeEnumName } from '$lib/common';
 import { staticData } from '$stores';
 import { SKILL_SORTS, type SkillsView } from './skills-view.svelte';
 
@@ -78,7 +78,7 @@ type Props = {
 const { view }: Props = $props();
 
 const attributeName = (id: EAttribute) =>
-	staticData.attributes?.find((a) => a.id === id)?.name ?? normalizeText(EAttribute[id]);
+	staticData.attributes?.find((a) => a.id === id)?.name ?? attributeEnumName(id);
 
 /** Escape closes the open filter overlay (the backdrop click / Apply are the other paths). */
 const onKeydown = (e: KeyboardEvent) => {

--- a/UI/src/tests/common/attribute-display.test.ts
+++ b/UI/src/tests/common/attribute-display.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { EAttribute } from '$lib/api';
+import { attributeEnumName } from '../../lib/common/attribute-display';
+
+describe('attributeEnumName', () => {
+	it('returns the normalized enum key for a known attribute id', () => {
+		expect(attributeEnumName(EAttribute.MaxHealth)).toBe('Max Health');
+	});
+
+	it('returns the single-word name for a single-word attribute', () => {
+		expect(attributeEnumName(EAttribute.Strength)).toBe('Strength');
+	});
+
+	it('degrades to "Unknown" for an out-of-range id rather than throwing', () => {
+		// `EAttribute[id]` is `undefined` for an unknown id; the fallback must not crash a
+		// hot display path (#493) and should render a readable label, not a blank string.
+		const unknownId = 999 as EAttribute;
+		expect(() => attributeEnumName(unknownId)).not.toThrow();
+		expect(attributeEnumName(unknownId)).toBe('Unknown');
+	});
+});

--- a/UI/src/tests/common/functions.test.ts
+++ b/UI/src/tests/common/functions.test.ts
@@ -64,6 +64,16 @@ describe('capitalize', () => {
 	it('handles single character', () => {
 		expect(capitalize('a')).toBe('A');
 	});
+
+	it('returns an empty string for empty input rather than throwing', () => {
+		expect(() => capitalize('')).not.toThrow();
+		expect(capitalize('')).toBe('');
+	});
+
+	it('returns an empty string for undefined input rather than throwing', () => {
+		expect(() => capitalize(undefined)).not.toThrow();
+		expect(capitalize(undefined)).toBe('');
+	});
 });
 
 describe('normalizeText', () => {
@@ -77,6 +87,18 @@ describe('normalizeText', () => {
 
 	it('splits multiple camelCase words', () => {
 		expect(normalizeText('myLongVariableName')).toBe('My Long Variable Name');
+	});
+
+	it('returns an empty string for empty input rather than throwing', () => {
+		expect(() => normalizeText('')).not.toThrow();
+		expect(normalizeText('')).toBe('');
+	});
+
+	it('returns an empty string for undefined input rather than throwing', () => {
+		// Hot display paths call `normalizeText(EAttribute[id])`, where an unknown id yields
+		// `undefined`; this must degrade gracefully instead of crashing mid-render/tick (#493).
+		expect(() => normalizeText(undefined)).not.toThrow();
+		expect(normalizeText(undefined)).toBe('');
 	});
 });
 


### PR DESCRIPTION
## Summary

`capitalize` indexed `str[0]` unguarded (`UI/src/lib/common/functions.ts`), so an empty string (`str[0] === undefined`) or an `undefined` argument threw on `.toUpperCase()`. `normalizeText` forwards to it, and hot display paths call `normalizeText(EAttribute[id])` where an unknown/out-of-range enum id yields `undefined` — a latent crash mid-render/mid-tick.

This is **display/text-formatting only** (not battle math), so there is no frontend/backend battle-parity concern.

## How it addresses #493

- **Guard the root.** `capitalize` (and therefore `normalizeText`) now accepts an optional `string` and returns `''` for empty/falsy input instead of throwing. This alone makes every existing call site non-throwing.
- **Graceful safe default at the `EAttribute[id]` call sites.** Added a small, store-free `attributeEnumName` helper to `attribute-display.ts` that formats the `EAttribute[id]` fallback and degrades an unknown id to a readable `"Unknown"` label (rather than a blank string). All the `EAttribute[id]` fallback call sites now route through it — `battle-engine`, `battle-attributes`, the attributes / attribute-breakdown views, and the skill / effect / mod tooltips, skill inspector and sort-filter modal — and their now-unused `normalizeText`/`EAttribute` imports were removed.

The pre-existing `normalizeText(EChallengeType[id] ?? '')` call already passed a safe default, so it was left as-is.

## Test plan

- `npm run lint` (ESLint + `svelte-check`) — clean, 0 errors / 0 warnings.
- `npm run test:unit:ci` — 1612 passed, 0 failed.
- New unit tests:
  - `capitalize('')` / `capitalize(undefined)` and `normalizeText('')` / `normalizeText(undefined)` return `''` without throwing, plus the existing normal cases still pass.
  - `attributeEnumName` returns the normalized name for a known id and degrades to `"Unknown"` for an out-of-range id without throwing.

## Follow-up (not in this PR)

The `staticData.attributes?.find(...)?.name ?? attributeEnumName(id)` pattern is still duplicated as a per-file `attributeName` helper across ~7 components/views. Consolidating it into one shared helper is worthwhile but raises a store-coupling question (the `$lib/common` helpers are intentionally store-free, as noted in `challenge-type.ts`), so it's left as a separate tech-debt cleanup to keep this fix small.

Closes #493

https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6)_