### PR TITLE
Add ARIA progressbar semantics to HP and challenge progress bars (#455)

### DIFF
--- a/UI/src/routes/game/screens/challenges/ProgressBar.svelte
+++ b/UI/src/routes/game/screens/challenges/ProgressBar.svelte
@@ -1,4 +1,12 @@
-<div class="bar-track" style:height="{height}px" style:border-radius="{height / 2}px">
+<div
+	class="bar-track"
+	style:height="{height}px"
+	style:border-radius="{height / 2}px"
+	role="progressbar"
+	aria-valuenow={Math.round(clamped)}
+	aria-valuemin={0}
+	aria-valuemax={100}
+>
 	<div
 		class="bar-fill"
 		style:width="{clamped}%"

--- a/UI/src/routes/game/screens/fight/BattlerCard.svelte
+++ b/UI/src/routes/game/screens/fight/BattlerCard.svelte
@@ -9,7 +9,14 @@
 	</div>
 
 	<!-- HP Bar -->
-	<div class="hp-bar">
+	<div
+		class="hp-bar"
+		role="progressbar"
+		aria-label="{battler.name} health"
+		aria-valuenow={Math.round(battler.currentHealth)}
+		aria-valuemin={0}
+		aria-valuemax={maxHealth}
+	>
 		<div class="hp-disappearing" style:width="{healthPerc}%"></div>
 		<div class="hp-remaining" style:width="{healthPerc}%"></div>
 		<div class="hp-text">{healthText}</div>

--- a/UI/src/tests/routes/game/screens/challenges/ProgressBar.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/ProgressBar.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+
+import ProgressBar from '$routes/game/screens/challenges/ProgressBar.svelte';
+
+afterEach(cleanup);
+
+describe('ProgressBar — a11y', () => {
+	it('exposes progressbar semantics with the percent as aria-valuenow', () => {
+		const { container } = render(ProgressBar, { props: { percent: 42, accent: 'var(--accent)' } });
+		const track = container.querySelector('.bar-track') as HTMLElement;
+		expect(track.getAttribute('role')).toBe('progressbar');
+		expect(track.getAttribute('aria-valuenow')).toBe('42');
+		expect(track.getAttribute('aria-valuemin')).toBe('0');
+		expect(track.getAttribute('aria-valuemax')).toBe('100');
+	});
+
+	it('clamps aria-valuenow to the 0–100 range', () => {
+		const over = render(ProgressBar, { props: { percent: 150, accent: 'var(--accent)' } });
+		expect((over.container.querySelector('.bar-track') as HTMLElement).getAttribute('aria-valuenow')).toBe('100');
+		cleanup();
+
+		const under = render(ProgressBar, { props: { percent: -20, accent: 'var(--accent)' } });
+		expect((under.container.querySelector('.bar-track') as HTMLElement).getAttribute('aria-valuenow')).toBe('0');
+	});
+});

--- a/UI/src/tests/routes/game/screens/fight/BattlerCard.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/BattlerCard.test.ts
@@ -33,6 +33,22 @@ describe('BattlerCard', () => {
 		expect(card.querySelector('.hp-text')?.textContent).toContain('80 / 100');
 	});
 
+	it('exposes the HP bar as a progressbar with rounded current/max health', () => {
+		const battler = makeBattler({
+			name: 'Aelara',
+			attributes: [{ attributeId: EAttribute.MaxHealth, amount: 100 }],
+			currentHealth: 80.6
+		});
+		const { container } = render(BattlerCard, { props: { battler, side: 'player' } });
+
+		const bar = container.querySelector('.hp-bar') as HTMLElement;
+		expect(bar.getAttribute('role')).toBe('progressbar');
+		expect(bar.getAttribute('aria-label')).toBe('Aelara health');
+		expect(bar.getAttribute('aria-valuenow')).toBe('81');
+		expect(bar.getAttribute('aria-valuemin')).toBe('0');
+		expect(bar.getAttribute('aria-valuemax')).toBe('100');
+	});
+
 	it('sizes the health bar to the remaining health percentage', () => {
 		const battler = makeBattler({
 			attributes: [{ attributeId: EAttribute.MaxHealth, amount: 200 }],


### PR DESCRIPTION
## Summary

Two prominent game-state indicators were plain `<div>`s with no accessibility semantics, an inconsistency given the project's existing a11y investment (the modal backdrop is a real `<button>`, the `LogPanel` resize handle sets `aria-value*`, etc.). This adds `role="progressbar"` plus `aria-value*` to both:

- **HP bar** (`UI/src/routes/game/screens/fight/BattlerCard.svelte`): `role="progressbar"`, `aria-label="{battler.name} health"`, `aria-valuenow` = rounded current health, `aria-valuemin={0}`, `aria-valuemax={maxHealth}`. Edited only the HP-bar `<div>` markup; the `healthText` line is untouched.
- **Challenge `ProgressBar`** (`UI/src/routes/game/screens/challenges/ProgressBar.svelte`): same attributes on the `.bar-track`, using the already-clamped `percent` (rounded) as `aria-valuenow` over `[0, 100]`. As a generic reusable bar with no inherent subject, it carries no `aria-label` (its surrounding context — overview pane / progress readout — supplies the meaning).

## No visual change

Only ARIA attributes were added; no markup affecting layout/styling changed.

## Test plan

- Added a focused assertion in `BattlerCard.test.ts` that the HP bar renders `role="progressbar"`, the `{name} health` label, and rounded `aria-valuenow`/`min`/`max`.
- Added `ProgressBar.test.ts` asserting the progressbar role + value attributes and that `aria-valuenow` clamps to the 0–100 range.
- `npm run lint` (eslint + svelte-check): clean, 0 errors / 0 warnings.
- `npm run test:unit:ci`: 1608/1608 tests pass across 581 suites.

Closes #455

https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6)_