### PR TITLE
Redesign combat effect chips as skill-style icon tiles with a radial cooldown overlay

### DIFF
--- a/UI/src/components/CooldownOverlay.svelte
+++ b/UI/src/components/CooldownOverlay.svelte
@@ -1,0 +1,25 @@
+<!-- A radial (conic-gradient) cooldown/duration overlay for a square tile: a dark wedge covering the
+     tile from `sweep` degrees onward, leaving the rest transparent so the tile's icon shows through.
+     Shared by the skill slots (sweep grows as the skill charges toward ready) and the combat effect
+     chips (sweep = remaining-duration fraction, so the wedge grows as the effect expires and clears
+     when it is re-applied). Purely presentational; the consumer computes `sweep` and positions this
+     inside a `position: relative` tile. -->
+<div class="cooldown-overlay" style:--sweep="{sweep}deg" aria-hidden="true"></div>
+
+<script lang="ts">
+interface Props {
+	/** The transparent (revealed) arc in degrees, 0–360. The dark wedge covers the remainder. */
+	sweep: number;
+}
+
+const { sweep }: Props = $props();
+</script>
+
+<style lang="scss">
+.cooldown-overlay {
+	position: absolute;
+	inset: 0;
+	background: conic-gradient(transparent var(--sweep), color-mix(in srgb, var(--black) 65%, transparent) var(--sweep));
+	pointer-events: none;
+}
+</style>

--- a/UI/src/routes/game/screens/fight/ActiveEffectChips.svelte
+++ b/UI/src/routes/game/screens/fight/ActiveEffectChips.svelte
@@ -120,7 +120,6 @@ const hideChipTooltip = () => {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 6px;
-	margin-bottom: 12px;
 
 	&.reversed {
 		justify-content: flex-end;

--- a/UI/src/routes/game/screens/fight/ActiveEffectChips.svelte
+++ b/UI/src/routes/game/screens/fight/ActiveEffectChips.svelte
@@ -1,37 +1,42 @@
-<!-- The row of active-effect chips on a battler card: one chip per timed effect currently modifying the
-     battler, tinted by buff/debuff direction, with a render-interpolated countdown bar that depletes
-     smoothly between ticks and visibly refills when the effect is refreshed (re-applied). Reads the
-     battler's reactive `activeEffects` projection, so chips appear/expire as effects come and go. -->
+<!-- The row of active-effect chips on a battler card: one skill-style icon tile per timed effect
+     currently modifying the battler. Each tile shows the attribute's icon with a radial (conic)
+     cooldown overlay that depletes as the effect's remaining duration ticks down and refills when the
+     effect is refreshed (re-applied), a small magnitude badge, and a buff/debuff direction tint. Reads
+     the battler's reactive `activeEffects` projection, so tiles appear/expire as effects come and go. -->
 {#if battler.activeEffects.length > 0}
 	<div class="effect-chips" class:reversed data-testid="effect-chips">
 		{#each battler.activeEffects as effect (effect.sourceId)}
-			{@const color = effectDirectionColor(
-				effectDirection(attributeIsHarmful(effect.attribute, staticData.attributes), effect.modifierType, effect.amount)
+			{@const direction = effectDirection(
+				attributeIsHarmful(effect.attribute, staticData.attributes),
+				effect.modifierType,
+				effect.amount
 			)}
-			<!-- svelte-ignore a11y_no_static_element_interactions -->
-			<div
+			{@const magnitude = formatEffectMagnitude(effect.modifierType, effect.amount)}
+			<!-- A focusable button (mirroring the skill slots) so the attribute tooltip is reachable by
+			     keyboard and screen reader, not just on hover. Its accessible name describes the effect. -->
+			<button
+				type="button"
 				class="effect-chip"
-				style:--chip-accent={color}
+				style:--chip-accent={effectDirectionColor(direction)}
+				aria-label="{attributeName(effect.attribute, staticData.attributes)} {direction}, {magnitude}"
 				onmouseenter={(ev) => showChipTooltip(effect, ev)}
 				onmousemove={(ev) => tip.controller.move(ev)}
 				onmouseleave={hideChipTooltip}
+				onfocus={(ev) => showChipTooltip(effect, ev.currentTarget)}
+				onblur={hideChipTooltip}
 			>
-				<AttributeIcon id={effect.attribute} size={13} />
-				<span class="chip-mag">{formatEffectMagnitude(effect.modifierType, effect.amount)}</span>
-				<span class="chip-attr">{attributeName(effect.attribute, staticData.attributes)}</span>
-				<span class="chip-time">{remainingSeconds(effect)}s</span>
-				<div class="chip-track">
-					<div class="chip-fill" style:width="{remainingPercent(effect)}%"></div>
-				</div>
-			</div>
+				<AttributeIcon id={effect.attribute} size={26} />
+				<CooldownOverlay sweep={remainingSweep(effect)} />
+				<span class="chip-mag">{magnitude}</span>
+			</button>
 		{/each}
 	</div>
 {/if}
 
-<!-- One tooltip instance per chip row, anchored to whichever chip is hovered. Always mounted (it
-     stays hidden until a chip is hovered) so its registration survives chips coming and going. The
-     effect context is the live `ActiveEffectView` (resolved by source id), so the tooltip's countdown
-     pill keeps depleting and the panel closes itself if the hovered effect expires under the cursor. -->
+<!-- One tooltip instance per chip row, anchored to whichever chip is hovered/focused. Always mounted
+     (it stays hidden until a chip is triggered) so its registration survives chips coming and going.
+     The effect context is the live `ActiveEffectView` (resolved by source id), so the tooltip's
+     countdown pill keeps depleting and the panel closes itself if the hovered effect expires. -->
 <AttributeTooltip bind:this={tooltip} attributeId={tip.attributeId} effect={shownEffectContext} />
 
 <script lang="ts">
@@ -43,7 +48,9 @@ import {
 	formatEffectMagnitude
 } from '$lib/common';
 import { staticData, type TooltipComponent } from '$stores';
+import { type TooltipAnchor } from '$stores/tooltip.svelte';
 import AttributeIcon from '$components/AttributeIcon.svelte';
+import CooldownOverlay from '$components/CooldownOverlay.svelte';
 import AttributeTooltip from '$components/tooltip/AttributeTooltip.svelte';
 import { createAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
 import type { ActiveEffectView, Battler } from '$lib/battle';
@@ -92,12 +99,15 @@ $effect(() => {
 	}
 });
 
-const remainingSeconds = (effect: ActiveEffectView) => (effect.renderRemainingMs / 1000).toFixed(2);
-const remainingPercent = (effect: ActiveEffectView) =>
-	effect.durationMs > 0 ? Math.max(0, Math.min(100, (effect.renderRemainingMs / effect.durationMs) * 100)) : 0;
-const showChipTooltip = (effect: ActiveEffectView, ev: MouseEvent) => {
+// The transparent (revealed) arc of the radial overlay: the render-interpolated remaining fraction of
+// the effect's duration, in degrees. Depletes toward 0 as the effect expires; resets to 360 (the icon
+// fully revealed) when the effect is refreshed, since refresh restores `renderRemainingMs`.
+const remainingSweep = (effect: ActiveEffectView) =>
+	effect.durationMs > 0 ? Math.max(0, Math.min(360, (effect.renderRemainingMs / effect.durationMs) * 360)) : 0;
+
+const showChipTooltip = (effect: ActiveEffectView, anchor: TooltipAnchor) => {
 	shownSourceId = effect.sourceId;
-	tip.controller.show(effect.attribute, ev);
+	tip.controller.show(effect.attribute, anchor);
 };
 const hideChipTooltip = () => {
 	shownSourceId = undefined;
@@ -118,51 +128,49 @@ const hideChipTooltip = () => {
 }
 
 .effect-chip {
+	// Reset native button chrome (the chip is a <button> so its tooltip is keyboard-reachable),
+	// then lay out as a square icon tile mirroring the skill slots.
+	appearance: none;
+	margin: 0;
+	padding: 0;
+	font: inherit;
+	color: inherit;
 	position: relative;
+	width: 38px;
+	height: 38px;
 	display: flex;
-	align-items: baseline;
-	gap: 5px;
-	padding: 3px 7px 5px;
+	align-items: center;
+	justify-content: center;
 	border: 1px solid color-mix(in srgb, var(--chip-accent) 45%, transparent);
 	border-radius: 2px;
 	background: color-mix(in srgb, var(--chip-accent) 10%, transparent);
 	overflow: hidden;
+	cursor: default;
+	transition: border-color 140ms;
+
+	&:focus-visible {
+		outline: 2px solid var(--chip-accent);
+		outline-offset: 2px;
+	}
 
 	:global(.attr-icon) {
-		align-self: center;
+		opacity: 0.92;
 	}
 }
 
+// Sits last in the DOM (above the overlay) so the magnitude stays legible as the wedge sweeps in.
 .chip-mag {
-	font-family: var(--mono);
-	font-size: 10px;
-	font-weight: 600;
-	color: var(--chip-accent);
-}
-
-.chip-attr {
-	font-size: 10px;
-	color: var(--text-secondary);
-	white-space: nowrap;
-}
-
-.chip-time {
-	font-family: var(--mono);
-	font-size: 8.5px;
-	color: var(--text-muted);
-}
-
-.chip-track {
 	position: absolute;
 	left: 0;
 	right: 0;
 	bottom: 0;
-	height: 2px;
-	background: color-mix(in srgb, var(--white) 8%, transparent);
-}
-
-.chip-fill {
-	height: 100%;
-	background: var(--chip-accent);
+	padding: 1px 0;
+	font-family: var(--mono);
+	font-size: 9px;
+	font-weight: 600;
+	line-height: 1;
+	text-align: center;
+	color: var(--chip-accent);
+	background: color-mix(in srgb, var(--black) 55%, transparent);
 }
 </style>

--- a/UI/src/routes/game/screens/fight/BattlerCard.svelte
+++ b/UI/src/routes/game/screens/fight/BattlerCard.svelte
@@ -13,11 +13,14 @@
 		<HpBar currentHealth={battler.currentHealth} {maxHealth} ariaLabel="{battler.name} health" />
 	</div>
 
-	<!-- Active timed effects -->
-	<ActiveEffectChips {battler} reversed={side === 'enemy'} />
-
 	<!-- Skills -->
 	<Skills {battler} {side} />
+
+	<!-- Active timed effects float below the card (absolutely positioned) so effects coming and
+	     going never change the card's height — which would shift the vertically-centred combatants row. -->
+	<div class="effect-chips-slot">
+		<ActiveEffectChips {battler} reversed={side === 'enemy'} />
+	</div>
 </div>
 
 <script lang="ts">
@@ -41,6 +44,7 @@ const maxHealth = $derived(battler.attributes.getValue(EAttribute.MaxHealth));
 
 <style lang="scss">
 .battler-card {
+	position: relative;
 	background: color-mix(in srgb, var(--white) 3%, transparent);
 	border: 1px solid var(--border-light);
 	border-radius: 3px;
@@ -106,5 +110,15 @@ const maxHealth = $derived(battler.attributes.getValue(EAttribute.MaxHealth));
 
 .hp-bar-slot {
 	margin-bottom: 14px;
+}
+
+// Anchored to the card's bottom edge and inset to the content padding, so the effect tiles line up
+// under the skill row without occupying card height.
+.effect-chips-slot {
+	position: absolute;
+	top: 100%;
+	left: 20px;
+	right: 20px;
+	padding-top: 12px;
 }
 </style>

--- a/UI/src/routes/game/screens/fight/Skills.svelte
+++ b/UI/src/routes/game/screens/fight/Skills.svelte
@@ -11,7 +11,6 @@
 					type="button"
 					class="skill-slot"
 					class:ready={charge.ready}
-					style:--skill-sweep="{charge.sweep}deg"
 					style:--pulse-color={pulseColor}
 					onmousemove={handleMouseMove}
 					onmouseenter={(ev) => handleEnter(ev, index)}
@@ -20,7 +19,7 @@
 					onblur={() => handleLeave(index)}
 				>
 					<img class="skill-icon" src={skill.iconPath} alt={skill.name} />
-					<div class="cooldown-overlay"></div>
+					<CooldownOverlay sweep={charge.sweep} />
 					{#if charge.ready}
 						<div class="ready-glow"></div>
 					{/if}
@@ -47,6 +46,7 @@ import {
 	type TooltipComponent
 } from '$stores/tooltip.svelte';
 import SkillEffectBadge from '$components/SkillEffectBadge.svelte';
+import CooldownOverlay from '$components/CooldownOverlay.svelte';
 import SkillTooltip from './SkillTooltip.svelte';
 
 type Props = {
@@ -162,16 +162,6 @@ const chargeState = (skill: Skill) => {
 	width: 100%;
 	height: 100%;
 	opacity: 0.92;
-}
-
-.cooldown-overlay {
-	position: absolute;
-	inset: 0;
-	background: conic-gradient(
-		transparent var(--skill-sweep),
-		color-mix(in srgb, var(--black) 65%, transparent) var(--skill-sweep)
-	);
-	pointer-events: none;
 }
 
 .ready-glow {

--- a/UI/src/routes/game/screens/fight/boss/BossBattlerCard.svelte
+++ b/UI/src/routes/game/screens/fight/boss/BossBattlerCard.svelte
@@ -14,10 +14,14 @@
 
 	<BossHpBar currentHealth={battler.currentHealth} {maxHealth} />
 
-	<ActiveEffectChips {battler} reversed />
-
 	<div class="skills">
 		<Skills {battler} side="enemy" accent="var(--boss-accent)" />
+	</div>
+
+	<!-- Active timed effects float below the card (absolutely positioned) so effects coming and
+	     going never change the card's height — which would shift the vertically-centred combatants row. -->
+	<div class="effect-chips-slot">
+		<ActiveEffectChips {battler} reversed />
 	</div>
 </div>
 
@@ -91,5 +95,15 @@ const maxHealth = $derived(battler.attributes.getValue(EAttribute.MaxHealth));
 
 .skills {
 	margin-top: 16px;
+}
+
+// Anchored to the card's bottom edge and inset to the content padding, so the effect tiles line up
+// under the skill row without occupying card height.
+.effect-chips-slot {
+	position: absolute;
+	top: 100%;
+	left: 20px;
+	right: 20px;
+	padding-top: 12px;
 }
 </style>

--- a/UI/src/tests/routes/game/screens/fight/ActiveEffectChips.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/ActiveEffectChips.test.ts
@@ -52,7 +52,7 @@ describe('ActiveEffectChips', () => {
 		expect(queryByTestId('effect-chips')).toBeNull();
 	});
 
-	it('renders one chip per active effect, tinted by buff/debuff direction', () => {
+	it('renders one icon tile per active effect, tinted by buff/debuff direction', () => {
 		battler.applyEffect(effect({ id: 1, attributeId: EAttribute.Strength, amount: 5 }));
 		battler.applyEffect(
 			effect({ id: 2, target: ESkillEffectTarget.Opponent, attributeId: EAttribute.Defense, amount: -5 })
@@ -63,29 +63,29 @@ describe('ActiveEffectChips', () => {
 		expect(chips).toHaveLength(2);
 		// A raised Strength is a buff; a lowered Defense is a debuff.
 		expect((chips[0] as HTMLElement).style.getPropertyValue('--chip-accent')).toBe('var(--effect-buff)');
-		expect(chips[0].textContent).toContain('+5');
-		expect(chips[0].textContent).toContain('Strength');
+		expect(chips[0].querySelector('.chip-mag')?.textContent).toContain('+5');
 		expect((chips[1] as HTMLElement).style.getPropertyValue('--chip-accent')).toBe('var(--effect-debuff)');
-		expect(chips[1].textContent).toContain('-5');
-		expect(chips[1].textContent).toContain('Defense');
+		expect(chips[1].querySelector('.chip-mag')?.textContent).toContain('-5');
+		// The attribute name moves to the tooltip/accessible name rather than crowding the tile.
+		expect(chips[0].getAttribute('aria-label')).toContain('Strength');
+		expect(chips[1].getAttribute('aria-label')).toContain('Defense');
 	});
 
-	it('sizes the countdown fill from the render-interpolated remaining duration', () => {
+	it('sweeps the radial overlay from the render-interpolated remaining duration', () => {
 		battler.applyEffect(effect({ id: 1, durationMs: 1000 }));
-		battler.activeEffects[0].renderRemainingMs = 500; // half elapsed
+		battler.activeEffects[0].renderRemainingMs = 500; // half remaining
 		const { container } = render(ActiveEffectChips, { props: { battler } });
 
-		const fill = container.querySelector('.chip-fill') as HTMLElement;
-		expect(fill.style.width).toBe('50%');
-		expect((container.querySelector('.chip-time') as HTMLElement).textContent).toContain('0.50s');
+		// Half remaining -> the revealed arc is 180 of 360 degrees.
+		expect(container.querySelector('.cooldown-overlay')?.getAttribute('style')).toContain('180deg');
 	});
 
-	it('formats integer seconds with two decimal places to prevent width jitter', () => {
+	it('fully reveals the icon (360deg sweep) for a freshly applied effect', () => {
 		battler.applyEffect(effect({ id: 1, durationMs: 2000 }));
-		battler.activeEffects[0].renderRemainingMs = 2000;
+		battler.activeEffects[0].renderRemainingMs = 2000; // just applied / refreshed
 		const { container } = render(ActiveEffectChips, { props: { battler } });
 
-		expect((container.querySelector('.chip-time') as HTMLElement).textContent).toContain('2.00s');
+		expect(container.querySelector('.cooldown-overlay')?.getAttribute('style')).toContain('360deg');
 	});
 
 	it('right-aligns the row when reversed (enemy/boss layout)', () => {
@@ -118,6 +118,22 @@ describe('ActiveEffectChips', () => {
 		expect(container.querySelector('.tt-title-name')).not.toBeNull();
 
 		await fireEvent.mouseLeave(container.querySelector('.effect-chip') as HTMLElement);
+		expect(container.querySelector('.tt-title-name')).toBeNull();
+	});
+
+	it('makes each chip a focusable button that opens the tooltip on focus and hides it on blur', async () => {
+		battler.applyEffect(effect({ id: 1, attributeId: EAttribute.Strength, amount: 5, durationMs: 1000 }));
+		const { container } = render(ActiveEffectChips, { props: { battler } });
+
+		const chip = container.querySelector('.effect-chip') as HTMLElement;
+		// A real <button> so the tooltip is keyboard/screen-reader reachable, mirroring the skill slots.
+		expect(chip.tagName).toBe('BUTTON');
+		expect(container.querySelector('.tt-title-name')).toBeNull();
+
+		await fireEvent.focus(chip);
+		expect((container.querySelector('.tt-title-name') as HTMLElement).textContent).toBe('Strength');
+
+		await fireEvent.blur(chip);
 		expect(container.querySelector('.tt-title-name')).toBeNull();
 	});
 

--- a/UI/src/tests/routes/game/screens/fight/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/Skills.test.ts
@@ -63,7 +63,7 @@ describe('Skills', () => {
 		expect(slots[0].classList.contains('ready')).toBe(true);
 		expect(slots[1].classList.contains('ready')).toBe(false);
 		// The cooldown sweep tracks the charge percentage (50% -> 180 of 360 degrees).
-		expect((slots[1] as HTMLElement).getAttribute('style')).toContain('180deg');
+		expect(slots[1].querySelector('.cooldown-overlay')?.getAttribute('style')).toContain('180deg');
 	});
 
 	it('shows the effect badge only on skills that carry effects', () => {


### PR DESCRIPTION
## Summary

Redesigns the combat **active-effect chips** (`ActiveEffectChips.svelte`) to read like the skill slots: a square **icon tile** with a **radial (conic-gradient) cooldown overlay** that depletes as the effect's remaining duration ticks down, instead of the old text chip (magnitude + name + linear countdown bar). Closes #677.

The dependencies this issue called out are both already merged — `AttributeIcon` (#531) and `AttributeTooltip` (#532) were already wired into this file — so this PR depends on #532's tooltip and applies it to the redesigned tile rather than rebuilding it.

## What changed

- **Extracted a shared `CooldownOverlay` component** (`$components/CooldownOverlay.svelte`) — the conic-gradient overlay + dark-tint token + sweep var — and adopted it in **both** `Skills.svelte` and the redesigned chips, so the cooldown formula has a single source of truth.
  - On the *tile* itself: the skill slot (ready glow, label, empty placeholder) and the effect chip (accent tint, magnitude badge) diverge too much to share without a leaky, prop-heavy abstraction, so only the overlay is shared. The issue invited extraction "if it factors out cleanly" — the overlay does; the full tile does not.
- **Each effect now renders as a focusable `<button>` icon tile**: `AttributeIcon` + `CooldownOverlay` (`sweep = remaining fraction × 360`) + a small magnitude badge, tinted by buff/debuff direction (`--chip-accent`).
  - **Refresh behavior preserved**: re-applying an effect restores `renderRemainingMs`, so the sweep returns to 360° (icon fully revealed) and depletes again — same as the old chip's refill.
  - **Remaining** is surfaced via the radial overlay (visually) and the tooltip's depleting countdown pill (numeric); **magnitude** via the on-tile badge and the tooltip.
- **Accessibility**: the chip is a real `<button>` with a descriptive `aria-label` (e.g. `Strength buff, +5`) and opens the `AttributeTooltip` on hover **and** keyboard focus / blur, mirroring the skill slots.

## How it addresses the issue

- ✅ Icon tile + radial conic cooldown overlay reusing the skill-slot pattern (overlay extracted to a shared component).
- ✅ Sweep driven by `renderRemainingMs / durationMs`; refill on refresh preserved.
- ✅ Buff/debuff direction tint preserved; magnitude + remaining surfaced (badge + radial + tooltip).
- ✅ `AttributeTooltip` (from #532) reused, replacing the native `title=` — coordinated by depending on #532, not rebuilding the tooltip.
- ✅ Focusable `<button>` for keyboard/screen-reader reachability.

## Test plan

- [x] `ActiveEffectChips.test.ts` updated for the new structure: one icon tile per effect, buff/debuff accent, magnitude badge, sweep from remaining duration (50% → 180°), full reveal (360°) on fresh/refreshed effect, focusable-button tooltip open-on-focus / hide-on-blur, plus the retained hover and expire-under-cursor cases.
- [x] `Skills.test.ts` sweep assertion retargeted to the extracted overlay element (no behavior change).
- [x] `npm run lint` (eslint + svelte-check) clean.
- [x] `npm run test:unit:ci` — 1750 tests passing.

Closes #677.

https://claude.ai/code/session_0121GUMpPft1BtLuDzqVjzyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0121GUMpPft1BtLuDzqVjzyQ)_