### PR TITLE
Consolidate the two challenge-reward resolvers (#476)

### DIFF
--- a/UI/src/lib/common/challenge-unlocks.ts
+++ b/UI/src/lib/common/challenge-unlocks.ts
@@ -1,4 +1,4 @@
-import type { IChallenge, IItem, IItemMod, ISkill, IZone } from '$lib/api';
+import { ERarity, type IChallenge, type IItem, type IItemMod, type ISkill, type IZone } from '$lib/api';
 import { itemCategoryName, modTypeLabel } from './item-display';
 import { rarityColor, rarityLabel } from './rarity';
 
@@ -6,19 +6,42 @@ import { rarityColor, rarityLabel } from './rarity';
    `unlockChallengeId`) and award a single reward (an item, a mod, or a skill). These pure helpers
    resolve that "what does this unlock" view from the reference data so it can be surfaced wherever
    a challenge appears — the locked-zone tooltip, the challenges screen, etc. — without each call
-   site re-deriving the relationship. */
+   site re-deriving the relationship. This is the single home for the item > mod > skill precedence
+   and the rarity/accent/sub-label of a reward; richer surfaces (the challenges screen's
+   `resolveReward`) build their preview on top of this resolution rather than re-deriving it. */
 
 export type UnlockRewardKind = 'item' | 'mod' | 'skill';
 
-export interface UnlockReward {
-	kind: UnlockRewardKind;
+interface UnlockRewardBase {
 	/** The reward's real name. Callers mask it themselves (e.g. `???`) while the challenge is sealed. */
 	name: string;
 	/** Themeable accent: the rarity hue for items/mods, a neutral skill accent for skills. */
 	accent: string;
 	/** Teaser sub-label, e.g. `Rare · Helm`, `Epic · Prefix`, or `Skill`. */
 	sub: string;
+	/** Rarity tier (drives the rarity sort/glow on richer surfaces). Skills carry none, so they resolve to `Common`. */
+	rarity: ERarity;
 }
+
+export interface ItemUnlockReward extends UnlockRewardBase {
+	kind: 'item';
+	/** The rewarded item's reference record; the screen builds its preview item from this. */
+	item: IItem;
+}
+
+export interface ModUnlockReward extends UnlockRewardBase {
+	kind: 'mod';
+	/** The rewarded mod's reference record, passed through to the mod tooltip. */
+	mod: IItemMod;
+}
+
+export interface SkillUnlockReward extends UnlockRewardBase {
+	kind: 'skill';
+	/** The rewarded skill's reference record, passed through to the skill tooltip. */
+	skill: ISkill;
+}
+
+export type UnlockReward = ItemUnlockReward | ModUnlockReward | SkillUnlockReward;
 
 /** The zero-based-id reference pools the reward resolver reads (any may be undefined before load). */
 export interface RewardRefs {
@@ -49,9 +72,11 @@ export function resolveUnlockReward(challenge: IChallenge, refs: RewardRefs): Un
 		if (item) {
 			return {
 				kind: 'item',
+				item,
 				name: item.name,
 				accent: rarityColor(item.rarityId),
-				sub: `${rarityLabel(item.rarityId)} · ${itemCategoryName(item.itemCategoryId)}`
+				sub: `${rarityLabel(item.rarityId)} · ${itemCategoryName(item.itemCategoryId)}`,
+				rarity: item.rarityId
 			};
 		}
 	}
@@ -60,9 +85,11 @@ export function resolveUnlockReward(challenge: IChallenge, refs: RewardRefs): Un
 		if (mod) {
 			return {
 				kind: 'mod',
+				mod,
 				name: mod.name,
 				accent: rarityColor(mod.rarityId),
-				sub: `${rarityLabel(mod.rarityId)} · ${modTypeLabel(mod.itemModTypeId)}`
+				sub: `${rarityLabel(mod.rarityId)} · ${modTypeLabel(mod.itemModTypeId)}`,
+				rarity: mod.rarityId
 			};
 		}
 	}
@@ -71,9 +98,12 @@ export function resolveUnlockReward(challenge: IChallenge, refs: RewardRefs): Un
 		if (skill) {
 			return {
 				kind: 'skill',
+				skill,
 				name: skill.name,
 				accent: 'var(--accent-light)',
-				sub: 'Skill'
+				sub: 'Skill',
+				// Skills carry no rarity tier; resolve to the lowest so they sort with Common.
+				rarity: ERarity.Common
 			};
 		}
 	}

--- a/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
+++ b/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
@@ -2,8 +2,9 @@ import {
 	EChallengeGoalComparison,
 	EChallengeType,
 	EEntityType,
-	ERarity,
+	type ERarity,
 	type IChallenge,
+	type IItem,
 	type IItemMod,
 	type IPlayerChallenge,
 	type ISkill
@@ -12,12 +13,9 @@ import { BattleAttributes, type Item } from '$lib/battle';
 import {
 	challengeTypeColor,
 	challengeTypeName,
-	itemCategoryName,
-	modTypeLabel,
-	rarityColor,
 	rarityGlow,
-	rarityLabel,
 	rarityLevel,
+	resolveUnlockReward,
 	zonesUnlockedBy
 } from '$lib/common';
 import { staticData } from '$stores';
@@ -117,11 +115,7 @@ function targetName(ch: IChallenge): string | null {
 }
 
 /** A non-owned preview item (base stats, empty mod slots) for the item tooltip. */
-function buildPreviewItem(itemId: number): Item | null {
-	const itemData = staticData.items?.[itemId];
-	if (!itemData) {
-		return null;
-	}
+function buildPreviewItem(itemData: IItem): Item {
 	return {
 		...itemData,
 		itemId: itemData.id,
@@ -133,58 +127,40 @@ function buildPreviewItem(itemId: number): Item | null {
 }
 
 /* ─── Reward resolution (+ reveal gating) ────────────────────────────── */
+/** Build the rich, reveal-gated reward view on top of the shared `resolveUnlockReward` resolution:
+ *  the precedence, accent, rarity and sub-label come from the shared helper, and this layer adds the
+ *  reveal flag, the rarity glow, and the per-kind tooltip preview (battle item / raw mod / raw skill). */
 export function resolveReward(ch: IChallenge, revealed: boolean): ResolvedReward | null {
-	if (ch.rewardItemId != null) {
-		const item = buildPreviewItem(ch.rewardItemId);
-		if (!item) {
-			return null;
-		}
-		return {
-			kind: 'item',
-			revealed,
-			rarity: item.rarityId,
-			accent: rarityColor(item.rarityId),
-			glow: rarityGlow(item.rarityId),
-			name: item.name,
-			sub: `${rarityLabel(item.rarityId)} · ${itemCategoryName(item.itemCategoryId)}`,
-			item
-		};
+	const base = resolveUnlockReward(ch, {
+		items: staticData.items,
+		itemMods: staticData.itemMods,
+		skills: staticData.skills
+	});
+	if (base == null) {
+		return null;
 	}
-	if (ch.rewardItemModId != null) {
-		const mod = staticData.itemMods?.[ch.rewardItemModId];
-		if (!mod) {
-			return null;
-		}
-		return {
-			kind: 'mod',
-			revealed,
-			rarity: mod.rarityId,
-			accent: rarityColor(mod.rarityId),
-			glow: rarityGlow(mod.rarityId),
-			name: mod.name,
-			sub: `${rarityLabel(mod.rarityId)} · ${modTypeLabel(mod.itemModTypeId)}`,
-			mod
-		};
+	const resolved: ResolvedReward = {
+		kind: base.kind,
+		revealed,
+		rarity: base.rarity,
+		accent: base.accent,
+		// Skills carry no rarity tier, so they get no glow; items/mods glow by tier.
+		glow: base.kind === 'skill' ? '0' : rarityGlow(base.rarity),
+		name: base.name,
+		sub: base.sub
+	};
+	switch (base.kind) {
+		case 'item':
+			resolved.item = buildPreviewItem(base.item);
+			break;
+		case 'mod':
+			resolved.mod = base.mod;
+			break;
+		case 'skill':
+			resolved.skill = base.skill;
+			break;
 	}
-	if (ch.rewardSkillId != null) {
-		const skill = staticData.skills?.[ch.rewardSkillId];
-		if (!skill) {
-			return null;
-		}
-		// Skills carry no rarity tier; sort with the lowest and use the neutral skill accent
-		// (mirroring the shared `resolveUnlockReward` so both reward surfaces agree).
-		return {
-			kind: 'skill',
-			revealed,
-			rarity: ERarity.Common,
-			accent: 'var(--accent-light)',
-			glow: '0',
-			name: skill.name,
-			sub: 'Skill',
-			skill
-		};
-	}
-	return null;
+	return resolved;
 }
 
 /* ─── Progress maths (branches on comparison direction) ──────────────── */

--- a/UI/src/tests/lib/common/challenge-unlocks.test.ts
+++ b/UI/src/tests/lib/common/challenge-unlocks.test.ts
@@ -59,20 +59,24 @@ describe('resolveUnlockReward', () => {
 	skills[5] = { id: 5, name: 'Cleave' } as ISkill;
 	const refs = { items, itemMods, skills };
 
-	it('resolves an item reward with rarity accent and a "rarity · category" sub-label', () => {
+	it('resolves an item reward with rarity tier/accent, "rarity · category" sub-label and the source record', () => {
 		const reward = resolveUnlockReward(challenge({ rewardItemId: 3 }), refs);
-		expect(reward).toMatchObject({ kind: 'item', name: 'Iron Helm', sub: 'Rare · Helm' });
+		expect(reward).toMatchObject({ kind: 'item', name: 'Iron Helm', sub: 'Rare · Helm', rarity: ERarity.Rare });
 		expect(reward?.accent).toContain('--rarity-');
+		// The matched reference record is carried so richer surfaces build their preview without re-looking-up.
+		expect(reward?.kind === 'item' && reward.item).toBe(items[3]);
 	});
 
-	it('resolves a mod reward with rarity accent and a "rarity · modtype" sub-label', () => {
+	it('resolves a mod reward with rarity tier/accent, a "rarity · modtype" sub-label and the source record', () => {
 		const reward = resolveUnlockReward(challenge({ rewardItemModId: 4 }), refs);
-		expect(reward).toMatchObject({ kind: 'mod', name: 'of Fury', sub: 'Epic · Suffix' });
+		expect(reward).toMatchObject({ kind: 'mod', name: 'of Fury', sub: 'Epic · Suffix', rarity: ERarity.Epic });
+		expect(reward?.kind === 'mod' && reward.mod).toBe(itemMods[4]);
 	});
 
-	it('resolves a skill reward (no rarity) with a neutral accent and "Skill" sub-label', () => {
+	it('resolves a skill reward (Common tier) with a neutral accent, "Skill" sub-label and the source record', () => {
 		const reward = resolveUnlockReward(challenge({ rewardSkillId: 5 }), refs);
-		expect(reward).toMatchObject({ kind: 'skill', name: 'Cleave', sub: 'Skill' });
+		expect(reward).toMatchObject({ kind: 'skill', name: 'Cleave', sub: 'Skill', rarity: ERarity.Common });
+		expect(reward?.kind === 'skill' && reward.skill).toBe(skills[5]);
 	});
 
 	it('returns null when the challenge grants no reward', () => {


### PR DESCRIPTION
## Summary

There were two resolvers that both encoded the **item > mod > skill** reward precedence and the rarity sub-line/accent:

- `resolveReward` (`challenges-view.svelte.ts`) — the richer `ResolvedReward` for the challenges screen (preview battle `Item`, raw `IItemMod`/`ISkill`, rarity/accent/glow, reveal gating).
- `resolveUnlockReward` (`$lib/common/challenge-unlocks.ts`) — the lightweight `UnlockReward` for the compact `ChallengeTooltip`.

The precedence and labelling were duplicated, so a change to one (a new reward kind, a sub-line tweak) had to be mirrored in the other or the two surfaces silently drift.

## How it addresses the issue

`resolveUnlockReward` is now the **single home** for "what does this challenge reward, and how is it labelled" — the precedence, rarity tier, accent, and sub-label. It returns a discriminated union (`ItemUnlockReward | ModUnlockReward | SkillUnlockReward`) that also carries the matched reference record.

The screen's `resolveReward` builds its richer `ResolvedReward` **on top of** that shared resolution — adding only the reveal flag, the rarity glow, and the per-kind tooltip preview (battle `Item` for items, raw `mod`/`skill` pass-through) — instead of re-deriving the precedence and labels itself.

- The rich-preview construction (`buildPreviewItem`, which depends on `$lib/battle`) stays in the screen layer; **the shared helper takes no new dependency** (it returns the raw `IItem`/`IItemMod`/`ISkill` from `$lib/api`, not a battle object).
- `buildPreviewItem` now takes the already-resolved `IItem`, dropping its now-dead missing-item null branch and the redundant re-lookup.
- `ChallengeTooltip` and the challenges screen now resolve precedence/sub-line from one place, so they can't drift.

## Test plan

- [x] Shared-resolver tests (`challenge-unlocks.test.ts`) extended to assert the new rarity tier and the source-record pass-through for each kind.
- [x] The screen's `resolveReward` tests are unchanged (same `ResolvedReward` shape) and still pass.
- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors / 0 warnings.
- [x] `npm run test:unit:ci` — **1636 passed (171 files)**.

## Notes

No docs change: this is a duplication-removal refactor with no user-facing or architectural change — it doesn't establish a new cross-cutting pattern, so per the project's docs guidance it isn't documented.

Closes #476

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsiFiuH8cBfBBoKjztR5TN)_