### PR TITLE
Latch boot-guard redirect to prevent a mid-navigation re-fire (#659)

### DIFF
--- a/UI/src/routes/+layout.svelte
+++ b/UI/src/routes/+layout.svelte
@@ -80,9 +80,15 @@ onMount(async () => {
 
 // Safety net once booted: if the in-memory player state is lost (e.g. an auth failure tore it down)
 // while on a protected route, return to login. Inert during boot and on the login route itself.
+// `redirecting` latches the in-flight navigation so a reactive re-run (a tracked dep changing before
+// `pathname` settles) can't fire a redundant second goto; it clears once the navigation completes.
+let redirecting = false;
 $effect(() => {
-	if (booted && !playerManager.name && page.url.pathname !== '/') {
-		goto(resolve('/'));
+	if (booted && !playerManager.name && page.url.pathname !== '/' && !redirecting) {
+		redirecting = true;
+		goto(resolve('/')).finally(() => {
+			redirecting = false;
+		});
 	}
 });
 </script>

--- a/UI/src/tests/routes/layout.svelte.test.ts
+++ b/UI/src/tests/routes/layout.svelte.test.ts
@@ -1,14 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, screen, waitFor } from '@testing-library/svelte';
 import { createRawSnippet } from 'svelte';
+import { SvelteURL } from 'svelte/reactivity';
 
+// The layout's boot guard reads `page.url.pathname` reactively, so the URL mock must be reactive too —
+// otherwise the post-boot $effect never re-runs and the latch can't be exercised. A single stable
+// `SvelteURL` (created in beforeEach, mutated in place by `setPath`) makes the `.pathname` read inside
+// the effect track it. The URL is filled in beforeEach because vi.hoisted runs before module imports
+// resolve, so `SvelteURL` isn't available inside the factory.
 const { goto, getTokens, onSocketError, resumeSession, playerManager, page } = vi.hoisted(() => ({
 	goto: vi.fn(() => Promise.resolve()),
 	getTokens: vi.fn(),
 	onSocketError: vi.fn(),
 	resumeSession: vi.fn(),
 	playerManager: { name: '' },
-	page: { url: new URL('http://localhost/') }
+	page: { url: new URL('http://localhost/') as URL }
 }));
 
 vi.mock('$app/navigation', () => ({ goto }));
@@ -32,8 +38,10 @@ const childSnippet = createRawSnippet(() => ({
 
 const renderLayout = () => render(Layout, { props: { children: childSnippet } });
 
+// Mutate the stable reactive URL in place (don't reassign) so the effect's `page.url.pathname` read
+// re-fires.
 const setPath = (pathname: string) => {
-	page.url = new URL(`http://localhost${pathname}`);
+	page.url.href = `http://localhost${pathname}`;
 };
 
 beforeEach(() => {
@@ -41,7 +49,8 @@ beforeEach(() => {
 	getTokens.mockReturnValue(null);
 	resumeSession.mockResolvedValue('login');
 	playerManager.name = '';
-	setPath('/');
+	// Fresh reactive URL per test so an in-place mutation re-runs the boot-guard effect.
+	page.url = new SvelteURL('http://localhost/');
 });
 
 afterEach(cleanup);
@@ -109,5 +118,32 @@ describe('root layout boot gate', () => {
 		resolveResume('game');
 		await waitFor(() => expect(goto).toHaveBeenCalledWith('/game'));
 		await waitFor(() => expect(screen.queryByTestId('boot-splash')).toBeNull());
+	});
+});
+
+describe('root layout boot-guard redirect latch', () => {
+	it('issues only one redirect while the post-boot safety net navigation is still settling', async () => {
+		// Boot completes in place (a `game` resume on a real in-app route stays put), so the post-boot
+		// $effect — not the boot gate's onMount — owns the redirect. With no player name on a protected
+		// route it fires goto('/'), which we hold open so `pathname` never settles.
+		getTokens.mockReturnValue({ accessToken: 'a', refreshToken: 'r' });
+		resumeSession.mockResolvedValue('game');
+		playerManager.name = '';
+		setPath('/admin');
+		let resolveGoto!: () => void;
+		goto.mockReturnValue(new Promise<void>((r) => (resolveGoto = r)));
+		renderLayout();
+
+		await waitFor(() => expect(goto).toHaveBeenCalledWith('/'));
+		expect(goto).toHaveBeenCalledTimes(1);
+
+		// A tracked dep (pathname) changes mid-navigation; without the latch this re-run would fire a
+		// redundant second goto('/') before the first navigation resolves.
+		setPath('/game');
+		await waitFor(() => expect(page.url.pathname).toBe('/game'));
+		expect(goto).toHaveBeenCalledTimes(1);
+
+		// Once the navigation settles the latch releases for any genuine future redirect.
+		resolveGoto();
 	});
 });


### PR DESCRIPTION
Closes #659

## Problem

The root layout's post-boot safety net (`UI/src/routes/+layout.svelte`) is an unguarded side-effecting `$effect` that tracks `playerManager.name` (a reactive `statify` field) and `page.url.pathname`, and fires `goto('/')` without awaiting or guarding the in-flight navigation. While the async redirect to `/` is still settling, any reactive change to a tracked dep re-runs the effect and can issue a redundant **second** `goto('/')` before `pathname` updates — the redundant-navigation race described in the issue, and an instance of the unguarded `$effect` pattern `docs/frontend.md` steers away from.

## The latch

Make the redirect idempotent with a non-reactive `redirecting` latch:

- It is set to `true` before `goto` and cleared in `.finally()` once the navigation completes.
- The effect guard now also checks `!redirecting`, so a re-run during the in-flight navigation early-returns and is a no-op.

`redirecting` is a plain `let` (not `$state`) on purpose — it is a guard flag, not a tracked dependency; making it reactive would re-trigger the effect on its own mutation. The auth-teardown behaviour (bounce to login when in-memory player state is lost on a protected route) is unchanged; only the redundant-navigation race is removed.

The change is confined to the `$effect` in the `<script>` block and deliberately does not touch the `<style>`/head tokens (PR #658's area) to avoid overlap.

## Tests

- Renamed `layout.test.ts` → `layout.svelte.test.ts` and backed the `page.url` mock with a `SvelteURL` so the boot-guard effect genuinely re-runs when the path changes (a plain object mock did not notify Svelte reactivity, so the race wasn't reproducible before).
- Added a regression test: boot completes in place (a `game` resume on a real in-app route stays put) so the post-boot effect — not the boot gate's `onMount` — owns the redirect; it fires `goto('/')`, which is held open so `pathname` never settles, then a tracked dep changes mid-navigation. The test asserts exactly one `goto('/')`. Reverting the latch makes it observe two calls, so the test has teeth.

### Verification

- `npx vitest run` (in `UI/`): **179 files / 1709 tests passing**.
- `npm run lint` (eslint + svelte-check): **0 errors, 0 warnings**.

https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3)_