### PR TITLE
Map socket close reasons to appropriate WebSocket status codes

### DIFF
--- a/Game.Api.Tests/Unit/SocketCloseReasonTests.cs
+++ b/Game.Api.Tests/Unit/SocketCloseReasonTests.cs
@@ -1,4 +1,5 @@
 using Game.Api;
+using System.Net.WebSockets;
 using Xunit;
 
 namespace Game.Api.Tests.Unit
@@ -49,6 +50,59 @@ namespace Game.Api.Tests.Unit
             var undefined = (ESocketCloseReason)int.MaxValue;
 
             Assert.Throws<ArgumentOutOfRangeException>(() => undefined.GetDescription());
+        }
+
+        [Theory]
+        [InlineData(ESocketCloseReason.Finished)]
+        [InlineData(ESocketCloseReason.SocketReplaced)]
+        [InlineData(ESocketCloseReason.ServerShuttingDown)]
+        public void GetCloseStatus_GracefulReason_IsNormalClosure(ESocketCloseReason reason)
+        {
+            // A finished connection, an intentional takeover, and a planned shutdown are all clean closures —
+            // they must not be reported as errors by status code.
+            Assert.Equal(WebSocketCloseStatus.NormalClosure, reason.GetCloseStatus());
+        }
+
+        [Fact]
+        public void GetCloseStatus_MessageTooBig_IsMessageTooBig()
+        {
+            Assert.Equal(WebSocketCloseStatus.MessageTooBig, ESocketCloseReason.MessageTooBig.GetCloseStatus());
+        }
+
+        [Fact]
+        public void GetCloseStatus_Inactivity_IsPolicyViolation()
+        {
+            Assert.Equal(WebSocketCloseStatus.PolicyViolation, ESocketCloseReason.Inactivity.GetCloseStatus());
+        }
+
+        [Theory]
+        [InlineData(ESocketCloseReason.Inactivity)]
+        [InlineData(ESocketCloseReason.MessageTooBig)]
+        public void GetCloseStatus_NonGracefulReason_IsNotNormalClosure(ESocketCloseReason reason)
+        {
+            // The motivating bug: error/abnormal closures previously reported NormalClosure, so a client
+            // inspecting the status code couldn't tell them apart from a clean finish.
+            Assert.NotEqual(WebSocketCloseStatus.NormalClosure, reason.GetCloseStatus());
+        }
+
+        [Theory]
+        [InlineData(ESocketCloseReason.Finished)]
+        [InlineData(ESocketCloseReason.Inactivity)]
+        [InlineData(ESocketCloseReason.SocketReplaced)]
+        [InlineData(ESocketCloseReason.MessageTooBig)]
+        [InlineData(ESocketCloseReason.ServerShuttingDown)]
+        public void GetCloseStatus_AnyDefinedReason_ReturnsAStatus(ESocketCloseReason reason)
+        {
+            // Every defined reason must map to a status; an unhandled one would throw rather than fall through.
+            Assert.True(Enum.IsDefined(reason.GetCloseStatus()));
+        }
+
+        [Fact]
+        public void GetCloseStatus_UndefinedReason_Throws()
+        {
+            var undefined = (ESocketCloseReason)int.MaxValue;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => undefined.GetCloseStatus());
         }
     }
 }

--- a/Game.Api.Tests/Unit/SocketContextTests.cs
+++ b/Game.Api.Tests/Unit/SocketContextTests.cs
@@ -61,6 +61,37 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
+        public async Task Close_ErrorReason_SendsCloseFrameWithMatchingStatusCode()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var socket = new GatedCloseWebSocket();
+            var context = CreateContext(socket);
+
+            var closeTask = context.Close(ESocketCloseReason.MessageTooBig, cancellationToken);
+            await socket.CloseStarted.WaitAsync(WaitTimeout, cancellationToken);
+            socket.CompleteClose();
+            await closeTask.WaitAsync(WaitTimeout, cancellationToken);
+
+            // The close frame carries the error status code, not a hardcoded NormalClosure (#610).
+            Assert.Equal(WebSocketCloseStatus.MessageTooBig, socket.CloseStatusUsed);
+        }
+
+        [Fact]
+        public async Task Close_GracefulReason_SendsCloseFrameWithNormalClosure()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var socket = new GatedCloseWebSocket();
+            var context = CreateContext(socket);
+
+            var closeTask = context.Close(ESocketCloseReason.Finished, cancellationToken);
+            await socket.CloseStarted.WaitAsync(WaitTimeout, cancellationToken);
+            socket.CompleteClose();
+            await closeTask.WaitAsync(WaitTimeout, cancellationToken);
+
+            Assert.Equal(WebSocketCloseStatus.NormalClosure, socket.CloseStatusUsed);
+        }
+
+        [Fact]
         public async Task Close_WhenSocketNotOpen_SettlesWithoutSendingCloseFrame()
         {
             var cancellationToken = TestContext.Current.CancellationToken;
@@ -91,6 +122,7 @@ namespace Game.Api.Tests.Unit
             /// <summary>Completes once <see cref="CloseAsync"/> has begun (and is blocking on the gate).</summary>
             public Task CloseStarted => _closeStarted.Task;
             public bool CloseAsyncCalled { get; private set; }
+            public WebSocketCloseStatus? CloseStatusUsed { get; private set; }
             public WebSocketState StateOverride { get; init; } = WebSocketState.Open;
 
             public void CompleteClose() => _closeGate.TrySetResult();
@@ -104,6 +136,7 @@ namespace Game.Api.Tests.Unit
             public override async Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
             {
                 CloseAsyncCalled = true;
+                CloseStatusUsed = closeStatus;
                 _closeStarted.TrySetResult();
                 await _closeGate.Task;
             }

--- a/Game.Api/Extensions.cs
+++ b/Game.Api/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using Game.Api.Models;
+using System.Net.WebSockets;
 
 namespace Game.Api
 {
@@ -13,6 +14,27 @@ namespace Game.Api
                 ESocketCloseReason.SocketReplaced => "The socket has been closed because a new one was established.",
                 ESocketCloseReason.MessageTooBig => "The socket has been closed because a message exceeded the maximum allowed size.",
                 ESocketCloseReason.ServerShuttingDown => "The socket has been closed because the server is shutting down.",
+                _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, "Unhandled socket close reason.")
+            };
+        }
+
+        /// <summary>
+        /// Maps a close reason to the WebSocket status code sent on the close frame, so a client inspecting
+        /// the status code alone can tell an error/abnormal closure from a graceful one. Graceful, expected
+        /// closures use <see cref="WebSocketCloseStatus.NormalClosure"/>: a finished connection, an intentional
+        /// single-session takeover, and a planned shutdown drain (the client treats that normal closure as a
+        /// cue to reconnect to a healthy instance). Non-graceful closures get a distinct status — an idle
+        /// timeout as a policy violation, an oversized message as the matching message-too-big code.
+        /// </summary>
+        public static WebSocketCloseStatus GetCloseStatus(this ESocketCloseReason reason)
+        {
+            return reason switch
+            {
+                ESocketCloseReason.Finished => WebSocketCloseStatus.NormalClosure,
+                ESocketCloseReason.SocketReplaced => WebSocketCloseStatus.NormalClosure,
+                ESocketCloseReason.ServerShuttingDown => WebSocketCloseStatus.NormalClosure,
+                ESocketCloseReason.Inactivity => WebSocketCloseStatus.PolicyViolation,
+                ESocketCloseReason.MessageTooBig => WebSocketCloseStatus.MessageTooBig,
                 _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, "Unhandled socket close reason.")
             };
         }

--- a/Game.Api/Sockets/SocketContext.cs
+++ b/Game.Api/Sockets/SocketContext.cs
@@ -132,7 +132,7 @@ namespace Game.Api.Sockets
                     {
                         if (_socket.State is WebSocketState.Open)
                         {
-                            await _socket.CloseAsync(WebSocketCloseStatus.NormalClosure, closeReason.GetDescription(), cancellationToken);
+                            await _socket.CloseAsync(closeReason.GetCloseStatus(), closeReason.GetDescription(), cancellationToken);
                         }
                     }
                     finally


### PR DESCRIPTION
## Summary

Fixes #610. Follow-up to #607, which corrected the close-frame *description* but left `SocketContext.Close` hardcoding `WebSocketCloseStatus.NormalClosure` for every reason. As a result, a client inspecting only the WebSocket close **status code** (e.g. for telemetry) still saw `NormalClosure` on genuine error paths like an oversized message.

This adds a `GetCloseStatus` extension (mirroring the existing `GetDescription`) that maps each `ESocketCloseReason` to the status code reflecting graceful-vs-error semantics, and wires it into the close frame.

## Design decision — graceful vs. error closures

The issue flagged this as a design decision (graceful vs. error semantics), so the split is intentional:

| Reason | Status code | Rationale |
| --- | --- | --- |
| `Finished` | `NormalClosure` (1000) | Client finished — clean. |
| `SocketReplaced` | `NormalClosure` (1000) | Intentional single-session takeover; the client already handles this explicitly. |
| `ServerShuttingDown` | `NormalClosure` (1000) | A planned drain is normal operations, not an error — and keeping it normal preserves the documented "client treats normal closure as a cue to reconnect" contract (see backend.md *Graceful socket drain on shutdown* and `SocketDrainTests`). |
| `Inactivity` | `PolicyViolation` (1008) | Idle-timeout policy enforcement — abnormal from the connection's perspective. |
| `MessageTooBig` | `MessageTooBig` (1009) | Protocol/anti-abuse error, exactly as the issue suggested. |

Graceful closures stay `NormalClosure` so planned shutdowns/takeovers don't pollute error telemetry; non-graceful ones now carry a distinct code so a client can tell them apart by status code alone.

### Client-side impact

The frontend (`api-socket.ts`) only branches on `=== NORMAL_CLOSURE`. The three graceful reasons are unchanged. For `Inactivity`/`MessageTooBig` (previously `NormalClosure`, now non-normal), the client no longer stops its keepalive on close and instead lets the keepalive background-reconnect — which is benign-to-beneficial: an inactivity close only fires when the client's heartbeats stopped reaching the server, so auto-reconnecting on revival is the desired recovery. No client change was required, and no frontend test pins a server reason to a specific code.

No doc update: the mapping is a transport detail captured in a code comment, and backend.md's shutdown section ("send each socket a normal-closure close frame") remains accurate.

## Tests

- `SocketCloseReasonTests`: full mapping coverage — graceful reasons → `NormalClosure`, `MessageTooBig` → `MessageTooBig`, `Inactivity` → `PolicyViolation`, non-graceful reasons are non-normal, every defined reason returns a status, undefined throws.
- `SocketContextTests`: the test double now captures the status passed to `CloseAsync`, with tests proving an error reason sends a matching code and a graceful reason sends `NormalClosure`.
- All `Game.Api.Tests` unit tests (88) and the `SocketDrainTests` integration tests pass.

https://claude.ai/code/session_01J1eJfykJE9FL73B47g9zQC

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1eJfykJE9FL73B47g9zQC)_