### PR TITLE
chore: ignore transient agent worktrees under .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 # Backing-service marker written by .claude/hooks/session-start.sh in constrained sandboxes
 .container-info.json
 
+# Transient isolated git worktrees created for background agents
+.claude/worktrees/
+
 # Redis persistence dump generated when running redis-server locally
 dump.rdb
 


### PR DESCRIPTION
## Summary

Background agents (Claude Code's isolated-worktree mode) materialize their git worktrees under `.claude/worktrees/`, which otherwise shows up as untracked content in the primary working tree. This adds a `.gitignore` rule so those transient worktrees are never accidentally staged or committed.

This is session-orchestration housekeeping; the actual backlog work lands in its own per-issue PRs.

## Test plan
- `git status --porcelain` is clean with the rule in place (the `.claude/worktrees/` entry no longer appears as untracked).

https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw)_