### PR TITLE
Materialize attribute matches once and drop needless HashSet alloc in PlayerStatPoints/Player (#451)

### DIFF
--- a/Game.Core.Tests/Players/PlayerStatPointsTests.cs
+++ b/Game.Core.Tests/Players/PlayerStatPointsTests.cs
@@ -87,6 +87,79 @@ namespace Game.Core.Tests.Players
             Assert.Equal(7, stats.StatPointsUsed);
         }
 
+        [Fact]
+        public void TryUpdateAttributes_MixedAddEditAndZero_AppliesEachAllocation()
+        {
+            var stats = MakeStats(gained: 10, used: 1);
+            stats.StatAllocations.First(a => a.Attribute == EAttribute.Endurance).Amount = 1;
+
+            var result = stats.TryUpdateAttributes([
+                new Update(EAttribute.Strength, 2),   // add to a zeroed allocation
+                new Update(EAttribute.Endurance, 1),  // edit an existing allocation
+                new Update(EAttribute.Agility, 0),    // zero — no-op spend
+            ]);
+
+            Assert.True(result);
+            Assert.Equal(4, stats.StatPointsUsed); // 1 already used + 2 + 1 + 0
+            Assert.Equal(2, stats.StatAllocations.First(a => a.Attribute == EAttribute.Strength).Amount);
+            Assert.Equal(2, stats.StatAllocations.First(a => a.Attribute == EAttribute.Endurance).Amount);
+            Assert.Equal(0, stats.StatAllocations.First(a => a.Attribute == EAttribute.Agility).Amount);
+        }
+
+        [Fact]
+        public void TryUpdateAttributes_OneAllocationWouldGoNegative_RejectsEntireSet()
+        {
+            // The Strength reduction is legal on its own, but Endurance would drop below zero, so the
+            // whole set must be rejected with no allocation or point changes applied.
+            var stats = MakeStats(gained: 10, used: 5);
+            stats.StatAllocations.First(a => a.Attribute == EAttribute.Strength).Amount = 4;
+
+            var result = stats.TryUpdateAttributes([
+                new Update(EAttribute.Strength, -2),
+                new Update(EAttribute.Endurance, -1),
+            ]);
+
+            Assert.False(result);
+            Assert.Equal(5, stats.StatPointsUsed);
+            Assert.Equal(4, stats.StatAllocations.First(a => a.Attribute == EAttribute.Strength).Amount);
+            Assert.Equal(0, stats.StatAllocations.First(a => a.Attribute == EAttribute.Endurance).Amount);
+        }
+
+        [Fact]
+        public void TryUpdateAttributes_UnknownAttribute_IsIgnoredButStillSucceeds()
+        {
+            // An update targeting an attribute the player has no allocation row for is silently ignored
+            // (current contract — the separate concern of #488). It neither spends points nor mutates state.
+            var allocations = new List<StatAllocation>
+            {
+                new() { Attribute = EAttribute.Strength, Amount = 0 },
+            };
+            var stats = new PlayerStatPoints(allocations) { StatPointsGained = 10, StatPointsUsed = 0 };
+
+            var result = stats.TryUpdateAttributes([new Update(EAttribute.Luck, 3)]);
+
+            Assert.True(result);
+            Assert.Equal(0, stats.StatPointsUsed);
+            Assert.Equal(0, stats.StatAllocations.Single().Amount);
+        }
+
+        [Fact]
+        public void TryUpdateAttributes_DuplicateUpdatesForSameAttribute_AppliesOnlyTheFirst()
+        {
+            // Indexing keeps the first update per attribute (matching the prior FirstOrDefault), so a
+            // second update for the same attribute is ignored rather than summed.
+            var stats = MakeStats(gained: 10, used: 0);
+
+            var result = stats.TryUpdateAttributes([
+                new Update(EAttribute.Strength, 2),
+                new Update(EAttribute.Strength, 5),
+            ]);
+
+            Assert.True(result);
+            Assert.Equal(2, stats.StatPointsUsed);
+            Assert.Equal(2, stats.StatAllocations.First(a => a.Attribute == EAttribute.Strength).Amount);
+        }
+
         private static PlayerStatPoints MakeStats(int gained, int used)
         {
             var allocations = new List<StatAllocation>

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -322,6 +322,21 @@ namespace Game.Core.Tests.Players
         }
 
         [Fact]
+        public void TrySetSelectedSkills_DuplicateAtCapBoundary_ReturnsFalseAndRaisesNoEvent()
+        {
+            // A full-size loadout whose duplicate is the last pair — exercises the nested duplicate scan
+            // across the whole list, not just an early-out at the front.
+            var player = MakePlayerWithUnlockedSkills(1, 2, 3, 4);
+            player.ClearEvents();
+
+            var result = player.TrySetSelectedSkills([1, 2, 3, 1]);
+
+            Assert.False(result);
+            Assert.Empty(player.SelectedSkills);
+            Assert.Empty(player.DomainEvents.OfType<SelectedSkillsChangedEvent>());
+        }
+
+        [Fact]
         public void TrySetSelectedSkills_NotUnlockedId_ReturnsFalseAndRaisesNoEvent()
         {
             var player = MakePlayerWithUnlockedSkills(1, 2, 3);

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -140,7 +140,7 @@ namespace Game.Core.Players
                 return false;
             }
 
-            if (orderedSkillIds.Distinct().Count() != orderedSkillIds.Count)
+            if (HasDuplicate(orderedSkillIds))
             {
                 return false;
             }
@@ -154,6 +154,26 @@ namespace Game.Core.Players
             SelectedSkills = orderedSkillIds.Select(id => unlockedById[id]).ToList();
             RaiseEvent(new SelectedSkillsChangedEvent(Id, orderedSkillIds.ToList()));
             return true;
+        }
+
+        /// <summary>
+        /// Returns whether <paramref name="ids"/> contains a duplicate. A nested scan is allocation-free
+        /// and clearer than a HashSet for the loadout's tiny size (≤ <see cref="GameConstants.MaxSelectedSkills"/>).
+        /// </summary>
+        private static bool HasDuplicate(IReadOnlyList<int> ids)
+        {
+            for (var i = 0; i < ids.Count; i++)
+            {
+                for (var j = i + 1; j < ids.Count; j++)
+                {
+                    if (ids[i] == ids[j])
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         public bool TryEquipItem(int itemId, EEquipmentSlot slot)

--- a/Game.Core/Players/PlayerStatPoints.cs
+++ b/Game.Core/Players/PlayerStatPoints.cs
@@ -37,7 +37,17 @@ namespace Game.Core.Players
         public bool TryUpdateAttributes(IEnumerable<IAttributeUpdate> changedAttributes)
         {
             var availablePoints = StatPointsGained - StatPointsUsed;
-            var matchedAttributes = StatAllocations.Select(att => (att, upd: changedAttributes.FirstOrDefault(chg => chg.Attribute == att.Attribute)));
+            // Index the updates by attribute once (first update wins per attribute, matching the prior
+            // FirstOrDefault), then materialize the matched pairs so the Sum/All/foreach below run a single pass.
+            var updatesByAttribute = new Dictionary<EAttribute, IAttributeUpdate>();
+            foreach (var update in changedAttributes)
+            {
+                updatesByAttribute.TryAdd(update.Attribute, update);
+            }
+
+            var matchedAttributes = StatAllocations
+                .Select(att => (att, upd: updatesByAttribute.GetValueOrDefault(att.Attribute)))
+                .ToList();
             var changedPoints = matchedAttributes.Sum(match => match.upd?.Amount ?? 0);
             if (availablePoints - changedPoints >= 0 && matchedAttributes.All(match => match.att.Amount + (match.upd?.Amount ?? 0) >= 0))
             {


### PR DESCRIPTION
## Summary

Two pure-domain micro-optimizations in `Game.Core/Players`, both behavior-preserving.

### 1. `PlayerStatPoints.TryUpdateAttributes` — triple-enumeration + per-element rescan
The old `matchedAttributes` was a **deferred** LINQ chain over `StatAllocations` where each element re-ran a `changedAttributes.FirstOrDefault(...)` scan, and it was then enumerated **three times** (`Sum`, `All`, and a `foreach`) — O(3·k·m), and silently fragile if `changedAttributes` ever became a forward-only stream (the three passes would see different/empty data).

Now the updates are indexed into a `Dictionary<EAttribute, IAttributeUpdate>` **once** (using `TryAdd`, so the *first* update wins per attribute — matching the prior `FirstOrDefault` semantics, including for duplicate updates), and the matched pairs are materialized with `.ToList()` before first use. The `Sum`/`All`/`foreach` then run a single pass over a stable collection.

### 2. `Player.TrySetSelectedSkills` — needless HashSet alloc
`orderedSkillIds.Distinct().Count() != orderedSkillIds.Count` allocated a `HashSet` via LINQ on every loadout-change validation. The list is capped at 4 (`GameConstants.MaxSelectedSkills`), so this is replaced with an allocation-free nested `HasDuplicate` scan — consistent with the project's deliberate hot-path allocation discipline (#286).

## Behavior unchanged / scope boundary
This is a **behavior-preserving refactor** — the matching, validation, and accept semantics of both methods are identical. In particular, the separate concern of **#488** (`TryUpdateAttributes` silently ignoring updates to attributes that have no existing allocation row, while still returning `true`) is **intentionally out of scope here** and left exactly as-is; a new unit test pins that current behavior so the refactor is provably unchanged.

## Test plan
`dotnet build` (0 warnings) + full `dotnet test` suite — all green:
- Game.Core.Tests: 406 passed (includes the new cases below)
- Game.Application.Tests: 164, Game.Api.Tests: 370, Game.Infrastructure.Tests: 26

New/strengthened `Game.Core.Tests` cases:
- `TryUpdateAttributes`: mixed add/edit/zero set applies each allocation; one allocation going negative rejects the entire set with no mutation; unknown-attribute update is ignored but still succeeds (pins the #488 contract); duplicate updates for the same attribute apply only the first.
- `TrySetSelectedSkills`: duplicate at the cap boundary (`[1,2,3,1]`) is rejected — exercises the nested scan across a full-size list rather than an early front-of-list out.

Closes #451

https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6i7JQ1zhEUVXvYhzSfGZ6)_