### PR TITLE
Replace biased enemy skill shuffle with partial Fisher–Yates

### DIFF
--- a/Game.Core.Tests/Enemies/EnemyTests.cs
+++ b/Game.Core.Tests/Enemies/EnemyTests.cs
@@ -40,6 +40,57 @@ namespace Game.Core.Tests.Enemies
         }
 
         [Fact]
+        public void SelectBattleSkills_OverManyRuns_AlwaysYieldsADistinctCappedSubset()
+        {
+            // The selection uses Random.Shared (no injectable seam), so rather than assert an exact
+            // permutation we assert the invariants hold on every run: capped count, drawn from the
+            // available pool, and no duplicates.
+            var available = Skills(8);
+            var availableIds = available.Select(s => s.Id).ToHashSet();
+            var enemy = MakeEnemy(available);
+
+            for (var run = 0; run < 1000; run++)
+            {
+                enemy.SelectBattleSkills();
+                var selectedIds = enemy.BattleSkills.Select(s => s.Id).ToList();
+
+                Assert.Equal(4, selectedIds.Count);
+                Assert.All(selectedIds, id => Assert.Contains(id, availableIds));
+                Assert.Equal(selectedIds.Count, selectedIds.Distinct().Count());
+            }
+        }
+
+        [Fact]
+        public void SelectBattleSkills_OverManyRuns_CanSelectEverySkillAndEveryPosition()
+        {
+            // A degenerate or structurally-biased selection would systematically exclude some skill or
+            // never place a skill in some slot. Across many runs an unbiased partial Fisher–Yates must
+            // reach every available skill, in every loadout position.
+            var available = Skills(8);
+            var enemy = MakeEnemy(available);
+            var seenSkillIds = new HashSet<int>();
+            var seenAtPosition = new HashSet<int>[4];
+            for (var pos = 0; pos < seenAtPosition.Length; pos++)
+            {
+                seenAtPosition[pos] = [];
+            }
+
+            for (var run = 0; run < 2000; run++)
+            {
+                enemy.SelectBattleSkills();
+                var selectedIds = enemy.BattleSkills.Select(s => s.Id).ToList();
+                for (var pos = 0; pos < selectedIds.Count; pos++)
+                {
+                    seenSkillIds.Add(selectedIds[pos]);
+                    seenAtPosition[pos].Add(selectedIds[pos]);
+                }
+            }
+
+            Assert.Equal(8, seenSkillIds.Count);
+            Assert.All(seenAtPosition, positionIds => Assert.Equal(8, positionIds.Count));
+        }
+
+        [Fact]
         public void SelectBattleSkills_DoesNotMutateAvailableSkills()
         {
             var enemy = MakeEnemy(Skills(6));

--- a/Game.Core/Enemies/Enemy.cs
+++ b/Game.Core/Enemies/Enemy.cs
@@ -43,7 +43,17 @@ namespace Game.Core.Enemies
         /// </summary>
         public void SelectBattleSkills()
         {
-            _battleSkills = [.. AvailableSkills.OrderBy(_ => Random.Shared.Next()).Take(MaxBattleSkills)];
+            // Partial Fisher–Yates: draw an unbiased, uniformly-distributed sample (and ordering) of the
+            // available skills, rather than the biased OrderBy(random) sort it replaces.
+            var pool = AvailableSkills.ToArray();
+            var take = Math.Min(MaxBattleSkills, pool.Length);
+            for (var i = 0; i < take; i++)
+            {
+                var swap = Random.Shared.Next(i, pool.Length);
+                (pool[i], pool[swap]) = (pool[swap], pool[i]);
+            }
+
+            _battleSkills = [.. pool[..take]];
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

`Enemy.SelectBattleSkills` picked its battle loadout with `AvailableSkills.OrderBy(_ => Random.Shared.Next()).Take(MaxBattleSkills)` — the classic "random sort". The comparison keys do not form a stable permutation, so both *which* skills are chosen and *their order* are non-uniformly distributed. Since the selected loadout is the source of truth that gets snapshotted and sent to the client, that bias directly skews which skills enemies actually fight with (and the ordering bias can interact with anything order-dependent downstream).

This replaces it with an unbiased **partial Fisher–Yates** selection that draws `MaxBattleSkills` items uniformly (and in uniform order) from `AvailableSkills`. The public contract is preserved:
- capped at `MaxBattleSkills` (4) when more are available;
- returns all skills when fewer than the cap are available;
- same `IReadOnlyList<Skill>` return type / `BattleSkills` behavior.

## Battle-parity reasoning

Per CLAUDE.md, battle logic must stay consistent between frontend and backend with mirrored tests. Enemy battle-skill *selection* is **not** part of that shared deterministic simulation — it is **server-only, non-deterministic loadout setup**:

- It uses ambient randomness (`Random.Shared`), deliberately *not* the battle seed. `backend.md` (Battle setup) states the seed is reserved for the simulation's RNG so the server's setup draws never advance the seed's stream and diverge from the client, which receives the loadout ready-made.
- The chosen loadout is **snapshotted** onto `PlayerState.ActiveEnemySkillIds` and sent to the client; validation reconstructs the enemy via `Enemy.SetBattleSkills(ids)`, so both sides simulate the identical loadout. The randomness happens *before* the deterministic sim and is captured.
- The deterministic boss path (`SelectAllBattleSkills`) is untouched.

Conclusion: this is server-only setup, so **no frontend change and no mirrored frontend parity test are required**. The mirrored parity matrix covers the simulation, not the loadout draw.

## Tests

Pure domain logic (`Game.Core.Tests`) — no DB/Redis. The selection uses `Random.Shared` with no injectable RNG seam; rather than over-engineer a seam just for tests, the new tests assert distributional/structural invariants:
- existing tests already cover count (cap and keep-all), subset-of-available, and distinctness for a single run;
- `SelectBattleSkills_OverManyRuns_AlwaysYieldsADistinctCappedSubset` — invariants hold on every run over 1000 runs;
- `SelectBattleSkills_OverManyRuns_CanSelectEverySkillAndEveryPosition` — across runs every available skill and every loadout position is reachable, which a degenerate/structurally-biased selection would fail.

`dotnet build Game.sln`: succeeded, 0 warnings. `dotnet test Game.Core.Tests`: 528 passed, 0 failed.

Closes #700

https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7)_