### PR TITLE
Consolidate per-component attributeName resolvers into a shared helper (#518)

### DIFF
--- a/UI/src/lib/common/attribute-display.ts
+++ b/UI/src/lib/common/attribute-display.ts
@@ -1,4 +1,4 @@
-import { EAttribute } from '$lib/api';
+import { EAttribute, type IAttribute } from '$lib/api';
 import { normalizeText } from './functions';
 
 /*
@@ -44,3 +44,12 @@ export const attributeCode = (id: EAttribute): string => ATTRIBUTE_CODE[id] ?? '
  *  used when the live `Attributes` reference data is unavailable. An unknown/out-of-range id
  *  has no enum key, so it degrades to a readable `Unknown` rather than a blank label. */
 export const attributeEnumName = (id: EAttribute): string => normalizeText(EAttribute[id]) || 'Unknown';
+
+/**
+ * The attribute's display name — the authored name from the `Attributes` reference set when
+ * available, falling back to the normalised enum name. The reference set is passed in (rather
+ * than read from `$stores`) so this module stays free of a store dependency, mirroring the other
+ * param-based `$lib/common` helpers (e.g. `challengeTypeName`).
+ */
+export const attributeName = (id: EAttribute, attributes?: IAttribute[]): string =>
+	attributes?.find((a) => a.id === id)?.name ?? attributeEnumName(id);

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -2,7 +2,7 @@ import { Battler, battleStep, type BattleStepLog } from '$lib/battle';
 import { staticData } from '$stores';
 import { ELogType, IEnemyInstance } from '$lib/api';
 import { logMessage } from '../log';
-import { formatNum, createHook, Action, effectLogMessage, attributeEnumName } from '$lib/common';
+import { formatNum, createHook, Action, effectLogMessage, attributeName } from '$lib/common';
 import { onLogicalUpdate } from '../logical-engine';
 import { onRenderUpdate } from '../render-engine';
 import { inventoryManager } from '../engine';
@@ -138,9 +138,7 @@ export class BattleEngine {
 	 *  (#297), falling back to the formatted enum name when the reference set is unavailable. */
 	private logEffectApplications() {
 		for (const { effect, onPlayer } of this.stepLog.appliedEffects) {
-			const name =
-				staticData.attributes?.find((attr) => attr.id === effect.attributeId)?.name ??
-				attributeEnumName(effect.attributeId);
+			const name = attributeName(effect.attributeId, staticData.attributes);
 			logMessage(ELogType.SkillEffect, effectLogMessage(effect, name, onPlayer, this.enemy.name));
 		}
 	}

--- a/UI/src/routes/game/screens/attribute-breakdown/AttributeListRow.svelte
+++ b/UI/src/routes/game/screens/attribute-breakdown/AttributeListRow.svelte
@@ -9,7 +9,7 @@
 	onclick={() => onSelect(meta.id)}
 >
 	<span class="info">
-		<span class="name">{attributeName(meta.id)}</span>
+		<span class="name">{attributeName(meta.id, staticData.attributes)}</span>
 		<StackBar {computed} height={6} radius={1} />
 	</span>
 	<span class="total">{fmtNum(computed.total, meta.dec)}</span>
@@ -17,8 +17,10 @@
 
 <script lang="ts">
 import type { ComputedAttribute } from '$lib/battle';
+import { attributeName } from '$lib/common';
+import { staticData } from '$stores';
 import StackBar from './StackBar.svelte';
-import { attributeName, fmtNum, type BreakdownAttrMeta, type LabeledModifier } from './attribute-breakdown-view.svelte';
+import { fmtNum, type BreakdownAttrMeta, type LabeledModifier } from './attribute-breakdown-view.svelte';
 
 interface Props {
 	meta: BreakdownAttrMeta;

--- a/UI/src/routes/game/screens/attribute-breakdown/BreakdownDetail.svelte
+++ b/UI/src/routes/game/screens/attribute-breakdown/BreakdownDetail.svelte
@@ -5,7 +5,7 @@
 	<div class="head">
 		<div class="heading">
 			<div class="title-row">
-				<h2 class="name">{attributeName(view.selected)}</h2>
+				<h2 class="name">{attributeName(view.selected, staticData.attributes)}</h2>
 				<KindTag group={view.selectedMeta.group} />
 			</div>
 			{#if description}
@@ -36,12 +36,9 @@ import SourceLegend from './SourceLegend.svelte';
 import KindTag from './KindTag.svelte';
 import BySourceBreakdown from './BySourceBreakdown.svelte';
 import ApplyOrderTrace from './ApplyOrderTrace.svelte';
-import {
-	attributeDescription,
-	attributeName,
-	fmtNum,
-	type AttributeBreakdownView
-} from './attribute-breakdown-view.svelte';
+import { attributeName } from '$lib/common';
+import { staticData } from '$stores';
+import { attributeDescription, fmtNum, type AttributeBreakdownView } from './attribute-breakdown-view.svelte';
 
 interface Props {
 	view: AttributeBreakdownView;

--- a/UI/src/routes/game/screens/attribute-breakdown/BySourceBreakdown.svelte
+++ b/UI/src/routes/game/screens/attribute-breakdown/BySourceBreakdown.svelte
@@ -15,7 +15,10 @@
 				<div class="line">
 					<span class="line-label">
 						{#if line.source === EAttributeModifierSource.Derived}
-							{attributeName(line.derivedSource)} ({line.amount}× of {fmtNum(line.derivedValue ?? 0, 1)})
+							{attributeName(line.derivedSource, staticData.attributes)} ({line.amount}× of {fmtNum(
+								line.derivedValue ?? 0,
+								1
+							)})
 						{:else if line.source === EAttributeModifierSource.ItemMod && line.modType !== undefined}
 							{modifierLabel(line)} · {modTypeLabel(line.modType)}
 						{:else}
@@ -31,15 +34,10 @@
 
 <script lang="ts">
 import { EAttributeModifierSource, type SourceGroup } from '$lib/battle';
-import { modTypeLabel } from '$lib/common';
+import { modTypeLabel, attributeName } from '$lib/common';
+import { staticData } from '$stores';
 import { sourceColor, sourceLabel } from './source-display';
-import {
-	attributeName,
-	fmtNum,
-	fmtSigned,
-	modifierLabel,
-	type LabeledModifier
-} from './attribute-breakdown-view.svelte';
+import { fmtNum, fmtSigned, modifierLabel, type LabeledModifier } from './attribute-breakdown-view.svelte';
 
 interface Props {
 	groups: SourceGroup<LabeledModifier>[];

--- a/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
+++ b/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
@@ -28,7 +28,7 @@ import {
 	type AppliedModifier,
 	type ComputedAttribute
 } from '$lib/battle';
-import { attributeEnumName } from '$lib/common';
+import { attributeName } from '$lib/common';
 import { playerManager, inventoryManager, type EEquipmentSlot } from '$lib/engine';
 import { staticData } from '$stores';
 
@@ -76,12 +76,6 @@ export const ATTRIBUTE_GROUPS: { key: AttributeGroup; label: string }[] = [
 	{ key: 'core', label: 'Core' },
 	{ key: 'derived', label: 'Derived' }
 ];
-
-/** Display name for an attribute, preferring the live reference data and falling
- *  back to a normalised enum key (e.g. `MaxHealth` → `Max Health`). */
-export function attributeName(id: EAttribute): string {
-	return staticData.attributes?.find((a) => a.id === id)?.name ?? attributeEnumName(id);
-}
 
 /** Reference-data description for an attribute (empty when not yet loaded). */
 export function attributeDescription(id: EAttribute): string {

--- a/UI/src/routes/game/screens/attributes/AttributesRadar.svelte
+++ b/UI/src/routes/game/screens/attributes/AttributesRadar.svelte
@@ -27,8 +27,8 @@
 			role="button"
 			tabindex={clickable ? 0 : -1}
 			aria-label={clickable
-				? `Adjust ${attributeName(coreIds[i])} — drag to allocate or click to add a point`
-				: `Adjust ${attributeName(coreIds[i])} — drag to refund points`}
+				? `Adjust ${attributeName(coreIds[i], staticData.attributes)} — drag to allocate or click to add a point`
+				: `Adjust ${attributeName(coreIds[i], staticData.attributes)} — drag to refund points`}
 			onpointerdown={(e) => startDrag(e, i)}
 			onclick={() => onVertexClick(i)}
 			onkeydown={(e) => clickable && handleKey(e, i)}
@@ -59,8 +59,9 @@
 
 <script lang="ts">
 import { onMount, untrack } from 'svelte';
-import { attributeColor, attributeCode } from '$lib/common';
-import { CORE_ATTRIBUTES, attributeName, radarValueAtPointer, type AttributesView } from './attributes-view.svelte';
+import { attributeColor, attributeCode, attributeName } from '$lib/common';
+import { staticData } from '$stores';
+import { CORE_ATTRIBUTES, radarValueAtPointer, type AttributesView } from './attributes-view.svelte';
 
 interface Props {
 	view: AttributesView;

--- a/UI/src/routes/game/screens/attributes/DerivedPanel.svelte
+++ b/UI/src/routes/game/screens/attributes/DerivedPanel.svelte
@@ -12,7 +12,7 @@
 					{@const isChanged = from !== to}
 					<div class="stat" class:changed={isChanged}>
 						<div class="info">
-							<div class="name">{attributeName(d.id)}</div>
+							<div class="name">{attributeName(d.id, staticData.attributes)}</div>
 							<div class="fed-by">
 								{#each contributorsFor(d.id) as cid (cid)}
 									<span class="src" style="color: {attributeColor(cid)}">{attributeCode(cid)}</span>
@@ -33,12 +33,12 @@
 </div>
 
 <script lang="ts">
-import { formatNum, attributeColor, attributeCode } from '$lib/common';
+import { formatNum, attributeColor, attributeCode, attributeName } from '$lib/common';
+import { staticData } from '$stores';
 import {
 	DERIVED_GROUPS,
 	DERIVED_STATS,
 	CORE_ATTRIBUTES,
-	attributeName,
 	derivedUnit,
 	feedsFor,
 	type AttributesView,

--- a/UI/src/routes/game/screens/attributes/GuidedRow.svelte
+++ b/UI/src/routes/game/screens/attributes/GuidedRow.svelte
@@ -12,7 +12,7 @@
 				<span class="feed empty" title="No derived-stat contribution yet">—</span>
 			{:else}
 				{#each feeds as fid (fid)}
-					<span class="feed" class:changed={changed.has(fid)}>{attributeName(fid)}</span>
+					<span class="feed" class:changed={changed.has(fid)}>{attributeName(fid, staticData.attributes)}</span>
 				{/each}
 			{/if}
 		</div>
@@ -23,10 +23,11 @@
 </div>
 
 <script lang="ts">
-import { attributeColor, attributeCode } from '$lib/common';
+import { attributeColor, attributeCode, attributeName } from '$lib/common';
+import { staticData } from '$stores';
 import Delta from './Delta.svelte';
 import Stepper from './Stepper.svelte';
-import { CORE_ATTRIBUTES, DERIVED_STATS, attributeName, feedsFor, type AttributesView } from './attributes-view.svelte';
+import { CORE_ATTRIBUTES, DERIVED_STATS, feedsFor, type AttributesView } from './attributes-view.svelte';
 
 interface Props {
 	i: number;
@@ -38,7 +39,7 @@ const { i, view }: Props = $props();
 const id = $derived(CORE_ATTRIBUTES[i]);
 const color = $derived(attributeColor(id));
 const code = $derived(attributeCode(id));
-const name = $derived(attributeName(id));
+const name = $derived(attributeName(id, staticData.attributes));
 const feeds = $derived(feedsFor(i));
 
 // The set of derived stats whose value differs between the saved and pending

--- a/UI/src/routes/game/screens/attributes/TheoryRow.svelte
+++ b/UI/src/routes/game/screens/attributes/TheoryRow.svelte
@@ -39,11 +39,11 @@
 </div>
 
 <script lang="ts">
-import { formatNum, attributeColor, attributeCode } from '$lib/common';
+import { formatNum, attributeColor, attributeCode, attributeName } from '$lib/common';
+import { staticData } from '$stores';
 import Stepper from './Stepper.svelte';
 import {
 	CORE_ATTRIBUTES,
-	attributeName,
 	derivedShortLabel,
 	derivedUnit,
 	perPointYields,
@@ -60,7 +60,7 @@ const { i, view }: Props = $props();
 const id = $derived(CORE_ATTRIBUTES[i]);
 const color = $derived(attributeColor(id));
 const code = $derived(attributeCode(id));
-const name = $derived(attributeName(id));
+const name = $derived(attributeName(id, staticData.attributes));
 
 const value = $derived(view.values[i]);
 const saved = $derived(view.savedValues[i]);

--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -23,7 +23,7 @@
 
 import { apiSocket, EAttribute, type IAttributeUpdate, type IBattlerAttribute } from '$lib/api';
 import { BattleAttributes } from '$lib/battle';
-import { attributeEnumName } from '$lib/common';
+import { attributeName } from '$lib/common';
 import { playerManager } from '$lib/engine';
 import { staticData, toastError } from '$stores';
 
@@ -137,12 +137,6 @@ export function radarValueAtPointer(
 	return (projection / axisLength) * hexMax;
 }
 
-/** The display name for an attribute, preferring the live reference data and
- *  falling back to a normalised enum key (e.g. `MaxHealth` → `Max Health`). */
-export function attributeName(id: EAttribute): string {
-	return staticData.attributes?.find((a) => a.id === id)?.name ?? attributeEnumName(id);
-}
-
 /** Compact labels for the dense theorycraft "per point" line. Falls back to the
  *  full name so a newly surfaced derived stat still reads correctly. */
 const DERIVED_SHORT: Partial<Record<EAttribute, string>> = {
@@ -152,7 +146,7 @@ const DERIVED_SHORT: Partial<Record<EAttribute, string>> = {
 };
 
 export function derivedShortLabel(id: EAttribute): string {
-	return DERIVED_SHORT[id] ?? attributeName(id);
+	return DERIVED_SHORT[id] ?? attributeName(id, staticData.attributes);
 }
 
 /** The unit suffix configured for a surfaced derived stat (empty if none). */

--- a/UI/src/routes/game/screens/challenges/ModTooltip.svelte
+++ b/UI/src/routes/game/screens/challenges/ModTooltip.svelte
@@ -23,7 +23,8 @@
 
 <script lang="ts">
 import { type IItemMod } from '$lib/api';
-import { attributeEnumName, modTypeColor, modTypeLabel, rarityColor } from '$lib/common';
+import { attributeName, modTypeColor, modTypeLabel, rarityColor } from '$lib/common';
+import { staticData } from '$stores';
 import TooltipShell from '$components/tooltip/TooltipShell.svelte';
 import TooltipSection from '$components/tooltip/TooltipSection.svelte';
 import TooltipStatsGrid from '$components/tooltip/TooltipStatsGrid.svelte';
@@ -37,7 +38,7 @@ const { mod }: Props = $props();
 
 const typeColor = $derived(modTypeColor(mod.itemModTypeId));
 const effects = $derived(
-	(mod.attributes ?? []).map((a) => ({ name: attributeEnumName(a.attributeId), value: a.amount }))
+	(mod.attributes ?? []).map((a) => ({ name: attributeName(a.attributeId, staticData.attributes), value: a.amount }))
 );
 </script>
 

--- a/UI/src/routes/game/screens/challenges/SkillRewardTooltip.svelte
+++ b/UI/src/routes/game/screens/challenges/SkillRewardTooltip.svelte
@@ -46,8 +46,8 @@
 </TooltipShell>
 
 <script lang="ts">
-import { EAttribute, type ISkill } from '$lib/api';
-import { attributeColor, attributeEnumName, describeEffect, effectDirectionColor, formatNum } from '$lib/common';
+import type { ISkill } from '$lib/api';
+import { attributeColor, attributeName, describeEffect, effectDirectionColor, formatNum } from '$lib/common';
 import { staticData } from '$stores';
 import TooltipShell from '$components/tooltip/TooltipShell.svelte';
 import TooltipSection from '$components/tooltip/TooltipSection.svelte';
@@ -59,15 +59,10 @@ interface Props {
 
 const { skill }: Props = $props();
 
-// Reference-data attribute name (the full names live in the `Attributes` set); falls back to the
-// humanised enum key, matching the battle skill tooltip.
-const attributeName = (id: EAttribute) =>
-	staticData.attributes?.find((a) => a.id === id)?.name ?? attributeEnumName(id);
-
 const scaling = $derived(
 	skill.damageMultipliers.map((m) => ({
 		attributeId: m.attributeId,
-		name: attributeName(m.attributeId),
+		name: attributeName(m.attributeId, staticData.attributes),
 		multiplier: m.multiplier
 	}))
 );
@@ -75,7 +70,10 @@ const cooldownSeconds = $derived(formatNum(skill.cooldownMs / 1000));
 // One display line per authored effect, reusing the shared helper so wording/direction match the
 // battle tooltip's "On hit" lines; `id` is kept for a stable each-key.
 const effectLines = $derived(
-	skill.effects.map((effect) => ({ id: effect.id, ...describeEffect(effect, attributeName(effect.attributeId)) }))
+	skill.effects.map((effect) => ({
+		id: effect.id,
+		...describeEffect(effect, attributeName(effect.attributeId, staticData.attributes))
+	}))
 );
 </script>
 

--- a/UI/src/routes/game/screens/fight/ActiveEffectChips.svelte
+++ b/UI/src/routes/game/screens/fight/ActiveEffectChips.svelte
@@ -8,7 +8,7 @@
 			{@const color = effectDirectionColor(effectDirection(effect.attribute, effect.modifierType, effect.amount))}
 			<div class="effect-chip" style:--chip-accent={color} title={chipTitle(effect)}>
 				<span class="chip-mag">{formatEffectMagnitude(effect.modifierType, effect.amount)}</span>
-				<span class="chip-attr">{attributeName(effect.attribute)}</span>
+				<span class="chip-attr">{attributeName(effect.attribute, staticData.attributes)}</span>
 				<span class="chip-time">{remainingSeconds(effect)}s</span>
 				<div class="chip-track">
 					<div class="chip-fill" style:width="{remainingPercent(effect)}%"></div>
@@ -19,8 +19,7 @@
 {/if}
 
 <script lang="ts">
-import { EAttribute } from '$lib/api';
-import { attributeEnumName, effectDirection, effectDirectionColor, formatEffectMagnitude } from '$lib/common';
+import { attributeName, effectDirection, effectDirectionColor, formatEffectMagnitude } from '$lib/common';
 import { staticData } from '$stores';
 import type { ActiveEffectView, Battler } from '$lib/battle';
 
@@ -32,14 +31,11 @@ type Props = {
 
 const { battler, reversed = false }: Props = $props();
 
-const attributeName = (id: EAttribute) =>
-	staticData.attributes?.find((attr) => attr.id === id)?.name ?? attributeEnumName(id);
-
 const remainingSeconds = (effect: ActiveEffectView) => (effect.renderRemainingMs / 1000).toFixed(2);
 const remainingPercent = (effect: ActiveEffectView) =>
 	effect.durationMs > 0 ? Math.max(0, Math.min(100, (effect.renderRemainingMs / effect.durationMs) * 100)) : 0;
 const chipTitle = (effect: ActiveEffectView) =>
-	`${formatEffectMagnitude(effect.modifierType, effect.amount)} ${attributeName(effect.attribute)}`;
+	`${formatEffectMagnitude(effect.modifierType, effect.amount)} ${attributeName(effect.attribute, staticData.attributes)}`;
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/game/screens/fight/SkillTooltip.svelte
+++ b/UI/src/routes/game/screens/fight/SkillTooltip.svelte
@@ -25,7 +25,7 @@
 <script lang="ts">
 import { EAttribute } from '$lib/api';
 import { applyDefense, skillContributions, type Skill } from '$lib/battle';
-import { attributeEnumName, describeEffect } from '$lib/common';
+import { attributeName, describeEffect } from '$lib/common';
 import { battleEngine } from '$lib/engine';
 import { staticData } from '$stores';
 import TooltipShell from '$components/tooltip/TooltipShell.svelte';
@@ -53,7 +53,7 @@ const opponent = $derived(skill?.owner ? battleEngine.getOpponent(skill.owner) :
 const baseDamage = $derived(skill?.baseDamage ?? 0);
 const multipliers = $derived(
 	(skill ? skillContributions(skill, skill.owner.attributes) : []).map((contribution) => ({
-		name: attributeName(contribution.attributeId),
+		name: attributeName(contribution.attributeId, staticData.attributes),
 		multiplier: contribution.multiplier,
 		value: contribution.value
 	}))
@@ -69,9 +69,8 @@ const cooldownProgress = $derived(isReady ? 100 : Math.max(0, ((adjustedCd - rem
 const remainingCdFormatted = $derived(remainingCd.toFixed(2));
 
 const effectLines = $derived(
-	(skill?.effects ?? []).map((effect) => describeEffect(effect, attributeName(effect.attributeId)))
+	(skill?.effects ?? []).map((effect) =>
+		describeEffect(effect, attributeName(effect.attributeId, staticData.attributes))
+	)
 );
-
-const attributeName = (attrId: number) =>
-	staticData.attributes?.find((a) => a.id === attrId)?.name ?? attributeEnumName(attrId);
 </script>

--- a/UI/src/routes/game/screens/skills/SkillInspector.svelte
+++ b/UI/src/routes/game/screens/skills/SkillInspector.svelte
@@ -102,11 +102,10 @@
 </div>
 
 <script lang="ts">
-import { EAttribute } from '$lib/api';
 import {
 	attributeCode,
 	attributeColor,
-	attributeEnumName,
+	attributeName,
 	describeEffect,
 	effectDirectionColor,
 	formatNum
@@ -128,15 +127,12 @@ const full = $derived(view.equipped.length >= view.cap);
 
 const fmt = (n: number) => formatNum(Math.round(n));
 
-const attributeName = (id: EAttribute) =>
-	staticData.attributes?.find((a) => a.id === id)?.name ?? attributeEnumName(id);
-
 // One display description per authored effect, reusing the shared helper so wording/direction
 // match the battle tooltip's "On hit" lines; `id` is kept for a stable each-key.
 const effects = $derived(
 	(metrics?.skill.effects ?? []).map((effect) => ({
 		id: effect.id,
-		...describeEffect(effect, attributeName(effect.attributeId))
+		...describeEffect(effect, attributeName(effect.attributeId, staticData.attributes))
 	}))
 );
 

--- a/UI/src/routes/game/screens/skills/SortFilterModal.svelte
+++ b/UI/src/routes/game/screens/skills/SortFilterModal.svelte
@@ -35,7 +35,7 @@
 								style:--ac={attributeColor(attr)}
 								onclick={() => view.toggleAttributeFilter(attr)}
 							>
-								{attributeName(attr)}
+								{attributeName(attr, staticData.attributes)}
 							</button>
 						{/each}
 					</div>
@@ -66,8 +66,7 @@
 {/if}
 
 <script lang="ts">
-import { EAttribute } from '$lib/api';
-import { attributeColor, attributeEnumName } from '$lib/common';
+import { attributeColor, attributeName } from '$lib/common';
 import { staticData } from '$stores';
 import { SKILL_SORTS, type SkillsView } from './skills-view.svelte';
 
@@ -76,9 +75,6 @@ type Props = {
 };
 
 const { view }: Props = $props();
-
-const attributeName = (id: EAttribute) =>
-	staticData.attributes?.find((a) => a.id === id)?.name ?? attributeEnumName(id);
 
 /** Escape closes the open filter overlay (the backdrop click / Apply are the other paths). */
 const onKeydown = (e: KeyboardEvent) => {

--- a/UI/src/tests/common/attribute-display.test.ts
+++ b/UI/src/tests/common/attribute-display.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { EAttribute } from '$lib/api';
-import { attributeEnumName } from '../../lib/common/attribute-display';
+import { EAttribute, type IAttribute } from '$lib/api';
+import { attributeEnumName, attributeName } from '../../lib/common/attribute-display';
 
 describe('attributeEnumName', () => {
 	it('returns the normalized enum key for a known attribute id', () => {
@@ -17,5 +17,33 @@ describe('attributeEnumName', () => {
 		const unknownId = 999 as EAttribute;
 		expect(() => attributeEnumName(unknownId)).not.toThrow();
 		expect(attributeEnumName(unknownId)).toBe('Unknown');
+	});
+});
+
+describe('attributeName', () => {
+	const mockAttributes: IAttribute[] = [
+		{ id: EAttribute.Strength, name: 'Physical Power', description: '' },
+		{ id: EAttribute.MaxHealth, name: 'Maximum Life', description: '' }
+	];
+
+	it('returns the reference-data name when attributes are provided', () => {
+		expect(attributeName(EAttribute.Strength, mockAttributes)).toBe('Physical Power');
+		expect(attributeName(EAttribute.MaxHealth, mockAttributes)).toBe('Maximum Life');
+	});
+
+	it('falls back to the normalised enum name when attributes are absent', () => {
+		expect(attributeName(EAttribute.Strength)).toBe('Strength');
+		expect(attributeName(EAttribute.MaxHealth)).toBe('Max Health');
+		expect(attributeName(EAttribute.CooldownRecovery)).toBe('Cooldown Recovery');
+	});
+
+	it('falls back to the normalised enum name when the id is absent from the provided list', () => {
+		expect(attributeName(EAttribute.Luck, mockAttributes)).toBe('Luck');
+	});
+
+	it('degrades to "Unknown" for an out-of-range id rather than throwing', () => {
+		const unknownId = 999 as EAttribute;
+		expect(() => attributeName(unknownId)).not.toThrow();
+		expect(attributeName(unknownId)).toBe('Unknown');
 	});
 });

--- a/UI/src/tests/routes/game/screens/attribute-breakdown/attribute-breakdown-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attribute-breakdown/attribute-breakdown-view.test.ts
@@ -15,10 +15,10 @@ const { mockPlayerManager, mockInventoryManager, staticData } = vi.hoisted(() =>
 vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager, inventoryManager: mockInventoryManager }));
 vi.mock('$stores', () => ({ staticData }));
 
+import { attributeName } from '$lib/common';
 import {
 	AttributeBreakdownView,
 	BREAKDOWN_ATTRS,
-	attributeName,
 	buildPlayerModifiers,
 	fmtNum,
 	fmtSigned,

--- a/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
@@ -23,6 +23,7 @@ vi.mock('$lib/api', async (importOriginal) => {
 	return { ...actual, apiSocket: { sendSocketCommand } };
 });
 
+import { attributeName } from '$lib/common';
 import {
 	AttributesView,
 	CORE_ATTRIBUTES,
@@ -32,7 +33,6 @@ import {
 	feedsFor,
 	derivedShortLabel,
 	derivedUnit,
-	attributeName,
 	radarValueAtPointer
 } from '$routes/game/screens/attributes/attributes-view.svelte';
 


### PR DESCRIPTION
## Summary

- Adds `attributeName(id, attributes?)` to `$lib/common/attribute-display.ts`, following the same store-free, param-based pattern as `challengeTypeName` in `challenge-type.ts`. Callers pass `staticData.attributes` so the helper stays free of a store dependency.
- Removes the duplicated local `attributeName` resolver from every component/file that had one: `attributes-view.svelte.ts`, `attribute-breakdown-view.svelte.ts`, `SkillTooltip`, `ActiveEffectChips`, `SkillRewardTooltip`, `SkillInspector`, `SortFilterModal`, `battle-engine.ts`, and the child components that imported from the view files (`AttributesRadar`, `GuidedRow`, `TheoryRow`, `DerivedPanel`, `AttributeListRow`, `BySourceBreakdown`, `BreakdownDetail`).
- Also upgrades `ModTooltip` from using `attributeEnumName` directly to the full resolver so its effect names respect live reference data.
- Adds unit tests for the new helper in `attribute-display.test.ts`.
- No user-facing changes — pure DRY/maintainability.

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run test:unit:ci` — 1620 tests passed (170 test files)
- [x] New `attributeName` tests cover: reference-data name, enum-key fallback (absent list), fallback for id absent from provided list, out-of-range id degrades to "Unknown" without throwing

Closes #518

https://claude.ai/code/session_01K4uaJTrbsULkXkEj8N4z2r

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4uaJTrbsULkXkEj8N4z2r)_