### PR TITLE
fix(a11y): make challenge reward affordances keyboard accessible

### DIFF
--- a/UI/src/routes/game/screens/challenges/Challenges.svelte
+++ b/UI/src/routes/game/screens/challenges/Challenges.svelte
@@ -63,7 +63,7 @@ import { Loading } from '$components';
 import { playerChallenges, registerTooltipComponent, toastError, type TooltipComponent } from '$stores';
 import { onMount } from 'svelte';
 import { ChallengesView, type ResolvedReward } from './challenges-view.svelte';
-import { setRewardTooltip, type RewardTooltipController } from './reward-tooltip-context';
+import { anchorPosition, setRewardTooltip, type RewardTooltipController } from './reward-tooltip-context';
 import ChallengeDetailCard from './ChallengeDetailCard.svelte';
 import OverviewPane from './OverviewPane.svelte';
 import RewardTooltip from './RewardTooltip.svelte';
@@ -82,12 +82,12 @@ const { setTooltipPosition, showTooltip, hideTooltip } = registerTooltipComponen
 // One reward tooltip for the whole screen, driven through context so nested
 // reward affordances don't have to thread hover handlers down the tree.
 const controller: RewardTooltipController = {
-	show: (reward, ev) => {
+	show: (reward, anchor) => {
 		hoveredReward = reward;
-		setTooltipPosition({ x: ev.clientX, y: ev.clientY });
+		setTooltipPosition(anchorPosition(anchor));
 		showTooltip();
 	},
-	move: (ev) => setTooltipPosition({ x: ev.clientX, y: ev.clientY }),
+	move: (anchor) => setTooltipPosition(anchorPosition(anchor)),
 	hide: () => {
 		hoveredReward = undefined;
 		hideTooltip();

--- a/UI/src/routes/game/screens/challenges/RewardAffordance.svelte
+++ b/UI/src/routes/game/screens/challenges/RewardAffordance.svelte
@@ -1,10 +1,11 @@
 {#if !reward}
 	<span class="no-reward">No reward</span>
 {:else if variant === 'chip'}
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<span
+	<button
+		type="button"
 		class="chip"
 		class:hovered
+		aria-label={ariaLabel}
 		style:background={tintColor(accent, hovered ? 0.16 : 0.08)}
 		style:border="1px {reward.revealed ? 'solid' : 'dashed'}
 		{tintColor(accent, hovered ? 0.6 : 0.34)}"
@@ -12,20 +13,25 @@
 		onmouseenter={onEnter}
 		onmousemove={onMove}
 		onmouseleave={onLeave}
+		onfocus={onFocus}
+		onblur={onLeave}
 	>
 		<RewardIcon {reward} size={18} {glow} />
 		<span class="chip-name" style:color={accent}>{reward.revealed ? reward.name : '???'}</span>
-	</span>
+	</button>
 {:else}
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div
+	<button
+		type="button"
 		class="tile"
+		aria-label={ariaLabel}
 		style:background={tintColor(accent, hovered ? 0.1 : 0.05)}
 		style:border="1px {reward.revealed ? 'solid' : 'dashed'}
 		{tintColor(accent, hovered ? 0.6 : 0.3)}"
 		onmouseenter={onEnter}
 		onmousemove={onMove}
 		onmouseleave={onLeave}
+		onfocus={onFocus}
+		onblur={onLeave}
 	>
 		<RewardIcon {reward} size={46} {glow} animate={!reward.revealed} />
 		<div class="tile-text">
@@ -41,6 +47,7 @@
 		</div>
 		<svg
 			class="tile-info"
+			aria-hidden="true"
 			width="13"
 			height="13"
 			viewBox="0 0 16 16"
@@ -51,7 +58,7 @@
 			<circle cx="8" cy="8" r="6" />
 			<path d="M8 5.2v.2M8 7.4v3.4" stroke-linecap="round" />
 		</svg>
-	</div>
+	</button>
 {/if}
 
 <script lang="ts">
@@ -74,6 +81,15 @@ let hovered = $state(false);
 
 const accent = $derived(reward?.accent ?? 'var(--text-tertiary)');
 
+// Describe the reward for assistive tech: the revealed name, or a sealed teaser.
+const ariaLabel = $derived(
+	reward == null
+		? undefined
+		: reward.revealed
+			? `Reward: ${reward.name}, ${reward.sub}`
+			: `Sealed reward: ${reward.sub}`
+);
+
 const onEnter = (ev: MouseEvent) => {
 	hovered = true;
 	if (reward) {
@@ -81,6 +97,13 @@ const onEnter = (ev: MouseEvent) => {
 	}
 };
 const onMove = (ev: MouseEvent) => tooltip?.move(ev);
+// Keyboard focus opens the same tooltip, positioned off the element's box.
+const onFocus = (ev: FocusEvent) => {
+	hovered = true;
+	if (reward && ev.currentTarget instanceof HTMLElement) {
+		tooltip?.show(reward, ev.currentTarget);
+	}
+};
 const onLeave = () => {
 	hovered = false;
 	tooltip?.hide();
@@ -94,12 +117,27 @@ const onLeave = () => {
 	font-style: italic;
 }
 
+.chip,
+.tile {
+	// Reset native button chrome; the visual treatment is the inline rarity styles.
+	appearance: none;
+	margin: 0;
+	font: inherit;
+	color: inherit;
+	text-align: left;
+	cursor: help;
+
+	&:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+}
+
 .chip {
 	display: inline-flex;
 	align-items: center;
 	gap: 8px;
 	padding: 4px 11px 4px 5px;
-	cursor: help;
 	max-width: 100%;
 	border-radius: 2px;
 	transition: all 120ms;
@@ -118,7 +156,7 @@ const onLeave = () => {
 	align-items: center;
 	gap: 13px;
 	padding: 10px 12px;
-	cursor: help;
+	width: 100%;
 	border-radius: 3px;
 	transition: all 130ms;
 }

--- a/UI/src/routes/game/screens/challenges/RewardIcon.svelte
+++ b/UI/src/routes/game/screens/challenges/RewardIcon.svelte
@@ -32,7 +32,15 @@
 		style:border="1px dashed {tintColor(accent, 0.5)}"
 		style:--seal-glow={glow ? tintColor(accent, 0.5) : 'transparent'}
 	>
-		<svg width={size * 0.42} height={size * 0.42} viewBox="0 0 16 16" fill="none" stroke={accent} stroke-width="1.3">
+		<svg
+			aria-hidden="true"
+			width={size * 0.42}
+			height={size * 0.42}
+			viewBox="0 0 16 16"
+			fill="none"
+			stroke={accent}
+			stroke-width="1.3"
+		>
 			<rect x="3.5" y="7" width="9" height="6.5" rx="1" />
 			<path d="M5.5 7V5.2a2.5 2.5 0 0 1 5 0V7" />
 		</svg>

--- a/UI/src/routes/game/screens/challenges/reward-tooltip-context.ts
+++ b/UI/src/routes/game/screens/challenges/reward-tooltip-context.ts
@@ -1,4 +1,5 @@
 import { getContext, setContext } from 'svelte';
+import type { Position } from '$stores';
 import type { ResolvedReward } from './challenges-view.svelte';
 
 /**
@@ -7,12 +8,27 @@ import type { ResolvedReward } from './challenges-view.svelte';
  * context — so we don't thread hover handlers through the rail/overview/detail
  * component tree. Mirrors how the inventory grid drives the shared tooltip, but
  * shared through context rather than props.
+ *
+ * `show`/`move` accept either a pointer event (positioned at the cursor) or a
+ * focused element (positioned at the element's box), so the same affordance is
+ * reachable by keyboard/screen reader as well as by mouse.
  */
+export type RewardAnchor = MouseEvent | HTMLElement;
+
 export interface RewardTooltipController {
-	show: (reward: ResolvedReward, ev: MouseEvent) => void;
-	move: (ev: MouseEvent) => void;
+	show: (reward: ResolvedReward, anchor: RewardAnchor) => void;
+	move: (anchor: RewardAnchor) => void;
 	hide: () => void;
 }
+
+/** Resolve the tooltip position from a cursor (pointer) or an element's box (focus). */
+export const anchorPosition = (anchor: RewardAnchor): Position => {
+	if (anchor instanceof HTMLElement) {
+		const rect = anchor.getBoundingClientRect();
+		return { x: rect.left + rect.width / 2, y: rect.bottom };
+	}
+	return { x: anchor.clientX, y: anchor.clientY };
+};
 
 const REWARD_TOOLTIP_KEY = Symbol('reward-tooltip');
 

--- a/UI/src/tests/routes/game/screens/challenges/RewardAffordance.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/RewardAffordance.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/svelte';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
 import { EAttribute, ERarity, EItemModType, type IItemMod, type ISkill } from '$lib/api';
 import RewardAffordance from '$routes/game/screens/challenges/RewardAffordance.svelte';
+import RewardAffordanceFixture from './RewardAffordanceFixture.svelte';
+import type { RewardTooltipController } from '$routes/game/screens/challenges/reward-tooltip-context';
 import type { ResolvedReward } from '$routes/game/screens/challenges/challenges-view.svelte';
 
 const sampleMod: IItemMod = {
@@ -90,5 +92,62 @@ describe('RewardAffordance', () => {
 	it('shows a fallback when there is no reward', () => {
 		const { getByText } = render(RewardAffordance, { props: { reward: null } });
 		expect(getByText('No reward')).toBeTruthy();
+	});
+
+	describe('keyboard / screen-reader accessibility', () => {
+		const stubController = (): RewardTooltipController => ({
+			show: vi.fn(),
+			move: vi.fn(),
+			hide: vi.fn()
+		});
+
+		it('renders each variant as a focusable button so keyboard users can reach it', () => {
+			for (const variant of ['tile', 'chip'] as const) {
+				const { getByRole } = render(RewardAffordance, { props: { reward: modReward(true), variant } });
+				// A real <button> is in the tab order without any explicit tabindex.
+				expect(getByRole('button').tabIndex).toBe(0);
+				cleanup();
+			}
+		});
+
+		it('labels a revealed reward with its name and teaser for assistive tech', () => {
+			const { getByRole } = render(RewardAffordance, { props: { reward: modReward(true), variant: 'tile' } });
+			expect(getByRole('button').getAttribute('aria-label')).toBe('Reward: Honed, Rare · Prefix');
+		});
+
+		it('labels a sealed reward as sealed rather than leaking its name', () => {
+			const { getByRole } = render(RewardAffordance, { props: { reward: modReward(false), variant: 'tile' } });
+			expect(getByRole('button').getAttribute('aria-label')).toBe('Sealed reward: Rare · Prefix');
+		});
+
+		it('hides the decorative tile info icon from assistive tech', () => {
+			const { container } = render(RewardAffordance, { props: { reward: modReward(true), variant: 'tile' } });
+			expect(container.querySelector('.tile-info')?.getAttribute('aria-hidden')).toBe('true');
+		});
+
+		it('opens the shared tooltip on focus, anchored to the focused element', async () => {
+			const controller = stubController();
+			const reward = modReward(true);
+			const { getByRole } = render(RewardAffordanceFixture, { props: { reward, variant: 'tile', controller } });
+
+			const button = getByRole('button');
+			await fireEvent.focus(button);
+
+			// Focus drives the same controller hover does, anchored to the element (not a cursor).
+			expect(controller.show).toHaveBeenCalledWith(reward, button);
+		});
+
+		it('closes the shared tooltip on blur', async () => {
+			const controller = stubController();
+			const { getByRole } = render(RewardAffordanceFixture, {
+				props: { reward: modReward(true), variant: 'chip', controller }
+			});
+
+			const button = getByRole('button');
+			await fireEvent.focus(button);
+			await fireEvent.blur(button);
+
+			expect(controller.hide).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/UI/src/tests/routes/game/screens/challenges/RewardAffordanceFixture.svelte
+++ b/UI/src/tests/routes/game/screens/challenges/RewardAffordanceFixture.svelte
@@ -1,0 +1,22 @@
+<!-- Registers a reward-tooltip controller (the Challenges screen's role) so a
+     RewardAffordance can be tested in isolation for its focus/hover wiring. -->
+<RewardAffordance {reward} {variant} />
+
+<script lang="ts">
+import RewardAffordance from '$routes/game/screens/challenges/RewardAffordance.svelte';
+import { setRewardTooltip, type RewardTooltipController } from '$routes/game/screens/challenges/reward-tooltip-context';
+import type { ResolvedReward } from '$routes/game/screens/challenges/challenges-view.svelte';
+
+interface Props {
+	reward: ResolvedReward | null;
+	variant?: 'tile' | 'chip';
+	controller: RewardTooltipController;
+}
+
+const { reward, variant = 'tile', controller }: Props = $props();
+
+// Context is registered once on mount (as the real Challenges screen does); the
+// test controller is a fixed object, so capturing its initial value is intended.
+// svelte-ignore state_referenced_locally
+setRewardTooltip(controller);
+</script>

--- a/UI/src/tests/routes/game/screens/challenges/reward-tooltip-context.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/reward-tooltip-context.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { anchorPosition } from '$routes/game/screens/challenges/reward-tooltip-context';
+
+describe('anchorPosition', () => {
+	it('positions a pointer anchor at the cursor coordinates', () => {
+		const ev = { clientX: 120, clientY: 45 } as MouseEvent;
+		expect(anchorPosition(ev)).toEqual({ x: 120, y: 45 });
+	});
+
+	it('positions a focus anchor under the centre of the element box', () => {
+		// Focus has no cursor, so the tooltip anchors off the element's rect instead.
+		const el = document.createElement('button');
+		el.getBoundingClientRect = () =>
+			({
+				left: 100,
+				width: 40,
+				bottom: 200,
+				top: 180,
+				right: 140,
+				height: 20,
+				x: 100,
+				y: 180,
+				toJSON: () => ({})
+			}) as DOMRect;
+		expect(anchorPosition(el)).toEqual({ x: 120, y: 200 });
+	});
+});


### PR DESCRIPTION
## Summary

The challenge-screen reward affordance (`RewardAffordance.svelte`) rendered its chip and tile variants as static, pointer-only elements (`onmouseenter`/`onmousemove`/`onmouseleave` with `cursor: help` and an `a11y_no_static_element_interactions` suppression). There was no `tabindex`, no `onfocus`/`onblur`, and no keyboard path, so keyboard and screen-reader users could not inspect any challenge reward — the screen's core payoff. Decorative SVGs also lacked `aria-hidden`.

This makes the affordance a focusable, labelled control and broadens the shared tooltip controller to drive off focus as well as hover.

- **Focusable control.** Both variants now render as real `<button>`s, so they are in the tab order without an explicit `tabindex`. Native button chrome is reset and a `:focus-visible` outline is added.
- **Focus-driven tooltip.** The reward-tooltip controller (`reward-tooltip-context.ts`) now accepts a `RewardAnchor = MouseEvent | HTMLElement`: pointer events still position at the cursor, while a focused element positions off its `getBoundingClientRect()` (centre of the box, just below it). The new `anchorPosition` helper resolves either form, so existing hover consumers keep working unchanged.
- **Focus/blur wiring.** `onfocus` opens the same tooltip hover does (anchored to the element); `onblur` closes it.
- **Labels.** An `aria-label` describes the reward — `Reward: <name>, <teaser>` when revealed, `Sealed reward: <teaser>` when still sealed (so the name isn't leaked).
- **Decorative SVGs hidden.** The `RewardIcon` seal-lock and the tile info icon are marked `aria-hidden`.

## Test plan

- `cd UI && npm ci`
- `npm run lint` — eslint + svelte-check, **0 errors / 0 warnings**.
- `npm run test:unit:ci` — **1649/1649 passing**, including new coverage:
  - `RewardAffordance.test.ts` — both variants render as focusable buttons; revealed vs sealed `aria-label`; the tile info icon is `aria-hidden`; focus opens the shared tooltip anchored to the focused element; blur closes it.
  - `reward-tooltip-context.test.ts` — `anchorPosition` resolves a pointer anchor at the cursor and a focus anchor at the centre/bottom of the element box.

Closes #594

https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw)_