### PR TITLE
Add Skills tab icon to game navbar

### DIFF
--- a/UI/src/components/nav-menu/SideGlyph.svelte
+++ b/UI/src/components/nav-menu/SideGlyph.svelte
@@ -9,6 +9,8 @@
 	{:else if kind === 'inventory'}
 		<rect x="2" y="4" width="12" height="9.5" rx="0.5" />
 		<path d="M5.5 4V2.5h5V4" stroke-linecap="round" />
+	{:else if kind === 'skills'}
+		<path d="M8.7 1.3L2 9.3H8l-.7 5.4L14 6.7H8z" stroke-linejoin="round" stroke-linecap="round" />
 	{:else if kind === 'attributes'}
 		<path d="M8 1.5l4.7 2v4.7c0 2.9-2.3 4.7-4.7 5.8-2.4-1.1-4.7-2.9-4.7-5.8V3.5z" stroke-linejoin="round" />
 	{:else if kind === 'attributeBreakdown'}

--- a/UI/src/tests/components/nav-menu/SideGlyph.test.ts
+++ b/UI/src/tests/components/nav-menu/SideGlyph.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import SideGlyph from '../../../components/nav-menu/SideGlyph.svelte';
+import { GAME_SCREENS } from '$routes/game/screens/screen-defs';
+
+afterEach(cleanup);
+
+const SHAPE_SELECTOR = 'path, rect, circle, line, polygon, polyline';
+
+describe('SideGlyph', () => {
+	// Guards against shipping a sidebar screen whose key has no matching glyph branch (the Skills
+	// tab regression, #434): an unmatched kind renders an empty <svg> with no drawn shapes.
+	it('renders a drawn glyph for every game screen key', () => {
+		for (const screen of GAME_SCREENS) {
+			const { container } = render(SideGlyph, { props: { kind: screen.key } });
+			const shapes = container.querySelectorAll(SHAPE_SELECTOR);
+
+			expect(shapes.length, `expected a drawn glyph for screen "${screen.key}"`).toBeGreaterThan(0);
+			cleanup();
+		}
+	});
+
+	it('strokes with the accent colour when active', () => {
+		const { container } = render(SideGlyph, { props: { kind: 'skills', active: true } });
+		const svg = container.querySelector('svg');
+
+		expect(svg?.getAttribute('stroke')).toContain('var(--accent)');
+	});
+});


### PR DESCRIPTION
## Summary

The Skills tab in the in-game navbar rendered without an icon. The sidebar's `SideGlyph` component renders a per-screen SVG glyph selected by `screen.key`, but it had no `skills` branch — every other `GAME_SCREENS` key (`fight`, `cardGame`, `challenges`, `inventory`, `attributes`, …) had one, so Skills alone fell through to an empty `<svg>`.

## How it addresses the issue

- Added a `skills` branch to `SideGlyph.svelte` with a lightning-bolt glyph. The bolt conveys an "active ability" and is visually distinct from the diagonal sword used by Fight. It follows the same conventions as the surrounding glyphs (16×16 viewBox, stroked path, round joins, themed `--accent`/text colour).
- Added `SideGlyph.test.ts` as a regression guard: it asserts that **every** `GAME_SCREENS` key renders at least one drawn shape, so a future screen can't silently ship without an icon, plus a check that the glyph strokes with the accent colour when active.

## Test plan

- [x] `npm run lint` — clean (eslint + svelte-check, 0 errors / 0 warnings)
- [x] `npm run test:unit:ci` — 171 files / 1626 tests pass, all coverage thresholds met
- [x] New `SideGlyph` test exercises all 12 screen keys and the active-colour path

Frontend-only change; no backend or battle logic touched.

Closes #434

https://claude.ai/code/session_01MPAWTEX9aEEgyfB8puDV8u

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPAWTEX9aEEgyfB8puDV8u)_