### PR TITLE
Split oversized screen components and compose shared rail/modal primitives

### DIFF
--- a/UI/src/components/Popover.svelte
+++ b/UI/src/components/Popover.svelte
@@ -1,0 +1,138 @@
+<!--
+	Reusable, non-blocking popover/overlay primitive. It owns the interaction model the content
+	stays free of — backdrop-click / Escape dismissal, a focus trap, focus capture+restore, and a
+	body scroll lock — the same chrome `ModalHost` provides for blocking dialogs, but driven by a
+	plain `open` boolean rather than the promise-based modal queue (so it suits in-screen filter
+	popovers and other non-blocking overlays).
+
+	The layer is absolutely positioned, so it overlays its nearest positioned ancestor rather than
+	the whole viewport; mount it inside a `position: relative` container.
+-->
+<svelte:window onkeydown={onKeydown} />
+
+{#if open}
+	<div class="popover-layer">
+		<button class="popover-backdrop" type="button" tabindex="-1" aria-label={closeLabel} onclick={onClose}></button>
+		<div class="popover-shell" role="dialog" aria-modal="true" aria-label={label} tabindex="-1" bind:this={shell}>
+			{@render children()}
+		</div>
+	</div>
+{/if}
+
+<script lang="ts">
+import type { Snippet } from 'svelte';
+
+interface Props {
+	/** Whether the popover is shown. */
+	open: boolean;
+	/** Called on every dismissal path (backdrop click, Escape). */
+	onClose: () => void;
+	/** Accessible name for the dialog. */
+	label: string;
+	/** Accessible name for the backdrop dismiss button. */
+	closeLabel?: string;
+	/** The popover's content. */
+	children: Snippet;
+}
+
+const { open, onClose, label, closeLabel = 'Close', children }: Props = $props();
+
+let shell = $state<HTMLElement | null>(null);
+// The element focus is returned to once the popover closes. A plain field (not reactive): only read
+// inside effects/handlers, never rendered.
+let restoreFocus: HTMLElement | null = null;
+
+const onKeydown = (event: KeyboardEvent) => {
+	if (!open) {
+		return;
+	}
+	if (event.key === 'Escape') {
+		event.preventDefault();
+		onClose();
+	} else if (event.key === 'Tab') {
+		trapTab(event);
+	}
+};
+
+// Keep Tab focus inside the popover while it is open.
+const trapTab = (event: KeyboardEvent) => {
+	if (!shell) {
+		return;
+	}
+	const focusables = [...shell.querySelectorAll<HTMLElement>('button:not([disabled])')];
+	if (focusables.length === 0) {
+		return;
+	}
+	const first = focusables[0];
+	const last = focusables[focusables.length - 1];
+	const focused = document.activeElement;
+	if (!shell.contains(focused)) {
+		event.preventDefault();
+		first.focus();
+	} else if (event.shiftKey && focused === first) {
+		event.preventDefault();
+		last.focus();
+	} else if (!event.shiftKey && focused === last) {
+		event.preventDefault();
+		first.focus();
+	}
+};
+
+// On open, capture the outgoing focus and move it onto the first focusable inside the popover (or
+// the shell itself if it has none) so the trap has somewhere to anchor.
+$effect(() => {
+	if (open && shell) {
+		restoreFocus ??= document.activeElement as HTMLElement | null;
+		const target = shell.querySelector<HTMLElement>('button:not([disabled])');
+		(target ?? shell).focus();
+	}
+});
+
+// On close, return focus to wherever it was before the popover opened.
+$effect(() => {
+	if (!open && restoreFocus) {
+		restoreFocus.focus();
+		restoreFocus = null;
+	}
+});
+
+// Lock background scroll while open.
+$effect(() => {
+	if (!open) {
+		return;
+	}
+	document.body.classList.add('popover-open');
+	return () => document.body.classList.remove('popover-open');
+});
+</script>
+
+<style lang="scss">
+:global(body.popover-open) {
+	overflow: hidden;
+}
+
+.popover-layer {
+	position: absolute;
+	inset: 0;
+	z-index: 40;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 16px;
+}
+
+.popover-backdrop {
+	position: absolute;
+	inset: 0;
+	padding: 0;
+	border: none;
+	cursor: pointer;
+	background: color-mix(in srgb, var(--black) 55%, transparent);
+	backdrop-filter: blur(3px);
+}
+
+.popover-shell {
+	position: relative;
+	outline: none;
+}
+</style>

--- a/UI/src/components/index.ts
+++ b/UI/src/components/index.ts
@@ -4,6 +4,7 @@ export { default as HpBar } from './HpBar.svelte';
 export { default as Loading } from './Loading.svelte';
 export { default as Modal } from './Modal.svelte';
 export { default as ModalHost } from './ModalHost.svelte';
+export { default as Popover } from './Popover.svelte';
 export { default as StatusGlyph } from './StatusGlyph.svelte';
 export { default as Toast } from './Toast.svelte';
 export { default as ToastContainer } from './ToastContainer.svelte';

--- a/UI/src/components/sidebar/RailNavItem.svelte
+++ b/UI/src/components/sidebar/RailNavItem.svelte
@@ -1,4 +1,12 @@
-<button class="side-item" class:active data-testid={testid} title={!expanded ? title : undefined} {onclick}>
+<button
+	class="side-item"
+	class:active
+	class:disabled
+	{disabled}
+	data-testid={testid}
+	title={!expanded ? title : undefined}
+	{onclick}
+>
 	<div class="glyph-slot">
 		{@render glyph(active)}
 	</div>
@@ -15,6 +23,8 @@ import type { Snippet } from 'svelte';
 interface Props {
 	/** Whether this item is the active screen/tool. */
 	active?: boolean;
+	/** Whether the item is non-interactive (dimmed, unfocusable, ignores clicks). */
+	disabled?: boolean;
 	/** Visible label, shown when expanded. */
 	label: string;
 	/** Tooltip title shown only when the rail is collapsed. */
@@ -30,7 +40,7 @@ interface Props {
 	trailing?: Snippet<[boolean]>;
 }
 
-const { active = false, label, title, testid, expanded, onclick, glyph, trailing }: Props = $props();
+const { active = false, disabled = false, label, title, testid, expanded, onclick, glyph, trailing }: Props = $props();
 </script>
 
 <style lang="scss">
@@ -56,7 +66,7 @@ $collapsed: 60px;
 	white-space: nowrap;
 	overflow: hidden;
 
-	&:hover {
+	&:hover:not(.disabled) {
 		background: color-mix(in srgb, var(--white) 3%, transparent);
 		color: var(--text-primary);
 	}
@@ -64,6 +74,11 @@ $collapsed: 60px;
 	&.active {
 		background: color-mix(in srgb, var(--accent) 8%, transparent);
 		color: var(--text-primary);
+	}
+
+	&.disabled {
+		color: color-mix(in srgb, var(--text-primary) 32%, transparent);
+		cursor: default;
 	}
 }
 

--- a/UI/src/routes/game/screens/card-game/loom/Board.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/Board.svelte
@@ -19,17 +19,7 @@
 
 	<!-- board entities -->
 	{#each game.ents as e (e.id)}
-		<div
-			class="ent {e.type}"
-			class:resolved={e.resolved}
-			class:cancelled={e.cancelled}
-			style:width="{entW(e)}px"
-			style:transform="translateX({entX(e)}px)"
-		>
-			{#if hasWindup(e.type)}<div class="windup"></div>{/if}
-			{#if e.type === 'enemychannel'}<span class="ecl">{e.label}</span>{:else}{e.label}{/if}
-			{#if hasTip(e.type)}<span class="tip"></span>{/if}
-		</div>
+		<BoardEntity entity={e} x={entX(e)} w={entW(e)} />
 	{/each}
 
 	<!-- placement preview (drag aim or hover hint) -->
@@ -51,11 +41,8 @@
 		<div class="flash" style:left="{view.nowX}px" style:top="{f.y}px" style:color={f.color}>{f.text}</div>
 	{/each}
 
-	{#if game.over}
-		<div class="banner {game.outcome}">
-			<h2>{game.outcome === 'win' ? 'VICTORY' : 'DOWNED'}</h2>
-			<span class="bsub">{game.outcomeSub}</span>
-		</div>
+	{#if game.over && game.outcome}
+		<OutcomeBanner outcome={game.outcome} sub={game.outcomeSub} />
 	{/if}
 </div>
 
@@ -63,6 +50,8 @@
 import { onMount } from 'svelte';
 import { CARDS, PX_PER_TICK, type CritMark, type Entity, type EntityType } from '$lib/card-game';
 import type { CardGameView } from '../card-game-view.svelte';
+import BoardEntity from './BoardEntity.svelte';
+import OutcomeBanner from './OutcomeBanner.svelte';
 
 interface Props {
 	view: CardGameView;
@@ -74,9 +63,6 @@ const PXT = PX_PER_TICK;
 let boardEl: HTMLDivElement;
 
 const isCover = (type: EntityType) => type === 'block' || type === 'enemyblock';
-const hasWindup = (type: EntityType) => type === 'attack' || type === 'enemychannel';
-const hasTip = (type: EntityType) =>
-	type === 'enemyhit' || type === 'enemychannel' || type === 'attack' || type === 'channel';
 
 const entX = (e: Entity) => view.nowX + (e.start - game.playTick) * PXT - (isCover(e.type) ? PXT / 2 : 0);
 const entW = (e: Entity) => Math.max((e.end - e.start) * PXT, 30);
@@ -190,172 +176,6 @@ onMount(() => {
 	}
 }
 
-/* ── entities ──────────────────────────────────────────────────────────── */
-.ent {
-	position: absolute;
-	height: 44px;
-	border-radius: 7px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 5px;
-	font-family: var(--mono);
-	font-weight: 500;
-	font-size: 12px;
-	will-change: transform;
-	overflow: hidden;
-	z-index: 3;
-	border: 1px solid;
-	color: var(--text-primary);
-}
-
-.ent .tip {
-	position: absolute;
-	right: -1px;
-	top: -1px;
-	bottom: -1px;
-	width: 3px;
-	z-index: 4;
-}
-
-.ent .windup {
-	position: absolute;
-	left: 0;
-	top: 0;
-	bottom: 0;
-	right: 4px;
-	background: repeating-linear-gradient(
-		45deg,
-		color-mix(in srgb, var(--white) 6%, transparent) 0 6px,
-		transparent 6px 12px
-	);
-}
-
-.ent.enemyhit {
-	top: 26px;
-	border-color: color-mix(in srgb, var(--enemy-accent) 90%, transparent);
-	background: linear-gradient(
-		180deg,
-		color-mix(in srgb, var(--enemy-accent) 52%, var(--surface)),
-		color-mix(in srgb, var(--enemy-accent) 34%, var(--surface))
-	);
-	color: color-mix(in srgb, var(--enemy-accent) 12%, var(--white));
-	box-shadow:
-		0 2px 10px color-mix(in srgb, var(--black) 45%, transparent),
-		0 0 14px -4px color-mix(in srgb, var(--enemy-accent) 70%, transparent);
-
-	.tip {
-		background: var(--enemy-accent);
-		box-shadow: 0 0 8px var(--enemy-accent);
-	}
-}
-
-.ent.enemychannel {
-	top: 26px;
-	border-color: var(--enemy-accent);
-	background: linear-gradient(
-		180deg,
-		color-mix(in srgb, var(--enemy-accent) 42%, var(--surface)),
-		color-mix(in srgb, var(--enemy-accent) 24%, var(--surface))
-	);
-	color: color-mix(in srgb, var(--enemy-accent) 12%, var(--white));
-	letter-spacing: 0.04em;
-	box-shadow:
-		0 0 22px -2px color-mix(in srgb, var(--enemy-accent) 85%, transparent),
-		inset 0 0 18px color-mix(in srgb, var(--enemy-accent) 25%, transparent);
-
-	.ecl {
-		position: relative;
-		z-index: 1;
-		font-weight: 700;
-	}
-	.tip {
-		background: var(--white);
-		box-shadow:
-			0 0 10px var(--white),
-			0 0 18px var(--enemy-accent);
-	}
-}
-
-.ent.attack {
-	top: 118px;
-	border-color: color-mix(in srgb, var(--log-enemy) 88%, transparent);
-	background: linear-gradient(
-		180deg,
-		color-mix(in srgb, var(--log-enemy) 46%, var(--surface)),
-		color-mix(in srgb, var(--log-enemy) 30%, var(--surface))
-	);
-	color: color-mix(in srgb, var(--log-enemy) 12%, var(--white));
-	box-shadow: 0 2px 10px color-mix(in srgb, var(--black) 45%, transparent);
-
-	.tip {
-		background: color-mix(in srgb, var(--log-enemy) 60%, var(--white));
-		box-shadow: 0 0 8px color-mix(in srgb, var(--log-enemy) 70%, transparent);
-	}
-}
-
-.ent.channel {
-	top: 118px;
-	border-color: color-mix(in srgb, var(--rarity-epic) 92%, transparent);
-	background: linear-gradient(
-		180deg,
-		color-mix(in srgb, var(--rarity-epic) 50%, var(--surface)),
-		color-mix(in srgb, var(--rarity-epic) 32%, var(--surface))
-	);
-	color: color-mix(in srgb, var(--rarity-epic) 12%, var(--white));
-	box-shadow:
-		0 2px 10px color-mix(in srgb, var(--black) 45%, transparent),
-		0 0 14px -4px color-mix(in srgb, var(--rarity-epic) 60%, transparent);
-
-	.tip {
-		background: var(--rarity-epic);
-		box-shadow: 0 0 8px var(--rarity-epic);
-	}
-}
-
-/* defensive cover spans (76px tall, top-aligned, translucent) */
-.ent.block {
-	top: 8px;
-	height: 76px;
-	z-index: 2;
-	align-items: flex-start;
-	padding-top: 3px;
-	border-style: dashed;
-	border-color: color-mix(in srgb, var(--health-remaining-color) 50%, transparent);
-	background: color-mix(in srgb, var(--health-remaining-color) 12%, transparent);
-	box-shadow: inset 0 0 16px color-mix(in srgb, var(--health-remaining-color) 12%, transparent);
-	color: color-mix(in srgb, var(--health-remaining-color) 35%, var(--white));
-	font-size: 10px;
-	letter-spacing: 0.12em;
-}
-
-.ent.enemyblock {
-	top: 100px;
-	height: 76px;
-	z-index: 2;
-	align-items: flex-start;
-	padding-top: 3px;
-	border-style: dashed;
-	border-color: color-mix(in srgb, var(--enemy-accent) 50%, transparent);
-	color: var(--log-enemy);
-	background: repeating-linear-gradient(
-		45deg,
-		color-mix(in srgb, var(--enemy-accent) 13%, transparent) 0 6px,
-		color-mix(in srgb, var(--enemy-accent) 4%, transparent) 6px 12px
-	);
-	font-size: 10px;
-	letter-spacing: 0.12em;
-}
-
-.ent.resolved {
-	opacity: 0.2;
-	filter: saturate(0.4);
-}
-.ent.cancelled {
-	opacity: 0.3;
-	text-decoration: line-through;
-}
-
 /* ── crit columns ──────────────────────────────────────────────────────── */
 .critmark {
 	position: absolute;
@@ -460,43 +280,6 @@ onMount(() => {
 	100% {
 		opacity: 0;
 		transform: translate(-50%, -120%) scale(1.1);
-	}
-}
-
-/* ── banner ────────────────────────────────────────────────────────────── */
-.banner {
-	position: absolute;
-	inset: 0;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	gap: 6px;
-	z-index: 12;
-	background: color-mix(in srgb, var(--surface) 82%, transparent);
-	backdrop-filter: blur(3px);
-	font-family: var(--sans);
-
-	h2 {
-		font-size: 38px;
-		margin: 0;
-		letter-spacing: 0.06em;
-		font-weight: 700;
-	}
-
-	.bsub {
-		font-family: var(--mono);
-		font-size: 12px;
-		color: var(--text-tertiary);
-	}
-
-	&.win h2 {
-		color: var(--health-remaining-color);
-		text-shadow: 0 0 24px color-mix(in srgb, var(--health-remaining-color) 60%, transparent);
-	}
-	&.lose h2 {
-		color: var(--enemy-accent);
-		text-shadow: 0 0 24px color-mix(in srgb, var(--enemy-accent) 60%, transparent);
 	}
 }
 </style>

--- a/UI/src/routes/game/screens/card-game/loom/BoardEntity.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/BoardEntity.svelte
@@ -1,0 +1,197 @@
+<div
+	class="ent {entity.type}"
+	class:resolved={entity.resolved}
+	class:cancelled={entity.cancelled}
+	style:width="{w}px"
+	style:transform="translateX({x}px)"
+>
+	{#if hasWindup}<div class="windup"></div>{/if}
+	{#if entity.type === 'enemychannel'}<span class="ecl">{entity.label}</span>{:else}{entity.label}{/if}
+	{#if hasTip}<span class="tip"></span>{/if}
+</div>
+
+<script lang="ts">
+import type { Entity } from '$lib/card-game';
+
+interface Props {
+	entity: Entity;
+	/** Pre-computed horizontal offset (px) within the board. */
+	x: number;
+	/** Pre-computed width (px). */
+	w: number;
+}
+
+const { entity, x, w }: Props = $props();
+
+const hasWindup = $derived(entity.type === 'attack' || entity.type === 'enemychannel');
+const hasTip = $derived(
+	entity.type === 'enemyhit' || entity.type === 'enemychannel' || entity.type === 'attack' || entity.type === 'channel'
+);
+</script>
+
+<style lang="scss">
+.ent {
+	position: absolute;
+	height: 44px;
+	border-radius: 7px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 5px;
+	font-family: var(--mono);
+	font-weight: 500;
+	font-size: 12px;
+	will-change: transform;
+	overflow: hidden;
+	z-index: 3;
+	border: 1px solid;
+	color: var(--text-primary);
+}
+
+.ent .tip {
+	position: absolute;
+	right: -1px;
+	top: -1px;
+	bottom: -1px;
+	width: 3px;
+	z-index: 4;
+}
+
+.ent .windup {
+	position: absolute;
+	left: 0;
+	top: 0;
+	bottom: 0;
+	right: 4px;
+	background: repeating-linear-gradient(
+		45deg,
+		color-mix(in srgb, var(--white) 6%, transparent) 0 6px,
+		transparent 6px 12px
+	);
+}
+
+.ent.enemyhit {
+	top: 26px;
+	border-color: color-mix(in srgb, var(--enemy-accent) 90%, transparent);
+	background: linear-gradient(
+		180deg,
+		color-mix(in srgb, var(--enemy-accent) 52%, var(--surface)),
+		color-mix(in srgb, var(--enemy-accent) 34%, var(--surface))
+	);
+	color: color-mix(in srgb, var(--enemy-accent) 12%, var(--white));
+	box-shadow:
+		0 2px 10px color-mix(in srgb, var(--black) 45%, transparent),
+		0 0 14px -4px color-mix(in srgb, var(--enemy-accent) 70%, transparent);
+
+	.tip {
+		background: var(--enemy-accent);
+		box-shadow: 0 0 8px var(--enemy-accent);
+	}
+}
+
+.ent.enemychannel {
+	top: 26px;
+	border-color: var(--enemy-accent);
+	background: linear-gradient(
+		180deg,
+		color-mix(in srgb, var(--enemy-accent) 42%, var(--surface)),
+		color-mix(in srgb, var(--enemy-accent) 24%, var(--surface))
+	);
+	color: color-mix(in srgb, var(--enemy-accent) 12%, var(--white));
+	letter-spacing: 0.04em;
+	box-shadow:
+		0 0 22px -2px color-mix(in srgb, var(--enemy-accent) 85%, transparent),
+		inset 0 0 18px color-mix(in srgb, var(--enemy-accent) 25%, transparent);
+
+	.ecl {
+		position: relative;
+		z-index: 1;
+		font-weight: 700;
+	}
+	.tip {
+		background: var(--white);
+		box-shadow:
+			0 0 10px var(--white),
+			0 0 18px var(--enemy-accent);
+	}
+}
+
+.ent.attack {
+	top: 118px;
+	border-color: color-mix(in srgb, var(--log-enemy) 88%, transparent);
+	background: linear-gradient(
+		180deg,
+		color-mix(in srgb, var(--log-enemy) 46%, var(--surface)),
+		color-mix(in srgb, var(--log-enemy) 30%, var(--surface))
+	);
+	color: color-mix(in srgb, var(--log-enemy) 12%, var(--white));
+	box-shadow: 0 2px 10px color-mix(in srgb, var(--black) 45%, transparent);
+
+	.tip {
+		background: color-mix(in srgb, var(--log-enemy) 60%, var(--white));
+		box-shadow: 0 0 8px color-mix(in srgb, var(--log-enemy) 70%, transparent);
+	}
+}
+
+.ent.channel {
+	top: 118px;
+	border-color: color-mix(in srgb, var(--rarity-epic) 92%, transparent);
+	background: linear-gradient(
+		180deg,
+		color-mix(in srgb, var(--rarity-epic) 50%, var(--surface)),
+		color-mix(in srgb, var(--rarity-epic) 32%, var(--surface))
+	);
+	color: color-mix(in srgb, var(--rarity-epic) 12%, var(--white));
+	box-shadow:
+		0 2px 10px color-mix(in srgb, var(--black) 45%, transparent),
+		0 0 14px -4px color-mix(in srgb, var(--rarity-epic) 60%, transparent);
+
+	.tip {
+		background: var(--rarity-epic);
+		box-shadow: 0 0 8px var(--rarity-epic);
+	}
+}
+
+/* defensive cover spans (76px tall, top-aligned, translucent) */
+.ent.block {
+	top: 8px;
+	height: 76px;
+	z-index: 2;
+	align-items: flex-start;
+	padding-top: 3px;
+	border-style: dashed;
+	border-color: color-mix(in srgb, var(--health-remaining-color) 50%, transparent);
+	background: color-mix(in srgb, var(--health-remaining-color) 12%, transparent);
+	box-shadow: inset 0 0 16px color-mix(in srgb, var(--health-remaining-color) 12%, transparent);
+	color: color-mix(in srgb, var(--health-remaining-color) 35%, var(--white));
+	font-size: 10px;
+	letter-spacing: 0.12em;
+}
+
+.ent.enemyblock {
+	top: 100px;
+	height: 76px;
+	z-index: 2;
+	align-items: flex-start;
+	padding-top: 3px;
+	border-style: dashed;
+	border-color: color-mix(in srgb, var(--enemy-accent) 50%, transparent);
+	color: var(--log-enemy);
+	background: repeating-linear-gradient(
+		45deg,
+		color-mix(in srgb, var(--enemy-accent) 13%, transparent) 0 6px,
+		color-mix(in srgb, var(--enemy-accent) 4%, transparent) 6px 12px
+	);
+	font-size: 10px;
+	letter-spacing: 0.12em;
+}
+
+.ent.resolved {
+	opacity: 0.2;
+	filter: saturate(0.4);
+}
+.ent.cancelled {
+	opacity: 0.3;
+	text-decoration: line-through;
+}
+</style>

--- a/UI/src/routes/game/screens/card-game/loom/OutcomeBanner.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/OutcomeBanner.svelte
@@ -1,0 +1,52 @@
+<div class="banner {outcome}">
+	<h2>{outcome === 'win' ? 'VICTORY' : 'DOWNED'}</h2>
+	<span class="bsub">{sub}</span>
+</div>
+
+<script lang="ts">
+interface Props {
+	outcome: 'win' | 'lose';
+	/** Flavour line shown beneath the headline. */
+	sub: string;
+}
+
+const { outcome, sub }: Props = $props();
+</script>
+
+<style lang="scss">
+.banner {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	z-index: 12;
+	background: color-mix(in srgb, var(--surface) 82%, transparent);
+	backdrop-filter: blur(3px);
+	font-family: var(--sans);
+
+	h2 {
+		font-size: 38px;
+		margin: 0;
+		letter-spacing: 0.06em;
+		font-weight: 700;
+	}
+
+	.bsub {
+		font-family: var(--mono);
+		font-size: 12px;
+		color: var(--text-tertiary);
+	}
+
+	&.win h2 {
+		color: var(--health-remaining-color);
+		text-shadow: 0 0 24px color-mix(in srgb, var(--health-remaining-color) 60%, transparent);
+	}
+	&.lose h2 {
+		color: var(--enemy-accent);
+		text-shadow: 0 0 24px color-mix(in srgb, var(--enemy-accent) 60%, transparent);
+	}
+}
+</style>

--- a/UI/src/routes/game/screens/options/SettingsRail.svelte
+++ b/UI/src/routes/game/screens/options/SettingsRail.svelte
@@ -1,28 +1,31 @@
 <div class="settings-rail" data-testid="settings-rail">
-	<div class="rail-header">Categories</div>
-	{#each SETTINGS_CATS as cat (cat.key)}
-		{@const isActive = active === cat.key}
-		<button
-			class="rail-item"
-			class:active={isActive}
-			class:disabled={!cat.built}
-			disabled={!cat.built}
-			data-testid="settings-cat-{cat.key}"
-			onclick={() => cat.built && onPick(cat.key)}
-		>
-			{#if isActive}
-				<span class="active-bar"></span>
-			{/if}
-			<SettingsGlyph glyph={cat.glyph} color={isActive ? 'var(--accent)' : 'currentColor'} />
-			<span class="rail-label">{cat.label}</span>
-			{#if !cat.built}
-				<span class="soon-badge">soon</span>
-			{/if}
-		</button>
-	{/each}
+	<RailNavGroup label="Categories" first expanded>
+		{#each SETTINGS_CATS as cat (cat.key)}
+			<RailNavItem
+				active={active === cat.key}
+				disabled={!cat.built}
+				label={cat.label}
+				title={cat.label}
+				testid="settings-cat-{cat.key}"
+				expanded
+				onclick={() => onPick(cat.key)}
+			>
+				{#snippet glyph(isActive)}
+					<SettingsGlyph glyph={cat.glyph} color={isActive ? 'var(--accent)' : 'currentColor'} />
+				{/snippet}
+				{#snippet trailing()}
+					{#if !cat.built}
+						<span class="soon-badge">soon</span>
+					{/if}
+				{/snippet}
+			</RailNavItem>
+		{/each}
+	</RailNavGroup>
 </div>
 
 <script lang="ts">
+import RailNavGroup from '$components/sidebar/RailNavGroup.svelte';
+import RailNavItem from '$components/sidebar/RailNavItem.svelte';
 import SettingsGlyph from './SettingsGlyph.svelte';
 import { SETTINGS_CATS } from './options-view.svelte';
 
@@ -44,63 +47,8 @@ const { active, onPick }: Props = $props();
 	flex-direction: column;
 }
 
-.rail-header {
-	font-family: var(--mono);
-	font-size: 9.5px;
-	letter-spacing: 2px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-	padding: 0 22px 12px;
-}
-
-.rail-item {
-	position: relative;
-	display: flex;
-	align-items: center;
-	gap: 12px;
-	width: 100%;
-	padding: 10px 22px;
-	border: none;
-	text-align: left;
-	background: transparent;
-	color: color-mix(in srgb, var(--text-primary) 72%, transparent);
-	font-family: inherit;
-	font-size: 13.5px;
-	cursor: pointer;
-	transition:
-		background 130ms,
-		color 130ms;
-
-	&:hover:not(.disabled) {
-		background: color-mix(in srgb, var(--white) 2.5%, transparent);
-	}
-
-	&.active {
-		background: color-mix(in srgb, var(--accent) 7%, transparent);
-		color: var(--text-primary);
-	}
-
-	&.disabled {
-		color: color-mix(in srgb, var(--text-primary) 32%, transparent);
-		cursor: default;
-	}
-}
-
-.active-bar {
-	position: absolute;
-	left: 0;
-	top: 6px;
-	bottom: 6px;
-	width: 2px;
-	background: var(--accent);
-	box-shadow: 0 0 10px color-mix(in srgb, var(--accent) 67%, transparent);
-}
-
-.rail-label {
-	flex: 1;
-}
-
 .soon-badge {
+	margin-right: 12px;
 	font-family: var(--mono);
 	font-size: 8px;
 	letter-spacing: 0.6px;

--- a/UI/src/routes/game/screens/skills/SkillCta.svelte
+++ b/UI/src/routes/game/screens/skills/SkillCta.svelte
@@ -1,0 +1,89 @@
+<div class="d-cta">
+	{#if !metrics.unlocked}
+		<button type="button" class="btn dim" disabled>🔒 Locked</button>
+		<div class="d-hint">Unlock by completing<br /><b>{metrics.source?.name ?? 'a challenge'}</b></div>
+	{:else if equipped}
+		<button type="button" class="btn danger" onclick={() => view.toggle(metrics.skill.id)}>✓ In loadout · Remove</button
+		>
+		<div class="d-hint">priority slot {view.slotOf(metrics.skill.id)} · drag below to reorder</div>
+	{:else if pending}
+		<button type="button" class="btn ghost" onclick={() => view.cancelSwap()}>Cancel swap</button>
+		<div class="d-hint">pick an equipped card below to replace</div>
+	{:else if full}
+		<button type="button" class="btn ghost" onclick={() => view.toggle(metrics.skill.id)}>Loadout full · Swap…</button>
+		<div class="d-hint">choose which slot to replace</div>
+	{:else}
+		<button type="button" class="btn" onclick={() => view.toggle(metrics.skill.id)}>Equip ▸</button>
+		<div class="d-hint">{view.cap - view.equipped.length} slot(s) free</div>
+	{/if}
+</div>
+
+<script lang="ts">
+import type { SkillMetrics, SkillsView } from './skills-view.svelte';
+
+type Props = {
+	view: SkillsView;
+	metrics: SkillMetrics;
+	equipped: boolean;
+	pending: boolean;
+	full: boolean;
+};
+
+const { view, metrics, equipped, pending, full }: Props = $props();
+</script>
+
+<style lang="scss">
+.d-cta {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	align-items: flex-end;
+	flex-shrink: 0;
+}
+
+.d-hint {
+	max-width: 170px;
+	font-family: var(--mono);
+	font-size: 8.5px;
+	letter-spacing: 0.4px;
+	line-height: 1.5;
+	text-align: right;
+	color: var(--text-muted);
+
+	b {
+		color: var(--text-secondary);
+	}
+}
+
+.btn {
+	padding: 8px 16px;
+	border: 1px solid var(--accent);
+	border-radius: 3px;
+	background: var(--accent);
+	color: var(--text-on-accent);
+	font-family: var(--sans);
+	font-size: 13px;
+	font-weight: 500;
+	white-space: nowrap;
+	cursor: pointer;
+
+	&.ghost {
+		background: transparent;
+		color: var(--text-primary);
+		border-color: var(--border-medium);
+	}
+
+	&.danger {
+		background: color-mix(in srgb, var(--enemy-accent) 16%, transparent);
+		color: var(--enemy-accent);
+		border-color: color-mix(in srgb, var(--enemy-accent) 55%, transparent);
+	}
+
+	&.dim {
+		background: transparent;
+		color: var(--text-muted);
+		border-color: var(--border-light);
+		cursor: not-allowed;
+	}
+}
+</style>

--- a/UI/src/routes/game/screens/skills/SkillDamageBreakdown.svelte
+++ b/UI/src/routes/game/screens/skills/SkillDamageBreakdown.svelte
@@ -1,0 +1,166 @@
+<div class="d-sec">
+	<div class="label">Damage breakdown</div>
+	{#if metrics.contributions.length}
+		{#each metrics.contributions as contribution (contribution.attributeId)}
+			<div class="scale" style:--ac={attributeColor(contribution.attributeId)}>
+				<!-- svelte-ignore a11y_no_static_element_interactions -->
+				<span
+					class="achip"
+					onmouseenter={(e) => tip.controller.show(contribution.attributeId, e)}
+					onmousemove={(e) => tip.controller.move(e)}
+					onmouseleave={() => tip.controller.hide()}
+				>
+					<AttributeIcon id={contribution.attributeId} size={12} />
+					{attributeCode(contribution.attributeId, staticData.attributes)}
+				</span>
+				<div class="bar"><i style:width="{Math.round((contribution.value / maxContribution) * 100)}%"></i></div>
+				<span class="contrib"
+					>{attributeName(contribution.attributeId, staticData.attributes)} ×{contribution.multiplier} = +{fmt(
+						contribution.value
+					)}</span
+				>
+			</div>
+		{/each}
+	{:else}
+		<div class="d-desc">No attribute scaling.</div>
+	{/if}
+	<div class="brk-line def">
+		<span class="brk-k">Enemy defense</span><span class="brk-v">−{fmt(view.appliedDefense(metrics.skill.id))}</span>
+	</div>
+	<div class="brk-line total">
+		<span class="brk-k">Effective hit</span><span class="brk-v">{fmt(view.effective(metrics.skill.id))}</span>
+	</div>
+</div>
+
+<!-- One shared tooltip for the scaling chips, anchored to whichever chip is hovered. -->
+<AttributeTooltip bind:this={tooltip} attributeId={tip.attributeId} />
+
+<script lang="ts">
+import { attributeCode, attributeColor, attributeName, formatNum } from '$lib/common';
+import { staticData, type TooltipComponent } from '$stores';
+import AttributeIcon from '$components/AttributeIcon.svelte';
+import AttributeTooltip from '$components/tooltip/AttributeTooltip.svelte';
+import { createAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
+import type { SkillMetrics, SkillsView } from './skills-view.svelte';
+
+type Props = {
+	view: SkillsView;
+	metrics: SkillMetrics;
+};
+
+const { view, metrics }: Props = $props();
+
+let tooltip = $state<TooltipComponent>();
+const tip = createAttributeTooltip(() => tooltip);
+
+const fmt = (n: number) => formatNum(Math.round(n));
+
+const maxContribution = $derived(Math.max(metrics.skill.baseDamage, ...metrics.contributions.map((c) => c.value), 1));
+</script>
+
+<style lang="scss">
+.d-sec {
+	margin-top: 16px;
+}
+
+.label {
+	font-family: var(--mono);
+	font-size: 9.5px;
+	letter-spacing: 1.6px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+}
+
+.d-desc {
+	margin-top: 3px;
+	font-size: 13.5px;
+	color: var(--text-tertiary);
+}
+
+.scale {
+	display: flex;
+	align-items: center;
+	gap: 11px;
+	margin-top: 8px;
+}
+
+.achip {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 4px;
+	min-width: 46px;
+	padding: 2px 8px;
+	border: 1px solid color-mix(in srgb, var(--ac) 38%, transparent);
+	border-radius: 3px;
+	background: color-mix(in srgb, var(--ac) 12%, transparent);
+	color: var(--ac);
+	font-family: var(--mono);
+	font-size: 10px;
+	letter-spacing: 0.5px;
+	text-align: center;
+	white-space: nowrap;
+}
+
+.bar {
+	flex: 1;
+	height: 6px;
+	border-radius: 4px;
+	background: color-mix(in srgb, var(--white) 7%, transparent);
+	overflow: hidden;
+
+	i {
+		display: block;
+		height: 100%;
+		border-radius: 4px;
+		background: var(--ac);
+	}
+}
+
+.contrib {
+	min-width: 128px;
+	font-family: var(--mono);
+	font-size: 9.5px;
+	color: var(--text-tertiary);
+	white-space: nowrap;
+}
+
+.brk-line {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	padding-top: 7px;
+	font-size: 12px;
+
+	.brk-k {
+		color: var(--text-secondary);
+	}
+
+	.brk-v {
+		font-family: var(--mono);
+		font-size: 11.5px;
+	}
+
+	&.def {
+		.brk-k {
+			color: var(--enemy-accent);
+		}
+
+		.brk-v {
+			color: var(--error);
+		}
+	}
+
+	&.total {
+		margin-top: 6px;
+		padding-top: 8px;
+		border-top: 1px solid color-mix(in srgb, var(--text-primary) 10%, transparent);
+		font-weight: 600;
+
+		.brk-v {
+			color: var(--accent);
+			font-size: 13px;
+		}
+	}
+}
+</style>

--- a/UI/src/routes/game/screens/skills/SkillInspector.svelte
+++ b/UI/src/routes/game/screens/skills/SkillInspector.svelte
@@ -12,28 +12,7 @@
 				<div class="d-name">{metrics.skill.name}</div>
 				<div class="d-desc">{metrics.skill.description}</div>
 			</div>
-			<div class="d-cta">
-				{#if !metrics.unlocked}
-					<button type="button" class="btn dim" disabled>🔒 Locked</button>
-					<div class="d-hint">Unlock by completing<br /><b>{metrics.source?.name ?? 'a challenge'}</b></div>
-				{:else if equipped}
-					<button type="button" class="btn danger" onclick={() => view.toggle(metrics.skill.id)}
-						>✓ In loadout · Remove</button
-					>
-					<div class="d-hint">priority slot {view.slotOf(metrics.skill.id)} · drag below to reorder</div>
-				{:else if pending}
-					<button type="button" class="btn ghost" onclick={() => view.cancelSwap()}>Cancel swap</button>
-					<div class="d-hint">pick an equipped card below to replace</div>
-				{:else if full}
-					<button type="button" class="btn ghost" onclick={() => view.toggle(metrics.skill.id)}
-						>Loadout full · Swap…</button
-					>
-					<div class="d-hint">choose which slot to replace</div>
-				{:else}
-					<button type="button" class="btn" onclick={() => view.toggle(metrics.skill.id)}>Equip ▸</button>
-					<div class="d-hint">{view.cap - view.equipped.length} slot(s) free</div>
-				{/if}
-			</div>
+			<SkillCta {view} {metrics} {equipped} {pending} {full} />
 		</div>
 
 		<div class="bignums">
@@ -48,39 +27,7 @@
 		</div>
 		<div class="rawnote">{rawNote}</div>
 
-		<div class="d-sec">
-			<div class="label">Damage breakdown</div>
-			{#if metrics.contributions.length}
-				{#each metrics.contributions as contribution (contribution.attributeId)}
-					<div class="scale" style:--ac={attributeColor(contribution.attributeId)}>
-						<!-- svelte-ignore a11y_no_static_element_interactions -->
-						<span
-							class="achip"
-							onmouseenter={(e) => tip.controller.show(contribution.attributeId, e)}
-							onmousemove={(e) => tip.controller.move(e)}
-							onmouseleave={() => tip.controller.hide()}
-						>
-							<AttributeIcon id={contribution.attributeId} size={12} />
-							{attributeCode(contribution.attributeId, staticData.attributes)}
-						</span>
-						<div class="bar"><i style:width="{Math.round((contribution.value / maxContribution) * 100)}%"></i></div>
-						<span class="contrib"
-							>{attributeName(contribution.attributeId, staticData.attributes)} ×{contribution.multiplier} = +{fmt(
-								contribution.value
-							)}</span
-						>
-					</div>
-				{/each}
-			{:else}
-				<div class="d-desc">No attribute scaling.</div>
-			{/if}
-			<div class="brk-line def">
-				<span class="brk-k">Enemy defense</span><span class="brk-v">−{fmt(view.appliedDefense(metrics.skill.id))}</span>
-			</div>
-			<div class="brk-line total">
-				<span class="brk-k">Effective hit</span><span class="brk-v">{fmt(view.effective(metrics.skill.id))}</span>
-			</div>
-		</div>
+		<SkillDamageBreakdown {view} {metrics} />
 
 		{#if effects.length}
 			<div class="d-sec">
@@ -110,26 +57,21 @@
 			</div>
 		</div>
 	{/if}
-
-	<!-- One shared tooltip for the scaling chips, anchored to whichever chip is hovered. -->
-	<AttributeTooltip bind:this={tooltip} attributeId={tip.attributeId} />
 </div>
 
 <script lang="ts">
 import {
 	attributeCode,
-	attributeColor,
 	attributeIsHarmful,
 	attributeName,
 	describeEffect,
 	effectDirectionColor,
 	formatNum
 } from '$lib/common';
-import { staticData, type TooltipComponent } from '$stores';
-import AttributeIcon from '$components/AttributeIcon.svelte';
-import AttributeTooltip from '$components/tooltip/AttributeTooltip.svelte';
-import { createAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
+import { staticData } from '$stores';
 import SkillIcon from './SkillIcon.svelte';
+import SkillCta from './SkillCta.svelte';
+import SkillDamageBreakdown from './SkillDamageBreakdown.svelte';
 import type { SkillMetrics, SkillsView } from './skills-view.svelte';
 
 type Props = {
@@ -137,9 +79,6 @@ type Props = {
 };
 
 const { view }: Props = $props();
-
-let tooltip = $state<TooltipComponent>();
-const tip = createAttributeTooltip(() => tooltip);
 
 const metrics = $derived<SkillMetrics | undefined>(view.selected);
 const equipped = $derived(metrics ? view.isEquipped(metrics.skill.id) : false);
@@ -190,9 +129,6 @@ const statusSummary = $derived(
 );
 
 const castsPer10s = $derived(metrics && metrics.cooldown > 0 ? (10 / metrics.cooldown).toFixed(1) : '—');
-const maxContribution = $derived(
-	metrics ? Math.max(metrics.skill.baseDamage, ...metrics.contributions.map((c) => c.value), 1) : 1
-);
 const rawNote = $derived.by(() => {
 	if (!metrics) {
 		return '';
@@ -273,60 +209,6 @@ const rawNote = $derived.by(() => {
 	color: var(--text-tertiary);
 }
 
-.d-cta {
-	display: flex;
-	flex-direction: column;
-	gap: 6px;
-	align-items: flex-end;
-	flex-shrink: 0;
-}
-
-.d-hint {
-	max-width: 170px;
-	font-family: var(--mono);
-	font-size: 8.5px;
-	letter-spacing: 0.4px;
-	line-height: 1.5;
-	text-align: right;
-	color: var(--text-muted);
-
-	b {
-		color: var(--text-secondary);
-	}
-}
-
-.btn {
-	padding: 8px 16px;
-	border: 1px solid var(--accent);
-	border-radius: 3px;
-	background: var(--accent);
-	color: var(--text-on-accent);
-	font-family: var(--sans);
-	font-size: 13px;
-	font-weight: 500;
-	white-space: nowrap;
-	cursor: pointer;
-
-	&.ghost {
-		background: transparent;
-		color: var(--text-primary);
-		border-color: var(--border-medium);
-	}
-
-	&.danger {
-		background: color-mix(in srgb, var(--enemy-accent) 16%, transparent);
-		color: var(--enemy-accent);
-		border-color: color-mix(in srgb, var(--enemy-accent) 55%, transparent);
-	}
-
-	&.dim {
-		background: transparent;
-		color: var(--text-muted);
-		border-color: var(--border-light);
-		cursor: not-allowed;
-	}
-}
-
 .bignums {
 	display: flex;
 	gap: 30px;
@@ -377,93 +259,6 @@ const rawNote = $derived.by(() => {
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
 	color: var(--text-muted);
-}
-
-.scale {
-	display: flex;
-	align-items: center;
-	gap: 11px;
-	margin-top: 8px;
-}
-
-.achip {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	gap: 4px;
-	min-width: 46px;
-	padding: 2px 8px;
-	border: 1px solid color-mix(in srgb, var(--ac) 38%, transparent);
-	border-radius: 3px;
-	background: color-mix(in srgb, var(--ac) 12%, transparent);
-	color: var(--ac);
-	font-family: var(--mono);
-	font-size: 10px;
-	letter-spacing: 0.5px;
-	text-align: center;
-	white-space: nowrap;
-}
-
-.bar {
-	flex: 1;
-	height: 6px;
-	border-radius: 4px;
-	background: color-mix(in srgb, var(--white) 7%, transparent);
-	overflow: hidden;
-
-	i {
-		display: block;
-		height: 100%;
-		border-radius: 4px;
-		background: var(--ac);
-	}
-}
-
-.contrib {
-	min-width: 128px;
-	font-family: var(--mono);
-	font-size: 9.5px;
-	color: var(--text-tertiary);
-	white-space: nowrap;
-}
-
-.brk-line {
-	display: flex;
-	justify-content: space-between;
-	align-items: baseline;
-	padding-top: 7px;
-	font-size: 12px;
-
-	.brk-k {
-		color: var(--text-secondary);
-	}
-
-	.brk-v {
-		font-family: var(--mono);
-		font-size: 11.5px;
-	}
-
-	&.def {
-		.brk-k {
-			color: var(--enemy-accent);
-		}
-
-		.brk-v {
-			color: var(--error);
-		}
-	}
-
-	&.total {
-		margin-top: 6px;
-		padding-top: 8px;
-		border-top: 1px solid color-mix(in srgb, var(--text-primary) 10%, transparent);
-		font-weight: 600;
-
-		.brk-v {
-			color: var(--accent);
-			font-size: 13px;
-		}
-	}
 }
 
 .effect-row {

--- a/UI/src/routes/game/screens/skills/SortFilterModal.svelte
+++ b/UI/src/routes/game/screens/skills/SortFilterModal.svelte
@@ -1,73 +1,69 @@
-<svelte:window onkeydown={onKeydown} />
+<Popover open={view.modalOpen} onClose={() => (view.modalOpen = false)} label="Sort and filter skills">
+	<div class="modal">
+		<div class="msub">Library</div>
+		<h3>Sort &amp; Filter</h3>
 
-{#if view.modalOpen}
-	<div class="modal-layer">
-		<button type="button" class="backdrop" aria-label="Close" onclick={() => (view.modalOpen = false)}></button>
-		<div class="modal" role="dialog" aria-label="Sort and filter skills">
-			<div class="msub">Library</div>
-			<h3>Sort &amp; Filter</h3>
+		<div class="mgroup">
+			<div class="gl">Sort by</div>
+			<div class="opts">
+				{#each SKILL_SORTS as option (option.key)}
+					<button
+						type="button"
+						class="opt"
+						class:on={view.sort === option.key}
+						onclick={() => view.setSort(option.key)}
+					>
+						{option.label}
+					</button>
+				{/each}
+			</div>
+		</div>
 
+		{#if view.usedAttributes.length}
 			<div class="mgroup">
-				<div class="gl">Sort by</div>
+				<div class="gl">Filter by attribute</div>
 				<div class="opts">
-					{#each SKILL_SORTS as option (option.key)}
+					{#each view.usedAttributes as attr (attr)}
 						<button
 							type="button"
-							class="opt"
-							class:on={view.sort === option.key}
-							onclick={() => view.setSort(option.key)}
+							class="opt attr"
+							class:on={view.filterAttributes.includes(attr)}
+							style:--ac={attributeColor(attr)}
+							onclick={() => view.toggleAttributeFilter(attr)}
 						>
-							{option.label}
+							{attributeName(attr, staticData.attributes)}
 						</button>
 					{/each}
 				</div>
 			</div>
+		{/if}
 
-			{#if view.usedAttributes.length}
-				<div class="mgroup">
-					<div class="gl">Filter by attribute</div>
-					<div class="opts">
-						{#each view.usedAttributes as attr (attr)}
-							<button
-								type="button"
-								class="opt attr"
-								class:on={view.filterAttributes.includes(attr)}
-								style:--ac={attributeColor(attr)}
-								onclick={() => view.toggleAttributeFilter(attr)}
-							>
-								{attributeName(attr, staticData.attributes)}
-							</button>
-						{/each}
-					</div>
-				</div>
-			{/if}
-
-			<div class="mgroup">
-				<div class="mrow">
-					<span class="ml">Show locked skills</span>
-					<button
-						type="button"
-						class="switch"
-						class:on={view.showLocked}
-						role="switch"
-						aria-checked={view.showLocked}
-						aria-label="Show locked skills"
-						onclick={() => view.toggleShowLocked()}
-					></button>
-				</div>
-			</div>
-
-			<div class="mfoot">
-				<button type="button" class="btn dim" onclick={() => view.resetFilters()}>Reset</button>
-				<button type="button" class="btn" onclick={() => (view.modalOpen = false)}>Apply</button>
+		<div class="mgroup">
+			<div class="mrow">
+				<span class="ml">Show locked skills</span>
+				<button
+					type="button"
+					class="switch"
+					class:on={view.showLocked}
+					role="switch"
+					aria-checked={view.showLocked}
+					aria-label="Show locked skills"
+					onclick={() => view.toggleShowLocked()}
+				></button>
 			</div>
 		</div>
+
+		<div class="mfoot">
+			<button type="button" class="btn dim" onclick={() => view.resetFilters()}>Reset</button>
+			<button type="button" class="btn" onclick={() => (view.modalOpen = false)}>Apply</button>
+		</div>
 	</div>
-{/if}
+</Popover>
 
 <script lang="ts">
 import { attributeColor, attributeName } from '$lib/common';
 import { staticData } from '$stores';
+import { Popover } from '$components';
 import { SKILL_SORTS, type SkillsView } from './skills-view.svelte';
 
 type Props = {
@@ -75,38 +71,12 @@ type Props = {
 };
 
 const { view }: Props = $props();
-
-/** Escape closes the open filter overlay (the backdrop click / Apply are the other paths). */
-const onKeydown = (e: KeyboardEvent) => {
-	if (e.key === 'Escape' && view.modalOpen) {
-		view.modalOpen = false;
-	}
-};
 </script>
 
 <style lang="scss">
-.modal-layer {
-	position: absolute;
-	inset: 0;
-	z-index: 40;
-}
-
-.backdrop {
-	position: absolute;
-	inset: 0;
-	border: none;
-	background: color-mix(in srgb, var(--black) 55%, transparent);
-	backdrop-filter: blur(3px);
-	cursor: pointer;
-}
-
 .modal {
-	position: absolute;
-	left: 50%;
-	top: 46%;
-	transform: translate(-50%, -50%);
 	width: 420px;
-	max-width: calc(100% - 32px);
+	max-width: 100%;
 	padding: 22px 24px 20px;
 	border: 1px solid var(--border-medium);
 	border-radius: 6px;

--- a/UI/src/tests/components/Popover.test.ts
+++ b/UI/src/tests/components/Popover.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { createRawSnippet, tick } from 'svelte';
+import Popover from '$components/Popover.svelte';
+
+afterEach(() => {
+	cleanup();
+	document.body.classList.remove('popover-open');
+});
+
+// Two focusable buttons so the focus-trap edges can be exercised.
+const children = createRawSnippet(() => ({
+	render: () => '<div><button data-testid="first">first</button><button data-testid="last">last</button></div>'
+}));
+
+const setup = (open: boolean, onClose = vi.fn()) => {
+	const result = render(Popover, { props: { open, onClose, label: 'Filters', children } });
+	return { ...result, onClose };
+};
+
+describe('Popover', () => {
+	it('renders nothing while closed and the dialog chrome once open', async () => {
+		const { container, rerender } = setup(false);
+		expect(container.querySelector('.popover-shell')).toBeNull();
+
+		await rerender({ open: true, onClose: vi.fn(), label: 'Filters', children });
+		const shell = container.querySelector('.popover-shell') as HTMLElement;
+		expect(shell).not.toBeNull();
+		expect(shell.getAttribute('role')).toBe('dialog');
+		expect(shell.getAttribute('aria-label')).toBe('Filters');
+		expect(container.querySelector('[data-testid="first"]')).not.toBeNull();
+	});
+
+	it('closes on Escape and on a backdrop click', async () => {
+		const { container, onClose } = setup(true);
+		await fireEvent.keyDown(window, { key: 'Escape' });
+		expect(onClose).toHaveBeenCalledTimes(1);
+
+		await fireEvent.click(container.querySelector('.popover-backdrop')!);
+		expect(onClose).toHaveBeenCalledTimes(2);
+	});
+
+	it('ignores Escape while closed', async () => {
+		const { onClose } = setup(false);
+		await fireEvent.keyDown(window, { key: 'Escape' });
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('moves focus into the popover on open and traps Tab within it', async () => {
+		const { getByTestId } = setup(true);
+		await tick();
+		const first = getByTestId('first');
+		const last = getByTestId('last');
+		// Opening focuses the first focusable inside the shell.
+		expect(document.activeElement).toBe(first);
+
+		// Tab off the last element wraps back to the first.
+		last.focus();
+		await fireEvent.keyDown(window, { key: 'Tab' });
+		expect(document.activeElement).toBe(first);
+
+		// Shift+Tab off the first element wraps to the last.
+		first.focus();
+		await fireEvent.keyDown(window, { key: 'Tab', shiftKey: true });
+		expect(document.activeElement).toBe(last);
+	});
+
+	it('restores focus to the prior element when it closes', async () => {
+		const outside = document.createElement('button');
+		document.body.appendChild(outside);
+		outside.focus();
+		expect(document.activeElement).toBe(outside);
+
+		const { rerender } = setup(false);
+		await rerender({ open: true, onClose: vi.fn(), label: 'Filters', children });
+		await tick();
+		expect(document.activeElement).not.toBe(outside);
+
+		await rerender({ open: false, onClose: vi.fn(), label: 'Filters', children });
+		await tick();
+		expect(document.activeElement).toBe(outside);
+		outside.remove();
+	});
+
+	it('locks body scroll while open and releases it on close', async () => {
+		const { rerender } = setup(true);
+		await tick();
+		expect(document.body.classList.contains('popover-open')).toBe(true);
+
+		await rerender({ open: false, onClose: vi.fn(), label: 'Filters', children });
+		await tick();
+		expect(document.body.classList.contains('popover-open')).toBe(false);
+	});
+});

--- a/UI/src/tests/routes/game/screens/card-game/loom/BoardEntity.test.ts
+++ b/UI/src/tests/routes/game/screens/card-game/loom/BoardEntity.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import type { Entity, EntityType } from '$lib/card-game';
+import BoardEntity from '$routes/game/screens/card-game/loom/BoardEntity.svelte';
+
+afterEach(cleanup);
+
+const ent = (over: Partial<Entity> & { type: EntityType }): Entity => ({
+	id: 1,
+	start: 0,
+	end: 3,
+	resolved: false,
+	label: 'X',
+	...over
+});
+
+describe('BoardEntity', () => {
+	it('renders an enemy channel with a windup, a labelled .ecl span and a tip', () => {
+		const { container } = render(BoardEntity, {
+			props: { entity: ent({ type: 'enemychannel', label: 'CHANNEL' }), x: 12, w: 90 }
+		});
+		const el = container.querySelector('.ent') as HTMLElement;
+		expect(el.classList.contains('enemychannel')).toBe(true);
+		expect(el.querySelector('.windup')).not.toBeNull();
+		expect(el.querySelector('.ecl')?.textContent).toBe('CHANNEL');
+		expect(el.querySelector('.tip')).not.toBeNull();
+		// Geometry is driven by the parent-computed x/w.
+		expect(el.style.transform).toBe('translateX(12px)');
+		expect(el.style.width).toBe('90px');
+	});
+
+	it('renders a player attack with a windup + tip and a plain text label', () => {
+		const { container } = render(BoardEntity, {
+			props: { entity: ent({ type: 'attack', label: 'SLASH' }), x: 0, w: 30 }
+		});
+		const el = container.querySelector('.ent.attack') as HTMLElement;
+		expect(el.querySelector('.windup')).not.toBeNull();
+		expect(el.querySelector('.tip')).not.toBeNull();
+		expect(el.querySelector('.ecl')).toBeNull();
+		expect(el.textContent?.trim()).toBe('SLASH');
+	});
+
+	it('renders a defensive block as a cover span with no windup or tip', () => {
+		const { container } = render(BoardEntity, {
+			props: { entity: ent({ type: 'block', label: 'GUARD' }), x: 0, w: 60 }
+		});
+		const el = container.querySelector('.ent.block') as HTMLElement;
+		expect(el.querySelector('.windup')).toBeNull();
+		expect(el.querySelector('.tip')).toBeNull();
+	});
+
+	it('reflects resolved/cancelled state as classes', () => {
+		const { container } = render(BoardEntity, {
+			props: { entity: ent({ type: 'enemyhit', resolved: true, cancelled: true }), x: 0, w: 30 }
+		});
+		const el = container.querySelector('.ent') as HTMLElement;
+		expect(el.classList.contains('resolved')).toBe(true);
+		expect(el.classList.contains('cancelled')).toBe(true);
+	});
+});

--- a/UI/src/tests/routes/game/screens/card-game/loom/OutcomeBanner.test.ts
+++ b/UI/src/tests/routes/game/screens/card-game/loom/OutcomeBanner.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import OutcomeBanner from '$routes/game/screens/card-game/loom/OutcomeBanner.svelte';
+
+afterEach(cleanup);
+
+describe('OutcomeBanner', () => {
+	it('shows the victory headline and flavour line on a win', () => {
+		const { container } = render(OutcomeBanner, { props: { outcome: 'win', sub: 'The Warden unravels.' } });
+		const banner = container.querySelector('.banner') as HTMLElement;
+		expect(banner.classList.contains('win')).toBe(true);
+		expect(banner.querySelector('h2')?.textContent).toBe('VICTORY');
+		expect(banner.querySelector('.bsub')?.textContent).toBe('The Warden unravels.');
+	});
+
+	it('shows the downed headline on a loss', () => {
+		const { container } = render(OutcomeBanner, { props: { outcome: 'lose', sub: 'The present caught you.' } });
+		const banner = container.querySelector('.banner') as HTMLElement;
+		expect(banner.classList.contains('lose')).toBe(true);
+		expect(banner.querySelector('h2')?.textContent).toBe('DOWNED');
+	});
+});

--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -375,6 +375,25 @@ describe('Skills screen', () => {
 		expect(container.querySelector('.effect-row')).toBeNull();
 	});
 
+	it('shows the locked CTA in the inspector for a locked skill', async () => {
+		const { container } = render(Skills);
+		// Reveal locked skills, then select Echo (locked) into the inspector.
+		await fireEvent.click(container.querySelector<HTMLButtonElement>('.filt-btn')!);
+		await fireEvent.click(container.querySelector<HTMLButtonElement>('.switch')!);
+		await fireEvent.click(rowByName(container, 'Echo')!);
+		const cta = container.querySelector<HTMLButtonElement>('.d-cta .btn')!;
+		expect(cta.disabled).toBe(true);
+		expect(cta.textContent).toContain('Locked');
+		expect(container.querySelector('.d-hint')?.textContent).toContain('Unlock by completing');
+	});
+
+	it('shows the no-scaling note in the damage breakdown for a skill without multipliers', async () => {
+		const { container } = render(Skills);
+		// Charlie (id 2) has no damage multipliers, so the breakdown reports no scaling.
+		await fireEvent.click(rowByName(container, 'Charlie')!);
+		expect(screen.getByText('No attribute scaling.')).toBeTruthy();
+	});
+
 	it('filters the rail by search term', async () => {
 		const { container } = render(Skills);
 		const search = container.querySelector<HTMLInputElement>('.search input')!;

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -96,6 +96,8 @@ Blocking confirmation dialogs are the toast system's counterpart, from the same 
 - **Dismissal semantics depend on kind** — backdrop-click/Escape are a cancel for `confirm`/`destructive` but an acknowledgement for `acknowledge`.
 - **The host owns the interaction model so the card stays presentational** — backdrop/Escape dismissal, a focus trap, focus capture+restore, and a scroll lock; it focuses the safe action for a destructive dialog (so a stray Enter can't confirm) and the primary action otherwise. All motion is CSS so `prefers-reduced-motion` collapses it.
 
+**Non-blocking overlays compose `Popover` (`components/Popover.svelte`), not a hand-rolled backdrop.** It is the `ModalHost` counterpart for overlays that aren't a blocking confirm — driven by a plain `open` boolean + `onClose` rather than the promise queue — and owns the same chrome: backdrop/Escape dismissal, a focus trap, focus capture+restore, and a body scroll lock, with the content passed as a snippet. The layer is absolutely positioned, so it overlays its nearest positioned ancestor (mount it inside a `position: relative` container) rather than the whole viewport.
+
 ## Styling
 
 Most styling lives in each component's scoped scss; global styles and theming live in `UI/src/styles`. **All colours are CSS variables, used by semantic intent — never hard-coded.** Core colours are declared in `+layout.svelte` (pulled from `_colors.scss`); the palette is intentionally limited for consistency and contrast. The frontend is built for future custom themes that override those variables, so any colour must be a variable (added to `+layout.svelte`) and used according to its semantic meaning, even when two roles happen to share a hue.


### PR DESCRIPTION
Closes #600.

Frontend tech debt: break up two oversized screen components and route two re-implemented patterns through the shared building blocks the frontend doc says to compose.

## Oversized components → split into subcomponents

- **`skills/SkillInspector.svelte`** (~490 → ~316 lines): extracted
  - `SkillCta.svelte` — the CTA button state machine (locked / equipped / pending-swap / full / equip).
  - `SkillDamageBreakdown.svelte` — the scaling chips + bars + def/total lines, which now also own the single attribute tooltip those chips drive (it was only ever consumed by this section).
- **`card-game/loom/Board.svelte`** (~498 → ~285 lines): extracted
  - `BoardEntity.svelte` — the six near-parallel `.ent.*` lane variants and their windup/tip/label structure (kept class-driven; see the scope note below).
  - `OutcomeBanner.svelte` — the win/lose banner.

## Re-implemented primitives → composed

- **`options/SettingsRail.svelte`**: now composes the shared `RailNavGroup` + `RailNavItem` instead of hand-rolling button items, active-bar and hover states. Added an opt-in `disabled` prop to `RailNavItem` for the not-yet-built categories.
- **`skills/SortFilterModal.svelte`**: routes through a **new reusable `components/Popover.svelte`** primitive that owns the overlay chrome the hand-rolled version was missing — backdrop / Escape dismissal, a focus trap, focus capture+restore, and a body scroll lock. It's the non-blocking counterpart to `ModalHost`, driven by a plain `open` boolean + `onClose` rather than the promise-based modal queue, with content passed as a snippet.

## Notes / deviations

- The issue suggested routing `SettingsRail` through `CollapsibleRail` too. I deliberately **didn't**: `CollapsibleRail` is the hover-collapsing app shell (brand wordmark, pin toggle, footer status, `position: absolute` 60↔240px), whereas `SettingsRail` is a static in-screen category rail. The genuinely duplicated pieces were the nav **group/item**, so those are what's composed; the static rail frame stays local.
- `BoardEntity` keeps the six variants as a `class="ent {type}"` switch rather than fully data-driving the per-variant CSS. Each variant has distinct gradients/shadows/positions; collapsing them to CSS variables is a larger, visual-regression-prone change beyond this cleanup's intent — flagging it as a possible follow-up if desired.

## Test plan

- `npm run lint` (eslint + `svelte-check`) — clean.
- `npm run test:unit:coverage` — full suite green, all per-area coverage floors pass (exit 0).
- New tests:
  - `components/Popover.test.ts` — open/close rendering, Escape + backdrop dismissal, Tab focus trap (both edges), focus capture+restore, body scroll lock.
  - `card-game/loom/BoardEntity.test.ts` + `OutcomeBanner.test.ts` — variant structure (windup/tip/`.ecl`), geometry props, resolved/cancelled classes, win/lose headlines.
  - Added `Skills.test.ts` cases for the locked-skill CTA and the no-scaling breakdown branch.
- Existing `Skills.test.ts` (sort/filter modal, swap/equip CTA) and `Board.test.ts` (pointer drag wiring) continue to pass against the refactor.
- Documented the `Popover` primitive in `docs/frontend.md`.

https://claude.ai/code/session_019ouTjmGYZpvDamodgDoari

---
_Generated by [Claude Code](https://claude.ai/code/session_019ouTjmGYZpvDamodgDoari)_