### PR TITLE
Fix MessageTooBig socket close reporting "closed normally" (#577)

### DIFF
--- a/Game.Api.Tests/Unit/SocketCloseReasonTests.cs
+++ b/Game.Api.Tests/Unit/SocketCloseReasonTests.cs
@@ -13,6 +13,14 @@ namespace Game.Api.Tests.Unit
             Assert.Contains("shutting down", description, StringComparison.OrdinalIgnoreCase);
         }
 
+        [Fact]
+        public void GetDescription_MessageTooBig_DescribesOversizedMessage()
+        {
+            var description = ESocketCloseReason.MessageTooBig.GetDescription();
+
+            Assert.Contains("maximum allowed size", description, StringComparison.OrdinalIgnoreCase);
+        }
+
         [Theory]
         [InlineData(ESocketCloseReason.Finished)]
         [InlineData(ESocketCloseReason.Inactivity)]
@@ -22,6 +30,25 @@ namespace Game.Api.Tests.Unit
         public void GetDescription_AnyReason_ReturnsNonEmptyDescription(ESocketCloseReason reason)
         {
             Assert.False(string.IsNullOrWhiteSpace(reason.GetDescription()));
+        }
+
+        [Fact]
+        public void GetDescription_EveryDefinedReason_HasADistinctNonDefaultDescription()
+        {
+            var reasons = Enum.GetValues<ESocketCloseReason>();
+            var descriptions = reasons.Select(r => r.GetDescription()).ToList();
+
+            // Every defined reason must map to its own description; none should silently
+            // inherit another reason's text (the bug that motivated this test).
+            Assert.Equal(reasons.Length, descriptions.Distinct().Count());
+        }
+
+        [Fact]
+        public void GetDescription_UndefinedReason_Throws()
+        {
+            var undefined = (ESocketCloseReason)int.MaxValue;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => undefined.GetDescription());
         }
     }
 }

--- a/Game.Api/Extensions.cs
+++ b/Game.Api/Extensions.cs
@@ -8,10 +8,12 @@ namespace Game.Api
         {
             return reason switch
             {
+                ESocketCloseReason.Finished => "The socket has been closed normally.",
                 ESocketCloseReason.Inactivity => "The socket has been closed due to inactivity.",
                 ESocketCloseReason.SocketReplaced => "The socket has been closed because a new one was established.",
+                ESocketCloseReason.MessageTooBig => "The socket has been closed because a message exceeded the maximum allowed size.",
                 ESocketCloseReason.ServerShuttingDown => "The socket has been closed because the server is shutting down.",
-                _ => "The socket has been closed normally."
+                _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, "Unhandled socket close reason.")
             };
         }
 


### PR DESCRIPTION
## Summary

`Extensions.GetDescription(this ESocketCloseReason)` only mapped `Inactivity`, `SocketReplaced` and `ServerShuttingDown`. Every other reason — including `MessageTooBig` and `Finished` — fell through to the `_ => "The socket has been closed normally."` default.

As a result, when `SocketContext.ReadMessage` closes a connection for exceeding the buffer cap (`SocketContext.cs:110`), the WebSocket close-frame description told the client the closure was **normal**, masking a genuine error path and hurting client-side diagnosis/telemetry.

## How it addresses the issue

- Added an explicit `MessageTooBig` arm with a description that names the oversized-message cause.
- Added an explicit `Finished` arm carrying the normal-closure text (it is the only reason that should read "closed normally").
- Replaced the catch-all `_ => "...normally."` default with `throw new ArgumentOutOfRangeException(...)`, making the switch exhaustive over the enum. Future `ESocketCloseReason` additions now surface loudly during testing instead of silently inheriting the normal-closure text — directly addressing the issue's "make the switch exhaustive" suggestion.

## Test plan

- [x] `dotnet build Game.Api.Tests` — 0 warnings, 0 errors.
- [x] `dotnet test Game.Api.Tests` — **388 passed, 0 failed**.
- Added/strengthened tests in `SocketCloseReasonTests`:
  - `GetDescription_MessageTooBig_DescribesOversizedMessage` — would have caught the original bug (the prior theory only asserted non-empty).
  - `GetDescription_EveryDefinedReason_HasADistinctNonDefaultDescription` — guards against any reason silently sharing another's text.
  - `GetDescription_UndefinedReason_Throws` — locks in the exhaustive-switch behaviour.

## Notes

No docs change: this is a correctness fix to existing behaviour, not a new cross-cutting pattern.

Closes #577

---
_Generated by [Claude Code](https://claude.ai/code/session_016RxpmGEiGsf5dZE4kHt7WG)_