### PR TITLE
Clear combat log and reset its id counter on game stop

### DIFF
--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -7,7 +7,7 @@ import { RenderEngine } from './render-engine';
 import { LogicalEngine } from './logical-engine';
 import { InventoryManager } from './player/inventory-manager';
 import { EnemyManager } from './battle/enemy-manager';
-import { staticData, statistics, playerChallenges, acknowledgeModal } from '$stores';
+import { staticData, statistics, playerChallenges, acknowledgeModal, resetLogs } from '$stores';
 import { apiSocket, type IApiSocketResponse } from '$lib/api';
 import { playerManager } from './player/player-manager';
 
@@ -90,6 +90,7 @@ const stopGame = () => {
 	battleEngine.stop();
 	statistics.reset();
 	playerChallenges.reset();
+	resetLogs();
 	socketReplacedUnhook?.();
 	challengeCompletedUnhook?.();
 };

--- a/UI/src/lib/engine/log.ts
+++ b/UI/src/lib/engine/log.ts
@@ -1,6 +1,6 @@
 import { ELogType } from '$lib/api';
 import { playerManager } from './player/player-manager';
-import { logs } from '$stores';
+import { addLog } from '$stores';
 
 export interface LogMessage {
 	id: number;
@@ -8,20 +8,8 @@ export interface LogMessage {
 	message: string;
 }
 
-const maxLogEntries = 40;
-
-let id = (logs()?.[0]?.id ?? -1) + 1;
-
 export const logMessage = (logType: ELogType, message: string) => {
 	if (playerManager.logTypeEnabled(logType)) {
-		if (logs().length >= maxLogEntries) {
-			logs().pop();
-		}
-		id++;
-		logs().unshift({
-			id,
-			logType,
-			message
-		});
+		addLog(logType, message);
 	}
 };

--- a/UI/src/stores/logs.svelte.ts
+++ b/UI/src/stores/logs.svelte.ts
@@ -1,5 +1,26 @@
 import { LogMessage } from '$lib/engine/log';
+import { ELogType } from '$lib/api';
+
+const maxLogEntries = 40;
 
 const logsData = $state<LogMessage[]>([]);
+// 1-based running count of entries this session; doubles as each entry's monotonic id and
+// backs the log panel's total-events readout.
+let lastId = 0;
 
 export const logs = () => logsData;
+
+/** Prepend a combat-log entry (newest-first), assigning its id and capping the list length. */
+export const addLog = (logType: ELogType, message: string) => {
+	if (logsData.length >= maxLogEntries) {
+		logsData.pop();
+	}
+	logsData.unshift({ id: ++lastId, logType, message });
+};
+
+/** Clear the combat log and its id counter (e.g. on logout / session replacement) so the
+ *  previous session's entries don't leak into the next one. */
+export const resetLogs = () => {
+	logsData.length = 0;
+	lastId = 0;
+};

--- a/UI/src/tests/lib/engine/engine.test.ts
+++ b/UI/src/tests/lib/engine/engine.test.ts
@@ -12,10 +12,11 @@ vi.mock('$app/paths', () => ({ resolve: (path: string) => path }));
 
 // Use the real modal store (so the full show → acknowledge → navigate flow is exercised) but stub
 // staticData so we can toggle whether startGame runs.
-const { staticDataStub, statisticsStub, playerChallengesStub } = vi.hoisted(() => ({
+const { staticDataStub, statisticsStub, playerChallengesStub, resetLogs } = vi.hoisted(() => ({
 	staticDataStub: { loaded: true },
 	statisticsStub: { load: vi.fn(), reset: vi.fn() },
-	playerChallengesStub: { load: vi.fn(), reset: vi.fn(), markCompleted: vi.fn() }
+	playerChallengesStub: { load: vi.fn(), reset: vi.fn(), markCompleted: vi.fn() },
+	resetLogs: vi.fn()
 }));
 vi.mock('$stores', async () => {
 	const modal = await vi.importActual<typeof import('$stores/modal.svelte')>('$stores/modal.svelte');
@@ -23,7 +24,8 @@ vi.mock('$stores', async () => {
 		...modal,
 		staticData: staticDataStub,
 		statistics: statisticsStub,
-		playerChallenges: playerChallengesStub
+		playerChallenges: playerChallengesStub,
+		resetLogs
 	};
 });
 
@@ -122,6 +124,12 @@ describe('handleSocketReplaced', () => {
 		expect(renderEngine.stop).toHaveBeenCalledTimes(1);
 		expect(enemyManager.stop).toHaveBeenCalledTimes(1);
 		expect(battleEngine.stop).toHaveBeenCalledTimes(1);
+	});
+
+	it('resets the combat log so its entries do not leak into the next session', () => {
+		void handleSocketReplaced();
+
+		expect(resetLogs).toHaveBeenCalledTimes(1);
 	});
 
 	it('shows an acknowledgement modal with the session-replaced title and body', () => {

--- a/UI/src/tests/lib/engine/log.test.ts
+++ b/UI/src/tests/lib/engine/log.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ELogType } from '$lib/api';
 
-const { mockLogs, mockPlayerManager } = vi.hoisted(() => {
-	const mockLogs: { id: number; logType: number; message: string }[] = [];
+const { addLog, mockPlayerManager } = vi.hoisted(() => {
+	const addLog = vi.fn();
 	// Mirrors PlayerManager's prebuilt map: an unknown type defaults to enabled.
 	const mockPlayerManager = {
 		logPreferences: [] as { id: number; enabled: boolean }[],
@@ -10,7 +10,7 @@ const { mockLogs, mockPlayerManager } = vi.hoisted(() => {
 			return mockPlayerManager.logPreferences.find((pref) => pref.id === logType)?.enabled ?? true;
 		}
 	};
-	return { mockLogs, mockPlayerManager };
+	return { addLog, mockPlayerManager };
 });
 
 vi.mock('$lib/engine/player/player-manager', () => ({
@@ -19,15 +19,14 @@ vi.mock('$lib/engine/player/player-manager', () => ({
 	}
 }));
 
-vi.mock('$stores', () => ({
-	logs: () => mockLogs
-}));
+// logMessage only gates on the player's preferences and delegates the append to the logs store.
+vi.mock('$stores', () => ({ addLog }));
 
 import { logMessage } from '$lib/engine/log';
 
 describe('logMessage', () => {
 	beforeEach(() => {
-		mockLogs.length = 0;
+		addLog.mockClear();
 		mockPlayerManager.logPreferences = [
 			{ id: ELogType.Damage, enabled: false },
 			{ id: ELogType.Exp, enabled: true },
@@ -36,47 +35,21 @@ describe('logMessage', () => {
 		];
 	});
 
-	it('adds message for enabled log type', () => {
+	it('forwards an enabled log type to the store', () => {
 		logMessage(ELogType.Exp, 'Earned 50 exp.');
 
-		expect(mockLogs.length).toBe(1);
-		expect(mockLogs[0].logType).toBe(ELogType.Exp);
-		expect(mockLogs[0].message).toBe('Earned 50 exp.');
+		expect(addLog).toHaveBeenCalledWith(ELogType.Exp, 'Earned 50 exp.');
 	});
 
-	it('does not add message for disabled log type', () => {
+	it('does not forward a disabled log type', () => {
 		logMessage(ELogType.Damage, 'Hit for 10 damage.');
 
-		expect(mockLogs.length).toBe(0);
+		expect(addLog).not.toHaveBeenCalled();
 	});
 
-	it('adds message for unknown log type (defaults to enabled)', () => {
+	it('forwards an unknown log type (defaults to enabled)', () => {
 		logMessage(ELogType.EnemyDefeated, 'Enemy defeated!');
 
-		expect(mockLogs.length).toBe(1);
-		expect(mockLogs[0].message).toBe('Enemy defeated!');
-	});
-
-	it('prepends new messages to the front', () => {
-		logMessage(ELogType.Exp, 'First');
-		logMessage(ELogType.Exp, 'Second');
-
-		expect(mockLogs[0].message).toBe('Second');
-		expect(mockLogs[1].message).toBe('First');
-	});
-
-	it('assigns incrementing ids', () => {
-		logMessage(ELogType.Exp, 'A');
-		logMessage(ELogType.LevelUp, 'B');
-
-		expect(mockLogs[0].id).toBeGreaterThan(mockLogs[1].id);
-	});
-
-	it('caps log list at 40 entries', () => {
-		for (let i = 0; i < 45; i++) {
-			logMessage(ELogType.Exp, `Message ${i}`);
-		}
-
-		expect(mockLogs.length).toBeLessThanOrEqual(40);
+		expect(addLog).toHaveBeenCalledWith(ELogType.EnemyDefeated, 'Enemy defeated!');
 	});
 });

--- a/UI/src/tests/stores/logs.test.ts
+++ b/UI/src/tests/stores/logs.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ELogType } from '$lib/api';
+import { logs, addLog, resetLogs } from '$stores/logs.svelte';
+
+describe('logs store', () => {
+	beforeEach(() => {
+		resetLogs();
+	});
+
+	it('prepends new entries newest-first', () => {
+		addLog(ELogType.Exp, 'First');
+		addLog(ELogType.Exp, 'Second');
+
+		expect(logs().map((l) => l.message)).toEqual(['Second', 'First']);
+	});
+
+	it('assigns incrementing ids', () => {
+		addLog(ELogType.Exp, 'A');
+		addLog(ELogType.LevelUp, 'B');
+
+		// Newest-first, so index 0 (the latest) holds the higher id.
+		expect(logs()[0].id).toBeGreaterThan(logs()[1].id);
+	});
+
+	it('caps the list at 40 entries, dropping the oldest', () => {
+		for (let i = 0; i < 45; i++) {
+			addLog(ELogType.Exp, `Message ${i}`);
+		}
+
+		expect(logs()).toHaveLength(40);
+		expect(logs()[0].message).toBe('Message 44'); // newest kept
+		expect(logs()[39].message).toBe('Message 5'); // oldest five dropped
+	});
+
+	it('resetLogs clears the entries so a prior session does not leak into the next', () => {
+		addLog(ELogType.Exp, 'Stale');
+		expect(logs()).toHaveLength(1);
+
+		resetLogs();
+
+		expect(logs()).toHaveLength(0);
+	});
+
+	it('resetLogs resets the id counter so ids restart from 1', () => {
+		addLog(ELogType.Exp, 'A');
+		addLog(ELogType.Exp, 'B');
+		expect(logs()[0].id).toBe(2);
+
+		resetLogs();
+		addLog(ELogType.Exp, 'C');
+
+		expect(logs()[0].id).toBe(1);
+	});
+});


### PR DESCRIPTION
## Problem

The combat `logs` store (`UI/src/stores/logs.svelte.ts`) and the module-level log `id` counter in `UI/src/lib/engine/log.ts` persisted across a logout / session-replacement. `stopGame()` reset the `statistics` and `playerChallenges` stores but not the logs, so the previous session's combat-log entries leaked into the next logged-in user's panel until they scrolled off — a privacy/correctness wart (capped at 40 entries, so staleness rather than unbounded growth).

While an explicit logout's full-page navigation happens to wipe module state, the in-app `SocketReplaced` teardown path (`handleSocketReplaced`) uses `goto()` and does **not** reload the page, so the stale log genuinely survived into the next session there.

## Change

- **Single owner for the log data and counter.** Moved the `id` counter and the append/cap logic into the `logs` store as `addLog`, and added `resetLogs` to clear the array and the counter atomically. This follows the issue's suggested fix (move the counter into the store so it resets consistently) and keeps the data + counter from drifting apart.
- **`logMessage` keeps only its policy concern** — gating on the player's `logTypeEnabled` preference — and delegates the append to `addLog` (DRY; no duplicated cap/id logic).
- **`stopGame()` now calls `resetLogs()`** alongside the other game-state resets, so both teardown paths (the quit control's `logout()` and the `SocketReplaced` handler) truly reset the combat log between sessions.

## Tests

- New `UI/src/tests/stores/logs.test.ts` covers `addLog` (newest-first prepend, incrementing ids, 40-entry cap) and `resetLogs` (clears entries and restarts ids from 1).
- `log.test.ts` retargeted to `logMessage`'s remaining responsibility (gating + delegation to the store); the id/cap/prepend assertions now live with the store logic in `logs.test.ts`.
- `engine.test.ts` asserts `stopGame` (via `handleSocketReplaced`) calls `resetLogs`.

Verified locally: `npm --prefix UI run test:unit -- --run` (1641 passed) and `npm --prefix UI run check` (0 errors, 0 warnings).

Closes #592

https://claude.ai/code/session_01B59BYxC4Cw62VgUB3yY8EX

---
_Generated by [Claude Code](https://claude.ai/code/session_01B59BYxC4Cw62VgUB3yY8EX)_