### PR TITLE
Fix BattleEngine loading-hook leak and concurrent getNewEnemy double-spawn

### DIFF
--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -35,6 +35,9 @@ export class BattleEngine {
 	private logicalUnhook?: Action;
 	private renderUnhook?: Action;
 	private enemyLoadedUnhook?: Action;
+	/** Tears down the in-flight post-victory loading countdown (removes its render hook and resolves the
+	 *  awaited promise); undefined when no countdown is active. */
+	private finishLoading?: Action;
 
 	/** Reused per-tick sink the shared battleStep populates with this tick's newly-applied effects and
 	 *  DoT/HoT amounts, so the engine can turn them into combat-log lines (frontend-only). */
@@ -69,6 +72,9 @@ export class BattleEngine {
 			this.renderUnhook?.();
 			this.enemyLoadedUnhook?.();
 		}
+		// A loading countdown is driven by the render engine independently of `running`, so cancel it
+		// unconditionally — otherwise its render hook leaks and the awaiting getNewEnemy path hangs.
+		this.finishLoading?.();
 	}
 
 	public pause() {
@@ -85,6 +91,9 @@ export class BattleEngine {
 
 	public reset = (enemyInstance: IEnemyInstance) => {
 		const enemyData = staticData.enemies ?? [];
+		// Re-arming the battle cancels any in-flight post-victory cooldown so its render hook is removed
+		// and the awaiting caller is released rather than stranded mid-countdown.
+		this.finishLoading?.();
 		this.timeElapsed = 0;
 		this.resetEffectDamage();
 		this.player.reset(playerManager, inventoryManager.equipmentStats);
@@ -97,16 +106,24 @@ export class BattleEngine {
 	}
 
 	public startLoading(loadingTime: number) {
+		// Cancel any countdown still in flight so re-invoking can't leak the previous render hook.
+		this.finishLoading?.();
 		this.loadingTime = loadingTime;
 		this.setBattleStage(Loading);
 		const { promise, resolve } = Promise.withResolvers<void>();
-		onRenderUpdate((delta, _, unhook) => {
+		const unhook = onRenderUpdate((delta) => {
 			this.loadingTime -= delta;
 			if (this.loadingTime <= 0) {
-				resolve();
-				unhook();
+				this.finishLoading?.();
 			}
 		}, false);
+		// Single idempotent teardown shared by the natural countdown-complete path and the stop()/reset()
+		// cancellation path: remove the render hook and release the awaiting caller exactly once.
+		this.finishLoading = () => {
+			this.finishLoading = undefined;
+			unhook();
+			resolve();
+		};
 		return promise;
 	}
 

--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -1,4 +1,4 @@
-import { apiSocket, ELogType, IApiSocketResponse, IEnemyInstance } from '$lib/api';
+import { apiSocket, ELogType, IEnemyInstance } from '$lib/api';
 import { Action, createHook, delay, isZoneUnlocked, nextZoneByOrder } from '$lib/common';
 import { staticData, statistics, playerChallenges } from '$stores';
 import { battleEngine, BattleStage, onBattleStageChanged, playerManager } from '../';
@@ -43,11 +43,13 @@ export class EnemyManager {
 	 *  incomplete to complete). Drives the Zone-Cleared overlay's "Next zone unlocked" line. */
 	public bossUnlockedNextZone = false;
 
-	private newEnemyPromise: Promise<IApiSocketResponse<'NewEnemy'>> | undefined;
 	private battleStageUnhook?: Action;
 	/** Guards the challenge/retreat transitions so a resolving stage change for the battle being
 	 *  swapped out is not mistaken for an outcome of the new one. */
 	private transitioning = false;
+	/** Re-entrancy guard for getNewEnemy: overlapping stage handlers must not both spawn-and-notify an
+	 *  enemy (a double-spawn the backend replay would flag as cheating). */
+	private fetchingEnemy = false;
 
 	public start() {
 		if (!this.started) {
@@ -66,31 +68,38 @@ export class EnemyManager {
 	}
 
 	public async getNewEnemy() {
-		// Retry iteratively rather than via self-recursion: each attempt returns to a flat stack
-		// (a sustained outage no longer grows the async chain without bound) and `stop()` cancels
-		// the loop by flipping `started`.
-		while (this.started) {
-			if (!this.newEnemyPromise) {
-				this.newEnemyPromise = apiSocket.sendSocketCommand('NewEnemy', {
+		// Single re-entrancy guard: overlapping stage handlers (e.g. an idle victory racing an Idle/
+		// Defeated change) can both reach here, and each would request-and-notify a new enemy —
+		// double-counting a spawn. Because the backend replays what the client reports, a double-spawn
+		// has anti-cheat consequences, so the second, re-entrant call drops; the first still spawns one.
+		if (this.fetchingEnemy) {
+			return;
+		}
+		this.fetchingEnemy = true;
+		try {
+			// Retry iteratively rather than via self-recursion: each attempt returns to a flat stack
+			// (a sustained outage no longer grows the async chain without bound) and `stop()` cancels
+			// the loop by flipping `started`.
+			while (this.started) {
+				const result = await apiSocket.sendSocketCommand('NewEnemy', {
 					newZoneId: playerManager.currentZone
 				});
-			}
+				if (result.data?.enemyInstance) {
+					this.currentEnemy = result.data.enemyInstance;
+					notifyNewEnemyLoaded(this.currentEnemy);
+					return;
+				}
 
-			const result = await this.newEnemyPromise;
-			this.newEnemyPromise = undefined;
-			if (result.data?.enemyInstance) {
-				this.currentEnemy = result.data.enemyInstance;
-				notifyNewEnemyLoaded(this.currentEnemy);
-				return;
+				// No enemy this time: either the zone is on cooldown (wait it out) or the request failed
+				// (`data` is absent — note the optional chaining; an error response carries no data).
+				// Back off in both cases, then retry.
+				if (result.error) {
+					logMessage(ELogType.Debug, 'There was an error loading a new enemy: ' + result.error);
+				}
+				await delay(result.data?.cooldown ?? NEW_ENEMY_RETRY_DELAY_MS);
 			}
-
-			// No enemy this time: either the zone is on cooldown (wait it out) or the request failed
-			// (`data` is absent — note the optional chaining; the original code dereferenced `data`
-			// here and threw on an error response). Back off in both cases, then retry.
-			if (result.error) {
-				logMessage(ELogType.Debug, 'There was an error loading a new enemy: ' + result.error);
-			}
-			await delay(result.data?.cooldown ?? NEW_ENEMY_RETRY_DELAY_MS);
+		} finally {
+			this.fetchingEnemy = false;
 		}
 	}
 
@@ -173,6 +182,13 @@ export class EnemyManager {
 			if (cooldown > 0) {
 				await battleEngine.startLoading(cooldown);
 			}
+		}
+
+		// The awaited claim/cooldown above can overlap a boss challenge or retreat that hands the loop
+		// off (and resolves the cooldown early via reset); if we've since left idle mode or a transition
+		// is mid-flight, don't spawn an idle enemy over the new fight.
+		if (this.transitioning || this.mode !== 'idle') {
+			return;
 		}
 
 		if (stage === BattleStage.Victorious || stage === BattleStage.Defeated || stage === BattleStage.Idle) {

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -253,20 +253,62 @@ describe('BattleEngine', () => {
 
 		it('counts the loading time down each render frame and resolves + unhooks at zero', async () => {
 			const promise = engine.startLoading(100);
-			const unhook = vi.fn();
-			// startLoading registers a render hook that also receives an `unhook` third arg (provided by
-			// the real render engine); the shared RenderCallback type only models the first two.
-			const countdown = renderUpdateCallbacks[0] as (delta: number, logicalDelta: number, unhook: () => void) => void;
+			const countdown = renderUpdateCallbacks[0];
+			expect(renderUpdateCallbacks).toHaveLength(1);
 
 			// First frame doesn't reach zero — still ticking, not yet unhooked.
-			countdown(60, 0, unhook);
+			countdown(60, 0);
 			expect(engine.loadingTime).toBe(40);
-			expect(unhook).not.toHaveBeenCalled();
+			expect(renderUpdateCallbacks).toHaveLength(1);
 
 			// Second frame drives it past zero — the promise resolves and the hook removes itself.
-			countdown(60, 0, unhook);
+			countdown(60, 0);
 			await expect(promise).resolves.toBeUndefined();
-			expect(unhook).toHaveBeenCalledTimes(1);
+			expect(renderUpdateCallbacks).toHaveLength(0);
+		});
+
+		it('resolves the promise and removes the countdown hook when stopped mid-loading', async () => {
+			engine.start(); // registers the engine's own render hook
+			const promise = engine.startLoading(1000);
+			// The engine render hook plus the loading countdown are both registered.
+			expect(renderUpdateCallbacks).toHaveLength(2);
+
+			engine.stop();
+
+			// A stop mid-cooldown must release the awaiting getNewEnemy path rather than hang it forever,
+			// and tear down every render hook so a later renderEngine.start() can't resume a stale countdown.
+			await expect(promise).resolves.toBeUndefined();
+			expect(renderUpdateCallbacks).toHaveLength(0);
+		});
+
+		it('resolves the promise and removes the countdown hook when reset mid-loading', async () => {
+			engine.start();
+			const promise = engine.startLoading(1000);
+			expect(renderUpdateCallbacks).toHaveLength(2);
+
+			engine.reset({ id: 1, level: 1, seed: 0, selectedSkills: [0], attributes: [] });
+
+			// Reset cancels the in-flight cooldown (releasing the awaiter) but leaves the engine's own
+			// render hook in place for the re-armed battle.
+			await expect(promise).resolves.toBeUndefined();
+			expect(renderUpdateCallbacks).toHaveLength(1);
+		});
+
+		it('does not leave a stale countdown hook behind when re-invoked while one is pending', async () => {
+			const first = engine.startLoading(1000);
+			expect(renderUpdateCallbacks).toHaveLength(1);
+
+			// Re-invoking before the first countdown completes cancels it (releasing its awaiter) instead
+			// of stacking a second leaked hook.
+			const second = engine.startLoading(500);
+			await expect(first).resolves.toBeUndefined();
+			expect(renderUpdateCallbacks).toHaveLength(1);
+
+			// The new countdown still resolves normally at zero.
+			const countdown = renderUpdateCallbacks[0];
+			countdown(500, 0);
+			await expect(second).resolves.toBeUndefined();
+			expect(renderUpdateCallbacks).toHaveLength(0);
 		});
 	});
 

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -291,6 +291,40 @@ describe('EnemyManager boss mode', () => {
 		expect(manager.autoFight).toBe(false);
 	});
 
+	it('does not spawn an idle enemy when a boss handoff lands during the post-victory cooldown', async () => {
+		// An idle victory enters a cooldown; mid-cooldown the player challenges the boss (mode flips to
+		// boss, and reset resolves the cooldown early). When the cooldown resolves, the idle handler must
+		// not spawn a stray idle enemy over the new boss fight.
+		await manager.getNewEnemy(); // idle enemy loaded; mode stays idle
+		let releaseCooldown!: () => void;
+		const cooldownGate = new Promise<void>((resolve) => (releaseCooldown = resolve));
+		h.battleEngine.startLoading.mockReturnValueOnce(cooldownGate);
+		// The idle victory must report a cooldown so the handler waits on startLoading.
+		send.mockImplementation((name: string) =>
+			name === 'DefeatEnemy'
+				? Promise.resolve(
+						resp('DefeatEnemy', {
+							cooldown: 3000,
+							rewards: { expReward: 50, newLevel: 1, newExp: 50, statPointsGained: 0, statPointsUsed: 0 }
+						})
+					)
+				: Promise.resolve(newEnemyResponse)
+		);
+
+		const handled = fireStage(h.BattleStage.Victorious);
+		// Let claimVictory settle so the handler is parked on the awaited startLoading.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(h.battleEngine.startLoading).toHaveBeenCalledWith(3000);
+
+		// Simulate the boss handoff during the cooldown, then release it.
+		manager.mode = 'boss';
+		send.mockClear();
+		releaseCooldown();
+		await handled;
+
+		expect(send).not.toHaveBeenCalledWith('NewEnemy', { newZoneId: 3 });
+	});
+
 	it('still resolves a normal idle victory (DefeatEnemy + next enemy)', async () => {
 		// Load a normal enemy first (idle mode), then win.
 		await manager.getNewEnemy();

--- a/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
@@ -132,4 +132,24 @@ describe('EnemyManager.getNewEnemy', () => {
 		expect(sendSocketCommand).toHaveBeenCalledTimes(1);
 		expect(manager.currentEnemy).toBeUndefined();
 	});
+
+	it('drops a concurrent re-entrant call so a stage-change race spawns a single enemy', async () => {
+		// Two overlapping stage handlers (e.g. an idle victory racing an Idle change) can both reach
+		// getNewEnemy; each would request-and-notify an enemy, double-counting the spawn. Since the
+		// backend replays what the client reports, that is an anti-cheat hazard — the second call drops.
+		const enemy = makeEnemy(7);
+		let resolveSend!: (r: IApiSocketResponse<'NewEnemy'>) => void;
+		sendSocketCommand.mockReturnValueOnce(new Promise((resolve) => (resolveSend = resolve)));
+		const loaded: IEnemyInstance[] = [];
+		onNewEnemyLoaded((e) => loaded.push(e), false);
+
+		const first = manager.getNewEnemy();
+		const second = manager.getNewEnemy(); // re-entrant while the first request is still in flight
+		resolveSend(enemyResponse(enemy));
+		await Promise.all([first, second]);
+
+		expect(sendSocketCommand).toHaveBeenCalledTimes(1);
+		expect(loaded).toEqual([enemy]);
+		expect(manager.currentEnemy).toEqual(enemy);
+	});
 });


### PR DESCRIPTION
Closes #702

## Summary

Two related correctness bugs in the client battle-engine lifecycle.

### 1. `startLoading` loading-hook leak / stranded `await` on teardown

`startLoading` registered an `onRenderUpdate` hook (`cleanupOnDestroy=false`) that only unhooked and resolved its promise from **inside its own callback** when the countdown hit zero. A `stop()` / `reset()` / `SocketReplaced` teardown **mid-cooldown** never removed the hook, and the awaiting `getNewEnemy` path hung forever — while a later `renderEngine.start()` resumed a stale `loadingTime`. Stopping during the post-victory cooldown is a common path.

**Fix:** the unhook + resolve is now a single idempotent teardown (`finishLoading`) stored on the instance, invoked from `stop()`, `reset()`, and the natural countdown-complete path. `stop()` cancels unconditionally (the countdown is driven by the render engine, independent of `running`). `startLoading` also cancels any prior in-flight countdown before starting a new one, so a re-invoke can't leak the previous hook.

### 2. Concurrent `getNewEnemy` double-spawn / double-notify

The async stage handlers weren't serialized; `transitioning` guarded only the boss/retreat transitions, not the idle victory→`getNewEnemy` path. Two overlapping stage changes could both set `currentEnemy` and call `notifyNewEnemyLoaded`, double-counting a spawn. Because the backend replays what the client reports, an enemy-spawn race has anti-cheat consequences.

**Fix:** `getNewEnemy` gets a single re-entrancy guard (`fetchingEnemy`); the second concurrent caller drops and the first spawns exactly one enemy. The now-redundant `newEnemyPromise` socket-dedup field is removed (with only one `getNewEnemy` body ever running, it never fired across loop iterations).

Additionally, `watchIdleStage` re-checks `transitioning`/`mode` **after** the awaited claim/cooldown. Because the bug-1 fix now resolves the cooldown promise on `reset()`, a boss challenge landing mid-cooldown would otherwise let the idle handler resume and spawn a stray idle enemy over the new boss fight — the re-check prevents that.

## How it addresses the issue

- Stop during loading resolves the promise and removes the hook — per the issue's "Direction" for bug 1.
- A single re-entrancy flag serializes `getNewEnemy` — per the issue's "Direction" for bug 2.

## Test plan

- [x] `npm run lint` — clean (0 errors, 0 warnings)
- [x] `npm run test:unit:ci` — 1782 passed
- [x] New tests:
  - battle-engine: resolves + unhooks when **stopped** mid-loading; resolves + unhooks when **reset** mid-loading; no stale hook left behind when **re-invoked** while a countdown is pending; existing countdown-to-zero test updated to assert hook removal directly.
  - enemy-manager: a **concurrent re-entrant** `getNewEnemy` drops so a stage-change race spawns a single enemy / notifies once.
  - enemy-manager (boss): a **boss handoff during the post-victory cooldown** does not spawn a stray idle enemy.

## Notes

These are purely client-side lifecycle/orchestration changes — the shared `battleStep` arithmetic is untouched, so there is no frontend/backend battle-parity impact and no backend change required.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KmrpnF8aPC52HhYZSgcsmu)_