### PR TITLE
Key EquippedBand cards by skill identity, not array index

### DIFF
--- a/UI/src/routes/game/screens/skills/EquippedBand.svelte
+++ b/UI/src/routes/game/screens/skills/EquippedBand.svelte
@@ -11,7 +11,7 @@
 </div>
 
 <div class="band" style:--cap={view.cap}>
-	{#each slots as id, index (index)}
+	{#each slots as id, index (id ?? `empty-${index}`)}
 		{@const metrics = id != null ? view.metric(id) : undefined}
 		{#if id != null && metrics}
 			<div

--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -193,6 +193,30 @@ describe('Skills screen', () => {
 		expect(sendSocketCommand).toHaveBeenCalledWith('SetSelectedSkills', [1, 2, 0]);
 	});
 
+	it('keeps a filled card bound to its skill across a reorder (keyed by skill, not slot index)', async () => {
+		const { container } = render(Skills);
+		// Tag the first card's DOM node so we can recognise it after the reorder.
+		const movedCard = container.querySelectorAll<HTMLElement>('.eqcard')[0];
+		expect(movedCard.getAttribute('aria-label')).toContain('Alpha');
+		movedCard.dataset.identityProbe = 'alpha';
+
+		// Move Alpha (slot 1) to the end → loadout [Bravo, Charlie, Alpha].
+		await fireEvent.dragStart(movedCard);
+		const cards = container.querySelectorAll<HTMLElement>('.eqcard');
+		await fireEvent.dragOver(cards[2]);
+		await fireEvent.drop(cards[2]);
+		await fireEvent.dragEnd(cards[2]);
+		expect(sendSocketCommand).toHaveBeenCalledWith('SetSelectedSkills', [1, 2, 0]);
+
+		// Stable keying: the same DOM node follows Alpha to slot 3, rather than the
+		// slot-1 node being reused for Bravo (which index keying would do).
+		const probed = container.querySelector<HTMLElement>('[data-identity-probe="alpha"]');
+		expect(probed).toBe(movedCard);
+		expect(probed?.getAttribute('aria-label')).toContain('Alpha');
+		const reordered = Array.from(container.querySelectorAll<HTMLElement>('.eqcard'));
+		expect(reordered.indexOf(movedCard)).toBe(2);
+	});
+
 	it('resolves a pending swap from a band card via the keyboard', async () => {
 		const { container } = render(Skills);
 		await fireEvent.click(rowByName(container, 'Delta')!);


### PR DESCRIPTION
## Summary

The equipped loadout band in `EquippedBand.svelte` keyed its `{#each}` loop by the array `index`. Because the cards are drag-reorderable and act as swap targets, index keying meant the DOM node bound to a slot *position* was reused when its skill changed, rather than the node following its skill across a reorder. Any transitions or node-bound state therefore attached to the position, not the skill — a reorder/animation correctness hazard.

### Fix

Changed the key from `(index)` to `(id ?? \`empty-${index}\`)` so filled cards follow their skill while empty slots stay distinct. This matches the sibling convention: `SkillRail.svelte` keys by `metrics.skill.id` and the inventory grid keys by `item.itemId`.

### Drag-reorder correctness check

I verified the change is safe against every band handler (`onDragStart`, `onDragOver`, `onDrop`, `onCardKeydown`, `swapInto`, `remove`, `pick`). All of them receive the loop's `index` / `id` as call-time arguments at render. In Svelte 5 the `{#each ... as id, index (key)}` key controls only DOM-node identity/reuse — it does **not** change the `index`/`id` values bound into each rendered block, which Svelte still recomputes for the block's current array position. So the handlers continue to target the correct slot position after the key change; only node reuse improves. The view-model edits (`reorder`, `swapInto`) operate purely on slot positions in `equipped`, never on the loop key.

## Testing

- Added a regression test in `Skills.test.ts` that tags the first card's DOM node, drags it to the end, and asserts the *same* node follows its skill to the new slot (it fails under index keying — the slot-1 node would be reused for the skill that shifts into slot 1).
- Confirmed the test is a meaningful guard: it fails with the old `(index)` key (`expected 'Bravo, loadout slot 1' to contain 'Alpha'`) and passes with the fix.
- `npx vitest run src/tests/routes/game/screens/skills/` → 49 passed.
- `npm run check` (svelte-kit sync + svelte-check) → 0 errors, 0 warnings.
- `npx eslint .` → clean.

Closes #703

https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7)_