### PR TITLE
Harden Game.Infrastructure concurrency/memory model (#696)

### DIFF
--- a/Game.Infrastructure.Tests/RedisMultiplexerFactoryTests.cs
+++ b/Game.Infrastructure.Tests/RedisMultiplexerFactoryTests.cs
@@ -1,0 +1,104 @@
+using Game.Infrastructure.Redis;
+using Xunit;
+
+namespace Game.Infrastructure.Tests
+{
+    /// <summary>
+    /// Tests the keyed get-or-add reuse semantics of <see cref="RedisMultiplexerFactory"/> (#696). The connect
+    /// step itself opens a real Redis connection, so it is covered by integration tests rather than here; this
+    /// exercises the cache/lock logic through the generic <c>GetOrAdd</c> seam with sentinel values and a stub
+    /// factory, which is exactly the branch that decides whether two requests share a multiplexer or each open
+    /// their own.
+    /// </summary>
+    public class RedisMultiplexerFactoryTests
+    {
+        [Fact]
+        public void GetOrAdd_SameKey_ReturnsSameValueAndCreatesOnce()
+        {
+            var cache = new Dictionary<string, object>();
+            var syncRoot = new object();
+            var created = 0;
+            object Factory(string _)
+            {
+                created++;
+                return new object();
+            }
+
+            var first = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "localhost:6379", Factory);
+            var second = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "localhost:6379", Factory);
+
+            // Same key reuses the cached instance and never invokes the factory again.
+            Assert.Same(first, second);
+            Assert.Equal(1, created);
+        }
+
+        [Fact]
+        public void GetOrAdd_DifferentKeys_ReturnsDistinctValues()
+        {
+            var cache = new Dictionary<string, object>();
+            var syncRoot = new object();
+            object Factory(string _) => new object();
+
+            var cacheValue = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "cache:6379", Factory);
+            var pubSubValue = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "pubsub:6380", Factory);
+
+            // Distinct connection strings get distinct instances; identical ones (above) would share.
+            Assert.NotSame(cacheValue, pubSubValue);
+        }
+
+        [Fact]
+        public void GetOrAdd_KeysByExactString_DoesNotNormalize()
+        {
+            var cache = new Dictionary<string, object>();
+            var syncRoot = new object();
+            object Factory(string _) => new object();
+
+            // Two strings that are semantically equivalent but not byte-identical are treated as different keys —
+            // the deliberate trade-off of keying by the raw string rather than a normalized configuration.
+            var lower = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "localhost:6379", Factory);
+            var upper = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "LOCALHOST:6379", Factory);
+
+            Assert.NotSame(lower, upper);
+        }
+
+        [Fact]
+        public void GetOrAdd_ConcurrentFirstRequests_ShareOneCreatedValue()
+        {
+            var cache = new Dictionary<string, object>();
+            var syncRoot = new object();
+            var created = 0;
+            object Factory(string _)
+            {
+                Interlocked.Increment(ref created);
+                return new object();
+            }
+
+            // Many threads racing on the same key must collapse onto a single created instance — the startup race
+            // the locked get-or-add closes. Dedicated threads (not the thread pool) start together on a barrier so
+            // the race is genuine and so the test does not starve the pool the BackgroundWorker tests share.
+            const int threadCount = 16;
+            var results = new object[threadCount];
+            using var barrier = new Barrier(threadCount);
+            var threads = new Thread[threadCount];
+
+            for (var i = 0; i < threadCount; i++)
+            {
+                var index = i;
+                threads[index] = new Thread(() =>
+                {
+                    barrier.SignalAndWait();
+                    results[index] = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "localhost:6379", Factory);
+                });
+                threads[index].Start();
+            }
+
+            foreach (var thread in threads)
+            {
+                thread.Join();
+            }
+
+            Assert.Equal(1, created);
+            Assert.All(results, value => Assert.Same(results[0], value));
+        }
+    }
+}

--- a/Game.Infrastructure/BackgroundWorker.cs
+++ b/Game.Infrastructure/BackgroundWorker.cs
@@ -17,8 +17,12 @@ namespace Game.Infrastructure
         private readonly ILogger<BackgroundWorker> _logger;
         private readonly string _uniqueId = Guid.NewGuid().ToString();
         private readonly RegisteredWaitHandle _workerHandle;
-        private bool _hasBeenKilled = false;
-        private bool _disposed = false;
+
+        // Teardown flags written by Kill()/Dispose() and read by Start(), potentially from different threads, so
+        // they are volatile to publish the write promptly: without it a Start() racing a Dispose() could read a
+        // stale _disposed == false and then Set() an already-disposed _resetEvent.
+        private volatile bool _hasBeenKilled = false;
+        private volatile bool _disposed = false;
 
         // Written on the Start() caller's thread and on the thread-pool worker-loop thread, and read from
         // arbitrary threads, so it is volatile to guarantee writes are published and reads observe transitions

--- a/Game.Infrastructure/Redis/RedisMultiplexerFactory.cs
+++ b/Game.Infrastructure/Redis/RedisMultiplexerFactory.cs
@@ -6,9 +6,14 @@ namespace Game.Infrastructure.Redis
 {
     internal static class RedisMultiplexerFactory
     {
-        private static ConnectionMultiplexer? _cacheInstance;
-        private static ConnectionMultiplexer? _pubsubInstance;
-        private static readonly object _cacheLock = new();
+        // Multiplexers are keyed by the *original* connection string under a single lock. Keying by the raw
+        // string (rather than comparing against ConnectionMultiplexer.Configuration, which StackExchange.Redis
+        // normalizes/rewrites) makes reuse reliable: the cache and pub/sub services share one multiplexer
+        // whenever their connection strings match, and two getters racing on first startup resolve to the same
+        // instance instead of each opening their own (#696). The whole get-or-add runs under the lock, so a
+        // partially-constructed multiplexer is never published to another thread.
+        private static readonly Dictionary<string, ConnectionMultiplexer> _multiplexers = new();
+        private static readonly object _lock = new();
 
         // Minimum size to grow the thread pool to before connecting (see ConnectMultiplexer).
         private const int MinThreadPoolThreads = 32;
@@ -19,33 +24,8 @@ namespace Game.Infrastructure.Redis
             {
                 throw new InvalidOperationException($"{nameof(config.CacheConnectionString)} cannot be null.");
             }
-            else if (_cacheInstance is null)
-            {
-                lock (_cacheLock)
-                {
-                    if (_pubsubInstance is not null && _pubsubInstance.Configuration == config.CacheConnectionString)
-                    {
-                        _cacheInstance = _pubsubInstance;
-                    }
-                    else
-                    {
-                        _cacheInstance ??= ConnectMultiplexer(config.CacheConnectionString);
-                    }
-                }
-            }
 
-            return _cacheInstance;
-        }
-
-        internal static void ResetForTesting()
-        {
-            lock (_cacheLock)
-            {
-                _cacheInstance?.Dispose();
-                _cacheInstance = null;
-                _pubsubInstance?.Dispose();
-                _pubsubInstance = null;
-            }
+            return GetOrConnect(config.CacheConnectionString);
         }
 
         public static ConnectionMultiplexer GetMultiplexer(IPubSubOptions config)
@@ -55,22 +35,48 @@ namespace Game.Infrastructure.Redis
                 throw new InvalidOperationException($"{nameof(config.PubSubConnectionString)} cannot be null.");
             }
 
-            if (_pubsubInstance is null)
-            {
-                lock (_cacheLock)
-                {
-                    if (_cacheInstance is not null && _cacheInstance.Configuration == config.PubSubConnectionString)
-                    {
-                        _pubsubInstance = _cacheInstance;
-                    }
-                    else
-                    {
-                        _pubsubInstance ??= ConnectMultiplexer(config.PubSubConnectionString);
-                    }
-                }
-            }
+            return GetOrConnect(config.PubSubConnectionString);
+        }
 
-            return _pubsubInstance;
+        private static ConnectionMultiplexer GetOrConnect(string connectionString)
+        {
+            return GetOrAdd(_multiplexers, _lock, connectionString, ConnectMultiplexer);
+        }
+
+        /// <summary>
+        /// Locked get-or-add: returns the value cached for <paramref name="key"/>, or invokes
+        /// <paramref name="factory"/> under <paramref name="syncRoot"/> to create and cache one on first request.
+        /// Running the whole lookup-and-create inside the lock is what makes the cache safe to read from multiple
+        /// threads without a partially-constructed value escaping, and what collapses a first-startup race onto a
+        /// single created instance. Generic over the value type so the keyed-reuse semantics are unit-testable
+        /// without a live connection (#696); production keys <see cref="ConnectionMultiplexer"/> by connection
+        /// string.
+        /// </summary>
+        internal static T GetOrAdd<T>(Dictionary<string, T> cache, object syncRoot, string key, Func<string, T> factory)
+        {
+            lock (syncRoot)
+            {
+                if (!cache.TryGetValue(key, out var value))
+                {
+                    value = factory(key);
+                    cache[key] = value;
+                }
+
+                return value;
+            }
+        }
+
+        internal static void ResetForTesting()
+        {
+            lock (_lock)
+            {
+                foreach (var multiplexer in _multiplexers.Values)
+                {
+                    multiplexer.Dispose();
+                }
+
+                _multiplexers.Clear();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes the three grouped memory-model / concurrency issues from the `Game.Infrastructure` health review.

### 1. Broken double-checked locking on the Redis multiplexer singletons
`RedisMultiplexerFactory`'s `_cacheInstance` / `_pubsubInstance` were plain `static` fields read outside the lock and written inside it — classic broken DCL, which under the .NET memory model permits observing a partially-constructed `ConnectionMultiplexer`.

### 2. Unreliable multiplexer reuse
The "reuse the other multiplexer if configs match" branch (a) raced on first startup (two getters resolved concurrently could each connect a multiplexer for the same config), and (b) compared against `ConnectionMultiplexer.Configuration`, which StackExchange.Redis normalizes/rewrites — so it could be unequal to the raw connection string even when semantically identical, silently defeating reuse.

### 3. `BackgroundWorker` teardown race on non-volatile flags
`_disposed` / `_hasBeenKilled` (read in `Start`, written in `Kill`/`Dispose` from another thread) were plain bools. A `Start()` racing a `Dispose()` could read a stale `_disposed == false` and then `Set()` a disposed `AutoResetEvent`.

## Approach

Following the issue's prescribed direction:

- **Collapsed both `GetMultiplexer` overloads onto a single keyed get-or-add** — a `Dictionary<string, ConnectionMultiplexer>` keyed by the **original** connection string, with the whole lookup-and-create running under one lock. This kills both the broken DCL (a partially-constructed value can never escape the lock) and the unreliable reuse (keying by the raw string means cache and pub/sub naturally share one multiplexer whenever their connection strings match, with no normalization comparison and no startup race). The two public overloads remain as thin null-guarded wrappers that delegate to the shared path, so the call sites in `CacheServiceFactory` / `PubSubServiceFactory` are unchanged.
- **Marked `_disposed` / `_hasBeenKilled` `volatile`**, consistent with the already-volatile `_isRunning` the issue points to as the established pattern.

The production thread-pool floor (32) in `ConnectMultiplexer` and the `ResetForTesting()` method the test infrastructure relies on (`IntegrationTestContainers`) are both preserved.

### Rationale notes
- The keyed get-or-add is factored into a small generic internal seam (`GetOrAdd<T>(cache, syncRoot, key, factory)`) purely so the reuse semantics are unit-testable without a live Redis connection (`ConnectionMultiplexer` is sealed and the in-process `Game.Infrastructure.Tests` project deliberately has no Redis dependency). Production always supplies the real `ConnectMultiplexer` connector.
- The null-connection-string guards are retained (defensive; config always supplies one — `docs/backend.md` notes them as measure-only), so the public API and its failure behavior are unchanged.

## Tests
- Added `RedisMultiplexerFactoryTests` covering the get-or-add reuse semantics: same key → same instance (factory invoked once), distinct keys → distinct instances, exact-string (non-normalized) keying, and a concurrent first-request race collapsing onto one created instance (driven on dedicated threads via a `Barrier` so it neither starves the shared thread pool the `BackgroundWorker` timing tests depend on nor relies on it).
- Existing `BackgroundWorkerTests` kept green.
- `dotnet build Game.sln` succeeds; `dotnet test Game.Infrastructure.Tests` passes (37/37) and was verified stable across repeated runs.

Closes #696

## Follow-ups
None required.

https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7)_