### PR TITLE
Share tooltip stats/description chrome with ItemDrawer (#599)

### DIFF
--- a/UI/src/components/tooltip/TooltipDescription.svelte
+++ b/UI/src/components/tooltip/TooltipDescription.svelte
@@ -1,0 +1,19 @@
+<div class="tt-description">{text}</div>
+
+<script lang="ts">
+interface Props {
+	/** The flavour/description text rendered as the shared italic tooltip body. */
+	text: string;
+}
+
+const { text }: Props = $props();
+</script>
+
+<style lang="scss">
+.tt-description {
+	font-size: 11.5px;
+	font-style: italic;
+	color: color-mix(in srgb, var(--text-primary) 60%, transparent);
+	line-height: 1.55;
+}
+</style>

--- a/UI/src/routes/game/screens/challenges/ModTooltip.svelte
+++ b/UI/src/routes/game/screens/challenges/ModTooltip.svelte
@@ -16,7 +16,7 @@
 
 	{#if mod.description}
 		<TooltipSection label="Description" last>
-			<div class="tt-description">{mod.description}</div>
+			<TooltipDescription text={mod.description} />
 		</TooltipSection>
 	{/if}
 </TooltipShell>
@@ -29,6 +29,7 @@ import TooltipShell from '$components/tooltip/TooltipShell.svelte';
 import TooltipSection from '$components/tooltip/TooltipSection.svelte';
 import TooltipStatsGrid from '$components/tooltip/TooltipStatsGrid.svelte';
 import TooltipTitle from '$components/tooltip/TooltipTitle.svelte';
+import TooltipDescription from '$components/tooltip/TooltipDescription.svelte';
 
 interface Props {
 	mod: IItemMod;
@@ -41,12 +42,3 @@ const effects = $derived(
 	(mod.attributes ?? []).map((a) => ({ name: attributeName(a.attributeId, staticData.attributes), value: a.amount }))
 );
 </script>
-
-<style lang="scss">
-.tt-description {
-	font-size: 11.5px;
-	font-style: italic;
-	color: color-mix(in srgb, var(--text-primary) 60%, transparent);
-	line-height: 1.55;
-}
-</style>

--- a/UI/src/routes/game/screens/inventory/ItemDrawer.svelte
+++ b/UI/src/routes/game/screens/inventory/ItemDrawer.svelte
@@ -17,24 +17,20 @@
 </div>
 
 <div class="drawer-body">
-	<div class="section">
-		<div class="section-rule">
-			<span class="mono-label">Stats</span>
-			<div class="line"></div>
-		</div>
-		<StatList attrs={stats} />
-	</div>
+	{#if attributeMap?.length}
+		<TooltipSection label="Stats">
+			<TooltipStatsGrid entries={attributeMap} />
+		</TooltipSection>
+	{/if}
 
-	<div class="section">
-		<div class="section-rule">
-			<span class="mono-label">Mod slots · {item.modSlots?.length ?? 0}</span>
-			<div class="line"></div>
-		</div>
+	<TooltipSection label="Mod slots · {item.modSlots?.length ?? 0}">
 		<ModSlots {item} {view} />
-	</div>
+	</TooltipSection>
 
 	{#if item.description}
-		<div class="description">{item.description}</div>
+		<TooltipSection label="Description" last>
+			<TooltipDescription text={item.description} />
+		</TooltipSection>
 	{/if}
 </div>
 
@@ -46,10 +42,12 @@
 </div>
 
 <script lang="ts">
-import StatList from './StatList.svelte';
 import ModSlots from './ModSlots.svelte';
 import TooltipTitle from '$components/tooltip/TooltipTitle.svelte';
-import { BattleAttributes, type Item } from '$lib/battle';
+import TooltipSection from '$components/tooltip/TooltipSection.svelte';
+import TooltipStatsGrid from '$components/tooltip/TooltipStatsGrid.svelte';
+import TooltipDescription from '$components/tooltip/TooltipDescription.svelte';
+import { type Item } from '$lib/battle';
 import { itemCategoryColor, itemCategoryName, rarityColor, rarityLabel, rarityTint } from '$lib/common';
 import { type InventoryView } from './inventory-view.svelte';
 
@@ -59,11 +57,10 @@ const accent = $derived(itemCategoryColor(item.itemCategoryId));
 const rc = $derived(rarityColor(item.rarityId));
 const equipped = $derived(item.equipmentSlotId != null);
 
-// Recompute from the item's current attributes + applied mods so the panel
-// reflects mod changes live.
-const stats = $derived(
-	new BattleAttributes([...item.attributes, ...item.appliedMods.flatMap((m) => m.attributes)], false).getAttributeMap()
-);
+// Merged item + applied-mod attributes, from the item's own source-of-truth
+// projection (the same one ItemTooltip reads) so the drawer and tooltip can't
+// drift; it recomputes as mods are applied/removed.
+const attributeMap = $derived(item.totalAttributes?.getAttributeMap());
 </script>
 
 <style lang="scss">
@@ -108,38 +105,6 @@ const stats = $derived(
 	flex: 1;
 	overflow-y: auto;
 	padding: 14px 18px;
-}
-
-.section {
-	margin-bottom: 16px;
-}
-
-.section-rule {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	margin-bottom: 10px;
-}
-
-.mono-label {
-	font-family: var(--mono);
-	font-size: 9.5px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-}
-
-.line {
-	flex: 1;
-	height: 1px;
-	background: var(--border-subtle);
-}
-
-.description {
-	font-size: 11.5px;
-	font-style: italic;
-	color: var(--text-tertiary);
-	line-height: 1.55;
 }
 
 .drawer-footer {

--- a/UI/src/routes/game/screens/inventory/ItemTooltip.svelte
+++ b/UI/src/routes/game/screens/inventory/ItemTooltip.svelte
@@ -26,7 +26,7 @@
 	<!-- Description -->
 	{#if item?.description}
 		<TooltipSection label="Description" last>
-			<div class="tt-description">{item.description}</div>
+			<TooltipDescription text={item.description} />
 		</TooltipSection>
 	{/if}
 </TooltipShell>
@@ -38,6 +38,7 @@ import TooltipShell from '$components/tooltip/TooltipShell.svelte';
 import TooltipSection from '$components/tooltip/TooltipSection.svelte';
 import TooltipStatsGrid from '$components/tooltip/TooltipStatsGrid.svelte';
 import TooltipTitle from '$components/tooltip/TooltipTitle.svelte';
+import TooltipDescription from '$components/tooltip/TooltipDescription.svelte';
 import EquippedBadge from './item-tooltip/EquippedBadge.svelte';
 import ModList from './item-tooltip/ModList.svelte';
 
@@ -74,12 +75,3 @@ const categoryName = $derived(item ? itemCategoryName(item.itemCategoryId) : 'It
 // Item name reflects its applied mods: prefix mod names prepend, suffix names append.
 const displayName = $derived(item ? composeItemName(item.name, item.appliedMods) : '');
 </script>
-
-<style lang="scss">
-.tt-description {
-	font-size: 11.5px;
-	font-style: italic;
-	color: color-mix(in srgb, var(--text-primary) 60%, transparent);
-	line-height: 1.55;
-}
-</style>

--- a/UI/src/tests/routes/game/screens/inventory/ItemDrawer.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/ItemDrawer.test.ts
@@ -114,4 +114,32 @@ describe('ItemDrawer', () => {
 		const { getByText } = render(ItemDrawer, { props: { item: makeItem(), view: makeView() } });
 		expect(getByText('A trusty blade.')).toBeTruthy();
 	});
+
+	it('renders the Stats section through the shared tooltip stats grid', () => {
+		const { container } = render(ItemDrawer, { props: { item: makeItem(), view: makeView() } });
+		const grid = container.querySelector('.tt-stats-grid') as HTMLElement;
+		expect(grid).toBeTruthy();
+		expect(grid.textContent).toContain('Strength');
+		expect(grid.textContent).toContain('+10');
+	});
+
+	it('derives the Stats from item.totalAttributes, not a manual item+mod flatten', () => {
+		// totalAttributes carries an attribute (Agility) absent from `attributes`/`appliedMods`,
+		// so it only renders if the drawer reads the item's own merged projection.
+		const item = makeItem({
+			attributes: [{ attributeId: EAttribute.Strength, amount: 10 }],
+			appliedMods: [],
+			totalAttributes: new BattleAttributes(
+				[
+					{ attributeId: EAttribute.Strength, amount: 10 },
+					{ attributeId: EAttribute.Agility, amount: 5 }
+				],
+				false
+			)
+		});
+		const { container } = render(ItemDrawer, { props: { item, view: makeView() } });
+		const text = (container.querySelector('.tt-stats-grid') as HTMLElement).textContent ?? '';
+		expect(text).toContain('Agility');
+		expect(text).toContain('+5');
+	});
 });


### PR DESCRIPTION
## Summary

`inventory/ItemDrawer.svelte` re-implemented the same three sections (Stats / Mod slots / Description) that `ItemTooltip.svelte` composes from the shared `components/tooltip` primitives, and — more importantly — **derived its merged item+mod stats divergently**: it built them with a manual `new BattleAttributes([...item.attributes, ...item.appliedMods.flatMap(m => m.attributes)], false)` instead of the item's own `totalAttributes` projection the tooltip reads (the documented convention). Two code paths computing the same "merged item + mod attributes" can drift. This addresses #599.

### Changes

- **Stat derivation unified (the latent-bug fix).** The drawer now derives its Stats from `item.totalAttributes.getAttributeMap()` — the same source `ItemTooltip` uses — so the two surfaces can no longer disagree, and it still recomputes live as mods are applied/removed.
- **Composes the shared tooltip chrome.** The drawer's hand-rolled `.section-rule`/`.mono-label`/`.line` headers and its `StatList` usage are replaced with `TooltipSection` + `TooltipStatsGrid`, per the frontend doc's "compose the shared building blocks rather than re-implement them" guidance. (Description now also gets a proper "Description" section header, consistent with the drawer's other two sections and with the tooltip.)
- **New `TooltipDescription` primitive.** The identical `.tt-description` italic block was duplicated in **three** files (`ItemTooltip`, `ModTooltip`, `ItemDrawer`); it's extracted into `components/tooltip/TooltipDescription.svelte` and all three now compose it.

### Deliberate divergence (noted for review)

The drawer keeps the **interactive `ModSlots`** (install/remove mods, slot picker) for its Mods section rather than the tooltip's **read-only `ModList`** — the drawer is the *edit* surface, the tooltip is a hover preview, so their mod bodies legitimately can't be the single shared component. The Stats and Description bodies are now genuinely identical between the two; the Mods section shares only the `TooltipSection` header chrome. I went with composing the shared primitives in each surface (the building blocks the frontend doc tells us to compose) rather than forcing a leaky shared "body" aggregate around that interactivity difference.

## How it addresses the issue

- Removes the divergent stat derivation called out in #599 (drawer now reads `item.totalAttributes`).
- Removes the duplicated tooltip-chrome markup/styles the shared primitives exist to prevent.

## Test plan

- `npm run lint` (eslint + svelte-check) — clean, 0 errors/warnings.
- `npm run test:unit:ci` — **1752 passed** (182 files). Added drawer tests: Stats render through the shared `.tt-stats-grid`, and stats derive from `item.totalAttributes` (pinned with an attribute present only in `totalAttributes`, not in `attributes`/`appliedMods`).
- No backend changes.

## Follow-up

- **#688** — `StatList` (now only used by `EquippedTotals`) still duplicates `TooltipStatsGrid`; folding its `emptyText` + decimal-formatting features into the shared primitive and deleting `StatList` was kept out of scope here.

Closes #599

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXUCbh1jWajqkNnZas6Fuz)_