### PR TITLE
Enforce one active account per username with a partial unique index

### DIFF
--- a/Game.Abstractions/DataAccess/IUsers.cs
+++ b/Game.Abstractions/DataAccess/IUsers.cs
@@ -20,9 +20,11 @@ namespace Game.Abstractions.DataAccess
         /// Persists a brand-new account: the user record described by <paramref name="account"/> together
         /// with its initial player graph (built from the <paramref name="player"/> blueprint), linked via
         /// the navigation property so EF resolves the foreign key without the user's store-generated id.
-        /// The inserts are queued in the surrounding unit of work.
+        /// The insert is committed immediately (not deferred to the surrounding unit of work) so the
+        /// active-username uniqueness guard can be honoured: returns <see langword="false"/> when the
+        /// username was claimed by a concurrently-created active account, <see langword="true"/> otherwise.
         /// </summary>
-        void CreateAccount(NewAccount account, NewPlayer player);
+        Task<bool> CreateAccount(NewAccount account, NewPlayer player);
 
         /// <summary>
         /// Loads the credentials of the active (non-archived) account with the given username — the data

--- a/Game.Api.Tests/Integration/LoginControllerTests.cs
+++ b/Game.Api.Tests/Integration/LoginControllerTests.cs
@@ -163,6 +163,30 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task CreateAccount_ConcurrentDuplicate_ReturnsCleanErrorNotServerError()
+        {
+            // CreateAccount inserts PlayerSkills with SkillId 0, 1, 2.
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            await TestDataSeeder.CreateSkillAsync(context, "Skill0");
+            await TestDataSeeder.CreateSkillAsync(context, "Skill1");
+            await TestDataSeeder.CreateSkillAsync(context, "Skill2");
+
+            var creds = new { Username = "raceuser", Password = "racepass" };
+
+            // Two concurrent requests racing past the existence check both reach the commit. The
+            // active-username unique index lets exactly one through; the loser must surface as a clean
+            // BadRequest, not the 500 the violation would otherwise raise outside the action.
+            var responses = await Task.WhenAll(
+                Client.PostAsJsonAsync("/api/Login/CreateAccount", creds, CancellationToken),
+                Client.PostAsJsonAsync("/api/Login/CreateAccount", creds, CancellationToken));
+
+            Assert.Equal(1, responses.Count(response => response.StatusCode == HttpStatusCode.OK));
+            Assert.Equal(1, responses.Count(response => response.StatusCode == HttpStatusCode.BadRequest));
+            Assert.DoesNotContain(responses, response => response.StatusCode == HttpStatusCode.InternalServerError);
+        }
+
+        [Fact]
         public async Task Status_Unauthenticated_Returns401()
         {
             var response = await Client.GetAsync("/api/Login/Status", CancellationToken);

--- a/Game.Application.Tests/Services/AccountServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/AccountServiceIntegrationTests.cs
@@ -1,7 +1,6 @@
 using Game.Abstractions.Auth;
 using Game.Abstractions.DataAccess;
 using Game.Infrastructure.Entities;
-using Game.Application;
 using Game.Application.Auth;
 using Game.Application.Services;
 using Game.Core;
@@ -42,9 +41,8 @@ namespace Game.Application.Tests.Services
             var status = await accountService.CreateAccount("newaccount", "newpass");
             Assert.Equal(CreateAccountStatus.Success, status);
 
-            // The inserts are queued in the change tracker; the surrounding unit of work persists them.
-            await scope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
-
+            // CreateAccount commits its own insert (so the active-username guard can be honoured), so the
+            // graph is already persisted — no separate unit-of-work commit is needed.
             using var verifyScope = CreateScope();
             var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
             var createdUser = await verifyContext.Users
@@ -102,6 +100,81 @@ namespace Game.Application.Tests.Services
             var status = await accountService.CreateAccount("existing", "anotherpass");
 
             Assert.Equal(CreateAccountStatus.UsernameTaken, status);
+        }
+
+        [Fact]
+        public async Task CreateAccount_ConcurrentSameUsername_CreatesExactlyOneActiveAccount()
+        {
+            // The starter skills 0/1/2 must exist for each new player's player-skill FK.
+            using (var seedScope = CreateScope())
+            {
+                var seedContext = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                await TestDataSeeder.CreateSkillAsync(seedContext, "Skill0");
+                await TestDataSeeder.CreateSkillAsync(seedContext, "Skill1");
+                await TestDataSeeder.CreateSkillAsync(seedContext, "Skill2");
+            }
+
+            // Each attempt runs on its own scope/DbContext (a context is not thread-safe). Whether both race
+            // past the existence check or one observes the other's row, the active-username unique index must
+            // ensure only one insert wins; the loser is reported as taken rather than failing.
+            async Task<CreateAccountStatus> Attempt()
+            {
+                using var scope = CreateScope();
+                return await CreateAccountService(scope.ServiceProvider).CreateAccount("raceuser", "racepass");
+            }
+
+            var results = await Task.WhenAll(Attempt(), Attempt());
+
+            Assert.Equal(1, results.Count(status => status == CreateAccountStatus.Success));
+            Assert.Equal(1, results.Count(status => status == CreateAccountStatus.UsernameTaken));
+
+            using var verifyScope = CreateScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
+            var activeCount = await verifyContext.Users
+                .CountAsync(user => user.Username == "raceuser" && user.ArchivedAt == null, CancellationToken);
+            Assert.Equal(1, activeCount);
+        }
+
+        [Fact]
+        public async Task CreateAccount_UsernameOfArchivedAccount_SucceedsLeavingOneActiveRow()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // An archived row must not block reuse of its username — the partial index filters it out.
+            var archived = await TestDataSeeder.CreateUserAsync(context, "reusable", "oldpass");
+            archived.ArchivedAt = DateTime.UtcNow;
+            await context.SaveChangesAsync(CancellationToken);
+
+            // The starter skills 0/1/2 must exist for the new player's player-skill FK.
+            await TestDataSeeder.CreateSkillAsync(context, "Skill0");
+            await TestDataSeeder.CreateSkillAsync(context, "Skill1");
+            await TestDataSeeder.CreateSkillAsync(context, "Skill2");
+
+            var status = await CreateAccountService(scope.ServiceProvider).CreateAccount("reusable", "newpass");
+            Assert.Equal(CreateAccountStatus.Success, status);
+
+            using var verifyScope = CreateScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
+            var rows = await verifyContext.Users
+                .Where(user => user.Username == "reusable")
+                .ToListAsync(CancellationToken);
+            Assert.Equal(2, rows.Count);
+            Assert.Equal(1, rows.Count(user => user.ArchivedAt == null));
+        }
+
+        [Fact]
+        public async Task ActiveUsername_SecondActiveDuplicateInsert_IsRejectedByUniqueIndex()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            await TestDataSeeder.CreateUserAsync(context, "dupe", "pass");
+
+            // A second active row for the same username must be rejected at the DB level — the guard the
+            // concurrent-creation handling relies on — independent of any application-level pre-check.
+            context.Users.Add(new User { Username = "dupe", PassHash = "hash", LastLogin = DateTime.UtcNow });
+
+            await Assert.ThrowsAsync<DbUpdateException>(() => context.SaveChangesAsync(CancellationToken));
         }
 
         [Fact]

--- a/Game.Application/Services/AccountService.cs
+++ b/Game.Application/Services/AccountService.cs
@@ -33,7 +33,8 @@ namespace Game.Application.Services
         /// credential material plus the new-player blueprint to the Identity context for persistence. The
         /// new-player defaults (starter skills, attributes, and log preferences) are a domain concern
         /// owned by <see cref="NewPlayerFactory"/>; this method only orchestrates — it builds no entity
-        /// graphs. The inserts are persisted by the surrounding unit of work.
+        /// graphs. The up-front check is a fast path; the data tier's active-username uniqueness guard is
+        /// the authority, so a username claimed concurrently (past the check) is still reported as taken.
         /// </summary>
         public async Task<CreateAccountStatus> CreateAccount(string username, string password)
         {
@@ -48,9 +49,9 @@ namespace Game.Application.Services
                 PassHash = _passwordHasher.Hash(password),
             };
 
-            _users.CreateAccount(account, _newPlayerFactory.Create(username));
+            var created = await _users.CreateAccount(account, _newPlayerFactory.Create(username));
 
-            return CreateAccountStatus.Success;
+            return created ? CreateAccountStatus.Success : CreateAccountStatus.UsernameTaken;
         }
 
         /// <summary>

--- a/Game.DataAccess/Repositories/Users.cs
+++ b/Game.DataAccess/Repositories/Users.cs
@@ -5,6 +5,7 @@ using Game.Core.Players;
 using Game.DataAccess.Mapping;
 using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using UserEntity = Game.Infrastructure.Entities.User;
 
 namespace Game.DataAccess.Repositories
@@ -47,11 +48,11 @@ namespace Game.DataAccess.Repositories
             _context = context;
         }
 
-        public void CreateAccount(NewAccount account, NewPlayer player)
+        public async Task<bool> CreateAccount(NewAccount account, NewPlayer player)
         {
-            // The account graph is persisted straight through the unit of work (no cache write or domain
-            // events): a freshly created player is only loaded into the cache later, on login. The player
-            // links to the user via navigation, so EF resolves the FK without the store-generated user id.
+            // The account graph carries no cache write or domain events: a freshly created player is only
+            // loaded into the cache later, on login. The player links to the user via navigation, so EF
+            // resolves the FK without the store-generated user id.
             var user = new UserEntity
             {
                 Username = account.Username,
@@ -61,6 +62,24 @@ namespace Game.DataAccess.Repositories
 
             _context.Users.Add(user);
             _context.Players.Add(PlayerMapper.ToEntity(player, user));
+
+            try
+            {
+                // Commit here (rather than deferring to the per-request unit of work) so the active-username
+                // unique index's rejection of a concurrent duplicate surfaces as a result, not a 500 raised
+                // outside the action by the commit filter.
+                await _context.SaveChangesAsync();
+                return true;
+            }
+            catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation })
+            {
+                // The only unique constraint a new account can violate is the active-username index, so a
+                // unique violation means another request created the same active username concurrently.
+                // Clear the tracker (it holds only this account's rolled-back inserts) so the unit-of-work
+                // commit filter doesn't re-attempt them after the action returns.
+                _context.ChangeTracker.Clear();
+                return false;
+            }
         }
 
         public Task<AccountCredentials?> GetUser(string username)

--- a/Game.Infrastructure/Database/GameContext.cs
+++ b/Game.Infrastructure/Database/GameContext.cs
@@ -435,6 +435,13 @@ namespace Game.Infrastructure.Database
                 // Self-contained PBKDF2 hash: $pbkdf2-sha256$<iterations>$<base64-salt>$<base64-key>.
                 entity.Property(u => u.PassHash)
                     .HasMaxLength(128);
+
+                // At most one active (non-archived) account per username, enforced at the DB level so two
+                // concurrent CreateAccount requests can't both insert a duplicate active row. The partial
+                // filter excludes archived users, preserving username reuse after archival.
+                entity.HasIndex(u => u.Username)
+                    .IsUnique()
+                    .HasFilter("\"ArchivedAt\" IS NULL");
             });
 
             modelBuilder.Entity<BrowserInfo>(entity =>

--- a/Game.Infrastructure/Migrations/20260615165510_AddActiveUsernameUniqueIndex.Designer.cs
+++ b/Game.Infrastructure/Migrations/20260615165510_AddActiveUsernameUniqueIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Game.Infrastructure.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20260615165510_AddActiveUsernameUniqueIndex")]
+    partial class AddActiveUsernameUniqueIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Game.Infrastructure/Migrations/20260615165510_AddActiveUsernameUniqueIndex.cs
+++ b/Game.Infrastructure/Migrations/20260615165510_AddActiveUsernameUniqueIndex.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Game.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddActiveUsernameUniqueIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_Username",
+                table: "Users",
+                column: "Username",
+                unique: true,
+                filter: "\"ArchivedAt\" IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Users_Username",
+                table: "Users");
+        }
+    }
+}

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -137,6 +137,8 @@ Passwords use **PBKDF2-HMAC-SHA256** behind an `IPasswordHasher` abstraction. A 
 
 Account creation and the login/refresh/logout flows are orchestrated by `AccountService` in the application layer; the controller is a thin HTTP adapter that maps the result and wires the request-scoped session (a presentation concern). The new-player defaults (starter skills, base attributes, default preferences) are a domain concern built by a `NewPlayerFactory` in `Game.Core`, so the application layer neither encodes the defaults nor constructs entity graphs. Access-token issuance sits behind an `IAccessTokenService` abstraction so the application layer stays free of the JWT libraries, while the concrete implementation lives at the presentation edge alongside the bearer-validation pipeline.
 
+At most one active account may hold a given username, enforced by a **partial unique index** (`Username WHERE ArchivedAt IS NULL`) so two concurrent creations can't both slip past the up-front availability check and insert duplicate active rows. The filter excludes archived users, preserving username reuse after archival. Account creation therefore commits its own insert in the data tier (rather than deferring to the per-request unit of work) so the index's unique-violation surfaces as a clean "username taken" result instead of a 500 raised after the action returns.
+
 ## CORS allowed origins (deployment config)
 
 The browser CORS policy's allowed origins are **configuration-bound, not hardcoded** — they are deployment-specific. The list supports multiple origins and is validated at startup (must be non-empty), so a misconfigured environment fails fast rather than silently rejecting every browser request. The local dev origin ships in the Development config.


### PR DESCRIPTION
## Summary

Fixes #694.

`CreateAccount` enforced "one non-archived row per username" only by application convention: it called `CheckIfUsernameExists` and then inserted, with nothing serializing the two against a concurrent request. Two concurrent `CreateAccount` calls for the same username could both pass the check and both insert, producing **two active rows** — login would then authenticate against an arbitrary one.

This change closes that race at the database level and reports the loser cleanly.

## Changes

- **Partial unique index** on `Username WHERE ArchivedAt IS NULL` (`GameContext` + migration `AddActiveUsernameUniqueIndex`). The filter excludes archived users, so username reuse after archival is preserved while concurrent active duplicates become impossible.
- **Clean unique-violation handling.** `IUsers.CreateAccount` now commits its own insert in the data tier and maps the index's unique-violation (`23505`) to a `false`/`UsernameTaken` result. Previously the violation would surface as a `DbUpdateException` in the global commit filter *after* the controller action returned — an unhandled 500. The change tracker is cleared on the caught violation so the commit filter doesn't re-attempt the rolled-back inserts.
- The up-front `CheckIfUsernameExists` check is kept as a fast path (it avoids hashing+insert work for the common case); the index is now the authority for the race.

### Why commit in the data tier

The unit-of-work commit filter runs *outside* the controller action, so a deferred commit raises the violation where it can only become a 500. Committing the self-contained account graph in the data tier lets the violation be translated to a domain result — mapping EF/Npgsql exception knowledge stays in the data tier, consistent with how `SetUserRoles`/`ArchiveUser` already return data-tier outcomes.

## Tests

- `CreateAccount_ConcurrentSameUsername_CreatesExactlyOneActiveAccount` — two concurrent creations (separate scopes/contexts) yield exactly one `Success` and one `UsernameTaken`, with one active row.
- `CreateAccount_ConcurrentDuplicate_ReturnsCleanErrorNotServerError` — the same race over the full HTTP path returns one `200` and one `400`, never a `500` (exercises the commit-filter path the bug lived in).
- `ActiveUsername_SecondActiveDuplicateInsert_IsRejectedByUniqueIndex` — deterministic guard that a second active duplicate insert is rejected, independent of timing.
- `CreateAccount_UsernameOfArchivedAccount_SucceedsLeavingOneActiveRow` — confirms the filter preserves reuse-after-archive (a regression to a non-filtered index would fail this).
- Updated `CreateAccount_NewUsername_InsertsUserAndInitialPlayerGraph` for the now-self-committing insert.

Full suites green locally: Application.Tests (240), Api.Tests (450), Infrastructure.Tests (37).

## Docs

Added a concise note to `docs/backend.md` (Account/login orchestration) on the active-username invariant and the data-tier self-commit rationale.

https://claude.ai/code/session_01Dm1pxdU1bs7RKqTDpmoPJ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dm1pxdU1bs7RKqTDpmoPJ7)_