### PR TITLE
Remove unused UnlockRewardKind type alias

### DIFF
--- a/UI/src/lib/common/challenge-unlocks.ts
+++ b/UI/src/lib/common/challenge-unlocks.ts
@@ -10,8 +10,6 @@ import { rarityColor, rarityLabel } from './rarity';
    and the rarity/accent/sub-label of a reward; richer surfaces (the challenges screen's
    `resolveReward`) build their preview on top of this resolution rather than re-deriving it. */
 
-export type UnlockRewardKind = 'item' | 'mod' | 'skill';
-
 interface UnlockRewardBase {
 	/** The reward's real name. Callers mask it themselves (e.g. `???`) while the challenge is sealed. */
 	name: string;


### PR DESCRIPTION
## Summary

PR #573 refactored `UnlockReward` (`UI/src/lib/common/challenge-unlocks.ts`) from a flat interface into a discriminated union (`ItemUnlockReward | ModUnlockReward | SkillUnlockReward`), where each member declares its own `kind` string literal. That made the pre-existing `export type UnlockRewardKind = 'item' | 'mod' | 'skill';` alias dead code — nothing referenced it anymore.

This change removes that alias, per CLAUDE.md's guidance on not leaving dead code (unused types) behind.

## Verification

- Grepped the entire `UI/src` tree for `UnlockRewardKind` before and after: the alias was the only occurrence, and there are now zero references. No other symbol was orphaned by the removal (`UnlockRewardBase`, the union members, `UnlockReward`, `RewardRefs`, and the two helper functions all remain in use).
- `npm --prefix UI run check` — passed (0 errors, 0 warnings, 893 files).
- `npm --prefix UI run test:unit -- --run` — passed (1638 tests across 171 files).

Closes #602

https://claude.ai/code/session_01B59BYxC4Cw62VgUB3yY8EX

---
_Generated by [Claude Code](https://claude.ai/code/session_01B59BYxC4Cw62VgUB3yY8EX)_