### PR TITLE
Gate TagsController behind admin authorization filter (#690)

### DIFF
--- a/Game.Api.Tests/Integration/TagsControllerTests.cs
+++ b/Game.Api.Tests/Integration/TagsControllerTests.cs
@@ -13,8 +13,9 @@ namespace Game.Api.Tests.Integration
 {
     /// <summary>
     /// Integration tests for the Tags reference reads — the only remaining HTTP-exclusive reference
-    /// endpoints (consumed by the Workbench). They are read live from the database (no in-memory cache),
-    /// so seeding a tag and reading it back exercises the controller and the IAsyncEnumerable projection.
+    /// endpoints (consumed by the admin Workbench). They are read live from the database (no in-memory
+    /// cache), so seeding a tag and reading it back exercises the controller and the IAsyncEnumerable
+    /// projection. The endpoints are admin-only (#690), so the authenticated reader is granted the Admin role.
     /// </summary>
     [Collection("Integration")]
     public class TagsControllerTests : ApiIntegrationTestBase
@@ -31,6 +32,7 @@ namespace Game.Api.Tests.Integration
                 var context = scope.ServiceProvider.GetRequiredService<GameContext>();
                 var user = await TestDataSeeder.CreateUserAsync(context, Username, Password);
                 await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+                await TestDataSeeder.AssignRoleToUserAsync(context, user.Id, ERole.Admin);
                 await TestDataSeeder.CreateTagAsync(context, tagName, ETagCategory.Accessory);
             }
 
@@ -78,6 +80,29 @@ namespace Game.Api.Tests.Integration
             var response = await Client.GetAsync("/api/Tags", CancellationToken);
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("/api/Tags")]
+        [InlineData("/api/Tags/TagCategories")]
+        public async Task TagsEndpoints_NonAdmin_Returns403(string url)
+        {
+            int userId, playerId;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                var user = await TestDataSeeder.CreateUserAsync(context, "nonadmintags", "nonadminpass");
+                var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+                userId = user.Id;
+                playerId = player.Id;
+            }
+
+            // Non-admin token: the endpoints are gated by AdminRoleAuthorizationFilter (#690).
+            using var client = CreateAuthenticatedClient(userId, playerId);
+
+            var response = await client.GetAsync(url, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
     }
 }

--- a/Game.Api/Controllers/TagsController.cs
+++ b/Game.Api/Controllers/TagsController.cs
@@ -1,5 +1,6 @@
 using Game.Abstractions.Contracts;
 using Game.Abstractions.DataAccess;
+using Game.Api.Filters;
 using Game.Api.Models.Common;
 using Microsoft.AspNetCore.Mvc;
 
@@ -7,6 +8,7 @@ namespace Game.Api.Controllers
 {
     [Route("/api/[controller]/[action]")]
     [ApiController]
+    [ServiceFilter(typeof(AdminRoleAuthorizationFilter))]
     public class TagsController(ITags tags, ITagCategories tagCategories) : ControllerBase
     {
         private readonly ITags _tags = tags;


### PR DESCRIPTION
## Summary

`docs/backend.md` classifies the `Tags` / `Tags/TagCategories` endpoints as **admin-only** reference reads, and they are only consumed by the admin Workbench (`UI/src/routes/admin/workbench/`). But `TagsController` carried only `[ApiController]` plus the global authenticate-only fallback policy, so **any authenticated non-admin player could enumerate the full tag catalogue** — code and docs disagreed, which is exactly the kind of drift that hides a real authorization hole.

This takes the documented direction: gate the controller as admin-only so code and docs agree.

## Changes

- Add `[ServiceFilter(typeof(AdminRoleAuthorizationFilter))]` to `TagsController`, matching every sibling admin reference-data controller.
- No docs change needed — `docs/backend.md` already lists `Tags` / `Tags/TagCategories` among "the admin-only reference/user reads".

## How it addresses the issue

The issue offered two forks (gate it as admin, or reclassify it as player-readable). I verified the frontend only ever calls these endpoints from the admin Workbench reference loader (`reference.svelte.ts` and `entities/tag.ts`), so the documented admin-only intent is correct and no player UI breaks. Took the gate-it path.

## Test plan

- Existing reference-read integration tests (`Tags_ReturnsSeededTag`, `TagCategories_ReturnsIntrinsicCategories`) now grant the seeded reader the `Admin` role via the real login flow, so they continue to assert a `200` + correct payload through the now-gated endpoint.
- New theory `TagsEndpoints_NonAdmin_Returns403` asserts an authenticated non-admin token gets `403` on both `/api/Tags` and `/api/Tags/TagCategories`.
- `Tags_Unauthenticated_Returns401` still covers the unauthenticated `401` case.
- Full `Game.Api.Tests` suite: **440 passed, 0 failed**. `dotnet build`: clean.

Closes #690


---
_Generated by [Claude Code](https://claude.ai/code/session_01H8AAj6AsVb6fXkxfdTN3Zu)_