### PR TITLE
Replace O(n) array scans in frontend battle/skills hot paths (#454)

### DIFF
--- a/UI/src/lib/engine/log.ts
+++ b/UI/src/lib/engine/log.ts
@@ -13,7 +13,7 @@ const maxLogEntries = 40;
 let id = (logs()?.[0]?.id ?? -1) + 1;
 
 export const logMessage = (logType: ELogType, message: string) => {
-	if (playerManager.logPreferences.find((pref) => pref.id === logType)?.enabled ?? true) {
+	if (playerManager.logTypeEnabled(logType)) {
 		if (logs().length >= maxLogEntries) {
 			logs().pop();
 		}

--- a/UI/src/lib/engine/player/player-manager.ts
+++ b/UI/src/lib/engine/player/player-manager.ts
@@ -12,11 +12,16 @@ export class PlayerManager implements IPlayerData {
 	public statPointsUsed = 0;
 	public attributes: IBattlerAttribute[] = [];
 	public unlockedSkills: IUnlockedSkill[] = [];
-	public logPreferences: ILogPreference[] = [];
+	private logPreferenceList: ILogPreference[] = [];
 	public inventoryData: IInventoryData = {
 		unlockedItems: [],
 		unlockedMods: []
 	};
+
+	/** O(1) `enabled`-by-type lookup, rebuilt whenever {@link logPreferences} is assigned, so the
+	 *  per-tick combat-log writer (`log.ts`) never linear-scans the preference list. `#`-private so
+	 *  `statify` leaves it alone — it is read imperatively, never inside a reactive derivation. */
+	#enabledByType = new Map<ELogType, boolean>();
 
 	/**
 	 * The equipped skill ids in loadout order, derived from the unlocked set. The wire payload
@@ -28,6 +33,21 @@ export class PlayerManager implements IPlayerData {
 			.filter((skill) => skill.selected)
 			.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
 			.map((skill) => skill.skillId);
+	}
+
+	/** The player's combat-log preferences. Assigning rebuilds the by-type enabled lookup. */
+	public get logPreferences(): ILogPreference[] {
+		return this.logPreferenceList;
+	}
+	public set logPreferences(preferences: ILogPreference[]) {
+		this.logPreferenceList = preferences;
+		this.#enabledByType = new Map(preferences.map((pref): [ELogType, boolean] => [pref.id, pref.enabled]));
+	}
+
+	/** Whether a log type is enabled, defaulting an unknown type to enabled (matching the combat-log
+	 *  writer's historical `?? true` fallback). O(1) via the prebuilt by-type map. */
+	public logTypeEnabled(logType: ELogType): boolean {
+		return this.#enabledByType.get(logType) ?? true;
 	}
 
 	public initialize(data: IPlayerData) {

--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -104,16 +104,36 @@ export function zoneSpawnLevel(zone: IZone): number {
 	return (zone.levelMin + zone.levelMax) / 2;
 }
 
+/** Memoised flat-Defense by enemy identity → level. Enemy defense at a fixed level is a pure
+ *  function of the (static, immutable mid-session) attribute distribution, so it never changes for a
+ *  given enemy record. Keying the outer cache on the enemy object means a record replaced when
+ *  reference data reloads is recomputed (and the stale entry GC'd) rather than served a wrong value. */
+const enemyDefenseCache = new WeakMap<IEnemy, Map<number, number>>();
+
 /** An enemy's flat Defense at a given level — the value the battle subtracts in `Battler.takeDamage`.
  *  Mirrors the backend enemy build (`Enemy.GetAttributeModifiers`): each attribute distribution
  *  contributes `baseAmount + amountPerLevel * level` additively, then Defense is resolved through the
- *  same derived-attribute composition the battle uses (base + per-Endurance + per-Agility). */
+ *  same derived-attribute composition the battle uses (base + per-Endurance + per-Agility). Memoised
+ *  per enemy+level so a Compare-vs recompute doesn't rebuild a full `BattleAttributes` per pill. */
 export function enemyDefense(enemy: IEnemy, level: number): number {
+	let byLevel = enemyDefenseCache.get(enemy);
+	if (byLevel === undefined) {
+		// A plain memo cache, not reactive state.
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		byLevel = new Map<number, number>();
+		enemyDefenseCache.set(enemy, byLevel);
+	}
+	const cached = byLevel.get(level);
+	if (cached !== undefined) {
+		return cached;
+	}
 	const modifiers = enemy.attributeDistribution.map((dist) => ({
 		attributeId: dist.attributeId,
 		amount: dist.baseAmount + dist.amountPerLevel * level
 	}));
-	return new BattleAttributes(modifiers, true).getValue(EAttribute.Defense);
+	const defense = new BattleAttributes(modifiers, true).getValue(EAttribute.Defense);
+	byLevel.set(level, defense);
+	return defense;
 }
 
 /* ── reactive view-model ──────────────────────────────────────────────────── */
@@ -153,14 +173,14 @@ export class SkillsView {
 	/** The loadout cap (number of equip slots) — the single generated game constant. */
 	readonly cap = MAX_SELECTED_SKILLS;
 
-	/** Ids the player has unlocked. */
-	readonly unlockedIds = $derived(playerManager.unlockedSkills.map((s) => s.skillId));
+	/** Ids the player has unlocked, as a set for O(1) membership in the catalogue/metric derivations.
+	 *  Rebuilt from reactive deps on each change (a lookup, not mutable held state). */
+	// eslint-disable-next-line svelte/prefer-svelte-reactivity
+	readonly unlockedIds = $derived(new Set(playerManager.unlockedSkills.map((s) => s.skillId)));
 
 	/** Skills shown on the page: every non-retired skill, plus any retired skill the
 	 *  player still owns (retirement keeps owned records resolvable). */
-	readonly catalogue = $derived(
-		(staticData.skills ?? []).filter((s) => this.unlockedIds.includes(s.id) || !s.retiredAt)
-	);
+	readonly catalogue = $derived((staticData.skills ?? []).filter((s) => this.unlockedIds.has(s.id) || !s.retiredAt));
 
 	/** The player's resolved battle attributes (allocation + equipped item/mod stats),
 	 *  the same composition the battle uses. */
@@ -178,7 +198,7 @@ export class SkillsView {
 		for (const skill of this.catalogue) {
 			byId[skill.id] = {
 				skill,
-				unlocked: this.unlockedIds.includes(skill.id),
+				unlocked: this.unlockedIds.has(skill.id),
 				rawDamage: calculateSkillDamage(skill, attrs),
 				cooldown: cdMultiplier > 0 ? skill.cooldownMs / 1000 / cdMultiplier : skill.cooldownMs / 1000,
 				contributions: skillContributions(skill, attrs),
@@ -320,7 +340,7 @@ export class SkillsView {
 
 	/** Equip / unequip a skill. Equipping into a full loadout starts a swap instead. */
 	toggle(id: number): void {
-		if (!this.unlockedIds.includes(id)) {
+		if (!this.unlockedIds.has(id)) {
 			return;
 		}
 		if (this.isEquipped(id)) {
@@ -414,10 +434,13 @@ export class SkillsView {
 	 *  the new equipped set/order without a reload (reassigned so the reactive proxy
 	 *  observes the change). */
 	private applyToPlayer(orderedIds: number[]): void {
-		playerManager.unlockedSkills = playerManager.unlockedSkills.map((s) => ({
-			...s,
-			selected: orderedIds.includes(s.skillId),
-			order: orderedIds.includes(s.skillId) ? orderedIds.indexOf(s.skillId) : 0
-		}));
+		playerManager.unlockedSkills = playerManager.unlockedSkills.map((s) => {
+			const order = orderedIds.indexOf(s.skillId);
+			return {
+				...s,
+				selected: order >= 0,
+				order: order >= 0 ? order : 0
+			};
+		});
 	}
 }

--- a/UI/src/tests/lib/engine/log.test.ts
+++ b/UI/src/tests/lib/engine/log.test.ts
@@ -3,8 +3,12 @@ import { ELogType } from '$lib/api';
 
 const { mockLogs, mockPlayerManager } = vi.hoisted(() => {
 	const mockLogs: { id: number; logType: number; message: string }[] = [];
+	// Mirrors PlayerManager's prebuilt map: an unknown type defaults to enabled.
 	const mockPlayerManager = {
-		logPreferences: [] as { id: number; enabled: boolean }[]
+		logPreferences: [] as { id: number; enabled: boolean }[],
+		logTypeEnabled(logType: number): boolean {
+			return mockPlayerManager.logPreferences.find((pref) => pref.id === logType)?.enabled ?? true;
+		}
 	};
 	return { mockLogs, mockPlayerManager };
 });

--- a/UI/src/tests/lib/engine/player/player-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/player-manager.test.ts
@@ -170,6 +170,30 @@ describe('PlayerManager', () => {
 		});
 	});
 
+	describe('logTypeEnabled', () => {
+		it('returns the stored enabled flag for a known log type via the prebuilt map', () => {
+			manager.initialize(makePlayerData());
+
+			expect(manager.logTypeEnabled(ELogType.Damage)).toBe(false);
+			expect(manager.logTypeEnabled(ELogType.Exp)).toBe(true);
+		});
+
+		it('defaults an unknown log type to enabled', () => {
+			manager.initialize(makePlayerData({ logPreferences: [] }));
+
+			expect(manager.logTypeEnabled(ELogType.LevelUp)).toBe(true);
+		});
+
+		it('rebuilds the lookup when preferences are reassigned', () => {
+			manager.initialize(makePlayerData());
+			expect(manager.logTypeEnabled(ELogType.Damage)).toBe(false);
+
+			manager.logPreferences = [{ id: ELogType.Damage, enabled: true }];
+
+			expect(manager.logTypeEnabled(ELogType.Damage)).toBe(true);
+		});
+	});
+
 	describe('default state', () => {
 		it('starts with empty defaults before initialization', () => {
 			expect(manager.name).toBe('');

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -222,6 +222,18 @@ describe('pure helpers', () => {
 		expect(enemyDefense(ENEMIES[0], 5)).toBe(12); // 2 + 2*5
 		expect(enemyDefense(ENEMIES[2], 10)).toBe(32); // boss: 2 + 3*10
 	});
+
+	it('memoises enemy defense per enemy and level', () => {
+		const e = enemy({ id: 99, attributeDistribution: enemyDist(4) });
+		expect(enemyDefense(e, 5)).toBe(22); // 2 + 4*5
+
+		// The result is cached by enemy identity, so a later mutation of the (in practice immutable)
+		// distribution is not observed at the cached level — proving it is served from the memo.
+		e.attributeDistribution = enemyDist(100);
+		expect(enemyDefense(e, 5)).toBe(22);
+		// A different level is a distinct cache entry and reflects the current distribution.
+		expect(enemyDefense(e, 1)).toBe(102); // 2 + 100*1
+	});
 });
 
 describe('SkillsView — initial state', () => {
@@ -235,6 +247,12 @@ describe('SkillsView — initial state', () => {
 		const ids = view.catalogue.map((s) => s.id);
 		expect(ids).toContain(4); // locked, not retired → aspirational
 		expect(ids).not.toContain(5); // retired and unowned
+	});
+
+	it('exposes unlocked ids as a set for O(1) membership', () => {
+		expect(view.unlockedIds).toBeInstanceOf(Set);
+		expect(view.unlockedIds.has(0)).toBe(true); // unlocked starter
+		expect(view.unlockedIds.has(4)).toBe(false); // locked
 	});
 
 	it('exposes the skill catalogue defense ceiling for the slider', () => {


### PR DESCRIPTION
## Summary

Three independent, mechanical hot-path cleanups from the codebase-health review in #454. Several reactive/per-tick lookups linear-scanned arrays used as sets; this swaps them for `Set`/`Map`/memo lookups. **No behaviour change** — the existing skills-view and log tests stay green, with membership/memo assertions added.

## Changes

### 1. `logMessage` no longer scans the preference list per emit
`logMessage` (`log.ts`) is invoked several times per 40ms tick (per skill activation, per applied effect, per exp grant) and did `logPreferences.find(pref => pref.id === logType)` each call. `PlayerManager` now prebuilds an `enabled`-by-type `Map<ELogType, boolean>` — rebuilt only when `logPreferences` is assigned (via a getter/setter, so the invariant lives in one place) — and exposes `logTypeEnabled(logType)` for an O(1) check that preserves the historical `?? true` default.

The map is built on the player manager (the source of truth) rather than coupling `log.ts` to the `OptionsView` screen view-model that the issue mentioned. The map is a `#`-private field so `statify` leaves it non-reactive (it's read imperatively, never in a derivation); the backing list stays reactive exactly as before.

### 2. `SkillsView.unlockedIds` is now a `Set`
`unlockedIds` was an array queried with `.includes()` in `catalogue`, `metricsById`, and `toggle`. It's now `$derived(new Set(...))` and queried with `.has()`. `applyToPlayer` computed `includes()` then `indexOf()` for the same id (two scans) — it now computes the index once and derives `selected` from it.

### 3. `enemyDefense` is memoised
`comparePresets` called `enemyDefense(enemy, level)` per matching enemy, and each call built a full `new BattleAttributes(..., true)`. Enemy defense at a fixed level is a pure function of the static attribute distribution, so it's now memoised in a `WeakMap<IEnemy, Map<level, defense>>`. Keying the outer cache on the enemy object (rather than `id:level`) means a record replaced when reference data reloads is recomputed and the stale entry GC'd, so the cache can't serve a wrong value. I chose memoisation over the issue's alternative `$derived.by` isolation because the per-pill level varies (spawn midpoint vs. boss level), which a `staticData.enemies`-keyed derivation alone can't precompute.

`enemyDefense` is a display-only Compare-vs helper, not part of the parity-guarded per-tick `battleStep`, and its output is unchanged — so no backend mirroring is required.

## Test plan
- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors/warnings
- [x] `npm run test:unit:ci` — **1631 passed (171 files)**
- [x] Added `logTypeEnabled` tests (known/unknown/rebuild-on-reassign), a `unlockedIds` Set-membership assertion, and an `enemyDefense` per-enemy/per-level memo assertion

Closes #454


---
_Generated by [Claude Code](https://claude.ai/code/session_012SauV7VWHqGHba1TQw1YUW)_