### PR TITLE
Add AsSplitQuery() to ItemModsCacheHolder to avoid cartesian row explosion

### DIFF
--- a/Game.DataAccess/Repositories/Caching/ItemModsCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/ItemModsCacheHolder.cs
@@ -28,6 +28,7 @@ namespace Game.DataAccess.Repositories.Caching
                 .AsNoTracking()
                 .Include(im => im.ItemModAttributes)
                 .Include(im => im.Tags)
+                .AsSplitQuery()
                 .OrderBy(im => im.Id)
                 .ToListAsync(cancellationToken);
 


### PR DESCRIPTION
## Summary

`ItemModsCacheHolder.BuildSnapshotAsync` eager-loads two collection navigations (`ItemModAttributes` and `Tags`) on a single query without `.AsSplitQuery()`. With two collection `Include`s in one query, EF Core emits a single join that produces a cartesian product (`ItemModAttributes` × `Tags`) per mod, multiplying the rows transferred and materialized.

This inflated the query payload and slowed the item-mod cache (re)build, which is incurred at startup and on every admin write that reloads the reference caches.

## Fix

Add `.AsSplitQuery()` to `ItemModsCacheHolder` so each collection is loaded in a separate round-trip, eliminating the cartesian explosion. This brings it in line with both of its directly-analogous siblings, which already split their multi-collection eager loads:

- `ItemsCacheHolder` — three collection Includes + `.AsSplitQuery()`
- `SkillsCacheHolder` — two collection Includes + `.AsSplitQuery()`
- `EnemiesCacheHolder` — three collection Includes + `.AsSplitQuery()`

The change is behavior-preserving: a split query materializes identical data, just via separate SQL round-trips instead of one cartesian join.

## Scope check

I reviewed all seven cache holders. `ItemModsCacheHolder` was the only one with the defect:
- `ChallengesCacheHolder` uses an EF-translatable projection with no `Include`s (no cartesian risk).
- `ZonesCacheHolder` has a single collection `Include` (`ZoneEnemies`), which cannot produce a cartesian product, so it correctly needs no split.

No related holder needs the same fix, so the change stays tightly scoped to one line in one file.

## Testing

- `dotnet build Game.sln` — succeeded, 0 warnings, 0 errors.
- `dotnet test Game.Core.Tests` — 456 passed, 0 failed.

The cache-holder reload behavior is covered by existing integration tests (`ReferenceCacheHolderTests`), which share the Postgres/Redis containers with other agents and were intentionally not run here. No new test is warranted: a split-vs-single query is an EF-internal SQL detail with no observable behavioral difference to assert.

Closes #581

https://claude.ai/code/session_01B59BYxC4Cw62VgUB3yY8EX

---
_Generated by [Claude Code](https://claude.ai/code/session_01B59BYxC4Cw62VgUB3yY8EX)_