### PR TITLE
Show ChallengeTooltip on hover for challenge-gated skills (#471)

### DIFF
--- a/UI/src/routes/game/screens/skills/SkillRail.svelte
+++ b/UI/src/routes/game/screens/skills/SkillRail.svelte
@@ -30,7 +30,7 @@
 				<span>{view.equipped.length}/{view.cap}</span>
 			</div>
 			{#each view.equippedRail as metrics (metrics.skill.id)}
-				<SkillRow {metrics} {view} />
+				<SkillRow {metrics} {view} onGateEnter={showChallenge} onGateMove={moveChallenge} onGateLeave={hideChallenge} />
 			{/each}
 		{/if}
 		<div class="grp">
@@ -39,7 +39,7 @@
 		</div>
 		{#if view.availableRail.length}
 			{#each view.availableRail as metrics (metrics.skill.id)}
-				<SkillRow {metrics} {view} />
+				<SkillRow {metrics} {view} onGateEnter={showChallenge} onGateMove={moveChallenge} onGateLeave={hideChallenge} />
 			{/each}
 		{:else}
 			<div class="empty">none match the filter</div>
@@ -47,16 +47,41 @@
 	</div>
 </div>
 
+<ChallengeTooltip bind:this={tooltip} {challengeId} />
+
 <script lang="ts">
-import { SKILL_SORTS, type SkillsView } from './skills-view.svelte';
+import { SKILL_SORTS, type SkillMetrics, type SkillsView } from './skills-view.svelte';
 import SkillRow from './SkillRow.svelte';
 import { attributeCode } from '$lib/common';
+import { ChallengeTooltip } from '$components';
+import { registerTooltipComponent, type TooltipComponent } from '$stores';
 
 type Props = {
 	view: SkillsView;
 };
 
 const { view }: Props = $props();
+
+// A locked skill rewarded by a not-yet-completed challenge surfaces that gating challenge — its
+// requirement and everything completing it unlocks — through the shared ChallengeTooltip on hover,
+// exactly as the locked-zone arrow does. SkillRow fires these callbacks only for gated rows.
+let tooltip = $state<TooltipComponent>();
+let challengeId = $state<number | undefined>();
+const { setTooltipPosition, showTooltip, hideTooltip } = registerTooltipComponent(() => tooltip);
+
+const showChallenge = (metrics: SkillMetrics, ev: MouseEvent) => {
+	if (metrics.source == null) {
+		return;
+	}
+	challengeId = metrics.source.id;
+	setTooltipPosition({ x: ev.clientX, y: ev.clientY });
+	showTooltip();
+};
+const moveChallenge = (ev: MouseEvent) => setTooltipPosition({ x: ev.clientX, y: ev.clientY });
+const hideChallenge = () => {
+	hideTooltip();
+	challengeId = undefined;
+};
 
 const sortLabel = $derived(SKILL_SORTS.find((s) => s.key === view.sort)?.label ?? 'DPS');
 const filterLabel = $derived.by(() => {

--- a/UI/src/routes/game/screens/skills/SkillRow.svelte
+++ b/UI/src/routes/game/screens/skills/SkillRow.svelte
@@ -4,6 +4,9 @@
 	class:sel={view.selectedId === metrics.skill.id}
 	class:lock={!metrics.unlocked}
 	onclick={() => view.select(metrics.skill.id)}
+	onmouseenter={gated ? (e) => onGateEnter?.(metrics, e) : undefined}
+	onmousemove={gated ? onGateMove : undefined}
+	onmouseleave={gated ? onGateLeave : undefined}
 >
 	<SkillIcon skill={metrics.skill} locked={!metrics.unlocked} size={30} />
 	<span class="body">
@@ -27,11 +30,20 @@ import type { SkillMetrics, SkillsView } from './skills-view.svelte';
 type Props = {
 	metrics: SkillMetrics;
 	view: SkillsView;
+	/** Hover callbacks that surface a gated skill's gating challenge. Fired only when the row is
+	 *  gated (locked + rewarded by a challenge); unlocked rows never invoke them. */
+	onGateEnter?: (metrics: SkillMetrics, ev: MouseEvent) => void;
+	onGateMove?: (ev: MouseEvent) => void;
+	onGateLeave?: () => void;
 };
 
-const { metrics, view }: Props = $props();
+const { metrics, view, onGateEnter, onGateMove, onGateLeave }: Props = $props();
 
 const fmt = (n: number) => formatNum(Math.round(n));
+
+// A locked skill that is some challenge's reward is gated behind that challenge — hovering it
+// surfaces the gate. Unlocked skills (and locked ones with no challenge source) show no tooltip.
+const gated = $derived(!metrics.unlocked && metrics.source != null);
 </script>
 
 <style lang="scss">

--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { render, cleanup, fireEvent, screen } from '@testing-library/svelte';
 import {
 	EAttribute,
 	EModifierType,
@@ -13,7 +13,15 @@ import {
 
 // Same engine/stores/api mocks as the view-model test: the rendered screen builds
 // its own SkillsView from these at mount.
-const { mockPlayerManager, mockInventoryManager, sendSocketCommand, toastError, staticData } = vi.hoisted(() => {
+const {
+	mockPlayerManager,
+	mockInventoryManager,
+	sendSocketCommand,
+	toastError,
+	staticData,
+	playerChallenges,
+	registerTooltipComponent
+} = vi.hoisted(() => {
 	const playerManager = {
 		unlockedSkills: [] as { skillId: number; selected: boolean; order?: number }[],
 		currentZone: 0,
@@ -30,18 +38,29 @@ const { mockPlayerManager, mockInventoryManager, sendSocketCommand, toastError, 
 		mockInventoryManager: { equipmentStats: [] as { attributeId: number; amount: number }[] },
 		sendSocketCommand: vi.fn(),
 		toastError: vi.fn(),
+		// The rail registers a ChallengeTooltip; the registration is stubbed and the tooltip
+		// resolves the gating challenge from this same reference data (completion from the store).
+		playerChallenges: { isChallengeCompleted: vi.fn(() => false) },
+		registerTooltipComponent: vi.fn(() => ({
+			setTooltipPosition: vi.fn(),
+			showTooltip: vi.fn(),
+			hideTooltip: vi.fn()
+		})),
 		staticData: {
 			skills: [] as ISkill[],
 			challenges: [] as IChallenge[],
 			zones: undefined as IZone[] | undefined,
 			enemies: undefined as IEnemy[] | undefined,
-			attributes: undefined as unknown
+			attributes: undefined as unknown,
+			challengeTypes: undefined as unknown,
+			items: undefined as unknown,
+			itemMods: undefined as unknown
 		}
 	};
 });
 
 vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager, inventoryManager: mockInventoryManager }));
-vi.mock('$stores', () => ({ staticData, toastError }));
+vi.mock('$stores', () => ({ staticData, toastError, playerChallenges, registerTooltipComponent }));
 vi.mock('$lib/api', async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, unknown>;
 	return { ...actual, apiSocket: { sendSocketCommand } };
@@ -106,6 +125,7 @@ const rowByName = (container: HTMLElement, name: string): HTMLElement | undefine
 beforeEach(() => {
 	sendSocketCommand.mockReset().mockResolvedValue({});
 	toastError.mockReset();
+	playerChallenges.isChallengeCompleted.mockReset().mockReturnValue(false);
 	staticData.skills = SKILLS;
 	staticData.challenges = CHALLENGES;
 	staticData.zones = ZONES;
@@ -337,5 +357,44 @@ describe('Skills screen', () => {
 		await fireEvent.input(search, { target: { value: 'delta' } });
 		expect(container.querySelectorAll('.row').length).toBe(1);
 		expect(rowByName(container, 'Delta')).toBeTruthy();
+	});
+
+	it('surfaces the gating challenge tooltip when hovering a locked, challenge-gated skill', async () => {
+		// Echo (id 4) is locked and is the reward of challenge 0; give that challenge a requirement.
+		staticData.challenges = [
+			{
+				id: 0,
+				name: 'Slay Ten',
+				description: 'Defeat 10 enemies',
+				challengeTypeId: 0,
+				progressGoal: 10,
+				rewardSkillId: 4
+			}
+		] as unknown as IChallenge[];
+		const { container } = render(Skills);
+
+		// Reveal locked skills so Echo (gated) appears in the rail.
+		await fireEvent.click(container.querySelector<HTMLButtonElement>('.filt-btn')!);
+		await fireEvent.click(container.querySelector<HTMLButtonElement>('.switch')!);
+		const echo = rowByName(container, 'Echo')!;
+
+		// Nothing is shown until the locked row is hovered.
+		expect(screen.queryByText('Slay Ten')).toBeNull();
+
+		await fireEvent.mouseEnter(echo, { clientX: 5, clientY: 5 });
+		// The gating challenge's name + requirement surface; the skill reward stays sealed (incomplete).
+		expect(screen.getByText('Slay Ten')).toBeTruthy();
+		expect(screen.getByText('Defeat 10 enemies')).toBeTruthy();
+
+		// Leaving the row clears the gate so it no longer renders.
+		await fireEvent.mouseLeave(echo);
+		expect(screen.queryByText('Slay Ten')).toBeNull();
+	});
+
+	it('does not surface a challenge tooltip when hovering an unlocked skill', async () => {
+		const { container } = render(Skills);
+		// Alpha is an unlocked, equipped skill — hovering it must not show any gate.
+		await fireEvent.mouseEnter(rowByName(container, 'Alpha')!, { clientX: 5, clientY: 5 });
+		expect(screen.queryByText('Slay Ten')).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

Wires the reusable `ChallengeTooltip` (`UI/src/components/tooltip/ChallengeTooltip.svelte`) into the skills page as its second consumer. When a skill is locked behind a challenge — i.e. it is some challenge's `rewardSkillId` and that challenge is not yet completed — hovering its rail row now surfaces the gating challenge (its requirement + everything completing it unlocks, sealed-aware), **exactly as the locked-zone nav arrow does** (`ZoneNav.svelte`).

Closes #471.

## How it addresses the issue

- **Prerequisite confirmed first.** The issue noted this "depends on the skills page actually distinguishing locked vs unlocked skills." It already does: `SkillMetrics.unlocked` flags ownership and `SkillMetrics.source` already resolves the gating challenge (`challenges.find(c => c.rewardSkillId === skill.id)`), driving the inspector's existing "Unlock by completing X" line. So no new gating or resolution logic was needed.
- **Reuses the shared helpers.** `ChallengeTooltip` already consumes `$lib/common/challenge-unlocks` (`zonesUnlockedBy`, `resolveUnlockReward`) internally; the rail just passes the metric's existing `source.id` to it.
- **Gated rows only.** `SkillRow` attaches the hover handlers only when the row is *gated* (locked **and** has a `source` challenge). Unlocked rows (and locked rows with no challenge source) show no tooltip — mirroring how only a locked zone arrow shows the tooltip.
- **Single tooltip instance.** `SkillRail` owns one `ChallengeTooltip` registered via `registerTooltipComponent`, following the established per-container pattern (same as the fight screen's `Skills.svelte`).

## Implementation notes

- `SkillRow.svelte` — added optional `onGateEnter` / `onGateMove` / `onGateLeave` callback props; the row's button fires them on `mouseenter`/`mousemove`/`mouseleave` only when `gated`.
- `SkillRail.svelte` — registers the tooltip, threads the three handlers into each row, and renders `<ChallengeTooltip>`.
- Locked skills appear in the rail when the existing **"Show locked skills"** filter is enabled, so the new hover affordance pairs with that toggle.

## Test plan

- [x] `Skills.test.ts` — added two cases: hovering a locked, challenge-gated skill (Echo, rewarded by an uncompleted challenge) surfaces the gate's name + requirement and clears it on `mouseleave`; hovering an unlocked skill surfaces nothing. Updated the `$stores` mock for the new `registerTooltipComponent` / `playerChallenges` dependencies (mirroring `ZoneNav.test.ts`).
- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors/0 warnings.
- [x] Full frontend unit suite — 1636 passed (171 files), no regressions.

## Notes / follow-ups

- This change covers the rail (browse) surface. The inspector already names the gating challenge in text ("Unlock by completing **X**"); making that text hover-expand into the same tooltip is a small, optional future enhancement, intentionally left out to keep this focused.
- As the issue mentions, this pairs naturally with the sibling follow-up to render a locked skill's reward on the challenges screen.

https://claude.ai/code/session_01PAEufF3QxW4Dio4fbLHn4y

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAEufF3QxW4Dio4fbLHn4y)_