### PR TITLE
Batch HandleSelectedSkillsChanged and align HandleLogPreferenceChanged to a single write

### DIFF
--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -547,6 +547,74 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task ProcessQueue_LogPreferenceChangedEvent_UpdatesExistingPreferenceIdempotently()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id, level: 5, zoneId: 0);
+
+            // The player already has an enabled Damage-log preference; the event toggles it off.
+            await TestDataSeeder.AddLogPreferenceAsync(context, player.Id, ELogType.Damage, enabled: true);
+
+            var evt = new LogPreferenceChangedEvent(player.Id, ELogType.Damage, Enabled: false);
+
+            var logger = new CapturingLogger<DataProviderSynchronizer>();
+            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
+            var synchronizer = new DataProviderSynchronizer(scope.ServiceProvider, pubsub, logger, TestRetryPolicy);
+
+            // Delivered twice: the absolute update must converge to a single row toggled off.
+            var queue = new InMemoryPubSubQueue(Serialize(evt), Serialize(evt));
+
+            await synchronizer.ProcessQueue(queue);
+
+            Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+            Assert.Empty(await DrainDeadLetterQueue(pubsub));
+
+            using var verifyScope = CreateScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
+            var rows = await verifyContext.LogPreferences
+                .Where(lp => lp.PlayerId == player.Id && lp.LogTypeId == (int)ELogType.Damage)
+                .ToListAsync(CancellationToken);
+            var row = Assert.Single(rows);
+            Assert.False(row.Enabled);
+        }
+
+        [Fact]
+        public async Task ProcessQueue_LogPreferenceChangedEvent_FirstTimeInsertsPreferenceIdempotently()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id, level: 5, zoneId: 0);
+
+            // No preference row exists yet for this log type: the first apply must insert it, the second update it.
+            var evt = new LogPreferenceChangedEvent(player.Id, ELogType.Exp, Enabled: false);
+
+            var logger = new CapturingLogger<DataProviderSynchronizer>();
+            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
+            var synchronizer = new DataProviderSynchronizer(scope.ServiceProvider, pubsub, logger, TestRetryPolicy);
+
+            // Delivered twice: the update-then-insert path must leave exactly one row (no duplicate-key failure).
+            var queue = new InMemoryPubSubQueue(Serialize(evt), Serialize(evt));
+
+            await synchronizer.ProcessQueue(queue);
+
+            Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+            Assert.Empty(await DrainDeadLetterQueue(pubsub));
+
+            using var verifyScope = CreateScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
+            var rows = await verifyContext.LogPreferences
+                .Where(lp => lp.PlayerId == player.Id && lp.LogTypeId == (int)ELogType.Exp)
+                .ToListAsync(CancellationToken);
+            var row = Assert.Single(rows);
+            Assert.False(row.Enabled);
+        }
+
+        [Fact]
         public async Task StopAsync_CompletesWithoutError()
         {
             using var scope = CreateScope();

--- a/Game.DataAccess/DataProviderSynchronizer.cs
+++ b/Game.DataAccess/DataProviderSynchronizer.cs
@@ -319,24 +319,36 @@ namespace Game.DataAccess
 
         private static async Task HandleSelectedSkillsChanged(GameContext context, SelectedSkillsChangedEvent evt)
         {
-            // Delete-then-rebuild for idempotency: first clear every Selected/Order flag for the
-            // player, then mark each id in the ordered loadout Selected = true with its index as Order.
-            // Re-applying the event converges to the same state (same shape as the mod-applied handler).
-            await context.PlayerSkills
+            // Delete-then-rebuild for idempotency, applied as a single write (the same shape as the
+            // attribute-allocations handler): fetch the player's skill rows, reset every flag, then mark
+            // each id in the ordered loadout Selected = true with its index as Order. Re-applying the event
+            // converges to the same state, and EF batches the touched rows into one round-trip rather than
+            // issuing one ExecuteUpdate per skill.
+            var playerSkills = await context.PlayerSkills
                 .Where(ps => ps.PlayerId == evt.PlayerId)
-                .ExecuteUpdateAsync(s => s
-                    .SetProperty(ps => ps.Selected, false)
-                    .SetProperty(ps => ps.Order, 0));
+                .ToListAsync();
 
+            var orderBySkillId = new Dictionary<int, int>(evt.OrderedSkillIds.Count);
             for (var index = 0; index < evt.OrderedSkillIds.Count; index++)
             {
-                var skillId = evt.OrderedSkillIds[index];
-                await context.PlayerSkills
-                    .Where(ps => ps.PlayerId == evt.PlayerId && ps.SkillId == skillId)
-                    .ExecuteUpdateAsync(s => s
-                        .SetProperty(ps => ps.Selected, true)
-                        .SetProperty(ps => ps.Order, index));
+                orderBySkillId[evt.OrderedSkillIds[index]] = index;
             }
+
+            foreach (var playerSkill in playerSkills)
+            {
+                if (orderBySkillId.TryGetValue(playerSkill.SkillId, out var order))
+                {
+                    playerSkill.Selected = true;
+                    playerSkill.Order = order;
+                }
+                else
+                {
+                    playerSkill.Selected = false;
+                    playerSkill.Order = 0;
+                }
+            }
+
+            await context.SaveChangesAsync();
         }
 
         private static async Task HandleModApplied(GameContext context, ModAppliedEvent evt)
@@ -374,14 +386,15 @@ namespace Game.DataAccess
         private static async Task HandleLogPreferenceChanged(GameContext context, LogPreferenceChangedEvent evt)
         {
             var logTypeId = (int)evt.LogType;
-            var existing = await context.LogPreferences
-                .FirstOrDefaultAsync(lp => lp.PlayerId == evt.PlayerId && lp.LogTypeId == logTypeId);
 
-            if (existing is not null)
-            {
-                existing.Enabled = evt.Enabled;
-            }
-            else
+            // Idempotent upsert mirroring HandleItemFavoriteChanged: attempt the absolute update first as a
+            // single self-committing write; if no row exists yet (rows-affected 0) fall through to the insert.
+            // Re-applying the event converges to the same state under the write-behind retry policy.
+            var updated = await context.LogPreferences
+                .Where(lp => lp.PlayerId == evt.PlayerId && lp.LogTypeId == logTypeId)
+                .ExecuteUpdateAsync(s => s.SetProperty(lp => lp.Enabled, evt.Enabled));
+
+            if (updated == 0)
             {
                 context.LogPreferences.Add(new LogPreference
                 {
@@ -389,9 +402,8 @@ namespace Game.DataAccess
                     LogTypeId = logTypeId,
                     Enabled = evt.Enabled,
                 });
+                await context.SaveChangesAsync();
             }
-
-            await context.SaveChangesAsync();
         }
 
         private static T Deserialize<T>(string json)

--- a/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
+++ b/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
@@ -382,6 +382,23 @@ namespace Game.TestInfrastructure.Helpers
             await context.SaveChangesAsync();
         }
 
+        // LogTypes are intrinsic, migration-seeded reference data, so the preference references an
+        // existing seeded log type rather than creating one.
+        public static async Task AddLogPreferenceAsync(
+            GameContext context,
+            int playerId,
+            ELogType logType,
+            bool enabled)
+        {
+            context.LogPreferences.Add(new LogPreference
+            {
+                PlayerId = playerId,
+                LogTypeId = (int)logType,
+                Enabled = enabled,
+            });
+            await context.SaveChangesAsync();
+        }
+
         public static async Task<Enemy> CreateStrongEnemyAsync(GameContext context)
         {
             return await CreateEnemyAsync(context, "Strong Enemy",


### PR DESCRIPTION
## Summary

Two handlers in the `DataProviderSynchronizer` switch didn't follow the "one event → one apply" shape the rest of the write-behind file holds. This is the sibling of #438 (attribute allocations).

### 1. `HandleSelectedSkillsChanged` was N+1

It cleared the player's flags with one `ExecuteUpdateAsync`, then issued **one more `ExecuteUpdateAsync` per skill** in the new loadout inside a loop — up to `1 + MaxSelectedSkills` sequential round-trips per loadout reorder/select/deselect.

It now fetches the player's `PlayerSkill` rows once, resets every flag, and marks each id in the ordered loadout `Selected = true` with its index as `Order`, persisting the whole thing with a single `SaveChangesAsync` (EF batches the touched rows into one round-trip). This mirrors `HandleAttributeAllocationsChanged` and preserves the idempotent delete-then-rebuild semantics — re-applying the event converges to the same state.

### 2. `HandleLogPreferenceChanged` read before writing

The update branch did `FirstOrDefaultAsync` + entity mutation + `SaveChangesAsync` — two round-trips where the neighbouring `HandleItemFavoriteChanged` does a single self-committing `ExecuteUpdateAsync`.

It now uses `ExecuteUpdateAsync` for the update branch and only falls through to an insert when **rows-affected is 0** (the genuinely new-row case). It stays idempotent under the write-behind retry policy: a retry/duplicate after the insert finds the row and updates it in place, so there's never a duplicate-key failure.

## How it addresses the issue

Both handlers are reworked exactly as the [issue](https://github.com/ginderjeremiah/GameServer/issues/447) directed, keeping idempotency-on-retry intact. No public API or behaviour changes — purely the persistence shape.

## Test plan

- [x] `dotnet build Game.sln` — 0 warnings / 0 errors
- [x] `dotnet format --verify-no-changes` — clean
- [x] Full backend suite green: Infrastructure 26, Core 438, Application 170, Api 372
- [x] New synchronizer integration tests for `HandleLogPreferenceChanged`: an existing-preference toggle and a first-time insert, both delivered twice for idempotency
- [x] The existing `SelectedSkillsChangedEvent` tests (multi-skill swap, reorder-only, deselect-to-empty — each delivered twice) now exercise the new batched path and still pass

## Notes

- Added a small `TestDataSeeder.AddLogPreferenceAsync` helper, matching the existing `Add*`/`Link*` seeding conventions.
- No docs change: the documented delete-then-rebuild / idempotent-on-retry semantics are unchanged; only the round-trip shape (an internal efficiency detail) moved.

Closes #447

---
_Generated by [Claude Code](https://claude.ai/code/session_012QFAuk6C3Ee3BBxrdKjHXy)_