### PR TITLE
Make tag-category accents themeable via CSS tokens (#658)

### DIFF
--- a/UI/src/lib/common/index.ts
+++ b/UI/src/lib/common/index.ts
@@ -1,6 +1,7 @@
 export * from './functions';
 export * from './rarity';
 export * from './challenge-type';
+export * from './tag-color';
 export * from './challenge-unlocks';
 export * from './zone-progression';
 export * from './attribute-display';

--- a/UI/src/lib/common/tag-color.ts
+++ b/UI/src/lib/common/tag-color.ts
@@ -1,0 +1,32 @@
+/*
+ * Single source of truth for tag-category accent visuals (workbench tag UI).
+ * The hue is procedural — a deterministic, well-spread value per category id so
+ * the set stays scannable — but the lightness, chroma and per-variant alphas are
+ * declared as `--tag-*` custom properties in `+layout.svelte` so they remain
+ * themeable (mirroring the rarity / challenge-type helpers). These helpers only
+ * compose the `oklch()` colour from those variables and the procedural hue.
+ */
+
+export interface TagColor {
+	fg: string;
+	bd: string;
+	bg: string;
+}
+
+/** Deterministic, well-spread hue per category so the set is scannable. */
+const tagHue = (catId: number): number => Math.round((catId * 137.508) % 360);
+
+/**
+ * Themeable tag-category accent trio for a category id. The lightness/chroma and
+ * the border/background alphas come from the `--tag-*` tokens, so a theme can
+ * restyle tag accents while the per-category hue stays procedural.
+ */
+export const tagColor = (catId: number): TagColor => {
+	const hue = tagHue(catId);
+	const base = `oklch(var(--tag-lightness) var(--tag-chroma) ${hue}`;
+	return {
+		fg: `${base})`,
+		bd: `${base} / var(--tag-border-alpha))`,
+		bg: `${base} / var(--tag-bg-alpha))`
+	};
+};

--- a/UI/src/routes/+layout.svelte
+++ b/UI/src/routes/+layout.svelte
@@ -195,6 +195,14 @@ $effect(() => {
 	--category-weapon: #{colors.$category-weapon};
 	--category-accessory: #{colors.$category-accessory};
 
+	// Tag-category accents (workbench tag UI). The hue is procedural per category,
+	// but the oklch lightness/chroma and border/background alphas are themeable here.
+	// Consumed via the tagColor helper in $lib/common/tag-color.
+	--tag-lightness: 0.85;
+	--tag-chroma: 0.06;
+	--tag-border-alpha: 0.45;
+	--tag-bg-alpha: 0.12;
+
 	// Challenge-type accents (one per EChallengeType). Consumed via the helpers
 	// in $lib/common/challenge-type.
 	--challenge-enemies-killed: #{colors.$challenge-enemies-killed};

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -14,15 +14,9 @@ import {
 	type ITag,
 	type ITagCategory
 } from '$lib/api';
-import { enumPairs, rarityColor as rarityVar, rarityLabel } from '$lib/common';
+import { enumPairs, rarityColor as rarityVar, rarityLabel, tagColor } from '$lib/common';
 import { staticData } from '$stores';
 import type { SelectOption } from './entities/types';
-
-export interface TagColor {
-	fg: string;
-	bd: string;
-	bg: string;
-}
 
 const toOptions = (pairs: { id: number; name: string }[]): SelectOption[] =>
 	pairs.map((p) => ({ value: p.id, text: p.name }));
@@ -185,15 +179,8 @@ class WorkbenchReference {
 	tagById = (id: number) => this.tags.find((t) => t.id === id);
 	tagsByCategory = (catId: number) => this.tags.filter((t) => t.tagCategoryId === catId);
 
-	/** Deterministic, well-spread low-chroma hue per category so the set is scannable. */
-	tagColor = (catId: number): TagColor => {
-		const hue = Math.round((catId * 137.508) % 360);
-		return {
-			fg: `oklch(0.85 0.06 ${hue})`,
-			bd: `oklch(0.85 0.06 ${hue} / 0.45)`,
-			bg: `oklch(0.85 0.06 ${hue} / 0.12)`
-		};
-	};
+	/** Themeable tag-category accent trio (procedural hue, `--tag-*` lightness/chroma/alpha). */
+	tagColor = (catId: number) => tagColor(catId);
 
 	/** Items and mods that reference a tag — drives the read-only Tags "Usage" tab. */
 	tagUsage = (tagId: number) => {

--- a/UI/src/tests/lib/common/tag-color.test.ts
+++ b/UI/src/tests/lib/common/tag-color.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { tagColor } from '$lib/common';
+
+describe('tagColor', () => {
+	it('composes the accent trio from the themeable --tag-* tokens and a procedural hue', () => {
+		const hue = Math.round((100 * 137.508) % 360);
+		expect(tagColor(100)).toEqual({
+			fg: `oklch(var(--tag-lightness) var(--tag-chroma) ${hue})`,
+			bd: `oklch(var(--tag-lightness) var(--tag-chroma) ${hue} / var(--tag-border-alpha))`,
+			bg: `oklch(var(--tag-lightness) var(--tag-chroma) ${hue} / var(--tag-bg-alpha))`
+		});
+	});
+
+	it('is deterministic for a given category id', () => {
+		expect(tagColor(100)).toEqual(tagColor(100));
+	});
+
+	it('spreads distinct hues across categories', () => {
+		expect(tagColor(200).fg).not.toBe(tagColor(100).fg);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/reference.test.ts
+++ b/UI/src/tests/routes/admin/workbench/reference.test.ts
@@ -313,13 +313,13 @@ describe('tag lookups and colour', () => {
 		]);
 	});
 
-	it('derives a deterministic low-chroma colour per category', () => {
+	it('derives a deterministic themeable colour per category', () => {
 		const a = reference.tagColor(100);
 		const b = reference.tagColor(100);
 		expect(a).toEqual(b); // deterministic
-		expect(a.fg).toMatch(/^oklch\(/);
-		expect(a.bd).toContain('/ 0.45');
-		expect(a.bg).toContain('/ 0.12');
+		expect(a.fg).toMatch(/^oklch\(var\(--tag-lightness\) var\(--tag-chroma\)/);
+		expect(a.bd).toContain('/ var(--tag-border-alpha))');
+		expect(a.bg).toContain('/ var(--tag-bg-alpha))');
 		// Different categories yield different hues.
 		expect(reference.tagColor(200).fg).not.toBe(a.fg);
 	});


### PR DESCRIPTION
Closes #658

## Problem

Tag-category accent colors were generated as `oklch()` literals in TypeScript (`reference.svelte.ts` `tagColor`) and injected as inline styles (consumed by `TagPill`, `TagBrowse`, `TagSearch`, `UsageSection`). The procedural hue was fine, but the lightness `0.85`, chroma `0.06`, and the border/background alphas were hardcoded color literals — the one place that escaped the project's theming discipline, so a custom theme could not restyle tag accents at all.

## Change

Mirrored the established **data-driven accent** pattern (`rarityColor` / `challengeTypeColor` in `$lib/common` + their `var(--…)` declarations in `+layout.svelte`):

- **New tokens in `+layout.svelte`** (in the styling/token area, alongside the item-category and challenge-type accents): `--tag-lightness` (`0.85`), `--tag-chroma` (`0.06`), `--tag-border-alpha` (`0.45`), `--tag-bg-alpha` (`0.12`).
- **New helper `$lib/common/tag-color.ts`** (`tagColor`) — the single place that reads those tokens, composing the `oklch()` accent trio (`fg`/`bd`/`bg`) from the themeable lightness/chroma/alpha and the **procedural per-category hue** (kept). Exported via `$lib/common/index.ts`, mirroring `rarity.ts` / `challenge-type.ts`.
- **`reference.svelte.ts`** now delegates to the shared helper (same pass-through convention it already uses for `rarityColor`/`rarityLabel`); removed the inline `oklch()` literals and the duplicate `TagColor` interface (dead code).

The consumed shape (`{ fg, bd, bg }`) is unchanged, so no consumer components were touched and the rendered appearance is **equivalent under the default theme** — the default token values reproduce the previous `oklch(0.85 0.06 hue …)` exactly.

## Pattern mirrored / tokens

- Helper pattern: `rarityColor` / `challengeTypeColor` (`$lib/common`).
- New tokens: `--tag-lightness`, `--tag-chroma`, `--tag-border-alpha`, `--tag-bg-alpha`.

## Tests

- Added `tests/lib/common/tag-color.test.ts` mirroring `rarity.test.ts` / `challenge-type.test.ts` (asserts the `var(--tag-*)` composition, determinism, distinct hues per category).
- Updated the existing colour assertion in `tests/routes/admin/workbench/reference.test.ts` to expect the `var(--tag-*)` composition.
- `npx vitest --run`: **1711 passed (180 files)**. `npm run lint` (eslint + svelte-check): **0 errors / 0 warnings**. `npm run build`: succeeds.

Scope: small, admin-only theming consistency fix. `+layout.svelte` change is confined to the styling/token area to avoid overlap with the sibling PR (#659) touching a script `$effect`.

https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3)_