### PR TITLE
A11y: name the chip in the ChipsSection remove button aria-label

### DIFF
--- a/UI/src/routes/admin/workbench/components/ChipsSection.svelte
+++ b/UI/src/routes/admin/workbench/components/ChipsSection.svelte
@@ -9,7 +9,13 @@
 					<span class="nm">{entry ? section.labelOf(entry) : `#${id}`}</span>
 					<span class="dm">{entry ? section.metaOf(entry) : ''}</span>
 					{#if entry?.retired}<span class="retired-tag">retired</span>{/if}
-					<button type="button" class="x" title="Remove" aria-label="Remove" onclick={() => remove(id)}>
+					<button
+						type="button"
+						class="x"
+						title="Remove"
+						aria-label={`Remove ${entry ? section.labelOf(entry) : `#${id}`}`}
+						onclick={() => remove(id)}
+					>
 						<WorkbenchIcon kind="x" size={11} />
 					</button>
 				</div>

--- a/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
@@ -133,12 +133,20 @@ describe('ChipsSection', () => {
 		expect(store.items[0].skillPool).toEqual([2]);
 	});
 
-	it('renders the remove control as a real, labelled button (not a clickable span)', () => {
+	it('names the chip in the remove control so each button is distinguishable to a screen reader', () => {
 		const { store, record, baseline } = setup([1]);
 		const { container } = renderChips(store, record, baseline);
 		const remove = container.querySelector('.skill-chip .x') as HTMLElement;
 		expect(remove.tagName).toBe('BUTTON');
-		expect(remove.getAttribute('aria-label')).toBe('Remove');
+		expect(remove.getAttribute('aria-label')).toBe('Remove Cleave');
+	});
+
+	it('falls back to the raw id in the remove label when the chip is unresolved', () => {
+		// Id 99 has no catalogue entry, so the label uses the same `#id` fallback as the chip name.
+		const { store, record, baseline } = setup([99]);
+		const { container } = renderChips(store, record, baseline);
+		const remove = container.querySelector('.skill-chip .x') as HTMLElement;
+		expect(remove.getAttribute('aria-label')).toBe('Remove #99');
 	});
 
 	it('excludes a retired catalogue entry from the add select but keeps an assigned one as a chip', () => {


### PR DESCRIPTION
## Summary

The remove "×" button in `ChipsSection.svelte` carried a bare `aria-label="Remove"`. Because a section renders many chips, a screen-reader user heard "Remove, button" repeatedly with no way to tell which entry each control removed.

This folds the chip's resolved label (via `section.labelOf(entry)`) into the accessible name, falling back to the same `#${id}` form the chip name itself uses when the catalogue entry is unresolved. This matches the sibling patterns introduced in #687 — `TagPill` (`Remove tag {tag.name}`) and `ModSlots` (`Remove {applied.name}`).

No visual change (`title="Remove"` and the rendered markup are unchanged).

Closes #717

## Testing

From `UI/`:
- `npx vitest run src/tests/routes/admin/workbench/ChipsSection.test.ts` — 11 passed (updated the existing assertion to `Remove Cleave` and added a `#99` fallback-label case)
- `npx vitest run` — 1771 passed (184 files)
- `npm run check` — 0 errors, 0 warnings
- `npx eslint .` — clean

https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7)_