### PR TITLE
Bounds-check gameplay Get* reference reads with descriptive errors (#487)

### DIFF
--- a/Game.Application.Tests/DataAccess/ReferenceDataBoundsCheckTests.cs
+++ b/Game.Application.Tests/DataAccess/ReferenceDataBoundsCheckTests.cs
@@ -1,0 +1,66 @@
+using Game.Abstractions.DataAccess;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Game.Application.Tests.DataAccess
+{
+    /// <summary>
+    /// Pins the gameplay <c>Get*</c> bounds-checking (#487): an id that no longer resolves (a stale player row,
+    /// migration drift) surfaces as a descriptive <see cref="ArgumentOutOfRangeException"/> naming the id and
+    /// set rather than a bare indexer crash on the hot player-load path. Exercised through the DI-resolved
+    /// repositories against the eagerly-loaded reference snapshots; both the above-range and negative branches
+    /// are covered.
+    /// </summary>
+    [Collection("Integration")]
+    public class ReferenceDataBoundsCheckTests : ApplicationIntegrationTestBase
+    {
+        public ReferenceDataBoundsCheckTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        [Fact]
+        public void GetItem_IdOutOfRange_ThrowsDescriptiveArgumentOutOfRange()
+        {
+            using var scope = CreateScope();
+            var items = scope.ServiceProvider.GetRequiredService<IItems>();
+
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => items.GetItem(int.MaxValue));
+            Assert.Contains("item", ex.Message);
+            Assert.Throws<ArgumentOutOfRangeException>(() => items.GetItem(-1));
+        }
+
+        [Fact]
+        public void GetSkill_IdOutOfRange_ThrowsDescriptiveArgumentOutOfRange()
+        {
+            using var scope = CreateScope();
+            var skills = scope.ServiceProvider.GetRequiredService<ISkills>();
+
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => skills.GetSkill(int.MaxValue));
+            Assert.Contains("skill", ex.Message);
+            Assert.Throws<ArgumentOutOfRangeException>(() => skills.GetSkill(-1));
+        }
+
+        [Fact]
+        public void GetItemMod_IdOutOfRange_ThrowsDescriptiveArgumentOutOfRange()
+        {
+            using var scope = CreateScope();
+            var itemMods = scope.ServiceProvider.GetRequiredService<IItemMods>();
+
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => itemMods.GetItemMod(int.MaxValue));
+            Assert.Contains("item mod", ex.Message);
+            Assert.Throws<ArgumentOutOfRangeException>(() => itemMods.GetItemMod(-1));
+        }
+
+        [Fact]
+        public void GetChallenge_IdOutOfRange_ThrowsDescriptiveArgumentOutOfRange()
+        {
+            using var scope = CreateScope();
+            var challenges = scope.ServiceProvider.GetRequiredService<IChallenges>();
+
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => challenges.GetChallenge(int.MaxValue));
+            Assert.Contains("challenge", ex.Message);
+            Assert.Throws<ArgumentOutOfRangeException>(() => challenges.GetChallenge(-1));
+        }
+    }
+}

--- a/Game.Application.Tests/DataAccess/ReferenceSnapshotExtensionsTests.cs
+++ b/Game.Application.Tests/DataAccess/ReferenceSnapshotExtensionsTests.cs
@@ -1,0 +1,71 @@
+using Game.DataAccess.Repositories;
+using Xunit;
+
+namespace Game.Application.Tests.DataAccess
+{
+    /// <summary>
+    /// Pins the zero-based-id reference snapshot index helpers (#487): <c>Lookup</c> returns null for an
+    /// out-of-range id, while <c>GetById</c> throws a descriptive <see cref="ArgumentOutOfRangeException"/>
+    /// naming the id and set. Pure logic with no out-of-process dependency, so covered by classical unit tests
+    /// rather than the integration suite.
+    /// </summary>
+    public class ReferenceSnapshotExtensionsTests
+    {
+        private static readonly IReadOnlyList<string> Snapshot = ["a", "b", "c"];
+
+        [Theory]
+        [InlineData(0, "a")]
+        [InlineData(1, "b")]
+        [InlineData(2, "c")]
+        public void Lookup_IdInRange_ReturnsRecord(int id, string expected)
+        {
+            Assert.Equal(expected, Snapshot.Lookup(id));
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(3)]
+        [InlineData(int.MaxValue)]
+        public void Lookup_IdOutOfRange_ReturnsNull(int id)
+        {
+            Assert.Null(Snapshot.Lookup(id));
+        }
+
+        [Fact]
+        public void Lookup_EmptySnapshot_ReturnsNull()
+        {
+            IReadOnlyList<string> empty = [];
+
+            Assert.Null(empty.Lookup(0));
+        }
+
+        [Theory]
+        [InlineData(0, "a")]
+        [InlineData(2, "c")]
+        public void GetById_IdInRange_ReturnsRecord(int id, string expected)
+        {
+            Assert.Equal(expected, Snapshot.GetById(id, "thing"));
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(3)]
+        [InlineData(int.MaxValue)]
+        public void GetById_IdOutOfRange_ThrowsDescriptiveArgumentOutOfRange(int id)
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => Snapshot.GetById(id, "widget"));
+
+            Assert.Equal(id, ex.ActualValue);
+            Assert.Contains("widget", ex.Message);
+            Assert.Contains(id.ToString(), ex.Message);
+        }
+
+        [Fact]
+        public void GetById_EmptySnapshot_Throws()
+        {
+            IReadOnlyList<string> empty = [];
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => empty.GetById(0, "thing"));
+        }
+    }
+}

--- a/Game.Core.Tests/Enemies/EnemyTests.cs
+++ b/Game.Core.Tests/Enemies/EnemyTests.cs
@@ -113,6 +113,18 @@ namespace Game.Core.Tests.Enemies
             Assert.Throws<InvalidOperationException>(() => _ = enemy.BattleSkills);
         }
 
+        [Fact]
+        public void SetBattleSkills_UnknownSkillId_ThrowsDescriptiveInvalidOperation()
+        {
+            // A snapshot id no longer among the enemy's available skills (e.g. SetEnemySkills changed the
+            // loadout between battle start and validation) fails meaningfully rather than with a bare
+            // KeyNotFoundException from the dictionary indexer.
+            var enemy = MakeEnemy(Skills(3));
+
+            var ex = Assert.Throws<InvalidOperationException>(() => enemy.SetBattleSkills([0, 99]));
+            Assert.Contains("99", ex.Message);
+        }
+
         private static List<Skill> Skills(int count) =>
             [.. Enumerable.Range(0, count).Select(MakeSkill)];
 

--- a/Game.Core/Enemies/Enemy.cs
+++ b/Game.Core/Enemies/Enemy.cs
@@ -66,7 +66,10 @@ namespace Game.Core.Enemies
         public void SetBattleSkills(IReadOnlyList<int> skillIds)
         {
             var available = AvailableSkills.ToDictionary(skill => skill.Id);
-            _battleSkills = [.. skillIds.Select(id => available[id])];
+            _battleSkills = [.. skillIds.Select(id => available.TryGetValue(id, out var skill)
+                ? skill
+                : throw new InvalidOperationException(
+                    $"Cannot restore battle skill {id}: it is not among enemy {Id}'s available skills."))];
         }
     }
 }

--- a/Game.DataAccess/Repositories/Challenges.cs
+++ b/Game.DataAccess/Repositories/Challenges.cs
@@ -15,7 +15,7 @@ namespace Game.DataAccess.Repositories
 
         public Challenge GetChallenge(int challengeId)
         {
-            return holder.Current[challengeId];
+            return holder.Current.GetById(challengeId, "challenge");
         }
     }
 }

--- a/Game.DataAccess/Repositories/Enemies.cs
+++ b/Game.DataAccess/Repositories/Enemies.cs
@@ -18,8 +18,7 @@ namespace Game.DataAccess.Repositories
 
         public Enemy? GetEnemy(int enemyId)
         {
-            var enemies = Snapshot.Enemies;
-            return enemyId < 0 || enemies.Count <= enemyId ? null : enemies[enemyId];
+            return Snapshot.Enemies.Lookup(enemyId);
         }
 
         public Enemy GetRandomEnemy(int zoneId)

--- a/Game.DataAccess/Repositories/ItemMods.cs
+++ b/Game.DataAccess/Repositories/ItemMods.cs
@@ -23,15 +23,14 @@ namespace Game.DataAccess.Repositories
 
         public ItemMod? LookupItemMod(int itemModId)
         {
-            var itemMods = Entities;
-            return itemMods.Count <= itemModId || itemModId < 0 ? null : itemMods[itemModId];
+            return Entities.Lookup(itemModId);
         }
 
         public CoreItemMod GetItemMod(int itemModId)
         {
             // Returns the snapshot's shared, pre-materialized instance rather than rebuilding a fresh graph
             // per call. Applied mods are reference data treated as immutable by every caller, so sharing is safe.
-            return holder.Current.CoreItemMods[itemModId];
+            return holder.Current.CoreItemMods.GetById(itemModId, "item mod");
         }
     }
 }

--- a/Game.DataAccess/Repositories/Items.cs
+++ b/Game.DataAccess/Repositories/Items.cs
@@ -18,8 +18,7 @@ namespace Game.DataAccess.Repositories
 
         public Item? LookupItem(int itemId)
         {
-            var items = Entities;
-            return items.Count <= itemId || itemId < 0 ? null : items[itemId];
+            return Entities.Lookup(itemId);
         }
 
         public CoreItem GetItem(int itemId)
@@ -28,7 +27,7 @@ namespace Game.DataAccess.Repositories
             // per call. The model is reference data treated as immutable by every caller (the battle path
             // composes modifiers into a separate AttributeCollection; applied mods live on the player's
             // UnlockedItemSlot, never on the shared Item.ModSlots), so sharing is safe.
-            return holder.Current.CoreItems[itemId];
+            return holder.Current.CoreItems.GetById(itemId, "item");
         }
     }
 }

--- a/Game.DataAccess/Repositories/ReferenceSnapshotExtensions.cs
+++ b/Game.DataAccess/Repositories/ReferenceSnapshotExtensions.cs
@@ -1,0 +1,38 @@
+namespace Game.DataAccess.Repositories
+{
+    /// <summary>
+    /// Index helpers for the zero-based-id reference snapshots (items, skills, item mods, enemies, zones,
+    /// challenges). A static reference record's Id is its index into the cached list — contiguity is
+    /// guaranteed structurally by retire-not-delete (see docs/backend.md → Reference Data) — so resolving one
+    /// by id is an array index. Centralizing the bounds check keeps the <c>Lookup*</c> (null) and <c>Get*</c>
+    /// (throw) shapes symmetric and makes a bad id (a stale player row, migration drift) fail meaningfully
+    /// rather than throwing a bare <see cref="ArgumentOutOfRangeException"/> from the raw indexer.
+    /// </summary>
+    internal static class ReferenceSnapshotExtensions
+    {
+        /// <summary>
+        /// Returns the record whose Id (index) is <paramref name="id"/>, or <c>null</c> when the id is out of
+        /// range. This is the <c>Lookup*</c> shape, for callers that handle a missing record themselves.
+        /// </summary>
+        public static T? Lookup<T>(this IReadOnlyList<T> snapshot, int id) where T : class
+        {
+            return id < 0 || snapshot.Count <= id ? null : snapshot[id];
+        }
+
+        /// <summary>
+        /// Returns the record whose Id (index) is <paramref name="id"/>, throwing a descriptive
+        /// <see cref="ArgumentOutOfRangeException"/> naming the id and <paramref name="setName"/> when the id is
+        /// out of range. This is the gameplay <c>Get*</c> shape, where a non-resolving id is a corrupt
+        /// reference that should surface meaningfully rather than as an opaque indexer crash.
+        /// </summary>
+        public static T GetById<T>(this IReadOnlyList<T> snapshot, int id, string setName)
+        {
+            if (id < 0 || snapshot.Count <= id)
+            {
+                throw new ArgumentOutOfRangeException(nameof(id), id, $"No {setName} exists with Id {id}.");
+            }
+
+            return snapshot[id];
+        }
+    }
+}

--- a/Game.DataAccess/Repositories/Skills.cs
+++ b/Game.DataAccess/Repositories/Skills.cs
@@ -23,8 +23,7 @@ namespace Game.DataAccess.Repositories
 
         public Skill? LookupSkill(int skillId)
         {
-            var skills = Entities;
-            return skills.Count <= skillId || skillId < 0 ? null : skills[skillId];
+            return Entities.Lookup(skillId);
         }
 
         public CoreSkill GetSkill(int skillId)
@@ -32,7 +31,7 @@ namespace Game.DataAccess.Repositories
             // Returns the snapshot's shared, pre-materialized instance rather than rebuilding a fresh graph
             // per call. The skill template is reference data treated as immutable by every caller — BattleSkill
             // only reads from it — so sharing is safe.
-            return holder.Current.CoreSkills[skillId];
+            return holder.Current.CoreSkills.GetById(skillId, "skill");
         }
     }
 }


### PR DESCRIPTION
## Summary

The gameplay `Get*` reference reads indexed the cached snapshot directly, so a non-resolving id threw a bare `ArgumentOutOfRangeException` from the raw indexer — while the `Lookup*`/`GetEnemy` siblings already bounds-checked their lookups. These reads sit on the hot player-load path (`PlayerMapper.ToCore` → `GetItem`/`GetSkill`/`GetItemMod`; `PlayerProgressRepository` → `GetChallenge`), so a stale id from a player row that no longer resolves (data reset / migration drift) crashed the whole player load with an opaque exception.

This PR closes that asymmetry uniformly and removes the duplicated bounds-check logic.

## Changes

- **New `ReferenceSnapshotExtensions` helper** (`Game.DataAccess/Repositories`) centralizing the zero-based-id bounds check in two symmetric shapes:
  - `Lookup` → returns `null` out of range (the `Lookup*` shape)
  - `GetById` → throws a descriptive `ArgumentOutOfRangeException` naming the id and set (the gameplay `Get*` shape, matching the existing `Enemies.GetRandomEnemy` "No zone exists with Id N" precedent)
- **Routed the four flagged `Get*` reads through `GetById`**: `Items.GetItem`, `Skills.GetSkill`, `ItemMods.GetItemMod`, `Challenges.GetChallenge`.
- **Harmonized the `Lookup*`/`GetEnemy` siblings onto `Lookup`** (`LookupItem`/`LookupSkill`/`LookupItemMod`/`GetEnemy`), removing the duplicated inline `id < 0 || count <= id` checks — directly addressing the "asymmetry is a maintenance hazard" framing.
- **Hardened `Enemy.SetBattleSkills`** to throw a descriptive `InvalidOperationException` (naming the id) instead of a bare `KeyNotFoundException` when a snapshot skill id is no longer among the enemy's `AvailableSkills` (which `SetEnemySkills` can change between battle start and validation).

`Zones.GetZone`/`GetDomainZone` were already bounds-checked (via `ValidateZoneId`) and map the entity rather than indexing a pre-built core list, so they were left as-is — out of the issue's scope.

> Note: `Enemy.SetBattleSkills` is a backend-only validation/reconstruction path. The frontend receives the enemy loadout ready-made from the server (`enemy-manager.ts`), so there is no frontend mirror to keep in parity for this guard.

## Test plan

- [x] Classical unit tests for `ReferenceSnapshotExtensions` covering edge cases (in-range, negative, at-count, far-out-of-range, empty snapshot) for both `Lookup` and `GetById`.
- [x] Integration tests asserting each gameplay `Get*` surfaces a descriptive `ArgumentOutOfRangeException` through the DI-resolved repository (above-range and negative branches).
- [x] `Enemy.SetBattleSkills` unit test for the descriptive `InvalidOperationException` on an unknown skill id.
- [x] Full backend suites pass: Core (440), Application (194), Api (372), Infrastructure (29). `dotnet build` clean (0 warnings).

Closes #487


---
_Generated by [Claude Code](https://claude.ai/code/session_0172obdbkYRsZH5DXtodXp88)_