### PR TITLE
Fix options save retry on failure and drop dead socket try/catch

### DIFF
--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -312,26 +312,17 @@ export class AttributesView {
 
 		const netSpent = sum(this.draft) - sum(this.committed);
 		this.saving = true;
-		let result: IBattlerAttribute[] | undefined;
-		try {
-			const response = await apiSocket.sendSocketCommand('UpdatePlayerStats', updates);
-			if (!response.error) {
-				result = response.data;
-			}
-		} catch {
-			result = undefined;
-		} finally {
-			this.saving = false;
-		}
+		const response = await apiSocket.sendSocketCommand('UpdatePlayerStats', updates);
+		this.saving = false;
 
-		if (!result) {
+		if (response.error || !response.data) {
 			toastError('Your attribute changes could not be saved. Please try again.');
 			return;
 		}
 
 		// Persist to the player manager so battles and other screens use the new
 		// allocation, then re-seed the baseline to clear the dirty state.
-		playerManager.attributes = result;
+		playerManager.attributes = response.data;
 		playerManager.statPointsUsed += netSpent;
 		this.syncFromPlayer();
 		this.flashSaved();

--- a/UI/src/routes/game/screens/options/options-view.svelte.ts
+++ b/UI/src/routes/game/screens/options/options-view.svelte.ts
@@ -196,26 +196,21 @@ export class OptionsView {
 		}
 
 		this.saving = true;
-		let ok = false;
-		try {
-			const response = await apiSocket.sendSocketCommand('SaveLogPreferences', changed);
-			ok = !response.error;
-		} catch {
-			ok = false;
-		} finally {
-			this.saving = false;
+		const response = await apiSocket.sendSocketCommand('SaveLogPreferences', changed);
+		this.saving = false;
+
+		// On failure keep the change dirty (baseline unadvanced, not applied to the
+		// player) so Save/Discard stay enabled and the user can retry (#701).
+		if (response.error) {
+			toastError('Log preferences could not be saved. Please try again.');
+			return;
 		}
 
-		// Apply locally regardless so the combat-log filter reflects the choice
-		// for the rest of the session, then advance the baseline to clear dirty.
+		// Mirror the saved draft onto the player manager so the combat-log filter
+		// reflects the choice, then advance the baseline to clear the dirty state.
 		applyToPlayer(this.draft);
 		this.baseline = { ...this.draft };
-
-		if (ok) {
-			this.flashSaved();
-		} else {
-			toastError('Log preferences were applied for this session but could not be saved to the server.');
-		}
+		this.flashSaved();
 	}
 
 	private flashSaved(): void {

--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -418,12 +418,8 @@ export class SkillsView {
 		const previous = this.equipped;
 		this.equipped = next;
 		this.applyToPlayer(next);
-		try {
-			const response = await apiSocket.sendSocketCommand('SetSelectedSkills', next);
-			if (response.error) {
-				throw new Error(response.error);
-			}
-		} catch {
+		const response = await apiSocket.sendSocketCommand('SetSelectedSkills', next);
+		if (response.error) {
 			this.equipped = previous;
 			this.applyToPlayer(previous);
 			toastError('Your loadout could not be saved. Please try again.');

--- a/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
@@ -366,15 +366,6 @@ describe('AttributesView.save', () => {
 		expect(mockPlayerManager.statPointsUsed).toBe(0);
 	});
 
-	it('warns and keeps the changes when the request throws', async () => {
-		sendSocketCommand.mockRejectedValue(new Error('network'));
-		view.inc(idx.str);
-		await view.save();
-
-		expect(toastError).toHaveBeenCalledTimes(1);
-		expect(view.dirty).toBe(true);
-	});
-
 	it('does nothing when there are no changes', async () => {
 		await view.save();
 		expect(sendSocketCommand).not.toHaveBeenCalled();

--- a/UI/src/tests/routes/game/screens/options/options-view.test.ts
+++ b/UI/src/tests/routes/game/screens/options/options-view.test.ts
@@ -145,24 +145,35 @@ describe('OptionsView.save', () => {
 		expect(toastError).not.toHaveBeenCalled();
 	});
 
-	it('still applies locally but warns when the server rejects the save', async () => {
+	it('keeps the change dirty and unapplied (so Save/Discard stay enabled) when the server rejects the save', async () => {
 		mockSendSocketCommand.mockResolvedValue({ error: 'Unknown log type.' });
 		view.setOne(ELogType.Exp, false);
 		await view.save();
 
-		expect(mockPlayerManager.logPreferences.find((p) => p.id === ELogType.Exp)?.enabled).toBe(false);
-		expect(view.isDirty).toBe(false);
+		// Not applied to the player and the baseline is unadvanced, so the change is
+		// still dirty — the SaveBar enables Save/Discard on `isDirty`, allowing retry (#701).
+		expect(mockPlayerManager.logPreferences.find((p) => p.id === ELogType.Exp)?.enabled).toBe(true);
+		expect(view.isDirty).toBe(true);
+		expect(view.dirtyCount).toBe(1);
+		expect(view.saving).toBe(false);
 		expect(view.saved).toBe(false);
 		expect(toastError).toHaveBeenCalledTimes(1);
 	});
 
-	it('applies locally and warns when the request throws', async () => {
-		mockSendSocketCommand.mockRejectedValue(new Error('network'));
+	it('retries successfully after a failed save (the change survived the failure)', async () => {
+		mockSendSocketCommand.mockResolvedValueOnce({ error: 'transient' });
 		view.setOne(ELogType.Exp, false);
 		await view.save();
+		expect(view.isDirty).toBe(true);
 
+		// A second attempt resolves cleanly and commits the still-dirty change.
+		mockSendSocketCommand.mockResolvedValueOnce({});
+		await view.save();
+
+		expect(mockSendSocketCommand).toHaveBeenCalledTimes(2);
+		expect(mockPlayerManager.logPreferences.find((p) => p.id === ELogType.Exp)?.enabled).toBe(false);
 		expect(view.isDirty).toBe(false);
-		expect(toastError).toHaveBeenCalledTimes(1);
+		expect(view.saved).toBe(true);
 	});
 
 	it('does nothing when there are no changes', async () => {


### PR DESCRIPTION
## Summary

Two coupled view-model fixes (they overlap in `options-view.save()`).

### #701 — Options save advanced the baseline even on a failed save (blocked retry)
`OptionsView.save()` ran `applyToPlayer(draft)` and advanced `baseline` even when `SaveLogPreferences` **failed**, zeroing the dirty count. `SaveBar` keys off the dirty count, so a failed save showed "No unsaved changes" and **disabled Save/Discard** — the user couldn't retry, and a refresh silently reverted to the unsaved server state.

Now, on failure it **returns early** — baseline unadvanced, draft not applied, error toast surfaced — so the change stays dirty and Save/Discard remain enabled. This mirrors the correct `attributes-view.save()` pattern.

### #707 — Remove dead try/catch around the non-throwing `sendSocketCommand`
Per the documented socket lifecycle, `sendSocketCommand` **never rejects** (every failure resolves with `response.error`), so the `catch` blocks wrapping it were unreachable. Removed them in the **attributes**, **options**, and **skills** view-models; each now branches on `response.error` and resets the `saving` flag inline. The skills variant that `throw`ew its own error purely to drive control flow is rewritten to branch directly.

## Testing

From `UI/` (run on this branch):
- `npx vitest run` for the affected view-models (options / attributes / skills) → **183 passed**. Includes new options-view coverage for the failed-save path (dirty preserved, Save still enabled) and a successful-retry-after-failure path; the obsolete attributes throw-path test (unreachable under the non-throwing transport contract) was removed.
- `npm run lint` (`eslint .` + `svelte-kit sync && svelte-check`) → **0 errors, 0 warnings**.

Closes #701
Closes #707

https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTW8cH6o56mgL7oWQVPiB7)_