### PR TITLE
Extract shared EnemyInstance.FromBattleResult and BattlerAttribute projection (#492)

### DIFF
--- a/Game.Abstractions/Contracts/BattlerAttribute.cs
+++ b/Game.Abstractions/Contracts/BattlerAttribute.cs
@@ -7,5 +7,19 @@ namespace Game.Abstractions.Contracts
     {
         public EAttribute AttributeId { get; set; }
         public decimal Amount { get; set; }
+
+        /// <summary>
+        /// Projects an attribute/amount pair onto the wire contract — the single source of truth for the
+        /// <c>(decimal)</c> cast applied to every domain attribute amount, shared by all sites that emit a
+        /// <see cref="BattlerAttribute"/> (enemy modifiers and player stat allocations).
+        /// </summary>
+        public static BattlerAttribute From(EAttribute attribute, double amount)
+        {
+            return new BattlerAttribute
+            {
+                AttributeId = attribute,
+                Amount = (decimal)amount,
+            };
+        }
     }
 }

--- a/Game.Api.Tests/Unit/EnemyInstanceMappingTests.cs
+++ b/Game.Api.Tests/Unit/EnemyInstanceMappingTests.cs
@@ -1,0 +1,73 @@
+using Game.Application.Services;
+using Game.Core;
+using Game.Core.Attributes;
+using Game.Core.Enemies;
+using Game.Core.Skills;
+using Xunit;
+using EnemyInstanceModel = Game.Api.Models.Enemies.EnemyInstance;
+
+namespace Game.Api.Tests.Unit
+{
+    public class EnemyInstanceMappingTests
+    {
+        [Fact]
+        public void FromSource_ProjectsBattleStartResultOntoEnemyInstance()
+        {
+            var enemy = MakeEnemy();
+            enemy.SetBattleSkills([20, 10]);
+            var result = new BattleStartResult { Enemy = enemy, Seed = 12345u };
+
+            var model = EnemyInstanceModel.FromSource(result);
+
+            Assert.Equal(7, model.Id);
+            Assert.Equal(3, model.Level);
+            Assert.Equal(12345u, model.Seed);
+            // Loadout order is preserved exactly as the enemy's battle skills.
+            Assert.Equal([20, 10], model.SelectedSkills);
+        }
+
+        [Fact]
+        public void FromSource_ProjectsAttributeModifiersWithDecimalCast()
+        {
+            // BaseAmount 5 at level 3 => 5 + (2 * 3) = 11; the projection must (decimal)-cast the amount.
+            var enemy = MakeEnemy();
+            enemy.SetBattleSkills([]);
+            var result = new BattleStartResult { Enemy = enemy, Seed = 1u };
+
+            var model = EnemyInstanceModel.FromSource(result);
+
+            var attribute = Assert.Single(model.Attributes);
+            Assert.Equal(EAttribute.Strength, attribute.AttributeId);
+            Assert.Equal(11m, attribute.Amount);
+        }
+
+        private static Enemy MakeEnemy() => new()
+        {
+            Id = 7,
+            Name = "Test Enemy",
+            IsBoss = false,
+            Level = 3,
+            AttributeDistributions =
+            [
+                new AttributeDistribution
+                {
+                    AttributeId = EAttribute.Strength,
+                    BaseAmount = 5m,
+                    AmountPerLevel = 2m,
+                },
+            ],
+            AvailableSkills = [MakeSkill(10), MakeSkill(20)],
+        };
+
+        private static Skill MakeSkill(int id) => new()
+        {
+            Id = id,
+            Name = $"Skill {id}",
+            BaseDamage = 1,
+            Description = string.Empty,
+            CooldownMs = 1000,
+            DamageMultipliers = [],
+            Effects = [],
+        };
+    }
+}

--- a/Game.Api/Models/Enemies/EnemyInstance.cs
+++ b/Game.Api/Models/Enemies/EnemyInstance.cs
@@ -1,13 +1,33 @@
-﻿using Game.Abstractions.Contracts;
+using Game.Abstractions.Contracts;
+using Game.Application.Services;
 
 namespace Game.Api.Models.Enemies
 {
-    public class EnemyInstance : IModel
+    public class EnemyInstance : IModelFromSource<EnemyInstance, BattleStartResult>
     {
         public int Id { get; set; }
         public int Level { get; set; }
         public required IEnumerable<BattlerAttribute> Attributes { get; set; }
         public uint Seed { get; set; }
         public required List<int> SelectedSkills { get; set; }
+
+        /// <summary>
+        /// Projects a battle-start result onto the wire model. The single source of truth for the
+        /// enemy-instance projection shared by the <c>NewEnemy</c> and <c>ChallengeBoss</c> socket commands,
+        /// keeping the two from drifting (#492).
+        /// </summary>
+        public static EnemyInstance FromSource(BattleStartResult source)
+        {
+            var enemy = source.Enemy;
+            return new EnemyInstance
+            {
+                Id = enemy.Id,
+                Level = enemy.Level,
+                Seed = source.Seed,
+                SelectedSkills = enemy.BattleSkills.Select(skill => skill.Id).ToList(),
+                Attributes = enemy.GetAttributeModifiers()
+                    .Select(modifier => BattlerAttribute.From(modifier.Attribute, modifier.Amount)),
+            };
+        }
     }
 }

--- a/Game.Api/Sockets/Commands/ChallengeBoss.cs
+++ b/Game.Api/Sockets/Commands/ChallengeBoss.cs
@@ -1,4 +1,3 @@
-using Game.Abstractions.Contracts;
 using Game.Api.Models.Common;
 using Game.Api.Models.Enemies;
 using Game.Application.Services;
@@ -44,19 +43,7 @@ namespace Game.Api.Sockets.Commands
 
             return Success(new NewEnemyModel
             {
-                EnemyInstance = new EnemyInstance
-                {
-                    Id = result.Enemy.Id,
-                    Level = result.Enemy.Level,
-                    Seed = result.Seed,
-                    SelectedSkills = result.Enemy.BattleSkills.Select(s => s.Id).ToList(),
-                    Attributes = result.Enemy.GetAttributeModifiers()
-                        .Select(m => new BattlerAttribute
-                        {
-                            AttributeId = m.Attribute,
-                            Amount = (decimal)m.Amount,
-                        }),
-                }
+                EnemyInstance = EnemyInstance.FromSource(result)
             });
         }
     }

--- a/Game.Api/Sockets/Commands/NewEnemy.cs
+++ b/Game.Api/Sockets/Commands/NewEnemy.cs
@@ -1,5 +1,4 @@
-﻿using Game.Abstractions.Contracts;
-using Game.Api.Models.Common;
+﻿using Game.Api.Models.Common;
 using Game.Api.Models.Enemies;
 using Game.Application.Services;
 
@@ -42,19 +41,7 @@ namespace Game.Api.Sockets.Commands
 
             return Success(new NewEnemyModel
             {
-                EnemyInstance = new EnemyInstance
-                {
-                    Id = result.Enemy.Id,
-                    Level = result.Enemy.Level,
-                    Seed = result.Seed,
-                    SelectedSkills = result.Enemy.BattleSkills.Select(s => s.Id).ToList(),
-                    Attributes = result.Enemy.GetAttributeModifiers()
-                        .Select(m => new BattlerAttribute
-                        {
-                            AttributeId = m.Attribute,
-                            Amount = (decimal)m.Amount,
-                        }),
-                }
+                EnemyInstance = EnemyInstance.FromSource(result)
             });
         }
     }

--- a/Game.Api/Sockets/Commands/UpdatePlayerStats.cs
+++ b/Game.Api/Sockets/Commands/UpdatePlayerStats.cs
@@ -33,11 +33,7 @@ namespace Game.Api.Sockets.Commands
             var success = await _playerService.TryUpdateAttributes(player, Parameters.Cast<IAttributeUpdate>());
 
             var allocations = player.StatPoints.StatAllocations
-                .Select(a => new BattlerAttribute
-                {
-                    AttributeId = a.Attribute,
-                    Amount = (decimal)a.Amount,
-                })
+                .Select(allocation => BattlerAttribute.From(allocation.Attribute, allocation.Amount))
                 .ToList();
 
             return success


### PR DESCRIPTION
## Summary

`NewEnemy` and `ChallengeBoss` built a **verbatim-identical** `EnemyInstance` from a battle-start result (`Id`, `Level`, `Seed`, `SelectedSkills`, and the `GetAttributeModifiers().Select(... BattlerAttribute ...)` projection), and the `BattlerAttribute` `(decimal)`-cast projection was repeated a third time in `UpdatePlayerStats`. These copies were free to drift (e.g. a new field added to one). This consolidates all three onto single shared seams.

- **`EnemyInstance.FromSource(BattleStartResult)`** — the single enemy-instance projection, used by both `NewEnemy` and `ChallengeBoss`.
- **`BattlerAttribute.From(EAttribute, double)`** — the single home for the `(decimal)amount` cast, consumed by the factory and by `UpdatePlayerStats`.

The inline projections at all three call sites were removed (along with two now-unused `using Game.Abstractions.Contracts;` imports).

## Layering / placement decision

- **The enemy-instance factory lives on `EnemyInstance` (Api layer).** `EnemyInstance` is a `Game.Api` wire model and the `result` type (`BattleStartResult`) lives in `Game.Application`; `result.Enemy` is a `Game.Core` type. `Game.Api` already references both `Game.Application` and `Game.Core`, so a factory here is a clean **downward** dependency (Api -> Application -> Core) with no cross-layer leak — the `result` type is fully visible from `EnemyInstance`'s layer, so the leaky-factory concern raised in the issue does not apply.

- **I named it `FromSource`, not `FromBattleResult`, to match the established convention.** The codebase already has an `IModelFromSource<TModel, TSource>` interface with a static `FromSource(TSource)` factory (`Game.Api/Models/Attributes/Attribute.cs`, `Game.Api/Models/Progress/*`). `BattleStartResult` is exactly the single `TSource` carrying both `Enemy` and `Seed`, so `EnemyInstance : IModelFromSource<EnemyInstance, BattleStartResult>` slots in cleanly and is consistent with the rest of the Api model layer (and works with the existing `ModelMapper<TSource>.Model<TModel>()` helper). The issue's `FromBattleResult` name was a suggestion; aligning with the existing convention is the better consistency call.

- **The attribute-projection helper lives on the `BattlerAttribute` contract.** `BattlerAttribute` is in `Game.Abstractions.Contracts`, which already references `Game.Core` and already uses `EAttribute`. `BattlerAttribute.From(EAttribute attribute, double amount)` takes **primitives** rather than a `Game.Core` modifier/allocation type, so it stays reachable by all three Api call sites (which all reference `Game.Abstractions`) without the contract layer taking on any new dependency — and it serves both source shapes uniformly (`AttributeModifier` for the enemy sites, `StatAllocation` for `UpdatePlayerStats`), since both expose `.Attribute` and `.Amount`.

## How this addresses #492

A single factory + a single projection helper now back all three sites, so they cannot drift; a new field on the enemy instance or a change to the cast is made in exactly one place.

## Behavioral impact

None. This is a pure DTO-projection refactor — same fields, same `(decimal)m.Amount` cast, same loadout ordering. Outputs are identical, so there is no frontend/backend battle-parity impact.

## Test plan

- `dotnet build` — clean (0 warnings, 0 errors).
- `dotnet test --no-build --no-restore` — all green: Core 401, Application 164, Api 372 (incl. the existing `NewEnemy`/`ChallengeBoss`/`UpdatePlayerStats` integration tests, unchanged output), Infrastructure 26.
- Added `Game.Api.Tests/Unit/EnemyInstanceMappingTests.cs` pinning the new factory: that it projects `Id`/`Level`/`Seed`/`SelectedSkills` (loadout order preserved) and that the attribute projection applies the `(decimal)` cast.

## Follow-ups

None.

Closes #492

https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6)_