### PR TITLE
Use id-as-index skill lookup in EnemyMapper instead of building a dictionary per resolution (#440)

### DIFF
--- a/Game.DataAccess/Mapping/EnemyMapper.cs
+++ b/Game.DataAccess/Mapping/EnemyMapper.cs
@@ -41,8 +41,6 @@ namespace Game.DataAccess.Mapping
             int level,
             IReadOnlyList<EntitySkill> allSkills)
         {
-            var skillLookup = allSkills.ToDictionary(s => s.Id);
-
             return new Enemy
             {
                 Id = entity.Id,
@@ -56,9 +54,13 @@ namespace Game.DataAccess.Mapping
                         BaseAmount = ad.BaseAmount,
                         AmountPerLevel = ad.AmountPerLevel,
                     }).ToList(),
+                // The cached skill list is the zero-based, contiguous-id reference set (docs/backend.md
+                // → Reference Data), so a skill resolves by direct index instead of a per-call dictionary.
+                // The bounds check skips a malformed out-of-range ref, matching the prior skip-if-missing
+                // behaviour (a persisted EnemySkill.SkillId is FK-guaranteed in range, so it is defensive).
                 AvailableSkills = entity.EnemySkills
-                    .Where(es => skillLookup.ContainsKey(es.SkillId))
-                    .Select(es => SkillMapper.ToCore(skillLookup[es.SkillId]))
+                    .Where(es => es.SkillId >= 0 && es.SkillId < allSkills.Count)
+                    .Select(es => SkillMapper.ToCore(allSkills[es.SkillId]))
                     .ToList(),
             };
         }


### PR DESCRIPTION
## Summary

`EnemyMapper.ToCore` built `allSkills.ToDictionary(s => s.Id)` on **every** call, allocating O(all skills) on a hot, per-battle path: `Enemies.GetRandomDomainEnemy` runs on every idle encounter spawn, and `GetDomainEnemy` on every boss start and battle-replay validation. That also quietly violated the documented index-by-id convention — for the six zero-based contiguous-id reference sets, the cached list is indexed directly by id (`docs/backend.md` → Reference Data).

This replaces the per-call dictionary with a bounds-checked direct index lookup over the cached, `OrderBy(Id)`, zero-based skill list, matching the exact shape `Items.LookupItem` and the other reference repos already use.

```csharp
AvailableSkills = entity.EnemySkills
    .Where(es => es.SkillId >= 0 && es.SkillId < allSkills.Count)
    .Select(es => SkillMapper.ToCore(allSkills[es.SkillId]))
    .ToList(),
```

## How it addresses #440

- Removes the per-resolution `ToDictionary` allocation on a hot path.
- Aligns the skill resolution with the documented id-as-index convention for the zero-based contiguous reference sets, consistent with the other reference repos.
- No dead code left behind (the `skillLookup` local is gone).

## Behavior-equivalence note (out-of-range id)

I verified the prior behavior before swapping the projection. The old path filtered with `Where(es => skillLookup.ContainsKey(es.SkillId))` — it **silently skipped** any `SkillId` not present in the catalogue; it did **not** throw. For a contiguous zero-based set, "not present in the dictionary" is exactly "index out of range", so the new `Where(es => es.SkillId >= 0 && es.SkillId < allSkills.Count)` preserves the identical skip-if-missing semantics. There is no behavior change for valid data, and a malformed out-of-range ref is dropped exactly as before.

That skip branch is purely **defensive**: `EnemySkill.SkillId` has an EF-convention foreign key to `Skill.Id` (via the `EnemySkill.Skill` navigation), so a persisted enemy-skill ref is FK-guaranteed to reference an existing skill — the out-of-range case is unreachable through the real database. I deliberately did **not** add an integration test pinning the skip branch, because seeding an orphan `EnemySkill.SkillId` would require violating that FK constraint (a brittle, non-representative test). The existing happy-path integration coverage already pins the mapping.

## Test plan

- `dotnet build` — succeeded, 0 warnings / 0 errors.
- `dotnet test --no-build --no-restore` — all suites green:
  - Game.Core.Tests: 401 passed
  - Game.Application.Tests: 164 passed (includes `EnemiesIntegrationTests.GetRandomDomainEnemy_ValidZone_MapsEntityAtRequestedLevel`, which pins that a linked skill maps through `ToCore`)
  - Game.Api.Tests: 370 passed
  - Game.Infrastructure.Tests: 26 passed

Closes #440

https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6)_