### PR TITLE
Add GetPlayerStatistics socket command and migrate the statistics store off HTTP

### DIFF
--- a/Game.Api.Tests/Integration/GetPlayerStatisticsSocketTests.cs
+++ b/Game.Api.Tests/Integration/GetPlayerStatisticsSocketTests.cs
@@ -1,0 +1,94 @@
+using Game.Api.Models.Progress;
+using Game.Core;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net.WebSockets;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    /// <summary>
+    /// Integration tests for the player-scoped <c>GetPlayerStatistics</c> socket command (#563),
+    /// the WebSocket replacement for the <c>GET /api/Statistics</c> read.
+    /// </summary>
+    [Collection("Integration")]
+    public class GetPlayerStatisticsSocketTests : ApiIntegrationTestBase
+    {
+        public GetPlayerStatisticsSocketTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper) : base(containers, testOutputHelper) { }
+
+        private async Task<TestSocketClient> ConnectAsync(int userId)
+        {
+            var socketClient = new TestSocketClient();
+            var wsClient = Factory.Server.CreateWebSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+            Assert.Equal(WebSocketState.Open, socketClient.State);
+            return socketClient;
+        }
+
+        [Fact]
+        public async Task GetPlayerStatistics_WithSeededStatistics_ReturnsThisPlayersStatistics()
+        {
+            int userId;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+                var user = await TestDataSeeder.CreateUserAsync(context, "playerstatsuser", "playerstatspass");
+                var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+                userId = user.Id;
+
+                await TestDataSeeder.AddPlayerStatisticAsync(context, player.Id, EStatisticType.EnemiesKilled, 7m);
+                await TestDataSeeder.AddPlayerStatisticAsync(context, player.Id, EStatisticType.EnemiesKilled, 3m, entityId: 1);
+
+                // A second player with different stats: the command must resolve the player from the socket
+                // session, so none of these may leak into the connected player's response.
+                var otherUser = await TestDataSeeder.CreateUserAsync(context, "otherstatsuser", "otherstatspass");
+                var otherPlayer = await TestDataSeeder.CreatePlayerAsync(context, otherUser.Id);
+                await TestDataSeeder.AddPlayerStatisticAsync(context, otherPlayer.Id, EStatisticType.BattlesWon, 99m);
+            }
+
+            // Login creates the Redis session the socket handshake requires.
+            await LoginAsync("playerstatsuser", "playerstatspass");
+            await using var socketClient = await ConnectAsync(userId);
+
+            var response = await socketClient.SendCommandAsync<List<PlayerStatistic>>("GetPlayerStatistics");
+
+            Assert.Null(response.Error);
+            Assert.NotNull(response.Data);
+            Assert.Equal(2, response.Data.Count);
+
+            var total = Assert.Single(response.Data, s => s.StatisticTypeId == EStatisticType.EnemiesKilled && s.EntityId is null);
+            Assert.Equal(7m, total.Value);
+
+            var perEnemy = Assert.Single(response.Data, s => s.StatisticTypeId == EStatisticType.EnemiesKilled && s.EntityId == 1);
+            Assert.Equal(3m, perEnemy.Value);
+
+            // The other player's stat must not bleed through.
+            Assert.DoesNotContain(response.Data, s => s.StatisticTypeId == EStatisticType.BattlesWon);
+        }
+
+        [Fact]
+        public async Task GetPlayerStatistics_NewPlayer_ReturnsEmptyWithoutError()
+        {
+            int userId;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                var user = await TestDataSeeder.CreateUserAsync(context, "newstatsuser", "newstatspass");
+                await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+                userId = user.Id;
+            }
+
+            await LoginAsync("newstatsuser", "newstatspass");
+            await using var socketClient = await ConnectAsync(userId);
+
+            var response = await socketClient.SendCommandAsync<List<PlayerStatistic>>("GetPlayerStatistics");
+
+            Assert.Null(response.Error);
+            Assert.NotNull(response.Data);
+            Assert.Empty(response.Data);
+        }
+    }
+}

--- a/Game.Api/Sockets/Commands/GetPlayerStatistics.cs
+++ b/Game.Api/Sockets/Commands/GetPlayerStatistics.cs
@@ -1,0 +1,32 @@
+using Game.Abstractions.DataAccess;
+using Game.Api.Models.Common;
+using Game.Api.Models.Progress;
+
+namespace Game.Api.Sockets.Commands
+{
+    /// <summary>
+    /// Returns the connected player's tracked statistics (player progress). Unlike the reference-data
+    /// commands this is player-scoped: it resolves the player from the socket session and delegates to
+    /// <see cref="IPlayerProgressRepository.GetStatistics"/> — the same read the <c>GET /api/Statistics</c>
+    /// endpoint runs (cache-first, so it serves warm cached progress). Named to stay unambiguous against
+    /// the reference-data <see cref="GetStatisticTypes"/> command, which returns statistic metadata rather
+    /// than the player's values.
+    /// </summary>
+    public class GetPlayerStatistics : AbstractSocketCommandWithResponseData<IEnumerable<PlayerStatistic>>
+    {
+        private readonly IPlayerProgressRepository _playerProgress;
+
+        public override string Name { get; set; } = nameof(GetPlayerStatistics);
+
+        public GetPlayerStatistics(IPlayerProgressRepository playerProgress)
+        {
+            _playerProgress = playerProgress;
+        }
+
+        public override async Task<ApiSocketResponse<IEnumerable<PlayerStatistic>>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
+        {
+            var stats = await _playerProgress.GetStatistics(context.Session.SelectedPlayerId);
+            return Success(stats.To().Model<PlayerStatistic>());
+        }
+    }
+}

--- a/UI/src/lib/api/types/api-socket-type-map.ts
+++ b/UI/src/lib/api/types/api-socket-type-map.ts
@@ -20,6 +20,7 @@ import type {
 	ILogPreference,
 	INewEnemyModel,
 	INewEnemyRequest,
+	IPlayerStatistic,
 	IReferenceDataVersion,
 	IRemoveModRequest,
 	ISetItemFavoriteRequest,
@@ -41,6 +42,7 @@ export type ApiSocketResponseTypes = {
 	'GetEnemies': IEnemy[];
 	'GetItemMods': IItemMod[];
 	'GetItems': IItem[];
+	'GetPlayerStatistics': IPlayerStatistic[];
 	'GetReferenceDataVersions': IReferenceDataVersion[];
 	'GetSkills': ISkill[];
 	'GetStatisticTypes': IStatisticType[];

--- a/UI/src/stores/statistics.svelte.ts
+++ b/UI/src/stores/statistics.svelte.ts
@@ -1,10 +1,10 @@
 /* Player statistics store — the player's tracked statistic values
-   (`GET /api/Statistics`), shared across screens so the source is fetched once and
-   stays consistent. The Statistics screen renders the full breakdown from it; the
+   (`GetPlayerStatistics` socket command), shared across screens so the source is fetched
+   once and stays consistent. The Statistics screen renders the full breakdown from it; the
    Fight screen reads the per-zone `ZonesCleared` value to show the boss "Cleared"
    seal and marks a zone cleared optimistically the moment its boss is defeated. */
 
-import { ApiRequest, EStatisticType, type IPlayerStatistic } from '$lib/api';
+import { fetchSocketData, EStatisticType, type IPlayerStatistic } from '$lib/api';
 
 let stats = $state<IPlayerStatistic[]>([]);
 let loaded = $state(false);
@@ -14,7 +14,8 @@ let inFlight: Promise<void> | undefined;
 
 const fetchStats = async () => {
 	try {
-		stats = (await ApiRequest.get('Statistics')) ?? [];
+		// fetchSocketData throws on a socket error, preserving this try/catch contract.
+		stats = (await fetchSocketData('GetPlayerStatistics')) ?? [];
 		error = false;
 		loaded = true;
 	} catch {

--- a/UI/src/tests/routes/game/screens/stats/Statistics.test.ts
+++ b/UI/src/tests/routes/game/screens/stats/Statistics.test.ts
@@ -3,9 +3,9 @@ import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
 import { EStatisticType, type IPlayerStatistic } from '$lib/api';
 import { SERVER_STAT_TYPES } from './stat-fixtures';
 
-// Statistics fetches values via ApiRequest and resolves entities from staticData.
-const { mockGet, mockToastError, staticData } = vi.hoisted(() => ({
-	mockGet: vi.fn(),
+// Statistics fetches values over the socket (GetPlayerStatistics) and resolves entities from staticData.
+const { mockFetchSocket, mockToastError, staticData } = vi.hoisted(() => ({
+	mockFetchSocket: vi.fn(),
 	mockToastError: vi.fn(),
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	staticData: {} as any
@@ -13,7 +13,7 @@ const { mockGet, mockToastError, staticData } = vi.hoisted(() => ({
 
 vi.mock('$lib/api', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('$lib/api')>();
-	return { ...actual, ApiRequest: { get: mockGet } };
+	return { ...actual, fetchSocketData: mockFetchSocket };
 });
 // Override staticData + toastError; keep the other real stores ($components →
 // log-panel pulls in the engine, which reads the logs store).
@@ -42,7 +42,7 @@ beforeEach(() => {
 	staticData.zones = [{ id: 0, name: 'Verdant Hollow', order: 1 }];
 	staticData.skills = [{ id: 0, name: 'Cleave' }];
 	mockToastError.mockClear();
-	mockGet.mockResolvedValue(STATS);
+	mockFetchSocket.mockResolvedValue(STATS);
 });
 
 afterEach(() => cleanup());
@@ -54,7 +54,7 @@ describe('Statistics screen', () => {
 		// The Combat category is active by default → its stat cards appear once loaded.
 		expect(await screen.findByText('Enemies Killed')).toBeTruthy();
 		expect(screen.getByTestId('stat-card-grid')).toBeTruthy();
-		expect(mockGet).toHaveBeenCalledWith('Statistics');
+		expect(mockFetchSocket).toHaveBeenCalledWith('GetPlayerStatistics');
 	});
 
 	it('switches to the by-entity view via the top toggle', async () => {
@@ -85,7 +85,7 @@ describe('Statistics screen', () => {
 	});
 
 	it('shows a friendly empty state for a player with no statistics', async () => {
-		mockGet.mockResolvedValue([]);
+		mockFetchSocket.mockResolvedValue([]);
 		render(Statistics);
 		expect(await screen.findByTestId('statistics-empty')).toBeTruthy();
 		expect(screen.queryByTestId('stat-card-grid')).toBeNull();
@@ -93,7 +93,7 @@ describe('Statistics screen', () => {
 	});
 
 	it('surfaces an error (not the empty state) when the fetch fails', async () => {
-		mockGet.mockRejectedValue(new Error('network down'));
+		mockFetchSocket.mockRejectedValue(new Error('network down'));
 		render(Statistics);
 		expect(await screen.findByTestId('statistics-error')).toBeTruthy();
 		// A failed load must not masquerade as the new-player empty state.

--- a/UI/src/tests/stores/statistics.test.ts
+++ b/UI/src/tests/stores/statistics.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { ApiRequest, EStatisticType, type IPlayerStatistic } from '$lib/api';
+
+// The store reads over the socket via fetchSocketData; stub just that export while keeping the real
+// EStatisticType/IPlayerStatistic from the barrel so the assertions use the genuine enum values.
+const { mockFetchSocket } = vi.hoisted(() => ({ mockFetchSocket: vi.fn() }));
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return { ...actual, fetchSocketData: mockFetchSocket };
+});
+
+import { EStatisticType, type IPlayerStatistic } from '$lib/api';
 import { statistics } from '$stores/statistics.svelte';
 
 const zonesCleared = (entityId: number, value: number): IPlayerStatistic => ({
@@ -9,48 +18,46 @@ const zonesCleared = (entityId: number, value: number): IPlayerStatistic => ({
 });
 
 describe('statistics store', () => {
-	let get: ReturnType<typeof vi.spyOn>;
-
 	beforeEach(() => {
 		statistics.reset();
-		get = vi.spyOn(ApiRequest, 'get');
-		get.mockReset();
+		mockFetchSocket.mockReset();
 	});
 
 	it('loads the player statistics once and exposes them', async () => {
-		get.mockResolvedValue([zonesCleared(3, 1)]);
+		mockFetchSocket.mockResolvedValue([zonesCleared(3, 1)]);
 
 		await statistics.load();
 
 		expect(statistics.loaded).toBe(true);
 		expect(statistics.stats).toEqual([zonesCleared(3, 1)]);
+		expect(mockFetchSocket).toHaveBeenCalledWith('GetPlayerStatistics');
 
 		// Idempotent: a second (non-forced) load does not re-fetch.
 		await statistics.load();
-		expect(get).toHaveBeenCalledTimes(1);
+		expect(mockFetchSocket).toHaveBeenCalledTimes(1);
 	});
 
 	it('re-fetches when forced', async () => {
-		get.mockResolvedValue([]);
+		mockFetchSocket.mockResolvedValue([]);
 		await statistics.load();
 
-		get.mockResolvedValue([zonesCleared(3, 1)]);
+		mockFetchSocket.mockResolvedValue([zonesCleared(3, 1)]);
 		await statistics.load(true);
 
-		expect(get).toHaveBeenCalledTimes(2);
+		expect(mockFetchSocket).toHaveBeenCalledTimes(2);
 		expect(statistics.stats).toEqual([zonesCleared(3, 1)]);
 	});
 
 	it('coalesces concurrent loads onto a single request', async () => {
-		get.mockResolvedValue([]);
+		mockFetchSocket.mockResolvedValue([]);
 
 		await Promise.all([statistics.load(), statistics.load()]);
 
-		expect(get).toHaveBeenCalledTimes(1);
+		expect(mockFetchSocket).toHaveBeenCalledTimes(1);
 	});
 
 	it('flags an error and leaves stats empty when the fetch fails', async () => {
-		get.mockRejectedValue(new Error('boom'));
+		mockFetchSocket.mockRejectedValue(new Error('boom'));
 
 		await statistics.load();
 
@@ -60,7 +67,7 @@ describe('statistics store', () => {
 	});
 
 	it('reports whether a given zone is cleared', async () => {
-		get.mockResolvedValue([zonesCleared(3, 1), zonesCleared(4, 0)]);
+		mockFetchSocket.mockResolvedValue([zonesCleared(3, 1), zonesCleared(4, 0)]);
 		await statistics.load();
 
 		expect(statistics.isZoneCleared(3)).toBe(true);
@@ -69,7 +76,7 @@ describe('statistics store', () => {
 	});
 
 	it('optimistically marks a zone cleared by adding a row', async () => {
-		get.mockResolvedValue([]);
+		mockFetchSocket.mockResolvedValue([]);
 		await statistics.load();
 
 		statistics.markZoneCleared(3);
@@ -78,7 +85,7 @@ describe('statistics store', () => {
 	});
 
 	it('optimistically promotes an existing uncleared row without duplicating it', async () => {
-		get.mockResolvedValue([zonesCleared(3, 0)]);
+		mockFetchSocket.mockResolvedValue([zonesCleared(3, 0)]);
 		await statistics.load();
 
 		statistics.markZoneCleared(3);
@@ -88,14 +95,14 @@ describe('statistics store', () => {
 	});
 
 	it('reset() clears state and allows a fresh load', async () => {
-		get.mockResolvedValue([zonesCleared(3, 1)]);
+		mockFetchSocket.mockResolvedValue([zonesCleared(3, 1)]);
 		await statistics.load();
 
 		statistics.reset();
 		expect(statistics.loaded).toBe(false);
 		expect(statistics.stats).toEqual([]);
 
-		get.mockResolvedValue([zonesCleared(4, 1)]);
+		mockFetchSocket.mockResolvedValue([zonesCleared(4, 1)]);
 		await statistics.load();
 		expect(statistics.isZoneCleared(4)).toBe(true);
 	});


### PR DESCRIPTION
Closes #563. From the #473 spike ([`docs/spikes/473-client-http-to-websocket.md`](https://github.com/ginderjeremiah/GameServer/blob/main/docs/spikes/473-client-http-to-websocket.md)) — moving the player-statistics read off HTTP onto the socket, in line with the WebSocket-everything direction.

## What changed

- **New `GetPlayerStatistics` socket command** (`Game.Api/Sockets/Commands/GetPlayerStatistics.cs`). Unlike the reference-data commands it is **player-scoped**: it resolves the player from the socket session (`context.Session.SelectedPlayerId`) and delegates to `IPlayerProgressRepository.GetStatistics` — the exact logic `StatisticsController.Statistics()` runs today. The repo read is cache-first (after #550), so the socket read serves warm cached progress. It extends `AbstractSocketCommandWithResponseData<IEnumerable<PlayerStatistic>>` directly (not `AbstractReferenceDataCommand`), so it is correctly **not** versioned by `GetReferenceDataVersions`.
- **Naming:** `GetPlayerStatistics` (not `GetStatistics`) to stay unambiguous against the existing reference-data `GetStatisticTypes` command — this returns *player progress* (`IPlayerStatistic[]`), not metadata.
- **Store migration:** `UI/src/stores/statistics.svelte.ts` now uses `fetchSocketData('GetPlayerStatistics')` instead of `ApiRequest.get('Statistics')`. `fetchSocketData` throws on socket error, preserving the store's existing try/catch contract.
- **Regenerated the API client type maps** via `dotnet run --project Game.Api -- codegen` (adds `'GetPlayerStatistics': IPlayerStatistic[]` to the socket response map as a no-request command).
- **Left `GET /api/Statistics` in place** — its removal is the do-last type-map/docs cleanup (#567).

## Tests

- New `GetPlayerStatisticsSocketTests` integration test: a player with recorded stats gets its values back (and a second player's stats do **not** bleed through, validating the session-scoped resolution); a new player gets an empty, non-error response.
- Updated the store unit test (`UI/src/tests/stores/statistics.test.ts`) and the Statistics screen test (`UI/src/tests/routes/game/screens/stats/Statistics.test.ts`) for the socket transport.

## Verification

- Full `Game.Api.Tests` suite: 409 passed.
- Full frontend (vitest) suite: 1682 passed.
- `svelte-check`: 0 errors / 0 warnings; eslint clean on changed files.

https://claude.ai/code/session_018ZATiV1CsggYKPoQ81fC7K

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZATiV1CsggYKPoQ81fC7K)_