### PR TITLE
refactor: harden TypeScript codegen against silently-wrong output

### DIFF
--- a/Game.Api.Tests/CodeGen/ApiInterfaceWriterTests.cs
+++ b/Game.Api.Tests/CodeGen/ApiInterfaceWriterTests.cs
@@ -118,6 +118,48 @@ namespace Game.Api.Tests.CodeGen
         }
 
         [Fact]
+        public void WriteApiInterfaces_ByteBackedEnum_RendersRawValues()
+        {
+            var writer = new ApiInterfaceWriter(_options);
+            var descriptor = new CodeGenTypeDescriptor(typeof(ByteBackedEnum));
+
+            writer.WriteApiInterfaces([descriptor], "// Auto-generated");
+
+            var content = File.ReadAllText(Path.Combine(_options.TargetDirectory, "enums.ts"));
+            Assert.Contains("export enum ByteBackedEnum {", content);
+            Assert.Contains("Zero = 0,", content);
+            Assert.Contains("TwoHundred = 200,", content);
+        }
+
+        [Fact]
+        public void WriteApiInterfaces_LongBackedEnum_RendersValueOutsideIntRange()
+        {
+            var writer = new ApiInterfaceWriter(_options);
+            var descriptor = new CodeGenTypeDescriptor(typeof(LongBackedEnum));
+
+            writer.WriteApiInterfaces([descriptor], "// Auto-generated");
+
+            var content = File.ReadAllText(Path.Combine(_options.TargetDirectory, "enums.ts"));
+            // The old (int)value cast would have overflowed; rendering the raw long keeps the true value.
+            Assert.Contains("Huge = 5000000000,", content);
+        }
+
+        [Fact]
+        public void WriteApiInterfaces_AliasedEnum_RendersBothMemberNames()
+        {
+            var writer = new ApiInterfaceWriter(_options);
+            var descriptor = new CodeGenTypeDescriptor(typeof(AliasedEnum));
+
+            writer.WriteApiInterfaces([descriptor], "// Auto-generated");
+
+            var content = File.ReadAllText(Path.Combine(_options.TargetDirectory, "enums.ts"));
+            // Rendering from field.Name keeps the alias distinct; value.ToString() would emit "First"
+            // twice and drop "AliasOfFirst".
+            Assert.Contains("First = 1,", content);
+            Assert.Contains("AliasOfFirst = 1,", content);
+        }
+
+        [Fact]
         public void WriteApiInterfaces_NestedClass_WritesImports()
         {
             var writer = new ApiInterfaceWriter(_options);

--- a/Game.Api.Tests/CodeGen/CodeGenExtensionsTests.cs
+++ b/Game.Api.Tests/CodeGen/CodeGenExtensionsTests.cs
@@ -1,10 +1,38 @@
 using Game.Api.CodeGen;
+using Game.Api.Sockets.Commands;
 using Xunit;
 
 namespace Game.Api.Tests.CodeGen
 {
     public class CodeGenExtensionsTests
     {
+        [Fact]
+        public void GetClosedGenericBase_DirectBase_ReturnsClosedType()
+        {
+            var result = typeof(TestSocketCommandFull).GetClosedGenericBase(typeof(AbstractSocketCommand<,>));
+
+            Assert.NotNull(result);
+            Assert.Equal(typeof(AbstractSocketCommand<SimpleModel, SocketParamModel>), result);
+        }
+
+        [Fact]
+        public void GetClosedGenericBase_AncestorBase_WalksChain()
+        {
+            // AbstractSocketCommandWithResponseData<SimpleModel> is a grandparent of the full command.
+            var result = typeof(TestSocketCommandFull).GetClosedGenericBase(typeof(AbstractSocketCommandWithResponseData<>));
+
+            Assert.NotNull(result);
+            Assert.Equal(typeof(AbstractSocketCommandWithResponseData<SimpleModel>), result);
+        }
+
+        [Fact]
+        public void GetClosedGenericBase_NotDerived_ReturnsNull()
+        {
+            var result = typeof(TestSocketCommandBasic).GetClosedGenericBase(typeof(AbstractSocketCommandWithParams<>));
+
+            Assert.Null(result);
+        }
+
         [Fact]
         public void IsEnumerable_List_ReturnsTrue()
         {

--- a/Game.Api.Tests/CodeGen/CodeGenTypeFormatterTests.cs
+++ b/Game.Api.Tests/CodeGen/CodeGenTypeFormatterTests.cs
@@ -286,6 +286,24 @@ namespace Game.Api.Tests.CodeGen
             var descriptor = GetPropertyDescriptor<ModelWithDictionary>("StringToInt");
             Assert.Null(CodeGenTypeFormatter.GetImportText(descriptor));
         }
+
+        [Fact]
+        public void GetTypeText_UnmappedByte_Throws()
+        {
+            // byte has no TypeScript mapping and is rejected by NeedsInterface (it is a primitive), so the
+            // formatter must throw rather than silently emit a reference to a never-generated interface.
+            var descriptor = GetPropertyDescriptor<ModelWithUnmappedType>("ByteValue");
+            var ex = Assert.Throws<InvalidOperationException>(() => CodeGenTypeFormatter.GetTypeText(descriptor));
+            Assert.Contains("Byte", ex.Message);
+        }
+
+        [Fact]
+        public void GetTypeText_UnmappedChar_Throws()
+        {
+            var descriptor = GetPropertyDescriptor<ModelWithUnmappedType>("CharValue");
+            var ex = Assert.Throws<InvalidOperationException>(() => CodeGenTypeFormatter.GetTypeText(descriptor));
+            Assert.Contains("Char", ex.Message);
+        }
     }
 
     public class GenericHolder

--- a/Game.Api.Tests/CodeGen/ControllerMetadataExtractorTests.cs
+++ b/Game.Api.Tests/CodeGen/ControllerMetadataExtractorTests.cs
@@ -129,6 +129,27 @@ namespace Game.Api.Tests.CodeGen
         }
 
         [Fact]
+        public void Endpoint_ApiPrefix_RemovedCleanlyWithoutLeadingSlash()
+        {
+            var extractor = new ControllerMetadataExtractor(typeof(PrefixController));
+            var get = extractor.Endpoints.Single();
+
+            // Route "/api/Prefix" → after removing the "api/" prefix → "Prefix" (no leading slash, no
+            // dropped character).
+            Assert.Equal("Prefix", get.Endpoint);
+        }
+
+        [Fact]
+        public void Endpoint_NonApiRoute_LeftIntact()
+        {
+            var extractor = new ControllerMetadataExtractor(typeof(NonApiRouteController));
+            var check = extractor.Endpoints.Single();
+
+            // A route that does not start with "api/" must not be sliced at all.
+            Assert.Equal("health/Check", check.Endpoint);
+        }
+
+        [Fact]
         public void ExcludesNonActionMethods()
         {
             var extractor = new ControllerMetadataExtractor(typeof(ControllerWithNonAction));

--- a/Game.Api.Tests/CodeGen/SocketCommandMetadataTests.cs
+++ b/Game.Api.Tests/CodeGen/SocketCommandMetadataTests.cs
@@ -53,6 +53,28 @@ namespace Game.Api.Tests.CodeGen
             Assert.Null(metadata.ResponseDescriptor);
             Assert.Null(metadata.ParameterDescriptor);
         }
+
+        [Fact]
+        public void Constructor_DerivedCommand_ResolvesGenericBaseFromChain()
+        {
+            var metadata = new SocketCommandMetadata(typeof(TestSocketCommandDerivedFull));
+
+            Assert.NotNull(metadata.ResponseDescriptor);
+            Assert.NotNull(metadata.ParameterDescriptor);
+            Assert.Equal(typeof(SimpleModel), metadata.ResponseDescriptor.UnderlyingType);
+            Assert.Equal(typeof(SocketParamModel), metadata.ParameterDescriptor.UnderlyingType);
+        }
+
+        [Fact]
+        public void Constructor_DecoyMembers_NotExtractedWithoutGenericBase()
+        {
+            // Members named "Parameters"/"HandleExecute" that are not from the typed generic base must
+            // not be mistaken for the real descriptors.
+            var metadata = new SocketCommandMetadata(typeof(TestSocketCommandWithDecoyMembers));
+
+            Assert.Null(metadata.ResponseDescriptor);
+            Assert.Null(metadata.ParameterDescriptor);
+        }
     }
 
     public class SocketParamModel
@@ -94,6 +116,33 @@ namespace Game.Api.Tests.CodeGen
     public class TestSocketCommandBasic : AbstractSocketCommand
     {
         public override string Name { get; set; } = "TestBasic";
+
+        public override ApiSocketResponse Execute(SocketContext context)
+        {
+            return Success();
+        }
+    }
+
+    // A multi-level hierarchy: the response/parameter generic bases are not the direct base, so the
+    // metadata must walk the base chain to find the closed generic base rather than only inspecting it.
+    public class TestSocketCommandDerivedFull : TestSocketCommandFull
+    {
+        public override string Name { get; set; } = "TestDerivedFull";
+    }
+
+    // A basic command (no params/response generic base) that nonetheless declares members named
+    // "Parameters" and "HandleExecute". Resolving by raw member name would mis-extract these; gating on
+    // the typed generic base means neither descriptor is set.
+    public class TestSocketCommandWithDecoyMembers : AbstractSocketCommand
+    {
+        public override string Name { get; set; } = "TestDecoy";
+
+        public string Parameters { get; set; } = "";
+
+        public int HandleExecute(SocketContext context)
+        {
+            return 0;
+        }
 
         public override ApiSocketResponse Execute(SocketContext context)
         {

--- a/Game.Api.Tests/CodeGen/TestFixtures.cs
+++ b/Game.Api.Tests/CodeGen/TestFixtures.cs
@@ -57,6 +57,41 @@ namespace Game.Api.Tests.CodeGen
         Pending = 3
     }
 
+    // A byte-backed enum: casting its members to int (the old enum-rendering path) would have worked
+    // here but throwing/truncation risk exists for larger backing types; this pins that the raw
+    // constant value is rendered regardless of backing type.
+    public enum ByteBackedEnum : byte
+    {
+        Zero = 0,
+        TwoHundred = 200
+    }
+
+    // A long-backed enum with a value outside the int range: the old (int)value cast would overflow,
+    // so this pins that GetRawConstantValue renders the true value.
+    public enum LongBackedEnum : long
+    {
+        Small = 1,
+        Huge = 5_000_000_000
+    }
+
+    // An enum with an aliased member (two names sharing a value): rendering from field.Name keeps both
+    // distinct names, where value.ToString() would have emitted the same canonical name twice.
+    public enum AliasedEnum
+    {
+        First = 1,
+        Second = 2,
+        AliasOfFirst = 1
+    }
+
+    // A model whose property types (byte, char) have no TypeScript mapping and are rejected by
+    // NeedsInterface (they are primitives), so GetTypeText must throw rather than emit a reference to an
+    // interface that is never generated.
+    public class ModelWithUnmappedType : IModel
+    {
+        public byte ByteValue { get; set; }
+        public char CharValue { get; set; }
+    }
+
     public class NestedModel : IModel
     {
         public SimpleModel Child { get; set; } = new();
@@ -114,6 +149,32 @@ namespace Game.Api.Tests.CodeGen
         public ApiResponse Save([FromBody] SimpleModel model)
         {
             return new ApiResponse();
+        }
+    }
+
+    // Resolves to the route "api/Prefix" (no [action]); pins that the "api/" prefix is removed cleanly
+    // to "Prefix" with no leading slash and no dropped character (the route["api/".Length..] slice).
+    [Route("/api/[controller]")]
+    [ApiController]
+    public class PrefixController : ControllerBase
+    {
+        [HttpGet]
+        public ApiResponse<SimpleModel> Get()
+        {
+            return new ApiResponse<SimpleModel>();
+        }
+    }
+
+    // Resolves to a route that does NOT start with "api/"; pins that such a route is left intact rather
+    // than being silently mis-sliced.
+    [Route("/health/[action]")]
+    [ApiController]
+    public class NonApiRouteController : ControllerBase
+    {
+        [HttpGet]
+        public ApiResponse<SimpleModel> Check()
+        {
+            return new ApiResponse<SimpleModel>();
         }
     }
 

--- a/Game.Api/CodeGen/CodeGenTypeFormatter.cs
+++ b/Game.Api/CodeGen/CodeGenTypeFormatter.cs
@@ -81,9 +81,19 @@ namespace Game.Api.CodeGen
                 var typeText = genericParameter.IsNullable ? $"({GetTypeText(genericParameter)} | undefined)" : GetTypeText(genericParameter);
                 return $"{typeText}[]";
             }
-            else
+            else if (type.NeedsInterface())
             {
                 return GetInterfaceName(descriptor);
+            }
+            else
+            {
+                // A type with no TypeScript mapping that NeedsInterface() also rejects (e.g. Guid,
+                // TimeSpan, byte, char) would otherwise silently emit a reference to an interface that
+                // is never generated, breaking the frontend build with nothing flagged here. Throw so
+                // the unmapped type surfaces at generation time instead.
+                throw new InvalidOperationException(
+                    $"CodeGen has no TypeScript mapping for type '{type.FullName ?? type.Name}'. " +
+                    "Add an explicit mapping in CodeGenTypeFormatter.GetTypeText (and CodeGenExtensions.NeedsInterface if it should generate an interface).");
             }
         }
 

--- a/Game.Api/CodeGen/Data/ControllerMetadataExtractor.cs
+++ b/Game.Api/CodeGen/Data/ControllerMetadataExtractor.cs
@@ -48,15 +48,16 @@ namespace Game.Api.CodeGen.Data
                 ? routeTemplate.Replace("[controller]", _name).Replace("[action]", endpoint.Name)
                 : $"/api/{_name}/{endpoint.Name}";
 
+            const string apiPrefix = "api/";
             route = route.TrimStart('/');
-            if (route.StartsWith("api/"))
+            if (route.StartsWith(apiPrefix))
             {
-                route = route[3..];
+                route = route[apiPrefix.Length..];
             }
 
             return new EndpointMetadata(endpoint)
             {
-                Endpoint = route.TrimStart('/'),
+                Endpoint = route,
                 IsGet = methodAtt?.HttpMethods?.Contains("GET") ?? true
             };
         }

--- a/Game.Api/CodeGen/Data/SocketCommandMetadata.cs
+++ b/Game.Api/CodeGen/Data/SocketCommandMetadata.cs
@@ -1,4 +1,5 @@
 ﻿using Game.Api.Sockets.Commands;
+using System.Reflection;
 
 namespace Game.Api.CodeGen.Data
 {
@@ -12,16 +13,27 @@ namespace Game.Api.CodeGen.Data
         {
             CommandName = socketCommand.Name;
 
-            var method = socketCommand.GetMethods().FirstOrDefault(m => m.Name == nameof(AbstractSocketCommandWithResponseData<>.HandleExecute));
-            if (method is not null)
+            // Resolve the response/parameter members against the typed generic bases rather than by raw
+            // member name: that way a rename or an added overload of HandleExecute/Parameters surfaces as
+            // a missed extraction or a loud error here instead of silently mis-extracting a same-named
+            // member, and the generic argument is read with a guarded index.
+            if (socketCommand.GetClosedGenericBase(typeof(AbstractSocketCommandWithResponseData<>)) is not null)
             {
-                ResponseDescriptor = new CodeGenTypeDescriptor(method.ReturnParameter.GetNullabilityInfo().GenericTypeArguments[0]);
+                var method = socketCommand.GetMethod(nameof(AbstractSocketCommandWithResponseData<>.HandleExecute));
+                if (method is not null && method.ReturnParameter.GetNullabilityInfo().GenericTypeArguments is [var responseArg, ..])
+                {
+                    ResponseDescriptor = new CodeGenTypeDescriptor(responseArg);
+                }
             }
 
-            var property = socketCommand.GetProperties().FirstOrDefault(p => p.Name == nameof(AbstractSocketCommandWithParams<>.Parameters));
-            if (property is not null)
+            if (socketCommand.GetClosedGenericBase(typeof(AbstractSocketCommandWithParams<>)) is not null
+                || socketCommand.GetClosedGenericBase(typeof(AbstractSocketCommand<,>)) is not null)
             {
-                ParameterDescriptor = new CodeGenTypeDescriptor(property);
+                var property = socketCommand.GetProperty(nameof(AbstractSocketCommandWithParams<>.Parameters));
+                if (property is not null)
+                {
+                    ParameterDescriptor = new CodeGenTypeDescriptor(property);
+                }
             }
         }
     }

--- a/Game.Api/CodeGen/Extensions.cs
+++ b/Game.Api/CodeGen/Extensions.cs
@@ -16,6 +16,25 @@ namespace Game.Api.CodeGen
             return nullabilityContext.Create(parameter);
         }
 
+        /// <summary>
+        /// Walks <paramref name="type"/>'s base-class chain for the closed constructed type that
+        /// matches the supplied open generic base definition (e.g. <c>AbstractSocketCommand&lt;,&gt;</c>),
+        /// or <c>null</c> if the type does not derive from it. Used by the codegen to resolve a command's
+        /// response/parameter members against the typed generic base instead of by raw member name.
+        /// </summary>
+        internal static Type? GetClosedGenericBase(this Type type, Type openGenericBase)
+        {
+            for (var current = type; current is not null; current = current.BaseType)
+            {
+                if (current.IsGenericType && current.GetGenericTypeDefinition() == openGenericBase)
+                {
+                    return current;
+                }
+            }
+
+            return null;
+        }
+
         internal static bool NeedsInterface(this Type type)
         {
             if (type.IsEnumerable())

--- a/Game.Api/CodeGen/Writers/ApiInterfaceWriter.cs
+++ b/Game.Api/CodeGen/Writers/ApiInterfaceWriter.cs
@@ -1,5 +1,6 @@
 ﻿using Game.Api.CodeGen.Data;
 using Game.Core;
+using System.Globalization;
 using System.Reflection;
 using System.Text;
 
@@ -97,14 +98,18 @@ namespace Game.Api.CodeGen.Writers
             var fields = descriptor.UnderlyingType.GetFields(BindingFlags.Public | BindingFlags.Static);
             foreach (var field in fields)
             {
-                var value = field.GetValue(null) ?? throw new InvalidOperationException($"Failed to get enum value for {descriptor.Name}->{field.Name}");
+                // Render from the member name and its declared raw constant value rather than casting
+                // to int: that keeps the right name for aliased members and avoids truncating/throwing
+                // on a non-int backing type (e.g. byte/long-backed enums) — the same approach
+                // ConstantsWriter.RenderValue takes.
+                var rawValue = field.GetRawConstantValue() ?? throw new InvalidOperationException($"Failed to get enum value for {descriptor.Name}->{field.Name}");
                 var obsoleteAttribute = field.GetCustomAttribute<ObsoleteAttribute>();
                 if (obsoleteAttribute is not null)
                 {
                     builder.AppendLine($"\t/** @deprecated {obsoleteAttribute.Message} */");
                 }
 
-                builder.AppendLine($"\t{value.ToString()} = {(int)value},");
+                builder.AppendLine($"\t{field.Name} = {Convert.ToString(rawValue, CultureInfo.InvariantCulture)},");
             }
 
             builder.Append('}');


### PR DESCRIPTION
## Summary

Hardens the reflection-based TypeScript client generator (`Game.Api` codegen) against the four latent footguns described in #586, each of which would fail silently (producing wrong/non-compiling TS) rather than loudly on a future change.

1. **Fragile route slice** (`ControllerMetadataExtractor`) — replaced `route[3..]` (which dropped `api` but kept a leading slash, only saved by a redundant follow-up `TrimStart`) with `route["api/".Length..]`, so an `api/`-prefixed route is removed exactly and a route that does **not** start with `api/` is left intact instead of being silently mis-sliced.
2. **Unmapped types → bogus interface name** (`CodeGenTypeFormatter.GetTypeText`) — the fall-through now throws an `InvalidOperationException` naming the offending type for any type with no TypeScript mapping that `NeedsInterface()` also rejects (e.g. `byte`, `char`), instead of emitting a reference to an interface that is never generated. (Note: `Guid`/`TimeSpan`/`DateTimeOffset` are structs that `NeedsInterface()` already accepts, so they generate an interface rather than hitting this throw; the throw guards the primitive-ish unmapped types.)
3. **Enum codegen assumed int backing + unique values** (`ApiInterfaceWriter`) — enum members are now rendered from `field.Name` + `field.GetRawConstantValue()` (the same approach `ConstantsWriter.RenderValue` takes) rather than `value.ToString()` / `(int)value`, so an aliased member keeps its distinct name and a non-`int` backing type is not truncated/overflowed.
4. **Name-based member coupling** (`SocketCommandMetadata`) — the response/parameter members are now resolved against the typed generic base (new `Type.GetClosedGenericBase` helper that walks the base-class chain) with guarded index access, so a rename or added overload of `HandleExecute`/`Parameters` surfaces as a missed extraction here rather than silently mis-extracting a same-named member or throwing a cryptic index error.

Added focused codegen unit tests pinning each path (api/non-api route shapes, the unmapped-type throw, byte/long-backed and aliased enum rendering, generic-base member resolution including a decoy same-named member and a multi-level hierarchy).

## Generated output (`UI/src/lib/api/types`)

**Unchanged — byte-identical to `main`.** After the generator changes I ran `dotnet run --project Game.Api -- codegen` and `git diff -- UI/src/lib/api/types` is empty. All current DTOs/enums are within the previously-safe subset (every enum is `int`-backed with unique values, every DTO type is mapped), so the hardening is fully output-preserving. The enum-rendering change (`field.Name`/`GetRawConstantValue()`) and the "throw on unmapped type" change did not alter any current output, and the throw did not fire — confirming no type is currently unmapped.

## Test plan

- `dotnet build` — succeeds, 0 warnings / 0 errors.
- `dotnet run --project Game.Api --no-build --no-restore -- codegen` then `git diff -- UI/src/lib/api/types` — clean (no output change).
- Codegen unit tests (run without the integration DB/Redis fixture via the xUnit `-namespace "Game.Api.Tests.CodeGen"` filter, since codegen short-circuits before host construction): **196 passed, 0 failed**.
- `dotnet format` — no changes.

Closes #586

https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw)_