### PR TITLE
Make HandleItemEquipped a single atomic write (#484)

### DIFF
--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -386,6 +386,78 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task ProcessQueue_ItemEquippedEvent_ClearsPriorOccupantAndEquipsIdempotently()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id, level: 5, zoneId: 0);
+            var occupant = await TestDataSeeder.CreateItemAsync(context, name: "Occupant");
+            var incoming = await TestDataSeeder.CreateItemAsync(context, name: "Incoming");
+
+            // The slot already holds one item; the incoming item is unlocked but unequipped.
+            await TestDataSeeder.LinkItemToPlayerAsync(context, player.Id, occupant.Id, equipmentSlot: EEquipmentSlot.HelmSlot);
+            await TestDataSeeder.LinkItemToPlayerAsync(context, player.Id, incoming.Id, equipmentSlot: null);
+
+            var evt = new ItemEquippedEvent(player.Id, incoming.Id, (int)EEquipmentSlot.HelmSlot);
+
+            var logger = new CapturingLogger<DataProviderSynchronizer>();
+            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
+            var synchronizer = new DataProviderSynchronizer(scope.ServiceProvider, pubsub, logger, TestRetryPolicy);
+
+            // Delivered twice: the single-statement absolute upsert must converge — the incoming item holds the
+            // slot, the prior occupant is cleared, and re-applying changes nothing.
+            var queue = new InMemoryPubSubQueue(Serialize(evt), Serialize(evt));
+
+            await synchronizer.ProcessQueue(queue);
+
+            Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+            Assert.Empty(await DrainDeadLetterQueue(pubsub));
+
+            using var verifyScope = CreateScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
+            var rows = await verifyContext.UnlockedItems
+                .Where(ui => ui.PlayerId == player.Id)
+                .ToListAsync(CancellationToken);
+
+            Assert.Equal((int)EEquipmentSlot.HelmSlot, Assert.Single(rows, ui => ui.ItemId == incoming.Id).EquipmentSlotId);
+            Assert.Null(Assert.Single(rows, ui => ui.ItemId == occupant.Id).EquipmentSlotId);
+        }
+
+        [Fact]
+        public async Task ProcessQueue_ItemEquippedEvent_MovingItemBetweenSlots_VacatesOldSlot()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id, level: 5, zoneId: 0);
+            var item = await TestDataSeeder.CreateItemAsync(context);
+
+            // The item starts equipped in the Helm slot; the event re-equips it into the Chest slot.
+            await TestDataSeeder.LinkItemToPlayerAsync(context, player.Id, item.Id, equipmentSlot: EEquipmentSlot.HelmSlot);
+
+            var evt = new ItemEquippedEvent(player.Id, item.Id, (int)EEquipmentSlot.ChestSlot);
+
+            var logger = new CapturingLogger<DataProviderSynchronizer>();
+            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
+            var synchronizer = new DataProviderSynchronizer(scope.ServiceProvider, pubsub, logger, TestRetryPolicy);
+
+            await synchronizer.ProcessQueue(new InMemoryPubSubQueue(Serialize(evt)));
+
+            Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+
+            using var verifyScope = CreateScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
+            var row = await verifyContext.UnlockedItems
+                .SingleAsync(ui => ui.PlayerId == player.Id && ui.ItemId == item.Id, CancellationToken);
+
+            // The item moved to the new slot; reassigning its own row vacates the old slot in the same statement.
+            Assert.Equal((int)EEquipmentSlot.ChestSlot, row.EquipmentSlotId);
+        }
+
+        [Fact]
         public async Task ProcessQueue_ModUnlockedEvent_InsertsUnlockedModIdempotently()
         {
             using var scope = CreateScope();

--- a/Game.DataAccess/DataProviderSynchronizer.cs
+++ b/Game.DataAccess/DataProviderSynchronizer.cs
@@ -267,15 +267,17 @@ namespace Game.DataAccess
 
         private static async Task HandleItemEquipped(GameContext context, ItemEquippedEvent evt)
         {
-            // Clear the target slot
+            // Absolute per-slot upsert in a single atomic UPDATE: the equipped item takes the slot and any
+            // prior occupant is cleared, in one statement. The previous two-statement clear-then-set left a
+            // window where a crash between the writes (the queue read is a destructive pop, so the event is
+            // not redelivered) emptied the slot for good. Folding both into one CASE-driven update over the
+            // affected rows removes that window and stays idempotent — re-applying converges to the same state,
+            // including when the item is moving from another slot (its own row is reassigned, vacating the old).
             await context.UnlockedItems
-                .Where(ui => ui.PlayerId == evt.PlayerId && ui.EquipmentSlotId == evt.SlotId)
-                .ExecuteUpdateAsync(s => s.SetProperty(ui => ui.EquipmentSlotId, (int?)null));
-
-            // Equip the item
-            await context.UnlockedItems
-                .Where(ui => ui.PlayerId == evt.PlayerId && ui.ItemId == evt.ItemId)
-                .ExecuteUpdateAsync(s => s.SetProperty(ui => ui.EquipmentSlotId, evt.SlotId));
+                .Where(ui => ui.PlayerId == evt.PlayerId && (ui.ItemId == evt.ItemId || ui.EquipmentSlotId == evt.SlotId))
+                .ExecuteUpdateAsync(s => s.SetProperty(
+                    ui => ui.EquipmentSlotId,
+                    ui => ui.ItemId == evt.ItemId ? evt.SlotId : (int?)null));
         }
 
         private static async Task HandleItemUnequipped(GameContext context, ItemUnequippedEvent evt)


### PR DESCRIPTION
## Summary

Closes #484.

`DataProviderSynchronizer.HandleItemEquipped` cleared the target equipment slot and set the new item in **two separate** `ExecuteUpdateAsync` calls with no enclosing transaction. Because the `PlayerUpdateQueue` read is a destructive pop with no crash-safe redelivery (documented under "Caching and Pub/Sub"), a crash — or a failure of the second statement — *between* the two writes left the previous occupant unequipped and the new item not equipped: the slot was emptied in the DB for good, and the event was already gone from the queue, so it never replayed. This was the one write-behind handler that wasn't atomic across its write pair, contradicting the documented "handlers are idempotent so retries converge" invariant.

## How it addresses the issue

Both writes are folded into **one** `CASE`-driven `UPDATE` over exactly the affected rows — the item being equipped plus any item currently occupying the target slot:

```csharp
await context.UnlockedItems
    .Where(ui => ui.PlayerId == evt.PlayerId && (ui.ItemId == evt.ItemId || ui.EquipmentSlotId == evt.SlotId))
    .ExecuteUpdateAsync(s => s.SetProperty(
        ui => ui.EquipmentSlotId,
        ui => ui.ItemId == evt.ItemId ? evt.SlotId : (int?)null));
```

The equipped item takes the slot and any prior occupant is cleared in a single atomic statement, so there is no longer any partial-write window. It's an **absolute per-slot upsert** in the same spirit as the other handlers (`HandleModApplied`, `HandleAttributeAllocationsChanged`): re-applying the event converges to the same state, and it also correctly **vacates the old slot** when an item moves between slots (its own row is reassigned). As a bonus it's one round-trip instead of two.

This reproduces exactly the domain semantics of `Inventory.TryEquipItem` (clear the item from any prior slot, then overwrite whatever occupies the target slot).

## Test plan

Added two integration tests to `DataProviderSynchronizerTests` (real Postgres, matching the existing per-handler style):

- **`ClearsPriorOccupantAndEquipsIdempotently`** — equips an incoming item into an already-occupied slot, delivered twice; asserts the prior occupant is cleared, the incoming item holds the slot, and re-applying changes nothing.
- **`MovingItemBetweenSlots_VacatesOldSlot`** — re-equips an item from one slot into another; asserts the old slot is vacated by the same statement.

- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] `Game.Application.Tests` — 196 passed, 0 failed (incl. the 2 new tests)

## Notes

Backend-only change to the write-behind persistence path — no battle logic and no frontend equivalent, so no parity mirroring is needed. No docs change: the fix restores conformance to the already-documented idempotency invariant ("absolute `ExecuteUpdate`s") rather than introducing a new design decision.

https://claude.ai/code/session_01EKzqLZQvE71jjPaTa9Tu4i

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKzqLZQvE71jjPaTa9Tu4i)_