### PR TITLE
Roll back RedisPubSubService subscribe registration on SubscribeAsync failure (#655)

### DIFF
--- a/Game.Infrastructure.Tests/RedisPubSubSubscribeRollbackTests.cs
+++ b/Game.Infrastructure.Tests/RedisPubSubSubscribeRollbackTests.cs
@@ -1,0 +1,59 @@
+using Game.Abstractions.Infrastructure;
+using Game.Infrastructure.PubSub.Redis;
+using Microsoft.Extensions.Logging.Abstractions;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Game.Infrastructure.Tests
+{
+    /// <summary>
+    /// Pins the registration-rollback invariant for the queue-based <see cref="RedisPubSubService"/>
+    /// subscribe overloads (#655): when <c>SubscribeAsync</c> throws a transient connection error after the
+    /// handle id was already added to the process-wide registry, the partial registration is rolled back, so a
+    /// later retry with the same id is not wedged with "a handle already exists" while nothing is subscribed.
+    /// <para>
+    /// This needs no Redis server: a multiplexer pointed at a dead endpoint (<c>abortConnect=false</c>) connects
+    /// lazily and then throws a real <see cref="RedisConnectionException"/> from <c>SubscribeAsync</c> — the exact
+    /// transient failure the fix guards. The retry's outcome distinguishes fixed from broken deterministically:
+    /// reaching <c>SubscribeAsync</c> again (another <see cref="RedisConnectionException"/>) proves the id was
+    /// freed, whereas the unpatched code would throw <see cref="InvalidOperationException"/> at the registry add.
+    /// It therefore stays an in-process test (no out-of-process dependency, like the sibling factory failure-path
+    /// test), while the happy-path subscribe round-trips live in the Redis integration suite.
+    /// </para>
+    /// </summary>
+    public class RedisPubSubSubscribeRollbackTests
+    {
+        // A refused/unreachable endpoint: abortConnect=false returns a non-connected multiplexer so the failure
+        // surfaces at SubscribeAsync rather than at Connect, and the short timeout/no-retry keep the test quick.
+        private const string DeadEndpoint = "127.0.0.1:1,abortConnect=false,connectTimeout=500,connectRetry=0";
+
+        [Fact]
+        public async Task Subscribe_ActionOverload_WhenSubscribeAsyncFails_RollsBackIdForRetry()
+        {
+            await AssertFailedSubscribeFreesId((service, id) =>
+                service.Subscribe("rollback-channel", "rollback-queue", (Action<(IPubSubQueue queue, string channel)>)(_ => { }), id));
+        }
+
+        [Fact]
+        public async Task Subscribe_AsyncOverload_WhenSubscribeAsyncFails_RollsBackIdForRetry()
+        {
+            await AssertFailedSubscribeFreesId((service, id) =>
+                service.Subscribe("rollback-channel", "rollback-queue", (Func<(IPubSubQueue queue, string channel), Task>)(_ => Task.CompletedTask), id));
+        }
+
+        // Subscribes the same id twice against a failing connection. Both attempts must fail at SubscribeAsync
+        // (RedisConnectionException); a second attempt failing at the registry (InvalidOperationException) would
+        // mean the first failure wedged the id — the leak this rolls back.
+        private static async Task AssertFailedSubscribeFreesId(Func<RedisPubSubService, string, Task> subscribe)
+        {
+            await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(DeadEndpoint);
+            var service = new RedisPubSubService(multiplexer, NullLoggerFactory.Instance);
+            var id = $"rollback-{Guid.NewGuid()}";
+
+            await Assert.ThrowsAsync<RedisConnectionException>(() => subscribe(service, id));
+
+            // The retry must get past the registry add and fail at SubscribeAsync again — proving the id was freed.
+            await Assert.ThrowsAsync<RedisConnectionException>(() => subscribe(service, id));
+        }
+    }
+}

--- a/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
@@ -98,21 +98,7 @@ namespace Game.Infrastructure.PubSub.Redis
                 Name = $"RedisSubWorker_{queueName}"
             };
 
-            if (id is not null)
-            {
-                if (!_handles.TryAdd(id, (handle, worker)))
-                {
-                    worker.Dispose();
-                    throw new InvalidOperationException($"Cannot create handle with id: {id} because one already exists.");
-                }
-            }
-
-            await Subscriber.SubscribeAsync(RedisChannel.Literal(channel), handle);
-
-            void handle(RedisChannel _c, RedisValue _v)
-            {
-                worker.Start();
-            }
+            await SubscribeWithWorker(channel, worker, id);
         }
 
         public async Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string? id = null)
@@ -124,16 +110,33 @@ namespace Game.Infrastructure.PubSub.Redis
                 Name = $"RedisSubWorker_{queueName}"
             };
 
-            if (id is not null)
+            await SubscribeWithWorker(channel, worker, id);
+        }
+
+        // Registers a queue worker's handle and subscribes it, keeping the two atomic: a SubscribeAsync failure
+        // rolls back the partial registration (removes the id and disposes the worker) so a transient Redis error
+        // can't wedge the id permanently with "a handle already exists" while nothing is actually subscribed (#655).
+        private async Task SubscribeWithWorker(string channel, BackgroundWorker worker, string? id)
+        {
+            if (id is not null && !_handles.TryAdd(id, (handle, worker)))
             {
-                if (!_handles.TryAdd(id, (handle, worker)))
-                {
-                    worker.Dispose();
-                    throw new InvalidOperationException($"Cannot create handle with id: {id} because one already exists.");
-                }
+                worker.Dispose();
+                throw new InvalidOperationException($"Cannot create handle with id: {id} because one already exists.");
             }
 
-            await Subscriber.SubscribeAsync(RedisChannel.Literal(channel), handle);
+            try
+            {
+                await Subscriber.SubscribeAsync(RedisChannel.Literal(channel), handle);
+            }
+            catch
+            {
+                if (id is not null)
+                {
+                    _handles.TryRemove(id, out _);
+                }
+                worker.Dispose();
+                throw;
+            }
 
             void handle(RedisChannel _c, RedisValue _v)
             {


### PR DESCRIPTION
Closes #655

## Problem
In the two queue-based `Subscribe` overloads of `RedisPubSubService`, the handle id was added to the static `_handles` registry and the `BackgroundWorker` constructed **before** `await Subscriber.SubscribeAsync(...)`. If `SubscribeAsync` threw a transient Redis error after a successful `TryAdd`, nothing rolled back the partial registration: the `_handles` entry and the worker leaked, so a later `Subscribe` retry with the same id failed permanently with "a handle already exists" even though nothing was actually subscribed. Because per-socket command listeners subscribe by id on every socket registration, a transient subscribe failure could wedge a player's id for the process lifetime.

## Fix (rollback, not reorder)
Extracted a shared private `SubscribeWithWorker(channel, worker, id)` helper used by both queue overloads (DRY), making the registration atomic:
- `TryAdd` the handle (preserving the existing duplicate-id rejection path), then
- `await SubscribeAsync` inside a `try`/`catch` that, on failure, removes the id from `_handles` (when present) and disposes the worker before rethrowing.

I chose **rollback over subscribe-first reorder** deliberately: the local `handle` closes over `worker` and calls `worker.Start()`, so subscribing before the worker/handle are registered would risk a message arriving with no registered handler. Rollback keeps the existing ordering and simply undoes a partial registration, which is the safer change.

Scope was kept to the two queue overloads called out in the issue. Note (follow-up candidate): the plain non-worker `Subscribe(channel, action, id)` overload has the same `_handles`-leak-on-`SubscribeAsync`-throw shape (no worker/OS-handle leak, just the wedged id); left out of this scope-small change.

## Test
Added `Game.Infrastructure.Tests/RedisPubSubSubscribeRollbackTests.cs` — an in-process integration test that drives a real `RedisPubSubService` against a dead endpoint (`abortConnect=false`) so `SubscribeAsync` throws a genuine `RedisConnectionException`, then re-subscribes the **same id**. The retry reaching `SubscribeAsync` again (another `RedisConnectionException`) rather than throwing `InvalidOperationException` at the registry proves the id was freed. Covers **both** queue overloads. It needs no Redis server (same spirit as the sibling `PubSubServiceFactoryTests` failure-path test), so it fits `Game.Infrastructure.Tests`' "no out-of-process dependency" boundary; the happy-path subscribe round-trips remain in the Redis integration suite.

Verified the test genuinely pins the bug: temporarily reverting the rollback made the test fail with `InvalidOperationException` on the retry; restoring the fix makes it pass.

## Results
- `dotnet test Game.Infrastructure.Tests/Game.Infrastructure.Tests.csproj -- --filter-class "*RedisPubSubSubscribeRollbackTests"` → Passed: 2.
- Full `Game.Infrastructure.Tests` → Passed: 33.
- Sibling Redis integration coverage `dotnet test Game.Application.Tests/Game.Application.Tests.csproj -- --filter-class "*RedisPubSubServiceIntegrationTests"` → Passed: 6 (confirms the duplicate-id/worker-disposal branches still hold after the refactor).

https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3)_