### PR TITLE
Harden ProbabilityTable.GetRandomValue against float edge cases

### DIFF
--- a/Game.Core.Tests/Probability/ProbabilityTableTests.cs
+++ b/Game.Core.Tests/Probability/ProbabilityTableTests.cs
@@ -29,6 +29,122 @@ namespace Game.Core.Tests.Probability
         }
 
         [Fact]
+        public void SingleZeroWeightList_ProducesValueFromList()
+        {
+            List<WeightedValue<int>> list = [new WeightedValue<int>(42, 0)];
+            var table = new ProbabilityTable<int>(list);
+
+            Assert.Equal(42, table.GetRandomValue());
+        }
+
+        [Fact]
+        public void AllZeroWeights_ProducesUniformDistribution()
+        {
+            // An all-zero set makes the average weight zero; entries should fall back to uniform.
+            List<WeightedValue<int>> list = [
+                new WeightedValue<int>(0, 0),
+                new WeightedValue<int>(1, 0),
+                new WeightedValue<int>(2, 0),
+            ];
+            var table = new ProbabilityTable<int>(list);
+            var buckets = list.Select(x => 0L).ToList();
+            var iterations = 300_000;
+
+            for (int i = 0; i < iterations; i++)
+            {
+                buckets[table.GetRandomValue()]++;
+            }
+
+            for (int i = 0; i < buckets.Count; i++)
+            {
+                var sampleProbability = (double)buckets[i] / iterations;
+                Assert.True(Math.Abs(sampleProbability - (1.0 / buckets.Count)) < 0.01);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(UnevenWeightSets))]
+        public void UnevenlyDividingWeights_AlwaysProduceValidIndex(WeightedValue<int>[] entries)
+        {
+            // Unevenly-dividing weights previously risked leaving an unpopulated _values slot,
+            // which would surface as a NullReferenceException or an out-of-range alias lookup.
+            var table = new ProbabilityTable<int>([.. entries]);
+            var validValues = entries.Select(x => x.Value).ToHashSet();
+
+            for (int i = 0; i < 500_000; i++)
+            {
+                var value = table.GetRandomValue();
+                Assert.Contains(value, validValues);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(UnevenWeightSets))]
+        public void UnevenlyDividingWeights_ProduceReasonableDistribution(WeightedValue<int>[] entries)
+        {
+            var list = entries.ToList();
+            var table = new ProbabilityTable<int>(list);
+            var buckets = list.Select(x => 0L).ToList();
+            var iterations = 1_000_000;
+
+            for (int i = 0; i < iterations; i++)
+            {
+                buckets[table.GetRandomValue()]++;
+            }
+
+            AssertDistributionIsReasonable(list, buckets);
+        }
+
+        public static IEnumerable<object[]> UnevenWeightSets()
+        {
+            // Three thirds: 1/3 cannot be represented exactly, so residual weights never land on 1.0.
+            yield return new object[]
+            {
+                new[]
+                {
+                    new WeightedValue<int>(0, 1),
+                    new WeightedValue<int>(1, 1),
+                    new WeightedValue<int>(2, 1),
+                },
+            };
+            // Prime weights over a prime total produce repeating-decimal normalized weights.
+            yield return new object[]
+            {
+                new[]
+                {
+                    new WeightedValue<int>(0, 1),
+                    new WeightedValue<int>(1, 2),
+                    new WeightedValue<int>(2, 4),
+                    new WeightedValue<int>(3, 7),
+                    new WeightedValue<int>(4, 9),
+                    new WeightedValue<int>(5, 11),
+                },
+            };
+            // A heavy skew mixed with several tiny weights stresses the small/big rebalancing.
+            yield return new object[]
+            {
+                new[]
+                {
+                    new WeightedValue<int>(0, 997),
+                    new WeightedValue<int>(1, 1),
+                    new WeightedValue<int>(2, 1),
+                    new WeightedValue<int>(3, 1),
+                },
+            };
+            // Zero-weight entries should never be returned but must not break construction.
+            yield return new object[]
+            {
+                new[]
+                {
+                    new WeightedValue<int>(0, 0),
+                    new WeightedValue<int>(1, 3),
+                    new WeightedValue<int>(2, 0),
+                    new WeightedValue<int>(3, 5),
+                },
+            };
+        }
+
+        [Fact]
         public void MultiInitializationList_ProducesReasonableDistribution()
         {
             var list = SetupMultiElementList();

--- a/Game.Core/Probability/ProbabilityTable.cs
+++ b/Game.Core/Probability/ProbabilityTable.cs
@@ -1,20 +1,26 @@
-﻿namespace Game.Core.Probability
+namespace Game.Core.Probability
 {
     /// <summary>
     /// A class for generating a random value based on a collection of values with probability weights.
     /// </summary>
     public class ProbabilityTable<T>
     {
+        // Tolerance used when classifying normalized weights so that values which are
+        // mathematically equal to the average but land just off 1.0 due to floating-point
+        // rounding are still treated as "exactly average" rather than small/big.
+        private const double Epsilon = 1e-9;
+
         private readonly ProbabilityData<T>[] _values;
         private readonly T[] _aliases;
 
         /// <summary>
-        /// Generates a probability table based on a collection of <see cref="WeightedValue{T}"/> objects.
+        /// Generates a probability table based on a collection of <see cref="WeightedValue{T}"/> objects
+        /// using Vose's alias method.
         /// </summary>
-        /// <param name="values"></param>
+        /// <param name="values">The weighted values to build the table from.</param>
         public ProbabilityTable(IEnumerable<WeightedValue<T>> values)
         {
-            // Convert to list to avoid repeated enumeration of a potential linq expression
+            // Convert to list to avoid repeated enumeration of a potential linq expression.
             var valueList = values.ToList();
 
             if (valueList.Count <= 0)
@@ -23,14 +29,13 @@
             }
 
             _values = new ProbabilityData<T>[valueList.Count];
-            _aliases = new T[_values.Length];
-            var valuesCurrentIndex = 0;
-            var aliasesCurrentIndex = 0;
+            _aliases = new T[valueList.Count];
             var averageWeight = valueList.Average(x => x.Weight);
-            var smallList = new List<NormalizedWeightedValue<T>>(valueList.Count); //List to hold values where probability is less than average;
-            var bigList = new List<NormalizedWeightedValue<T>>(valueList.Count); //List to hold values where probability is greater than average;
 
-            // sort each value into either the small list, big list, or final list (_values) based on weight relative to average;
+            // Lists hold values whose normalized weight is below/at-or-above the average (1.0).
+            var smallList = new List<NormalizedWeightedValue<T>>(valueList.Count);
+            var bigList = new List<NormalizedWeightedValue<T>>(valueList.Count);
+
             foreach (var value in valueList)
             {
                 if (value.Weight < 0)
@@ -38,15 +43,11 @@
                     throw new ArgumentException($"{nameof(values)} cannot contain an element with a negative weight.", nameof(values));
                 }
 
-                var weight = value.Weight / averageWeight;
-                if (weight < 1)
+                // When every weight is zero the average is zero; treat all entries as uniform (weight 1.0).
+                var weight = averageWeight == 0 ? 1.0 : value.Weight / averageWeight;
+                if (weight < 1.0 - Epsilon)
                 {
                     smallList.Add(new(value.Value, weight));
-                }
-                else if (weight == 1.0)
-                {
-                    _values[valuesCurrentIndex] = new ProbabilityData<T>(value.Value, 1.0, -1);
-                    valuesCurrentIndex++;
                 }
                 else
                 {
@@ -54,47 +55,46 @@
                 }
             }
 
-            if (bigList.Count == 0)
-            {
-                return;
-            }
+            var valuesIndex = 0;
+            var aliasesIndex = 0;
 
-            var bigIndex = 0;
-
-            // For each element in the small list, fill its missing weight from an element in the bigList.
-            // Don't use foreach because smallList will have items added to it as we take weight from items in the bigList.
-            for (int smallIndex = 0; smallIndex < smallList.Count; smallIndex++)
+            // While both lists have entries, pair a small entry with a big one to fill a full column.
+            while (smallList.Count > 0 && bigList.Count > 0)
             {
-                if (bigIndex < bigList.Count)
+                var small = smallList[^1];
+                smallList.RemoveAt(smallList.Count - 1);
+                var big = bigList[^1];
+                bigList.RemoveAt(bigList.Count - 1);
+
+                _values[valuesIndex] = new ProbabilityData<T>(small.Value, small.NormalizedWeight, aliasesIndex);
+                valuesIndex++;
+                _aliases[aliasesIndex] = big.Value;
+                aliasesIndex++;
+
+                // Reduce the big entry by the portion donated to the small column and requeue it.
+                big.NormalizedWeight -= 1.0 - small.NormalizedWeight;
+                if (big.NormalizedWeight < 1.0 - Epsilon)
                 {
-                    var currentBig = bigList[bigIndex];
-                    var currentSmall = smallList[smallIndex];
-
-                    // Remove portion of big probability to give to small.
-                    currentBig.NormalizedWeight -= 1.0 - currentSmall.NormalizedWeight;
-
-                    // Add new entry in probabilities table for small and alias for big.
-                    _values[valuesCurrentIndex] = new ProbabilityData<T>(currentSmall.Value, currentSmall.NormalizedWeight, aliasesCurrentIndex);
-                    valuesCurrentIndex++;
-                    _aliases[aliasesCurrentIndex] = currentBig.Value;
-                    aliasesCurrentIndex++;
-
-                    // If big now has probability less than one than move to small list.
-                    if (currentBig.NormalizedWeight < 1.0)
-                    {
-                        bigIndex++;
-                        smallList.Add(currentBig);
-                    }
+                    smallList.Add(big);
                 }
                 else
                 {
-                    _values[valuesCurrentIndex] = new ProbabilityData<T>(smallList[smallIndex].Value, 1.0, -1);
+                    bigList.Add(big);
                 }
             }
 
-            if (bigIndex < bigList.Count)
+            // Any remaining entries occupy a full column on their own (alias unused).
+            foreach (var big in bigList)
             {
-                _values[valuesCurrentIndex] = new ProbabilityData<T>(bigList[bigIndex].Value, 1.0, -1);
+                _values[valuesIndex] = new ProbabilityData<T>(big.Value, 1.0, -1);
+                valuesIndex++;
+            }
+
+            // Leftover small entries arise only from floating-point residue; they also fill a full column.
+            foreach (var small in smallList)
+            {
+                _values[valuesIndex] = new ProbabilityData<T>(small.Value, 1.0, -1);
+                valuesIndex++;
             }
         }
 
@@ -109,11 +109,16 @@
         public T GetRandomValue()
         {
             var rand = Random.Shared.NextDouble() * _values.Length;
-            var randInt = (int)double.Floor(rand);
-            var remainder = rand - randInt;
-            var data = _values[randInt];
+            // Clamp to a valid index in case NextDouble() returns a value close enough to 1.0
+            // that the scaled product rounds up to _values.Length.
+            var index = Math.Clamp((int)double.Floor(rand), 0, _values.Length - 1);
+            var remainder = rand - index;
+            var data = _values[index];
 
-            return remainder <= data.Probability ? data.Value : _aliases[data.AliasIndex];
+            // Use the alias only when the draw falls into the donated portion and an alias exists.
+            return remainder < data.Probability || data.AliasIndex < 0
+                ? data.Value
+                : _aliases[data.AliasIndex];
         }
     }
 }


### PR DESCRIPTION
## Summary

`ProbabilityTable` builds a Vose alias table whose slot-count accounting relied on residual normalized weights landing exactly on `1.0` and on an exact `weight == 1.0` classification. With weights that don't divide evenly, floating-point residue could leave a `_values` slot unpopulated (`null` reference record), and the early `return` when `bigList` was empty compounded this. A null slot would throw `NullReferenceException`, and a stale `AliasIndex == -1` paired with `remainder > Probability` would index `_aliases[-1]` (`IndexOutOfRangeException`). These fire at enemy-roll time for per-zone spawn tables (`EnemiesCacheHolder` / `Enemies.GetRandomEnemy`), so a malformed/uneven authored weight set could crash rather than degrade.

## Changes

- **Construction** rewritten as a standard Vose alias method that always fills every column:
  - Classify normalized weights with an epsilon tolerance instead of an exact `== 1.0` comparison.
  - Pair small/big entries in a single loop, then drain any leftover entries from either list into full columns, so every `_values` slot is populated regardless of floating-point residue (removes the early-return null-slot hazard).
  - Handle the all-zero-weight case (zero average) by falling back to a uniform distribution instead of dividing by zero.
- **Draw (`GetRandomValue`)** hardened:
  - Clamp the computed index into valid bounds in case `NextDouble()` scales close enough to `_values.Length`.
  - Use the standard strict `remainder < Probability` comparison (the old `<=` added a small upward bias to the non-alias bucket).
  - Return the entry's own value when no alias exists (`AliasIndex < 0`) instead of indexing `_aliases[-1]`.

## Tests

Added unit tests in `ProbabilityTableTests` covering unevenly-dividing weights (thirds, prime weights, heavy skew, embedded zero weights) that assert every draw returns a valid value and the distribution stays reasonable, plus single-entry, single-zero-weight, and all-zero-weight tables.

Build and test commands run locally:
- `dotnet build Game.sln` — succeeded (0 errors; 2 pre-existing unrelated `IDE0011` warnings in `PlayerMapper.cs`).
- `dotnet test Game.Core.Tests` — passed (196 total, 15 in `ProbabilityTableTests`).

## Follow-ups

- Pre-existing `IDE0011` (missing braces) warnings in `Game.DataAccess/Mapping/PlayerMapper.cs` lines 27 and 36 violate the project's brace guideline; worth a small tech-debt cleanup.

Closes #582

https://claude.ai/code/session_01B59BYxC4Cw62VgUB3yY8EX

---
_Generated by [Claude Code](https://claude.ai/code/session_01B59BYxC4Cw62VgUB3yY8EX)_