### PR TITLE
Record a legitimate 0 statistic minimum instead of using 0 as a "no data" sentinel

### DIFF
--- a/Game.Core.Tests/Progress/PlayerChallengeTests.cs
+++ b/Game.Core.Tests/Progress/PlayerChallengeTests.cs
@@ -11,7 +11,7 @@ namespace Game.Core.Tests.Progress
         {
             var playerChallenge = MakePlayerChallenge(goal: 10);
 
-            playerChallenge.UpdateProgress(4m);
+            playerChallenge.UpdateProgress(4m, hasData: true);
 
             Assert.Equal(4m, playerChallenge.Progress);
             Assert.False(playerChallenge.Completed);
@@ -23,7 +23,7 @@ namespace Game.Core.Tests.Progress
         {
             var playerChallenge = MakePlayerChallenge(goal: 10);
 
-            playerChallenge.UpdateProgress(10m);
+            playerChallenge.UpdateProgress(10m, hasData: true);
 
             Assert.Equal(10m, playerChallenge.Progress);
             Assert.True(playerChallenge.Completed);
@@ -35,7 +35,7 @@ namespace Game.Core.Tests.Progress
         {
             var playerChallenge = MakePlayerChallenge(goal: 10);
 
-            playerChallenge.UpdateProgress(15m);
+            playerChallenge.UpdateProgress(15m, hasData: true);
 
             Assert.Equal(10m, playerChallenge.Progress);
             Assert.True(playerChallenge.Completed);
@@ -46,10 +46,10 @@ namespace Game.Core.Tests.Progress
         {
             var playerChallenge = MakePlayerChallenge(goal: 10);
 
-            playerChallenge.UpdateProgress(10m);
+            playerChallenge.UpdateProgress(10m, hasData: true);
             var firstCompletedAt = playerChallenge.CompletedAt;
 
-            playerChallenge.UpdateProgress(20m);
+            playerChallenge.UpdateProgress(20m, hasData: true);
 
             Assert.True(playerChallenge.Completed);
             Assert.Equal(firstCompletedAt, playerChallenge.CompletedAt);
@@ -62,7 +62,7 @@ namespace Game.Core.Tests.Progress
         {
             var playerChallenge = MakePlayerChallenge(goal: 10, type: EChallengeType.TimeTrial);
 
-            playerChallenge.UpdateProgress(7m);
+            playerChallenge.UpdateProgress(7m, hasData: true);
 
             Assert.Equal(7m, playerChallenge.Progress);
             Assert.True(playerChallenge.Completed);
@@ -74,7 +74,7 @@ namespace Game.Core.Tests.Progress
         {
             var playerChallenge = MakePlayerChallenge(goal: 10, type: EChallengeType.TimeTrial);
 
-            playerChallenge.UpdateProgress(10m);
+            playerChallenge.UpdateProgress(10m, hasData: true);
 
             Assert.True(playerChallenge.Completed);
         }
@@ -84,7 +84,7 @@ namespace Game.Core.Tests.Progress
         {
             var playerChallenge = MakePlayerChallenge(goal: 10, type: EChallengeType.TimeTrial);
 
-            playerChallenge.UpdateProgress(15m);
+            playerChallenge.UpdateProgress(15m, hasData: true);
 
             Assert.Equal(15m, playerChallenge.Progress);
             Assert.False(playerChallenge.Completed);
@@ -92,15 +92,29 @@ namespace Game.Core.Tests.Progress
         }
 
         [Fact]
-        public void UpdateProgress_AtMost_ZeroValue_TreatedAsNoDataAndDoesNotComplete()
+        public void UpdateProgress_AtMost_NoData_DoesNotComplete()
         {
-            // 0 means the underlying statistic (e.g. fastest victory) has no data yet,
-            // so it must not satisfy a "win within N seconds" goal.
+            // With no recorded statistic the goal is unmet, even though the placeholder value is 0 and
+            // 0 is at or below the goal — the absence of data, not the value, is what blocks completion.
             var playerChallenge = MakePlayerChallenge(goal: 10, type: EChallengeType.TimeTrial);
 
-            playerChallenge.UpdateProgress(0m);
+            playerChallenge.UpdateProgress(0m, hasData: false);
 
             Assert.False(playerChallenge.Completed);
+            Assert.Null(playerChallenge.CompletedAt);
+        }
+
+        [Fact]
+        public void UpdateProgress_AtMost_GenuineZeroValue_Completes()
+        {
+            // A recorded 0 (e.g. an instant victory) is a legitimate value at or below the goal, so it
+            // must complete — the old "0 means no data" sentinel made this case unwinnable.
+            var playerChallenge = MakePlayerChallenge(goal: 10, type: EChallengeType.TimeTrial);
+
+            playerChallenge.UpdateProgress(0m, hasData: true);
+
+            Assert.True(playerChallenge.Completed);
+            Assert.NotNull(playerChallenge.CompletedAt);
         }
 
         private static PlayerChallenge MakePlayerChallenge(decimal goal, EChallengeType type = EChallengeType.EnemiesKilled)

--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -331,7 +331,37 @@ namespace Game.Core.Tests.Progress
             Assert.Equal(3m, progress.GetStatisticValue(EStatisticType.FastestVictory, null));
         }
 
-        // ── GetStatisticValue ────────────────────────────────────────────────
+        [Fact]
+        public void RecordBattleCompleted_FirstVictoryWithZeroDuration_RecordsZeroFastestVictory()
+        {
+            var progress = MakeProgress();
+
+            // An instant (0ms) victory is a legitimate FastestVictory of 0, not "no data".
+            progress.RecordBattleCompleted(MakeEnemy(id: 1), victory: true, playerDied: false, totalMs: 0, new BattleStats(),
+                isBossBattle: false, zoneId: 0);
+
+            Assert.True(progress.TryGetStatisticValue(EStatisticType.FastestVictory, null, out var value));
+            Assert.Equal(0m, value);
+        }
+
+        [Fact]
+        public void RecordBattleCompleted_ZeroFastestVictory_IsNotOverwrittenBySlowerVictory()
+        {
+            // Regression for the "0 means no value yet" sentinel: once a 0 minimum is recorded a slower
+            // later victory must not overwrite it (previously stat.Value == 0 pinned the stat forever).
+            var progress = MakeProgress();
+            var enemy = MakeEnemy(id: 1);
+
+            progress.RecordBattleCompleted(enemy, victory: true, playerDied: false, totalMs: 0, new BattleStats(),
+                isBossBattle: false, zoneId: 0);
+            progress.RecordBattleCompleted(enemy, victory: true, playerDied: false, totalMs: 4000, new BattleStats(),
+                isBossBattle: false, zoneId: 0);
+
+            Assert.Equal(0m, progress.GetStatisticValue(EStatisticType.FastestVictory, null));
+            Assert.Equal(0m, progress.GetStatisticValue(EStatisticType.FastestVictory, 1));
+        }
+
+        // ── GetStatisticValue / TryGetStatisticValue ─────────────────────────
 
         [Fact]
         public void GetStatisticValue_UntrackedStatistic_ReturnsZero()
@@ -340,6 +370,25 @@ namespace Game.Core.Tests.Progress
 
             Assert.Equal(0m, progress.GetStatisticValue(EStatisticType.DamageDealt, null));
             Assert.Equal(0m, progress.GetStatisticValue(EStatisticType.EnemiesKilled, 999));
+        }
+
+        [Fact]
+        public void TryGetStatisticValue_UntrackedStatistic_ReturnsFalseAndZero()
+        {
+            var progress = MakeProgress();
+
+            Assert.False(progress.TryGetStatisticValue(EStatisticType.FastestVictory, null, out var value));
+            Assert.Equal(0m, value);
+        }
+
+        [Fact]
+        public void TryGetStatisticValue_RecordedZero_ReturnsTrueAndZero()
+        {
+            // A recorded 0 is data, not absence — the distinction the AtMost challenge path relies on.
+            var progress = MakeProgress(statistics: [Stat(EStatisticType.FastestVictory, null, 0m)]);
+
+            Assert.True(progress.TryGetStatisticValue(EStatisticType.FastestVictory, null, out var value));
+            Assert.Equal(0m, value);
         }
 
         // ── EvaluateChallenges ───────────────────────────────────────────────
@@ -508,6 +557,23 @@ namespace Game.Core.Tests.Progress
             var completed = progress.EvaluateChallenges([challenge]);
 
             Assert.Empty(completed);
+        }
+
+        [Fact]
+        public void EvaluateChallenges_TimeTrial_CompletesWhenFastestVictoryIsRecordedZero()
+        {
+            // A recorded FastestVictory of 0 (e.g. an instant victory) is a real value at or below the
+            // goal, so it must complete — distinct from the "no victory yet" case above.
+            var challenge = MakeChallenge(id: 0, EChallengeType.TimeTrial, goal: 10);
+            var progress = MakeProgress(statistics:
+            [
+                Stat(EStatisticType.FastestVictory, null, 0m),
+            ]);
+
+            var completed = progress.EvaluateChallenges([challenge]);
+
+            Assert.Single(completed);
+            Assert.True(Assert.Single(progress.ChallengeProgress).Completed);
         }
 
         [Fact]

--- a/Game.Core/Progress/Challenge.cs
+++ b/Game.Core/Progress/Challenge.cs
@@ -23,13 +23,13 @@ namespace Game.Core.Progress
         {
             if (Type.StatisticType is not null)
             {
-                var value = playerProgress.GetStatisticValue(Type.StatisticType.Id, TargetEntityId);
-                playerChallenge.UpdateProgress(value);
+                var hasData = playerProgress.TryGetStatisticValue(Type.StatisticType.Id, TargetEntityId, out var value);
+                playerChallenge.UpdateProgress(value, hasData);
             }
             else if (Type.Id is EChallengeType.LevelReached)
             {
-                var value = playerProgress.Player.Level;
-                playerChallenge.UpdateProgress(value);
+                // The player's level is always present, so the progress value is always real data.
+                playerChallenge.UpdateProgress(playerProgress.Player.Level, hasData: true);
             }
         }
     }

--- a/Game.Core/Progress/PlayerChallenge.cs
+++ b/Game.Core/Progress/PlayerChallenge.cs
@@ -18,7 +18,12 @@ namespace Game.Core.Progress
             CompletedAt = completedAt;
         }
 
-        public void UpdateProgress(decimal value)
+        /// <param name="hasData">
+        /// Whether the tracked statistic has a recorded value. "At most" goals only count when there is
+        /// data: with none, the goal is unmet regardless of the 0 placeholder <paramref name="value"/>,
+        /// while a genuine 0 (<paramref name="hasData"/> true) can satisfy it.
+        /// </param>
+        public void UpdateProgress(decimal value, bool hasData)
         {
             if (Completed)
             {
@@ -27,11 +32,10 @@ namespace Game.Core.Progress
 
             if (Challenge.Type.GoalComparison is EChallengeGoalComparison.AtMost)
             {
-                // "At most" goals (e.g. time trials) are satisfied by reaching a value at or below
-                // the goal. A value of 0 indicates the underlying statistic has no data yet (e.g. no
-                // victory has been recorded), so it does not count as meeting the goal.
+                // "At most" goals (e.g. time trials) are met by reaching a value at or below the goal.
+                // Completion keys off whether the statistic has data, never off a magic 0 — see hasData.
                 Progress = value;
-                if (value > 0 && value <= Challenge.ProgressGoal)
+                if (hasData && value <= Challenge.ProgressGoal)
                 {
                     Completed = true;
                     CompletedAt = DateTime.UtcNow;

--- a/Game.Core/Progress/PlayerProgress.cs
+++ b/Game.Core/Progress/PlayerProgress.cs
@@ -152,21 +152,41 @@ namespace Game.Core.Progress
 
         public decimal GetStatisticValue(EStatisticType type, int? entityId)
         {
-            var key = (type, entityId);
-            return _statistics.TryGetValue(key, out var stat) ? stat.Value : 0m;
+            TryGetStatisticValue(type, entityId, out var value);
+            return value;
+        }
+
+        /// <summary>
+        /// Looks up a recorded statistic value, reporting whether a row actually exists.
+        /// <para>
+        /// The canonical "no data yet" representation is the <b>absence of a row</b>: a row's
+        /// <see cref="PlayerStatistic.Value"/> is always a genuine recorded value, 0 included. A 0 from
+        /// <see cref="GetStatisticValue"/> is therefore ambiguous (an unrecorded stat and a recorded 0 read
+        /// alike), so a caller that must tell the two apart — e.g. an "at most" challenge a legitimate 0
+        /// should satisfy — branches on this return value, never on the value being 0.
+        /// </para>
+        /// </summary>
+        /// <returns><c>true</c> when a row exists for the (type, entityId) pair; otherwise <c>false</c>.</returns>
+        public bool TryGetStatisticValue(EStatisticType type, int? entityId, out decimal value)
+        {
+            var exists = _statistics.TryGetValue((type, entityId), out var stat);
+            value = stat?.Value ?? 0m;
+            return exists;
         }
 
         private decimal Increment(EStatisticType type, int? entityId, decimal amount)
         {
-            var stat = GetOrCreate(type, entityId);
+            var stat = GetOrCreate(type, entityId, out _);
             stat.Value += amount;
             return stat.Value;
         }
 
         private decimal SetMax(EStatisticType type, int? entityId, decimal value)
         {
-            var stat = GetOrCreate(type, entityId);
-            if (value > stat.Value)
+            var stat = GetOrCreate(type, entityId, out var created);
+            // Record on the first write (created) or a strictly greater value, so the first recorded value
+            // wins outright instead of racing the 0 a fresh row starts at.
+            if (created || value > stat.Value)
             {
                 stat.Value = value;
             }
@@ -176,8 +196,11 @@ namespace Game.Core.Progress
 
         private decimal SetMin(EStatisticType type, int? entityId, decimal value)
         {
-            var stat = GetOrCreate(type, entityId);
-            if (stat.Value == 0 || value < stat.Value)
+            var stat = GetOrCreate(type, entityId, out var created);
+            // Record on the first write (created) or a strictly lesser value. Keying off the explicit
+            // created flag — not "Value == 0" — lets a legitimate 0 minimum lock in rather than being
+            // overwritten forever as if it were the empty placeholder.
+            if (created || value < stat.Value)
             {
                 stat.Value = value;
             }
@@ -185,19 +208,20 @@ namespace Game.Core.Progress
             return stat.Value;
         }
 
-        private PlayerStatistic GetOrCreate(EStatisticType type, int? entityId)
+        private PlayerStatistic GetOrCreate(EStatisticType type, int? entityId, out bool created)
         {
             var key = (type, entityId);
-            if (!_statistics.TryGetValue(key, out var stat))
+            created = !_statistics.TryGetValue(key, out var stat);
+            if (stat is null)
             {
                 stat = new PlayerStatistic { Type = type, EntityId = entityId, Value = 0 };
                 _statistics[key] = stat;
             }
 
             // GetOrCreate is reached only from the mutators (Increment/SetMax/SetMin); reads use
-            // GetStatisticValue, which never lands here. So marking dirty here covers exactly the mutated
-            // stats. A no-op SetMax/SetMin over-marks at worst, which is harmless — the persist is an
-            // idempotent absolute write.
+            // GetStatisticValue/TryGetStatisticValue, which never land here. So marking dirty here covers
+            // exactly the mutated stats. A no-op SetMax/SetMin over-marks at worst, which is harmless — the
+            // persist is an idempotent absolute write.
             _dirtyStatistics.Add(key);
             return stat;
         }

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -79,7 +79,7 @@ Cache busting is an **eager build-then-swap** (stale-while-revalidate), not a nu
 
 Player-facing reads also avoid exposing EF entities, but — unlike reference data — they reuse the existing **gameplay domain models** rather than dedicated contracts (those models are already lean enough), with the API DTOs projecting from them.
 
-- **Statistics and challenge progress** go through the single `IPlayerProgressRepository`, which also owns the progress write path, giving one source of truth for player-progress data.
+- **Statistics and challenge progress** go through the single `IPlayerProgressRepository`, which also owns the progress write path, giving one source of truth for player-progress data. A statistic's "no data yet" state is the **absence of its row**, never a magic `0` value — a stored value (0 included) is always a genuine recording. Min/max aggregation and the "at most" challenge path therefore key off row presence (`TryGetStatisticValue`), so a legitimate `0` minimum (e.g. an instant `FastestVictory`) records and counts correctly instead of being treated as empty.
 - **The skill loadout is sent as the full unlocked set** (each skill with its `Selected`/`Order`), mirroring how inventory is sent as the full unlocked item set; the client derives the ordered equipped loadout from it. The loadout cap is a generated client constant, not a per-player wire field.
 - **The loadout is edited through one atomic socket command** that replaces the whole equipped set in order (handling select, deselect, and reorder in one path). Like the other player mutations it validates as **anti-cheat** — no duplicate ids, count within the cap, every id already unlocked — and rejects with no state mutation on any violation.
 


### PR DESCRIPTION
## Summary

`PlayerProgress.SetMin` used `stat.Value == 0` as a "no value yet" sentinel. Because a fresh stat row starts at `0`, a **legitimate** `0` minimum (e.g. an instant `FastestVictory` from a 0ms victory) made `stat.Value == 0` permanently true, so every subsequent `SetMin` overwrote it and the minimum could never lock in. The same implicit "0 means no data" contract was duplicated in `PlayerChallenge.UpdateProgress`'s `AtMost` path (`value > 0`), making a time-trial challenge unwinnable by a genuine `0`.

## How it's addressed

The absence of a statistic row is now the single, canonical "no data yet" representation; a row's `Value` is always a real recording (`0` included).

- **`PlayerProgress`**
  - `GetOrCreate` now signals whether it created the row (`out bool created`).
  - `SetMin`/`SetMax` apply on **first-create-or-strictly-better** instead of keying off `0`.
  - New `TryGetStatisticValue(type, entityId, out value)` reports row presence; `GetStatisticValue` is reimplemented in terms of it (DRY).
- **`Challenge.UpdateChallengeProgress`** uses `TryGetStatisticValue` and threads a `hasData` flag to `UpdateProgress`; `LevelReached` passes `hasData: true` (a level is always present).
- **`PlayerChallenge.UpdateProgress(value, hasData)`** — the `AtMost` path now completes on `hasData && value <= goal`, so a genuine `0` satisfies the goal while "no data yet" does not.
- **Docs**: the "no data = absence of a row" convention is documented in `docs/backend.md` and via XML docs on `TryGetStatisticValue`.

This is backend-only domain logic. The frontend only *displays* server-supplied statistics (it doesn't record battle progress or evaluate challenge completion), so there's no battle-parity surface to mirror and no API-model/codegen change.

## Test plan

- [x] `dotnet build` — clean, 0 warnings.
- [x] Full suite `dotnet test` — **1,259 passed, 0 failed** (Core, Infrastructure, Application, Api incl. integration tests against the Postgres/Redis containers).
- New/updated unit tests:
  - `RecordBattleCompleted_FirstVictoryWithZeroDuration_RecordsZeroFastestVictory`
  - `RecordBattleCompleted_ZeroFastestVictory_IsNotOverwrittenBySlowerVictory` (core regression)
  - `EvaluateChallenges_TimeTrial_CompletesWhenFastestVictoryIsRecordedZero`
  - `TryGetStatisticValue_UntrackedStatistic_ReturnsFalseAndZero` / `_RecordedZero_ReturnsTrueAndZero`
  - `PlayerChallengeTests`: split the old "0 = no data" test into `UpdateProgress_AtMost_NoData_DoesNotComplete` and `UpdateProgress_AtMost_GenuineZeroValue_Completes`; existing AtMost/AtLeast tests updated to the new signature.

Closes #697

https://claude.ai/code/session_019uJm9c4H7okJEa1CTbCzEc

---
_Generated by [Claude Code](https://claude.ai/code/session_019uJm9c4H7okJEa1CTbCzEc)_