### PR TITLE
Fix inventory grid page not resetting on filter/sort change

### DIFF
--- a/UI/src/routes/game/screens/inventory/InventoryGrid.svelte
+++ b/UI/src/routes/game/screens/inventory/InventoryGrid.svelte
@@ -68,6 +68,9 @@ const slice = $derived(view.visible.slice(pageClamped * perPage, pageClamped * p
 
 // Reset to the first page whenever the filter/sort changes.
 $effect(() => {
+	void view.sort;
+	void view.filterCat;
+	void view.favOnly;
 	view.page = 0;
 });
 

--- a/UI/src/tests/routes/game/screens/inventory/InventoryGrid.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/InventoryGrid.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
+import { flushSync } from 'svelte';
 import { render, cleanup, fireEvent } from '@testing-library/svelte';
 import { EItemCategory, ERarity } from '$lib/api';
 import { BattleAttributes, type Item } from '$lib/battle';
@@ -31,7 +32,7 @@ vi.mock('$stores', () => ({
 }));
 
 import InventoryGrid from '$routes/game/screens/inventory/InventoryGrid.svelte';
-import type { InventoryView } from '$routes/game/screens/inventory/inventory-view.svelte';
+import { InventoryView } from '$routes/game/screens/inventory/inventory-view.svelte';
 
 const makeGridItem = (itemId: number): Item =>
 	({
@@ -185,5 +186,37 @@ describe('InventoryGrid — drag interactions', () => {
 		const { container } = render(InventoryGrid, { props: { view } });
 		await fireEvent.dragEnd(container.querySelector('.grid-slot')!);
 		expect(view.dragItemId).toBeNull();
+	});
+});
+
+describe('InventoryGrid — page reset on filter/sort change', () => {
+	it('resets view.page to 0 when filterCat changes', () => {
+		const view = new InventoryView();
+		render(InventoryGrid, { props: { view } });
+		flushSync();
+		view.page = 2;
+		view.filterCat = EItemCategory.Weapon;
+		flushSync();
+		expect(view.page).toBe(0);
+	});
+
+	it('resets view.page to 0 when sort changes', () => {
+		const view = new InventoryView();
+		render(InventoryGrid, { props: { view } });
+		flushSync();
+		view.page = 2;
+		view.sort = 'name';
+		flushSync();
+		expect(view.page).toBe(0);
+	});
+
+	it('resets view.page to 0 when favOnly changes', () => {
+		const view = new InventoryView();
+		render(InventoryGrid, { props: { view } });
+		flushSync();
+		view.page = 2;
+		view.favOnly = true;
+		flushSync();
+		expect(view.page).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary

- The `$effect` in `InventoryGrid.svelte` that was supposed to reset `view.page = 0` on filter/sort change never re-ran after mount because it had no reactive dependencies — it only *wrote* `view.page` but never *read* any tracked state
- Added `void` reads of `view.sort`, `view.filterCat`, and `view.favOnly` so Svelte registers them as dependencies and re-runs the effect when any changes
- Added three regression tests in `InventoryGrid.test.ts` (one per tracked input) using a real `InventoryView` instance + `flushSync` to verify the page resets correctly

## Test plan

- [x] All 1624 existing unit tests pass
- [x] 3 new regression tests all pass (`resets view.page to 0 when filterCat/sort/favOnly changes`)
- [x] Lint clean

Closes #525

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCVCVbY6WZjV3PZ4M8Kscn)_