### PR TITLE
Frontend cleanup: dead code and small engine-robustness fixes

### DIFF
--- a/UI/src/components/Tooltip.svelte
+++ b/UI/src/components/Tooltip.svelte
@@ -7,11 +7,13 @@ import type { TooltipData } from '$stores';
 
 let { component, position, visible }: TooltipData = $props();
 
-let container: HTMLDivElement;
+let container = $state<HTMLDivElement>();
 
 $effect(() => {
 	const node = component()?.getBaseNode();
-	if (node) {
+	// Guard `container`: the effect tracks `component`, which can change before the bind:this
+	// binding establishes, so the node could be present while `container` is still unbound.
+	if (node && container) {
 		// eslint-disable-next-line svelte/no-dom-manipulating
 		container.replaceChildren();
 		// eslint-disable-next-line svelte/no-dom-manipulating

--- a/UI/src/lib/common/functions.ts
+++ b/UI/src/lib/common/functions.ts
@@ -1,9 +1,4 @@
-﻿// randomInt between num1 (inclusive) and num2 (exclusive)
-export function randomInt(num1: number, num2: number): number {
-	return Math.floor(num1 + Math.random() * (num2 - num1));
-}
-
-// formats a number to a specific string representation
+﻿// formats a number to a specific string representation
 export function formatNum(num: number): string {
 	return '' + parseFloat(num.toFixed(2));
 }
@@ -12,6 +7,16 @@ export async function delay(delay: number) {
 	return new Promise<void>((res) => {
 		setTimeout(res, delay);
 	});
+}
+
+/** Whether the OS `prefers-reduced-motion: reduce` preference is set (false during SSR). Use to
+ *  skip JS-driven motion the global CSS rule can't collapse (e.g. a perpetual ticker). */
+export function prefersReducedMotion(): boolean {
+	return (
+		typeof window !== 'undefined' &&
+		!!window.matchMedia &&
+		window.matchMedia('(prefers-reduced-motion: reduce)').matches
+	);
 }
 
 export function keys<T>(obj?: T) {

--- a/UI/src/lib/common/types.ts
+++ b/UI/src/lib/common/types.ts
@@ -1,13 +1,1 @@
-﻿export type Comparator<Type> = (currData: Type, objData: Type) => boolean;
-
 export type Action<T extends unknown[] = []> = (...args: T) => void;
-
-export type Converter<Type, Type2> = (data: Type) => Type2;
-
-export type CheckFunc<Type> = (data: Type) => boolean;
-
-export type ProgressionFunc = (percentComplete: number) => number;
-
-export type SlotVariant = 'equipped' | 'inventory';
-
-export type Screens = 'Fight' | 'Attributes' | 'Stats' | 'Help' | 'Options' | 'Quit' | 'Inventory' | 'cardGame';

--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -66,18 +66,24 @@ export class EnemyManager {
 	}
 
 	public async getNewEnemy() {
-		if (!this.newEnemyPromise) {
-			this.newEnemyPromise = apiSocket.sendSocketCommand('NewEnemy', {
-				newZoneId: playerManager.currentZone
-			});
-		}
+		// Retry iteratively rather than via self-recursion: each attempt returns to a flat stack
+		// (a sustained outage no longer grows the async chain without bound) and `stop()` cancels
+		// the loop by flipping `started`.
+		while (this.started) {
+			if (!this.newEnemyPromise) {
+				this.newEnemyPromise = apiSocket.sendSocketCommand('NewEnemy', {
+					newZoneId: playerManager.currentZone
+				});
+			}
 
-		const result = await this.newEnemyPromise;
-		this.newEnemyPromise = undefined;
-		if (result.data?.enemyInstance) {
-			this.currentEnemy = result.data.enemyInstance;
-			notifyNewEnemyLoaded(this.currentEnemy);
-		} else {
+			const result = await this.newEnemyPromise;
+			this.newEnemyPromise = undefined;
+			if (result.data?.enemyInstance) {
+				this.currentEnemy = result.data.enemyInstance;
+				notifyNewEnemyLoaded(this.currentEnemy);
+				return;
+			}
+
 			// No enemy this time: either the zone is on cooldown (wait it out) or the request failed
 			// (`data` is absent — note the optional chaining; the original code dereferenced `data`
 			// here and threw on an error response). Back off in both cases, then retry.
@@ -85,7 +91,6 @@ export class EnemyManager {
 				logMessage(ELogType.Debug, 'There was an error loading a new enemy: ' + result.error);
 			}
 			await delay(result.data?.cooldown ?? NEW_ENEMY_RETRY_DELAY_MS);
-			await this.getNewEnemy();
 		}
 	}
 

--- a/UI/src/lib/engine/player/player-manager.ts
+++ b/UI/src/lib/engine/player/player-manager.ts
@@ -77,16 +77,23 @@ export class PlayerManager implements IPlayerData {
 		logMessage(ELogType.ItemFound, 'New skill unlocked!');
 	}
 
+	/** Exp required to advance the current level (`Level * EXP_PER_LEVEL`, mirroring the backend).
+	 *  The level is clamped to ≥ 1 so the pre-`initialize` `level = 0` default can't produce a
+	 *  zero threshold that would let `grantExp` over-level. A real level (≥ 1) is unaffected. */
+	private get nextLevelThreshold(): number {
+		return Math.max(1, this.level) * EXP_PER_LEVEL;
+	}
+
 	public grantExp(exp: number) {
 		logMessage(ELogType.Exp, `Earned ${formatNum(exp)} exp.`);
 		this.exp += exp;
-		while (this.exp >= this.level * EXP_PER_LEVEL) {
+		while (this.exp >= this.nextLevelThreshold) {
 			this.levelUp();
 		}
 	}
 
 	public levelUp() {
-		this.exp -= this.level * EXP_PER_LEVEL;
+		this.exp -= this.nextLevelThreshold;
 		this.level++;
 		this.statPointsGained += STAT_POINTS_PER_LEVEL;
 		logMessage(ELogType.LevelUp, 'Congratulations, you leveled up!');

--- a/UI/src/routes/admin/workbench/entity-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/entity-store.svelte.ts
@@ -103,6 +103,7 @@ export class EntityStore<T extends Identified> {
 
 	restoreItem(id: number) {
 		this.deleted.delete(id);
+		this.saved = false;
 	}
 
 	/** True when a record is retired (out of circulation but kept at its slot and resolvable by id). */

--- a/UI/src/routes/game/screens/attributes/AttributesRadar.svelte
+++ b/UI/src/routes/game/screens/attributes/AttributesRadar.svelte
@@ -59,7 +59,7 @@
 
 <script lang="ts">
 import { onMount, untrack } from 'svelte';
-import { attributeColor, attributeCode, attributeName } from '$lib/common';
+import { attributeColor, attributeCode, attributeName, prefersReducedMotion } from '$lib/common';
 import { staticData } from '$stores';
 import { CORE_ATTRIBUTES, radarValueAtPointer, type AttributesView } from './attributes-view.svelte';
 
@@ -236,14 +236,6 @@ onMount(() => {
 		window.removeEventListener('pointercancel', onEnd);
 	};
 });
-
-function prefersReducedMotion(): boolean {
-	return (
-		typeof window !== 'undefined' &&
-		!!window.matchMedia &&
-		window.matchMedia('(prefers-reduced-motion: reduce)').matches
-	);
-}
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/game/screens/fight/boss/ChallengeButton.svelte
+++ b/UI/src/routes/game/screens/fight/boss/ChallengeButton.svelte
@@ -1,6 +1,6 @@
 <!-- The gold "Challenge" / "Re-challenge" action that starts a boss fight. Fills with
      the boss accent on hover (the diamond inverts to read on the filled background). -->
-<button class="challenge-btn" class:big type="button" data-testid="challenge-boss" onclick={onClick}>
+<button class="challenge-btn" type="button" data-testid="challenge-boss" onclick={onClick}>
 	<span class="btn-diamond" aria-hidden="true"></span>
 	{@render children()}
 </button>
@@ -11,11 +11,9 @@ import type { Snippet } from 'svelte';
 type Props = {
 	onClick: () => void;
 	children: Snippet;
-	/** A larger variant (unused by the current Banner trigger, kept for the affordance API). */
-	big?: boolean;
 };
 
-const { onClick, children, big = false }: Props = $props();
+const { onClick, children }: Props = $props();
 </script>
 
 <style lang="scss">
@@ -36,11 +34,6 @@ const { onClick, children, big = false }: Props = $props();
 	cursor: pointer;
 	padding: 6px 12px;
 	transition: all 150ms;
-
-	&.big {
-		font-size: 12px;
-		padding: 9px 18px;
-	}
 
 	&:hover {
 		color: var(--text-on-accent);

--- a/UI/src/routes/game/screens/inventory/EquippedTotals.svelte
+++ b/UI/src/routes/game/screens/inventory/EquippedTotals.svelte
@@ -57,7 +57,7 @@ const { view }: { view: InventoryView } = $props();
 	color: var(--text-muted);
 
 	&.accent {
-		color: var(--text-muted);
+		color: var(--accent-light);
 	}
 }
 

--- a/UI/src/routes/game/screens/inventory/FavoriteStar.svelte
+++ b/UI/src/routes/game/screens/inventory/FavoriteStar.svelte
@@ -1,0 +1,20 @@
+<!-- The shared favorite-star glyph used by the inventory grid slot and toolbar filter.
+     Fills with the accessory accent when `filled`; the stroke colour is overridable. -->
+<svg {width} {height} viewBox="0 0 16 16" style:fill={filled ? STAR_ACCENT : 'none'} style:stroke stroke-width="1.3">
+	<path d="M8 1.6l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.4 4.3 13.4l.7-4.3-3.1-3 4.3-.6z" stroke-linejoin="round" />
+</svg>
+
+<script lang="ts">
+const STAR_ACCENT = 'var(--category-accessory)';
+
+interface Props {
+	filled?: boolean;
+	size?: number;
+	/** Stroke colour; defaults to the accessory accent. */
+	stroke?: string;
+}
+
+const { filled = false, size = 12, stroke = STAR_ACCENT }: Props = $props();
+const width = $derived(size);
+const height = $derived(size);
+</script>

--- a/UI/src/routes/game/screens/inventory/GridSlot.svelte
+++ b/UI/src/routes/game/screens/inventory/GridSlot.svelte
@@ -42,16 +42,10 @@
 		title={item.favorite ? 'Unfavorite' : 'Favorite'}
 		onclick={stopPropagation(() => onToggleFav?.(item))}
 	>
-		<svg
-			width="12"
-			height="12"
-			viewBox="0 0 16 16"
-			style:fill={item.favorite ? 'var(--category-accessory)' : 'none'}
-			style:stroke={item.favorite ? 'var(--category-accessory)' : tintColor('var(--text-primary)', 0.85)}
-			stroke-width="1.3"
-		>
-			<path d="M8 1.6l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.4 4.3 13.4l.7-4.3-3.1-3 4.3-.6z" stroke-linejoin="round" />
-		</svg>
+		<FavoriteStar
+			filled={item.favorite}
+			stroke={item.favorite ? 'var(--category-accessory)' : tintColor('var(--text-primary)', 0.85)}
+		/>
 	</button>
 
 	<div class="cat-corner">
@@ -72,6 +66,7 @@ import type { Item } from '$lib/battle';
 import { itemCategoryColor, rarityColor, rarityGlow, rarityLevel, rarityTint, tintColor } from '$lib/common';
 import { stopPropagation } from '$lib/common/event-wrappers';
 import CategoryGlyph from './CategoryGlyph.svelte';
+import FavoriteStar from './FavoriteStar.svelte';
 
 interface Props {
 	item: Item;

--- a/UI/src/routes/game/screens/inventory/InventoryToolbar.svelte
+++ b/UI/src/routes/game/screens/inventory/InventoryToolbar.svelte
@@ -29,16 +29,7 @@
 			title="Show favorites only"
 			onclick={() => (view.favOnly = !view.favOnly)}
 		>
-			<svg
-				width="11"
-				height="11"
-				viewBox="0 0 16 16"
-				style:fill={view.favOnly ? 'var(--category-accessory)' : 'none'}
-				style:stroke="var(--category-accessory)"
-				stroke-width="1.3"
-			>
-				<path d="M8 1.6l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.4 4.3 13.4l.7-4.3-3.1-3 4.3-.6z" stroke-linejoin="round" />
-			</svg>
+			<FavoriteStar filled={view.favOnly} size={11} />
 			Favorites <span class="chip-count">{view.counts.fav}</span>
 		</button>
 	</div>
@@ -58,6 +49,7 @@
 <script lang="ts">
 import { itemCategoryColor, itemCategoryName } from '$lib/common';
 import { FILTER_CATEGORIES, SORTS, type InventoryView, type SortKey } from './inventory-view.svelte';
+import FavoriteStar from './FavoriteStar.svelte';
 
 const { view }: { view: InventoryView } = $props();
 const sortKeys = Object.keys(SORTS) as SortKey[];

--- a/UI/src/routes/game/screens/options/LivePreview.svelte
+++ b/UI/src/routes/game/screens/options/LivePreview.svelte
@@ -19,8 +19,10 @@
 
 <script lang="ts">
 import { LogRow } from '$components';
+import { untrack } from 'svelte';
 import type { LogMessage } from '$lib/engine/log';
 import { ELogType } from '$lib/api';
+import { prefersReducedMotion } from '$lib/common';
 import type { LogPrefMap } from './options-view.svelte';
 
 interface Props {
@@ -71,9 +73,11 @@ let nextId = 1;
 
 function makeEvent(): LogMessage {
 	const logType = WEIGHTS[Math.floor(Math.random() * WEIGHTS.length)];
-	const sample = SAMPLES.find((s) => s.logType === logType)!;
+	// Every weighted type has a sample, but guard the lookup rather than asserting it: fall back
+	// to the first sample so a future WEIGHTS/SAMPLES mismatch degrades instead of crashing.
+	const sample = SAMPLES.find((s) => s.logType === logType) ?? SAMPLES[0];
 	const message = sample.messages[Math.floor(Math.random() * sample.messages.length)];
-	return { id: nextId++, logType, message };
+	return { id: nextId++, logType: sample.logType, message };
 }
 
 // Stored oldest → newest; rendered newest-first to mirror the real LogPanel.
@@ -88,8 +92,16 @@ const shown = $derived(
 );
 
 $effect(() => {
+	// Skip the perpetual JS ticker under prefers-reduced-motion (the global CSS rule can't collapse
+	// a timer); the seeded feed stays static. The seed already produced the visible rows.
+	if (prefersReducedMotion()) {
+		return;
+	}
 	const timer = setInterval(() => {
-		events = [...events.slice(-(PREVIEW_BUFFER - 1)), makeEvent()];
+		// Read `events` untracked: the effect depends on nothing reactive, so reassigning `events`
+		// here must not tear down and recreate the timer every tick (cadence churn).
+		const current = untrack(() => events);
+		events = [...current.slice(-(PREVIEW_BUFFER - 1)), makeEvent()];
 	}, TICK_MS);
 	return () => clearInterval(timer);
 });

--- a/UI/src/tests/common/functions.test.ts
+++ b/UI/src/tests/common/functions.test.ts
@@ -1,14 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-	formatNum,
-	randomInt,
-	capitalize,
-	normalizeText,
-	plural,
-	keys,
-	groupBy,
-	enumPairs
-} from '../../lib/common/functions';
+import { formatNum, capitalize, normalizeText, plural, keys, groupBy, enumPairs } from '../../lib/common/functions';
 
 describe('formatNum', () => {
 	it('formats integers without trailing zeros', () => {
@@ -24,31 +15,6 @@ describe('formatNum', () => {
 	it('strips trailing zeros from decimals', () => {
 		expect(formatNum(1.1)).toBe('1.1');
 		expect(formatNum(2.0)).toBe('2');
-	});
-});
-
-describe('randomInt', () => {
-	it('returns values within the range [num1, num2)', () => {
-		for (let i = 0; i < 100; i++) {
-			const val = randomInt(5, 10);
-			expect(val).toBeGreaterThanOrEqual(5);
-			expect(val).toBeLessThan(10);
-		}
-	});
-
-	it('returns an integer', () => {
-		for (let i = 0; i < 20; i++) {
-			const val = randomInt(0, 100);
-			expect(val).toBe(Math.floor(val));
-		}
-	});
-
-	it('works with negative ranges', () => {
-		for (let i = 0; i < 50; i++) {
-			const val = randomInt(-10, -5);
-			expect(val).toBeGreaterThanOrEqual(-10);
-			expect(val).toBeLessThan(-5);
-		}
 	});
 });
 

--- a/UI/src/tests/components/Tooltip.test.ts
+++ b/UI/src/tests/components/Tooltip.test.ts
@@ -54,8 +54,8 @@ describe('Tooltip', () => {
 			window.innerHeight = 800;
 		});
 
-		// The style derived reads the (non-reactive) container binding, so it only recomputes once a
-		// reactive prop changes after mount — mirroring the real store toggling `visible` post-mount.
+		// Toggle `visible` after mount — mirroring the real store — so the style derived recomputes
+		// with the bound container in place.
 		const renderVisible = async (position: { x: number; y: number }) => {
 			const props = makeProps({ visible: false, position });
 			const result = render(Tooltip, { props });

--- a/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
@@ -56,6 +56,9 @@ describe('EnemyManager.getNewEnemy', () => {
 
 	beforeEach(() => {
 		manager = new EnemyManager();
+		// The retry loop runs while the manager is started; flip it on directly (start() would also
+		// hook battle-stage changes, which these focused unit tests don't exercise).
+		manager.started = true;
 		vi.mocked(logMessage).mockClear();
 		vi.mocked(delay).mockClear();
 		sendSocketCommand = vi.spyOn(apiSocket, 'sendSocketCommand');
@@ -105,5 +108,28 @@ describe('EnemyManager.getNewEnemy', () => {
 		// Backs off by the default retry delay (no explicit cooldown was provided).
 		expect(delay).toHaveBeenCalledWith(1000);
 		expect(manager.currentEnemy).toEqual(makeEnemy(4));
+	});
+
+	it('does not request an enemy when the manager is not started', async () => {
+		manager.started = false;
+
+		await manager.getNewEnemy();
+
+		expect(sendSocketCommand).not.toHaveBeenCalled();
+		expect(manager.currentEnemy).toBeUndefined();
+	});
+
+	it('stops retrying once the manager is stopped mid-backoff (a sustained outage is bounded)', async () => {
+		sendSocketCommand.mockResolvedValue(errorResponse('outage'));
+		// Simulate stop() landing during the retry backoff: the loop must not request again.
+		vi.mocked(delay).mockImplementationOnce(() => {
+			manager.started = false;
+			return Promise.resolve();
+		});
+
+		await manager.getNewEnemy();
+
+		expect(sendSocketCommand).toHaveBeenCalledTimes(1);
+		expect(manager.currentEnemy).toBeUndefined();
 	});
 });

--- a/UI/src/tests/lib/engine/player/player-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/player-manager.test.ts
@@ -118,6 +118,22 @@ describe('PlayerManager', () => {
 			expect(manager.level).toBe(2);
 			expect(manager.exp).toBe(199);
 		});
+
+		it('does not over-level from the pre-initialize level=0 default (threshold clamps to ≥ 1)', () => {
+			// Before initialize, level defaults to 0; a 0 * EXP_PER_LEVEL threshold would otherwise
+			// loop. The clamp keeps the threshold at one level's worth of exp.
+			manager.grantExp(50);
+
+			expect(manager.level).toBe(0);
+			expect(manager.exp).toBe(50);
+		});
+
+		it('levels up exactly once past the clamped threshold from a level=0 default', () => {
+			manager.grantExp(150);
+
+			expect(manager.level).toBe(1);
+			expect(manager.exp).toBe(50);
+		});
 	});
 
 	describe('levelUp', () => {

--- a/UI/src/tests/routes/admin/workbench/entity-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entity-store.test.ts
@@ -84,6 +84,13 @@ describe('EntityStore', () => {
 		expect(store.counts.total).toBe(0);
 	});
 
+	it('clears the saved flag on restore so the "Changes saved" banner cannot linger', () => {
+		const store = new EntityStore(makeConfig(), seed);
+		store.saved = true;
+		store.restoreItem(0);
+		expect(store.saved).toBe(false);
+	});
+
 	it('discard reverts every pending change', () => {
 		const store = new EntityStore(makeConfig(), seed);
 		store.addItem();

--- a/UI/src/tests/routes/game/screens/options/LivePreview.test.ts
+++ b/UI/src/tests/routes/game/screens/options/LivePreview.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { ELogType } from '$lib/api';
+import type { LogPrefMap } from '$routes/game/screens/options/options-view.svelte';
+
+// Stub LogRow so the test exercises the preview's ticker/effect logic, not the row's rendering.
+vi.mock('$components', () => ({ LogRow: (() => {}) as unknown }));
+
+// Control the reduced-motion gate per test.
+const { prefersReducedMotion } = vi.hoisted(() => ({ prefersReducedMotion: vi.fn(() => false) }));
+vi.mock('$lib/common', async (importOriginal) => ({
+	...(await importOriginal<typeof import('$lib/common')>()),
+	prefersReducedMotion
+}));
+
+import LivePreview from '$routes/game/screens/options/LivePreview.svelte';
+
+// Every log type enabled, so the preview always has content to render.
+const allOn: LogPrefMap = Object.fromEntries(
+	Object.values(ELogType)
+		.filter((v): v is number => typeof v === 'number')
+		.map((id) => [id, true])
+);
+
+describe('LivePreview ticker', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		prefersReducedMotion.mockReturnValue(false);
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.useRealTimers();
+		prefersReducedMotion.mockReset();
+	});
+
+	it('starts a single repeating ticker that is not torn down each tick', () => {
+		const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+		const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+
+		render(LivePreview, { props: { prefs: allOn } });
+
+		expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+		// Drive several ticks: reassigning `events` must not recreate the timer (the churn bug), so
+		// no further setInterval/clearInterval calls fire between ticks.
+		vi.advanceTimersByTime(1600 * 4);
+
+		expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+		expect(clearIntervalSpy).not.toHaveBeenCalled();
+	});
+
+	it('does not start the ticker under prefers-reduced-motion', () => {
+		prefersReducedMotion.mockReturnValue(true);
+		const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+
+		render(LivePreview, { props: { prefs: allOn } });
+		vi.advanceTimersByTime(1600 * 3);
+
+		expect(setIntervalSpy).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
A bundle of small, independent frontend cleanups from #601. Each is low-risk and surgical.

## Dead code
- **Unused common types removed** (`lib/common/types.ts`): `Comparator`, `Converter`, `CheckFunc`, `ProgressionFunc`, `SlotVariant`, and the stale `Screens` had no source references. Only `Action` (used by `api-socket.ts`) remains.
- **`randomInt` removed** (`lib/common/functions.ts`) along with its tests — no production caller, and a `Math.random()` determinism trap for anyone reaching for it in battle code.
- **No-op `.mono-label.accent` fixed** (`inventory/EquippedTotals.svelte`): `&.accent` now resolves to `--accent-light`, matching the working pattern in `Challenges.svelte`, instead of the base `--text-muted`.
- **`big` prop/rule dropped** (`fight/boss/ChallengeButton.svelte`): the prop and `.big` CSS were unused per the component's own comment.
- **`FavoriteStar.svelte` extracted**: the duplicated favorite-star SVG path in `inventory/GridSlot.svelte` and `inventory/InventoryToolbar.svelte` is now one small, focused component (size and stroke parameterized to cover both call sites).

## Small robustness fixes
- **`enemy-manager.ts` retry made iterative**: `getNewEnemy`'s self-recursive retry is now a `while (this.started)` loop with backoff, so a sustained outage no longer grows the async chain and `stop()` cancels it.
- **Level-up edge case clamped** (`player-manager.ts`): the threshold (`level * EXP_PER_LEVEL`) is computed via a shared `nextLevelThreshold` getter clamped to `level >= 1`, so the pre-`initialize` `level = 0` default can't over-level. A real level (>= 1) is unaffected, preserving backend parity.
- **`LivePreview.svelte` `$effect` fixed**: `events` is read via `untrack` so the ticker isn't torn down/recreated each tick; the ticker is now skipped under `prefers-reduced-motion` (a perpetual JS timer the global CSS rule can't collapse); and the `SAMPLES.find` null-forgiving `!` is replaced with a guarded fallback.
- **`entity-store.svelte.ts` `restoreItem`** now sets `this.saved = false` like every sibling mutator, so the "Changes saved" banner can't linger after a restore.
- **`Tooltip.svelte` `$effect` guarded**: the binding is now `$state` and the effect checks `container` so it can't run before the `bind:this` binding establishes.

### Skipped
- **`log.ts` id-seed simplification** — no longer applicable. The combat-log counter already lives in the `logs` store initialized to `0`; the dead `(logs()?.[0]?.id ?? -1) + 1` seed expression the issue describes has already been refactored away.

### Drive-by (DRY)
- The `prefers-reduced-motion` check was extracted into `$lib/common` (`prefersReducedMotion`), replacing the duplicate private copy in `AttributesRadar.svelte`.

## Test plan
- `npm ci` in `UI`
- `npm run lint` (eslint + svelte-check) — passes, 0 errors / 0 warnings
- `npm run test:unit:ci` — passes, 173 test files / 1649 tests
- Added/updated unit tests: the iterative retry loop (including stop-mid-backoff cancellation), the level-up clamp from the `level = 0` default, the LivePreview ticker (single timer + reduced-motion gating), the restore-banner fix, and the trimmed `functions`/`Tooltip` suites.

Closes #601

https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw)_