### PR TITLE
fix(a11y): add progressbar/status roles to HP & meter bars and the spinner

### DIFF
--- a/UI/src/components/Loading.svelte
+++ b/UI/src/components/Loading.svelte
@@ -2,8 +2,8 @@
 	{#if !hideOverlay}
 		<div class="overlay"></div>
 	{/if}
-	<div class="loading-spinner-container" {style}>
-		<div class="loading-spinner">
+	<div class="loading-spinner-container" {style} role="status" aria-live="polite">
+		<div class="loading-spinner" aria-hidden="true">
 			<div class="spinner-dot-container">
 				<div class="loading-spinner-dot"></div>
 			</div>
@@ -20,6 +20,7 @@
 				<div class="loading-spinner-dot"></div>
 			</div>
 		</div>
+		<span class="sr-only">Loading…</span>
 	</div>
 {/if}
 
@@ -58,6 +59,19 @@ $outer-rotation-count: 3;
 	z-index: 10;
 	inset: 0;
 	background: color-mix(in srgb, var(--black) 50%, transparent);
+}
+
+// Accessible label for screen readers without showing visible text.
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
 }
 
 .loading-spinner-container {

--- a/UI/src/routes/game/screens/card-game/loom/Combatants.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/Combatants.svelte
@@ -4,7 +4,17 @@
 			<span class="name"><span class="glyph"></span>The Warden</span>
 			<span class="hpnum">{game.enemyHP} / {game.enemyMax}</span>
 		</div>
-		<div class="bar enemy"><i style:width="{(game.enemyHP / game.enemyMax) * 100}%"></i></div>
+		<div
+			class="bar enemy"
+			role="progressbar"
+			aria-label="The Warden health"
+			aria-valuenow={Math.round(game.enemyHP)}
+			aria-valuemin={0}
+			aria-valuemax={game.enemyMax}
+			aria-valuetext="{game.enemyHP} / {game.enemyMax}"
+		>
+			<i style:width="{(game.enemyHP / game.enemyMax) * 100}%"></i>
+		</div>
 	</div>
 
 	<div class="combatant you">
@@ -12,13 +22,31 @@
 			<span class="name"><span class="glyph"></span>You</span>
 			<span class="hpnum">{game.playerHP} / {game.playerMax}</span>
 		</div>
-		<div class="bar player"><i style:width="{(game.playerHP / game.playerMax) * 100}%"></i></div>
+		<div
+			class="bar player"
+			role="progressbar"
+			aria-label="Your health"
+			aria-valuenow={Math.round(game.playerHP)}
+			aria-valuemin={0}
+			aria-valuemax={game.playerMax}
+			aria-valuetext="{game.playerHP} / {game.playerMax}"
+		>
+			<i style:width="{(game.playerHP / game.playerMax) * 100}%"></i>
+		</div>
 	</div>
 
 	<div class="drawcluster">
 		<span class="mono">deck</span><b>{game.deck.length}</b>
-		<div class="drawbar" title="next draw">
-			<i style:width="{Math.min(100, (game.drawAcc / game.drawIntervalSec) * 100)}%"></i>
+		<div
+			class="drawbar"
+			title="next draw"
+			role="progressbar"
+			aria-label="Next draw progress"
+			aria-valuenow={Math.round(drawPerc)}
+			aria-valuemin={0}
+			aria-valuemax={100}
+		>
+			<i style:width="{drawPerc}%"></i>
 		</div>
 		<span class="mono">used</span><b>{game.discard.length}</b>
 	</div>
@@ -31,6 +59,8 @@ interface Props {
 	game: LoomGame;
 }
 const { game }: Props = $props();
+
+const drawPerc = $derived(Math.min(100, (game.drawAcc / game.drawIntervalSec) * 100));
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/game/screens/card-game/loom/Controls.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/Controls.svelte
@@ -7,7 +7,17 @@
 	>
 		⏳ REFLEX
 	</button>
-	<div class="reflexmeter" title="Agility reserve"><i style:width="{view.game.reflex}%"></i></div>
+	<div
+		class="reflexmeter"
+		title="Agility reserve"
+		role="progressbar"
+		aria-label="Agility reserve"
+		aria-valuenow={Math.round(view.game.reflex)}
+		aria-valuemin={0}
+		aria-valuemax={100}
+	>
+		<i style:width="{view.game.reflex}%"></i>
+	</div>
 
 	<button class="btn reset" onclick={() => view.reset()}>↺ RESET</button>
 </div>

--- a/UI/src/routes/game/screens/fight/boss/BossHpBar.svelte
+++ b/UI/src/routes/game/screens/fight/boss/BossHpBar.svelte
@@ -1,6 +1,15 @@
 <!-- The boss's HP bar: the same green-over-missing treatment as a normal battler,
      taller and overlaid with phase pips at 25 / 50 / 75% to telegraph boss phases. -->
-<div class="boss-hp-bar" data-testid="boss-hp-bar">
+<div
+	class="boss-hp-bar"
+	data-testid="boss-hp-bar"
+	role="progressbar"
+	aria-label="Boss health"
+	aria-valuenow={Math.round(currentHealth)}
+	aria-valuemin={0}
+	aria-valuemax={maxHealth}
+	aria-valuetext={healthText}
+>
 	<div class="hp-disappearing" style:width="{healthPerc}%"></div>
 	<div class="hp-remaining" style:width="{healthPerc}%"></div>
 	{#each PHASE_PIPS as pip (pip)}

--- a/UI/src/tests/components/Loading.test.ts
+++ b/UI/src/tests/components/Loading.test.ts
@@ -25,6 +25,16 @@ describe('Loading', () => {
 		expect(container.querySelector('.overlay')).toBeNull();
 	});
 
+	it('announces a loading status with a visually-hidden label', () => {
+		const { container } = render(Loading, { props: { loading: true } });
+		const status = container.querySelector('.loading-spinner-container') as HTMLElement;
+		expect(status.getAttribute('role')).toBe('status');
+		expect(status.getAttribute('aria-live')).toBe('polite');
+		expect(container.querySelector('.sr-only')?.textContent).toContain('Loading');
+		// The decorative spinner itself is hidden from assistive tech.
+		expect(container.querySelector('.loading-spinner')?.getAttribute('aria-hidden')).toBe('true');
+	});
+
 	it('suppresses the spinner immediately when a delay is set', () => {
 		// With delay > 0, waitingOnDelay stays true after onMount, so the spinner is hidden
 		// until the timeout fires even though loading=true.

--- a/UI/src/tests/routes/game/screens/card-game/loom/Combatants.test.ts
+++ b/UI/src/tests/routes/game/screens/card-game/loom/Combatants.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { LoomGame } from '$lib/card-game';
+import Combatants from '$routes/game/screens/card-game/loom/Combatants.svelte';
+
+afterEach(cleanup);
+
+describe('Combatants', () => {
+	it('exposes the enemy and player HP bars as progressbars with value text', () => {
+		const game = new LoomGame();
+		game.enemyHP = 90.4;
+		game.enemyMax = 120;
+		game.playerHP = 40.6;
+		game.playerMax = 80;
+		const { container } = render(Combatants, { props: { game } });
+
+		const enemy = container.querySelector('.bar.enemy') as HTMLElement;
+		expect(enemy.getAttribute('role')).toBe('progressbar');
+		expect(enemy.getAttribute('aria-label')).toBe('The Warden health');
+		expect(enemy.getAttribute('aria-valuenow')).toBe('90');
+		expect(enemy.getAttribute('aria-valuemin')).toBe('0');
+		expect(enemy.getAttribute('aria-valuemax')).toBe('120');
+		expect(enemy.getAttribute('aria-valuetext')).toBe('90.4 / 120');
+
+		const player = container.querySelector('.bar.player') as HTMLElement;
+		expect(player.getAttribute('role')).toBe('progressbar');
+		expect(player.getAttribute('aria-label')).toBe('Your health');
+		expect(player.getAttribute('aria-valuenow')).toBe('41');
+		expect(player.getAttribute('aria-valuemax')).toBe('80');
+		expect(player.getAttribute('aria-valuetext')).toBe('40.6 / 80');
+	});
+
+	it('exposes the next-draw bar as a 0-100 progressbar of accumulated draw time', () => {
+		const game = new LoomGame();
+		// Half-way to the next draw → 50%.
+		game.drawAcc = game.drawIntervalSec / 2;
+		const { container } = render(Combatants, { props: { game } });
+
+		const draw = container.querySelector('.drawbar') as HTMLElement;
+		expect(draw.getAttribute('role')).toBe('progressbar');
+		expect(draw.getAttribute('aria-label')).toBe('Next draw progress');
+		expect(draw.getAttribute('aria-valuenow')).toBe('50');
+		expect(draw.getAttribute('aria-valuemin')).toBe('0');
+		expect(draw.getAttribute('aria-valuemax')).toBe('100');
+	});
+
+	it('clamps the next-draw bar to 100 when the accumulator overshoots the interval', () => {
+		const game = new LoomGame();
+		game.drawAcc = game.drawIntervalSec * 2;
+		const { container } = render(Combatants, { props: { game } });
+
+		const draw = container.querySelector('.drawbar') as HTMLElement;
+		expect(draw.getAttribute('aria-valuenow')).toBe('100');
+		expect((draw.querySelector('i') as HTMLElement).getAttribute('style')).toContain('width: 100%');
+	});
+});

--- a/UI/src/tests/routes/game/screens/card-game/loom/Controls.test.ts
+++ b/UI/src/tests/routes/game/screens/card-game/loom/Controls.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { CardGameView } from '$routes/game/screens/card-game/card-game-view.svelte';
+import Controls from '$routes/game/screens/card-game/loom/Controls.svelte';
+
+afterEach(cleanup);
+
+describe('Controls', () => {
+	it('exposes the reflex meter as a 0-100 progressbar of the agility reserve', () => {
+		const view = new CardGameView();
+		view.game.reflex = 60.7;
+		const { container } = render(Controls, { props: { view } });
+
+		const meter = container.querySelector('.reflexmeter') as HTMLElement;
+		expect(meter.getAttribute('role')).toBe('progressbar');
+		expect(meter.getAttribute('aria-label')).toBe('Agility reserve');
+		expect(meter.getAttribute('aria-valuenow')).toBe('61');
+		expect(meter.getAttribute('aria-valuemin')).toBe('0');
+		expect(meter.getAttribute('aria-valuemax')).toBe('100');
+	});
+});

--- a/UI/src/tests/routes/game/screens/fight/boss/BossHpBar.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/boss/BossHpBar.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import BossHpBar from '$routes/game/screens/fight/boss/BossHpBar.svelte';
+
+afterEach(cleanup);
+
+describe('BossHpBar', () => {
+	it('exposes the bar as a progressbar with rounded current/max health and value text', () => {
+		const { getByTestId } = render(BossHpBar, { props: { currentHealth: 80.6, maxHealth: 100 } });
+
+		const bar = getByTestId('boss-hp-bar');
+		expect(bar.getAttribute('role')).toBe('progressbar');
+		expect(bar.getAttribute('aria-label')).toBe('Boss health');
+		expect(bar.getAttribute('aria-valuenow')).toBe('81');
+		expect(bar.getAttribute('aria-valuemin')).toBe('0');
+		expect(bar.getAttribute('aria-valuemax')).toBe('100');
+		expect(bar.getAttribute('aria-valuetext')).toBe('80.6 / 100');
+	});
+
+	it('renders the current/max health text', () => {
+		const { getByTestId } = render(BossHpBar, { props: { currentHealth: 50, maxHealth: 200 } });
+		expect(getByTestId('boss-hp-bar').querySelector('.hp-text')?.textContent).toContain('50 / 200');
+	});
+});


### PR DESCRIPTION
## Summary

Several continuously-updating visual indicators conveyed state only through bar width/color, with no text alternative for assistive tech. This adds the missing a11y roles/attributes in place, mirroring the pattern the existing `BattlerCard` HP bar already uses (no shared-component refactor — that's #598).

- **`BossHpBar.svelte`** — now `role="progressbar"` with `aria-label="Boss health"`, `aria-valuemin/max/now` (rounded current health), and `aria-valuetext` for the formatted "current / max" string. A screen-reader user gets the boss's HP just like they do from a normal `BattlerCard`.
- **`card-game/loom/Combatants.svelte`** — the enemy/player HP bars and the next-draw bar are now progressbars with labels and `aria-value*`; the HP bars carry value text. The draw bar exposes a 0–100 percentage (the clamped fill math was lifted into a single `drawPerc` `$derived` so the `width` and `aria-valuenow` stay in lockstep).
- **`card-game/loom/Controls.svelte`** — the reflex meter is now a 0–100 progressbar labelled "Agility reserve".
- **`components/Loading.svelte`** — the spinner container is `role="status"` `aria-live="polite"` with a visually-hidden "Loading…" label; the decorative dots are `aria-hidden`.

## Test plan

- New `BossHpBar.test.ts`, `Combatants.test.ts`, and `Controls.test.ts` assert the progressbar role + `aria-value*` wiring (including rounding, value text, and the draw bar's clamp-to-100), following the existing `BattlerCard.test.ts` pattern.
- Extended `Loading.test.ts` to assert `role="status"`, `aria-live="polite"`, the sr-only label, and the `aria-hidden` decorative spinner.
- `npm run lint` — pass (0 errors, 0 warnings).
- `npm run test:unit:ci` — pass (175 files, 1648 tests).

Closes #597

https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw)_