### PR TITLE
Add AsSplitQuery to reference-cache holder queries to avoid cartesian explosion (#485)

### DIFF
--- a/Game.DataAccess/Repositories/Caching/EnemiesCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/EnemiesCacheHolder.cs
@@ -30,6 +30,7 @@ namespace Game.DataAccess.Repositories.Caching
                 .Include(e => e.AttributeDistributions)
                 .Include(e => e.EnemySkills)
                 .Include(e => e.ZoneEnemies)
+                .AsSplitQuery()
                 .OrderBy(e => e.Id)
                 .ToListAsync(cancellationToken);
 

--- a/Game.DataAccess/Repositories/Caching/ItemsCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/ItemsCacheHolder.cs
@@ -16,6 +16,7 @@ namespace Game.DataAccess.Repositories.Caching
                 .Include(i => i.ItemModSlots)
                 .Include(i => i.ItemAttributes)
                 .Include(i => i.Tags)
+                .AsSplitQuery()
                 .OrderBy(i => i.Id)
                 .ToListAsync(cancellationToken);
         }

--- a/Game.DataAccess/Repositories/Caching/SkillsCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/SkillsCacheHolder.cs
@@ -15,6 +15,7 @@ namespace Game.DataAccess.Repositories.Caching
                 .AsNoTracking()
                 .Include(s => s.SkillDamageMultipliers)
                 .Include(s => s.SkillEffects)
+                .AsSplitQuery()
                 .OrderBy(s => s.Id)
                 .ToListAsync(cancellationToken);
         }


### PR DESCRIPTION
## Summary

The three reference-cache snapshot holders each eager-load multiple **collection** navigations in a single EF Core query without `AsSplitQuery()`, producing a cartesian product across the child tables:

- `Game.DataAccess/Repositories/Caching/ItemsCacheHolder.cs` — 3 collection includes (`ItemModSlots`, `ItemAttributes`, `Tags`)
- `Game.DataAccess/Repositories/Caching/EnemiesCacheHolder.cs` — 3 collection includes (`AttributeDistributions`, `EnemySkills`, `ZoneEnemies`)
- `Game.DataAccess/Repositories/Caching/SkillsCacheHolder.cs` — 2 collection includes (`SkillDamageMultipliers`, `SkillEffects`)

This adds `.AsSplitQuery()` to all three holder queries, placed after the includes and before the terminal operator to match the existing `PlayerRepository.GetPlayerFromDb` precedent's placement/style.

## How it addresses #485

Each query now issues a separate SQL query per collection navigation rather than one query whose row count is the product of the child-collection sizes. This eliminates the wasteful row materialization on every startup load, every admin-write reload, and every cross-instance invalidation sweep. `AsSplitQuery` changes query execution but **not** results, so the cached snapshots — and therefore the reference-data version hashes — are unchanged. (The entity-relocation work (#138) moved these files to `Game.Infrastructure`-backed types under `Game.DataAccess`, so the paths differ slightly from the issue's `Game.DataAccess/...:line` citations but resolve to the same three holders.)

## Test plan

- `dotnet build` — succeeded, 0 warnings, 0 errors.
- `dotnet test --no-build --no-restore` — all green:
  - Game.Infrastructure.Tests: 26 passed
  - Game.Core.Tests: 401 passed
  - Game.Application.Tests: 164 passed
  - Game.Api.Tests: 370 passed (covers the reference-data/cache-holder load integration paths)

No new test was added: this is an execution-plan-only change with no result difference, and the existing cache-holder load integration tests already pin the (unchanged) snapshot contents.

Closes #485

https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6)_