### PR TITLE
Fix AddEditZones reporting boss error for invalid UnlockChallengeId

### DIFF
--- a/Game.Abstractions/DataAccess/Admin/IAdminZones.cs
+++ b/Game.Abstractions/DataAccess/Admin/IAdminZones.cs
@@ -10,11 +10,12 @@ namespace Game.Abstractions.DataAccess.Admin
     public interface IAdminZones
     {
         /// <summary>
-        /// Applies an identity-level Add/Edit/Delete change set to the zone catalogue. Returns <c>false</c>
-        /// (applying nothing) when an Add/Edit sets a <see cref="Zone.BossEnemyId"/> that does not reference
-        /// an existing boss enemy.
+        /// Applies an identity-level Add/Edit/Delete change set to the zone catalogue. Returns <c>null</c>
+        /// on success, or a user-facing error message (applying nothing) when an Add/Edit sets a
+        /// <see cref="Zone.BossEnemyId"/> that does not reference an existing boss enemy, or an
+        /// <see cref="Zone.UnlockChallengeId"/> that is out of range.
         /// </summary>
-        bool SaveZones(IReadOnlyList<Change<Zone>> changes);
+        string? SaveZones(IReadOnlyList<Change<Zone>> changes);
 
         /// <summary>Replaces a zone's enemy spawns. Returns <c>false</c> if the zone does not exist.</summary>
         bool SetEnemies(SetZoneEnemiesData data);

--- a/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
@@ -286,6 +286,7 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
             Assert.NotNull(result);
+            Assert.Contains("boss", result.ErrorMessage ?? "", StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(GetZones(), z => z.Name == "Ghost Zone");
         }
 
@@ -1856,6 +1857,9 @@ namespace Game.Api.Tests.Integration
             var response = await authClient.PostAsJsonAsync("/api/AdminTools/AddEditZones", changes, CancellationToken);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Contains("unlock challenge", result.ErrorMessage ?? "", StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(GetZones(), z => z.Name == "Phantom Gate");
         }
 

--- a/Game.Api/Controllers/Admin/AdminZonesController.cs
+++ b/Game.Api/Controllers/Admin/AdminZonesController.cs
@@ -23,9 +23,10 @@ namespace Game.Api.Controllers.Admin
         [HttpPost]
         public ApiResponse AddEditZones([FromBody] List<Change<Zone>> changes)
         {
-            return _adminZones.SaveZones(changes)
+            var error = _adminZones.SaveZones(changes);
+            return error is null
                 ? ApiResponse.Success()
-                : ApiResponse.Error("Boss enemy is invalid. A zone's boss must be an existing enemy marked as a boss.");
+                : ApiResponse.Error(error);
         }
 
         [HttpPost]

--- a/Game.DataAccess/Repositories/Admin/AdminZones.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminZones.cs
@@ -23,7 +23,7 @@ namespace Game.DataAccess.Repositories.Admin
         private readonly IChallenges _challenges = challenges;
         private readonly IEntityStore _entityStore = entityStore;
 
-        public bool SaveZones(IReadOnlyList<Change<Contracts.Zone>> changes)
+        public string? SaveZones(IReadOnlyList<Change<Contracts.Zone>> changes)
         {
             // A zone's dedicated boss must reference an existing enemy flagged IsBoss, and its unlock gate
             // must reference an existing challenge. Validate the whole change set up front so an invalid
@@ -39,14 +39,14 @@ namespace Game.DataAccess.Repositories.Admin
                 if (change.Item.BossEnemyId is int bossEnemyId
                     && _enemies.GetEnemy(bossEnemyId) is not { IsBoss: true })
                 {
-                    return false;
+                    return "Boss enemy is invalid. A zone's boss must be an existing enemy marked as a boss.";
                 }
 
                 // Challenges are zero-based-id reference data, so a valid id is an in-range index.
                 if (change.Item.UnlockChallengeId is int unlockChallengeId
                     && (unlockChallengeId < 0 || unlockChallengeId >= challengeCount))
                 {
-                    return false;
+                    return "Unlock challenge is invalid. A zone's unlock challenge must reference an existing challenge.";
                 }
             }
 
@@ -76,7 +76,7 @@ namespace Game.DataAccess.Repositories.Admin
                     RetiredAt = item.RetiredAt,
                 }));
 
-            return true;
+            return null;
         }
 
         public bool SetEnemies(SetZoneEnemiesData data)


### PR DESCRIPTION
## Summary

- Changed `IAdminZones.SaveZones` return type from `bool` to `string?` (null = success, non-null = user-facing error message)
- `AdminZones.SaveZones` now returns a distinct message for each validation failure: one for an invalid boss enemy, another for an out-of-range unlock challenge id
- `AdminZonesController.AddEditZones` threads the error string through directly instead of using a single hardcoded message
- Tightened two tests to assert the field-specific error messages: `AddEditZones_NonexistentBossEnemy_ReturnsError` (now checks for "boss") and `AddEditZones_WithOutOfRangeUnlockChallenge_ReturnsErrorAndPersistsNothing` (now checks for "unlock challenge")

## Test plan

- [x] `dotnet build` — clean, 0 warnings
- [x] All integration tests pass (372 total in `Game.Api.Tests`, 0 failures)
- [x] `AddEditZones_WithOutOfRangeUnlockChallenge_ReturnsErrorAndPersistsNothing` now asserts the unlock-challenge-specific error message
- [x] `AddEditZones_NonexistentBossEnemy_ReturnsError` now asserts the boss-specific error message

Closes #497

https://claude.ai/code/session_017ab5xYNuxfSgddUoMmF9T4

---
_Generated by [Claude Code](https://claude.ai/code/session_017ab5xYNuxfSgddUoMmF9T4)_