### PR TITLE
Log request-end event when the request pipeline throws

### DIFF
--- a/Game.Api.Tests/Unit/RequestLoggingMiddlewareTests.cs
+++ b/Game.Api.Tests/Unit/RequestLoggingMiddlewareTests.cs
@@ -1,0 +1,60 @@
+using Game.Abstractions.DataAccess;
+using Game.Api.Middleware;
+using Game.Api.Services;
+using Game.Core.Players;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Game.Api.Tests.Unit
+{
+    /// <summary>
+    /// Covers the middleware's error-path observability guarantee: the "Request Ended" event (status +
+    /// duration) is emitted even when the downstream pipeline throws, and the exception still propagates.
+    /// </summary>
+    public class RequestLoggingMiddlewareTests
+    {
+        [Fact]
+        public async Task ThrowingPipeline_StillLogsRequestEnded_AndRethrows()
+        {
+            var capturingProvider = new CapturingLoggerProvider();
+            using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(capturingProvider));
+            var logger = loggerFactory.CreateLogger<RequestLoggingMiddleware>();
+
+            var thrown = new InvalidOperationException("downstream boom");
+            RequestDelegate next = _ => throw thrown;
+            var middleware = new RequestLoggingMiddleware(next, logger);
+
+            var context = new DefaultHttpContext();
+            context.Request.Method = "GET";
+            context.Request.Path = "/api/Login/Status";
+            context.Response.StatusCode = 500;
+            var sessionService = new SessionService(new NoOpSessionStore());
+
+            var caught = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => middleware.InvokeAsync(context, sessionService));
+            Assert.Same(thrown, caught);
+
+            var category = typeof(RequestLoggingMiddleware).FullName;
+            Assert.NotNull(category);
+            var entries = capturingProvider.Entries.Where(e => e.Category == category).ToList();
+
+            Assert.Single(entries, e => e.Message == "Request Start");
+
+            var endedEntry = Assert.Single(entries, e => e.Message.StartsWith("Request Ended"));
+            Assert.Equal(LogLevel.Information, endedEntry.Level);
+            var statusCode = (int)Assert.IsType<int>(endedEntry.Properties.Single(p => p.Key == "StatusCode").Value);
+            Assert.Equal(500, statusCode);
+            var elapsedMs = (long)Assert.IsType<long>(endedEntry.Properties.Single(p => p.Key == "ElapsedMs").Value);
+            Assert.True(elapsedMs >= 0);
+        }
+
+        private sealed class NoOpSessionStore : ISessionStore
+        {
+            public Task<PlayerState?> GetSession(int userId) => Task.FromResult<PlayerState?>(null);
+            public void Update(PlayerState sessionData, int userId) { }
+            public void Clear(int userId) { }
+        }
+    }
+}

--- a/Game.Api/Middleware/RequestLoggingMiddleware.cs
+++ b/Game.Api/Middleware/RequestLoggingMiddleware.cs
@@ -26,11 +26,18 @@ namespace Game.Api.Middleware
             using var scope = _logger.BeginScope(loggingContext);
             _logger.LogInformation("Request Start");
 
-            await _next(context);
-
-            stopwatch.Stop();
-            _logger.LogInformation("Request Ended {StatusCode} {ElapsedMs}ms",
-                context.Response.StatusCode, stopwatch.ElapsedMilliseconds);
+            // Emit the end event from a finally so the status/duration are logged even when the
+            // pipeline throws — the failing request is the one most worth diagnosing.
+            try
+            {
+                await _next(context);
+            }
+            finally
+            {
+                stopwatch.Stop();
+                _logger.LogInformation("Request Ended {StatusCode} {ElapsedMs}ms",
+                    context.Response.StatusCode, stopwatch.ElapsedMilliseconds);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`RequestLoggingMiddleware` awaited `_next(context)` **outside** a `try/finally`, so when a downstream component threw, only the "Request Start" event was logged — `stopwatch.Stop()` and the "Request Ended" event (status code + duration) never ran. The failing request, the one most worth diagnosing, was left without an end log: an observability gap precisely on the error path.

## Change

- Wrap the downstream `await _next(context)` in `try/finally` and emit the "Request Ended" event from the `finally`. The exception still propagates unchanged (no `catch`), so nothing else in the pipeline's error handling is altered.
- The stopwatch is stopped inside the `finally`, so the duration is measured correctly across the throwing path. On an unhandled exception `context.Response.StatusCode` is the framework's default 500, which is exactly the status we want to surface.

## On "optionally logging the exception"

The issue suggested optionally logging the exception here too. I deliberately did **not** add an exception log: the middleware's documented responsibility is structured start/end events, and adding an error log would (a) broaden that responsibility and (b) risk double-logging the same exception once a dedicated exception-handling middleware is introduced. The `finally` already closes the actual observability gap (status + duration on the error path), and the exception continues to propagate to whatever logs it.

## Tests

Added a focused unit test (`Game.Api.Tests/Unit/RequestLoggingMiddlewareTests.cs`) that drives the middleware with a throwing `RequestDelegate` and asserts the "Request Ended" event (status 500 + non-negative elapsed) is still logged and the original exception is rethrown. The throwing path is pure in-process logic with no out-of-process dependency, so per the project's testing guidelines it belongs as a unit test rather than an integration test; this also makes it deterministic, independent of TestServer's exception-propagation semantics.

`dotnet build Game.sln` succeeds with 0 warnings/0 errors. `dotnet test Game.Api.Tests`: **443 passed, 0 failed**.

## Follow-ups noticed

- There is no exception-handling middleware (`UseExceptionHandler` / a problem-details handler) in the pipeline at all. Unhandled exceptions currently propagate to the host/TestServer default. A dedicated handler producing a consistent error response (and being the single place that logs the exception) would be a worthwhile separate enhancement.

Closes #695

https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7)_