### PR TITLE
Standardize admin not-found error message wording

### DIFF
--- a/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
@@ -713,7 +713,7 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
             Assert.NotNull(result);
-            Assert.Equal("Skill does not exist.", result.ErrorMessage);
+            Assert.Equal("Skill not found.", result.ErrorMessage);
         }
 
         [Fact]
@@ -1555,7 +1555,7 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
             Assert.NotNull(result);
-            Assert.Equal("Item does not exist.", result.ErrorMessage);
+            Assert.Equal("Item not found.", result.ErrorMessage);
         }
 
         [Fact]
@@ -1683,7 +1683,7 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
             Assert.NotNull(result);
-            Assert.Equal("Item Mod does not exist.", result.ErrorMessage);
+            Assert.Equal("Item mod not found.", result.ErrorMessage);
         }
 
         [Fact]
@@ -1697,7 +1697,7 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
             Assert.NotNull(result);
-            Assert.Equal("Skill does not exist.", result.ErrorMessage);
+            Assert.Equal("Skill not found.", result.ErrorMessage);
         }
 
         [Fact]

--- a/Game.Api/Controllers/Admin/AdminItemModsController.cs
+++ b/Game.Api/Controllers/Admin/AdminItemModsController.cs
@@ -32,7 +32,7 @@ namespace Game.Api.Controllers.Admin
         {
             return _adminItemMods.SetAttributes(changeData)
                 ? ApiResponse.Success()
-                : ApiResponse.Error("Item Mod does not exist.");
+                : ApiResponse.Error("Item mod not found.");
         }
 
         [HttpPost]

--- a/Game.Api/Controllers/Admin/AdminItemsController.cs
+++ b/Game.Api/Controllers/Admin/AdminItemsController.cs
@@ -32,7 +32,7 @@ namespace Game.Api.Controllers.Admin
         {
             return _adminItems.SetAttributes(changeData)
                 ? ApiResponse.Success()
-                : ApiResponse.Error("Item does not exist.");
+                : ApiResponse.Error("Item not found.");
         }
 
         [HttpPost]

--- a/Game.Api/Controllers/Admin/AdminSkillsController.cs
+++ b/Game.Api/Controllers/Admin/AdminSkillsController.cs
@@ -32,7 +32,7 @@ namespace Game.Api.Controllers.Admin
         {
             return _adminSkills.SetMultipliers(changeData)
                 ? ApiResponse.Success()
-                : ApiResponse.Error("Skill does not exist.");
+                : ApiResponse.Error("Skill not found.");
         }
 
         [HttpPost]
@@ -40,7 +40,7 @@ namespace Game.Api.Controllers.Admin
         {
             return _adminSkills.SetEffects(changeData)
                 ? ApiResponse.Success()
-                : ApiResponse.Error("Skill does not exist.");
+                : ApiResponse.Error("Skill not found.");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `"Item does not exist."` with `"Item not found."` in `AdminItemsController`
- Replaces `"Item Mod does not exist."` with `"Item mod not found."` in `AdminItemModsController`
- Replaces both `"Skill does not exist."` with `"Skill not found."` in `AdminSkillsController`
- Updates the four matching integration test assertions in `AdminToolsControllerTests.cs` to pin the new strings

All admin not-found error messages now follow the uniform `"X not found."` convention already used by `SetTagsForItem`, `SetTagsForItemMod`, `SetZoneEnemies`, `SetEnemySkills`, `SetEnemySpawns`, and `SetEnemyAttributeDistributions`. No behavior change beyond the message wording.

## Test plan

- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet test` — all 968 tests pass (including the four assertions updated to match the new wording)

Closes #496

https://claude.ai/code/session_01Rt5NJvMchhQwzxfvha7UQp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rt5NJvMchhQwzxfvha7UQp)_