### PR TITLE
Add /image skill: generate and refine images with Nano Banana

### DIFF
--- a/.claude/skills/image/SKILL.md
+++ b/.claude/skills/image/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: image
+description: >-
+  Generate and iteratively refine images using Google's Nano Banana (the Gemini 2.5 Flash Image
+  model). Use whenever the user wants to create, generate, draw, or make an image / picture /
+  artwork / illustration / icon / concept art / game asset from a text description — e.g.
+  "generate an image of a frost dragon", "make me a logo", "create concept art for a lava zone
+  boss", "draw an icon for a health potion". Also use to edit or refine an image: applying a
+  follow-up change to a previously generated image ("make it darker", "add a moon", "now in
+  pixel-art style"), editing a provided image, or composing/blending multiple reference images
+  into one. Drives a bundled script that calls the Gemini image API and saves results locally,
+  then loops on refinements while preserving each version.
+---
+
+# /image — Generate and refine images with Nano Banana
+
+Generate images from a description and refine them through follow-up edits, using Google's
+**Nano Banana** model (`gemini-2.5-flash-image`) via the Gemini API. The skill bundles a
+zero-dependency Python script that handles text-to-image, image editing, and multi-image
+composition; your job is to write strong prompts, manage the output files, show results, and
+loop on refinements.
+
+## Prerequisites (check first, before generating)
+
+1. **API key.** The script reads `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) from the environment.
+   If neither is set, stop and tell the user to create one at
+   https://aistudio.google.com/apikey and export it (`export GEMINI_API_KEY=...`). Don't try to
+   work around a missing key. Quick check: `printenv GEMINI_API_KEY GOOGLE_API_KEY`.
+2. **Network.** The script calls `generativelanguage.googleapis.com`. In a sandboxed/remote
+   session this requires the environment's network policy to allow it; if requests fail with a
+   network error, tell the user the egress is blocked rather than retrying blindly.
+3. **Python 3** is required (standard library only — no `pip install` needed).
+
+## The script
+
+`scripts/nano_banana.py` (path is relative to this skill's directory). Always invoke it with
+`python3` and an absolute path to the script.
+
+```bash
+python3 <skill_dir>/scripts/nano_banana.py \
+  --prompt "PROMPT OR EDIT INSTRUCTION" \
+  --output generated-images/<name>.png \
+  [--input PREVIOUS_OR_REFERENCE.png ...] \
+  [--aspect-ratio 1:1] \
+  [--model gemini-2.5-flash-image] \
+  [--dry-run]
+```
+
+- **Generate** (text → image): provide `--prompt` and `--output`, no `--input`.
+- **Refine / edit** (image → image): pass the image to change via `--input` and describe the
+  change in `--prompt`. Always write to a **new** `--output` so earlier versions are kept.
+- **Compose / blend**: pass multiple `--input` images and describe how to combine them.
+- `--aspect-ratio` is optional (e.g. `1:1`, `16:9`, `9:16`, `4:3`, `3:4`). Omit it for the
+  model's default. Useful: `1:1` icons, `16:9` scene/banner art, `9:16` mobile/portrait.
+- `--dry-run` prints the request body without calling the API — handy for sanity-checking.
+
+On success the script prints `Saved image: <path>` (and a `Model note:` line if the model
+returned text). On failure it prints a clear `error:` line and exits non-zero — relay the
+message instead of retrying identically.
+
+## Workflow
+
+1. **Understand the request.** Identify the subject, style, mood, composition, and any
+   constraints. Note whether it's a fresh generation, an edit of an existing/provided image, or
+   a composition of several. Pick a sensible aspect ratio for the use case.
+2. **Choose output paths.** Default to a `generated-images/` directory at the repo root. Use a
+   short descriptive slug and a version suffix so history is preserved, e.g.
+   `generated-images/frost-dragon-v1.png`, then `-v2`, `-v3` for refinements. Create the
+   directory if needed (the script also creates parent dirs).
+3. **Write a strong prompt** (see prompting tips below) and run the script.
+4. **Show the result.** If a file-sharing/upload tool is available in this environment, use it
+   to surface the saved image to the user; otherwise `Read` the output file so it renders
+   inline. Always state the saved path.
+5. **Offer refinement and loop.** Ask what they'd like to change. For each refinement, run the
+   script again with `--input` set to the **latest** saved version and `--output` set to the
+   next version. Keep iterating until they're satisfied. If the user wants to branch from an
+   earlier version, use that file as `--input`.
+
+## Prompting tips for Nano Banana
+
+- **Describe a scene, don't list keywords.** Nano Banana responds best to descriptive,
+  narrative prompts. Prefer "A weathered iron health potion icon, glowing red liquid in a
+  rounded glass vial with a cork, centered on a transparent-feeling dark background, crisp
+  game-UI style, soft rim light" over "potion, red, icon, game".
+- **Specify what matters:** subject, setting, composition/camera angle, lighting, color
+  palette, art style/medium, mood, and level of detail.
+- **For text in the image,** put the exact words in quotes and keep them short; describe font
+  feel and placement.
+- **When editing, be surgical.** Say exactly what to change and what to keep: "Change only the
+  dragon's scales to deep blue; keep the pose, gold hoard, lighting, and background identical."
+  This preserves consistency across versions (a strength of this model).
+- **For consistent characters/assets across a set,** feed a reference image via `--input` and
+  ask for the same subject in a new pose/scene/style.
+- **Iterate in small steps.** One or two changes per refinement gives more predictable results
+  than a long list of simultaneous edits.
+
+## Notes & limits
+
+- Generated images include an invisible **SynthID** watermark; the model may also decline
+  prompts that hit safety filters (the script surfaces the block reason).
+- Inputs must be `image/png`, `image/jpeg`, `image/webp`, `image/heic`, or `image/heif`, and
+  the total request stays under ~20 MB — for large reference images, expect to keep them modest.
+- Image generation is a **paid** Gemini API feature; each call consumes quota/credits. Don't
+  fire off many speculative generations — confirm the prompt with the user when in doubt.
+
+## Examples
+
+Generate a square game icon:
+
+```bash
+python3 <skill_dir>/scripts/nano_banana.py \
+  --prompt "A glossy game-UI icon of a health potion: a rounded glass vial with a cork stopper, filled with glowing crimson liquid and tiny bubbles, soft top-down rim lighting, subtle inner glow, clean edges, painterly fantasy style, centered composition on a neutral dark backdrop" \
+  --aspect-ratio 1:1 \
+  --output generated-images/health-potion-v1.png
+```
+
+Refine it (keep everything, change one thing):
+
+```bash
+python3 <skill_dir>/scripts/nano_banana.py \
+  --prompt "Keep the vial, lighting, and composition exactly the same, but change the liquid from crimson to a glowing emerald green and add a faint green mist above the cork." \
+  --input generated-images/health-potion-v1.png \
+  --output generated-images/health-potion-v2.png
+```

--- a/.claude/skills/image/scripts/nano_banana.py
+++ b/.claude/skills/image/scripts/nano_banana.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Generate and edit images with Google's Nano Banana (Gemini 2.5 Flash Image).
+
+Uses only the Python standard library so the skill works without any
+`pip install`. Reads the API key from an environment variable (default
+GEMINI_API_KEY, falling back to GOOGLE_API_KEY).
+
+Text-to-image:
+    nano_banana.py --prompt "a red dragon coiled on gold" --output out.png
+
+Edit / refine an existing image (pass it as input, describe the change):
+    nano_banana.py --prompt "make the dragon blue, keep everything else" \
+        --input out.png --output out-v2.png
+
+Compose / blend multiple references:
+    nano_banana.py --prompt "place this character in this scene" \
+        --input character.png scene.png --output composed.png
+"""
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_MODEL = "gemini-2.5-flash-image"
+API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
+# Formats Nano Banana accepts as inline input.
+SUPPORTED_INPUT_MIME = {
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/heic",
+    "image/heif",
+}
+EXT_BY_MIME = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/webp": ".webp",
+    "image/heic": ".heic",
+    "image/heif": ".heif",
+}
+
+
+def die(message):
+    """Print an error to stderr and exit non-zero."""
+    print(f"error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def guess_mime(path):
+    """Best-effort image MIME type for an input file."""
+    mime, _ = mimetypes.guess_type(path)
+    if mime is None:
+        # Default to PNG; the API rejects anything it cannot decode.
+        return "image/png"
+    return mime
+
+
+def build_parts(prompt, input_paths):
+    """Assemble the request `parts`: the text prompt plus any input images."""
+    parts = [{"text": prompt}]
+    for path in input_paths:
+        if not os.path.isfile(path):
+            die(f"input image not found: {path}")
+        mime = guess_mime(path)
+        if mime not in SUPPORTED_INPUT_MIME:
+            die(f"unsupported input image type {mime} for {path} "
+                f"(allowed: {', '.join(sorted(SUPPORTED_INPUT_MIME))})")
+        with open(path, "rb") as handle:
+            encoded = base64.b64encode(handle.read()).decode("ascii")
+        parts.append({"inlineData": {"mimeType": mime, "data": encoded}})
+    return parts
+
+
+def build_body(prompt, input_paths, aspect_ratio):
+    """Build the full generateContent request body."""
+    body = {"contents": [{"parts": build_parts(prompt, input_paths)}]}
+    if aspect_ratio:
+        body["generationConfig"] = {"imageConfig": {"aspectRatio": aspect_ratio}}
+    return body
+
+
+def call_api(model, api_key, body):
+    """POST to generateContent and return the decoded JSON response."""
+    url = f"{API_BASE}/{model}:generateContent"
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "x-goog-api-key": api_key,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=180) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", "replace")
+        die(f"API request failed ({error.code} {error.reason}): {detail}")
+    except urllib.error.URLError as error:
+        die(f"could not reach the Gemini API: {error.reason}. "
+            f"Check network access to generativelanguage.googleapis.com.")
+
+
+def extract(response):
+    """Pull image bytes and any text out of the response."""
+    feedback = response.get("promptFeedback", {})
+    if feedback.get("blockReason"):
+        die(f"prompt blocked by safety filters: {feedback['blockReason']}")
+
+    candidates = response.get("candidates", [])
+    if not candidates:
+        die(f"no candidates returned: {json.dumps(response)[:500]}")
+
+    candidate = candidates[0]
+    images, texts = [], []
+    for part in candidate.get("content", {}).get("parts", []):
+        inline = part.get("inlineData") or part.get("inline_data")
+        if inline and inline.get("data"):
+            mime = inline.get("mimeType") or inline.get("mime_type") or "image/png"
+            images.append((mime, base64.b64decode(inline["data"])))
+        elif part.get("text"):
+            texts.append(part["text"])
+
+    if not images:
+        reason = candidate.get("finishReason", "unknown")
+        note = " ".join(texts).strip()
+        die(f"no image in response (finishReason={reason})."
+            + (f" Model said: {note}" if note else ""))
+    return images, " ".join(texts).strip()
+
+
+def output_path_for(base_output, index, mime):
+    """Path for the Nth returned image (rare: usually one image)."""
+    if index == 0:
+        return base_output
+    root, ext = os.path.splitext(base_output)
+    if not ext:
+        ext = EXT_BY_MIME.get(mime, ".png")
+    return f"{root}-{index + 1}{ext}"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate or edit images with Nano Banana (Gemini 2.5 Flash Image).")
+    parser.add_argument("--prompt", required=True, help="Text prompt / edit instruction.")
+    parser.add_argument("--output", required=True, help="Where to write the generated image.")
+    parser.add_argument("--input", nargs="*", default=[],
+                        help="Input image(s) to edit, refine, or compose from.")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help=f"Model id (default: {DEFAULT_MODEL}).")
+    parser.add_argument("--aspect-ratio", default=None,
+                        help="Optional aspect ratio, e.g. 1:1, 16:9, 9:16, 4:3, 3:4.")
+    parser.add_argument("--api-key-env", default=None,
+                        help="Env var holding the API key (default: GEMINI_API_KEY then GOOGLE_API_KEY).")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print the request body (image data truncated) without calling the API.")
+    args = parser.parse_args()
+
+    body = build_body(args.prompt, args.input, args.aspect_ratio)
+
+    if args.dry_run:
+        preview = json.loads(json.dumps(body))
+        for part in preview["contents"][0]["parts"]:
+            inline = part.get("inlineData")
+            if inline:
+                inline["data"] = f"<{len(inline['data'])} base64 chars omitted>"
+        print(json.dumps({"model": args.model, "body": preview}, indent=2))
+        return
+
+    if args.api_key_env:
+        api_key = os.environ.get(args.api_key_env)
+        key_source = args.api_key_env
+    else:
+        api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        key_source = "GEMINI_API_KEY / GOOGLE_API_KEY"
+    if not api_key:
+        die(f"no API key found in {key_source}. "
+            f"Get a key at https://aistudio.google.com/apikey and export it, e.g. "
+            f"export GEMINI_API_KEY=...")
+
+    response = call_api(args.model, api_key, body)
+    images, text = extract(response)
+
+    out_dir = os.path.dirname(os.path.abspath(args.output))
+    os.makedirs(out_dir, exist_ok=True)
+
+    saved = []
+    for index, (mime, data) in enumerate(images):
+        path = output_path_for(args.output, index, mime)
+        with open(path, "wb") as handle:
+            handle.write(data)
+        saved.append(path)
+
+    for path in saved:
+        print(f"Saved image: {path}")
+    if text:
+        print(f"Model note: {text}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -377,3 +377,5 @@ FodyWeavers.xsd
 
 # Transpiled Typescript files
 /GameServer/wwwroot/js
+# Local output from the /image skill (Nano Banana generations)
+generated-images/


### PR DESCRIPTION
## Summary

Adds a Claude Code skill, `/image`, that generates images from a text prompt using Google's **Nano Banana** (`gemini-2.5-flash-image`) and iteratively refines them via image-to-image edits. Useful for spinning up concept art / game asset mockups (monster art, item icons, zone backdrops) and refining them in a loop.

## What's included

- **`.claude/skills/image/scripts/nano_banana.py`** — a zero-dependency (Python stdlib only, no `pip install`) helper that calls the Gemini `generateContent` API. Supports:
  - text → image generation
  - image → image editing / refinement (`--input`)
  - multi-image composition (multiple `--input`)
  - optional `--aspect-ratio` (e.g. `1:1`, `16:9`, `9:16`)
  - `--dry-run` to inspect the request body without spending quota
  - reads `GEMINI_API_KEY` / `GOOGLE_API_KEY`, and surfaces clear errors for a missing key, blocked/safety-filtered prompts, unsupported input types, network failures, and empty responses
- **`.claude/skills/image/SKILL.md`** — drives the workflow: prerequisite checks (API key, network, Python), prompting tips tuned for Nano Banana, versioned output under `generated-images/`, showing the result to the user, and looping on refinements while preserving each version.
- **`.gitignore`** — ignores `generated-images/` so local generations aren't accidentally committed.

## Usage

```
/image a frost dragon perched on a glacier, dramatic cinematic lighting
```

Then refine conversationally ("make it night-time", "add a moon", "now as a 1:1 icon"), each step writing a new `-vN` file from the latest version.

## Prerequisites / notes

- Requires a Gemini API key (`GEMINI_API_KEY`) — get one at https://aistudio.google.com/apikey.
- The script reaches `generativelanguage.googleapis.com`, so the session's network policy must allow that egress.
- Image generation is a paid Gemini feature and outputs carry an invisible SynthID watermark.

## Testing

Validated the script's `--help`, `--dry-run` (text-to-image and image-input variants), and all error paths (missing key, unsupported input type) locally. Live generation was not exercised here because outbound network/API key are not available in the build environment.

https://claude.ai/code/session_01VvMrA77bJL8DyYvCkFy7nU

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvMrA77bJL8DyYvCkFy7nU)_