### PR TITLE
Reject duplicate-attribute stat point updates (#698)

### DIFF
--- a/Game.Core.Tests/Players/PlayerStatPointsTests.cs
+++ b/Game.Core.Tests/Players/PlayerStatPointsTests.cs
@@ -166,10 +166,11 @@ namespace Game.Core.Tests.Players
         }
 
         [Fact]
-        public void TryUpdateAttributes_DuplicateUpdatesForSameAttribute_AppliesOnlyTheFirst()
+        public void TryUpdateAttributes_DuplicateUpdatesForSameAttribute_RejectsWithoutMutating()
         {
-            // Indexing keeps the first update per attribute (matching the prior FirstOrDefault), so a
-            // second update for the same attribute is ignored rather than summed.
+            // A payload containing more than one update for the same attribute is ambiguous and is
+            // rejected outright (#698) rather than silently keeping the first and discarding the rest,
+            // which would partially apply the payload while still reporting success.
             var stats = MakeStats(gained: 10, used: 0);
 
             var result = stats.TryUpdateAttributes([
@@ -177,9 +178,46 @@ namespace Game.Core.Tests.Players
                 new Update(EAttribute.Strength, 5),
             ]);
 
-            Assert.True(result);
-            Assert.Equal(2, stats.StatPointsUsed);
-            Assert.Equal(2, stats.StatAllocations.First(a => a.Attribute == EAttribute.Strength).Amount);
+            Assert.False(result);
+            Assert.Equal(0, stats.StatPointsUsed);
+            Assert.Equal(0, stats.StatAllocations.First(a => a.Attribute == EAttribute.Strength).Amount);
+        }
+
+        [Fact]
+        public void TryUpdateAttributes_DuplicateSummingToValidTotal_StillRejects()
+        {
+            // The { Str: +5, Str: -3 } payload from #698: even though the net spend (+2) and each step
+            // would be individually affordable, the duplicate attribute id makes the payload invalid and
+            // it must be rejected with no mutation rather than partially applied.
+            var stats = MakeStats(gained: 10, used: 0);
+
+            var result = stats.TryUpdateAttributes([
+                new Update(EAttribute.Strength, 5),
+                new Update(EAttribute.Strength, -3),
+            ]);
+
+            Assert.False(result);
+            Assert.Equal(0, stats.StatPointsUsed);
+            Assert.Equal(0, stats.StatAllocations.First(a => a.Attribute == EAttribute.Strength).Amount);
+        }
+
+        [Fact]
+        public void TryUpdateAttributes_DuplicateAmongOtherwiseValidUpdates_RejectsEntireSet()
+        {
+            // A duplicate appearing alongside an otherwise valid distinct update rejects the whole set,
+            // leaving every allocation and the point pool untouched.
+            var stats = MakeStats(gained: 10, used: 0);
+
+            var result = stats.TryUpdateAttributes([
+                new Update(EAttribute.Endurance, 3),
+                new Update(EAttribute.Strength, 2),
+                new Update(EAttribute.Strength, 1),
+            ]);
+
+            Assert.False(result);
+            Assert.Equal(0, stats.StatPointsUsed);
+            Assert.Equal(0, stats.StatAllocations.First(a => a.Attribute == EAttribute.Strength).Amount);
+            Assert.Equal(0, stats.StatAllocations.First(a => a.Attribute == EAttribute.Endurance).Amount);
         }
 
         private static PlayerStatPoints MakeStats(int gained, int used)

--- a/Game.Core/Players/PlayerStatPoints.cs
+++ b/Game.Core/Players/PlayerStatPoints.cs
@@ -37,11 +37,12 @@ namespace Game.Core.Players
         public bool TryUpdateAttributes(IEnumerable<IAttributeUpdate> changedAttributes)
         {
             var allocationsByAttribute = StatAllocations.ToDictionary(allocation => allocation.Attribute);
-            // Match each update to the player's existing allocation row, keeping the first update per
-            // attribute (matching the prior FirstOrDefault). An update targeting an attribute the player
-            // has no allocation row for is rejected outright (#488): only the core attributes are seeded
-            // as rows, so allocating into an unknown (or derived) attribute is an invalid request, not a
-            // silent no-op that still reports success.
+            // Match each update to the player's existing allocation row. An update targeting an attribute
+            // the player has no allocation row for is rejected outright (#488): only the core attributes
+            // are seeded as rows, so allocating into an unknown (or derived) attribute is invalid. A
+            // duplicate attribute id is likewise rejected (#698): keeping only the first update would
+            // partially apply the payload while still reporting success, mirroring the loadout path's
+            // duplicate rejection in TrySetSelectedSkills.
             var matchedUpdates = new Dictionary<EAttribute, (StatAllocation Allocation, IAttributeUpdate Update)>();
             foreach (var update in changedAttributes)
             {
@@ -50,7 +51,10 @@ namespace Game.Core.Players
                     return false;
                 }
 
-                matchedUpdates.TryAdd(update.Attribute, (allocation, update));
+                if (!matchedUpdates.TryAdd(update.Attribute, (allocation, update)))
+                {
+                    return false;
+                }
             }
 
             var changedPoints = matchedUpdates.Values.Sum(match => match.Update.Amount);


### PR DESCRIPTION
## Summary

`PlayerStatPoints.TryUpdateAttributes` built its matched-update set with `Dictionary.TryAdd`, which kept only the **first** update per attribute id and silently discarded any later duplicate, then still reported success. A payload like `{ Str: +5, Str: -3 }` would partially apply (`+5`) while the point accounting ran against a set the client never actually submitted — the silent-partial-apply class of bug. This violates the documented anti-cheat model: an invalid payload must be **rejected with no state mutation**.

The sibling loadout path (`Player.TrySetSelectedSkills`) already rejects duplicate ids via its `HasDuplicate` check, so the two anti-cheat paths were inconsistent. This brings stat allocation in line.

## Change

- In `Game.Core/Players/PlayerStatPoints.cs`, the matched-update loop now rejects (`return false`) before any mutation when `TryAdd` reports a duplicate attribute id, instead of swallowing it. The existing unknown-attribute rejection (#488) is preserved. Detecting the duplicate inline via the `TryAdd` result keeps it to a single pass and avoids an extra collection — the natural analog of the loadout path's up-front duplicate rejection.
- Comment updated to document the duplicate-rejection rationale.

## Tests

In `Game.Core.Tests/Players/PlayerStatPointsTests.cs`, the test that asserted the old silent-first-wins behavior is replaced with rejection-without-mutation coverage:

- duplicate attribute id -> returns false, `StatPointsUsed` and the allocation are untouched;
- the `{ Str: +5, Str: -3 }` case from the issue, whose net spend would otherwise be affordable, still rejects;
- a duplicate mixed with an otherwise valid distinct update rejects the entire set.

The existing valid single/multi-attribute paths are unchanged and still pass. `dotnet build Game.sln` is clean (0 warnings); `Game.Core.Tests` passes 528/528.

Closes #698

https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7)_