### PR TITLE
Batch HandleAttributeAllocationsChanged into single read + single SaveChanges

### DIFF
--- a/Game.DataAccess/DataProviderSynchronizer.cs
+++ b/Game.DataAccess/DataProviderSynchronizer.cs
@@ -208,39 +208,40 @@ namespace Game.DataAccess
 
         private static async Task HandleAttributeAllocationsChanged(GameContext context, AttributeAllocationsChangedEvent evt)
         {
+            var currentRows = await context.PlayerAttributes
+                .Where(pa => pa.PlayerId == evt.PlayerId)
+                .ToListAsync();
+
+            var rowsByAttributeId = currentRows.ToDictionary(pa => pa.AttributeId);
+
             foreach (var alloc in evt.Allocations)
             {
                 var attributeId = (int)alloc.Attribute;
                 var amount = (decimal)alloc.Amount;
 
-                if (amount == 0)
+                if (rowsByAttributeId.TryGetValue(attributeId, out var row))
                 {
-                    await context.PlayerAttributes
-                        .Where(pa => pa.PlayerId == evt.PlayerId && pa.AttributeId == attributeId)
-                        .ExecuteDeleteAsync();
-                }
-                else
-                {
-                    var existing = await context.PlayerAttributes
-                        .FirstOrDefaultAsync(pa => pa.PlayerId == evt.PlayerId && pa.AttributeId == attributeId);
-
-                    if (existing is not null)
+                    if (amount == 0)
                     {
-                        existing.Amount = amount;
+                        context.PlayerAttributes.Remove(row);
                     }
                     else
                     {
-                        context.PlayerAttributes.Add(new PlayerAttribute
-                        {
-                            PlayerId = evt.PlayerId,
-                            AttributeId = attributeId,
-                            Amount = amount,
-                        });
+                        row.Amount = amount;
                     }
-
-                    await context.SaveChangesAsync();
+                }
+                else if (amount != 0)
+                {
+                    context.PlayerAttributes.Add(new PlayerAttribute
+                    {
+                        PlayerId = evt.PlayerId,
+                        AttributeId = attributeId,
+                        Amount = amount,
+                    });
                 }
             }
+
+            await context.SaveChangesAsync();
         }
 
         private static async Task HandleItemUnlocked(GameContext context, ItemUnlockedEvent evt)


### PR DESCRIPTION
## Summary

- Replaced the per-allocation `FirstOrDefaultAsync` + `SaveChangesAsync` loop (and per-zero-allocation `ExecuteDeleteAsync`) in `HandleAttributeAllocationsChanged` with a single tracked `ToListAsync` over all `PlayerAttributes` for the player.
- In-memory diff: zero-amount allocations with an existing row call `context.PlayerAttributes.Remove(row)`; non-zero allocations update the tracked entity's `Amount` or add a new one; a zero-amount with no existing row is a no-op (idempotent delete).
- Single `SaveChangesAsync` at the end applies all changes in one batched write.
- This reduces ~2N DB round-trips to 2 (one read, one batched write), eliminates partial-allocation visibility between iterations, and closes the mid-loop crash window.

## Test plan

- [ ] Existing integration test `ProcessQueue_AttributeAllocationsChangedEvent_UpsertsInsertsAndDeletesIdempotently` already exercises all three branches (update, insert, delete via zero) in one event, delivered twice for idempotency — passes with the new implementation.
- [ ] Full test suite passes: 968 tests, 0 failures.

Closes #438

https://claude.ai/code/session_012Khpa5gvMG33vAe7DHkcSu

---
_Generated by [Claude Code](https://claude.ai/code/session_012Khpa5gvMG33vAe7DHkcSu)_