### PR TITLE
chore: remove dead backend code and fix inconsistent diagnostics

### DIFF
--- a/Game.Api/Models/Common/ApiResponse.cs
+++ b/Game.Api/Models/Common/ApiResponse.cs
@@ -79,24 +79,6 @@
                 ErrorMessage = message
             };
         }
-
-        public static ApiResponse<T> ErrorWithData<T>(string message, T data) where T : IModel
-        {
-            return new ApiResponse<T>
-            {
-                Data = data,
-                ErrorMessage = message
-            };
-        }
-
-        public static ApiEnumerableResponse<T> ErrorWithListData<T>(string message, List<T> data) where T : IModel
-        {
-            return new ApiEnumerableResponse<T>
-            {
-                Data = data,
-                ErrorMessage = message
-            };
-        }
     }
 
     public interface IApiAsyncEnumerableResponse<T> : IApiCollectionResponse where T : IModel

--- a/Game.Api/Models/Enemies/NewEnemyModel.cs
+++ b/Game.Api/Models/Enemies/NewEnemyModel.cs
@@ -1,6 +1,4 @@
-﻿using Game.Api.Models;
-
-namespace Game.Api.Models.Enemies
+﻿namespace Game.Api.Models.Enemies
 {
     public class NewEnemyModel : IModel
     {

--- a/Game.Api/Models/Player/LoginData.cs
+++ b/Game.Api/Models/Player/LoginData.cs
@@ -1,8 +1,0 @@
-﻿namespace Game.Api.Models.Player
-{
-    public class LoginData : IModel
-    {
-        public int CurrentZone { get; set; }
-        public required PlayerData PlayerData { get; set; }
-    }
-}

--- a/Game.Core/Attributes/Modifiers/ModifierTypeNotSupportedException.cs
+++ b/Game.Core/Attributes/Modifiers/ModifierTypeNotSupportedException.cs
@@ -9,6 +9,6 @@
         /// The default constructor.
         /// </summary>
         /// <param name="type"></param>
-        public ModifierTypeNotSupportedException(EModifierType type) : base($"The type ${type} is not supported by this class.") { }
+        public ModifierTypeNotSupportedException(EModifierType type) : base($"The type {type} is not supported by this class.") { }
     }
 }

--- a/Game.DataAccess/DatabaseMigrator.cs
+++ b/Game.DataAccess/DatabaseMigrator.cs
@@ -11,7 +11,7 @@ namespace Game.DataAccess
         public async Task Migrate()
         {
             var start = Stopwatch.GetTimestamp();
-            logger.LogDebug($"Beginning migration.");
+            logger.LogDebug("Beginning migration.");
 
             await context.Database.MigrateAsync();
 

--- a/Game.DataAccess/Mapping/ItemMapper.cs
+++ b/Game.DataAccess/Mapping/ItemMapper.cs
@@ -15,7 +15,7 @@ namespace Game.DataAccess.Mapping
             {
                 Id = entity.Id,
                 Name = entity.Name,
-                Description = entity.Description ?? string.Empty,
+                Description = entity.Description,
                 Category = (EItemCategory)entity.ItemCategoryId,
                 Rarity = (ERarity)entity.RarityId,
                 Attributes = entity.ItemAttributes
@@ -43,7 +43,7 @@ namespace Game.DataAccess.Mapping
             {
                 Id = entity.Id,
                 Name = entity.Name,
-                Description = entity.Description ?? string.Empty,
+                Description = entity.Description,
                 Type = (EItemModType)entity.ItemModTypeId,
                 Rarity = (ERarity)entity.RarityId,
                 Attributes = entity.ItemModAttributes

--- a/Game.Infrastructure.Tests/CacheServiceFactoryTests.cs
+++ b/Game.Infrastructure.Tests/CacheServiceFactoryTests.cs
@@ -1,0 +1,31 @@
+using Game.Abstractions.Infrastructure;
+using Game.Infrastructure.Cache;
+using Xunit;
+
+namespace Game.Infrastructure.Tests
+{
+    /// <summary>
+    /// Tests that <see cref="CacheServiceFactory"/> fails loud on an unsupported <see cref="CacheSystem"/>
+    /// rather than silently defaulting to Redis (the fail-loud convention #453 established). The happy path
+    /// (Redis) opens a real connection, so it is covered by integration tests rather than here — selecting an
+    /// unknown value never reaches the multiplexer, so this stays an in-process unit test. Note that, unlike
+    /// <see cref="DatabaseSystem"/>, the enum's default (0) is the valid <see cref="CacheSystem.Redis"/> member,
+    /// so only a genuinely unrecognized value can trip the guard.
+    /// </summary>
+    public class CacheServiceFactoryTests
+    {
+        [Fact]
+        public void GetCacheService_ForUnknownCacheSystem_ThrowsInvalidOperationException()
+        {
+            var options = new InfrastructureOptions
+            {
+                CacheSystem = (CacheSystem)99,
+                CacheConnectionString = "localhost"
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => CacheServiceFactory.GetCacheService(options));
+            Assert.Contains("CacheSystem", ex.Message);
+        }
+    }
+}

--- a/Game.Infrastructure.Tests/PubSubServiceFactoryTests.cs
+++ b/Game.Infrastructure.Tests/PubSubServiceFactoryTests.cs
@@ -1,0 +1,32 @@
+using Game.Abstractions.Infrastructure;
+using Game.Infrastructure.PubSub;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Game.Infrastructure.Tests
+{
+    /// <summary>
+    /// Tests that <see cref="PubSubServiceFactory"/> fails loud on an unsupported <see cref="PubSubSystem"/>
+    /// rather than silently defaulting to Redis (the fail-loud convention #453 established). The happy path
+    /// (Redis) opens a real connection, so it is covered by integration tests rather than here — selecting an
+    /// unknown value never reaches the multiplexer, so this stays an in-process unit test. Note that, unlike
+    /// <see cref="DatabaseSystem"/>, the enum's default (0) is the valid <see cref="PubSubSystem.Redis"/> member,
+    /// so only a genuinely unrecognized value can trip the guard.
+    /// </summary>
+    public class PubSubServiceFactoryTests
+    {
+        [Fact]
+        public void GetPubSubService_ForUnknownPubSubSystem_ThrowsInvalidOperationException()
+        {
+            var options = new InfrastructureOptions
+            {
+                PubSubSystem = (PubSubSystem)99,
+                PubSubConnectionString = "localhost"
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => PubSubServiceFactory.GetPubSubService(options, NullLoggerFactory.Instance));
+            Assert.Contains("PubSubSystem", ex.Message);
+        }
+    }
+}

--- a/Game.Infrastructure/Cache/CacheServiceFactory.cs
+++ b/Game.Infrastructure/Cache/CacheServiceFactory.cs
@@ -1,24 +1,26 @@
 ﻿using Game.Abstractions.Infrastructure;
 using Game.Infrastructure.Cache.Redis;
 using Game.Infrastructure.Redis;
-using Microsoft.Extensions.Logging;
 
 namespace Game.Infrastructure.Cache
 {
     internal static class CacheServiceFactory
     {
-        public static ICacheService GetCacheService(ICacheOptions config, ILoggerFactory loggerFactory)
+        public static ICacheService GetCacheService(ICacheOptions config)
         {
             return config.CacheSystem switch
             {
-                CacheSystem.Redis => CreateRedisService(config, loggerFactory),
-                _ => CreateRedisService(config, loggerFactory)
+                CacheSystem.Redis => CreateRedisService(config),
+                // Fail loud on an unsupported value rather than silently defaulting to Redis (#453).
+                _ => throw new InvalidOperationException(
+                    $"Unsupported CacheSystem '{config.CacheSystem}'. The application only supports "
+                    + $"{nameof(CacheSystem.Redis)}; an unrecognized value is rejected rather than defaulted.")
             };
         }
 
-        private static ICacheService CreateRedisService(ICacheOptions config, ILoggerFactory loggerFactory)
+        private static ICacheService CreateRedisService(ICacheOptions config)
         {
-            return new RedisService(RedisMultiplexerFactory.GetMultiplexer(config), loggerFactory.CreateLogger<RedisService>());
+            return new RedisService(RedisMultiplexerFactory.GetMultiplexer(config));
         }
     }
 }

--- a/Game.Infrastructure/Cache/Redis/RedisService.cs
+++ b/Game.Infrastructure/Cache/Redis/RedisService.cs
@@ -1,20 +1,17 @@
 ﻿using Game.Abstractions.Infrastructure;
 using Game.Core;
-using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 
 namespace Game.Infrastructure.Cache.Redis
 {
     internal class RedisService : ICacheService
     {
-        private readonly ILogger<RedisService> _logger;
         private ConnectionMultiplexer Multiplexer { get; }
         public IDatabase Redis => Multiplexer.GetDatabase();
 
-        public RedisService(ConnectionMultiplexer multiplexer, ILogger<RedisService> logger)
+        public RedisService(ConnectionMultiplexer multiplexer)
         {
             Multiplexer = multiplexer;
-            _logger = logger;
         }
 
         public async Task<string?> Get(string key)

--- a/Game.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Game.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -36,8 +36,7 @@ namespace Game.Infrastructure.DependencyInjection
             return services.AddTransient(sp =>
             {
                 var options = sp.GetRequiredService<InfrastructureOptions>();
-                var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
-                return CacheServiceFactory.GetCacheService(options, loggerFactory);
+                return CacheServiceFactory.GetCacheService(options);
             });
         }
 

--- a/Game.Infrastructure/PubSub/PubSubServiceFactory.cs
+++ b/Game.Infrastructure/PubSub/PubSubServiceFactory.cs
@@ -12,7 +12,10 @@ namespace Game.Infrastructure.PubSub
             return config.PubSubSystem switch
             {
                 PubSubSystem.Redis => CreateRedisPubSubService(config, loggerFactory),
-                _ => CreateRedisPubSubService(config, loggerFactory)
+                // Fail loud on an unsupported value rather than silently defaulting to Redis (#453).
+                _ => throw new InvalidOperationException(
+                    $"Unsupported PubSubSystem '{config.PubSubSystem}'. The application only supports "
+                    + $"{nameof(PubSubSystem.Redis)}; an unrecognized value is rejected rather than defaulted.")
             };
         }
 


### PR DESCRIPTION
A bundle of small, independent backend cleanups found during a health-review pass (#589). Each is low-risk and verified unused before removal.

## Dead code removed
- **`ApiResponse.ErrorWithData` / `ErrorWithListData`** — unreferenced. The live `ErrorWithData` calls resolve to `AbstractSocketCommand.ErrorWithData`; `ErrorWithListData` had zero usages.
- **`RedisService._logger`** — injected and assigned but never read. Removed the field + ctor param and threaded it out of `CacheServiceFactory.CreateRedisService` and the `AddCache` DI wiring (so `ILoggerFactory` is no longer plumbed where it was unused).
- **`LoginData`** — unreferenced. Confirmed it is not codegen-emitted to the TS client either: the generator walks types reachable from controllers/socket commands, and nothing references `LoginData`, so its removal produces no `UI/src/lib/api/types` change.
- **`ItemMapper` `Description ?? string.Empty`** (both `ToCore` and `ModToCore`) — dead null-coalesce; the entity `Item.Description`/`ItemMod.Description` properties are `required` (non-null).
- **`NewEnemyModel`** — redundant `using Game.Api.Models;` (`IModel` resolves via global usings; the type's own namespace is nested under `Game.Api.Models`).

## Diagnostics / robustness
- **`ModifierTypeNotSupportedException`** — removed the stray `$` inside the interpolation, which rendered as `The type $Multiplicative is not supported...`.
- **`DatabaseMigrator`** — `LogDebug($"Beginning migration.")` changed to a plain (non-interpolated) string template (CA2254), consistent with the structured call on the next line.
- **`CacheServiceFactory` / `PubSubServiceFactory`** — the `_ =>` arm now throws on an unsupported `CacheSystem`/`PubSubSystem` instead of silently defaulting to Redis, matching the fail-loud factory convention `GameContextFactory` adopted (#453). Note: unlike `DatabaseSystem` (which starts at 1 so an unset config trips the guard), both `CacheSystem` and `PubSubSystem` have `Redis = 0`, so an unset config still binds to the valid `Redis` member — only a genuinely unrecognized value can reach the throw. Added a parity unit test for each factory covering the throw branch (the Redis happy path opens a real connection and stays in the integration suite, per the testing guidelines).

## Test plan
- `dotnet build` — succeeded, 0 warnings / 0 errors (CA2254 fix confirmed clean).
- `dotnet format --verify-no-changes` — passed (no reformatting needed).
- `dotnet test Game.Infrastructure.Tests` — 31 passed (incl. the 2 new factory tests).
- `dotnet test Game.Core.Tests` — 466 passed (covers the exception-message change).
- Coverage gate unaffected: the only change in a gated project (`Game.Core`) is the exception message, still exercised by existing tests; the removed `ApiResponse` helpers / `ItemMapper` / `DatabaseMigrator` live in non-gated projects.
- No codegen run needed — no controller/DTO/socket-command shape changed and `LoginData` was never emitted.

Closes #589

https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw)_