### PR TITLE
Fail loud on unsupported DatabaseSystem instead of defaulting to SqlServer (#453)

### DIFF
--- a/Game.Abstractions/Infrastructure/Enums.cs
+++ b/Game.Abstractions/Infrastructure/Enums.cs
@@ -7,7 +7,8 @@
 
     public enum DatabaseSystem
     {
-        SqlServer = 0,
+        // Deliberately starts at 1 so an unset/missing config binds to the unnamed default (0) and fails loud
+        // in GameContextFactory rather than silently selecting a provider (the app is Postgres-only).
         Postgres = 1
     }
 

--- a/Game.Infrastructure.Tests/GameContextFactoryTests.cs
+++ b/Game.Infrastructure.Tests/GameContextFactoryTests.cs
@@ -1,0 +1,59 @@
+using Game.Abstractions.Infrastructure;
+using Game.Infrastructure.Database;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Game.Infrastructure.Tests
+{
+    /// <summary>
+    /// Tests that <see cref="GameContextFactory"/> maps the configured <see cref="DatabaseSystem"/> to a
+    /// provider and fails loud on an unset/unsupported value rather than silently defaulting (#453). Building
+    /// the <c>DbContextOptions</c> never opens a connection, so these stay in-process unit tests with no
+    /// out-of-process dependency.
+    /// </summary>
+    public class GameContextFactoryTests
+    {
+        [Fact]
+        public void GetGameContext_ForPostgres_ConfiguresNpgsqlProvider()
+        {
+            var options = new InfrastructureOptions
+            {
+                DatabaseSystem = DatabaseSystem.Postgres,
+                DbConnectionString = "Host=localhost;Database=Game"
+            };
+
+            using var context = GameContextFactory.GetGameContext(options, NullLoggerFactory.Instance);
+
+            Assert.Equal("Npgsql.EntityFrameworkCore.PostgreSQL", context.Database.ProviderName);
+        }
+
+        [Fact]
+        public void GetGameContext_ForUnsetDatabaseSystem_ThrowsInvalidOperationException()
+        {
+            // An unset/missing config binds to the enum's default (0), which has no member: the factory must
+            // reject it loudly instead of selecting a provider the app cannot actually use.
+            var options = new InfrastructureOptions
+            {
+                DatabaseSystem = default,
+                DbConnectionString = "Host=localhost;Database=Game"
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => GameContextFactory.GetGameContext(options, NullLoggerFactory.Instance));
+            Assert.Contains("DatabaseSystem", ex.Message);
+        }
+
+        [Fact]
+        public void GetGameContext_ForUnknownDatabaseSystem_ThrowsInvalidOperationException()
+        {
+            var options = new InfrastructureOptions
+            {
+                DatabaseSystem = (DatabaseSystem)99,
+                DbConnectionString = "Host=localhost;Database=Game"
+            };
+
+            Assert.Throws<InvalidOperationException>(
+                () => GameContextFactory.GetGameContext(options, NullLoggerFactory.Instance));
+        }
+    }
+}

--- a/Game.Infrastructure/Database/GameContextFactory.cs
+++ b/Game.Infrastructure/Database/GameContextFactory.cs
@@ -23,11 +23,11 @@ namespace Game.Infrastructure.Database
                     optionsBuilder.UseNpgsql(connectionString)
                         .EnableSensitiveDataLogging(config.EnableSensitiveLogging);
                     break;
-                case SqlServer:
                 default:
-                    optionsBuilder.UseSqlServer(config.DbConnectionString)
-                        .EnableSensitiveDataLogging(config.EnableSensitiveLogging);
-                    break;
+                    throw new InvalidOperationException(
+                        $"Unsupported DatabaseSystem '{config.DatabaseSystem}'. The application only supports "
+                        + $"{nameof(Postgres)} (DataAccessOptions:DatabaseSystem = {(int)Postgres}); a missing or "
+                        + "unrecognized value is rejected rather than defaulted because there is no other supported provider.");
             }
 
             return new GameContext(optionsBuilder.Options);

--- a/Game.Infrastructure/Game.Infrastructure.csproj
+++ b/Game.Infrastructure/Game.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Game.TestInfrastructure" />
+    <InternalsVisibleTo Include="Game.Infrastructure.Tests" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

The project is **Postgres-only**, yet `GameContextFactory` would silently select `UseSqlServer` whenever the `DatabaseSystem` config key was missing or misbound. That happened because `SqlServer` was the `0`-valued (CLR default) member of the `DatabaseSystem` enum and the factory's `switch` fell through to it as the `default` branch. A forgotten env var or a new appsettings file therefore failed *later* as a confusing Npgsql-vs-SqlServer wire error rather than a clear "you didn't configure the database" message at startup.

This takes the issue's **preferred** option: remove SqlServer entirely and fail loud on any unrecognized `DatabaseSystem`.

## Changes

- **`DatabaseSystem` enum** — removed the `SqlServer = 0` member. `Postgres` keeps value `1` (deliberately *not* renumbered to `0`), so an unset/missing config binds to the unnamed default `0` and is rejected instead of silently mapping to a real provider. Every existing config (`appsettings.*.json`, `docker-compose*.yml`, test infra) already uses `1`, so none of them change.
- **`GameContextFactory`** — dropped the `UseSqlServer` branch; the `default` arm now throws `InvalidOperationException` with a clear message naming the unsupported value and the only supported provider.
- **Tests** — added `GameContextFactoryTests` in the lightweight `Game.Infrastructure.Tests` project (in-process, no out-of-process dependency — building the options never opens a connection): Postgres → Npgsql provider, and unset/unknown `DatabaseSystem` → `InvalidOperationException`. Exposed the internal factory to the test project via `InternalsVisibleTo`.

## How it addresses the issue

A missing or unrecognized `DataAccessOptions:DatabaseSystem` now fails fast at startup with an actionable message, rather than defaulting to a provider the app can't use. The `Postgres = 1` choice (over the alternative "renumber Postgres to 0") is what preserves the *fail-loud-on-misconfig* behaviour the issue asks for — a `0` default would silently work but mask a misconfiguration.

## Follow-up

The `Microsoft.EntityFrameworkCore.SqlServer` package can't be cleanly dropped in this PR: ~32 stale `SqlServer:` annotations baked into historical migration snapshots/designer files still reference `SqlServerValueGenerationStrategy` (almost certainly a symptom of this very bug — migrations generated while `DatabaseSystem` was unset). Filed as #542 (tech debt) to regenerate the snapshot, strip those annotations, and remove the package.

I also noticed `CacheServiceFactory`/`PubSubServiceFactory` use the same `_ => CreateRedis(...)` silent-default shape, but it's benign there — `Redis` is the only supported value and is correctly the `0` default — so I left them unchanged.

## Test plan

- [x] `dotnet build Game.sln` — 0 warnings / 0 errors
- [x] `dotnet format --verify-no-changes` — clean
- [x] `Game.Infrastructure.Tests` — 29/29 (incl. 3 new)
- [x] Full `dotnet test Game.sln` — Core 438, Application 168, Api 372, Infrastructure 29 all green

Closes #453

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdVXJ5pQmAChNxFKsV9Vb3)_