### PR TITLE
Deduplicate the battle-end resolve/simulate preamble (#650)

### DIFF
--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Game.Abstractions.DataAccess;
 using Game.Core.Attributes;
 using Game.Core.Battle;
@@ -123,18 +124,10 @@ namespace Game.Application.Services
 
         public async Task<DefeatResult?> EndBattleVictory(Player player, PlayerState state, DateTime claimedTimestamp)
         {
-            if (state.ActiveEnemyId is not int enemyId || state.Snapshot is null)
+            if (!TryResolveActiveBattle(state, out var enemy, out var result))
             {
                 return null;
             }
-
-            var level = state.ActiveEnemyLevel ?? 1;
-            var enemySkillIds = state.ActiveEnemySkillIds ?? [];
-
-            var enemy = _enemies.GetDomainEnemy(enemyId, level)
-                ?? throw new InvalidOperationException($"Enemy {enemyId} not found");
-
-            var result = SimulateBattle(enemy, enemySkillIds, state.Snapshot);
 
             if (!result.Victory)
             {
@@ -168,18 +161,10 @@ namespace Game.Application.Services
 
         public async Task<bool> EndBattleLoss(Player player, PlayerState state)
         {
-            if (state.ActiveEnemyId is not int enemyId || state.Snapshot is null)
+            if (!TryResolveActiveBattle(state, out var enemy, out var result))
             {
                 return false;
             }
-
-            var level = state.ActiveEnemyLevel ?? 1;
-            var enemySkillIds = state.ActiveEnemySkillIds ?? [];
-
-            var enemy = _enemies.GetDomainEnemy(enemyId, level)
-                ?? throw new InvalidOperationException($"Enemy {enemyId} not found");
-
-            var result = SimulateBattle(enemy, enemySkillIds, state.Snapshot);
 
             if (result.Victory)
             {
@@ -198,26 +183,15 @@ namespace Game.Application.Services
 
         private async Task AbandonBattle(Player player, PlayerState state)
         {
-            if (state.ActiveEnemyId is not int enemyId || state.Snapshot is null)
-            {
-                state.ClearBattle();
-                return;
-            }
-
-            var level = state.ActiveEnemyLevel ?? 1;
-            var enemySkillIds = state.ActiveEnemySkillIds ?? [];
-
-            var enemy = _enemies.GetDomainEnemy(enemyId, level)
-                ?? throw new InvalidOperationException($"Enemy {enemyId} not found");
-
             var elapsedMs = (int)(DateTime.UtcNow - state.BattleStartTime).TotalMilliseconds;
-            if (elapsedMs <= 0)
+
+            // No active battle (nothing to resolve) or no elapsed window to re-simulate against — clear
+            // and return without recording an outcome or persisting.
+            if (elapsedMs <= 0 || !TryResolveActiveBattle(state, out var enemy, out var result, elapsedMs))
             {
                 state.ClearBattle();
                 return;
             }
-
-            var result = SimulateBattle(enemy, enemySkillIds, state.Snapshot, elapsedMs);
 
             if (result.Victory)
             {
@@ -240,6 +214,14 @@ namespace Game.Application.Services
         // challenge rewards driven off BattleCompletedEvent). Shared by the explicit victory path and
         // the won-abandon path so the two cannot drift — a battle that resolved as a win always pays
         // out the same way, regardless of how the battle was ended.
+        //
+        // Anti-cheat note: the two callers gate this payout differently and that asymmetry is intentional.
+        // EndBattleVictory validates the *client-supplied* claimed timestamp (within 100ms of the simulated
+        // earliest defeat, and not in the future) before paying out. The won-abandon path performs no such
+        // timestamp check because it re-simulates capped at the *server-measured* elapsed wall-clock time
+        // (AbandonBattle's elapsedMs) — a win only resolves if the enemy died within time the server itself
+        // observed, so the server-measured cap is the (stronger) control there and a client timestamp adds
+        // nothing. Both paths therefore require a server-validated timeline; neither can be claimed early.
         private static DefeatRewards RecordVictory(Player player, CoreEnemy enemy, BattleResult result, PlayerState state)
         {
             var rewards = new DefeatRewards(player, enemy);
@@ -269,6 +251,33 @@ namespace Game.Application.Services
         // produce uint.MaxValue and does not cleanly truncate — and this seed must reproduce identically
         // under the frontend Mulberry32 port for battle-replay parity (#178). Shared by both start paths.
         internal static uint CreateBattleSeed(DateTime now) => unchecked((uint)now.Ticks);
+
+        // Shared anti-cheat preamble for the three battle-end paths: guards that a battle is active, resolves
+        // the snapshotted enemy, and replays the fight once. Returns false (with no outputs) when there is no
+        // active battle, so each caller keeps only its outcome-specific branching. Centralising the guard, the
+        // ?? 1 / ?? [] fallbacks, and the simulate call here keeps the replay surface from silently drifting.
+        private bool TryResolveActiveBattle(
+            PlayerState state,
+            [MaybeNullWhen(false)] out CoreEnemy enemy,
+            [MaybeNullWhen(false)] out BattleResult result,
+            int? maxMs = null)
+        {
+            if (state.ActiveEnemyId is not int enemyId || state.Snapshot is null)
+            {
+                enemy = default;
+                result = default;
+                return false;
+            }
+
+            var level = state.ActiveEnemyLevel ?? 1;
+            var enemySkillIds = state.ActiveEnemySkillIds ?? [];
+
+            enemy = _enemies.GetDomainEnemy(enemyId, level)
+                ?? throw new InvalidOperationException($"Enemy {enemyId} not found");
+
+            result = SimulateBattle(enemy, enemySkillIds, state.Snapshot, maxMs);
+            return true;
+        }
 
         private BattleResult SimulateBattle(CoreEnemy enemy, IReadOnlyList<int> enemySkillIds, BattleSnapshot snapshot, int? maxMs = null)
         {


### PR DESCRIPTION
Closes #650

## What

The three battle-end paths in `BattleService` (`EndBattleVictory`, `EndBattleLoss`, `AbandonBattle`) each hand-repeated the identical anti-cheat replay preamble: guard that a battle is active, resolve the snapshotted enemy (with the `?? 1` / `?? []` fallbacks), and re-simulate the fight. Three copies of that block on the replay surface — where victory/loss/abandon semantics must stay consistent — risk silent drift, exactly the duplicated-battle-logic hazard the guidelines warn about.

This extracts a single private helper:

```csharp
private bool TryResolveActiveBattle(
    PlayerState state,
    [MaybeNullWhen(false)] out CoreEnemy enemy,
    [MaybeNullWhen(false)] out BattleResult result,
    int? maxMs = null)
```

It performs the guard, enemy resolution, and simulation once, returning `false` (no outputs) when no battle is active. Each caller keeps only its outcome-specific branching (`result.Victory` handling, reward/loss recording, cooldown, `ClearBattle`, `SavePlayer`).

## Behavior preserved exactly

- Same fallbacks (`?? 1`, `?? []`) and the same `InvalidOperationException` on a missing enemy.
- Same guard/return semantics per caller (`null` / `false` / clear-and-return).
- Only `AbandonBattle` passes the `maxMs` elapsed-time cap; the other two simulate uncapped — unchanged.
- `SimulateBattle` is untouched, so battle resolution is byte-for-byte identical. No frontend parity impact (no battle-outcome change).
- `AbandonBattle` now computes `elapsedMs` before the guard and short-circuits on `elapsedMs <= 0 || !TryResolveActiveBattle(...)`; the no-active-battle and zero-elapsed cases both still clear-and-return without recording or persisting — observationally identical, and it avoids a throwaway enemy lookup when the window is empty.
- The `Try`-pattern uses `[MaybeNullWhen(false)]` out params, so there is no null-forgiving `!`.

## Anti-cheat asymmetry — documented, not changed

Per the issue's sub-finding, the two payout callers gate `RecordVictory` differently and that asymmetry is **intentional**, so it is now documented next to `RecordVictory` rather than changed:

- `EndBattleVictory` validates the **client-supplied** claimed timestamp (within 100ms of the simulated earliest defeat, and not in the future).
- The won-abandon path performs no timestamp check because it re-simulates capped at the **server-measured** elapsed wall-clock time. A win only resolves if the enemy died within time the server itself observed, so the server cap is the stronger control there and a client timestamp adds nothing.

No anti-cheat behavior was altered.

## Tests

The existing `BattleServiceIntegrationTests` already cover all three paths (victory, loss, abandon-win, abandon-incomplete, and the no-active-battle guard returns), plus boss battles and zone locking. They pass unchanged, proving behavior is preserved.

```
dotnet test Game.Application.Tests/Game.Application.Tests.csproj -- --filter-class "*BattleService*"
Passed! - Failed: 0, Passed: 21, Skipped: 0, Total: 21
```

Build is clean (0 warnings, 0 errors).

https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjMmRyXEnd8GKCoJFVr9z3)_