### PR TITLE
Standardize edit-of-missing rejection across the remaining admin saves (Skills/Enemies/Zones/Challenges)

### DIFF
--- a/Game.Abstractions/DataAccess/Admin/IAdminChallenges.cs
+++ b/Game.Abstractions/DataAccess/Admin/IAdminChallenges.cs
@@ -10,7 +10,8 @@ namespace Game.Abstractions.DataAccess.Admin
     /// </summary>
     public interface IAdminChallenges
     {
-        /// <summary>Applies an identity-level Add/Edit/Delete change set to the challenge catalogue.</summary>
-        void SaveChallenges(IReadOnlyList<Change<Challenge>> changes);
+        /// <summary>Applies an identity-level Add/Edit/Delete change set to the challenge catalogue.
+        /// Returns <c>false</c> (applying nothing) if an edit targets a challenge that does not exist.</summary>
+        bool SaveChallenges(IReadOnlyList<Change<Challenge>> changes);
     }
 }

--- a/Game.Abstractions/DataAccess/Admin/IAdminEnemies.cs
+++ b/Game.Abstractions/DataAccess/Admin/IAdminEnemies.cs
@@ -11,8 +11,9 @@ namespace Game.Abstractions.DataAccess.Admin
     /// </summary>
     public interface IAdminEnemies
     {
-        /// <summary>Applies an identity-level Add/Edit/Delete change set to the enemy catalogue.</summary>
-        void SaveEnemies(IReadOnlyList<Change<Enemy>> changes);
+        /// <summary>Applies an identity-level Add/Edit/Delete change set to the enemy catalogue.
+        /// Returns <c>false</c> (applying nothing) if an edit targets an enemy that does not exist.</summary>
+        bool SaveEnemies(IReadOnlyList<Change<Enemy>> changes);
 
         /// <summary>Replaces an enemy's attribute distributions. Returns <c>false</c> if the enemy does not exist.</summary>
         bool SetAttributeDistributions(SetEnemyAttributeDistributions data);

--- a/Game.Abstractions/DataAccess/Admin/IAdminSkills.cs
+++ b/Game.Abstractions/DataAccess/Admin/IAdminSkills.cs
@@ -9,8 +9,9 @@ namespace Game.Abstractions.DataAccess.Admin
     /// </summary>
     public interface IAdminSkills
     {
-        /// <summary>Applies an identity-level Add/Edit/Delete change set to the skill catalogue.</summary>
-        void SaveSkills(IReadOnlyList<Change<Skill>> changes);
+        /// <summary>Applies an identity-level Add/Edit/Delete change set to the skill catalogue.
+        /// Returns <c>false</c> (applying nothing) if an edit targets a skill that does not exist.</summary>
+        bool SaveSkills(IReadOnlyList<Change<Skill>> changes);
 
         /// <summary>Applies a change set to a skill's damage multipliers. Returns <c>false</c> if the skill does not exist.</summary>
         bool SetMultipliers(AddEditAttributesData data);

--- a/Game.Abstractions/DataAccess/Admin/IAdminZones.cs
+++ b/Game.Abstractions/DataAccess/Admin/IAdminZones.cs
@@ -11,9 +11,9 @@ namespace Game.Abstractions.DataAccess.Admin
     {
         /// <summary>
         /// Applies an identity-level Add/Edit/Delete change set to the zone catalogue. Returns <c>null</c>
-        /// on success, or a user-facing error message (applying nothing) when an Add/Edit sets a
-        /// <see cref="Zone.BossEnemyId"/> that does not reference an existing boss enemy, or an
-        /// <see cref="Zone.UnlockChallengeId"/> that is out of range.
+        /// on success, or a user-facing error message (applying nothing) when an edit targets a zone that
+        /// does not exist, or an Add/Edit sets a <see cref="Zone.BossEnemyId"/> that does not reference an
+        /// existing boss enemy, or an <see cref="Zone.UnlockChallengeId"/> that is out of range.
         /// </summary>
         string? SaveZones(IReadOnlyList<Change<Zone>> changes);
 

--- a/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
@@ -146,6 +146,53 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task AddEditEnemies_EditUnknownEnemy_ReturnsErrorAndPersistsNothing()
+        {
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            // An identity-level edit of a non-existent enemy is a not-found rejection (not a 500 from the
+            // 0-row update), and the whole batch is rejected up front — so the valid Add alongside it is
+            // not persisted.
+            var changes = new[]
+            {
+                new
+                {
+                    Item = new
+                    {
+                        Id = 0,
+                        Name = "Ghost Enemy",
+                        IsBoss = false,
+                        AttributeDistribution = Array.Empty<object>(),
+                        SkillPool = Array.Empty<int>(),
+                        Spawns = Array.Empty<object>()
+                    },
+                    ChangeType = 0 // Add
+                },
+                new
+                {
+                    Item = new
+                    {
+                        Id = 999999,
+                        Name = "Phantom",
+                        IsBoss = false,
+                        AttributeDistribution = Array.Empty<object>(),
+                        SkillPool = Array.Empty<int>(),
+                        Spawns = Array.Empty<object>()
+                    },
+                    ChangeType = 1 // Edit
+                }
+            };
+
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/AddEditEnemies", changes, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Equal("Enemy not found.", result.ErrorMessage);
+            Assert.DoesNotContain(GetEnemies(), e => e.Name == "Ghost Enemy");
+        }
+
+        [Fact]
         public async Task AddEditZones_AddZone_Succeeds()
         {
             using var authClient = await SetupAuthenticatedClientAsync();
@@ -761,6 +808,57 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task AddEditSkills_EditUnknownSkill_ReturnsErrorAndPersistsNothing()
+        {
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            // An identity-level edit of a non-existent skill is a not-found rejection (not a 500 from the
+            // 0-row update), and the whole batch is rejected up front — so the valid Add alongside it is
+            // not persisted.
+            var changes = new[]
+            {
+                new
+                {
+                    Item = new
+                    {
+                        Id = 0,
+                        Name = "Ghost Skill",
+                        BaseDamage = 10m,
+                        CooldownMs = 1000,
+                        Description = "Should never be saved",
+                        IconPath = "skills/ghost.png",
+                        DamageMultipliers = Array.Empty<object>(),
+                        Effects = Array.Empty<object>()
+                    },
+                    ChangeType = 0 // Add
+                },
+                new
+                {
+                    Item = new
+                    {
+                        Id = 999999,
+                        Name = "Phantom",
+                        BaseDamage = 1m,
+                        CooldownMs = 1000,
+                        Description = "x",
+                        IconPath = "skills/phantom.png",
+                        DamageMultipliers = Array.Empty<object>(),
+                        Effects = Array.Empty<object>()
+                    },
+                    ChangeType = 1 // Edit
+                }
+            };
+
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/AddEditSkills", changes, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Equal("Skill not found.", result.ErrorMessage);
+            Assert.DoesNotContain(GetSkills(), s => s.Name == "Ghost Skill");
+        }
+
+        [Fact]
         public async Task AddEditChallenges_AddChallenge_Succeeds()
         {
             using var authClient = await SetupAuthenticatedClientAsync();
@@ -837,6 +935,57 @@ namespace Game.Api.Tests.Integration
 
             var created = Assert.Single(GetChallenges(), c => c.Name == "Pyromancer");
             Assert.Equal(skill.Id, created.RewardSkillId);
+        }
+
+        [Fact]
+        public async Task AddEditChallenges_EditUnknownChallenge_ReturnsErrorAndPersistsNothing()
+        {
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            // An identity-level edit of a non-existent challenge is a not-found rejection (not a 500 from
+            // the 0-row update), and the whole batch is rejected up front — so the valid Add alongside it
+            // is not persisted.
+            var changes = new[]
+            {
+                new
+                {
+                    Item = new
+                    {
+                        Id = 0,
+                        Name = "Ghost Challenge",
+                        Description = "Should never be saved",
+                        ChallengeTypeId = (int)EChallengeType.EnemiesKilled,
+                        TargetEntityId = (int?)null,
+                        ProgressGoal = 5m,
+                        RewardItemId = (int?)null,
+                        RewardItemModId = (int?)null
+                    },
+                    ChangeType = 0 // Add
+                },
+                new
+                {
+                    Item = new
+                    {
+                        Id = 999999,
+                        Name = "Phantom",
+                        Description = "x",
+                        ChallengeTypeId = (int)EChallengeType.EnemiesKilled,
+                        TargetEntityId = (int?)null,
+                        ProgressGoal = 1m,
+                        RewardItemId = (int?)null,
+                        RewardItemModId = (int?)null
+                    },
+                    ChangeType = 1 // Edit
+                }
+            };
+
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/AddEditChallenges", changes, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Equal("Challenge not found.", result.ErrorMessage);
+            Assert.DoesNotContain(GetChallenges(), c => c.Name == "Ghost Challenge");
         }
 
         // The reference-data HTTP GET endpoints were removed (#64); reads now go over the socket, which
@@ -1961,6 +2110,53 @@ namespace Game.Api.Tests.Integration
             Assert.NotNull(result);
             Assert.Contains("unlock challenge", result.ErrorMessage ?? "", StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(GetZones(), z => z.Name == "Phantom Gate");
+        }
+
+        [Fact]
+        public async Task AddEditZones_EditUnknownZone_ReturnsErrorAndPersistsNothing()
+        {
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            // An identity-level edit of a non-existent zone is a not-found rejection (not a 500 from the
+            // 0-row update), and the whole batch is rejected up front — so the valid Add alongside it is
+            // not persisted.
+            var changes = new[]
+            {
+                new
+                {
+                    Item = new
+                    {
+                        Id = 0,
+                        Name = "Ghost Zone",
+                        Description = "Should never be saved",
+                        Order = 0,
+                        LevelMin = 1,
+                        LevelMax = 5
+                    },
+                    ChangeType = 0 // Add
+                },
+                new
+                {
+                    Item = new
+                    {
+                        Id = 999999,
+                        Name = "Phantom",
+                        Description = "x",
+                        Order = 0,
+                        LevelMin = 1,
+                        LevelMax = 5
+                    },
+                    ChangeType = 1 // Edit
+                }
+            };
+
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/AddEditZones", changes, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Equal("Zone not found.", result.ErrorMessage);
+            Assert.DoesNotContain(GetZones(), z => z.Name == "Ghost Zone");
         }
 
         [Fact]

--- a/Game.Api/Controllers/Admin/AdminChallengesController.cs
+++ b/Game.Api/Controllers/Admin/AdminChallengesController.cs
@@ -24,8 +24,9 @@ namespace Game.Api.Controllers.Admin
         [HttpPost]
         public ApiResponse AddEditChallenges([FromBody] List<Change<Challenge>> changes)
         {
-            _adminChallenges.SaveChallenges(changes);
-            return ApiResponse.Success();
+            return _adminChallenges.SaveChallenges(changes)
+                ? ApiResponse.Success()
+                : ApiResponse.Error("Challenge not found.");
         }
     }
 }

--- a/Game.Api/Controllers/Admin/AdminEnemiesController.cs
+++ b/Game.Api/Controllers/Admin/AdminEnemiesController.cs
@@ -25,8 +25,9 @@ namespace Game.Api.Controllers.Admin
         [HttpPost]
         public ApiResponse AddEditEnemies([FromBody] List<Change<Enemy>> changes)
         {
-            _adminEnemies.SaveEnemies(changes);
-            return ApiResponse.Success();
+            return _adminEnemies.SaveEnemies(changes)
+                ? ApiResponse.Success()
+                : ApiResponse.Error("Enemy not found.");
         }
 
         [HttpPost]

--- a/Game.Api/Controllers/Admin/AdminSkillsController.cs
+++ b/Game.Api/Controllers/Admin/AdminSkillsController.cs
@@ -23,8 +23,9 @@ namespace Game.Api.Controllers.Admin
         [HttpPost]
         public ApiResponse AddEditSkills([FromBody] List<Change<Skill>> changes)
         {
-            _adminSkills.SaveSkills(changes);
-            return ApiResponse.Success();
+            return _adminSkills.SaveSkills(changes)
+                ? ApiResponse.Success()
+                : ApiResponse.Error("Skill not found.");
         }
 
         [HttpPost]

--- a/Game.DataAccess/Repositories/Admin/AdminChallenges.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminChallenges.cs
@@ -1,4 +1,5 @@
 using Game.Abstractions.Contracts.Admin;
+using Game.Abstractions.DataAccess;
 using Game.Abstractions.DataAccess.Admin;
 using Contracts = Game.Abstractions.Contracts;
 using Entities = Game.Infrastructure.Entities;
@@ -11,12 +12,24 @@ namespace Game.DataAccess.Repositories.Admin
     /// The contract's <c>StatisticType</c>/<c>EntityType</c> are read-only projections of the type
     /// and are ignored here — the type id is the only persisted classification.
     /// </summary>
-    internal class AdminChallenges(IEntityStore entityStore) : IAdminChallenges
+    internal class AdminChallenges(IChallenges challenges, IEntityStore entityStore) : IAdminChallenges
     {
+        private readonly IChallenges _challenges = challenges;
         private readonly IEntityStore _entityStore = entityStore;
 
-        public void SaveChallenges(IReadOnlyList<Change<Contracts.Challenge>> changes)
+        public bool SaveChallenges(IReadOnlyList<Change<Contracts.Challenge>> changes)
         {
+            // An edit must target an existing challenge; a missing id is a not-found rejection (matching the
+            // relationship setters), not an EF 0-row update that throws. Challenges are zero-based-id
+            // reference data, so a valid id is an in-range index. Validate the whole batch up front so the
+            // commit filter doesn't persist the rest of the batch alongside an invalid edit.
+            var challengeCount = _challenges.All().Count;
+            if (changes.Any(c => c.ChangeType == EChangeType.Edit
+                && (c.Item.Id < 0 || c.Item.Id >= challengeCount)))
+            {
+                return false;
+            }
+
             ChangeSetProcessor.Apply(changes,
                 add: item => _entityStore.Insert(new Entities.Challenge
                 {
@@ -42,6 +55,8 @@ namespace Game.DataAccess.Repositories.Admin
                     RewardSkillId = item.RewardSkillId,
                     RetiredAt = item.RetiredAt,
                 }));
+
+            return true;
         }
     }
 }

--- a/Game.DataAccess/Repositories/Admin/AdminEnemies.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminEnemies.cs
@@ -16,8 +16,16 @@ namespace Game.DataAccess.Repositories.Admin
         private readonly IEnemyEntityCache _enemies = enemies;
         private readonly IEntityStore _entityStore = entityStore;
 
-        public void SaveEnemies(IReadOnlyList<Change<Contracts.Enemy>> changes)
+        public bool SaveEnemies(IReadOnlyList<Change<Contracts.Enemy>> changes)
         {
+            // An edit must target an existing enemy; a missing id is a not-found rejection (matching the
+            // relationship setters), not an EF 0-row update that throws. Validate the whole batch up front
+            // so the commit filter doesn't persist the rest of the batch alongside an invalid edit.
+            if (changes.Any(c => c.ChangeType == EChangeType.Edit && _enemies.GetEnemy(c.Item.Id) is null))
+            {
+                return false;
+            }
+
             ChangeSetProcessor.Apply(changes,
                 add: item => _entityStore.Insert(new Entities.Enemy
                 {
@@ -31,6 +39,8 @@ namespace Game.DataAccess.Repositories.Admin
                     IsBoss = item.IsBoss,
                     RetiredAt = item.RetiredAt,
                 }));
+
+            return true;
         }
 
         public bool SetAttributeDistributions(SetEnemyAttributeDistributions data)

--- a/Game.DataAccess/Repositories/Admin/AdminSkills.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminSkills.cs
@@ -16,8 +16,16 @@ namespace Game.DataAccess.Repositories.Admin
         private readonly ISkillEntityCache _skills = skills;
         private readonly IEntityStore _entityStore = entityStore;
 
-        public void SaveSkills(IReadOnlyList<Change<Contracts.Skill>> changes)
+        public bool SaveSkills(IReadOnlyList<Change<Contracts.Skill>> changes)
         {
+            // An edit must target an existing skill; a missing id is a not-found rejection (matching the
+            // relationship setters), not an EF 0-row update that throws. Validate the whole batch up front
+            // so the commit filter doesn't persist the rest of the batch alongside an invalid edit.
+            if (changes.Any(c => c.ChangeType == EChangeType.Edit && _skills.LookupSkill(c.Item.Id) is null))
+            {
+                return false;
+            }
+
             ChangeSetProcessor.Apply(changes,
                 add: item => _entityStore.Insert(new Entities.Skill
                 {
@@ -37,6 +45,8 @@ namespace Game.DataAccess.Repositories.Admin
                     IconPath = item.IconPath,
                     RetiredAt = item.RetiredAt,
                 }));
+
+            return true;
         }
 
         public bool SetMultipliers(AddEditAttributesData data)

--- a/Game.DataAccess/Repositories/Admin/AdminZones.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminZones.cs
@@ -26,14 +26,20 @@ namespace Game.DataAccess.Repositories.Admin
         public string? SaveZones(IReadOnlyList<Change<Contracts.Zone>> changes)
         {
             // A zone's dedicated boss must reference an existing enemy flagged IsBoss, and its unlock gate
-            // must reference an existing challenge. Validate the whole change set up front so an invalid
-            // reference rejects the batch rather than partially applying.
+            // must reference an existing challenge. An edit must also target an existing zone — a missing id
+            // is a not-found rejection, not an EF 0-row update that throws. Validate the whole change set up
+            // front so an invalid reference rejects the batch rather than partially applying.
             var challengeCount = _challenges.All().Count;
             foreach (var change in changes)
             {
                 if (change.ChangeType == EChangeType.Delete)
                 {
                     continue;
+                }
+
+                if (change.ChangeType == EChangeType.Edit && _zones.LookupZone(change.Item.Id) is null)
+                {
+                    return "Zone not found.";
                 }
 
                 if (change.Item.BossEnemyId is int bossEnemyId


### PR DESCRIPTION
## Summary

Follow-up to #498. That issue made an identity-level `Save*` edit of a non-existent record a user-facing **not-found rejection** (validate the batch up front, apply nothing) for `SaveItems`/`SaveItemMods`. This PR brings the remaining four top-level reference saves in line.

Previously `SaveSkills`/`SaveEnemies`/`SaveZones`/`SaveChallenges` blind-updated a fresh entity for an `Edit`. When the id didn't resolve, EF marked it `Modified` and `SaveChangesAsync` issued an `UPDATE ... WHERE Id = <missing>` affecting 0 rows, throwing `DbUpdateConcurrencyException` — surfacing as an unhandled **500** instead of a clean **400 "not found"**.

## How it addresses the issue

- **`SaveSkills` / `SaveEnemies` / `SaveChallenges`**: changed from `void` → `bool`, with up-front batch validation (any `Edit` whose id isn't resolvable rejects the whole batch, applying nothing). Controllers map `false` to `"Skill not found." / "Enemy not found." / "Challenge not found."`. This mirrors the `bool` + controller-supplied-message convention from `SaveItems`/`SaveItemMods`.
- **`SaveZones`** (already returns `string?` because it carries multiple distinct messages): gains the same up-front edit-existence check, returning `"Zone not found."` alongside its existing boss/unlock-challenge validation.
- Validation rejects **before** staging, because the `CommitFilter` persists whatever is queued on a non-exception response.
- `AdminChallenges` now takes `IChallenges` to range-check the zero-based challenge id (`0 <= id < All().Count`), mirroring how `AdminZones` validates an `UnlockChallengeId`. (Challenges have no entity cache; this is the established existence mechanism for them.)

### Convention note
The single-message saves (Items, ItemMods, Skills, Enemies, Challenges) all use `bool` + controller message; `SaveZones` stays `string?` because it must disambiguate between several error messages — a `bool` can't carry which one. This keeps the five single-message saves uniform and respects Zones' existing shape.

### Docs
The `backend-admin.md` "Admin Tools API surface" note already reads generically ("identity-level saves validate the whole change set up front so they reject before staging anything") — the explicit "(the other identity-level saves don't yet front-validate edits … see #646)" caveat that #498 added was removed during the later doc-shortening commit. That generic statement is made accurate by this change, so no doc edit is needed.

## Test plan

- Added four integration tests in `AdminToolsControllerTests`, each mirroring the #498 item case: an edit of an unknown id → `400` + the expected message, with a valid `Add` alongside it confirmed **not** persisted.
  - `AddEditEnemies_EditUnknownEnemy_ReturnsErrorAndPersistsNothing`
  - `AddEditSkills_EditUnknownSkill_ReturnsErrorAndPersistsNothing`
  - `AddEditZones_EditUnknownZone_ReturnsErrorAndPersistsNothing`
  - `AddEditChallenges_EditUnknownChallenge_ReturnsErrorAndPersistsNothing`
- `dotnet build` — clean (0 warnings, 0 errors).
- `AdminToolsControllerTests` — **59 passed, 0 failed** (55 → 59, the four new tests).
- `Game.Application.Tests` admin integration tests — **8 passed, 0 failed**.

Closes #646

---
_Generated by [Claude Code](https://claude.ai/code/session_019LfEm2HB4u2oDiNsQxZJxP)_