### PR TITLE
refactor: name the SessionStore key parameter userId to match how it's keyed

### DIFF
--- a/Game.Abstractions/DataAccess/ISessionStore.cs
+++ b/Game.Abstractions/DataAccess/ISessionStore.cs
@@ -2,10 +2,11 @@
 
 namespace Game.Abstractions.DataAccess
 {
+    // Sessions are keyed by the user/account id (not PlayerState.PlayerId, which is a distinct value).
     public interface ISessionStore
     {
         public Task<PlayerState?> GetSession(int userId);
-        public void Update(PlayerState sessionData, int playerId);
+        public void Update(PlayerState sessionData, int userId);
         public void Clear(int userId);
     }
 }

--- a/Game.DataAccess/Repositories/SessionStore.cs
+++ b/Game.DataAccess/Repositories/SessionStore.cs
@@ -5,6 +5,8 @@ using Game.Core.Players;
 
 namespace Game.DataAccess.Repositories
 {
+    // Sessions are keyed by the user/account id (single active session per user).
+    // Note PlayerState.PlayerId is a distinct value and is not used as the key.
     internal class SessionStore : ISessionStore
     {
         private static string SessionPrefix => Constants.CACHE_SESSION_PREFIX;
@@ -21,9 +23,9 @@ namespace Game.DataAccess.Repositories
             return await _cache.Get<PlayerState>($"{SessionPrefix}_{userId}");
         }
 
-        public void Update(PlayerState playerState, int playerId)
+        public void Update(PlayerState playerState, int userId)
         {
-            _cache.SetAndForget($"{SessionPrefix}_{playerId}", playerState);
+            _cache.SetAndForget($"{SessionPrefix}_{userId}", playerState);
         }
 
         public void Clear(int userId)


### PR DESCRIPTION
## Summary

Behavior-preserving readability fix. The session cache is keyed by **userId** at every call site — `SessionService` passes `UserId` to `GetSession`, `Update`, and `Clear`. Only `SessionStore.Update`'s parameter was mislabeled `playerId` even though it receives the `userId`, so there was no runtime bug (the read/write keys already coincide).

Changes:
- Rename `SessionStore.Update`'s `playerId` parameter to `userId` and update the key interpolation accordingly, so all three methods (`GetSession`/`Update`/`Clear`) consistently express that the session is keyed by the user/account id.
- Match the rename on the `ISessionStore.Update` signature.
- Add a short comment on `ISessionStore`/`SessionStore` documenting that the session is keyed by the user/account id and that `PlayerState.PlayerId` is a distinct value, so the naming can't drift back.

We keep keying on `userId` (single active session is per user) rather than re-keying on `playerId`.

## Test plan
- `dotnet build` — succeeds, 0 warnings / 0 errors.
- `dotnet format` — no additional changes.
- `dotnet test Game.Api.Tests --filter ~Login` — 23/23 pass (the existing login/session round-trip integration path covers this thin cache wrapper; no new test needed for a pure rename).

Closes #579

https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw)_