### PR TITLE
A11y: real buttons for remove/toggle controls, labelled glyphs & inputs (#596)

### DIFF
--- a/UI/src/routes/admin/workbench/components/ChipsSection.svelte
+++ b/UI/src/routes/admin/workbench/components/ChipsSection.svelte
@@ -9,16 +9,9 @@
 					<span class="nm">{entry ? section.labelOf(entry) : `#${id}`}</span>
 					<span class="dm">{entry ? section.metaOf(entry) : ''}</span>
 					{#if entry?.retired}<span class="retired-tag">retired</span>{/if}
-					<span
-						class="x"
-						role="button"
-						tabindex="0"
-						title="Remove"
-						onclick={() => remove(id)}
-						onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && (e.preventDefault(), remove(id))}
-					>
+					<button type="button" class="x" title="Remove" aria-label="Remove" onclick={() => remove(id)}>
 						<WorkbenchIcon kind="x" size={11} />
-					</span>
+					</button>
 				</div>
 			{/each}
 		</div>

--- a/UI/src/routes/admin/workbench/components/FieldControl.svelte
+++ b/UI/src/routes/admin/workbench/components/FieldControl.svelte
@@ -1,19 +1,19 @@
 {#if field.type === 'toggle'}
 	<div class="fld">
 		{@render label()}
-		<div
+		<button
+			type="button"
 			class="toggle"
 			class:on={!!value}
 			class:dirty
 			role="switch"
 			aria-checked={!!value}
-			tabindex="0"
+			aria-label={field.label}
 			onclick={() => set(!value)}
-			onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && (e.preventDefault(), set(!value))}
 		>
 			<span class="track"><span class="knob"></span></span>
 			<span class="tg-label">{value ? field.onLabel : field.offLabel}</span>
-		</div>
+		</button>
 	</div>
 {:else if field.type === 'textarea'}
 	<div class="fld" style:flex={field.grow ? '1 1 100%' : 'none'} style:width="100%">
@@ -22,6 +22,7 @@
 			class="txtarea"
 			class:dirty
 			class:invalid={!!warn}
+			aria-label={field.label}
 			placeholder={field.placeholder}
 			value={value as string}
 			oninput={(e) => set(e.currentTarget.value)}
@@ -34,6 +35,7 @@
 		<div class="num-unit">
 			<NumInput
 				class="inp num{dirty ? ' dirty' : ''}{warn ? ' invalid' : ''}"
+				ariaLabel={field.label}
 				value={(value as number) ?? 0}
 				allowNegative={field.allowNegative}
 				onChange={(n) => set(n)}
@@ -50,6 +52,7 @@
 				class="sel"
 				class:dirty
 				class:invalid={!!warn}
+				aria-label={field.label}
 				value={value as number}
 				onchange={(e) => set(+e.currentTarget.value)}
 			>
@@ -68,6 +71,7 @@
 			class="inp"
 			class:dirty
 			class:invalid={!!warn}
+			aria-label={field.label}
 			placeholder={field.placeholder}
 			value={value as string}
 			oninput={(e) => set(e.currentTarget.value)}

--- a/UI/src/routes/admin/workbench/components/NumInput.svelte
+++ b/UI/src/routes/admin/workbench/components/NumInput.svelte
@@ -2,6 +2,7 @@
 	class={className}
 	type="text"
 	inputmode="decimal"
+	aria-label={ariaLabel}
 	{style}
 	value={text}
 	oninput={handleInput}
@@ -16,9 +17,18 @@ interface Props {
 	class?: string;
 	style?: string;
 	allowNegative?: boolean;
+	/** Accessible name for the input — the visible field labels are presentational `<span>`s, not associated `<label>`s. */
+	ariaLabel?: string;
 }
 
-let { value, onChange, class: className = '', style = undefined, allowNegative = false }: Props = $props();
+let {
+	value,
+	onChange,
+	class: className = '',
+	style = undefined,
+	allowNegative = false,
+	ariaLabel = undefined
+}: Props = $props();
 
 // Keep the in-progress text locally so typing "1." or "0.5" isn't clobbered by
 // re-coercion on every keystroke, and reflect external resets when not editing.

--- a/UI/src/routes/admin/workbench/components/TagBrowse.svelte
+++ b/UI/src/routes/admin/workbench/components/TagBrowse.svelte
@@ -15,7 +15,7 @@
 	<div class="cat-body">
 		<div class="search" style:max-width="360px" style:margin-bottom="14px">
 			<WorkbenchIcon kind="search" sw={1.4} />
-			<input class="inp" placeholder="Filter tags…" bind:value={q} />
+			<input class="inp" aria-label="Filter tags" placeholder="Filter tags…" bind:value={q} />
 		</div>
 		<div class="toggle-grid">
 			{#each shown as tag (tag.id)}

--- a/UI/src/routes/admin/workbench/components/TagPill.svelte
+++ b/UI/src/routes/admin/workbench/components/TagPill.svelte
@@ -8,16 +8,15 @@
 	<span class="tdot" style:background={color.fg}></span>
 	{tag.name}
 	{#if onRemove}
-		<span
+		<button
+			type="button"
 			class="x"
-			role="button"
-			tabindex="0"
 			title="Remove"
+			aria-label="Remove tag {tag.name}"
 			onclick={stopPropagation(() => onRemove?.())}
-			onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && (e.preventDefault(), onRemove?.())}
 		>
 			<WorkbenchIcon kind="x" size={10} />
-		</span>
+		</button>
 	{/if}
 </span>
 

--- a/UI/src/routes/admin/workbench/components/TagSearch.svelte
+++ b/UI/src/routes/admin/workbench/components/TagSearch.svelte
@@ -2,7 +2,7 @@
 	<div class="search" style:max-width="420px">
 		<WorkbenchIcon kind="search" sw={1.4} />
 		<!-- svelte-ignore a11y_autofocus -->
-		<input class="inp" autofocus placeholder="Search all tags…" bind:value={q} />
+		<input class="inp" autofocus aria-label="Search all tags" placeholder="Search all tags…" bind:value={q} />
 	</div>
 	<div class="result-summary">
 		{matchCount} match{matchCount === 1 ? '' : 'es'} across {groups.length} categor{groups.length === 1 ? 'y' : 'ies'} · click

--- a/UI/src/routes/admin/workbench/components/WorkbenchList.svelte
+++ b/UI/src/routes/admin/workbench/components/WorkbenchList.svelte
@@ -10,7 +10,12 @@
 		</div>
 		<div class="search">
 			<WorkbenchIcon kind="search" sw={1.4} />
-			<input class="inp" placeholder="Search {entity.label.toLowerCase()}…" bind:value={q} />
+			<input
+				class="inp"
+				aria-label="Search {entity.label.toLowerCase()}"
+				placeholder="Search {entity.label.toLowerCase()}…"
+				bind:value={q}
+			/>
 		</div>
 	</div>
 

--- a/UI/src/routes/admin/workbench/components/challenge/GoalField.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/GoalField.svelte
@@ -4,6 +4,7 @@
 	<div class="num-unit">
 		<NumInput
 			class="inp num{dirty ? ' dirty' : ''}"
+			ariaLabel="Goal {isMs ? '(time)' : 'amount'}"
 			style="padding-right: {pad}px"
 			value={challenge.progressGoal}
 			onChange={(v) => store.patch(challenge.id, (d) => ((d as unknown as IChallenge).progressGoal = v))}

--- a/UI/src/routes/admin/workbench/components/challenge/RewardPicker.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/RewardPicker.svelte
@@ -11,12 +11,15 @@
 			<input
 				class="inp"
 				autofocus
+				aria-label={`Search ${kind === 'item' ? 'items' : kind === 'mod' ? 'item mods' : 'skills'}`}
 				placeholder={`Search ${kind === 'item' ? 'items' : kind === 'mod' ? 'item mods' : 'skills'}…`}
 				bind:value={query}
 			/>
 		</div>
 		<span class="ch-picker-count">{availableCount} of {records.length} unclaimed</span>
-		<button type="button" class="row-x" title="Close" onclick={onClose}><WorkbenchIcon kind="x" size={11} /></button>
+		<button type="button" class="row-x" title="Close" aria-label="Close" onclick={onClose}>
+			<WorkbenchIcon kind="x" size={11} />
+		</button>
 	</div>
 	<div class="ch-picker-list">
 		{#each matches.slice(0, 80) as record (record.id)}

--- a/UI/src/routes/admin/workbench/components/challenge/RewardSlot.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/RewardSlot.svelte
@@ -18,7 +18,7 @@
 			{/if}
 		</div>
 		{#if valueId != null}
-			<button type="button" class="row-x" title="Clear reward" onclick={onClear}>
+			<button type="button" class="row-x" title="Clear reward" aria-label="Clear reward" onclick={onClear}>
 				<WorkbenchIcon kind="x" size={11} />
 			</button>
 		{/if}

--- a/UI/src/routes/admin/workbench/components/challenge/ScopeField.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/ScopeField.svelte
@@ -28,6 +28,7 @@
 					<select
 						class="sel"
 						class:dirty
+						aria-label="Target {entityTypeName(challenge.entityType)}"
 						value={challenge.targetEntityId}
 						onchange={(e) =>
 							store.patch(challenge.id, (d) => ((d as unknown as IChallenge).targetEntityId = +e.currentTarget.value))}

--- a/UI/src/routes/admin/workbench/workbench.scss
+++ b/UI/src/routes/admin/workbench/workbench.scss
@@ -263,6 +263,11 @@
 
 	/* toggle */
 	.toggle {
+		appearance: none;
+		background: none;
+		border: none;
+		color: inherit;
+		text-align: left;
 		display: inline-flex;
 		align-items: center;
 		gap: 9px;
@@ -397,11 +402,14 @@
 			color: var(--accent);
 		}
 		.x {
+			appearance: none;
+			border: none;
 			color: var(--text-muted);
 			cursor: pointer;
 			display: flex;
 			padding: 2px;
 			border-radius: 3px;
+			background: none;
 		}
 		.x:hover {
 			color: var(--change-removed);
@@ -744,12 +752,16 @@
 		white-space: nowrap;
 
 		.x {
+			appearance: none;
+			border: none;
+			color: inherit;
 			display: inline-flex;
 			cursor: pointer;
 			opacity: 0.65;
 			padding: 1px;
 			border-radius: 50%;
 			margin-left: 1px;
+			background: none;
 		}
 		.x:hover {
 			opacity: 1;

--- a/UI/src/routes/game/screens/inventory/EquipSlot.svelte
+++ b/UI/src/routes/game/screens/inventory/EquipSlot.svelte
@@ -44,7 +44,12 @@
 				<CategoryGlyph cat={item.itemCategoryId} color={itemCategoryColor(item.itemCategoryId)} size={40} />
 			{/if}
 			{#if hover}
-				<button class="unequip" title="Unequip" onclick={stopPropagation(() => onUnequip?.(slot.id))}>×</button>
+				<button
+					class="unequip"
+					title="Unequip"
+					aria-label="Unequip {item.name}"
+					onclick={stopPropagation(() => onUnequip?.(slot.id))}>×</button
+				>
 			{/if}
 			{#if item.appliedMods.length}
 				<span class="mod-count">{item.appliedMods.length}◈</span>

--- a/UI/src/routes/game/screens/inventory/GridSlot.svelte
+++ b/UI/src/routes/game/screens/inventory/GridSlot.svelte
@@ -40,6 +40,7 @@
 		class:on={item.favorite}
 		class:show={hover}
 		title={item.favorite ? 'Unfavorite' : 'Favorite'}
+		aria-label={item.favorite ? 'Unfavorite' : 'Favorite'}
 		onclick={stopPropagation(() => onToggleFav?.(item))}
 	>
 		<FavoriteStar
@@ -134,7 +135,13 @@ const handleClick = (e: MouseEvent) => {
 const handleKeydown = (e: KeyboardEvent) => {
 	if (e.key === 'Enter' || e.key === ' ') {
 		e.preventDefault();
-		onSelect?.(item);
+		// Mirror the pointer affordances: a modifier+activate equips (like ⌘/Ctrl-click and
+		// double-click), a plain activate selects — so the equip path has a keyboard equivalent.
+		if (e.metaKey || e.ctrlKey) {
+			onToggleEquip?.(item);
+		} else {
+			onSelect?.(item);
+		}
 	}
 };
 

--- a/UI/src/routes/game/screens/inventory/ModSlots.svelte
+++ b/UI/src/routes/game/screens/inventory/ModSlots.svelte
@@ -6,50 +6,20 @@
 			{@const applied = item.appliedMods.find((m) => m.itemModSlotId === slot.id)}
 			{@const accent = modTypeColor(slot.itemModSlotTypeId)}
 			<div class="mod-slot-wrap">
-				<div
-					class="mod-slot"
-					class:filled={!!applied}
-					style:border-left-color={accent}
-					role="button"
-					tabindex="0"
-					onclick={() => {
-						if (!applied) {
-							togglePicker(slot.id);
-						}
-					}}
-					onkeydown={(e) => {
-						if (!applied && (e.key === 'Enter' || e.key === ' ')) {
-							e.preventDefault();
-							togglePicker(slot.id);
-						}
-					}}
-				>
-					<div class="mod-info">
-						<div class="mod-head">
-							{#if applied}
-								<span class="mod-name" style:color={rarityColor(applied.rarityId)}>{applied.name}</span>
-							{:else}
-								<span class="mod-empty">Empty slot</span>
-							{/if}
-							<span class="mod-type" style:color={accent}>{modTypeLabel(slot.itemModSlotTypeId)}</span>
-						</div>
-						{#if applied}
-							<div class="mod-desc">{applied.description}</div>
-						{:else}
-							<div class="mod-hint">Click to install a {modTypeLabel(slot.itemModSlotTypeId).toLowerCase()}</div>
-						{/if}
+				<!--
+					An empty slot is the click target that opens the mod picker, so it's a real
+					<button>; a filled slot is non-interactive (it carries its own Remove button),
+					so it renders as a plain <div> to avoid nesting a button inside a button.
+				-->
+				{#if applied}
+					<div class="mod-slot filled" style:border-left-color={accent}>
+						{@render slotBody(applied, accent, slot)}
 					</div>
-
-					{#if applied}
-						<button
-							class="mod-remove"
-							title="Remove mod"
-							onclick={stopPropagation(() => view.removeMod(item.itemId, slot.id))}>×</button
-						>
-					{:else}
-						<span class="mod-add" style:color={accent}>+</span>
-					{/if}
-				</div>
+				{:else}
+					<button type="button" class="mod-slot" style:border-left-color={accent} onclick={() => togglePicker(slot.id)}>
+						{@render slotBody(applied, accent, slot)}
+					</button>
+				{/if}
 
 				{#if openSlotId === slot.id && !applied}
 					{@const options = view.compatibleMods(slot.itemModSlotTypeId, item)}
@@ -82,6 +52,39 @@
 		{/each}
 	</div>
 {/if}
+
+{#snippet slotBody(
+	applied: (typeof item.appliedMods)[number] | undefined,
+	accent: string,
+	slot: (typeof item.modSlots)[number]
+)}
+	<div class="mod-info">
+		<div class="mod-head">
+			{#if applied}
+				<span class="mod-name" style:color={rarityColor(applied.rarityId)}>{applied.name}</span>
+			{:else}
+				<span class="mod-empty">Empty slot</span>
+			{/if}
+			<span class="mod-type" style:color={accent}>{modTypeLabel(slot.itemModSlotTypeId)}</span>
+		</div>
+		{#if applied}
+			<div class="mod-desc">{applied.description}</div>
+		{:else}
+			<div class="mod-hint">Click to install a {modTypeLabel(slot.itemModSlotTypeId).toLowerCase()}</div>
+		{/if}
+	</div>
+
+	{#if applied}
+		<button
+			class="mod-remove"
+			title="Remove mod"
+			aria-label="Remove {applied.name}"
+			onclick={stopPropagation(() => view.removeMod(item.itemId, slot.id))}>×</button
+		>
+	{:else}
+		<span class="mod-add" style:color={accent} aria-hidden="true">+</span>
+	{/if}
+{/snippet}
 
 <script lang="ts">
 import type { Item } from '$lib/battle';
@@ -117,6 +120,8 @@ const togglePicker = (slotId: number) => {
 }
 
 .mod-slot {
+	appearance: none;
+	width: 100%;
 	display: flex;
 	align-items: flex-start;
 	gap: 8px;
@@ -127,6 +132,9 @@ const togglePicker = (slotId: number) => {
 	border-radius: 2px;
 	cursor: pointer;
 	min-height: 38px;
+	font: inherit;
+	color: inherit;
+	text-align: left;
 
 	&.filled {
 		background: color-mix(in srgb, var(--white) 3%, transparent);

--- a/UI/src/routes/game/screens/skills/EquippedBand.svelte
+++ b/UI/src/routes/game/screens/skills/EquippedBand.svelte
@@ -36,7 +36,13 @@
 				{#if swapping}
 					<span class="rep">↪ replace</span>
 				{:else}
-					<button type="button" class="rm" title="Remove from loadout" onclick={(e) => remove(e, id)}>✕</button>
+					<button
+						type="button"
+						class="rm"
+						title="Remove from loadout"
+						aria-label="Remove {metrics.skill.name} from loadout"
+						onclick={(e) => remove(e, id)}>✕</button
+					>
 				{/if}
 				<button type="button" class="en" onclick={(e) => pick(e, id)}>{metrics.skill.name}</button>
 				<div class="es">

--- a/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
@@ -133,6 +133,14 @@ describe('ChipsSection', () => {
 		expect(store.items[0].skillPool).toEqual([2]);
 	});
 
+	it('renders the remove control as a real, labelled button (not a clickable span)', () => {
+		const { store, record, baseline } = setup([1]);
+		const { container } = renderChips(store, record, baseline);
+		const remove = container.querySelector('.skill-chip .x') as HTMLElement;
+		expect(remove.tagName).toBe('BUTTON');
+		expect(remove.getAttribute('aria-label')).toBe('Remove');
+	});
+
 	it('excludes a retired catalogue entry from the add select but keeps an assigned one as a chip', () => {
 		const { store, record, baseline } = setup([4]);
 		const { container } = renderChips(store, record, baseline);

--- a/UI/src/tests/routes/admin/workbench/FieldControl.test.ts
+++ b/UI/src/tests/routes/admin/workbench/FieldControl.test.ts
@@ -107,7 +107,7 @@ describe('FieldControl — toggle field', () => {
 		expect(store.items[0].enabled).toBe(true);
 	});
 
-	it('toggles via the keyboard (Enter)', async () => {
+	it('renders the switch as a native, labelled button (keyboard-operable for free)', () => {
 		const { store, record, baseline } = setup();
 		const { container } = renderField(
 			field({ key: 'enabled', label: 'On', type: 'toggle', onLabel: 'Yes', offLabel: 'No' }),
@@ -115,8 +115,12 @@ describe('FieldControl — toggle field', () => {
 			record,
 			baseline
 		);
-		await fireEvent.keyDown(container.querySelector('.toggle') as HTMLElement, { key: 'Enter' });
-		expect(store.items[0].enabled).toBe(true);
+		// A real <button role="switch"> gets focus + Enter/Space activation natively, so there is no
+		// hand-rolled keydown handler to test — assert the accessible element instead.
+		const toggle = container.querySelector('.toggle') as HTMLElement;
+		expect(toggle.tagName).toBe('BUTTON');
+		expect(toggle.getAttribute('role')).toBe('switch');
+		expect(toggle.getAttribute('aria-label')).toBe('On');
 	});
 });
 

--- a/UI/src/tests/routes/admin/workbench/TagPill.test.ts
+++ b/UI/src/tests/routes/admin/workbench/TagPill.test.ts
@@ -32,6 +32,13 @@ describe('TagPill', () => {
 		expect(onRemove).toHaveBeenCalledOnce();
 	});
 
+	it('renders the remove control as a real, labelled button', () => {
+		const { container } = render(TagPill, { props: { tag, onRemove: vi.fn() } });
+		const remove = container.querySelector('.x') as HTMLElement;
+		expect(remove.tagName).toBe('BUTTON');
+		expect(remove.getAttribute('aria-label')).toBe('Remove tag Fire');
+	});
+
 	it('adds the new-pill inset ring only when isNew is set', () => {
 		const { container, rerender } = render(TagPill, { props: { tag, isNew: true } });
 		expect((container.querySelector('.tag-pill') as HTMLElement).getAttribute('style')).toContain('inset');

--- a/UI/src/tests/routes/game/screens/inventory/GridSlot.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/GridSlot.test.ts
@@ -148,6 +148,26 @@ describe('GridSlot — keyboard interactions', () => {
 		await fireEvent.keyDown(container.querySelector('.grid-slot')!, { key: 'ArrowRight' });
 		expect(onSelect).not.toHaveBeenCalled();
 	});
+
+	it('equips (not selects) on Ctrl+Enter — the keyboard equivalent of ⌘/Ctrl-click', async () => {
+		const onSelect = vi.fn();
+		const onToggleEquip = vi.fn();
+		const item = makeItem();
+		const { container } = render(GridSlot, { props: { item, onSelect, onToggleEquip } });
+		await fireEvent.keyDown(container.querySelector('.grid-slot')!, { key: 'Enter', ctrlKey: true });
+		expect(onToggleEquip).toHaveBeenCalledWith(item);
+		expect(onSelect).not.toHaveBeenCalled();
+	});
+
+	it('equips (not selects) on Meta+Space', async () => {
+		const onSelect = vi.fn();
+		const onToggleEquip = vi.fn();
+		const item = makeItem();
+		const { container } = render(GridSlot, { props: { item, onSelect, onToggleEquip } });
+		await fireEvent.keyDown(container.querySelector('.grid-slot')!, { key: ' ', metaKey: true });
+		expect(onToggleEquip).toHaveBeenCalledWith(item);
+		expect(onSelect).not.toHaveBeenCalled();
+	});
 });
 
 describe('GridSlot — hover interactions', () => {

--- a/UI/src/tests/routes/game/screens/inventory/ModSlots.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/ModSlots.test.ts
@@ -82,6 +82,13 @@ describe('ModSlots — empty slots', () => {
 		render(ModSlots, { props: { item, view: makeView() } });
 		expect(screen.getByText(/Click to install a/i)).toBeTruthy();
 	});
+
+	it('renders an empty slot as a real <button> (keyboard-operable, no hand-rolled keydown)', () => {
+		const item = makeItem({ modSlots: [makeModSlot(1)] });
+		const { container } = render(ModSlots, { props: { item, view: makeView() } });
+		const slot = container.querySelector('.mod-slot') as HTMLElement;
+		expect(slot.tagName).toBe('BUTTON');
+	});
 });
 
 describe('ModSlots — picker toggle', () => {
@@ -155,6 +162,25 @@ describe('ModSlots — filled slots', () => {
 		const item = makeItem({ modSlots: [slot], appliedMods: [mod as unknown as Item['appliedMods'][0]] });
 		const { container } = render(ModSlots, { props: { item, view: makeView() } });
 		expect(container.querySelector('.mod-remove')).toBeTruthy();
+	});
+
+	it('renders a filled slot as a non-interactive <div> (it carries its own remove button)', () => {
+		const slot = makeModSlot(1);
+		const mod = makeMod(10, 1);
+		const item = makeItem({ modSlots: [slot], appliedMods: [mod as unknown as Item['appliedMods'][0]] });
+		const { container } = render(ModSlots, { props: { item, view: makeView() } });
+		// A filled slot must not be a button (no nested button-in-button), unlike the empty slot.
+		expect((container.querySelector('.mod-slot') as HTMLElement).tagName).toBe('DIV');
+	});
+
+	it('labels the remove button with the applied mod name', () => {
+		const slot = makeModSlot(1);
+		const mod = makeMod(10, 1, { name: 'Power Core' });
+		const item = makeItem({ modSlots: [slot], appliedMods: [mod as unknown as Item['appliedMods'][0]] });
+		const { container } = render(ModSlots, { props: { item, view: makeView() } });
+		expect((container.querySelector('.mod-remove') as HTMLElement).getAttribute('aria-label')).toBe(
+			'Remove Power Core'
+		);
 	});
 
 	it('calls view.removeMod with itemId and slotId when the remove button is clicked', async () => {


### PR DESCRIPTION
## Summary

Addresses the bulk of #596: replace clickable `role="button"` spans/divs with real `<button>`s, give icon-only and form controls proper accessible names, and add the missing keyboard parity — all per the project's a11y convention (real buttons, e.g. `ModalHost`'s backdrop).

### Admin Workbench
- **`ChipsSection` / `TagPill` remove "×"** and **`FieldControl` toggle**: `span`/`div[role="button"|"switch"]` → real `<button>` (dropping the hand-rolled `role`/`tabindex`/keydown), with `aria-label`s. The toggle stays a `<button role="switch">` (the recommended switch pattern — native focus + Enter/Space for free).
- **Form controls labelled**: `aria-label` on the text/number/textarea/select inputs (the visible field labels are presentational `<span>`s, not associated `<label>`s); `NumInput` gains an `ariaLabel` prop, used by `FieldControl` and `GoalField`. `ScopeField`'s target select labelled too.
- **Search inputs** (`WorkbenchList`, `TagBrowse`, `TagSearch`, `RewardPicker`) and the **icon-only Close/Clear buttons** (`RewardPicker`, `RewardSlot`) get `aria-label`s.
- `workbench.scss` resets button chrome on the converted `.toggle` / `.x` rules so the look is unchanged.

### Inventory / Skills
- **`ModSlots`**: the empty slot is now a real `<button>` (the click target that opens the picker); a filled slot stays a plain `<div>` so its Remove button isn't nested inside a button. Shared body extracted to a `{#snippet}` to keep it DRY.
- **`GridSlot`**: keyboard equip parity — modifier+Enter/Space now equips, mirroring ⌘/Ctrl-click and double-click (previously the equip path had no keyboard equivalent); `aria-label` on the favorite star.
- `aria-label`s on the **`EquipSlot` unequip** and **`EquippedBand` remove** glyph buttons.

## How it addresses the issue

Covers the Inventory mod-slots, the Admin Workbench remove/toggle/label/search items, and the glyph-button labels and inventory keyboard-equip gap from #596.

## Deliberately split out (genuine design forks, filed as follow-ups)

- **#685** — inventory grid/equip **tile** structural conversion. The tiles contain nested interactive controls (favorite / unequip) and are drag handles, so they can't become a single `<button>`; they need an accessible-card redesign (and the empty `EquipSlot` tile should stop being focusable). Visual verification matters, so it wasn't done blind here.
- **#686** — gate/lock **tooltip** keyboard/AT reachability (`ZoneNav` locked arrow, `SkillRow` gated row). These are mouse-hover-only and cursor-positioned, and `ZoneNav`'s locked arrow is intentionally `disabled` (tested), so making them keyboard-reachable is a behavior/contract decision.

## Test plan
- `npm run lint` (eslint + svelte-check) — clean.
- `npx vitest run` — **1757 passed** (182 files), including updated/added coverage:
  - new button semantics asserted in `ChipsSection` / `TagPill` / `FieldControl` / `ModSlots` tests;
  - `FieldControl` toggle test now asserts the native labelled `<button role="switch">` (jsdom doesn't synthesize Enter→click on native buttons, so the old hand-rolled-keydown test was replaced);
  - new `GridSlot` keyboard-equip parity tests (Ctrl+Enter / Meta+Space → equip).
- No backend changes.

Refs #596 (does not fully close it — see follow-ups #685, #686)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZJPwmmVTPqCNeuybyUCME)_