### PR TITLE
Fix stopGame not unregistering SocketReplaced/ChallengeCompleted listeners

### DIFF
--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -2,7 +2,7 @@ import { onDestroy } from 'svelte';
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
 import { BattleEngine } from './battle/battle-engine';
-import { statify } from '$lib/common';
+import { statify, type Action } from '$lib/common';
 import { RenderEngine } from './render-engine';
 import { LogicalEngine } from './logical-engine';
 import { InventoryManager } from './player/inventory-manager';
@@ -22,6 +22,9 @@ export const SESSION_REPLACED_TITLE = 'Session Replaced';
 export const SESSION_REPLACED_BODY =
 	'Another session has started elsewhere. You have been disconnected. You will be taken to the login screen.';
 
+let socketReplacedUnhook: Action | undefined;
+let challengeCompletedUnhook: Action | undefined;
+
 export const startGame = () => {
 	if (staticData.loaded) {
 		inventoryManager.initialize();
@@ -34,8 +37,8 @@ export const startGame = () => {
 		startLogicEngine();
 		startRenderEngine();
 		startBattleEngine();
-		apiSocket.listenCommand('SocketReplaced', handleSocketReplaced);
-		apiSocket.listenCommand('ChallengeCompleted', handleChallengeCompleted);
+		socketReplacedUnhook = apiSocket.listenCommand('SocketReplaced', handleSocketReplaced);
+		challengeCompletedUnhook = apiSocket.listenCommand('ChallengeCompleted', handleChallengeCompleted);
 	}
 };
 
@@ -87,6 +90,8 @@ const stopGame = () => {
 	battleEngine.stop();
 	statistics.reset();
 	playerChallenges.reset();
+	socketReplacedUnhook?.();
+	challengeCompletedUnhook?.();
 };
 
 const startLogicEngine = () => {

--- a/UI/src/tests/lib/engine/engine.test.ts
+++ b/UI/src/tests/lib/engine/engine.test.ts
@@ -27,7 +27,19 @@ vi.mock('$stores', async () => {
 	};
 });
 
-const { listenCommand } = vi.hoisted(() => ({ listenCommand: vi.fn() }));
+const { listenCommand, unlistenSocketReplaced, unlistenChallengeCompleted } = vi.hoisted(() => {
+	const unlistenSocketReplaced = vi.fn();
+	const unlistenChallengeCompleted = vi.fn();
+	const listenCommand = vi.fn().mockImplementation((command: string) => {
+		if (command === 'SocketReplaced') {
+			return unlistenSocketReplaced;
+		}
+		if (command === 'ChallengeCompleted') {
+			return unlistenChallengeCompleted;
+		}
+	});
+	return { listenCommand, unlistenSocketReplaced, unlistenChallengeCompleted };
+});
 // Partial mock: keep $lib/api's real exports (other modules in the graph, e.g. $lib/common, rely on
 // them) but swap apiSocket for a stub whose listenCommand we can assert against.
 vi.mock('$lib/api', async (importOriginal) => ({
@@ -163,6 +175,14 @@ describe('startGame', () => {
 
 		expect(battleEngine.stop).toHaveBeenCalledTimes(1);
 		expect(activeModal.current?.body).toBe(SESSION_REPLACED_BODY);
+	});
+
+	it('stopGame unregisters SocketReplaced and ChallengeCompleted listeners', () => {
+		startGame();
+		void handleSocketReplaced();
+
+		expect(unlistenSocketReplaced).toHaveBeenCalledTimes(1);
+		expect(unlistenChallengeCompleted).toHaveBeenCalledTimes(1);
 	});
 });
 


### PR DESCRIPTION
## Summary

- Capture the `Action` unhook closures returned by `apiSocket.listenCommand` for both `SocketReplaced` and `ChallengeCompleted` in module-level variables (`socketReplacedUnhook` / `challengeCompletedUnhook`).
- Call them in `stopGame`, mirroring the `BattleEngine` `logicalUnhook`/`renderUnhook` pattern so teardown is symmetric with setup.
- Updated `listenCommand` mock in the engine test to return per-command spy unhook functions, and added a test verifying the unhooks are invoked when `stopGame` runs.

## Test plan

- [ ] All 1617 existing unit tests pass (`npm run test:unit:ci`)
- [ ] Lint and type-check clean (`npm run lint`)
- [ ] New test: `startGame > stopGame unregisters SocketReplaced and ChallengeCompleted listeners` — confirms both unhook closures are called exactly once when `stopGame` is triggered via `handleSocketReplaced`

Closes #456

https://claude.ai/code/session_01AtUahQyE67tsMLpHFfFDWx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtUahQyE67tsMLpHFfFDWx)_