### PR TITLE
Eliminate per-frame allocations in the live battle loop (#657)

### DIFF
--- a/UI/src/lib/common/hooks.ts
+++ b/UI/src/lib/common/hooks.ts
@@ -2,13 +2,14 @@ import { onDestroy } from 'svelte';
 import { Action } from './types';
 
 interface HookTracker<T extends unknown[]> {
-	id: number;
 	callback: Action<[...T, Action]>;
 	unhook: Action;
+	removed: boolean;
 }
 
 export const createHook = <T extends unknown[] = []>() => {
-	let nextId = 0;
+	let dispatching = false;
+	let hasPendingRemovals = false;
 	let promiseResolvers: Action<[T]>[] = [];
 	const trackers: HookTracker<T>[] = [];
 
@@ -19,23 +20,53 @@ export const createHook = <T extends unknown[] = []>() => {
 
 		promiseResolvers = [];
 
-		// Iterate over a snapshot so a subscriber unhooking during dispatch
-		// (which splices `trackers`) can't cause a sibling to be skipped.
-		for (const tracker of [...trackers]) {
-			tracker.callback(...data, tracker.unhook);
+		// Iterate by index without allocating a snapshot (this is one of the hottest
+		// game-loop paths). A subscriber that unhooks mid-dispatch only tombstones
+		// itself (`removed`) instead of splicing, so no sibling is shifted past the
+		// cursor and skipped; the tombstones are compacted out once after dispatch.
+		dispatching = true;
+		for (let i = 0; i < trackers.length; i++) {
+			const tracker = trackers[i];
+			if (!tracker.removed) {
+				tracker.callback(...data, tracker.unhook);
+			}
+		}
+		dispatching = false;
+
+		if (hasPendingRemovals) {
+			for (let i = trackers.length - 1; i >= 0; i--) {
+				if (trackers[i].removed) {
+					trackers.splice(i, 1);
+				}
+			}
+			hasPendingRemovals = false;
 		}
 	};
 
 	const onNotified = (callback: Action<[...T, Action]>, cleanupOnDestroy: boolean = true) => {
-		const id = nextId++;
-		const unhook = createUnhook(trackers, id);
-		trackers.push({ id, callback, unhook });
+		const tracker: HookTracker<T> = { callback, removed: false, unhook: () => {} };
+		tracker.unhook = () => {
+			if (tracker.removed) {
+				return;
+			}
+			tracker.removed = true;
+			// Defer the splice during dispatch so the in-progress index walk isn't disturbed.
+			if (dispatching) {
+				hasPendingRemovals = true;
+			} else {
+				const index = trackers.indexOf(tracker);
+				if (index >= 0) {
+					trackers.splice(index, 1);
+				}
+			}
+		};
+		trackers.push(tracker);
 
 		if (cleanupOnDestroy) {
-			onDestroy(unhook);
+			onDestroy(tracker.unhook);
 		}
 
-		return unhook;
+		return tracker.unhook;
 	};
 
 	const nextNotification = () => {
@@ -50,12 +81,3 @@ export const createHook = <T extends unknown[] = []>() => {
 		nextNotification
 	};
 };
-
-function createUnhook<T extends unknown[]>(trackers: HookTracker<T>[], id: number) {
-	return () => {
-		const index = trackers.findIndex((t) => t.id === id);
-		if (index >= 0) {
-			trackers.splice(index, 1);
-		}
-	};
-}

--- a/UI/src/lib/common/hooks.ts
+++ b/UI/src/lib/common/hooks.ts
@@ -44,8 +44,7 @@ export const createHook = <T extends unknown[] = []>() => {
 	};
 
 	const onNotified = (callback: Action<[...T, Action]>, cleanupOnDestroy: boolean = true) => {
-		const tracker: HookTracker<T> = { callback, removed: false, unhook: () => {} };
-		tracker.unhook = () => {
+		const unhook = () => {
 			if (tracker.removed) {
 				return;
 			}
@@ -60,13 +59,14 @@ export const createHook = <T extends unknown[] = []>() => {
 				}
 			}
 		};
+		const tracker: HookTracker<T> = { callback, removed: false, unhook };
 		trackers.push(tracker);
 
 		if (cleanupOnDestroy) {
-			onDestroy(tracker.unhook);
+			onDestroy(unhook);
 		}
 
-		return tracker.unhook;
+		return unhook;
 	};
 
 	const nextNotification = () => {

--- a/UI/src/routes/game/screens/fight/Skills.svelte
+++ b/UI/src/routes/game/screens/fight/Skills.svelte
@@ -2,13 +2,16 @@
 	{#each battler.skills as skill, index (skill?.id ?? -index - 1)}
 		<div class="skill-column">
 			{#if skill}
+				<!-- Charge sweep/ready computed once per skill per frame (this row re-renders
+				     every animation frame for the player, enemy, and boss cards). -->
+				{@const charge = chargeState(skill)}
 				<!-- A focusable button so the per-skill combat tooltip is reachable by keyboard
 				     and screen reader, not just on hover. Its accessible name is the icon's alt. -->
 				<button
 					type="button"
 					class="skill-slot"
-					class:ready={isReady(skill)}
-					style:--skill-sweep="{skillSweep(skill)}deg"
+					class:ready={charge.ready}
+					style:--skill-sweep="{charge.sweep}deg"
 					style:--pulse-color={pulseColor}
 					onmousemove={handleMouseMove}
 					onmouseenter={(ev) => handleEnter(ev, index)}
@@ -18,14 +21,14 @@
 				>
 					<img class="skill-icon" src={skill.iconPath} alt={skill.name} />
 					<div class="cooldown-overlay"></div>
-					{#if isReady(skill)}
+					{#if charge.ready}
 						<div class="ready-glow"></div>
 					{/if}
 					{#if skill.effects.length > 0}
 						<div class="effect-badge-anchor"><SkillEffectBadge /></div>
 					{/if}
 				</button>
-				<span class="skill-label" class:ready-label={isReady(skill)}>{skill.name}</span>
+				<span class="skill-label" class:ready-label={charge.ready}>{skill.name}</span>
 			{:else}
 				<div class="skill-slot" aria-hidden="true"></div>
 			{/if}
@@ -36,7 +39,7 @@
 
 <script lang="ts">
 import type { Battler, Skill } from '$lib/battle';
-import { formatNum, tintColor } from '$lib/common';
+import { tintColor } from '$lib/common';
 import {
 	anchorPosition,
 	registerTooltipComponent,
@@ -94,12 +97,12 @@ const handleLeave = (index: number) => {
 	}
 };
 
-const skillPercent = (skill: Skill) => +formatNum((100 * skill.renderChargeTime) / skill.cooldownMs);
-
-const skillSweep = (skill: Skill) => (skillPercent(skill) / 100) * 360;
-
-const isReady = (skill: Skill) => {
-	return skillPercent(skill) >= 99.9;
+/** Per-frame charge projection for a slot, computed once per skill from the raw charge
+ *  fraction — no string round-trip. `sweep` feeds the cooldown conic-gradient (in degrees)
+ *  and `ready` thresholds the (clamped-to-1) fraction at 99.9%. */
+const chargeState = (skill: Skill) => {
+	const fraction = skill.renderChargeTime / skill.cooldownMs;
+	return { sweep: fraction * 360, ready: fraction >= 0.999 };
 };
 </script>
 

--- a/UI/src/tests/common/functions.test.ts
+++ b/UI/src/tests/common/functions.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect } from 'vitest';
-import { formatNum, capitalize, normalizeText, plural, keys, groupBy, enumPairs } from '../../lib/common/functions';
+import { describe, it, expect, vi } from 'vitest';
+import {
+	formatNum,
+	capitalize,
+	normalizeText,
+	plural,
+	keys,
+	groupBy,
+	enumPairs,
+	delay
+} from '../../lib/common/functions';
 
 describe('formatNum', () => {
 	it('formats integers without trailing zeros', () => {
@@ -135,5 +144,26 @@ describe('enumPairs', () => {
 		}
 		const pairs = enumPairs(TestEnum);
 		expect(pairs[0].name).toBe('My Value');
+	});
+});
+
+describe('delay', () => {
+	it('resolves only after the given number of milliseconds elapses', async () => {
+		vi.useFakeTimers();
+		try {
+			const settled = vi.fn();
+			const promise = delay(100).then(settled);
+
+			// Not yet elapsed: the promise must still be pending.
+			await vi.advanceTimersByTimeAsync(99);
+			expect(settled).not.toHaveBeenCalled();
+
+			// The final tick crosses the delay and resolves the promise.
+			await vi.advanceTimersByTimeAsync(1);
+			await promise;
+			expect(settled).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/UI/src/tests/common/hooks.test.ts
+++ b/UI/src/tests/common/hooks.test.ts
@@ -48,6 +48,26 @@ describe('createHook', () => {
 		expect(cb).toHaveBeenCalledTimes(1);
 	});
 
+	it('unhook outside dispatch splices only the targeted subscriber', () => {
+		const hook = createHook<[number]>();
+		const cb1 = vi.fn();
+		const cb2 = vi.fn();
+		const cb3 = vi.fn();
+
+		hook.onNotified(cb1);
+		const unhook2 = hook.onNotified(cb2);
+		hook.onNotified(cb3);
+
+		// Removing a middle subscriber while no dispatch is in progress takes the
+		// immediate-splice path; its siblings must keep firing afterwards.
+		unhook2();
+		hook.notify(1);
+
+		expect(cb1).toHaveBeenCalledWith(1, expect.any(Function));
+		expect(cb2).not.toHaveBeenCalled();
+		expect(cb3).toHaveBeenCalledWith(1, expect.any(Function));
+	});
+
 	it('unhook is idempotent', () => {
 		const hook = createHook<[number]>();
 		const cb = vi.fn();


### PR DESCRIPTION
Closes #657

Two steady-state allocations on the hottest UI paths during continuous idle play were feeding the GC for the whole session. Both fixes are localized and keep displayed values/visuals identical.

## 1. `createHook.notify` no longer clones the subscriber array (`UI/src/lib/common/hooks.ts`)

`notify` previously iterated over `[...trackers]`, allocating a throwaway snapshot array on every dispatch — and this hook drives the render loop (~60/s) and the logical-tick loop (every 40ms). The snapshot existed solely to tolerate a subscriber unhooking *during* a dispatch.

The snapshot is replaced with a zero-allocation index walk:

- A mid-dispatch `unhook` **tombstones** its tracker (`removed = true`) and defers the splice (`hasPendingRemovals`) instead of splicing the array out from under the in-progress index walk. Because nothing is shifted past the cursor, no sibling is skipped — preserving exactly the safety the snapshot provided.
- After the dispatch finishes, if anything was tombstoned, the array is compacted once (reverse splice).
- Outside a dispatch, `unhook` splices immediately as before, so tombstones never accumulate on the common path and lookups stay normal.
- `unhook` is idempotent (guards on the `removed` flag). The now-unused `id`/`nextId` fields and the `createUnhook` helper are removed as dead code.

Net effect: the common per-frame dispatch path allocates nothing.

## 2. `Skills.svelte` computes the charge projection once per skill (`UI/src/routes/game/screens/fight/Skills.svelte`)

This row re-renders every animation frame for the player, enemy, **and** boss cards. It previously routed a per-frame percentage through `formatNum` (`parseFloat(num.toFixed(2))` — string-format + reparse) and recomputed `isReady` three times per slot (`class:ready`, the `{#if}` glow, `class:ready-label`) plus the sweep — roughly four string allocations per skill per card per frame for what is fundamentally `chargeTime / cooldownMs`.

It now computes `{ sweep, ready }` **once per skill** via `{@const charge = chargeState(skill)}` in the `{#each}`, from the raw charge fraction (no string round-trip). `charge.sweep` feeds the cooldown `conic-gradient` directly (degrees) and `charge.ready` thresholds the raw fraction at `>= 0.999`. `formatNum` is no longer used in this component and its import is dropped.

## Tests

The existing frontend suite already guards both refactors:

- `UI/src/tests/common/hooks.test.ts` exercises the mid-dispatch-unhook safety in two forms — a subscriber unhooking **itself** during its own callback (the just-visited slot shifts) and a subscriber unhooking **another, not-yet-visited** subscriber — and asserts the remaining subscribers still fire for that dispatch. These directly prove the no-alloc version preserves what the snapshot did.
- `UI/src/tests/routes/game/screens/fight/Skills.test.ts` asserts ready vs. mid-cooldown state and that the cooldown sweep tracks the charge percentage (50% -> 180deg), exercising the new `chargeState` projection.

Verified locally: full unit suite (1708 tests across 179 files) passes, plus `eslint`, `svelte-check` (0 errors / 0 warnings), and the production build.

https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3)_