### PR TITLE
Memoise BattleAttributes projection and align to attributeName convention (#660)

### DIFF
--- a/UI/src/lib/battle/battle-attributes.ts
+++ b/UI/src/lib/battle/battle-attributes.ts
@@ -1,5 +1,6 @@
 import { IBattlerAttribute, EAttribute } from '$lib/api';
-import { attributeEnumName } from '$lib/common';
+import { attributeName } from '$lib/common';
+import { staticData } from '$stores';
 import {
 	STATIC_ATTRIBUTE_MODIFIERS,
 	EModifierType,
@@ -10,6 +11,12 @@ import {
 import { computeAttributes } from './attribute-collection';
 
 const attributesMaxId = Object.values(EAttribute)[Object.values(EAttribute).length - 1] as number;
+
+/** A single attribute's display name and value, as projected for tooltip/inventory surfaces. */
+export interface AttributeEntry {
+	name: string;
+	value: number;
+}
 
 /**
  * The frontend's battle attribute set, mirroring the backend `AttributeCollection`. It retains its
@@ -25,8 +32,14 @@ const attributesMaxId = Object.values(EAttribute)[Object.values(EAttribute).leng
  * - The modifier list and the `calcDerived` flag are **private (`#`) fields**, invisible to
  *   `statify`, so they stay non-reactive. That keeps `removeModifier`'s reference identity intact
  *   (a reactive array would deep-proxy its elements, so the stored modifier would no longer be
- *   `===` the reference the caller holds). Only {@link attributeValues} — what the UI reads — is
- *   reactive, reassigned on each recompute.
+ *   `===` the reference the caller holds). Only the reactive fields — what the UI reads — are
+ *   reassigned on each recompute.
+ *
+ * The named display projections ({@link getAttributeMap}/{@link getAttributeCount}) are memoised
+ * alongside the totals (they depend only on the values), so every `$derived` tooltip/inventory
+ * consumer reads a shared cached array instead of rebuilding its own per call site. Names resolve
+ * through the documented {@link attributeName} convention against the live `Attributes` reference
+ * set, the single source other display surfaces use.
  */
 export class BattleAttributes {
 	/** Every modifier composing this set, in the order the backend applies them. */
@@ -35,6 +48,10 @@ export class BattleAttributes {
 	#calcDerived = true;
 	/** The memoised per-attribute totals, recomputed only when the modifier set changes. */
 	private attributeValues: number[] = new Array<number>(attributesMaxId + 1).fill(0);
+	/** Memoised display projection of every attribute (including zeroes), recomputed alongside the totals. */
+	private attributeMap: AttributeEntry[] = [];
+	/** Memoised display projection of only the non-zero attributes. */
+	private nonZeroAttributeMap: AttributeEntry[] = [];
 
 	constructor(attList: IBattlerAttribute[] = [], calcDerivedStats: boolean = true) {
 		this.setData(attList, calcDerivedStats);
@@ -76,14 +93,16 @@ export class BattleAttributes {
 		return this.attributeValues[attId];
 	}
 
-	public getAttributeMap = (includeZeroes: boolean = false) => {
-		return this.attributeValues
-			.map((att, i) => ({ name: attributeEnumName(i), value: att }))
-			.filter((att) => att.value != 0 || includeZeroes);
-	};
+	/** The memoised named projection — by default only the non-zero attributes; `includeZeroes`
+	 *  returns every attribute. Both arrays are rebuilt only on recompute, so this is an O(1) read. */
+	public getAttributeMap = (includeZeroes: boolean = false): AttributeEntry[] =>
+		includeZeroes ? this.attributeMap : this.nonZeroAttributeMap;
 
-	/** Recomputes the per-attribute totals from the current modifiers. Called only when the
-	 *  modifier set changes; reads then return the memoised result without recomputing. */
+	/** The memoised count of non-zero attributes, for consumers that only need the size. */
+	public getAttributeCount = (): number => this.nonZeroAttributeMap.length;
+
+	/** Recomputes the per-attribute totals and their named projections from the current modifiers.
+	 *  Called only when the modifier set changes; reads then return the memoised results. */
 	private recompute() {
 		const values = new Array<number>(attributesMaxId + 1).fill(0);
 		if (this.#calcDerived) {
@@ -96,5 +115,7 @@ export class BattleAttributes {
 			}
 		}
 		this.attributeValues = values;
+		this.attributeMap = values.map((value, id) => ({ name: attributeName(id, staticData.attributes), value }));
+		this.nonZeroAttributeMap = this.attributeMap.filter((entry) => entry.value != 0);
 	}
 }

--- a/UI/src/routes/game/screens/challenges/SealedItemTooltip.svelte
+++ b/UI/src/routes/game/screens/challenges/SealedItemTooltip.svelte
@@ -48,7 +48,7 @@ const { item }: Props = $props();
 const accent = $derived(rarityColor(item.rarityId));
 const categoryName = $derived(itemCategoryName(item.itemCategoryId));
 // One masked row per non-zero stat bonus, so the *count* still reads true.
-const statCount = $derived(item.totalAttributes.getAttributeMap().length);
+const statCount = $derived(item.totalAttributes.getAttributeCount());
 
 const STAT_BAR_WIDTHS = [78, 60, 92, 70];
 </script>

--- a/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
+++ b/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
@@ -1,6 +1,6 @@
 import { EItemCategory } from '$lib/api';
 import { EEquipmentSlot, getEquipmentSlotForCategory, inventoryManager } from '$lib/engine';
-import { BattleAttributes, type Item, type ItemMod } from '$lib/battle';
+import { BattleAttributes, type AttributeEntry, type Item, type ItemMod } from '$lib/battle';
 import { staticData } from '$stores';
 
 /* ─── Static config ─────────────────────────────────────────────────────
@@ -42,10 +42,8 @@ export const SORTS: Record<SortKey, { label: string; cmp: (a: Item, b: Item) => 
 	category: { label: 'Category', cmp: (a, b) => a.itemCategoryId - b.itemCategoryId || a.name.localeCompare(b.name) }
 };
 
-export interface StatEntry {
-	name: string;
-	value: number;
-}
+/** The inventory's named-stat row, sharing the projection shape produced by `BattleAttributes`. */
+export type StatEntry = AttributeEntry;
 
 /* ─── Reactive view-model ────────────────────────────────────────────────
    Holds only the UI state for the inventory screen (sort/filter/selection).

--- a/UI/src/tests/lib/battle/battle-attributes.test.ts
+++ b/UI/src/tests/lib/battle/battle-attributes.test.ts
@@ -1,7 +1,19 @@
-import { describe, it, expect } from 'vitest';
-import { EAttribute } from '$lib/api';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EAttribute, type IAttribute } from '$lib/api';
 import { BattleAttributes } from '$lib/battle/battle-attributes';
 import { EModifierType, EAttributeModifierSource, type AttributeModifier } from '$lib/battle/attribute-modifier';
+
+// The projection resolves names through `attributeName(id, staticData.attributes)`, so mock the
+// store to drive that reference set. Empty by default → names fall back to the normalised enum.
+const { mockAttributes } = vi.hoisted(() => ({ mockAttributes: [] as IAttribute[] }));
+
+vi.mock('$stores', () => ({
+	staticData: {
+		get attributes() {
+			return mockAttributes;
+		}
+	}
+}));
 
 const makeAttrs = (...pairs: [EAttribute, number][]) => pairs.map(([attributeId, amount]) => ({ attributeId, amount }));
 
@@ -77,6 +89,11 @@ describe('BattleAttributes', () => {
 	});
 
 	describe('getAttributeMap', () => {
+		// Reset the reference set between tests so each controls its own name resolution.
+		beforeEach(() => {
+			mockAttributes.length = 0;
+		});
+
 		it('returns only non-zero attributes by default', () => {
 			const ba = new BattleAttributes(makeAttrs([EAttribute.Strength, 10]), false);
 			const map = ba.getAttributeMap();
@@ -91,6 +108,73 @@ describe('BattleAttributes', () => {
 
 			expect(map.length).toBeGreaterThan(0);
 			expect(map.some((a) => a.value === 0)).toBe(true);
+		});
+
+		it('matches the prior projection: full map mirrors every value, non-zero map filters it', () => {
+			const ba = new BattleAttributes(makeAttrs([EAttribute.Strength, 10], [EAttribute.Agility, 4]), false);
+			const full = ba.getAttributeMap(true);
+			const nonZero = ba.getAttributeMap();
+
+			// The full map carries one entry per attribute id, value-aligned with getValue.
+			full.forEach((entry, id) => {
+				expect(entry.value).toBe(ba.getValue(id));
+			});
+			expect(nonZero).toEqual(full.filter((e) => e.value !== 0));
+			expect(nonZero).toEqual([
+				{ name: 'Strength', value: 10 },
+				{ name: 'Agility', value: 4 }
+			]);
+		});
+
+		it('memoises each projection: repeated reads return the same array reference', () => {
+			const ba = new BattleAttributes(makeAttrs([EAttribute.Strength, 10]), false);
+
+			expect(ba.getAttributeMap()).toBe(ba.getAttributeMap());
+			expect(ba.getAttributeMap(true)).toBe(ba.getAttributeMap(true));
+		});
+
+		it('rebuilds the projection after a modifier change', () => {
+			const ba = new BattleAttributes(makeAttrs([EAttribute.Strength, 10]), false);
+			const before = ba.getAttributeMap();
+			expect(before).toEqual([{ name: 'Strength', value: 10 }]);
+
+			ba.addModifier(additive(EAttribute.Agility, 6));
+			const after = ba.getAttributeMap();
+
+			expect(after).not.toBe(before);
+			expect(after).toEqual([
+				{ name: 'Strength', value: 10 },
+				{ name: 'Agility', value: 6 }
+			]);
+		});
+
+		it('resolves names from the Attributes reference set when available', () => {
+			mockAttributes[EAttribute.Strength] = { id: EAttribute.Strength, name: 'Physical Power' } as IAttribute;
+			const ba = new BattleAttributes(makeAttrs([EAttribute.Strength, 10]), false);
+
+			expect(ba.getAttributeMap()).toEqual([{ name: 'Physical Power', value: 10 }]);
+		});
+
+		it('falls back to the normalised enum name when reference data is absent', () => {
+			const ba = new BattleAttributes(makeAttrs([EAttribute.Strength, 10]), false);
+
+			expect(ba.getAttributeMap()[0].name).toBe('Strength');
+		});
+	});
+
+	describe('getAttributeCount', () => {
+		it('returns the non-zero attribute count without building the full map', () => {
+			const ba = new BattleAttributes(makeAttrs([EAttribute.Strength, 10], [EAttribute.Agility, 4]), false);
+			expect(ba.getAttributeCount()).toBe(ba.getAttributeMap().length);
+			expect(ba.getAttributeCount()).toBe(2);
+		});
+
+		it('reflects a modifier change', () => {
+			const ba = new BattleAttributes([], false);
+			expect(ba.getAttributeCount()).toBe(0);
+
+			ba.addModifier(additive(EAttribute.Strength, 5));
+			expect(ba.getAttributeCount()).toBe(1);
 		});
 	});
 


### PR DESCRIPTION
Closes #660

## Summary

`BattleAttributes.getAttributeMap` previously walked the full attribute array, resolved a name per entry, allocated an object per attribute and filtered — on **every** call, with no memoisation — so each `$derived` tooltip/inventory consumer (`ItemTooltip`, `SealedItemTooltip`, `ItemDrawer`, `inventory-view`) rebuilt its own copy. This aligns it with the already-memoised `getValue` and the documented name-resolution convention.

- **Memoise the projection.** Two named projections — the full map (incl. zeroes) and the non-zero-only map — are recomputed alongside the existing per-attribute totals in `recompute()` (they depend only on the values). `getAttributeMap(includeZeroes)` now returns the relevant cached array as an O(1) read, so consumers share one cached projection instead of rebuilding per call site.
- **Cached count for the sealed tooltip.** New `getAttributeCount()` returns the cached non-zero count, so `SealedItemTooltip` no longer builds the whole map just to read `.length`.
- **One source for name resolution.** Names now resolve through the documented `attributeName(id, staticData.attributes)` convention (#297, #530) — the same path `battle-engine`, the attributes screen and the breakdown screen use — rather than the stringly `attributeEnumName`. `staticData` is imported the same way the sibling `item.ts`/`item-mod.ts` already do, so layering is unchanged.
- **DRY.** The shared `AttributeEntry` shape is exported and reused for the inventory `StatEntry` type.

## Parity / behaviour

Displayed names and values are **unchanged**: `attributeName` falls back to the same normalised enum name `attributeEnumName` produced when no reference data is present, and resolves the authored name once the `Attributes` reference set is loaded (as it always is before inventory/tooltip surfaces render). This is a read-path optimisation + naming alignment on inventory/tooltip surfaces, not a battle-outcome change.

## Tests

Extended `battle-attributes.test.ts` to prove: the memoised map matches the prior output for `includeZeroes` both ways; each projection is memoised (same reference across reads) and rebuilds after a modifier change/`recompute()`; `getAttributeCount` matches the non-zero length; and names resolve via the `attributeName` reference set with the enum-name fallback.

- `npx vitest --run` — 179 files / 1715 tests pass
- `npx vitest --run --coverage` — passes the `src/lib/battle/**` floors (functions 100, lines 99)
- `npm run lint` (eslint + svelte-check) — 0 errors / 0 warnings
- `npm run build` — succeeds

https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3)_