### PR TITLE
Add test coverage for health-review gaps (#588)

### DIFF
--- a/Game.Api.Tests/Unit/ClientHintsTests.cs
+++ b/Game.Api.Tests/Unit/ClientHintsTests.cs
@@ -1,0 +1,85 @@
+using Game.Api.Http;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Game.Api.Tests.Unit
+{
+    /// <summary>
+    /// Covers the branching header parsing in <see cref="ClientHints"/> — the empty→null normalization of
+    /// the optional client-hint headers and the device-fingerprint header read — which previously had no
+    /// direct coverage.
+    /// </summary>
+    public class ClientHintsTests
+    {
+        [Fact]
+        public void FromHeaders_ReadsUserAgentAndClientHints()
+        {
+            var headers = new HeaderDictionary
+            {
+                ["User-Agent"] = "Mozilla/5.0",
+                ["Sec-CH-UA"] = "\"Chromium\";v=\"120\"",
+                ["Sec-CH-UA-Mobile"] = "?0",
+                ["Sec-CH-UA-Platform"] = "\"Windows\"",
+            };
+
+            var hints = ClientHints.FromHeaders(headers);
+
+            Assert.Equal("Mozilla/5.0", hints.UserAgent);
+            Assert.Equal("\"Chromium\";v=\"120\"", hints.SecChUa);
+            Assert.Equal("?0", hints.SecChUaMobile);
+            Assert.Equal("\"Windows\"", hints.SecChUaPlatform);
+        }
+
+        [Fact]
+        public void FromHeaders_MissingClientHints_AreNull()
+        {
+            var hints = ClientHints.FromHeaders(new HeaderDictionary { ["User-Agent"] = "UA" });
+
+            Assert.Equal("UA", hints.UserAgent);
+            Assert.Null(hints.SecChUa);
+            Assert.Null(hints.SecChUaMobile);
+            Assert.Null(hints.SecChUaPlatform);
+        }
+
+        [Fact]
+        public void FromHeaders_EmptyClientHintValues_NormalizeToNull()
+        {
+            var headers = new HeaderDictionary
+            {
+                ["Sec-CH-UA"] = "",
+                ["Sec-CH-UA-Mobile"] = "",
+                ["Sec-CH-UA-Platform"] = "",
+            };
+
+            var hints = ClientHints.FromHeaders(headers);
+
+            // The user-agent is reported verbatim (an absent header yields an empty string), while the
+            // optional hints are normalized to null.
+            Assert.Equal(string.Empty, hints.UserAgent);
+            Assert.Null(hints.SecChUa);
+            Assert.Null(hints.SecChUaMobile);
+            Assert.Null(hints.SecChUaPlatform);
+        }
+
+        [Fact]
+        public void DeviceFingerprint_ReturnsHeaderValue_WhenPresent()
+        {
+            var headers = new HeaderDictionary
+            {
+                [ClientHints.DeviceFingerprintHeader] = "fp-abc123",
+            };
+
+            Assert.Equal("fp-abc123", ClientHints.DeviceFingerprint(headers));
+        }
+
+        [Fact]
+        public void DeviceFingerprint_IsNull_WhenHeaderMissingOrEmpty()
+        {
+            Assert.Null(ClientHints.DeviceFingerprint(new HeaderDictionary()));
+            Assert.Null(ClientHints.DeviceFingerprint(new HeaderDictionary
+            {
+                [ClientHints.DeviceFingerprintHeader] = "",
+            }));
+        }
+    }
+}

--- a/Game.Api.Tests/Unit/ErrorStatusFilterTests.cs
+++ b/Game.Api.Tests/Unit/ErrorStatusFilterTests.cs
@@ -1,0 +1,81 @@
+using Game.Api.Filters;
+using Game.Api.Models.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+
+namespace Game.Api.Tests.Unit
+{
+    /// <summary>
+    /// Covers the 200→400 rewrite the whole error contract depends on: a success-status response
+    /// carrying an <see cref="IApiResponse"/> error is rewritten to 400, while every other shape
+    /// (no error, non-response value, non-object result, already-non-200 status) is left untouched.
+    /// </summary>
+    public class ErrorStatusFilterTests
+    {
+        // Runs the filter over the given result at the given starting status and returns the resulting code.
+        private static int RunFilter(IActionResult result, int startingStatusCode = StatusCodes.Status200OK)
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.StatusCode = startingStatusCode;
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+            var context = new ResultExecutingContext(actionContext, [], result, controller: new object());
+
+            new ErrorStatusFilter().OnResultExecuting(context);
+
+            return httpContext.Response.StatusCode;
+        }
+
+        [Fact]
+        public void RewritesTo400_WhenResponseCarriesAnError()
+        {
+            var result = new ObjectResult(ApiResponse.Error("Something went wrong."));
+
+            Assert.Equal(StatusCodes.Status400BadRequest, RunFilter(result));
+        }
+
+        [Fact]
+        public void LeavesStatus_WhenResponseHasNoError()
+        {
+            var result = new ObjectResult(ApiResponse.Success());
+
+            Assert.Equal(StatusCodes.Status200OK, RunFilter(result));
+        }
+
+        [Fact]
+        public void LeavesStatus_WhenResponseErrorIsEmptyString()
+        {
+            var result = new ObjectResult(new ApiResponse { ErrorMessage = "" });
+
+            Assert.Equal(StatusCodes.Status200OK, RunFilter(result));
+        }
+
+        [Fact]
+        public void LeavesStatus_WhenObjectResultValueIsNotAnApiResponse()
+        {
+            var result = new ObjectResult("just a string");
+
+            Assert.Equal(StatusCodes.Status200OK, RunFilter(result));
+        }
+
+        [Fact]
+        public void LeavesStatus_WhenResultIsNotAnObjectResult()
+        {
+            // EmptyResult is not an ObjectResult, so HasError can never inspect a value.
+            Assert.Equal(StatusCodes.Status200OK, RunFilter(new EmptyResult()));
+        }
+
+        [Fact]
+        public void DoesNotRewrite_WhenStartingStatusIsNot200()
+        {
+            // The rewrite is gated on a 200 status; an error response already returned with a non-200
+            // status (e.g. a controller that set 201) is left exactly as-is.
+            var result = new ObjectResult(ApiResponse.Error("boom"));
+
+            Assert.Equal(StatusCodes.Status201Created, RunFilter(result, StatusCodes.Status201Created));
+        }
+    }
+}

--- a/Game.Api.Tests/Unit/JwtTokenServiceTests.cs
+++ b/Game.Api.Tests/Unit/JwtTokenServiceTests.cs
@@ -1,0 +1,108 @@
+using Game.Abstractions.Auth;
+using Game.Api.Auth;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using System.Security.Claims;
+using System.Text;
+using Xunit;
+
+namespace Game.Api.Tests.Unit
+{
+    /// <summary>
+    /// Security-critical coverage for the JWT access-token issuance. Asserts that a token issued by
+    /// <see cref="JwtTokenService"/> validates against the same <see cref="TokenValidationParameters"/>
+    /// the bearer handler is configured with in <c>Startup.ConfigureAuth</c>, and that the claims,
+    /// signing algorithm and lifetime match the documented contract.
+    /// </summary>
+    public class JwtTokenServiceTests
+    {
+        // 32+ bytes so the HMAC-SHA256 signing key is large enough.
+        private const string SigningKey = "this-is-a-sufficiently-long-test-signing-key-0123456789";
+        private const string Issuer = "test-issuer";
+        private const string Audience = "test-audience";
+
+        private static JwtTokenService CreateService() => new(Options.Create(new JwtOptions
+        {
+            SigningKey = SigningKey,
+            Issuer = Issuer,
+            Audience = Audience,
+        }));
+
+        // Mirrors the parameters the bearer handler is configured with in Startup.ConfigureAuth so the
+        // test pins that issuance and validation agree.
+        private static TokenValidationParameters ValidationParameters() => new()
+        {
+            ValidateIssuer = true,
+            ValidIssuer = Issuer,
+            ValidateAudience = true,
+            ValidAudience = Audience,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(SigningKey)),
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.FromSeconds(30),
+            NameClaimType = JwtRegisteredClaimNames.Sub,
+            RoleClaimType = JwtTokenService.RoleClaimType,
+        };
+
+        [Fact]
+        public async Task CreateAccessToken_IssuesTokenThatValidatesAgainstStartupParameters()
+        {
+            var token = CreateService().CreateAccessToken(42, ["Admin"]);
+
+            var result = await new JsonWebTokenHandler().ValidateTokenAsync(token, ValidationParameters());
+
+            Assert.True(result.IsValid, result.Exception?.Message);
+        }
+
+        [Fact]
+        public async Task CreateAccessToken_SubClaimIsUserId_AndIsHmacSha256Signed()
+        {
+            var token = CreateService().CreateAccessToken(123, []);
+
+            var result = await new JsonWebTokenHandler().ValidateTokenAsync(token, ValidationParameters());
+            var jwt = Assert.IsType<JsonWebToken>(result.SecurityToken);
+
+            Assert.Equal("123", jwt.GetClaim(JwtRegisteredClaimNames.Sub).Value);
+            Assert.Equal(SecurityAlgorithms.HmacSha256, jwt.Alg);
+            Assert.Equal(Issuer, jwt.Issuer);
+            // A unique token id is stamped per issuance.
+            Assert.False(string.IsNullOrEmpty(jwt.GetClaim(JwtRegisteredClaimNames.Jti).Value));
+        }
+
+        [Fact]
+        public async Task CreateAccessToken_MapsEveryRoleOntoTheRoleClaimType()
+        {
+            var token = CreateService().CreateAccessToken(7, ["Admin", "Moderator"]);
+
+            var result = await new JsonWebTokenHandler().ValidateTokenAsync(token, ValidationParameters());
+            var principal = new ClaimsPrincipal(result.ClaimsIdentity);
+
+            Assert.True(principal.IsInRole("Admin"));
+            Assert.True(principal.IsInRole("Moderator"));
+            var roleValues = principal.FindAll(JwtTokenService.RoleClaimType).Select(c => c.Value).ToList();
+            Assert.Equal(["Admin", "Moderator"], roleValues);
+        }
+
+        [Fact]
+        public void CreateAccessToken_NoRoles_EmitsNoRoleClaims()
+        {
+            var token = CreateService().CreateAccessToken(7, []);
+
+            var jwt = new JsonWebToken(token);
+
+            Assert.DoesNotContain(jwt.Claims, c => c.Type == JwtTokenService.RoleClaimType);
+        }
+
+        [Fact]
+        public void CreateAccessToken_ExpiryMatchesConfiguredAccessTokenLifetime()
+        {
+            var token = CreateService().CreateAccessToken(1, []);
+
+            var jwt = new JsonWebToken(token);
+
+            // The token lives exactly AuthConstants.AccessTokenLifetime from its not-before instant.
+            Assert.Equal(AuthConstants.AccessTokenLifetime, jwt.ValidTo - jwt.ValidFrom);
+        }
+    }
+}

--- a/Game.Api.Tests/Unit/LoginTrackingIpResolutionTests.cs
+++ b/Game.Api.Tests/Unit/LoginTrackingIpResolutionTests.cs
@@ -1,0 +1,66 @@
+using Game.Api.Middleware;
+using Microsoft.AspNetCore.Http;
+using System.Net;
+using Xunit;
+
+namespace Game.Api.Tests.Unit
+{
+    /// <summary>
+    /// Covers <see cref="LoginTrackingMiddleware.ResolveIpAddress"/>: the <c>X-Forwarded-For</c>
+    /// split/trim, the empty/whitespace fallback to the transport remote address, and the final
+    /// "unknown" fallback — the multi-entry/whitespace branches that integration coverage missed.
+    /// </summary>
+    public class LoginTrackingIpResolutionTests
+    {
+        private static HttpContext ContextWith(string? forwardedFor, IPAddress? remoteIp)
+        {
+            var context = new DefaultHttpContext();
+            if (forwardedFor is not null)
+            {
+                context.Request.Headers["X-Forwarded-For"] = forwardedFor;
+            }
+            context.Connection.RemoteIpAddress = remoteIp;
+            return context;
+        }
+
+        [Fact]
+        public void PrefersSingleForwardedForEntry_Trimmed()
+        {
+            var context = ContextWith("  203.0.113.5  ", IPAddress.Parse("10.0.0.1"));
+
+            Assert.Equal("203.0.113.5", LoginTrackingMiddleware.ResolveIpAddress(context));
+        }
+
+        [Fact]
+        public void TakesFirstEntry_FromMultiHopForwardedFor()
+        {
+            var context = ContextWith("203.0.113.5, 70.41.3.18, 150.172.238.178", IPAddress.Parse("10.0.0.1"));
+
+            Assert.Equal("203.0.113.5", LoginTrackingMiddleware.ResolveIpAddress(context));
+        }
+
+        [Fact]
+        public void FallsBackToRemoteAddress_WhenForwardedForMissing()
+        {
+            var context = ContextWith(forwardedFor: null, IPAddress.Parse("198.51.100.7"));
+
+            Assert.Equal("198.51.100.7", LoginTrackingMiddleware.ResolveIpAddress(context));
+        }
+
+        [Fact]
+        public void FallsBackToRemoteAddress_WhenForwardedForIsWhitespace()
+        {
+            var context = ContextWith("   ", IPAddress.Parse("198.51.100.7"));
+
+            Assert.Equal("198.51.100.7", LoginTrackingMiddleware.ResolveIpAddress(context));
+        }
+
+        [Fact]
+        public void ReturnsUnknown_WhenNoForwardedForAndNoRemoteAddress()
+        {
+            var context = ContextWith(forwardedFor: null, remoteIp: null);
+
+            Assert.Equal("unknown", LoginTrackingMiddleware.ResolveIpAddress(context));
+        }
+    }
+}

--- a/Game.Api/Middleware/LoginTrackingMiddleware.cs
+++ b/Game.Api/Middleware/LoginTrackingMiddleware.cs
@@ -47,7 +47,7 @@ namespace Game.Api.Middleware
         /// Resolves the originating client IP, preferring the first <c>X-Forwarded-For</c> entry when the
         /// request arrives through a reverse proxy, and falling back to the transport remote address.
         /// </summary>
-        private static string ResolveIpAddress(HttpContext context)
+        internal static string ResolveIpAddress(HttpContext context)
         {
             var forwardedFor = context.Request.Headers["X-Forwarded-For"].ToString();
             if (!string.IsNullOrWhiteSpace(forwardedFor))

--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -1061,10 +1061,10 @@ namespace Game.Application.Tests.DataAccess
         /// </summary>
         private sealed class SubscribeSuppressingPubSubService(IPubSubService inner) : IPubSubService
         {
-            public Task Publish(string channel, string message) => inner.Publish(channel, message);
-            public Task Publish(string channel, string queueName, string queueData) => inner.Publish(channel, queueName, queueData);
-            public Task Publish<T>(string channel, string queueName, T queueData) => inner.Publish(channel, queueName, queueData);
-            public Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData) => inner.PublishBatch(channel, queueName, queueData);
+            public Task Publish(string channel, string message, CancellationToken cancellationToken = default) => inner.Publish(channel, message, cancellationToken);
+            public Task Publish(string channel, string queueName, string queueData, CancellationToken cancellationToken = default) => inner.Publish(channel, queueName, queueData, cancellationToken);
+            public Task Publish<T>(string channel, string queueName, T queueData, CancellationToken cancellationToken = default) => inner.Publish(channel, queueName, queueData, cancellationToken);
+            public Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default) => inner.PublishBatch(channel, queueName, queueData, cancellationToken);
             public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => Task.CompletedTask;
             public Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string? id = null) => Task.CompletedTask;
             public Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string? id = null) => Task.CompletedTask;

--- a/Game.Application.Tests/Mapping/PlayerMapperTests.cs
+++ b/Game.Application.Tests/Mapping/PlayerMapperTests.cs
@@ -1,0 +1,196 @@
+using Game.Abstractions.Contracts;
+using Game.Abstractions.DataAccess;
+using Game.Core;
+using Game.DataAccess.Mapping;
+using Xunit;
+using CoreItem = Game.Core.Items.Item;
+using CoreItemMod = Game.Core.Items.ItemMod;
+using CoreSkill = Game.Core.Skills.Skill;
+using EntityAppliedMod = Game.Infrastructure.Entities.AppliedMod;
+using EntityLogPreference = Game.Infrastructure.Entities.LogPreference;
+using EntityPlayer = Game.Infrastructure.Entities.Player;
+using EntityPlayerAttribute = Game.Infrastructure.Entities.PlayerAttribute;
+using EntityPlayerSkill = Game.Infrastructure.Entities.PlayerSkill;
+using EntityUnlockedItem = Game.Infrastructure.Entities.UnlockedItem;
+using EntityUnlockedMod = Game.Infrastructure.Entities.UnlockedMod;
+
+namespace Game.Application.Tests.Mapping
+{
+    /// <summary>
+    /// Parity-critical coverage for <see cref="PlayerMapper.ToCore"/>: the equipped-skill ordering
+    /// (including the legacy <c>Order == 0</c> tie-break that feeds <c>BattleSnapshot.SkillIds</c>),
+    /// the silent skip of an unknown equipment-slot id, and the per-item applied-mod grouping. A
+    /// regression here surfaces only as a subtle battle-parity failure, so it is pinned directly.
+    /// </summary>
+    public class PlayerMapperTests
+    {
+        [Fact]
+        public void ToCore_OrdersSelectedSkillsByOrderThenSkillId_WithLegacyZeroTieBreak()
+        {
+            // Skills 6 and 7 share the legacy Order == 0 (tie-break is SkillId asc), skill 5 is Order 1,
+            // skill 8 is unequipped. Expected equipped order: 6, 7 (Order 0, by id), then 5 (Order 1).
+            var entity = BuildPlayer(
+                skills:
+                [
+                    new() { SkillId = 5, Selected = true, Order = 1 },
+                    new() { SkillId = 7, Selected = true, Order = 0 },
+                    new() { SkillId = 6, Selected = true, Order = 0 },
+                    new() { SkillId = 8, Selected = false, Order = 0 },
+                ]);
+
+            var player = PlayerMapper.ToCore(entity, Catalog(), Catalog(), Catalog());
+
+            Assert.Equal([6, 7, 5], player.SelectedSkills.Select(s => s.Id));
+            // Every unlocked skill is mapped regardless of selection.
+            Assert.Equal([5, 6, 7, 8], player.Skills.Select(s => s.Id).OrderBy(id => id));
+        }
+
+        [Fact]
+        public void ToCore_EquipsItemInResolvedSlot_AndSilentlySkipsUnknownSlotId()
+        {
+            var entity = BuildPlayer(
+                unlockedItems:
+                [
+                    new() { ItemId = 10, EquipmentSlotId = (int)EEquipmentSlot.WeaponSlot },
+                    // 99 resolves to no equipment slot, so the item is kept but not equipped.
+                    new() { ItemId = 11, EquipmentSlotId = 99 },
+                    new() { ItemId = 12, EquipmentSlotId = null },
+                ]);
+
+            var player = PlayerMapper.ToCore(entity, Catalog(), Catalog(), Catalog());
+
+            var weaponSlot = player.Inventory.EquipmentSlots.Single(s => s.Value == EEquipmentSlot.WeaponSlot);
+            Assert.Equal(10, weaponSlot.ItemId);
+
+            // The unknown-slot item is present in the inventory but equipped in no slot.
+            Assert.Contains(player.Inventory.UnlockedItems, ui => ui.ItemId == 11);
+            Assert.DoesNotContain(player.Inventory.EquipmentSlots, s => s.ItemId == 11);
+        }
+
+        [Fact]
+        public void ToCore_GroupsAppliedModsByItem()
+        {
+            var entity = BuildPlayer(
+                unlockedItems:
+                [
+                    new() { ItemId = 10, EquipmentSlotId = null },
+                    new() { ItemId = 11, EquipmentSlotId = null },
+                ],
+                appliedMods:
+                [
+                    new() { ItemId = 10, ItemModSlotId = 0, ItemModId = 100 },
+                    new() { ItemId = 10, ItemModSlotId = 1, ItemModId = 101 },
+                    new() { ItemId = 11, ItemModSlotId = 0, ItemModId = 102 },
+                ]);
+
+            var player = PlayerMapper.ToCore(entity, Catalog(), Catalog(), Catalog());
+
+            var item10 = player.Inventory.UnlockedItems.Single(ui => ui.ItemId == 10);
+            var item11 = player.Inventory.UnlockedItems.Single(ui => ui.ItemId == 11);
+
+            Assert.Equal([100, 101], item10.AppliedMods.Select(m => m.ItemModId).OrderBy(id => id));
+            Assert.Equal([102], item11.AppliedMods.Select(m => m.ItemModId));
+            // Each applied mod resolves its domain model from the cached catalog.
+            Assert.All(item10.AppliedMods, m => Assert.Equal(m.ItemModId, m.ItemMod.Id));
+        }
+
+        [Fact]
+        public void ToCore_MapsScalarFields_StatAllocations_UnlockedMods_AndLogPreferences()
+        {
+            var entity = BuildPlayer(
+                attributes:
+                [
+                    new() { AttributeId = (int)EAttribute.Strength, Amount = 5m },
+                    new() { AttributeId = (int)EAttribute.Agility, Amount = 3m },
+                ],
+                unlockedMods: [new() { ItemModId = 100 }, new() { ItemModId = 101 }],
+                logPreferences: [new() { LogTypeId = (int)ELogType.Damage, Enabled = false }]);
+
+            var player = PlayerMapper.ToCore(entity, Catalog(), Catalog(), Catalog());
+
+            Assert.Equal(1, player.Id);
+            Assert.Equal("Hero", player.Name);
+            Assert.Equal(3, player.Level);
+            Assert.Contains(100, player.Inventory.UnlockedMods);
+            Assert.Contains(101, player.Inventory.UnlockedMods);
+            var strength = player.StatPoints.StatAllocations.Single(a => a.Attribute == EAttribute.Strength);
+            Assert.Equal(5d, strength.Amount);
+            var pref = Assert.Single(player.LogPreferences);
+            Assert.Equal(ELogType.Damage, pref.LogType);
+            Assert.False(pref.Enabled);
+        }
+
+        private static EntityPlayer BuildPlayer(
+            List<EntityPlayerSkill>? skills = null,
+            List<EntityUnlockedItem>? unlockedItems = null,
+            List<EntityAppliedMod>? appliedMods = null,
+            List<EntityUnlockedMod>? unlockedMods = null,
+            List<EntityPlayerAttribute>? attributes = null,
+            List<EntityLogPreference>? logPreferences = null) => new()
+            {
+                Id = 1,
+                Name = "Hero",
+                Level = 3,
+                Exp = 0,
+                CurrentZoneId = 0,
+                StatPointsGained = 0,
+                StatPointsUsed = 0,
+                PlayerSkills = skills ?? [],
+                UnlockedItems = unlockedItems ?? [],
+                AppliedMods = appliedMods ?? [],
+                UnlockedMods = unlockedMods ?? [],
+                PlayerAttributes = attributes ?? [],
+                LogPreferences = logPreferences ?? [],
+            };
+
+        private static InMemoryCatalog Catalog() => new();
+
+        /// <summary>
+        /// A trivial in-memory stand-in for the reference-data caches. ToCore only resolves a domain
+        /// model by id, so this builds one on demand rather than depending on the database-backed cache.
+        /// </summary>
+        private sealed class InMemoryCatalog : IItems, IItemMods, ISkills
+        {
+            public CoreItem GetItem(int itemId) => new()
+            {
+                Id = itemId,
+                Name = $"Item {itemId}",
+                Description = string.Empty,
+                Category = EItemCategory.Weapon,
+                Rarity = ERarity.Common,
+                Attributes = [],
+                ModSlots = [],
+                Tags = [],
+            };
+
+            public CoreItemMod GetItemMod(int itemModId) => new()
+            {
+                Id = itemModId,
+                Name = $"Mod {itemModId}",
+                Description = string.Empty,
+                Type = EItemModType.Component,
+                Rarity = ERarity.Common,
+                Attributes = [],
+                Tags = [],
+            };
+
+            public CoreSkill GetSkill(int skillId) => new()
+            {
+                Id = skillId,
+                Name = $"Skill {skillId}",
+                BaseDamage = 1,
+                Description = string.Empty,
+                CooldownMs = 1000,
+                DamageMultipliers = [],
+                Effects = [],
+            };
+
+            public bool ValidateItemModId(int itemModId) => true;
+
+            // ToCore never reads the full contract lists, only the per-id resolvers above.
+            List<Item> IItems.All() => throw new NotSupportedException();
+            List<ItemMod> IItemMods.All() => throw new NotSupportedException();
+            List<Skill> ISkills.AllSkills() => throw new NotSupportedException();
+        }
+    }
+}

--- a/UI/src/tests/lib/common/event-measuring.test.ts
+++ b/UI/src/tests/lib/common/event-measuring.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getEventCounter } from '$lib/common';
+
+// getEventCounter reports a windowed events-per-second figure every `eventsPerReport` events, using a
+// performance.now() delta and resetting its counter/window each time. Mock the clock so the windowed
+// math is deterministic.
+describe('getEventCounter', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('reports events-per-second once the threshold is reached', () => {
+		const nowSpy = vi.spyOn(performance, 'now').mockReturnValueOnce(1000); // captured at creation
+
+		const reports: number[] = [];
+		const tick = getEventCounter((eps) => reports.push(eps), 10);
+
+		nowSpy.mockReturnValueOnce(2000); // read on the 10th event: 1000ms elapsed
+		for (let i = 0; i < 10; i++) {
+			tick();
+		}
+
+		// 10 events over 1000ms = 10 events/second.
+		expect(reports).toEqual([10]);
+	});
+
+	it('does not report before the threshold is reached', () => {
+		vi.spyOn(performance, 'now').mockReturnValue(0);
+
+		const reports: number[] = [];
+		const tick = getEventCounter((eps) => reports.push(eps), 10);
+
+		for (let i = 0; i < 9; i++) {
+			tick();
+		}
+
+		expect(reports).toEqual([]);
+	});
+
+	it('resets the counter and window after each report', () => {
+		const nowSpy = vi.spyOn(performance, 'now').mockReturnValueOnce(0); // creation, lastCheck = 0
+
+		const reports: number[] = [];
+		const tick = getEventCounter((eps) => reports.push(eps), 5);
+
+		nowSpy.mockReturnValueOnce(500); // first report: 5 events / 500ms = 10/s
+		for (let i = 0; i < 5; i++) {
+			tick();
+		}
+
+		nowSpy.mockReturnValueOnce(1500); // second report: window restarts at 500, so 5 / 1000ms = 5/s
+		for (let i = 0; i < 5; i++) {
+			tick();
+		}
+
+		expect(reports).toEqual([10, 5]);
+	});
+
+	it('defaults to a 10-event window', () => {
+		const nowSpy = vi.spyOn(performance, 'now').mockReturnValueOnce(0);
+
+		const reports: number[] = [];
+		const tick = getEventCounter((eps) => reports.push(eps));
+
+		nowSpy.mockReturnValueOnce(1000);
+		for (let i = 0; i < 9; i++) {
+			tick();
+		}
+		expect(reports).toEqual([]); // not yet at 10
+
+		tick(); // 10th event fires the report
+		expect(reports).toEqual([10]);
+	});
+});

--- a/UI/src/tests/lib/common/statify.svelte.test.ts
+++ b/UI/src/tests/lib/common/statify.svelte.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { flushSync } from 'svelte';
+import { statify } from '$lib/common';
+
+class Inner {
+	value = 1;
+}
+
+class Outer {
+	count = 0;
+	inner = new Inner();
+	items: Inner[] = [new Inner()];
+}
+
+// Reads the `__statifyPerformed` idempotency marker the utility stamps on every processed object.
+const wasStatified = (obj: unknown) => (obj as { __statifyPerformed?: boolean }).__statifyPerformed === true;
+
+describe('statify', () => {
+	it('returns non-class values unchanged', () => {
+		expect(statify(5)).toBe(5);
+		expect(statify('hello')).toBe('hello');
+		expect(statify(null)).toBe(null);
+
+		// A plain object (constructor.name === 'Object') is not treated as a class and is left as-is.
+		const plain = { a: 1 };
+		expect(statify(plain)).toBe(plain);
+		expect(wasStatified(plain)).toBe(false);
+
+		// A bare array at the top level is not a class either, so it is returned as the same reference.
+		const arr = [1, 2, 3];
+		expect(statify(arr)).toBe(arr);
+	});
+
+	it('stamps the idempotency guard and is a no-op on re-entry', () => {
+		const outer = statify(new Outer());
+		expect(wasStatified(outer)).toBe(true);
+
+		// A second call short-circuits on the guard and returns the same instance untouched.
+		expect(statify(outer)).toBe(outer);
+	});
+
+	it('recursively statifies nested class instances and array elements', () => {
+		const outer = statify(new Outer());
+
+		expect(wasStatified(outer.inner)).toBe(true);
+		expect(wasStatified(outer.items[0])).toBe(true);
+	});
+
+	it('reacts to structural changes on a statified array', () => {
+		const outer = statify(new Outer());
+
+		let observedLength = -1;
+		const cleanup = $effect.root(() => {
+			const length = $derived(outer.items.length);
+			$effect(() => {
+				observedLength = length;
+			});
+		});
+
+		flushSync();
+		expect(observedLength).toBe(1);
+
+		outer.items.push(new Inner());
+		flushSync();
+		expect(observedLength).toBe(2);
+
+		cleanup();
+	});
+
+	// CHARACTERIZATION TEST documenting a known limitation (see follow-up issue): the `statifyArray`
+	// set-trap that is meant to re-statify values pushed/assigned after construction never fires,
+	// because the property is wrapped in `$state(...)` whose own deep proxy shadows the statify proxy.
+	// As a result a class instance added to a statified array later is NOT made reactive at the field
+	// level. This test pins the current behaviour so a future fix to `statify` updates it deliberately.
+	it('does not field-reactify a class instance pushed after construction (known limitation)', () => {
+		const outer = statify(new Outer());
+
+		const pushed = new Inner();
+		outer.items.push(pushed);
+
+		let observedValue = -1;
+		const cleanup = $effect.root(() => {
+			const value = $derived(outer.items[1].value);
+			$effect(() => {
+				observedValue = value;
+			});
+		});
+
+		flushSync();
+		expect(observedValue).toBe(1);
+
+		// Mutating the pushed instance's field does not propagate — it was never statified.
+		outer.items[1].value = 99;
+		flushSync();
+		expect(observedValue).toBe(1);
+
+		cleanup();
+	});
+
+	it('makes class properties reactive to a $derived read', () => {
+		const outer = statify(new Outer());
+
+		let observed = -1;
+		const cleanup = $effect.root(() => {
+			const derivedCount = $derived(outer.count);
+			$effect(() => {
+				observed = derivedCount;
+			});
+		});
+
+		flushSync();
+		expect(observed).toBe(0);
+
+		outer.count = 7;
+		flushSync();
+		expect(observed).toBe(7);
+
+		cleanup();
+	});
+
+	it('re-statifies a class-typed property reassigned through its setter', () => {
+		const outer = statify(new Outer());
+
+		const replacement = new Inner();
+		outer.inner = replacement;
+
+		// The setter routes a class-typed assignment back through statify.
+		expect(wasStatified(replacement)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Adds the direct unit coverage called out in #588 for logic-bearing code that had none. All changes are test-only except one tiny visibility change and one pre-existing compile fix (both noted below).

### Backend (`Game.Api.Tests/Unit`)
- **`JwtTokenServiceTests`** — issues a token and validates it against parameters mirroring `Startup.ConfigureAuth`; asserts `sub == userId`, every role maps to `JwtTokenService.RoleClaimType`, HMAC-SHA256 signing, a `jti` is stamped, no role claims when none are supplied, and `ValidTo - ValidFrom == AuthConstants.AccessTokenLifetime`.
- **`ClientHintsTests`** — `FromHeaders` empty→null normalization of the `Sec-CH-UA*` hints (and verbatim user-agent), plus `DeviceFingerprint` present/missing/empty.
- **`LoginTrackingIpResolutionTests`** — `ResolveIpAddress`: single + multi-hop `X-Forwarded-For` (first entry, trimmed), whitespace/missing fallback to the remote address, and the final `"unknown"`. `ResolveIpAddress` was changed from `private` to `internal` so the already-configured `InternalsVisibleTo("Game.Api.Tests")` can reach it (the testability extraction #588 suggested).
- **`ErrorStatusFilterTests`** — drives `OnResultExecuting`: the 200→400 rewrite when an `IApiResponse` carries an error, and no rewrite for null/empty error, a non-`IApiResponse` value, a non-`ObjectResult`, or an already-non-200 status.

### Backend (`Game.Application.Tests/Mapping`)
- **`PlayerMapperTests`** — `PlayerMapper.ToCore` (internal, hence in this project): equipped-skill ordering by `(Order, SkillId)` including the legacy `Order == 0` tie-break that feeds `BattleSnapshot.SkillIds`, the silent skip of an unknown `EquipmentSlotId`, per-item applied-mod grouping, and the scalar/stat-allocation/unlocked-mod/log-preference projection. Uses a tiny in-memory reference-data stand-in since `ToCore`'s logic only needs an id→model resolver, not the DB-backed cache.

### Frontend (`UI/src/tests/lib/common`)
- **`event-measuring.test.ts`** — the windowed events-per-second math, the no-report-before-threshold path, counter/window reset across batches, and the default 10-event window (clock mocked via `performance.now`).
- **`statify.svelte.test.ts`** — the `__statifyPerformed` idempotency guard, non-class passthrough, recursive statify of nested classes + initial array elements, class-field reactivity under `$derived`, and setter re-statify of a class-typed property.

## Notable findings

1. **Pre-existing compile break fixed.** `Game.Application.Tests` did not build on this branch: `SubscribeSuppressingPubSubService` (a test fake in `DataProviderSynchronizerTests`) was missed when #682 added `CancellationToken` overloads to `IPubSubService` (the sibling `ThrowingPubSubService` was updated). Added the four overloads so the project compiles. This means the test suite / CI was red before this PR.

2. **Latent `statify` reactivity bug → follow-up #683.** While testing `statify` I found the `statifyArray` set-trap meant to re-statify values pushed/assigned after construction **never fires** — the array field is wrapped in `$state(...)`, whose deep proxy shadows the statify proxy. So a *class instance* added to a statified array later is not field-reactified (Svelte's deep proxy doesn't proxy class instances, which is the gap `statify` exists to close). I added a clearly-labelled **characterization test** pinning the current behaviour and filed #683 to decide between removing the dead set-trap or fixing the gap.

## Test plan
- `dotnet build` (full solution) — succeeds.
- `dotnet test Game.Api.Tests` (Unit namespace) — 67 passed.
- `dotnet test Game.Application.Tests --filter-class *PlayerMapperTests` — 4 passed.
- `UI`: `npx vitest run` on both new files — 11 passed; `eslint` clean.

Closes #588

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcCVNWvL5APsaUkcNotsTc)_