### PR TITLE
refactor: fail fast on ambiguous constructors in reflection-based DI construction

### DIFF
--- a/Game.Api.Tests/Unit/SocketCommandFactoryTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandFactoryTests.cs
@@ -1,4 +1,5 @@
 using Game.Api.Services;
+using Game.Api.Sockets.Commands;
 using Xunit;
 
 namespace Game.Api.Tests.Unit
@@ -9,6 +10,20 @@ namespace Game.Api.Tests.Unit
         {
             // Populates the static command registry from the assembly; idempotent across tests.
             SocketCommandFactory.RegisterSocketCommandGenerators();
+        }
+
+        [Fact]
+        public void RegisterSocketCommandGenerators_AllConcreteCommandsHaveExactlyOnePublicConstructor()
+        {
+            // Registration binds each command via GetConstructors().Single(), so a concrete command
+            // gaining a second public constructor would throw at registration. Assert the invariant
+            // directly so the guard can't silently regress.
+            var concreteCommands = typeof(SocketCommandFactory).Assembly.GetTypes()
+                .Where(t => t.IsAssignableTo(typeof(AbstractSocketCommand)) && !t.IsAbstract)
+                .ToList();
+
+            Assert.NotEmpty(concreteCommands);
+            Assert.All(concreteCommands, command => Assert.Single(command.GetConstructors()));
         }
 
         [Theory]

--- a/Game.Api/Services/SocketCommandFactory.cs
+++ b/Game.Api/Services/SocketCommandFactory.cs
@@ -46,7 +46,9 @@ namespace Game.Api.Services
             var serviceExtensions = typeof(ServiceProviderServiceExtensions);
             foreach (var type in types.Where(t => t.IsAssignableTo(typeof(AbstractSocketCommand)) && !t.IsAbstract))
             {
-                var constructor = type.GetConstructors().First();
+                // Single() fails fast at registration if a command ever gains a second public constructor,
+                // rather than First() silently binding an arbitrary one that fails at invoke time.
+                var constructor = type.GetConstructors().Single();
                 var serviceDependencies = constructor.GetParameters();
                 var serviceProvider = Expression.Parameter(typeof(IServiceProvider));
                 var serviceInjectors = serviceDependencies.Select(p => Expression.Call(serviceExtensions, "GetRequiredService", [p.ParameterType], serviceProvider));

--- a/Game.Core.Tests/Events/DomainEventDispatcherTests.cs
+++ b/Game.Core.Tests/Events/DomainEventDispatcherTests.cs
@@ -33,6 +33,16 @@ namespace Game.Core.Tests.Events
         }
 
         [Fact]
+        public void RegisterDomainEventHandler_HandlerWithMultipleConstructors_ThrowsAtRegistration()
+        {
+            // Registration binds the handler via GetConstructors().Single(), so an ambiguous handler
+            // (more than one public constructor) fails fast here rather than silently binding an
+            // arbitrary constructor that would only fail when the event is later dispatched.
+            Assert.Throws<InvalidOperationException>(
+                DomainEventDispatcher.RegisterDomainEventHandler<AmbiguousEvent, AmbiguousCtorHandler>);
+        }
+
+        [Fact]
         public async Task DispatchAsync_HandlerRaisesEventsUnboundedly_ThrowsAfterSafetyBound()
         {
             DomainEventDispatcher.RegisterDomainEventHandler<LoopEvent, LoopEventHandler>();
@@ -166,6 +176,8 @@ namespace Game.Core.Tests.Events
 
         private sealed record MultiThrowEvent : IDomainEvent;
 
+        private sealed record AmbiguousEvent : IDomainEvent;
+
         // Records the order events were handled so the test can assert the cascade ran in one dispatch.
         private sealed class HandledLog
         {
@@ -289,6 +301,16 @@ namespace Game.Core.Tests.Events
                 log.Handled.Add("Child");
                 return Task.CompletedTask;
             }
+        }
+
+        // Two public constructors, so registration's GetConstructors().Single() throws — the ambiguity
+        // the fail-fast guard is meant to catch.
+        private sealed class AmbiguousCtorHandler : IDomainEventHandler<AmbiguousEvent>
+        {
+            public AmbiguousCtorHandler() { }
+            public AmbiguousCtorHandler(HandledLog log) { }
+            public Task HandleAsync(AmbiguousEvent domainEvent, CancellationToken cancellationToken = default) =>
+                Task.CompletedTask;
         }
 
         // Minimal provider resolving only the HandledLog the test handlers depend on, so the test needs no

--- a/Game.Core/Events/DomainEventDispatcher.cs
+++ b/Game.Core/Events/DomainEventDispatcher.cs
@@ -131,7 +131,9 @@ namespace Game.Core.Events
             }
 
             var serviceExtensions = typeof(ServiceProviderServiceExtensions);
-            var handlerConstructor = handlerType.GetConstructors().First();
+            // Single() fails fast at registration if a handler ever gains a second public constructor,
+            // rather than First() silently binding an arbitrary one that fails at invoke time.
+            var handlerConstructor = handlerType.GetConstructors().Single();
             var serviceDependencies = handlerConstructor.GetParameters();
             var serviceProvider = Expression.Parameter(typeof(IServiceProvider));
             var serviceInjectors = serviceDependencies.Select(p => Expression.Call(serviceExtensions, "GetRequiredService", [p.ParameterType], serviceProvider));


### PR DESCRIPTION
## Summary

Two reflection-based construction sites picked an arbitrary constructor via `GetConstructors().First()` with no ordering guarantee and no validation. If a socket command or domain event handler ever gained a second public constructor, `First()` would non-deterministically bind one and the compiled expression would fail at **invoke time** (a runtime error on that command/event) rather than at startup.

Both sites now use `GetConstructors().Single()`, so an ambiguous type throws loudly at **registration** instead. This is the cheap fail-fast the issue calls for — every concrete socket command and every registered handler genuinely has exactly one public constructor today, so `Single()` is the correct call.

The two sites changed:
- `Game.Api/Services/SocketCommandFactory.cs` — socket command generator registration.
- `Game.Core/Events/DomainEventDispatcher.cs` — domain event handler registration.

Added unit tests pinning the invariant so the guard can't silently regress:
- `SocketCommandFactoryTests`: asserts every concrete `AbstractSocketCommand` in the assembly has exactly one public constructor.
- `DomainEventDispatcherTests`: registering a handler that has multiple public constructors throws `InvalidOperationException` at registration.

No other `GetConstructors().First()` sites exist in the codebase (verified by grep).

## Test plan

- `dotnet build` — succeeds, 0 warnings, 0 errors.
- `dotnet format --verify-no-changes` — clean, no reformatting.
- `dotnet test Game.Core.Tests` (DomainEventDispatcher suite) — 467 passed.
- `dotnet test Game.Api.Tests` (SocketCommandFactory suite) — 405 passed.
- Full suite + coverage gate run in CI.

Closes #490

https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw)_