### PR TITLE
fix(a11y): add labels, autocomplete, and aria to the login form

### DIFF
--- a/UI/src/routes/+page.svelte
+++ b/UI/src/routes/+page.svelte
@@ -7,6 +7,9 @@
 		<form onsubmit={preventDefault(handleSubmit)}>
 			<UnderlineInput
 				testid="username-input"
+				id="username"
+				label="Username"
+				autocomplete="username"
 				placeholder="Username"
 				bind:value={username}
 				onblur={() => (touched.username = true)}
@@ -22,6 +25,9 @@
 
 			<UnderlineInput
 				testid="password-input"
+				id="password"
+				label="Password"
+				autocomplete={mode === 'signup' ? 'new-password' : 'current-password'}
 				type={showPassword ? 'text' : 'password'}
 				placeholder="Password"
 				bind:value={password}
@@ -36,6 +42,8 @@
 						type="button"
 						class="eye-button"
 						data-testid="password-toggle"
+						aria-label={showPassword ? 'Hide password' : 'Show password'}
+						aria-pressed={showPassword}
 						onclick={() => (showPassword = !showPassword)}
 					>
 						<EyeIcon visible={showPassword} />
@@ -43,7 +51,7 @@
 				{/snippet}
 				{#snippet below()}
 					{#if mode === 'signup' && password}
-						<PasswordStrengthMeter score={strength.score} />
+						<PasswordStrengthMeter score={strength.score} label={strength.label} />
 					{/if}
 				{/snippet}
 			</UnderlineInput>
@@ -51,6 +59,9 @@
 			{#if mode === 'signup'}
 				<UnderlineInput
 					testid="confirm-input"
+					id="confirm-password"
+					label="Confirm password"
+					autocomplete="new-password"
 					type={showPassword ? 'text' : 'password'}
 					placeholder="Confirm password"
 					bind:value={confirm}

--- a/UI/src/routes/login/PasswordStrengthMeter.svelte
+++ b/UI/src/routes/login/PasswordStrengthMeter.svelte
@@ -1,4 +1,15 @@
-<div class="strength-meter" data-testid="strength-meter">
+<!-- role="meter" gives the strength a non-visual, text equivalent so the level isn't conveyed by
+	colour alone (WCAG 1.4.1). aria-valuetext announces the human-readable label, e.g. "Strong". -->
+<div
+	class="strength-meter"
+	data-testid="strength-meter"
+	role="meter"
+	aria-label="Password strength"
+	aria-valuemin={0}
+	aria-valuemax={4}
+	aria-valuenow={score}
+	aria-valuetext={label}
+>
 	{#each [0, 1, 2, 3] as i (i)}
 		<div class="strength-segment" style:background={i < score ? fillColor : EMPTY_COLOR}></div>
 	{/each}
@@ -7,8 +18,14 @@
 <script lang="ts">
 const EMPTY_COLOR = 'color-mix(in srgb, var(--text-primary) 22%, transparent)';
 
-/** Number of filled segments, 0–4 (see {@link passwordStrength}). */
-let { score }: { score: number } = $props();
+interface Props {
+	/** Number of filled segments, 0–4 (see {@link passwordStrength}). */
+	score: number;
+	/** Human-readable strength label announced to screen readers (see {@link passwordStrength}). */
+	label: string;
+}
+
+let { score, label }: Props = $props();
 
 const fillColor = $derived(score >= 3 ? 'var(--success)' : score >= 2 ? 'var(--warning)' : 'var(--error)');
 </script>

--- a/UI/src/routes/login/UnderlineInput.svelte
+++ b/UI/src/routes/login/UnderlineInput.svelte
@@ -1,7 +1,12 @@
 <div class="field-group">
+	{#if label}
+		<label class="sr-only" for={id}>{label}</label>
+	{/if}
 	<input
+		{id}
 		{type}
 		{placeholder}
+		{autocomplete}
 		bind:value
 		data-testid={testid}
 		{onblur}
@@ -23,6 +28,7 @@
 
 <script lang="ts">
 import type { Snippet } from 'svelte';
+import type { HTMLInputAttributes } from 'svelte/elements';
 
 interface Props {
 	/** Two-way bound input value. */
@@ -30,6 +36,12 @@ interface Props {
 	type?: 'text' | 'password';
 	placeholder: string;
 	testid: string;
+	/** DOM id, associating the input with its label and enabling label-driven focus. */
+	id?: string;
+	/** Visually-hidden accessible name for the input (announced by screen readers). */
+	label?: string;
+	/** Autofill hint for password managers (e.g. 'username', 'current-password', 'new-password'). */
+	autocomplete?: HTMLInputAttributes['autocomplete'];
 	/** Applies the error accent to the underline. */
 	error?: boolean;
 	/** Applies the valid accent to the underline. */
@@ -48,6 +60,9 @@ let {
 	type = 'text',
 	placeholder,
 	testid,
+	id,
+	label,
+	autocomplete,
 	error = false,
 	valid = false,
 	onblur,
@@ -62,6 +77,19 @@ let {
 .field-group {
 	position: relative;
 	margin-bottom: 22px;
+}
+
+// Accessible label for screen readers without showing visible text.
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
 }
 
 .underline-input {

--- a/UI/src/tests/routes/login.test.ts
+++ b/UI/src/tests/routes/login.test.ts
@@ -114,4 +114,52 @@ describe('Login page', () => {
 
 		expect(screen.getByTestId('strength-meter')).toBeTruthy();
 	});
+
+	it('associates each input with an accessible label', () => {
+		render(LoginPage);
+
+		expect(screen.getByLabelText('Username')).toBe(screen.getByTestId('username-input'));
+		expect(screen.getByLabelText('Password')).toBe(screen.getByTestId('password-input'));
+	});
+
+	it('sets autocomplete hints for password-manager integration', async () => {
+		render(LoginPage);
+		const username = screen.getByTestId('username-input') as HTMLInputElement;
+		const password = screen.getByTestId('password-input') as HTMLInputElement;
+
+		expect(username.getAttribute('autocomplete')).toBe('username');
+		// Sign-in asks for the existing password; signup is choosing a new one.
+		expect(password.getAttribute('autocomplete')).toBe('current-password');
+
+		await fireEvent.click(screen.getByTestId('mode-toggle'));
+		const signupPassword = screen.getByTestId('password-input') as HTMLInputElement;
+		const confirmPassword = screen.getByTestId('confirm-input') as HTMLInputElement;
+		expect(signupPassword.getAttribute('autocomplete')).toBe('new-password');
+		expect(confirmPassword.getAttribute('autocomplete')).toBe('new-password');
+	});
+
+	it('exposes the reveal toggle state via aria-pressed and aria-label', async () => {
+		render(LoginPage);
+		const toggle = screen.getByTestId('password-toggle');
+
+		expect(toggle.getAttribute('aria-pressed')).toBe('false');
+		expect(toggle.getAttribute('aria-label')).toBe('Show password');
+
+		await fireEvent.click(toggle);
+		expect(toggle.getAttribute('aria-pressed')).toBe('true');
+		expect(toggle.getAttribute('aria-label')).toBe('Hide password');
+	});
+
+	it('gives the strength meter a text-equivalent role and value', async () => {
+		render(LoginPage);
+
+		await fireEvent.click(screen.getByTestId('mode-toggle'));
+		await fireEvent.input(screen.getByTestId('password-input'), { target: { value: 'Test123!' } });
+
+		const meter = screen.getByTestId('strength-meter');
+		expect(meter.getAttribute('role')).toBe('meter');
+		// 'Test123!' scores length>=8, mixed case, a digit and a symbol => 4 points.
+		expect(meter.getAttribute('aria-valuenow')).toBe('4');
+		expect(meter.getAttribute('aria-valuetext')).toBe('Strong');
+	});
 });


### PR DESCRIPTION
## Summary

The login/create-account form was placeholder-only, leaving screen-reader, colorblind, and password-manager users unsupported. This threads proper semantics through the shared login components without changing their look:

- **`UnderlineInput`** now accepts optional `id`, `label`, and `autocomplete` props. When `label` is set it renders a visually-hidden (`sr-only`) `<label for={id}>`, giving each input a real accessible name (a placeholder is not one). All new props are optional with sensible defaults so existing consumers are unaffected.
- **`+page.svelte`** wires those props for all three fields: `autocomplete="username"`, and `current-password` for sign-in vs `new-password` for signup/confirm, restoring password-manager autofill.
- **Password-reveal toggle** gains `aria-label` ("Show/Hide password") and `aria-pressed` reflecting its state.
- **`PasswordStrengthMeter`** gets `role="meter"` with `aria-valuemin`/`max`/`now` and `aria-valuetext` (the human-readable label, e.g. "Strong"), so strength is announced as text rather than conveyed by segment color alone (WCAG 1.4.1). The label reuses the existing single-source `passwordStrength` helper.

## Test plan

- Added unit tests in `login.test.ts` asserting: each input is reachable via `getByLabelText`; autocomplete hints (and the mode-dependent `current-password` -> `new-password` switch); `aria-pressed`/`aria-label` toggling on the reveal button; and the meter's `role`/`aria-valuenow`/`aria-valuetext`.
- `npm run lint` (eslint + svelte-check): pass (0 errors, 0 warnings).
- `npm run test:unit:ci`: pass (172 files, 1645 tests).

Closes #593

https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw)_