### PR TITLE
Fix asymmetric skew tolerance voiding legitimate victories (#699)

### DIFF
--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -236,6 +236,92 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task EndBattleVictory_ClaimedSlightlyAheadOfServer_WithinSkewTolerance_ReturnsDefeatResult()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, skill.Id);
+            var zone = await TestDataSeeder.CreateZoneAsync(context);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, skill.Id);
+
+            // Reference data was seeded directly; reload the caches so battle setup resolves it (the caches
+            // no longer lazily refill).
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+
+            await battleService.StartBattle(player, state, zoneId: zone.Id);
+            Assert.True(state.HasActiveBattle);
+
+            // Backdate the battle start so the simulation's TotalMs has already elapsed (the "too early"
+            // side is satisfied), isolating the future-side skew check.
+            state.BattleStartTime = DateTime.UtcNow.AddMinutes(-10);
+
+            // A benign client clock that leads the server by less than the skew tolerance must NOT void
+            // the win — the prior zero-tolerance future check would have dropped this legitimate victory.
+            var claimedTimestamp = DateTime.UtcNow.AddMilliseconds(50);
+            var result = await battleService.EndBattleVictory(player, state, claimedTimestamp);
+
+            Assert.NotNull(result);
+            Assert.True(result.ExpReward >= 0);
+            Assert.False(state.HasActiveBattle);
+        }
+
+        [Fact]
+        public async Task EndBattleVictory_ClaimedFarAheadOfServer_BeyondSkewTolerance_ReturnsNull()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, skill.Id);
+            var zone = await TestDataSeeder.CreateZoneAsync(context);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, skill.Id);
+
+            // Reference data was seeded directly; reload the caches so battle setup resolves it (the caches
+            // no longer lazily refill).
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+
+            await battleService.StartBattle(player, state, zoneId: zone.Id);
+            Assert.True(state.HasActiveBattle);
+
+            // Backdate so the "too early" side is satisfied, isolating the future-side skew check.
+            state.BattleStartTime = DateTime.UtcNow.AddMinutes(-10);
+
+            // A claim far beyond the skew tolerance into the future is anti-cheat and must still be rejected,
+            // and the active battle must remain so the client can re-claim with a corrected timestamp.
+            var claimedTimestamp = DateTime.UtcNow.AddSeconds(2);
+            var result = await battleService.EndBattleVictory(player, state, claimedTimestamp);
+
+            Assert.Null(result);
+            Assert.True(state.HasActiveBattle);
+        }
+
+        [Fact]
         public async Task EndBattleVictory_Success_PersistsPlayerToCache()
         {
             using var scope = CreateScope();

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -28,6 +28,11 @@ namespace Game.Application.Services
         private readonly ISkills _skills = skills;
         private readonly BattleFactory _battleFactory = battleFactory;
 
+        // Symmetric clock-skew tolerance for the client-claimed victory timestamp: benign skew in either
+        // direction (client clock lagging behind or leading the server) is absorbed, while a claim outside
+        // this envelope on either side is rejected by the anti-cheat check in EndBattleVictory.
+        private static readonly TimeSpan ClaimedTimestampSkewTolerance = TimeSpan.FromMilliseconds(100);
+
         public async Task<BattleStartResult> StartBattle(Player player, PlayerState state, int zoneId, int? newZoneId = null, CancellationToken cancellationToken = default)
         {
             if (state.HasActiveBattle)
@@ -138,7 +143,11 @@ namespace Game.Application.Services
             var earliestDefeat = state.BattleStartTime.AddMilliseconds(result.TotalMs);
             var now = DateTime.UtcNow;
 
-            if (earliestDefeat - claimedTimestamp > TimeSpan.FromMilliseconds(100) || claimedTimestamp > now)
+            // Reject a claim that lands outside the symmetric skew envelope on either side: too early
+            // (clock lagging) or too far in the future (clock leading) is anti-cheat, but benign skew
+            // within the tolerance is accepted so a slightly-ahead client clock does not void a real win.
+            if (earliestDefeat - claimedTimestamp > ClaimedTimestampSkewTolerance
+                || claimedTimestamp - now > ClaimedTimestampSkewTolerance)
             {
                 return null;
             }


### PR DESCRIPTION
## Summary

`BattleService.EndBattleVictory` validates the client-supplied claimed victory timestamp against the server's view of time. The check gave a ~100ms tolerance on the "too early" side (client clock lagging behind the server) but **zero** tolerance on the future side:

```csharp
if (earliestDefeat - claimedTimestamp > TimeSpan.FromMilliseconds(100) || claimedTimestamp > now)
{
    return null;
}
```

So a client whose clock leads the server by even a fraction of a millisecond produced `claimedTimestamp > now`, and the **entire victory was dropped** — earned exp and progress discarded with no retry. This is exactly the benign clock skew the 100ms past-tolerance exists to absorb, just on the other side.

## Change

Apply a **symmetric** skew envelope on both sides, reusing a single named constant rather than introducing a second magic number (DRY):

```csharp
private static readonly TimeSpan ClaimedTimestampSkewTolerance = TimeSpan.FromMilliseconds(100);
...
if (earliestDefeat - claimedTimestamp > ClaimedTimestampSkewTolerance
    || claimedTimestamp - now > ClaimedTimestampSkewTolerance)
{
    return null;
}
```

The existing 100ms value (previously inline) is preserved as the envelope on both sides — benign skew in either direction is now absorbed, while a claim that lands too early (clock lagging) or too far in the future (clock leading) is still rejected as the anti-cheat control.

## Battle-parity reasoning

CLAUDE.md requires that battle logic implemented on both frontend and backend stays consistent and that battle-logic tests be mirrored across suites. I evaluated whether this timestamp-skew validation falls under that rule and concluded it does **not**:

- The shared, parity-critical battle logic is the **deterministic simulation** in `Game.Core/Battle` (`BattleSimulator`, `Battler`, `BattleSkill`, `BattleContext`) and its frontend mirror in `UI/src/lib/engine` — pinned by the mirrored parity matrix. That simulation produces `result.TotalMs` from a seed + snapshot and is identical on both sides by construction.
- The skew check is **server-only anti-cheat**: it compares the client's wall-clock `claimedTimestamp` against the server's `DateTime.UtcNow`. `DateTime.UtcNow` has no frontend counterpart and is intentionally outside the deterministic simulation. The backend doc's "Anti-cheat note" on `RecordVictory` already frames this validation as a server-side timeline control, distinct from the parity-shared simulation.

Therefore no frontend change and no mirrored frontend test are needed. No API contract changed (signature, DTOs, and socket command shapes are untouched), so no codegen was run.

## Tests

Added two integration tests in `BattleServiceIntegrationTests` and kept the existing cases passing:
- `EndBattleVictory_ClaimedSlightlyAheadOfServer_WithinSkewTolerance_ReturnsDefeatResult` — client clock leads by 50ms: victory **accepted** (this is the regression the prior zero-tolerance future check caused).
- `EndBattleVictory_ClaimedFarAheadOfServer_BeyondSkewTolerance_ReturnsNull` — client clock leads by 2s: **rejected**, and the battle is left active so the client can re-claim with a corrected timestamp.
- Existing `EndBattleVictory_TimestampTooEarly_ReturnsNull` and `EndBattleVictory_ValidTimestamp_ReturnsDefeatResult` continue to pass.

Both new tests backdate `BattleStartTime` so `earliestDefeat` is well in the past, isolating the future-side check under test. `dotnet build Game.sln` succeeds with 0 warnings; the full `Game.Application.Tests` project passes (232/232).

Closes #699

https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7)_