### PR TITLE
refactor: extract a shared HpBar component and fix HP/damage formatting

### DIFF
--- a/UI/src/components/HpBar.svelte
+++ b/UI/src/components/HpBar.svelte
@@ -1,0 +1,100 @@
+<!-- Shared HP bar: the green-over-missing health treatment used by both the normal
+     BattlerCard and the boss card. The `tall` variant raises the height/text weight for
+     the boss, and `phasePips` overlays phase markers (e.g. 25/50/75%). -->
+<div
+	class="hp-bar"
+	class:tall
+	data-testid={testId}
+	role="progressbar"
+	aria-label={ariaLabel}
+	aria-valuenow={Math.round(currentHealth)}
+	aria-valuemin={0}
+	aria-valuemax={maxHealth}
+	aria-valuetext={healthText}
+>
+	<div class="hp-disappearing" style:width="{healthPerc}%"></div>
+	<div class="hp-remaining" style:width="{healthPerc}%"></div>
+	{#each phasePips as pip (pip)}
+		<div class="phase-pip" style:left="{pip}%" aria-hidden="true"></div>
+	{/each}
+	<div class="hp-text">{healthText}</div>
+</div>
+
+<script lang="ts">
+import { formatNum } from '$lib/common';
+
+type Props = {
+	currentHealth: number;
+	maxHealth: number;
+	/** Accessible name for the bar (e.g. "Aelara health"). */
+	ariaLabel: string;
+	/** Taller bar with bolder text, used by the boss card. */
+	tall?: boolean;
+	/** Percentages (0–100) to overlay as phase markers. */
+	phasePips?: number[];
+	testId?: string;
+};
+
+const { currentHealth, maxHealth, ariaLabel, tall = false, phasePips = [], testId }: Props = $props();
+
+const healthText = $derived(`${formatNum(currentHealth)} / ${formatNum(maxHealth)}`);
+const healthPerc = $derived(maxHealth ? formatNum(Math.max((currentHealth * 100) / maxHealth, 0)) : 100);
+</script>
+
+<style lang="scss">
+.hp-bar {
+	position: relative;
+	height: 20px;
+	background: var(--health-missing-color);
+	border: 1px solid color-mix(in srgb, var(--white) 12%, transparent);
+	border-radius: 2px;
+	overflow: hidden;
+
+	&.tall {
+		height: 22px;
+	}
+}
+
+.hp-disappearing {
+	position: absolute;
+	inset: 0;
+	background: var(--health-disappearing-color);
+	transition: width 1s ease-out;
+}
+
+.hp-remaining {
+	position: absolute;
+	inset: 0;
+	background: linear-gradient(180deg, var(--health-remaining-color) 0%, var(--health-remaining-dark) 100%);
+	transition: width 120ms ease-out;
+}
+
+.phase-pip {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	width: 1px;
+	background: color-mix(in srgb, var(--black) 45%, transparent);
+	box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--boss-accent) 20%, transparent);
+}
+
+.hp-text {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-family: var(--mono);
+	font-size: 11px;
+	color: var(--white);
+	text-shadow: 0 1px 2px color-mix(in srgb, var(--black) 70%, transparent);
+	letter-spacing: 0.3px;
+}
+
+.tall .hp-text {
+	font-size: 13px;
+	font-weight: 500;
+	text-shadow: 0 1px 3px color-mix(in srgb, var(--black) 85%, transparent);
+	letter-spacing: 0.4px;
+}
+</style>

--- a/UI/src/components/index.ts
+++ b/UI/src/components/index.ts
@@ -1,5 +1,6 @@
 export { default as ChallengeTooltip } from './tooltip/ChallengeTooltip.svelte';
 export { default as DiamondMark } from './DiamondMark.svelte';
+export { default as HpBar } from './HpBar.svelte';
 export { default as Loading } from './Loading.svelte';
 export { default as Modal } from './Modal.svelte';
 export { default as ModalHost } from './ModalHost.svelte';

--- a/UI/src/routes/game/screens/fight/BattlerCard.svelte
+++ b/UI/src/routes/game/screens/fight/BattlerCard.svelte
@@ -9,17 +9,8 @@
 	</div>
 
 	<!-- HP Bar -->
-	<div
-		class="hp-bar"
-		role="progressbar"
-		aria-label="{battler.name} health"
-		aria-valuenow={Math.round(battler.currentHealth)}
-		aria-valuemin={0}
-		aria-valuemax={maxHealth}
-	>
-		<div class="hp-disappearing" style:width="{healthPerc}%"></div>
-		<div class="hp-remaining" style:width="{healthPerc}%"></div>
-		<div class="hp-text">{healthText}</div>
+	<div class="hp-bar-slot">
+		<HpBar currentHealth={battler.currentHealth} {maxHealth} ariaLabel="{battler.name} health" />
 	</div>
 
 	<!-- Active timed effects -->
@@ -32,7 +23,8 @@
 <script lang="ts">
 import { EAttribute } from '$lib/api';
 import { type Battler } from '$lib/battle';
-import { formatNum, tintColor } from '$lib/common';
+import { tintColor } from '$lib/common';
+import { HpBar } from '$components';
 import ActiveEffectChips from './ActiveEffectChips.svelte';
 import Skills from './Skills.svelte';
 
@@ -45,8 +37,6 @@ const { battler, side }: Props = $props();
 
 const accent = $derived(side === 'player' ? 'var(--accent)' : 'var(--enemy-accent)');
 const maxHealth = $derived(battler.attributes.getValue(EAttribute.MaxHealth));
-const healthText = $derived(`${formatNum(battler.currentHealth)} / ${formatNum(maxHealth)}`);
-const healthPerc = $derived(maxHealth ? formatNum(Math.max((battler.currentHealth * 100) / maxHealth, 0)) : 100);
 </script>
 
 <style lang="scss">
@@ -114,40 +104,7 @@ const healthPerc = $derived(maxHealth ? formatNum(Math.max((battler.currentHealt
 	letter-spacing: 0.6px;
 }
 
-.hp-bar {
-	position: relative;
-	height: 20px;
-	background: var(--health-missing-color);
-	border: 1px solid color-mix(in srgb, var(--white) 12%, transparent);
-	border-radius: 2px;
-	overflow: hidden;
+.hp-bar-slot {
 	margin-bottom: 14px;
-}
-
-.hp-disappearing {
-	position: absolute;
-	inset: 0;
-	background: var(--health-disappearing-color);
-	transition: width 1s ease-out;
-}
-
-.hp-remaining {
-	position: absolute;
-	inset: 0;
-	background: linear-gradient(180deg, var(--health-remaining-color) 0%, var(--health-remaining-dark) 100%);
-	transition: width 120ms ease-out;
-}
-
-.hp-text {
-	position: absolute;
-	inset: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	font-family: var(--mono);
-	font-size: 11px;
-	color: var(--white);
-	text-shadow: 0 1px 2px color-mix(in srgb, var(--black) 70%, transparent);
-	letter-spacing: 0.3px;
 }
 </style>

--- a/UI/src/routes/game/screens/fight/boss/BossHpBar.svelte
+++ b/UI/src/routes/game/screens/fight/boss/BossHpBar.svelte
@@ -1,25 +1,9 @@
-<!-- The boss's HP bar: the same green-over-missing treatment as a normal battler,
-     taller and overlaid with phase pips at 25 / 50 / 75% to telegraph boss phases. -->
-<div
-	class="boss-hp-bar"
-	data-testid="boss-hp-bar"
-	role="progressbar"
-	aria-label="Boss health"
-	aria-valuenow={Math.round(currentHealth)}
-	aria-valuemin={0}
-	aria-valuemax={maxHealth}
-	aria-valuetext={healthText}
->
-	<div class="hp-disappearing" style:width="{healthPerc}%"></div>
-	<div class="hp-remaining" style:width="{healthPerc}%"></div>
-	{#each PHASE_PIPS as pip (pip)}
-		<div class="phase-pip" style:left="{pip}%" aria-hidden="true"></div>
-	{/each}
-	<div class="hp-text">{healthText}</div>
-</div>
+<!-- The boss's HP bar: the shared HpBar in its tall variant, overlaid with phase pips
+     at 25 / 50 / 75% to telegraph boss phases. -->
+<HpBar {currentHealth} {maxHealth} ariaLabel="Boss health" tall phasePips={PHASE_PIPS} testId="boss-hp-bar" />
 
 <script lang="ts">
-import { formatNum } from '$lib/common';
+import { HpBar } from '$components';
 
 type Props = {
 	currentHealth: number;
@@ -29,54 +13,4 @@ type Props = {
 const { currentHealth, maxHealth }: Props = $props();
 
 const PHASE_PIPS = [25, 50, 75];
-const healthText = $derived(`${formatNum(currentHealth)} / ${maxHealth}`);
-const healthPerc = $derived(maxHealth ? formatNum(Math.max((currentHealth * 100) / maxHealth, 0)) : 100);
 </script>
-
-<style lang="scss">
-.boss-hp-bar {
-	position: relative;
-	height: 22px;
-	background: var(--health-missing-color);
-	border: 1px solid color-mix(in srgb, var(--white) 12%, transparent);
-	border-radius: 2px;
-	overflow: hidden;
-}
-
-.hp-disappearing {
-	position: absolute;
-	inset: 0;
-	background: var(--health-disappearing-color);
-	transition: width 1s ease-out;
-}
-
-.hp-remaining {
-	position: absolute;
-	inset: 0;
-	background: linear-gradient(180deg, var(--health-remaining-color) 0%, var(--health-remaining-dark) 100%);
-	transition: width 120ms ease-out;
-}
-
-.phase-pip {
-	position: absolute;
-	top: 0;
-	bottom: 0;
-	width: 1px;
-	background: color-mix(in srgb, var(--black) 45%, transparent);
-	box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--boss-accent) 20%, transparent);
-}
-
-.hp-text {
-	position: absolute;
-	inset: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	font-family: var(--mono);
-	font-size: 13px;
-	font-weight: 500;
-	color: var(--white);
-	text-shadow: 0 1px 3px color-mix(in srgb, var(--black) 85%, transparent);
-	letter-spacing: 0.4px;
-}
-</style>

--- a/UI/src/routes/game/screens/fight/skill-tooltip/DamageBreakdown.svelte
+++ b/UI/src/routes/game/screens/fight/skill-tooltip/DamageBreakdown.svelte
@@ -1,7 +1,7 @@
 <div class="tt-dmg-list">
 	<div class="tt-dmg-row">
 		<span class="tt-dmg-label">Base</span>
-		<span class="tt-dmg-value">{base}</span>
+		<span class="tt-dmg-value">{formatNum(base)}</span>
 	</div>
 	{#each multipliers as mult (mult.name)}
 		<div class="tt-dmg-row">

--- a/UI/src/tests/components/HpBar.test.ts
+++ b/UI/src/tests/components/HpBar.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import HpBar from '$components/HpBar.svelte';
+
+afterEach(cleanup);
+
+describe('HpBar', () => {
+	it('exposes the bar as a progressbar with rounded current/max health and value text', () => {
+		const { container } = render(HpBar, {
+			props: { currentHealth: 80.6, maxHealth: 100, ariaLabel: 'Aelara health' }
+		});
+
+		const bar = container.querySelector('.hp-bar') as HTMLElement;
+		expect(bar.getAttribute('role')).toBe('progressbar');
+		expect(bar.getAttribute('aria-label')).toBe('Aelara health');
+		expect(bar.getAttribute('aria-valuenow')).toBe('81');
+		expect(bar.getAttribute('aria-valuemin')).toBe('0');
+		expect(bar.getAttribute('aria-valuemax')).toBe('100');
+		expect(bar.getAttribute('aria-valuetext')).toBe('80.6 / 100');
+	});
+
+	it('formats both sides of the health text, trimming floating-point noise', () => {
+		const { container } = render(HpBar, {
+			props: { currentHealth: 412.55, maxHealth: 523.4999999999, ariaLabel: 'Boss health' }
+		});
+		expect(container.querySelector('.hp-text')?.textContent).toContain('412.55 / 523.5');
+	});
+
+	it('sizes the remaining bar to the health percentage', () => {
+		const { container } = render(HpBar, {
+			props: { currentHealth: 50, maxHealth: 200, ariaLabel: 'health' }
+		});
+		// 50 / 200 = 25%.
+		expect((container.querySelector('.hp-remaining') as HTMLElement).getAttribute('style')).toContain('width: 25%');
+	});
+
+	it('clamps to full when there is no max health', () => {
+		const { container } = render(HpBar, {
+			props: { currentHealth: 0, maxHealth: 0, ariaLabel: 'health' }
+		});
+		expect((container.querySelector('.hp-remaining') as HTMLElement).getAttribute('style')).toContain('width: 100%');
+	});
+
+	it('overlays a phase pip for each provided percentage', () => {
+		const { container } = render(HpBar, {
+			props: { currentHealth: 50, maxHealth: 100, ariaLabel: 'Boss health', phasePips: [25, 50, 75] }
+		});
+		const pips = container.querySelectorAll('.phase-pip');
+		expect(pips).toHaveLength(3);
+		expect((pips[1] as HTMLElement).getAttribute('style')).toContain('left: 50%');
+	});
+
+	it('applies the tall variant and a test id when requested', () => {
+		const { getByTestId } = render(HpBar, {
+			props: { currentHealth: 10, maxHealth: 20, ariaLabel: 'Boss health', tall: true, testId: 'boss-hp-bar' }
+		});
+		expect(getByTestId('boss-hp-bar').classList.contains('tall')).toBe(true);
+	});
+});

--- a/UI/src/tests/routes/game/screens/fight/boss/BossHpBar.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/boss/BossHpBar.test.ts
@@ -21,4 +21,14 @@ describe('BossHpBar', () => {
 		const { getByTestId } = render(BossHpBar, { props: { currentHealth: 50, maxHealth: 200 } });
 		expect(getByTestId('boss-hp-bar').querySelector('.hp-text')?.textContent).toContain('50 / 200');
 	});
+
+	it('formats a fractional max health instead of rendering floating-point noise', () => {
+		const { getByTestId } = render(BossHpBar, { props: { currentHealth: 412.55, maxHealth: 523.4999999999 } });
+		expect(getByTestId('boss-hp-bar').querySelector('.hp-text')?.textContent).toContain('412.55 / 523.5');
+	});
+
+	it('renders the phase pips that telegraph boss phases', () => {
+		const { getByTestId } = render(BossHpBar, { props: { currentHealth: 50, maxHealth: 100 } });
+		expect(getByTestId('boss-hp-bar').querySelectorAll('.phase-pip')).toHaveLength(3);
+	});
 });


### PR DESCRIPTION
## Summary

`BattlerCard` and `BossHpBar` re-implemented nearly the same HP-bar structure (`hp-disappearing` / `hp-remaining` / `hp-text`), the same `healthPerc` clamp, and the same SCSS gradients/transitions — the duplication that let the two copies drift. This extracts a single shared **`HpBar.svelte`** primitive (in `src/components`, exported from `$components`) that both consumers compose, making them consistent by construction. The boss card only layers on the `tall` variant and its phase pips.

The component is parameterized with an `ariaLabel`, an optional `phasePips` list, a `tall` flag, and an optional `testId`. Both bars now render identically to before (the boss bar additionally gains the `formatNum` fix below).

### Formatting bugs fixed (the drift this duplication caused)
- **`BossHpBar`** interpolated raw `maxHealth` (`${formatNum(currentHealth)} / ${maxHealth}`), so it could render `412.55 / 523.4999999999`. It now runs both sides through `formatNum` via the shared component.
- **`DamageBreakdown`** rendered the `Base` row as `{base}` unformatted while every other number in the panel uses `formatNum`; it now uses `{formatNum(base)}`.

### #597 accessibility preserved
The shared `HpBar` carries through the a11y work #597 landed: `role="progressbar"`, `aria-label`, `aria-valuemin`/`aria-valuemax`/`aria-valuenow` (rounded), and `aria-valuetext`. So **neither bar loses its accessibility** — the boss bar keeps its full progressbar semantics, and the normal `BattlerCard` HP bar keeps (and, via the unified value text, slightly strengthens) its equivalent. The existing `BattlerCard`/`BossHpBar` tests that assert those attributes still pass.

## Test plan
- Added `tests/components/HpBar.test.ts` covering the progressbar role/aria, value-text formatting (fractional max health trimmed), percentage sizing, the no-max-health clamp, phase pips, and the `tall`/`testId` variant.
- Extended `BossHpBar.test.ts` with the fractional-max-health and phase-pip cases; existing a11y assertions retained.
- `npm run lint` (eslint + svelte-check): pass — 0 errors, 0 warnings.
- `npm run test:unit:ci`: pass — 178 files, 1682 tests.

Closes #598

https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs5TjxJE8j85zHN7FPihw)_