### PR TITLE
Reject duplicate-attribute stat updates instead of silently dropping them

### DIFF
--- a/Game.Core.Tests/Players/PlayerStatPointsTests.cs
+++ b/Game.Core.Tests/Players/PlayerStatPointsTests.cs
@@ -166,20 +166,20 @@ namespace Game.Core.Tests.Players
         }
 
         [Fact]
-        public void TryUpdateAttributes_DuplicateUpdatesForSameAttribute_AppliesOnlyTheFirst()
+        public void TryUpdateAttributes_DuplicateAttribute_RejectsWithNoMutation()
         {
-            // Indexing keeps the first update per attribute (matching the prior FirstOrDefault), so a
-            // second update for the same attribute is ignored rather than summed.
+            // A duplicate update for the same attribute is ambiguous, so the whole payload is rejected
+            // with no mutation rather than silently keeping only the first update (#698).
             var stats = MakeStats(gained: 10, used: 0);
 
             var result = stats.TryUpdateAttributes([
-                new Update(EAttribute.Strength, 2),
                 new Update(EAttribute.Strength, 5),
+                new Update(EAttribute.Strength, -3),
             ]);
 
-            Assert.True(result);
-            Assert.Equal(2, stats.StatPointsUsed);
-            Assert.Equal(2, stats.StatAllocations.First(a => a.Attribute == EAttribute.Strength).Amount);
+            Assert.False(result);
+            Assert.Equal(0, stats.StatPointsUsed);
+            Assert.Equal(0, stats.StatAllocations.First(a => a.Attribute == EAttribute.Strength).Amount);
         }
 
         private static PlayerStatPoints MakeStats(int gained, int used)

--- a/Game.Core/Players/PlayerStatPoints.cs
+++ b/Game.Core/Players/PlayerStatPoints.cs
@@ -37,11 +37,14 @@ namespace Game.Core.Players
         public bool TryUpdateAttributes(IEnumerable<IAttributeUpdate> changedAttributes)
         {
             var allocationsByAttribute = StatAllocations.ToDictionary(allocation => allocation.Attribute);
-            // Match each update to the player's existing allocation row, keeping the first update per
-            // attribute (matching the prior FirstOrDefault). An update targeting an attribute the player
-            // has no allocation row for is rejected outright (#488): only the core attributes are seeded
-            // as rows, so allocating into an unknown (or derived) attribute is an invalid request, not a
-            // silent no-op that still reports success.
+            // Match each update to the player's existing allocation row. Two payloads are rejected
+            // outright (no mutation, all-or-nothing anti-cheat contract):
+            //  - An update targeting an attribute the player has no allocation row for (#488): only the
+            //    core attributes are seeded as rows, so allocating into an unknown (or derived) attribute
+            //    is an invalid request, not a silent no-op that still reports success.
+            //  - A duplicate update for the same attribute (#698): an ambiguous payload can't be resolved
+            //    to a single intended amount, so the whole request is invalid rather than a silent
+            //    partial apply (keeping only the first update) that still reports success.
             var matchedUpdates = new Dictionary<EAttribute, (StatAllocation Allocation, IAttributeUpdate Update)>();
             foreach (var update in changedAttributes)
             {
@@ -50,7 +53,10 @@ namespace Game.Core.Players
                     return false;
                 }
 
-                matchedUpdates.TryAdd(update.Attribute, (allocation, update));
+                if (!matchedUpdates.TryAdd(update.Attribute, (allocation, update)))
+                {
+                    return false;
+                }
             }
 
             var changedPoints = matchedUpdates.Values.Sum(match => match.Update.Amount);


### PR DESCRIPTION
## Summary

Fixes #698.

`PlayerStatPoints.TryUpdateAttributes` built its matched-update set with `matchedUpdates.TryAdd(...)`, which keeps only the **first** update per attribute id and silently discards any later update for the same attribute while still reporting success. A payload like `{ Str: +5, Str: -3 }` would partially apply `+5`, and the point accounting operated on a different set than the client actually submitted — the silent-partial-apply class of bug, inconsistent with the all-or-nothing anti-cheat model for stat allocation.

## Change

- In the existing match loop, reject the whole payload with **no mutation** when `TryAdd` reports a duplicate attribute id:
  ```csharp
  if (!matchedUpdates.TryAdd(update.Attribute, (allocation, update)))
  {
      return false;
  }
  ```
  This sits right next to the #488 unknown-attribute `return false`, reusing the same structure (no extra `GroupBy`/scan pass).

## Tests

- Replaced the previous `TryUpdateAttributes_DuplicateUpdatesForSameAttribute_AppliesOnlyTheFirst` test (which asserted the old silent-drop behavior) with `TryUpdateAttributes_DuplicateAttribute_RejectsWithNoMutation`, asserting the duplicate payload is rejected and neither `StatPointsUsed` nor the allocation amount changes.
- The #488 unknown-attribute tests are untouched.
- Full `Game.Core.Tests` suite passes locally (526 tests).

## Note

This PR was rebased onto current `main` after #488 landed; the unknown-attribute rejection mentioned earlier as a possible follow-up is already implemented there, so no follow-up issue is filed.

https://claude.ai/code/session_01WYuRPiavGvHXrENj5Ly8Uv