### PR TITLE
Fix createHook.notify skipping a subscriber when one unhooks during dispatch (#576)

### DIFF
--- a/UI/src/lib/common/hooks.ts
+++ b/UI/src/lib/common/hooks.ts
@@ -19,7 +19,9 @@ export const createHook = <T extends unknown[] = []>() => {
 
 		promiseResolvers = [];
 
-		for (const tracker of trackers) {
+		// Iterate over a snapshot so a subscriber unhooking during dispatch
+		// (which splices `trackers`) can't cause a sibling to be skipped.
+		for (const tracker of [...trackers]) {
 			tracker.callback(...data, tracker.unhook);
 		}
 	};

--- a/UI/src/tests/common/hooks.test.ts
+++ b/UI/src/tests/common/hooks.test.ts
@@ -117,6 +117,52 @@ describe('createHook', () => {
 		expect(cb).toHaveBeenCalledWith(expect.any(Function));
 	});
 
+	it('still fires remaining subscribers when one unhooks itself during dispatch', () => {
+		const hook = createHook<[number]>();
+		const cb1 = vi.fn();
+		const cb2 = vi.fn();
+
+		// cb1 unhooks itself from inside its own callback, shifting cb2 into
+		// the just-visited slot — cb2 must not be skipped for this dispatch.
+		hook.onNotified((value, unhook) => {
+			cb1(value);
+			unhook();
+		});
+		hook.onNotified(cb2);
+
+		hook.notify(1);
+
+		expect(cb1).toHaveBeenCalledTimes(1);
+		expect(cb2).toHaveBeenCalledTimes(1);
+		expect(cb2).toHaveBeenCalledWith(1, expect.any(Function));
+
+		// cb1 is gone for the next dispatch; cb2 keeps firing.
+		hook.notify(2);
+		expect(cb1).toHaveBeenCalledTimes(1);
+		expect(cb2).toHaveBeenCalledTimes(2);
+	});
+
+	it('still fires remaining subscribers when one unhooks another during dispatch', () => {
+		const hook = createHook<[number]>();
+		const cb1 = vi.fn();
+		const cb3 = vi.fn();
+
+		hook.onNotified((value) => {
+			cb1(value);
+			// Unhook the next subscriber before it has been visited.
+			unhookSecond();
+		});
+		const unhookSecond = hook.onNotified(vi.fn());
+		hook.onNotified(cb3);
+
+		hook.notify(7);
+
+		// Removing a not-yet-visited subscriber mid-dispatch must not knock the
+		// snapshot off and skip the subscriber after it.
+		expect(cb1).toHaveBeenCalledTimes(1);
+		expect(cb3).toHaveBeenCalledWith(7, expect.any(Function));
+	});
+
 	it('subscriber added after notify does not receive past notifications', () => {
 		const hook = createHook<[number]>();
 


### PR DESCRIPTION
## Summary

`createHook.notify` dispatched by iterating the live `trackers` array with `for...of`. When a subscriber removed itself (or another) via `unhook()` from inside its own callback, `trackers.splice(...)` shifted the next subscriber into the just-visited slot, so `for...of` silently skipped it for that dispatch.

This was reachable in production: `BattleEngine.startLoading` subscribes to `onRenderUpdate` and calls the passed `unhook()` from inside its own callback while the persistent cooldown/effect subscriber is on the same render hook — depending on tracker order, the loading self-unhook could drop the sibling render callback for a frame.

## Fix

Iterate over a snapshot copy (`[...trackers]`), matching the reference-/order-independent approach the tooltip and toast stores already use. A subscriber removed mid-dispatch simply takes effect on the next dispatch instead of corrupting the current iteration.

## Test plan

- [x] Added a test that unhooks a subscriber from inside its own `notify` callback and asserts the remaining subscriber still fires (and stops firing on the next dispatch once removed).
- [x] Added a test for one subscriber unhooking another not-yet-visited subscriber mid-dispatch.
- [x] `npx vitest run src/tests/common/hooks.test.ts` — 13 passed.
- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors / 0 warnings.

## Notes

No docs change: this is a correctness fix to existing behaviour, not a new cross-cutting pattern.

Closes #576

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQhffeF1WrRF1DHKm7YQxZ)_