### PR TITLE
fix: guard against missing/retired reference-data ids in client lookups

### DIFF
--- a/UI/src/lib/battle/item-mod.ts
+++ b/UI/src/lib/battle/item-mod.ts
@@ -3,8 +3,13 @@ import { staticData } from '$stores';
 
 export interface ItemMod extends Omit<IAppliedModModel, 'itemModId'>, IItemMod {}
 
-export const newItemMod = (appliedMod: IAppliedModModel) => {
-	const itemModData = (staticData.itemMods ?? [])[appliedMod.itemModId];
+export const newItemMod = (appliedMod: IAppliedModModel): ItemMod | undefined => {
+	// Resolve the mod's static definition by id; a missing/retired id yields no record, so degrade
+	// gracefully (mirroring resolveUnlockReward) rather than spreading `undefined` and crashing.
+	const itemModData = staticData.itemMods?.[appliedMod.itemModId];
+	if (!itemModData) {
+		return undefined;
+	}
 	return {
 		...itemModData,
 		itemModSlotId: appliedMod.itemModSlotId

--- a/UI/src/lib/battle/item.ts
+++ b/UI/src/lib/battle/item.ts
@@ -12,9 +12,15 @@ export interface Item extends IItem {
 	totalAttributes: BattleAttributes;
 }
 
-export const newItem = (invItem: IInventoryItem): Item => {
-	const itemData = (staticData.items ?? [])[invItem.itemId];
-	const appliedMods = invItem.appliedMods.map((am) => newItemMod(am));
+export const newItem = (invItem: IInventoryItem): Item | undefined => {
+	// Resolve the item's static definition by id; a missing/retired id yields no record, so degrade
+	// gracefully (mirroring resolveUnlockReward) rather than spreading `undefined` and crashing.
+	const itemData = staticData.items?.[invItem.itemId];
+	if (!itemData) {
+		return undefined;
+	}
+	// Drop any applied mod whose own definition is missing/retired so one stale mod can't crash the item.
+	const appliedMods = invItem.appliedMods.map((am) => newItemMod(am)).filter((mod): mod is ItemMod => mod != null);
 	const allAttributes = [...itemData.attributes, ...appliedMods.flatMap((mod) => mod.attributes)];
 	const totalAttributes = new BattleAttributes(allAttributes, false);
 	return {

--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -241,11 +241,15 @@ export class EnemyManager {
 	 * and boss victory paths so the two cannot drift. Returns the post-victory cooldown (ms).
 	 */
 	private async claimVictory(): Promise<number> {
-		if (this.currentEnemy) {
-			logMessage(ELogType.EnemyDefeated, (staticData.enemies ?? [])[this.currentEnemy.id].name + ' was defeated!');
-		}
+		// Resolve the enemy's name up front (guarding a missing/retired id), but only log the defeat
+		// after a successful DefeatEnemy so a failed command can't show "X was defeated!" with no rewards.
+		const enemyId = this.currentEnemy?.id;
+		const enemyName = enemyId != null ? staticData.enemies?.[enemyId]?.name : undefined;
 		const defeatResponse = await apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: Date.now() });
 		if (!defeatResponse.error && defeatResponse.data?.rewards) {
+			if (enemyName) {
+				logMessage(ELogType.EnemyDefeated, enemyName + ' was defeated!');
+			}
 			playerManager.grantExp(defeatResponse.data.rewards.expReward);
 		} else {
 			logMessage(ELogType.Debug, 'There was an error defeating the enemy: ' + defeatResponse.error);

--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -67,6 +67,11 @@ export class InventoryManager {
 		// Load unlocked items
 		for (const invItem of data.unlockedItems) {
 			const item = newItem(invItem);
+			// Skip an item whose reference record is missing/retired rather than crashing inventory load.
+			if (!item) {
+				logMessage(ELogType.Debug, `Skipped unlocked item with unknown id ${invItem.itemId}.`);
+				continue;
+			}
 			this.unlockedItems.set(invItem.itemId, item);
 
 			// Place equipped items into their equipment slots
@@ -162,15 +167,14 @@ export class InventoryManager {
 	public applyMod(itemId: number, itemModId: number, itemModSlotId: number): Promise<boolean> {
 		return this.serialize(async () => {
 			const item = this.unlockedItems.get(itemId);
-			if (!this.unlockedMods.has(itemModId) || !item) {
+			const mod = newItemMod({ itemModId, itemModSlotId });
+			// Bail if the item, the mod's unlock, or the mod's reference record (missing/retired) is absent.
+			if (!this.unlockedMods.has(itemModId) || !item || !mod) {
 				return false;
 			}
 
 			const rollback = snapshotFields(item, 'appliedMods', 'totalAttributes');
-			item.appliedMods = [
-				...item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId),
-				newItemMod({ itemModId, itemModSlotId })
-			];
+			item.appliedMods = [...item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId), mod];
 			this.refreshItemAttributes(item);
 			this.publish();
 
@@ -244,6 +248,11 @@ export class InventoryManager {
 			return;
 		}
 		const item = newItem(invItem);
+		// Ignore a reward referencing a missing/retired item rather than crashing the grant path.
+		if (!item) {
+			logMessage(ELogType.Debug, `Skipped unlocking item with unknown id ${invItem.itemId}.`);
+			return;
+		}
 		this.unlockedItems.set(invItem.itemId, item);
 		this.publish();
 		logMessage(ELogType.ItemFound, `Unlocked: ${item.name}!`);

--- a/UI/src/tests/lib/battle/battle-sim-test-utils.ts
+++ b/UI/src/tests/lib/battle/battle-sim-test-utils.ts
@@ -146,6 +146,11 @@ export function equipmentFactory(itemRegistry: IItem[], itemModRegistry: IItemMo
 		});
 
 		const item = newItem({ itemId, equipped: true, favorite: false, appliedMods });
+		// The item was just registered, so resolution is guaranteed; assert it to satisfy the nullable
+		// return and surface a clear failure if that invariant is ever broken.
+		if (!item) {
+			throw new Error(`equipmentFactory failed to resolve just-registered item ${itemId}`);
+		}
 
 		// Mirror InventoryManager.equipmentStats: the equipped item's own
 		// attributes followed by every applied mod's attributes.

--- a/UI/src/tests/lib/battle/item-mod.test.ts
+++ b/UI/src/tests/lib/battle/item-mod.test.ts
@@ -39,21 +39,27 @@ describe('newItemMod', () => {
 			rarityId: ERarity.Legendary,
 			itemModSlotId: 10
 		});
-		expect(mod.attributes).toEqual(mockItemMods[7].attributes);
-		expect(mod.tags).toEqual([1, 2]);
+		expect(mod?.attributes).toEqual(mockItemMods[7].attributes);
+		expect(mod?.tags).toEqual([1, 2]);
 	});
 
 	it('carries the slot id through without leaking the source itemModId field', () => {
 		const mod = newItemMod({ itemModId: 7, itemModSlotId: 99 });
-		expect(mod.itemModSlotId).toBe(99);
+		expect(mod?.itemModSlotId).toBe(99);
 		// The applied model's itemModId is consumed for the lookup, not copied onto the result.
-		expect('itemModId' in mod).toBe(false);
+		expect(mod && 'itemModId' in mod).toBe(false);
 	});
 
 	it('looks the definition up positionally by itemModId', () => {
 		mockItemMods[3] = { ...mockItemMods[7], id: 3, name: 'Frosty' };
 		const mod = newItemMod({ itemModId: 3, itemModSlotId: 1 });
-		expect(mod.name).toBe('Frosty');
-		expect(mod.id).toBe(3);
+		expect(mod?.name).toBe('Frosty');
+		expect(mod?.id).toBe(3);
+	});
+
+	it('returns undefined for a missing/retired itemModId rather than spreading undefined', () => {
+		// Id 999 has no reference record (e.g. a retired or not-yet-downloaded mod); resolve to undefined
+		// so the caller can drop it instead of crashing on a spread of `undefined`.
+		expect(newItemMod({ itemModId: 999, itemModSlotId: 0 })).toBeUndefined();
 	});
 });

--- a/UI/src/tests/lib/battle/item.test.ts
+++ b/UI/src/tests/lib/battle/item.test.ts
@@ -55,17 +55,42 @@ describe('newItem', () => {
 	it('merges the applied mods stats into totalAttributes', () => {
 		const item = newItem(invItem);
 		// Strength: item 5 + mod 3 = 8; Agility: mod 2.
-		expect(item.totalAttributes.getValue(EAttribute.Strength)).toBe(8);
-		expect(item.totalAttributes.getValue(EAttribute.Agility)).toBe(2);
+		expect(item?.totalAttributes.getValue(EAttribute.Strength)).toBe(8);
+		expect(item?.totalAttributes.getValue(EAttribute.Agility)).toBe(2);
 	});
 
 	it('exposes the applied mods with their slot binding', () => {
 		const item = newItem(invItem);
-		expect(item.appliedMods).toHaveLength(1);
-		expect(item.appliedMods[0]).toMatchObject({
+		expect(item?.appliedMods).toHaveLength(1);
+		expect(item?.appliedMods[0]).toMatchObject({
 			name: 'Flaming',
 			itemModTypeId: EItemModType.Prefix,
 			itemModSlotId: 10
 		});
+	});
+
+	it('returns undefined for a missing/retired itemId rather than spreading undefined', () => {
+		// Id 999 has no reference record (e.g. a retired or not-yet-downloaded item); resolve to undefined
+		// so the inventory-load / reward-grant paths can skip it instead of crashing.
+		expect(newItem({ itemId: 999, equipped: false, favorite: false, appliedMods: [] })).toBeUndefined();
+	});
+
+	it('drops an applied mod whose own reference record is missing/retired', () => {
+		// One valid mod (7) and one stale mod (888): the stale one is filtered out so it can't crash the
+		// item, and only the valid mod's stats are merged.
+		const item = newItem({
+			itemId: 1,
+			equipped: false,
+			favorite: false,
+			appliedMods: [
+				{ itemModId: 7, itemModSlotId: 10 },
+				{ itemModId: 888, itemModSlotId: 11 }
+			]
+		});
+		expect(item?.appliedMods).toHaveLength(1);
+		expect(item?.appliedMods[0]).toMatchObject({ name: 'Flaming', itemModSlotId: 10 });
+		// Stats reflect only the surviving mod (Strength 5 + 3 = 8; Agility 2).
+		expect(item?.totalAttributes.getValue(EAttribute.Strength)).toBe(8);
+		expect(item?.totalAttributes.getValue(EAttribute.Agility)).toBe(2);
 	});
 });

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -93,6 +93,8 @@ describe('EnemyManager boss mode', () => {
 		h.statistics.markZoneCleared.mockClear();
 		// Default: no zones authored ⇒ no "next zone" to unlock; the unlock tests opt in.
 		h.staticData.zones = undefined;
+		// Restore the enemy reference record (a missing-id test clears it).
+		h.staticData.enemies = [{ id: 0, name: 'Catacomb Lich', isBoss: true }];
 		h.playerChallenges.isChallengeCompleted.mockReset();
 		h.playerChallenges.isChallengeCompleted.mockReturnValue(false);
 		h.playerChallenges.load.mockReset();
@@ -301,5 +303,44 @@ describe('EnemyManager boss mode', () => {
 		expect(h.statistics.markZoneCleared).not.toHaveBeenCalled();
 		expect(send).toHaveBeenCalledWith('NewEnemy', { newZoneId: 3 });
 		expect(manager.mode).toBe('idle');
+	});
+
+	it('logs the defeat only after a successful DefeatEnemy', async () => {
+		await manager.getNewEnemy();
+
+		await fireStage(h.BattleStage.Victorious);
+
+		// The "X was defeated!" line is logged with the resolved enemy name once rewards are granted.
+		expect(logMessage).toHaveBeenCalledWith(ELogType.EnemyDefeated, 'Catacomb Lich was defeated!');
+	});
+
+	it('does not log the defeat when DefeatEnemy fails (no premature "defeated" line)', async () => {
+		await manager.getNewEnemy();
+		// Fail the defeat command: no rewards ⇒ the player must not see "X was defeated!".
+		send.mockImplementation((name: string) =>
+			name === 'DefeatEnemy'
+				? Promise.resolve({ id: '1', name: 'DefeatEnemy', error: 'boom' } as IApiSocketResponse<'DefeatEnemy'>)
+				: Promise.resolve(newEnemyResponse)
+		);
+		vi.mocked(logMessage).mockClear();
+
+		await fireStage(h.BattleStage.Victorious);
+
+		expect(logMessage).not.toHaveBeenCalledWith(ELogType.EnemyDefeated, expect.anything());
+		expect(logMessage).toHaveBeenCalledWith(ELogType.Debug, 'There was an error defeating the enemy: boom');
+		expect(h.playerManager.grantExp).not.toHaveBeenCalled();
+	});
+
+	it('survives a missing/retired enemy id on victory (still grants rewards, omits the name log)', async () => {
+		// The current enemy's id has no reference record, so its name can't be resolved — the victory
+		// must not crash, and rewards still apply; the name-dependent log is simply skipped.
+		h.staticData.enemies = [];
+		await manager.getNewEnemy();
+		vi.mocked(logMessage).mockClear();
+
+		await expect(fireStage(h.BattleStage.Victorious)).resolves.not.toThrow();
+
+		expect(h.playerManager.grantExp).toHaveBeenCalledWith(50);
+		expect(logMessage).not.toHaveBeenCalledWith(ELogType.EnemyDefeated, expect.anything());
 	});
 });

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -132,6 +132,34 @@ describe('InventoryManager', () => {
 			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]?.itemId).toBe(1);
 		});
 
+		it('skips an unlocked item whose reference record is missing/retired without crashing', () => {
+			// Item 1 resolves; item 2 has no reference record (retired or not yet downloaded) and must be
+			// skipped — a single stale id can't take down the whole inventory load.
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [
+				{ itemId: 1, equipped: false, appliedMods: [], favorite: false },
+				{ itemId: 2, equipped: false, appliedMods: [], favorite: false }
+			];
+
+			expect(() => manager.initialize()).not.toThrow();
+
+			expect(manager.unlockedItems.has(1)).toBe(true);
+			expect(manager.unlockedItems.has(2)).toBe(false);
+			expect(manager.unlockedItems.size).toBe(1);
+			expect(logMessage).toHaveBeenCalledWith(ELogType.Debug, expect.stringContaining('2'));
+		});
+
+		it('does not place a skipped (unknown-id) equipped item into a slot', () => {
+			// A retired equipped item must not be slotted — its record is gone, so there's nothing to place.
+			mockInventoryData.unlockedItems = [
+				{ itemId: 2, equipped: true, equipmentSlotId: EEquipmentSlot.WeaponSlot, appliedMods: [], favorite: false }
+			];
+
+			manager.initialize();
+
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]).toBeUndefined();
+		});
+
 		it('clears previous state on re-initialize', () => {
 			mockItems[1] = makeItem(1);
 			mockInventoryData.unlockedItems = [{ itemId: 1, equipped: false, appliedMods: [], favorite: false }];
@@ -620,6 +648,21 @@ describe('InventoryManager', () => {
 			expect(mockSendSocketCommand).not.toHaveBeenCalled();
 		});
 
+		it('returns false and makes no socket call when the mod has no reference record', async () => {
+			// The mod is unlocked but its reference record is missing/retired (no mockItemMods entry), so
+			// newItemMod resolves to undefined — bail rather than apply a mod that can't be resolved.
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			mockInventoryData.unlockedMods = [10];
+			manager.initialize();
+
+			const result = await manager.applyMod(1, 10, 0);
+
+			expect(result).toBe(false);
+			expect(mockSendSocketCommand).not.toHaveBeenCalled();
+			expect(manager.unlockedItems.get(1)?.appliedMods).toEqual([]);
+		});
+
 		it('returns false and does not log when the socket returns an error', async () => {
 			mockItems[1] = makeItem(1);
 			mockItemMods[10] = makeItemMod(10);
@@ -762,6 +805,16 @@ describe('InventoryManager', () => {
 
 			expect(manager.unlockedItems.has(3)).toBe(true);
 			expect(logMessage).toHaveBeenCalledWith(ELogType.ItemFound, expect.stringContaining('Item 3'));
+		});
+
+		it('ignores a reward for an item whose reference record is missing/retired without crashing', () => {
+			// No reference record for id 5 ⇒ the grant degrades gracefully instead of crashing the reward path.
+			manager.initialize();
+
+			expect(() => manager.addUnlockedItem(makeInventoryItem({ itemId: 5 }))).not.toThrow();
+
+			expect(manager.unlockedItems.has(5)).toBe(false);
+			expect(logMessage).toHaveBeenCalledWith(ELogType.Debug, expect.stringContaining('5'));
 		});
 
 		it('is idempotent — an already-unlocked item is not overwritten or re-logged', () => {


### PR DESCRIPTION
## Summary

Several client paths guarded the *whole-set-missing* case for reference data but then dereferenced the *individual* record without a per-id guard, so a single unknown/retired id threw on inventory load, a reward grant, or a victory. This adds per-id guards (matching the existing `resolveUnlockReward` / `buildPreviewItem` `?.` + null-branch pattern) and reorders the premature `EnemyDefeated` log.

- **`newItem` / `newItemMod`** (`UI/src/lib/battle/item.ts`, `item-mod.ts`) — resolve the static definition via `staticData.x?.[id]` and return `undefined` for a missing record instead of spreading `undefined`. `newItem` additionally drops any applied mod whose own record is missing/retired so one stale mod can't crash the item.
- **`InventoryManager`** (`UI/src/lib/engine/player/inventory-manager.ts`) — skips an unresolvable item on `initialize()` and on the `addUnlockedItem` reward path (logging a debug line), and `applyMod` bails when the mod's reference record is absent.
- **`EnemyManager.claimVictory`** (`UI/src/lib/engine/battle/enemy-manager.ts`) — resolves the enemy name with a guarded lookup and logs `EnemyDefeated` only **after** a successful `DefeatEnemy`, so a failed command no longer shows "X was defeated!" with no rewards.

The newly-nullable `newItem` return is handled at the one remaining test-util consumer (`battle-sim-test-utils.ts`) with an explicit invariant check (no `!` operator).

## Test plan

Run in `UI/`:

- `npm ci`
- `npm run lint` — passed (eslint + svelte-check, 0 errors)
- `npm run test:unit:ci` — passed (172 files, 1651 tests)

Added vitest coverage for each new guard branch (missing item/mod id, dropped stale applied mod, skipped unlocked/reward item, `applyMod` bail on missing record) and the log reorder (defeat logged only on success, no premature line on a failed `DefeatEnemy`, missing-id victory still grants rewards and omits the name log).

Closes #590

https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw)_