### PR TITLE
Create AttributeCollection nodes lazily to cut battle-path allocations (#652)

### DIFF
--- a/Game.Core.Tests/Attributes/AttributeCollectionTests.cs
+++ b/Game.Core.Tests/Attributes/AttributeCollectionTests.cs
@@ -249,6 +249,89 @@ namespace Game.Core.Tests.Attributes
             Assert.True(allMods.Count >= 10);
         }
 
+        [Fact]
+        public void AllModifiers_EmptyCollection_ReturnsOnlyStaticModifiers()
+        {
+            // Untouched (lazily-uncreated) slots must not surface as null entries; an empty
+            // collection still carries exactly the static modifier set.
+            var collection = new AttributeCollection([]);
+
+            var allMods = collection.AllModifiers().ToList();
+
+            Assert.Equal(StaticAttributeModifiers.All.Count, allMods.Count);
+            Assert.All(allMods, modifier => Assert.NotNull(modifier));
+        }
+
+        [Fact]
+        public void Indexer_ReadingUntouchedAttribute_DoesNotAffectOtherAttributes()
+        {
+            // Reading an attribute lazily creates and caches its node; this must not leak any
+            // value into unrelated slots that were never written.
+            var collection = new AttributeCollection([Additive(EAttribute.Strength, 10)]);
+
+            Assert.Equal(0, collection[EAttribute.Intellect]);
+            Assert.Equal(0, collection[EAttribute.Dexterity]);
+            Assert.Equal(10, collection[EAttribute.Strength]);
+        }
+
+        [Fact]
+        public void Indexer_RepeatedReadOfUntouchedAttribute_IsStable()
+        {
+            // The first read of an empty slot creates the node and caches 0; subsequent reads
+            // must return the same cached value rather than diverging.
+            var collection = new AttributeCollection([]);
+
+            Assert.Equal(0, collection[EAttribute.Luck]);
+            Assert.Equal(0, collection[EAttribute.Luck]);
+        }
+
+        [Fact]
+        public void AddModifier_ToAttributeAlreadyReadWhileEmpty_UpdatesValue()
+        {
+            // Read first (lazily creates + caches the empty node), then add — the add must
+            // invalidate that cache so the next read reflects the new modifier.
+            var collection = new AttributeCollection([]);
+
+            Assert.Equal(0, collection[EAttribute.Strength]);
+            collection.AddModifier(Additive(EAttribute.Strength, 8));
+
+            Assert.Equal(8, collection[EAttribute.Strength]);
+        }
+
+        [Fact]
+        public void DerivedModifier_FromOtherwiseUntouchedSource_StillCascades()
+        {
+            // The derived source attribute is never read or directly modified, so its node only
+            // exists because the derived link lazily created it. The cascade must still fire.
+            var endurance = Additive(EAttribute.Endurance, 10);
+            var collection = new AttributeCollection([]);
+
+            // MaxHealth before any Endurance: base 50 only.
+            Assert.Equal(50, collection[EAttribute.MaxHealth]);
+
+            collection.AddModifier(endurance);
+
+            // 50 + 20*10 = 250 once Endurance feeds the static derived MaxHealth modifier.
+            Assert.Equal(250, collection[EAttribute.MaxHealth]);
+        }
+
+        [Fact]
+        public void SeparateCollections_DoNotShareNodeState()
+        {
+            // Lazy creation must give each collection its own nodes; a write to one must never
+            // bleed into another (the per-instance analogue of "each slot is its own object").
+            var first = new AttributeCollection([Additive(EAttribute.Strength, 10)]);
+            var second = new AttributeCollection([]);
+
+            Assert.Equal(10, first[EAttribute.Strength]);
+            Assert.Equal(0, second[EAttribute.Strength]);
+
+            second.AddModifier(Additive(EAttribute.Strength, 3));
+
+            Assert.Equal(10, first[EAttribute.Strength]);
+            Assert.Equal(3, second[EAttribute.Strength]);
+        }
+
         private static AttributeModifier Additive(EAttribute attribute, double amount) => new()
         {
             Attribute = attribute,

--- a/Game.Core/Attributes/AttributeCollection.cs
+++ b/Game.Core/Attributes/AttributeCollection.cs
@@ -8,7 +8,10 @@ namespace Game.Core.Attributes
     public class AttributeCollection
     {
         private static readonly int _attributesMaxId = GetMaxAttribute();
-        private readonly List<AttributeCollectionNode> _attributeNodeList = GetNodeList();
+
+        // One slot per attribute id; nodes are created lazily on first access so a freshly
+        // constructed collection allocates no per-attribute nodes for the (common) empty slots.
+        private readonly AttributeCollectionNode?[] _attributeNodes = new AttributeCollectionNode?[_attributesMaxId + 1];
 
         /// <inheritdoc cref="GetAttributeValue(EAttribute)"/>
         public double this[EAttribute index] => GetAttributeValue(index);
@@ -34,7 +37,7 @@ namespace Game.Core.Attributes
         public void AddModifier(AttributeModifier modifier)
         {
             AddModifierWithoutCacheInvalidation(modifier);
-            _attributeNodeList[(int)modifier.Attribute].SetCachedValue(null);
+            GetOrCreateNode((int)modifier.Attribute).SetCachedValue(null);
         }
 
         /// <summary>
@@ -45,12 +48,13 @@ namespace Game.Core.Attributes
         /// <param name="modifier"></param>
         public bool RemoveModifier(AttributeModifier modifier)
         {
-            var node = _attributeNodeList[(int)modifier.Attribute];
+            // A null slot (never created) holds no modifiers, so there is nothing to remove.
+            var node = _attributeNodes[(int)modifier.Attribute];
 
             // Identity removal: a node can hold several modifiers with the same Type (the
             // collection's sort key), so the exact instance must be matched, not a sort-equal one.
             // AttributeModifier does not override Equals, so the default comparer is reference equality.
-            if (node.Modifiers is null || !node.Modifiers.Remove(modifier, EqualityComparer<AttributeModifier>.Default))
+            if (node?.Modifiers is null || !node.Modifiers.Remove(modifier, EqualityComparer<AttributeModifier>.Default))
             {
                 return false;
             }
@@ -71,7 +75,9 @@ namespace Game.Core.Attributes
         /// <returns></returns>
         public double GetAttributeValue(EAttribute attribute)
         {
-            var node = _attributeNodeList[(int)attribute];
+            // Create the node lazily so the computed value can be cached, matching the
+            // pre-laziness behavior where every read populates the cache.
+            var node = GetOrCreateNode((int)attribute);
             if (node.CachedValue is not null)
             {
                 return node.CachedValue.Value;
@@ -97,18 +103,18 @@ namespace Game.Core.Attributes
         /// <returns></returns>
         public IEnumerable<AttributeModifier> AllModifiers()
         {
-            return _attributeNodeList.SelectNotNull(n => n.Modifiers).SelectMany(v => v);
+            return _attributeNodes.SelectNotNull(n => n?.Modifiers).SelectMany(v => v);
         }
 
         private void AddModifierWithoutCacheInvalidation(AttributeModifier modifier)
         {
-            var node = _attributeNodeList[(int)modifier.Attribute];
+            var node = GetOrCreateNode((int)modifier.Attribute);
 
             node.GetModifiersOrNew().Add(modifier);
 
             if (modifier.Source is EAttributeModifierSource.Derived)
             {
-                var sourceNode = _attributeNodeList[(int)modifier.DerivedSource];
+                var sourceNode = GetOrCreateNode((int)modifier.DerivedSource);
                 if (node.DerivedNodes.Contains(sourceNode))
                 {
                     throw new AttributeCircularDerivedModifierException(modifier);
@@ -133,7 +139,8 @@ namespace Game.Core.Attributes
                 }
             }
 
-            _attributeNodeList[(int)derivedSource].DerivedNodes.Remove(node);
+            // The source node exists because removing a Derived modifier implies it was hooked here.
+            GetOrCreateNode((int)derivedSource).DerivedNodes.Remove(node);
         }
 
         private void AddStaticModifiers()
@@ -144,12 +151,11 @@ namespace Game.Core.Attributes
             }
         }
 
-        private static List<AttributeCollectionNode> GetNodeList()
+        // Returns the node for the slot, creating its own instance on first access. Each slot
+        // gets a distinct node — they must never share one, since they hold per-attribute state.
+        private AttributeCollectionNode GetOrCreateNode(int index)
         {
-            // Enumerable.Repeat would share a single instance — each slot must be its own object.
-            return Enumerable.Range(0, _attributesMaxId + 1)
-                             .Select(_ => new AttributeCollectionNode())
-                             .ToList();
+            return _attributeNodes[index] ??= new AttributeCollectionNode();
         }
 
         private static int GetMaxAttribute()


### PR DESCRIPTION
Closes #652

## Approach

`AttributeCollection` previously allocated its full per-attribute node list eagerly on every construction via `Enumerable.Range(0, _attributesMaxId + 1).Select(_ => new AttributeCollectionNode()).ToList()` — the LINQ closure/iterator, a backing array, and one `AttributeCollectionNode` per attribute (17 today). Two collections are built per battle validation (player + enemy in `SimulateBattle`), which runs on **every** `EndBattleVictory`/`EndBattleLoss`/`AbandonBattle`, and most slots hold no modifiers, so the bulk of those freshly-`new`ed nodes were immediately wasted.

This change does **both** suggested directions at once:

- **Drops the LINQ allocation** by backing the collection with a sized `AttributeCollectionNode?[]` instead of a `Range().Select().ToList()`.
- **Creates nodes lazily** on first access via a `GetOrCreateNode(int)` helper (`_attributeNodes[index] ??= new AttributeCollectionNode()`), so a slot that is never read or written stays `null` and never allocates a node.

A `null` slot is semantically "no modifiers": read paths treat it as a value of `0` (`RemoveModifier` returns `false`, `AllModifiers` skips it). `GetAttributeValue` still creates-and-caches the node on read, exactly preserving the prior behavior where every read populated the value cache. Each slot keeps its own distinct node instance — the "each slot must be its own object" invariant the old `Enumerable.Repeat` comment guarded is preserved (no shared instance).

## No behavior change / parity preserved

This is a pure internal allocation optimization — no attribute value, cache-invalidation cascade, or modifier ordering changes. The frontend battle engine is a separate implementation, so a backend-only node-allocation change cannot affect frontend/backend battle parity, and the mirrored parity matrix (`BattleSimulatorParityTests`) still passes unchanged.

## Tests

Extended `Game.Core.Tests/Attributes/AttributeCollectionTests` with lazy-creation parity cases:
- empty-slot reads return `0` and don't leak into other slots,
- repeated reads of an untouched slot are stable,
- adding to an attribute already read while empty invalidates the cache,
- a derived modifier from an otherwise-untouched source still cascades (the lazily-created source node),
- separate collections never share node state.

Command (focused, pure unit suite — no Postgres/Redis):
`dotnet test Game.Core.Tests/Game.Core.Tests.csproj --nologo -- --filter-class "*AttributeCollectionTests"`

Result: 22 passed, 0 failed. The full `Game.Core.Tests.Attributes` (98) and `Game.Core.Tests.Battle` parity (107) namespaces also pass. Build is clean (0 warnings). The integration/performance suites were deliberately not run to avoid contending shared infra.

https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3)_