### PR TITLE
Add GetPlayerChallenges socket command and migrate the challenges store off HTTP

### DIFF
--- a/Game.Api.Tests/Integration/GetPlayerChallengesSocketTests.cs
+++ b/Game.Api.Tests/Integration/GetPlayerChallengesSocketTests.cs
@@ -1,0 +1,98 @@
+using Game.Api.Models.Progress;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net.WebSockets;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    /// <summary>
+    /// Integration tests for the player-scoped <c>GetPlayerChallenges</c> socket command (#564),
+    /// the WebSocket replacement for the <c>GET /api/Challenges/Player</c> read.
+    /// </summary>
+    [Collection("Integration")]
+    public class GetPlayerChallengesSocketTests : ApiIntegrationTestBase
+    {
+        public GetPlayerChallengesSocketTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper) : base(containers, testOutputHelper) { }
+
+        private async Task<TestSocketClient> ConnectAsync(int userId)
+        {
+            var socketClient = new TestSocketClient();
+            var wsClient = Factory.Server.CreateWebSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+            Assert.Equal(WebSocketState.Open, socketClient.State);
+            return socketClient;
+        }
+
+        [Fact]
+        public async Task GetPlayerChallenges_WithSeededProgress_ReturnsThisPlayersChallenges()
+        {
+            int userId;
+            int challengeId;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+                var user = await TestDataSeeder.CreateUserAsync(context, "challsockuser", "challsockpass");
+                var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+                userId = user.Id;
+
+                var challenge = await TestDataSeeder.CreateChallengeAsync(context);
+                challengeId = challenge.Id;
+                await TestDataSeeder.AddPlayerChallengeAsync(
+                    context, player.Id, challengeId, progress: 10m, completed: true, completedAt: DateTime.UtcNow);
+
+                // A second player with their own progress: the command must resolve the player from the
+                // socket session, so this must not leak into the connected player's response.
+                var otherUser = await TestDataSeeder.CreateUserAsync(context, "otherchallsockuser", "otherchallsockpass");
+                var otherPlayer = await TestDataSeeder.CreatePlayerAsync(context, otherUser.Id);
+                var otherChallenge = await TestDataSeeder.CreateChallengeAsync(context);
+                await TestDataSeeder.AddPlayerChallengeAsync(
+                    context, otherPlayer.Id, otherChallenge.Id, progress: 5m, completed: false);
+            }
+
+            // Reload the caches so the newly seeded challenges are resolvable by id during the read (the
+            // caches no longer lazily refill).
+            await ReloadReferenceCachesAsync();
+
+            // Login creates the Redis session the socket handshake requires.
+            await LoginAsync("challsockuser", "challsockpass");
+            await using var socketClient = await ConnectAsync(userId);
+
+            var response = await socketClient.SendCommandAsync<List<PlayerChallenge>>("GetPlayerChallenges");
+
+            Assert.Null(response.Error);
+            Assert.NotNull(response.Data);
+
+            var playerChallenge = Assert.Single(response.Data);
+            Assert.Equal(challengeId, playerChallenge.ChallengeId);
+            Assert.Equal(10m, playerChallenge.Progress);
+            Assert.True(playerChallenge.Completed);
+            Assert.NotNull(playerChallenge.CompletedAt);
+        }
+
+        [Fact]
+        public async Task GetPlayerChallenges_NewPlayer_ReturnsEmptyWithoutError()
+        {
+            int userId;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                var user = await TestDataSeeder.CreateUserAsync(context, "newchallsockuser", "newchallsockpass");
+                await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+                userId = user.Id;
+            }
+
+            await LoginAsync("newchallsockuser", "newchallsockpass");
+            await using var socketClient = await ConnectAsync(userId);
+
+            var response = await socketClient.SendCommandAsync<List<PlayerChallenge>>("GetPlayerChallenges");
+
+            Assert.Null(response.Error);
+            Assert.NotNull(response.Data);
+            Assert.Empty(response.Data);
+        }
+    }
+}

--- a/Game.Api/Sockets/Commands/GetPlayerChallenges.cs
+++ b/Game.Api/Sockets/Commands/GetPlayerChallenges.cs
@@ -1,0 +1,32 @@
+using Game.Abstractions.DataAccess;
+using Game.Api.Models.Common;
+using Game.Api.Models.Progress;
+
+namespace Game.Api.Sockets.Commands
+{
+    /// <summary>
+    /// Returns the connected player's challenge progress (player progress). Unlike the reference-data
+    /// commands this is player-scoped: it resolves the player from the socket session and delegates to
+    /// <see cref="IPlayerProgressRepository.GetChallenges"/> — the same read the <c>GET /api/Challenges/Player</c>
+    /// endpoint runs (cache-first, so it serves warm cached progress). Named to stay unambiguous against
+    /// the reference-data <see cref="GetChallenges"/> command, which returns the challenge definitions
+    /// rather than the player's progress.
+    /// </summary>
+    public class GetPlayerChallenges : AbstractSocketCommandWithResponseData<IEnumerable<PlayerChallenge>>
+    {
+        private readonly IPlayerProgressRepository _playerProgress;
+
+        public override string Name { get; set; } = nameof(GetPlayerChallenges);
+
+        public GetPlayerChallenges(IPlayerProgressRepository playerProgress)
+        {
+            _playerProgress = playerProgress;
+        }
+
+        public override async Task<ApiSocketResponse<IEnumerable<PlayerChallenge>>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
+        {
+            var progress = await _playerProgress.GetChallenges(context.Session.SelectedPlayerId);
+            return Success(progress.To().Model<PlayerChallenge>());
+        }
+    }
+}

--- a/UI/src/lib/api/types/api-socket-type-map.ts
+++ b/UI/src/lib/api/types/api-socket-type-map.ts
@@ -20,6 +20,7 @@ import type {
 	ILogPreference,
 	INewEnemyModel,
 	INewEnemyRequest,
+	IPlayerChallenge,
 	IPlayerStatistic,
 	IReferenceDataVersion,
 	IRemoveModRequest,
@@ -42,6 +43,7 @@ export type ApiSocketResponseTypes = {
 	'GetEnemies': IEnemy[];
 	'GetItemMods': IItemMod[];
 	'GetItems': IItem[];
+	'GetPlayerChallenges': IPlayerChallenge[];
 	'GetPlayerStatistics': IPlayerStatistic[];
 	'GetReferenceDataVersions': IReferenceDataVersion[];
 	'GetSkills': ISkill[];

--- a/UI/src/stores/challenges.svelte.ts
+++ b/UI/src/stores/challenges.svelte.ts
@@ -1,10 +1,10 @@
 /* Player challenge-completion store — which challenges the player has completed
-   (`GET /api/Challenges/Player`), shared across screens so the source is fetched once and
-   stays consistent. The Challenges screen renders the full progress breakdown from it; the
+   (`GetPlayerChallenges` socket command), shared across screens so the source is fetched once
+   and stays consistent. The Challenges screen renders the full progress breakdown from it; the
    Fight screen reads completion to gate zone navigation (a zone unlocks once its gating
    challenge is completed). */
 
-import { ApiRequest, type IPlayerChallenge } from '$lib/api';
+import { fetchSocketData, type IPlayerChallenge } from '$lib/api';
 
 let challenges = $state<IPlayerChallenge[]>([]);
 let loaded = $state(false);
@@ -14,7 +14,8 @@ let inFlight: Promise<void> | undefined;
 
 const fetchChallenges = async () => {
 	try {
-		challenges = (await ApiRequest.get('Challenges/Player')) ?? [];
+		// fetchSocketData throws on a socket error, preserving this try/catch contract.
+		challenges = (await fetchSocketData('GetPlayerChallenges')) ?? [];
 		error = false;
 		loaded = true;
 	} catch {

--- a/UI/src/tests/routes/game/screens/challenges/Challenges.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/Challenges.test.ts
@@ -8,10 +8,10 @@ import {
 	type IPlayerChallenge
 } from '$lib/api';
 
-// Challenges fetches the player's progress via ApiRequest and resolves the
-// challenge catalogue + reward pools from staticData.
-const { mockGet, mockToastError, staticData } = vi.hoisted(() => ({
-	mockGet: vi.fn(),
+// Challenges fetches the player's progress over the socket (via the playerChallenges store) and
+// resolves the challenge catalogue + reward pools from staticData.
+const { mockFetchSocket, mockToastError, staticData } = vi.hoisted(() => ({
+	mockFetchSocket: vi.fn(),
 	mockToastError: vi.fn(),
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	staticData: {} as any
@@ -19,7 +19,7 @@ const { mockGet, mockToastError, staticData } = vi.hoisted(() => ({
 
 vi.mock('$lib/api', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('$lib/api')>();
-	return { ...actual, ApiRequest: { get: mockGet } };
+	return { ...actual, fetchSocketData: mockFetchSocket };
 });
 // Override staticData + toastError; keep the other real stores (the screen also
 // uses registerTooltipComponent, and $components pulls in the engine/log store).
@@ -52,8 +52,8 @@ beforeEach(() => {
 		challenge({ id: 1, name: 'First Blood', challengeTypeId: EChallengeType.EnemiesKilled, progressGoal: 10 })
 	];
 	mockToastError.mockClear();
-	mockGet.mockClear();
-	mockGet.mockResolvedValue(PLAYER_CHALLENGES);
+	mockFetchSocket.mockClear();
+	mockFetchSocket.mockResolvedValue(PLAYER_CHALLENGES);
 });
 
 afterEach(() => cleanup());
@@ -65,12 +65,12 @@ describe('Challenges screen', () => {
 		// The type rail's "Overview" entry only renders in the normal body.
 		expect(await screen.findByText('Overview')).toBeTruthy();
 		expect(screen.queryByTestId('challenges-error')).toBeNull();
-		expect(mockGet).toHaveBeenCalledWith('Challenges/Player');
+		expect(mockFetchSocket).toHaveBeenCalledWith('GetPlayerChallenges');
 		expect(mockToastError).not.toHaveBeenCalled();
 	});
 
 	it('renders normally (no error) for a player with no recorded progress', async () => {
-		mockGet.mockResolvedValue([]);
+		mockFetchSocket.mockResolvedValue([]);
 		render(Challenges);
 		// A genuine empty result is the normal "no progress yet" view, not an error.
 		expect(await screen.findByText('Overview')).toBeTruthy();
@@ -79,7 +79,7 @@ describe('Challenges screen', () => {
 	});
 
 	it('surfaces an error (not the zero-progress view) when the fetch fails', async () => {
-		mockGet.mockRejectedValue(new Error('network down'));
+		mockFetchSocket.mockRejectedValue(new Error('network down'));
 		render(Challenges);
 		expect(await screen.findByTestId('challenges-error')).toBeTruthy();
 		// A failed load must not masquerade as a player with zero progress.

--- a/UI/src/tests/stores/challenges.test.ts
+++ b/UI/src/tests/stores/challenges.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { ApiRequest, type IPlayerChallenge } from '$lib/api';
+
+// The store reads over the socket via fetchSocketData; stub just that export while keeping the real
+// IPlayerChallenge type from the barrel.
+const { mockFetchSocket } = vi.hoisted(() => ({ mockFetchSocket: vi.fn() }));
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return { ...actual, fetchSocketData: mockFetchSocket };
+});
+
+import { type IPlayerChallenge } from '$lib/api';
 import { playerChallenges } from '$stores/challenges.svelte';
 
 const challenge = (challengeId: number, completed: boolean): IPlayerChallenge => ({
@@ -9,48 +18,46 @@ const challenge = (challengeId: number, completed: boolean): IPlayerChallenge =>
 });
 
 describe('challenges store', () => {
-	let get: ReturnType<typeof vi.spyOn>;
-
 	beforeEach(() => {
 		playerChallenges.reset();
-		get = vi.spyOn(ApiRequest, 'get');
-		get.mockReset();
+		mockFetchSocket.mockReset();
 	});
 
 	it('loads the player challenges once and exposes them', async () => {
-		get.mockResolvedValue([challenge(3, true)]);
+		mockFetchSocket.mockResolvedValue([challenge(3, true)]);
 
 		await playerChallenges.load();
 
 		expect(playerChallenges.loaded).toBe(true);
 		expect(playerChallenges.all).toEqual([challenge(3, true)]);
+		expect(mockFetchSocket).toHaveBeenCalledWith('GetPlayerChallenges');
 
 		// Idempotent: a second (non-forced) load does not re-fetch.
 		await playerChallenges.load();
-		expect(get).toHaveBeenCalledTimes(1);
+		expect(mockFetchSocket).toHaveBeenCalledTimes(1);
 	});
 
 	it('re-fetches when forced', async () => {
-		get.mockResolvedValue([]);
+		mockFetchSocket.mockResolvedValue([]);
 		await playerChallenges.load();
 
-		get.mockResolvedValue([challenge(3, true)]);
+		mockFetchSocket.mockResolvedValue([challenge(3, true)]);
 		await playerChallenges.load(true);
 
-		expect(get).toHaveBeenCalledTimes(2);
+		expect(mockFetchSocket).toHaveBeenCalledTimes(2);
 		expect(playerChallenges.all).toEqual([challenge(3, true)]);
 	});
 
 	it('coalesces concurrent loads onto a single request', async () => {
-		get.mockResolvedValue([]);
+		mockFetchSocket.mockResolvedValue([]);
 
 		await Promise.all([playerChallenges.load(), playerChallenges.load()]);
 
-		expect(get).toHaveBeenCalledTimes(1);
+		expect(mockFetchSocket).toHaveBeenCalledTimes(1);
 	});
 
 	it('flags an error and leaves challenges empty when the fetch fails', async () => {
-		get.mockRejectedValue(new Error('boom'));
+		mockFetchSocket.mockRejectedValue(new Error('boom'));
 
 		await playerChallenges.load();
 
@@ -60,7 +67,7 @@ describe('challenges store', () => {
 	});
 
 	it('reports whether a given challenge is completed', async () => {
-		get.mockResolvedValue([challenge(3, true), challenge(4, false)]);
+		mockFetchSocket.mockResolvedValue([challenge(3, true), challenge(4, false)]);
 		await playerChallenges.load();
 
 		expect(playerChallenges.isChallengeCompleted(3)).toBe(true);
@@ -70,7 +77,7 @@ describe('challenges store', () => {
 
 	describe('markCompleted', () => {
 		it('flips an existing recorded challenge to completed', async () => {
-			get.mockResolvedValue([challenge(3, false)]);
+			mockFetchSocket.mockResolvedValue([challenge(3, false)]);
 			await playerChallenges.load();
 
 			playerChallenges.markCompleted(3);
@@ -85,7 +92,7 @@ describe('challenges store', () => {
 		});
 
 		it('is a no-op when the challenge is already completed (no duplicate row)', async () => {
-			get.mockResolvedValue([challenge(3, true)]);
+			mockFetchSocket.mockResolvedValue([challenge(3, true)]);
 			await playerChallenges.load();
 
 			playerChallenges.markCompleted(3);
@@ -95,14 +102,14 @@ describe('challenges store', () => {
 	});
 
 	it('reset() clears state and allows a fresh load', async () => {
-		get.mockResolvedValue([challenge(3, true)]);
+		mockFetchSocket.mockResolvedValue([challenge(3, true)]);
 		await playerChallenges.load();
 
 		playerChallenges.reset();
 		expect(playerChallenges.loaded).toBe(false);
 		expect(playerChallenges.all).toEqual([]);
 
-		get.mockResolvedValue([challenge(4, true)]);
+		mockFetchSocket.mockResolvedValue([challenge(4, true)]);
 		await playerChallenges.load();
 		expect(playerChallenges.isChallengeCompleted(4)).toBe(true);
 	});


### PR DESCRIPTION
Closes #564.

Moves the player challenge-progress read off HTTP onto the socket, in line with the WebSocket-everything direction (`docs/backend.md` → _HTTP vs WebSocket Communication_). This mirrors the `GetPlayerStatistics` migration (#563).

## What changed

- **New `GetPlayerChallenges` socket command** (`Game.Api/Sockets/Commands`) returning `IEnumerable<PlayerChallenge>`. Player-scoped: it resolves the player via `context.Session.SelectedPlayerId` and delegates to `IPlayerProgressRepository.GetChallenges` — the same logic `ChallengesController.Player()` runs (cache-first after #550). Modeled directly on `GetPlayerStatistics`; registration is automatic via reflection in `SocketCommandFactory`.
- **Naming:** `GetPlayerChallenges`, not `GetChallenges` — the existing `GetChallenges` socket command returns the challenge **definitions** (`IChallenge[]`, reference data); this returns player **progress** (`IPlayerChallenge[]`).
- **Store migration:** `UI/src/stores/challenges.svelte.ts` now uses `fetchSocketData('GetPlayerChallenges')` instead of `ApiRequest.get('Challenges/Player')`. The throw-on-error contract is preserved (`fetchSocketData` rejects on a socket error, keeping the store's `try/catch`).
- **Regenerated** the client socket type map (`api-socket-type-map.ts`) via `dotnet run --project Game.Api -- codegen`.
- The `GET /api/Challenges/Player` HTTP endpoint is **left in place** for now; its removal is the separate type-map/docs cleanup issue (do-last).

## Tests

- **Integration** (`GetPlayerChallengesSocketTests`): a player with seeded challenge progress gets their own progress back (with a second player guarding per-session isolation), plus a new-player empty-without-error case.
- **Store unit test** (`challenges.test.ts`): updated to stub `fetchSocketData` and assert `'GetPlayerChallenges'`, following the statistics-store test pattern.
- **Challenges-screen route test** (`Challenges.test.ts`): updated to mock `fetchSocketData` (the screen loads through the `playerChallenges` store), since it no longer hits `ApiRequest.get`.

All affected backend integration tests, frontend unit/route tests, eslint, and `svelte-check` pass locally.

https://claude.ai/code/session_01GdATPDLDrg7DwjnxR1e4hx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdATPDLDrg7DwjnxR1e4hx)_