### PR TITLE
Cover the under-tested utility branches in Game.Core/Extensions.cs (#420)

### DIFF
--- a/Game.Core.Tests/ExtensionsTests.cs
+++ b/Game.Core.Tests/ExtensionsTests.cs
@@ -1,0 +1,159 @@
+using Game.Core;
+using Xunit;
+
+namespace Game.Core.Tests
+{
+    public class ExtensionsTests
+    {
+        private record Sample(int Id, string Name);
+
+        [Fact]
+        public void ToBase64_NonNull_EncodesToStringRepresentation()
+        {
+            // "abc" UTF-8 -> base64
+            Assert.Equal("YWJj", "abc".ToBase64());
+        }
+
+        [Fact]
+        public void ToBase64_NullReceiver_EncodesEmptyString()
+        {
+            string? value = null;
+
+            // The null-coalescing path falls back to "" which encodes to an empty base64 string.
+            Assert.Equal("", value.ToBase64());
+        }
+
+        [Fact]
+        public void Deserialize_HttpResponseWithContent_RoundTripsObject()
+        {
+            var original = new Sample(7, "thing");
+            using var msg = new HttpResponseMessage
+            {
+                Content = new StringContent(original.Serialize()),
+            };
+
+            var result = msg.Deserialize<Sample>();
+
+            Assert.Equal(original, result);
+        }
+
+        [Fact]
+        public void Deserialize_HttpResponseWithEmptyStream_ReturnsDefault()
+        {
+            using var msg = new HttpResponseMessage
+            {
+                Content = new StringContent(""),
+            };
+
+            Assert.Null(msg.Deserialize<Sample>());
+        }
+
+        [Fact]
+        public void Deserialize_NonNullString_RoundTripsObject()
+        {
+            var original = new Sample(3, "json");
+
+            var result = original.Serialize().Deserialize<Sample>();
+
+            Assert.Equal(original, result);
+        }
+
+        [Fact]
+        public void Deserialize_NullString_ReturnsDefault()
+        {
+            string? json = null;
+
+            Assert.Null(json.Deserialize<Sample>());
+        }
+
+        [Fact]
+        public void WhereNotNull_ReferenceTypes_KeepsOnlyNonNull()
+        {
+            var source = new string?[] { "a", null, "b", null, "c" };
+
+            Assert.Equal(new[] { "a", "b", "c" }, source.WhereNotNull());
+        }
+
+        [Fact]
+        public void WhereNotNull_NullableValueTypes_UnwrapsNonNull()
+        {
+            var source = new int?[] { 1, null, 2, null, 3 };
+
+            Assert.Equal(new[] { 1, 2, 3 }, source.WhereNotNull());
+        }
+
+        [Fact]
+        public void SelectNotNull_ReferenceTypes_DiscardsNullResults()
+        {
+            var source = new[] { "keep", "", "also", "" };
+
+            // Empty strings map to null and are filtered out.
+            var result = source.SelectNotNull(s => s.Length == 0 ? null : s);
+
+            Assert.Equal(new[] { "keep", "also" }, result);
+        }
+
+        [Fact]
+        public void SelectNotNull_NullableValueTypes_DiscardsNullResults()
+        {
+            var source = new[] { 1, 2, 3, 4 };
+
+            // Odd values map to null and are filtered out.
+            var result = source.SelectNotNull(n => n % 2 == 0 ? (int?)n : null);
+
+            Assert.Equal(new[] { 2, 4 }, result);
+        }
+
+        [Theory]
+        [InlineData("HelloWorld", "helloWorld")]
+        [InlineData("A", "a")]
+        [InlineData("alreadyLower", "alreadyLower")]
+        public void Decapitalize_LowercasesFirstCharacter(string input, string expected)
+        {
+            Assert.Equal(expected, input.Decapitalize());
+        }
+
+        [Fact]
+        public void Decapitalize_EmptyString_ReturnsEmpty()
+        {
+            Assert.Equal("", "".Decapitalize());
+        }
+
+        [Theory]
+        [InlineData("helloWorld", "HelloWorld")]
+        [InlineData("a", "A")]
+        [InlineData("AlreadyUpper", "AlreadyUpper")]
+        public void Capitalize_UppercasesFirstCharacter(string input, string expected)
+        {
+            Assert.Equal(expected, input.Capitalize());
+        }
+
+        [Fact]
+        public void Capitalize_EmptyString_ReturnsEmpty()
+        {
+            Assert.Equal("", "".Capitalize());
+        }
+
+        [Theory]
+        [InlineData("HelloWorld", "Hello World")]
+        [InlineData("oneTwoThree", "one Two Three")]
+        [InlineData("NoBreaks", "No Breaks")]
+        [InlineData("ALLCAPS", "ALLCAPS")]
+        [InlineData("", "")]
+        public void SpaceWords_InsertsSpaceBetweenLowerThenUpper(string input, string expected)
+        {
+            Assert.Equal(expected, input.SpaceWords());
+        }
+
+        [Theory]
+        [InlineData("HelloWorld", "hello-world")]
+        [InlineData("oneTwoThree", "one-two-three")]
+        [InlineData("NoBreaks", "no-breaks")]
+        [InlineData("nobreak", "nobreak")]
+        [InlineData("", "")]
+        public void SnakeCase_InsertsHyphenBetweenLowerThenUpperAndLowercases(string input, string expected)
+        {
+            Assert.Equal(expected, input.SnakeCase());
+        }
+    }
+}

--- a/Game.Core/Extensions.cs
+++ b/Game.Core/Extensions.cs
@@ -108,23 +108,23 @@ namespace Game.Core
         }
 
         /// <summary>
-        /// Returns a copy of this string, but the first letter is lowercase.
+        /// Returns a copy of this string, but the first letter is lowercase. An empty string is returned unchanged.
         /// </summary>
         /// <param name="str"></param>
         /// <returns>A string with the first letter lowercase.</returns>
         public static string Decapitalize(this string str)
         {
-            return string.Concat(str[0].ToString().ToLower(), str.AsSpan(1));
+            return str.Length == 0 ? str : string.Concat(str[0].ToString().ToLower(), str.AsSpan(1));
         }
 
         /// <summary>
-        /// Returns a copy of this string, but the first letter is uppercase.
+        /// Returns a copy of this string, but the first letter is uppercase. An empty string is returned unchanged.
         /// </summary>
         /// <param name="str"></param>
         /// <returns>A string with the first letter uppercase.</returns>
         public static string Capitalize(this string str)
         {
-            return string.Concat(str[0].ToString().ToUpper(), str.AsSpan(1));
+            return str.Length == 0 ? str : string.Concat(str[0].ToString().ToUpper(), str.AsSpan(1));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Closes #420. `Game.Core.Extensions` was the lowest-coverage class in the gated `Game.Core` assembly (86.0% line / **55.5%** branch vs ~97%/93% for the rest). These are pure, deterministic, dependency-free helpers — squarely in the "worth pinning" category — so this adds direct unit coverage for every previously under-covered branch.

## What changed

**New tests — `Game.Core.Tests/ExtensionsTests.cs`** (28 cases), covering both sides of every flagged branch, asserting on the actual transformed output rather than "didn't throw":

- **`ToBase64`** — non-null encoding **and** the `obj?.ToString() ?? ""` null-receiver path.
- **`Deserialize(HttpResponseMessage)`** — content round-trip **and** the empty-stream → `default` branch.
- **`Deserialize(string?)`** — round-trip **and** the `null → default` branch.
- **`WhereNotNull`** (reference + `Nullable` overloads) — sequences mixing nulls and non-nulls.
- **`SelectNotNull`** (reference + `Nullable` overloads) — filtered round-trip through each overload.
- **`Decapitalize` / `Capitalize` / `SpaceWords` / `SnakeCase`** — casing/word-break transforms across normal, single-char, no-break, all-caps, and empty inputs.

**Empty-string contract decision — `Game.Core/Extensions.cs`:** `Capitalize`/`Decapitalize` indexed `str[0]` directly and threw `IndexOutOfRangeException` on `""`. I settled the contract as a **no-op on empty input** (guard `str.Length == 0 ? str : …`), making the family consistent with the regex-based `SpaceWords`/`SnakeCase` (already `""`-safe) and removing the latent crash. The no-op is the safer contract for the current callers (codegen naming, UI display text) and is pinned by tests. Doc comments updated to state the behaviour.

## Notes

- One assertion was corrected during implementation to match real behaviour: `WordBreakRegex` (`([a-z])([A-Z])`) breaks on the *internal* lower→upper transition, so `"NoBreaks".SnakeCase()` is `"no-breaks"` (the leading capital is not a break point) — the tests document this with both internal-break and genuine no-break cases.
- No documentation in `docs/` was added: a single guard on a utility helper isn't a fundamental architectural decision under the project's "avoid over-documenting" guidance.

## Testing

`Game.Core.Tests` — **434 passed, 0 failed** (28 new in `ExtensionsTests`).

https://claude.ai/code/session_011xo3bUKjFyWr2BvrYF7csx

---
_Generated by [Claude Code](https://claude.ai/code/session_011xo3bUKjFyWr2BvrYF7csx)_