### PR TITLE
Use EquipmentSlot.Set() in PlayerMapper and drop unused GameContext from SessionStore (#450)

### DIFF
--- a/Game.DataAccess/Mapping/PlayerMapper.cs
+++ b/Game.DataAccess/Mapping/PlayerMapper.cs
@@ -112,8 +112,7 @@ namespace Game.DataAccess.Mapping
                         .FirstOrDefault(s => (int)s.Value == ui.EquipmentSlotId.Value);
                     if (eSlot is not null)
                     {
-                        eSlot.Item = coreItem;
-                        eSlot.ItemId = ui.ItemId;
+                        eSlot.Set(coreItem);
                     }
                 }
             }

--- a/Game.DataAccess/Repositories/SessionStore.cs
+++ b/Game.DataAccess/Repositories/SessionStore.cs
@@ -1,7 +1,6 @@
 ﻿using Game.Abstractions.DataAccess;
 using Game.Abstractions.Infrastructure;
 using Game.Core.Players;
-using Game.Infrastructure.Database;
 
 
 namespace Game.DataAccess.Repositories
@@ -12,7 +11,7 @@ namespace Game.DataAccess.Repositories
 
         private readonly ICacheService _cache;
 
-        public SessionStore(GameContext context, ICacheService cache)
+        public SessionStore(ICacheService cache)
         {
             _cache = cache;
         }


### PR DESCRIPTION
## Summary

Two isolated, low-risk DataAccess hygiene cleanups (`scope: small`):

1. **`PlayerMapper.ToCore` now routes equip-on-load through `EquipmentSlot.Set()`.** When hydrating a player from the DB, the equipped item was assigned with two direct property writes (`eSlot.Item = coreItem; eSlot.ItemId = ui.ItemId;`), bypassing the `EquipmentSlot.Set(item)` domain mutator that the live equip path (`Inventory.TryEquipItem`) uses. Replaced the two writes with a single `eSlot.Set(coreItem)` so load and the live path share one mutator — any invariant later added to `Set()` (validation, event, derived state) will apply to both paths instead of silently diverging on load.

2. **`SessionStore` no longer injects an unused `GameContext`.** The constructor took a `GameContext context` parameter it never assigned or read, so every request scope that resolved `ISessionStore` needlessly spun up an EF context. Dropped the parameter and the now-unused `Game.Infrastructure.Database` using. `SessionStore` is registered as `AddScoped<ISessionStore, SessionStore>()`, so DI resolves the trimmed constructor with no registration change.

## How this addresses #450

Directly implements both directions called out in the issue body: replace the direct slot assignments with the `Set()` mutator (#1), and remove the dead `GameContext` constructor dependency (#2).

## Test plan

- `dotnet build` — succeeded, 0 warnings / 0 errors (DI validation passes, confirming `SessionStore` still resolves).
- `dotnet test --no-build --no-restore` — all green: Infrastructure 26, Core 401, Application 164, Api 370 (961 total, 0 failures).
- The equip-on-load round-trip for #1 is already pinned by existing `PlayerServiceIntegrationTests` (`LoadPlayer_PersistedAppliedMod_IncludesModAttributesInEquippedModifiers` and the skill-load test) — they seed an equipped item via `LinkItemToPlayerAsync(..., EEquipmentSlot.WeaponSlot)`, load through `PlayerMapper.ToCore`, and assert on `GetEquippedAttributeModifiers()`, which depends on the slot's `Item` being set. `Set(coreItem)` is behaviorally identical to the prior two writes, so no new test was forced for this dead-code-style cleanup.

Closes #450

https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6)_