### PR TITLE
Fail loudly when an equipped item is missing from UnlockedItems

### DIFF
--- a/Game.Core.Tests/Battle/BattleSnapshotTests.cs
+++ b/Game.Core.Tests/Battle/BattleSnapshotTests.cs
@@ -78,6 +78,20 @@ namespace Game.Core.Tests.Battle
             Assert.Empty(equipped.AppliedModIds);
         }
 
+        [Fact]
+        public void FromPlayer_EquippedItemMissingFromUnlockedItems_ThrowsNamingItem()
+        {
+            var player = MakePlayer();
+            Equip(player, MakeItem(7, attributes: [MakeModifier(EAttribute.Strength, 5)]));
+
+            // Corrupt the inventory invariant: an item stays equipped but is no longer unlocked. The
+            // snapshot must fail loudly rather than silently capturing the item without its mods.
+            player.Inventory.UnlockedItems.Clear();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => BattleSnapshot.FromPlayer(player));
+            Assert.Contains("Equipped item 7", ex.Message);
+        }
+
         // ── ToBattler ────────────────────────────────────────────────────────
 
         [Fact]

--- a/Game.Core/Battle/BattleSnapshot.cs
+++ b/Game.Core/Battle/BattleSnapshot.cs
@@ -44,12 +44,19 @@ namespace Game.Core.Battle
                 .Select(itemId =>
                 {
                     // Applied mods live on the player's UnlockedItemSlot, so capture their IDs from there.
+                    // An equipped item must always have a matching unlocked entry (TryEquipItem enforces
+                    // this), so a missing entry means the inventory invariant is broken. Fail loudly rather
+                    // than silently capturing the item without its mods: this snapshot is the anti-cheat
+                    // parity surface, and a quiet capture would later validate a replay against weaker
+                    // attributes than the client simulated, failing legitimate victories with no signal.
                     var unlocked = player.Inventory.UnlockedItems
-                        .FirstOrDefault(u => u.ItemId == itemId);
+                        .FirstOrDefault(u => u.ItemId == itemId)
+                        ?? throw new InvalidOperationException(
+                            $"Equipped item {itemId} has no matching entry in the player's unlocked items.");
 
-                    var modIds = unlocked?.AppliedMods
+                    var modIds = unlocked.AppliedMods
                         .Select(m => m.ItemModId)
-                        .ToList() ?? [];
+                        .ToList();
 
                     return new EquippedItemSnapshot
                     {


### PR DESCRIPTION
## Summary

`BattleSnapshot.FromPlayer` resolved each equipped item's applied mods by scanning `UnlockedItems` and **silently falling back to an empty mod list** when no entry matched:

```csharp
var unlocked = player.Inventory.UnlockedItems
    .FirstOrDefault(u => u.ItemId == itemId);

var modIds = unlocked?.AppliedMods
    .Select(m => m.ItemModId)
    .ToList() ?? [];
```

`BattleSnapshot` is the **anti-cheat parity surface**: if the "equipped but not unlocked" invariant ever breaks (a bad data migration, a future inventory refactor, manual DB surgery), the snapshot would quietly capture the item *without its mods*. The replay would then validate against weaker player attributes than the client simulated, and legitimate victories would start failing validation with no signal pointing at the cause.

This PR replaces the silent `?? []` with a thrown `InvalidOperationException` naming the offending item id, turning a silent battle-outcome divergence into an immediate, diagnosable error.

## How it addresses the issue

- `FromPlayer` now throws `InvalidOperationException` (naming the item id) when an equipped item has no matching `UnlockedItems` entry, instead of capturing it with an empty mod list.
- The null-coalescing fallback is removed; the resolved `unlocked` is non-null past the guard, so the code avoids the null-forgiving operator per the project guidelines.

## Test plan

- [x] **New unit test** — `FromPlayer_EquippedItemMissingFromUnlockedItems_ThrowsNamingItem`: equips an item, corrupts the invariant by clearing `UnlockedItems`, and asserts the throw names the item.
- [x] **Existing coverage** — normal capture with mods (`FromPlayer_CapturesLevelStatsEquipmentAndSkills`), equipped item without mods, and the round-trip parity tests all still pass.
- [x] `dotnet build` — clean (0 warnings, 0 errors).
- [x] `dotnet test` — all backend suites green (Core 407, Application 164, Api 372, Infrastructure 26; 0 failures, 0 skipped).

## Notes / out of scope

The issue flagged the per-slot `FirstOrDefault` scan over `UnlockedItems` (repeated across `Inventory.cs` — `TryEquipItem`, `TryApplyMod`, `TryRemoveMod`, `TrySetFavorite`, `GetAppliedMods`) as O(slots × unlocked items) and a candidate for an id-keyed index, but explicitly as *optional scope*. That is a cross-cutting `Inventory.cs` refactor independent of this fail-loud fix, so I've kept this PR focused. It can be picked up separately if/when catalogue sizes warrant it.

This is a backend-only domain concern — `BattleSnapshot` is the server-side capture surface with no frontend mirror — so no frontend changes were needed.

Closes #442

https://claude.ai/code/session_019RxYuCLQNrquRvnuMd6oTL

---
_Generated by [Claude Code](https://claude.ai/code/session_019RxYuCLQNrquRvnuMd6oTL)_