### PR TITLE
test: relocate SocketSerializationTests out of the integration fixture

### DIFF
--- a/Game.Api.Tests/Unit/SocketSerializationTests.cs
+++ b/Game.Api.Tests/Unit/SocketSerializationTests.cs
@@ -1,39 +1,39 @@
+using Game.Abstractions.DataAccess;
 using Game.Api.Services;
 using Game.Api.Sockets;
 using Game.Api.Sockets.Commands;
-using Game.TestInfrastructure.Base;
-using Game.TestInfrastructure.Fixtures;
+using Game.Application;
+using Game.Core.Players;
 using Game.TestInfrastructure.Helpers;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace Game.Api.Tests.Integration
+namespace Game.Api.Tests.Unit
 {
     /// <summary>
     /// Deterministically verifies the per-socket serialization that makes the documented "websocket
     /// commands are handled sequentially for each player" guarantee hold for server-initiated (pub/sub)
     /// commands as well as read-loop commands (see <c>docs/backend.md</c> → "HTTP vs WebSocket
     /// Communication"). A <see cref="FakeWebSocket"/> stands in for the transport — the in-memory test-host
-    /// transport tolerates overlapping sends, so it cannot surface this race — while the rest of the
-    /// services are resolved from the real host. #478.
+    /// transport tolerates overlapping sends, so it cannot surface this race. These are pure serialization
+    /// tests: they drive <see cref="SocketContext"/>/<see cref="SocketHandler"/> directly and depend on no
+    /// out-of-process resource, so they run as plain unit tests with hand-built dependencies (the executed
+    /// <c>GetStatisticTypes</c> command returns intrinsic reference data and never touches the DB/Redis).
+    /// #478, #504.
     /// </summary>
-    [Collection("Integration")]
-    public class SocketSerializationTests : ApiIntegrationTestBase
+    public class SocketSerializationTests
     {
-        public SocketSerializationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
-            : base(containers, testOutputHelper) { }
+        private static CancellationToken CancellationToken => TestContext.Current.CancellationToken;
 
         [Fact]
         public async Task SendData_ConcurrentCalls_NeverOverlapWebSocketSends()
         {
             // WebSocket.SendAsync forbids overlapping sends, and the read loop, the pub/sub processor, and
             // the ping/close paths can all reach SendData, so it must serialize them itself.
-            using var scope = CreateScope();
-            var session = scope.ServiceProvider.GetRequiredService<SessionService>();
-            var logger = scope.ServiceProvider.GetRequiredService<ILogger<SocketContext>>();
+            var session = new SessionService(new NoOpSessionStore());
             var socket = new FakeWebSocket();
-            var context = new SocketContext(socket, playerId: 1, session, logger);
+            var context = new SocketContext(socket, playerId: 1, session, NullLogger<SocketContext>.Instance);
 
             var sends = Enumerable.Range(0, 10).Select(i => context.SendData($"message-{i}")).ToArray();
             var results = await Task.WhenAll(sends);
@@ -53,18 +53,21 @@ namespace Game.Api.Tests.Integration
             // first releases.
             SocketCommandFactory.RegisterSocketCommandGenerators();
 
-            using var scope = CreateScope();
-            var session = scope.ServiceProvider.GetRequiredService<SessionService>();
-            var contextLogger = scope.ServiceProvider.GetRequiredService<ILogger<SocketContext>>();
-            var handlerLogger = scope.ServiceProvider.GetRequiredService<ILogger<SocketHandler>>();
-            var commandFactory = scope.ServiceProvider.GetRequiredService<SocketCommandFactory>();
+            // A minimal in-memory provider: the executed GetStatisticTypes command needs no dependency, but
+            // SocketHandler.RunCommand commits an IUnitOfWork from each work scope.
+            await using var provider = new ServiceCollection()
+                .AddScoped<IUnitOfWork, NoOpUnitOfWork>()
+                .BuildServiceProvider();
+
+            var session = new SessionService(new NoOpSessionStore());
+            var commandFactory = new SocketCommandFactory();
             var countingScopeFactory = new CountingServiceScopeFactory(
-                scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>());
+                provider.GetRequiredService<IServiceScopeFactory>());
 
             var sendGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var socket = new FakeWebSocket(sendGate.Task);
-            var context = new SocketContext(socket, playerId: 1, session, contextLogger);
-            var handler = new SocketHandler(context, commandFactory, countingScopeFactory, handlerLogger, () => Task.CompletedTask);
+            var context = new SocketContext(socket, playerId: 1, session, NullLogger<SocketContext>.Instance);
+            var handler = new SocketHandler(context, commandFactory, countingScopeFactory, NullLogger<SocketHandler>.Instance, () => Task.CompletedTask);
 
             var first = handler.ExecuteCommand(new SocketCommandInfo("GetStatisticTypes") { Id = "first" });
             var second = handler.ExecuteCommand(new SocketCommandInfo("GetStatisticTypes") { Id = "second" });
@@ -81,6 +84,18 @@ namespace Game.Api.Tests.Integration
 
             Assert.Equal(2, countingScopeFactory.ScopesCreated);
             Assert.Equal(1, socket.MaxConcurrentSends);
+        }
+
+        private sealed class NoOpSessionStore : ISessionStore
+        {
+            public Task<PlayerState?> GetSession(int userId) => Task.FromResult<PlayerState?>(null);
+            public void Update(PlayerState sessionData, int playerId) { }
+            public void Clear(int userId) { }
+        }
+
+        private sealed class NoOpUnitOfWork : IUnitOfWork
+        {
+            public Task CommitAsync() => Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
## Summary

`SocketSerializationTests` drove `SocketContext` / `SocketHandler` through the `FakeWebSocket` helper but lived under `Integration/` and derived from `ApiIntegrationTestBase` / `IntegrationTestContainers`, so it paid the Postgres/Redis container spin-up cost (and took the cross-process integration lock) despite never touching the DB or Redis.

This moves it to a plain unit test:

- Relocated `Game.Api.Tests/Integration/SocketSerializationTests.cs` → `Game.Api.Tests/Unit/SocketSerializationTests.cs` (namespace `Game.Api.Tests.Unit`).
- Dropped the `[Collection("Integration")]` attribute and the `ApiIntegrationTestBase` / `IntegrationTestContainers` base class — the class no longer references the integration collection or container fixture, so it never provisions or reuses Postgres/Redis.
- Replaced the host-resolved DI (`CreateScope()` + `GetRequiredService<…>`) with hand-built dependencies: a `NoOpSessionStore` for `SessionService`, a `NoOpUnitOfWork` registered in a minimal `ServiceCollection` (the executed `GetStatisticTypes` command needs no dependency, but `SocketHandler.RunCommand` commits an `IUnitOfWork` from each work scope), and `NullLogger` instances.

No functional change — assertions are identical. This aligns with the backend Testing Guidelines: integration tests are reserved for out-of-process dependencies, and these are pure serialization tests.

## Test plan

- `dotnet build` — succeeds, 0 warnings / 0 errors.
- `dotnet format --verify-no-changes` — clean (no reformatting).
- Ran the relocated tests directly: `dotnet Game.Api.Tests/bin/Debug/net10.0/Game.Api.Tests.dll -class "Game.Api.Tests.Unit.SocketSerializationTests"` → 2 passed, 0 failed in ~0.8s, with no container spin-up. The sub-second run with no Postgres/Redis startup, plus the class no longer referencing the integration collection/fixture, confirms the tests no longer depend on out-of-process containers.
- Full suite runs in CI.

Closes #504

https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw)_