### PR TITLE
refactor: move SetUserRoles role-existence validation into the data layer

### DIFF
--- a/Game.Abstractions/DataAccess/IUsers.cs
+++ b/Game.Abstractions/DataAccess/IUsers.cs
@@ -3,6 +3,17 @@ using Game.Core.Players;
 
 namespace Game.Abstractions.DataAccess
 {
+    /// <summary>
+    /// Outcome of a <see cref="IUsers.SetUserRoles"/> attempt, so the caller can surface the
+    /// appropriate message. The data tier owns validating the assignment against the role set.
+    /// </summary>
+    public enum SetUserRolesStatus
+    {
+        Success,
+        UserNotFound,
+        UnknownRole,
+    }
+
     public interface IUsers
     {
         /// <summary>
@@ -45,9 +56,11 @@ namespace Game.Abstractions.DataAccess
         Task<int> CountUsers(string? search, int? roleId, bool? archived);
 
         /// <summary>
-        /// Replaces the set of roles granted to the user with the given role ids. Returns false if the user does not exist.
+        /// Replaces the set of roles granted to the user with the given role ids, validating that every id
+        /// refers to a real role. Returns <see cref="SetUserRolesStatus.UserNotFound"/> if the user does not
+        /// exist or <see cref="SetUserRolesStatus.UnknownRole"/> if any id is not a known role.
         /// </summary>
-        Task<bool> SetUserRoles(int userId, IReadOnlyCollection<int> roleIds);
+        Task<SetUserRolesStatus> SetUserRoles(int userId, IReadOnlyCollection<int> roleIds);
 
         /// <summary>
         /// Archives (soft-deletes) the user, freeing their username for reuse. Returns false if the user does not exist.

--- a/Game.Api.Tests/Integration/AdminUsersControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminUsersControllerTests.cs
@@ -262,6 +262,28 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task SetUserRoles_DuplicateValidRoleIds_GrantsRoleOnce()
+        {
+            using var authClient = await SetupAdminClientAsync();
+            int targetId;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                var target = await TestDataSeeder.CreateUserAsync(context, "dupe", "pw");
+                targetId = target.Id;
+            }
+
+            // The relocated validation dedups submitted ids, so repeating a valid role is not rejected.
+            var response = await authClient.PostAsJsonAsync(
+                "/api/AdminTools/SetUserRoles",
+                new { UserId = targetId, RoleIds = new[] { (int)ERole.Admin, (int)ERole.Admin } },
+                CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(new[] { nameof(ERole.Admin) }, await LoadRoleNamesAsync(targetId));
+        }
+
+        [Fact]
         public async Task SetUserRoles_UnknownUser_ReturnsError()
         {
             using var authClient = await SetupAdminClientAsync();

--- a/Game.Api/Controllers/Admin/AdminUsersController.cs
+++ b/Game.Api/Controllers/Admin/AdminUsersController.cs
@@ -60,15 +60,14 @@ namespace Game.Api.Controllers.Admin
         [HttpPost]
         public async Task<ApiResponse> SetUserRoles([FromBody] SetUserRolesData data)
         {
-            var roleIds = data.RoleIds.Distinct().ToList();
-            var knownRoleIds = _roles.GetRoles().Select(r => r.Id).ToHashSet();
-            if (roleIds.Any(id => !knownRoleIds.Contains(id)))
+            var status = await _users.SetUserRoles(data.UserId, data.RoleIds);
+            return status switch
             {
-                return ApiResponse.Error("One or more roles do not exist.");
-            }
-
-            var updated = await _users.SetUserRoles(data.UserId, roleIds);
-            return updated ? ApiResponse.Success() : ApiResponse.Error("User not found.");
+                SetUserRolesStatus.Success => ApiResponse.Success(),
+                SetUserRolesStatus.UserNotFound => ApiResponse.Error("User not found."),
+                SetUserRolesStatus.UnknownRole => ApiResponse.Error("One or more roles do not exist."),
+                _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
+            };
         }
 
         [HttpPost]

--- a/Game.DataAccess/Repositories/Users.cs
+++ b/Game.DataAccess/Repositories/Users.cs
@@ -101,7 +101,7 @@ namespace Game.DataAccess.Repositories
             return FilteredUsers(search, roleId, archived).CountAsync();
         }
 
-        public async Task<bool> SetUserRoles(int userId, IReadOnlyCollection<int> roleIds)
+        public async Task<SetUserRolesStatus> SetUserRoles(int userId, IReadOnlyCollection<int> roleIds)
         {
             var user = await _context.Users
                 .Include(u => u.Roles)
@@ -109,19 +109,27 @@ namespace Game.DataAccess.Repositories
 
             if (user is null)
             {
-                return false;
+                return SetUserRolesStatus.UserNotFound;
             }
 
-            user.Roles.RemoveAll(r => !roleIds.Contains(r.Id));
-
-            var existingRoleIds = user.Roles.Select(r => r.Id).ToList();
-            var rolesToAdd = await _context.Roles
-                .Where(r => roleIds.Contains(r.Id) && !existingRoleIds.Contains(r.Id))
+            // Reject the whole assignment if any submitted id is not a real role, validated against the
+            // persistence layer's own role set rather than a caller-side check.
+            var requestedRoleIds = roleIds.Distinct().ToList();
+            var knownRoles = await _context.Roles
+                .Where(r => requestedRoleIds.Contains(r.Id))
                 .ToListAsync();
 
-            user.Roles.AddRange(rolesToAdd);
+            if (knownRoles.Count != requestedRoleIds.Count)
+            {
+                return SetUserRolesStatus.UnknownRole;
+            }
 
-            return true;
+            user.Roles.RemoveAll(r => !requestedRoleIds.Contains(r.Id));
+
+            var existingRoleIds = user.Roles.Select(r => r.Id).ToHashSet();
+            user.Roles.AddRange(knownRoles.Where(r => !existingRoleIds.Contains(r.Id)));
+
+            return SetUserRolesStatus.Success;
         }
 
         public Task<bool> ArchiveUser(int userId)


### PR DESCRIPTION
## Summary

`AdminUsersController.SetUserRoles` previously deduped the submitted role ids, loaded the full role set via `IRoles.GetRoles()`, and rejected the request if any id was unknown. That is a valid-role business rule living in the HTTP layer, which the backend onion-architecture guideline forbids (the API layer holds HTTP/input concerns only; repositories own validation against reference data).

This moves the role-existence check into `IUsers.SetUserRoles` (the `Users` repository), so the data tier validates the assignment against its own persisted role set:

- `SetUserRoles` now returns a `SetUserRolesStatus` (`Success` / `UserNotFound` / `UnknownRole`). The repository dedups the requested ids and rejects the whole assignment if any id is not a real role, querying `_context.Roles` rather than relying on a caller-side check.
- The controller maps that status to the exact same responses it produced before (`"User not found."`, `"One or more roles do not exist."`), so the external behavior and error response shapes are unchanged. The controller no longer needs `IRoles` for the validation; `IRoles` remains injected only for `GetRoles`, its legitimate use.

No DTO/wire-shape change, so no codegen was required.

## Test plan

- `dotnet build` — succeeds (0 warnings, 0 errors).
- `dotnet format --verify-no-changes` — clean.
- Integration tests (`AdminUsersControllerTests`, run via the built test binary) — 17 pass, including:
  - `SetUserRoles_GrantsAndRevokesRoles` (success path)
  - `SetUserRoles_UnknownUser_ReturnsError` (`UserNotFound` -> "User not found.")
  - `SetUserRoles_UnknownRole_ReturnsError` (`UnknownRole` -> "One or more roles do not exist.")
  - `SetUserRoles_DuplicateValidRoleIds_GrantsRoleOnce` (new — pins the relocated dedup so duplicate valid ids are not rejected)

The validation now lives in a repository that talks to the DB, so it is covered through the existing integration test path per the backend testing guidelines. CI runs the full suite under coverage.

Closes #587

https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw)_