### PR TITLE
Clear out collected minor frontend tech-debt findings (#714)

### DIFF
--- a/UI/src/lib/api/api-socket.ts
+++ b/UI/src/lib/api/api-socket.ts
@@ -208,12 +208,10 @@ export class ApiSocket {
 		try {
 			const data = JSON.parse(ev.data) as IApiSocketResponse<ApiSocketCommand>;
 			const hook = this.getOrCreateHook(data.name);
-			if (hook) {
-				try {
-					hook.notify(data);
-				} catch (ex) {
-					console.error('An error occurred while executing a socket listener callback', ex);
-				}
+			try {
+				hook.notify(data);
+			} catch (ex) {
+				console.error('An error occurred while executing a socket listener callback', ex);
 			}
 
 			if (data.id) {

--- a/UI/src/lib/api/device-fingerprint.ts
+++ b/UI/src/lib/api/device-fingerprint.ts
@@ -5,22 +5,13 @@
  * sessions; it is cached in memory and local storage to avoid recomputing.
  */
 
-const STORAGE_KEY = 'gameserver.device-fingerprint';
+import { safeLocalStorage } from '$lib/common/local-storage';
+import type { NavigatorWithCapabilities } from './navigator';
 
-interface NavigatorWithCapabilities extends Navigator {
-	deviceMemory?: number;
-}
+const STORAGE_KEY = 'gameserver.device-fingerprint';
 
 let cached: string | undefined;
 let pending: Promise<string | undefined> | null = null;
-
-const storage = (): Storage | null => {
-	try {
-		return typeof localStorage !== 'undefined' ? localStorage : null;
-	} catch {
-		return null;
-	}
-};
 
 /**
  * The stable client-side signals that make up the fingerprint. Kept deterministic (no
@@ -76,7 +67,7 @@ export const getDeviceFingerprint = (): string | undefined => {
 		return cached;
 	}
 
-	const stored = storage()?.getItem(STORAGE_KEY) ?? undefined;
+	const stored = safeLocalStorage()?.getItem(STORAGE_KEY) ?? undefined;
 	if (stored) {
 		cached = stored;
 	}
@@ -103,7 +94,7 @@ export const ensureDeviceFingerprint = async (): Promise<string | undefined> => 
 		if (hash) {
 			cached = hash;
 			try {
-				storage()?.setItem(STORAGE_KEY, hash);
+				safeLocalStorage()?.setItem(STORAGE_KEY, hash);
 			} catch {
 				// Local storage unavailable (private mode) — the in-memory cache still serves the session.
 			}

--- a/UI/src/lib/api/device-info.ts
+++ b/UI/src/lib/api/device-info.ts
@@ -1,15 +1,12 @@
 import { ApiRequest } from './api-request';
 import type { IDeviceInfoRequest } from './types';
+import type { NavigatorWithCapabilities } from './navigator';
 
 /**
  * Reports the device capabilities that aren't carried on a regular request (and aren't part of the
  * fingerprint header): `deviceMemory` and `hardwareConcurrency`. Sent once after login to enrich the
  * device record — the device itself is identified by the fingerprint header the request layer attaches.
  */
-
-interface NavigatorWithCapabilities extends Navigator {
-	deviceMemory?: number;
-}
 
 /** Reads the JS-only device capabilities from the navigator. */
 export const collectDeviceInfo = (): IDeviceInfoRequest => {

--- a/UI/src/lib/api/navigator.ts
+++ b/UI/src/lib/api/navigator.ts
@@ -1,0 +1,7 @@
+/**
+ * Augments the standard `Navigator` with the optional Device Memory API field (`deviceMemory`), which
+ * the DOM lib types don't model. Shared by the device fingerprint and the device-info collector.
+ */
+export interface NavigatorWithCapabilities extends Navigator {
+	deviceMemory?: number;
+}

--- a/UI/src/lib/api/token-store.ts
+++ b/UI/src/lib/api/token-store.ts
@@ -4,6 +4,8 @@
  * truth for the current credentials — the request and socket layers read the access token from here
  * to authenticate, and the auth layer reads/rotates the refresh token.
  */
+import { safeLocalStorage } from '$lib/common/local-storage';
+
 export interface StoredTokens {
 	accessToken: string;
 	refreshToken: string;
@@ -11,21 +13,9 @@ export interface StoredTokens {
 
 const STORAGE_KEY = 'gameserver.auth-tokens';
 
-/**
- * Returns local storage when it is available (it is absent during SSR), or null otherwise. Access is
- * wrapped in a try/catch because reading `localStorage` throws in some privacy modes.
- */
-const storage = (): Storage | null => {
-	try {
-		return typeof localStorage !== 'undefined' ? localStorage : null;
-	} catch {
-		return null;
-	}
-};
-
 /** The currently stored token pair, or null when the user is not logged in. */
 export const getTokens = (): StoredTokens | null => {
-	const raw = storage()?.getItem(STORAGE_KEY);
+	const raw = safeLocalStorage()?.getItem(STORAGE_KEY);
 	if (!raw) {
 		return null;
 	}
@@ -44,12 +34,12 @@ export const getTokens = (): StoredTokens | null => {
 
 /** Persists a freshly issued token pair, replacing any previous one. */
 export const setTokens = (tokens: StoredTokens): void => {
-	storage()?.setItem(STORAGE_KEY, JSON.stringify(tokens));
+	safeLocalStorage()?.setItem(STORAGE_KEY, JSON.stringify(tokens));
 };
 
 /** Removes the stored token pair (logout, or after an unrecoverable auth failure). */
 export const clearTokens = (): void => {
-	storage()?.removeItem(STORAGE_KEY);
+	safeLocalStorage()?.removeItem(STORAGE_KEY);
 };
 
 export const getAccessToken = (): string | null => getTokens()?.accessToken ?? null;

--- a/UI/src/lib/card-game/loom-game.ts
+++ b/UI/src/lib/card-game/loom-game.ts
@@ -392,19 +392,21 @@ export class LoomGame {
 			if (e.resolved || e.resolve == null) {
 				continue;
 			}
-			if (e.resolve > a && e.resolve <= b) {
+			// `resolve` is narrowed to a number by the null check above; pass it through so the
+			// handlers don't need to re-assert it.
+			const resolve = e.resolve;
+			if (resolve > a && resolve <= b) {
 				if (e.type === 'enemyhit' || e.type === 'enemychannel') {
-					this.resolveEnemyHit(e);
+					this.resolveEnemyHit(e, resolve);
 				} else {
-					this.resolvePlayerStrike(e);
+					this.resolvePlayerStrike(e, resolve);
 				}
 			}
 		}
 	}
 
-	private resolveEnemyHit(e: Entity): void {
+	private resolveEnemyHit(e: Entity, resolve: number): void {
 		e.resolved = true;
-		const resolve = e.resolve as number;
 		if (spanActiveAt(this.blockLane, resolve)) {
 			this.flash(FLASH_Y.topImpact, 'BLOCK', FLASH_COLOR.block);
 			return;
@@ -421,12 +423,8 @@ export class LoomGame {
 		}
 	}
 
-	private resolvePlayerStrike(e: Entity): void {
-		if (e.cancelled) {
-			return;
-		}
+	private resolvePlayerStrike(e: Entity, resolve: number): void {
 		e.resolved = true;
-		const resolve = e.resolve as number;
 		const outcome = resolveStrike(e.dmg ?? 0, resolve, this.crits, this.enemyGuardLane);
 		if (outcome.crit) {
 			const mark = this.crits.find((c) => !c.used && Math.round(c.tick) === Math.round(resolve));

--- a/UI/src/lib/common/index.ts
+++ b/UI/src/lib/common/index.ts
@@ -1,4 +1,5 @@
 export * from './functions';
+export * from './local-storage';
 export * from './rarity';
 export * from './challenge-type';
 export * from './tag-color';

--- a/UI/src/lib/common/index.ts
+++ b/UI/src/lib/common/index.ts
@@ -1,5 +1,4 @@
 export * from './functions';
-export * from './local-storage';
 export * from './rarity';
 export * from './challenge-type';
 export * from './tag-color';

--- a/UI/src/lib/common/local-storage.ts
+++ b/UI/src/lib/common/local-storage.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns local storage when it is available (it is absent during SSR), or null otherwise. Access is
+ * wrapped in a try/catch because reading `localStorage` throws in some privacy modes. This is the single
+ * best-effort guard the token store, reference cache, and device fingerprint all share, so persistence
+ * degrades gracefully to in-memory only rather than throwing.
+ */
+export const safeLocalStorage = (): Storage | null => {
+	try {
+		return typeof localStorage !== 'undefined' ? localStorage : null;
+	} catch {
+		return null;
+	}
+};

--- a/UI/src/lib/common/local-storage.ts
+++ b/UI/src/lib/common/local-storage.ts
@@ -1,3 +1,8 @@
+/* Import this directly (`$lib/common/local-storage`), not via the `$lib/common` barrel: the barrel
+   transitively imports `$lib/api` (through `rarity`/`challenge-type`), so an api-layer consumer such as
+   the token store or device fingerprint pulling it through the barrel would form an import cycle. It is
+   intentionally left out of the barrel so that deep import can't be "tidied" back into a barrel import. */
+
 /**
  * Returns local storage when it is available (it is absent during SSR), or null otherwise. Access is
  * wrapped in a try/catch because reading `localStorage` throws in some privacy modes. This is the single

--- a/UI/src/lib/engine/reference-cache.ts
+++ b/UI/src/lib/engine/reference-cache.ts
@@ -7,6 +7,8 @@
  * Caching is strictly best-effort: every access is guarded so a corrupted entry, a full quota, or an
  * unavailable store (SSR / privacy mode) degrades to a normal fetch rather than breaking the boot.
  */
+import { safeLocalStorage } from '$lib/common/local-storage';
+
 export interface CachedReferenceData {
 	version: string;
 	data: unknown;
@@ -14,21 +16,9 @@ export interface CachedReferenceData {
 
 const KEY_PREFIX = 'gameserver.refdata.';
 
-/**
- * Returns local storage when it is available (it is absent during SSR), or null otherwise. Access is
- * wrapped in a try/catch because reading `localStorage` throws in some privacy modes.
- */
-const storage = (): Storage | null => {
-	try {
-		return typeof localStorage !== 'undefined' ? localStorage : null;
-	} catch {
-		return null;
-	}
-};
-
 /** Reads the cached payload for a reference-data set, or null when absent/corrupted/unavailable. */
 export const readReferenceCache = (key: string): CachedReferenceData | null => {
-	const raw = storage()?.getItem(KEY_PREFIX + key);
+	const raw = safeLocalStorage()?.getItem(KEY_PREFIX + key);
 	if (!raw) {
 		return null;
 	}
@@ -48,7 +38,7 @@ export const readReferenceCache = (key: string): CachedReferenceData | null => {
 /** Persists a reference-data set under its content version. Silently no-ops if storage is full/unavailable. */
 export const writeReferenceCache = (key: string, version: string, data: unknown): void => {
 	try {
-		storage()?.setItem(KEY_PREFIX + key, JSON.stringify({ version, data }));
+		safeLocalStorage()?.setItem(KEY_PREFIX + key, JSON.stringify({ version, data }));
 	} catch {
 		// Quota exceeded or storage unavailable — caching is best-effort, so fall back to in-memory only.
 	}

--- a/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
+++ b/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
@@ -149,35 +149,33 @@ export function slotLabel(slot: number | undefined): string {
 	return slot != null ? (SLOT_LABELS[slot] ?? '') : '';
 }
 
-/** The primary label for one contribution line: the source attribute for a
- *  derived line, a fixed phrase for base/stat-point lines, or the item/mod name
- *  for gear. */
-export function modifierLabel(line: AppliedModifier<LabeledModifier>): string {
+/** Shared shape of a contribution-line label: both the full and the short variants resolve a derived
+ *  line to its source attribute and any gear line to the item/mod name, differing only in the fixed
+ *  phrasing used for the base-value and stat-point sources (`base`/`statPoints`). */
+function contributionLabel(line: AppliedModifier<LabeledModifier>, base: string, statPoints: string): string {
 	switch (line.source) {
 		case EAttributeModifierSource.Derived:
 			return attributeName(line.derivedSource, staticData.attributes);
 		case EAttributeModifierSource.PlayerStatPoints:
-			return 'Allocated stat points';
+			return statPoints;
 		case EAttributeModifierSource.BaseValue:
-			return 'Engine base value';
+			return base;
 		default:
 			return line.label ?? '';
 	}
 }
 
+/** The primary label for one contribution line: the source attribute for a
+ *  derived line, a fixed phrase for base/stat-point lines, or the item/mod name
+ *  for gear. */
+export function modifierLabel(line: AppliedModifier<LabeledModifier>): string {
+	return contributionLabel(line, 'Engine base value', 'Allocated stat points');
+}
+
 /** A shortened label for the dense apply-order trace (e.g. `Base`, `Stat
  *  points`, or the derived source attribute / item name). */
 export function traceLabel(line: AppliedModifier<LabeledModifier>): string {
-	switch (line.source) {
-		case EAttributeModifierSource.Derived:
-			return attributeName(line.derivedSource, staticData.attributes);
-		case EAttributeModifierSource.PlayerStatPoints:
-			return 'Stat points';
-		case EAttributeModifierSource.BaseValue:
-			return 'Base';
-		default:
-			return line.label ?? '';
-	}
+	return contributionLabel(line, 'Base', 'Stat points');
 }
 
 /* ── modifier assembly (mirrors Player.GetAllModifiers + static modifiers) ──── */

--- a/UI/src/routes/game/screens/card-game/CardGame.svelte
+++ b/UI/src/routes/game/screens/card-game/CardGame.svelte
@@ -27,6 +27,7 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { CardGameView } from './card-game-view.svelte';
+import { runLoomLoop, bindLoomInput } from './loom-input';
 import Combatants from './loom/Combatants.svelte';
 import SandboxStrip from './loom/SandboxStrip.svelte';
 import Board from './loom/Board.svelte';
@@ -37,60 +38,11 @@ import Legend from './loom/Legend.svelte';
 const view = new CardGameView();
 
 onMount(() => {
-	// Real-time render/sim loop — the present advances on its own.
-	let last: number | null = null;
-	let raf = 0;
-	const loop = (ts: number) => {
-		if (last === null) {
-			last = ts;
-		}
-		const dt = (ts - last) / 1000;
-		last = ts;
-		view.game.advance(dt);
-		raf = requestAnimationFrame(loop);
-	};
-	raf = requestAnimationFrame(loop);
-
-	// Hotkeys: 1–7 quick-cast a hand slot, hold Space for Reflex slow-time.
-	// Yields to focused sandbox sliders so they keep working.
-	const onKeyDown = (e: KeyboardEvent) => {
-		const ae = document.activeElement;
-		if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA')) {
-			return;
-		}
-		if (e.code === 'Space') {
-			e.preventDefault();
-			if (!e.repeat) {
-				view.setReflex(true);
-			}
-			return;
-		}
-		if (view.game.over) {
-			return;
-		}
-		if (e.key >= '1' && e.key <= '7') {
-			view.castSlot(+e.key - 1);
-		}
-	};
-	const onKeyUp = (e: KeyboardEvent) => {
-		if (e.code === 'Space') {
-			view.setReflex(false);
-		}
-	};
-	// Releasing or cancelling the pointer anywhere ends a held Reflex (the button is press-and-hold).
-	const endReflex = () => view.setReflex(false);
-
-	window.addEventListener('keydown', onKeyDown);
-	window.addEventListener('keyup', onKeyUp);
-	window.addEventListener('pointerup', endReflex);
-	window.addEventListener('pointercancel', endReflex);
-
+	const stopLoop = runLoomLoop(view);
+	const unbindInput = bindLoomInput(view);
 	return () => {
-		cancelAnimationFrame(raf);
-		window.removeEventListener('keydown', onKeyDown);
-		window.removeEventListener('keyup', onKeyUp);
-		window.removeEventListener('pointerup', endReflex);
-		window.removeEventListener('pointercancel', endReflex);
+		stopLoop();
+		unbindInput();
 	};
 });
 </script>

--- a/UI/src/routes/game/screens/card-game/loom-input.ts
+++ b/UI/src/routes/game/screens/card-game/loom-input.ts
@@ -1,0 +1,69 @@
+/* loom-input.ts — the DOM-side drivers for the Card-Boss Duel screen, kept out of the component so the
+   real-time render loop and the global input bindings each read as one self-contained, testable unit
+   (and out of the DOM-free `$lib/card-game` engine, which never touches `window`/`requestAnimationFrame`).
+
+   Each binder owns its own setup + teardown and returns the teardown; the screen's `onMount` composes them. */
+
+import type { CardGameView } from './card-game-view.svelte';
+
+/** Drives the real-time simulation from a requestAnimationFrame loop — the present advances on its own.
+ *  Returns a stop function that cancels the pending frame. */
+export function runLoomLoop(view: CardGameView): () => void {
+	let last: number | null = null;
+	let raf = 0;
+	const loop = (ts: number) => {
+		if (last === null) {
+			last = ts;
+		}
+		const dt = (ts - last) / 1000;
+		last = ts;
+		view.game.advance(dt);
+		raf = requestAnimationFrame(loop);
+	};
+	raf = requestAnimationFrame(loop);
+	return () => cancelAnimationFrame(raf);
+}
+
+/** Binds the screen's global input: 1–7 quick-cast a hand slot, hold Space for Reflex slow-time, and a
+ *  pointer release/cancel anywhere ends a held Reflex (the button is press-and-hold, so the release can
+ *  land off the button). Returns a teardown that removes every listener. */
+export function bindLoomInput(view: CardGameView): () => void {
+	// Hotkeys yield to focused sandbox sliders so they keep working.
+	const onKeyDown = (e: KeyboardEvent) => {
+		const ae = document.activeElement;
+		if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA')) {
+			return;
+		}
+		if (e.code === 'Space') {
+			e.preventDefault();
+			if (!e.repeat) {
+				view.setReflex(true);
+			}
+			return;
+		}
+		if (view.game.over) {
+			return;
+		}
+		if (e.key >= '1' && e.key <= '7') {
+			view.castSlot(+e.key - 1);
+		}
+	};
+	const onKeyUp = (e: KeyboardEvent) => {
+		if (e.code === 'Space') {
+			view.setReflex(false);
+		}
+	};
+	const endReflex = () => view.setReflex(false);
+
+	window.addEventListener('keydown', onKeyDown);
+	window.addEventListener('keyup', onKeyUp);
+	window.addEventListener('pointerup', endReflex);
+	window.addEventListener('pointercancel', endReflex);
+
+	return () => {
+		window.removeEventListener('keydown', onKeyDown);
+		window.removeEventListener('keyup', onKeyUp);
+		window.removeEventListener('pointerup', endReflex);
+		window.removeEventListener('pointercancel', endReflex);
+	};
+}

--- a/UI/src/routes/game/screens/challenges/RewardIcon.svelte
+++ b/UI/src/routes/game/screens/challenges/RewardIcon.svelte
@@ -64,8 +64,10 @@ interface Props {
 const { reward, size, glow = true, animate = false }: Props = $props();
 
 const accent = $derived(reward.accent);
-// Blur radius/alpha scale with the rarity tier's glow intensity (themeable var).
-const revealGlow = $derived(`0 0 calc(4px + ${reward.glow} * 16px) ${tintColor(accent, 0.55)}`);
+// Blur radius scales with the rarity tier's glow intensity (themeable var); a rarity-less skill
+// (`glow == null`) gets only the flat base radius.
+const glowExtent = $derived(reward.glow ? `calc(4px + ${reward.glow} * 16px)` : '4px');
+const revealGlow = $derived(`0 0 ${glowExtent} ${tintColor(accent, 0.55)}`);
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
+++ b/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
@@ -35,8 +35,9 @@ export interface ResolvedReward {
 	rarity: ERarity;
 	/** Themeable accent: the rarity hue for items/mods, the neutral skill accent for skills. */
 	accent: string;
-	/** Themeable rarity glow intensity (`var(--rarity-*-glow)`); `0` for the (rarity-less) skill. */
-	glow: string;
+	/** Themeable rarity glow intensity token (`var(--rarity-*-glow)`), or `null` for the rarity-less
+	 *  skill (which gets only the flat base glow, no tier scaling). */
+	glow: string | null;
 	name: string;
 	/** Teaser sub-line, e.g. `Rare · Helm`, or `Skill`. */
 	sub: string;
@@ -92,8 +93,15 @@ export interface TypeGroup {
 }
 
 /* ─── Reference lookups ──────────────────────────────────────────────── */
-/** Goal-comparison direction is intrinsic to the type; sourced from reference data. */
-function comparisonFor(typeId: EChallengeType): EChallengeGoalComparison {
+/** Goal-comparison direction is intrinsic to the type; sourced from reference data. Bulk callers pass a
+ *  precomputed `byType` lookup so a rebuild doesn't re-scan the challenge-type list once per challenge. */
+function comparisonFor(
+	typeId: EChallengeType,
+	byType?: ReadonlyMap<EChallengeType, EChallengeGoalComparison>
+): EChallengeGoalComparison {
+	if (byType) {
+		return byType.get(typeId) ?? EChallengeGoalComparison.AtLeast;
+	}
 	return staticData.challengeTypes?.find((t) => t.id === typeId)?.goalComparison ?? EChallengeGoalComparison.AtLeast;
 }
 
@@ -145,7 +153,7 @@ export function resolveReward(ch: IChallenge, revealed: boolean): ResolvedReward
 		rarity: base.rarity,
 		accent: base.accent,
 		// Skills carry no rarity tier, so they get no glow; items/mods glow by tier.
-		glow: base.kind === 'skill' ? '0' : rarityGlow(base.rarity),
+		glow: base.kind === 'skill' ? null : rarityGlow(base.rarity),
 		name: base.name,
 		sub: base.sub
 	};
@@ -178,10 +186,14 @@ export function progressInfo(ch: IChallenge, comparison: EChallengeGoalCompariso
 }
 
 /* ─── View-model assembly ────────────────────────────────────────────── */
-export function buildChallengeVM(ch: IChallenge, player?: IPlayerChallenge): ChallengeVM {
+export function buildChallengeVM(
+	ch: IChallenge,
+	player?: IPlayerChallenge,
+	comparisonByType?: ReadonlyMap<EChallengeType, EChallengeGoalComparison>
+): ChallengeVM {
 	const completed = player?.completed ?? false;
 	const progress = player?.progress ?? 0;
-	const comparison = comparisonFor(ch.challengeTypeId);
+	const comparison = comparisonFor(ch.challengeTypeId, comparisonByType);
 	const prog = progressInfo(ch, comparison, progress);
 	const state: ChallengeState = completed ? 'done' : prog.percent > 0 ? 'active' : 'locked';
 	return {
@@ -279,9 +291,16 @@ export class ChallengesView {
 	// eslint-disable-next-line svelte/prefer-svelte-reactivity
 	readonly #progressById = $derived(new Map(this.playerChallenges.map((pc) => [pc.challengeId, pc])));
 
-	readonly all = $derived.by<ChallengeVM[]>(() =>
-		(staticData.challenges ?? []).filter(Boolean).map((ch) => buildChallengeVM(ch, this.#progressById.get(ch.id)))
-	);
+	readonly all = $derived.by<ChallengeVM[]>(() => {
+		// Build the type→comparison lookup once per rebuild instead of scanning the list per challenge.
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient lookup map, not held state
+		const comparisonByType = new Map(
+			(staticData.challengeTypes ?? []).map((t): [EChallengeType, EChallengeGoalComparison] => [t.id, t.goalComparison])
+		);
+		return (staticData.challenges ?? [])
+			.filter(Boolean)
+			.map((ch) => buildChallengeVM(ch, this.#progressById.get(ch.id), comparisonByType));
+	});
 
 	readonly groups = $derived.by(() => groupByType(this.all));
 	readonly summary = $derived.by(() => overallSummary(this.all));

--- a/UI/src/routes/game/screens/options/options-view.svelte.ts
+++ b/UI/src/routes/game/screens/options/options-view.svelte.ts
@@ -105,11 +105,10 @@ export interface SettingsCatDef {
 	label: string;
 	glyph: SettingsGlyphKind;
 	built: boolean;
-	blurb?: string;
 }
 
 export const SETTINGS_CATS: SettingsCatDef[] = [
-	{ key: 'logging', label: 'Logging', glyph: 'logging', built: true, blurb: 'Combat Log' },
+	{ key: 'logging', label: 'Logging', glyph: 'logging', built: true },
 	{ key: 'display', label: 'Display', glyph: 'display', built: false },
 	{ key: 'audio', label: 'Audio', glyph: 'audio', built: false },
 	{ key: 'gameplay', label: 'Gameplay', glyph: 'gameplay', built: false },
@@ -143,7 +142,7 @@ export class OptionsView {
 	}
 
 	/** Log types whose draft value differs from the persisted baseline. */
-	readonly dirtyIds = $derived(LOG_TYPES.filter((lt) => this.draft[lt.id] !== this.baseline[lt.id]).map((lt) => lt.id));
+	readonly dirtyIds = $derived(LOG_TYPES.filter((lt) => this.isDirtyId(lt.id)).map((lt) => lt.id));
 	readonly dirtyCount = $derived(this.dirtyIds.length);
 	readonly isDirty = $derived(this.dirtyCount > 0);
 	readonly enabledCount = $derived(LOG_TYPES.filter((lt) => this.draft[lt.id]).length);
@@ -152,6 +151,8 @@ export class OptionsView {
 		return !!this.draft[id];
 	}
 
+	/** Whether a log type's draft value differs from the persisted baseline — the single
+	 *  dirty predicate the dirty set and the changed-preferences diff both build on. */
 	isDirtyId(id: ELogType): boolean {
 		return this.draft[id] !== this.baseline[id];
 	}
@@ -183,7 +184,7 @@ export class OptionsView {
 	 *  Computed from plain state (not the `$derived` getters) so it is safe to
 	 *  read from non-reactive call sites like {@link save}. */
 	get changedPreferences(): ILogPreference[] {
-		return LOG_TYPES.filter((lt) => this.draft[lt.id] !== this.baseline[lt.id]).map((lt) => ({
+		return LOG_TYPES.filter((lt) => this.isDirtyId(lt.id)).map((lt) => ({
 			id: lt.id,
 			enabled: this.draft[lt.id]
 		}));

--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -432,7 +432,9 @@ export class SkillsView {
 		for (const unlockedSkill of playerManager.unlockedSkills) {
 			const order = orderedIds.indexOf(unlockedSkill.skillId);
 			unlockedSkill.selected = order >= 0;
-			unlockedSkill.order = order >= 0 ? order : 0;
+			// An unequipped skill has no loadout slot, so clear its order rather than
+			// pinning it to 0 (which would conflate "unequipped" with "first slot").
+			unlockedSkill.order = order >= 0 ? order : undefined;
 		}
 	}
 }

--- a/UI/src/routes/game/screens/stats/ByEntityView.svelte
+++ b/UI/src/routes/game/screens/stats/ByEntityView.svelte
@@ -21,13 +21,17 @@ interface Props {
 
 let { view }: Props = $props();
 
-const kindTabs: Tab[] = ENTITY_KINDS.map((k) => ({
-	key: k,
-	label: statKindPlural(k),
-	color: statKindColor(k),
-	count: view.data.entityList(k).length,
-	glyphKind: k
-}));
+// `$derived` (not a plain const) so the per-kind counts track live `staticData`
+// changes, mirroring `ByStatisticView`'s tabs.
+const kindTabs = $derived<Tab[]>(
+	ENTITY_KINDS.map((k) => ({
+		key: k,
+		label: statKindPlural(k),
+		color: statKindColor(k),
+		count: view.data.entityList(k).length,
+		glyphKind: k
+	}))
+);
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
+++ b/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
@@ -18,6 +18,7 @@
 
 import { EEntityType, EStatisticType, type IPlayerStatistic, type IStatisticType } from '$lib/api';
 import { staticData } from '$stores';
+import { statCategoryLabel } from './statistics-display';
 
 export type StatUnit = 'count' | 'damage' | 'time';
 export type StatAgg = 'sum' | 'max' | 'min';
@@ -133,12 +134,13 @@ export function buildStatEntities(): Record<StatEntityKind, StatEntity[]> {
 	};
 }
 
-export const STAT_CATEGORIES: { key: StatCategory; label: string }[] = [
-	{ key: 'combat', label: 'Combat' },
-	{ key: 'survival', label: 'Survival' },
-	{ key: 'exploration', label: 'Exploration' },
-	{ key: 'time', label: 'Time' }
-];
+/** The four stat categories in display order; labels come from the single source in
+ *  `statistics-display` so the tab labels and the category accents can't drift apart. */
+const STAT_CATEGORY_KEYS: StatCategory[] = ['combat', 'survival', 'exploration', 'time'];
+export const STAT_CATEGORIES: { key: StatCategory; label: string }[] = STAT_CATEGORY_KEYS.map((key) => ({
+	key,
+	label: statCategoryLabel(key)
+}));
 
 export const ENTITY_KINDS: StatEntityKind[] = ['enemy', 'zone', 'skill'];
 

--- a/UI/src/tests/routes/game/screens/card-game/loom-input.test.ts
+++ b/UI/src/tests/routes/game/screens/card-game/loom-input.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { runLoomLoop, bindLoomInput } from '$routes/game/screens/card-game/loom-input';
+import type { CardGameView } from '$routes/game/screens/card-game/card-game-view.svelte';
+
+/** A minimal stand-in for the view: only the members the input drivers touch. */
+function fakeView(over = false) {
+	return {
+		game: { over, advance: vi.fn() },
+		setReflex: vi.fn(),
+		castSlot: vi.fn()
+	} as unknown as CardGameView & { game: { over: boolean; advance: ReturnType<typeof vi.fn> } };
+}
+
+afterEach(() => {
+	document.body.innerHTML = '';
+	vi.restoreAllMocks();
+});
+
+describe('runLoomLoop', () => {
+	it('advances the game by the inter-frame delta each frame and stops on teardown', () => {
+		// An object slot (not a local) so TS keeps `frame` as the callback type across the rAF closure.
+		const scheduled: { frame?: FrameRequestCallback } = {};
+		let nextId = 1;
+		const cancelled: number[] = [];
+		vi.stubGlobal('requestAnimationFrame', (fn: FrameRequestCallback) => {
+			scheduled.frame = fn;
+			return nextId++;
+		});
+		vi.stubGlobal('cancelAnimationFrame', (id: number) => cancelled.push(id));
+
+		const view = fakeView();
+		const stop = runLoomLoop(view);
+
+		// First frame seeds `last`, so dt is 0; the second advances by the elapsed seconds.
+		scheduled.frame?.(0);
+		scheduled.frame?.(1000);
+		expect(view.game.advance).toHaveBeenNthCalledWith(1, 0);
+		expect(view.game.advance).toHaveBeenNthCalledWith(2, 1);
+
+		stop();
+		// The most recently scheduled frame id is cancelled.
+		expect(cancelled).toContain(nextId - 1);
+	});
+});
+
+describe('bindLoomInput', () => {
+	const keydown = (init: KeyboardEventInit) => window.dispatchEvent(new KeyboardEvent('keydown', init));
+	const keyup = (init: KeyboardEventInit) => window.dispatchEvent(new KeyboardEvent('keyup', init));
+
+	it('holds Reflex while Space is down and releases it on key up', () => {
+		const view = fakeView();
+		const unbind = bindLoomInput(view);
+
+		keydown({ code: 'Space' });
+		expect(view.setReflex).toHaveBeenLastCalledWith(true);
+
+		keyup({ code: 'Space' });
+		expect(view.setReflex).toHaveBeenLastCalledWith(false);
+
+		unbind();
+	});
+
+	it('ignores auto-repeat so a held Space only engages Reflex once', () => {
+		const view = fakeView();
+		const unbind = bindLoomInput(view);
+
+		keydown({ code: 'Space', repeat: true });
+		expect(view.setReflex).not.toHaveBeenCalled();
+
+		unbind();
+	});
+
+	it('quick-casts the hand slot for number keys 1–7', () => {
+		const view = fakeView();
+		const unbind = bindLoomInput(view);
+
+		keydown({ key: '3' });
+		expect(view.castSlot).toHaveBeenCalledWith(2);
+
+		unbind();
+	});
+
+	it('yields hotkeys to a focused text input so sliders/fields keep working', () => {
+		const input = document.createElement('input');
+		document.body.appendChild(input);
+		input.focus();
+
+		const view = fakeView();
+		const unbind = bindLoomInput(view);
+
+		keydown({ key: '3' });
+		expect(view.castSlot).not.toHaveBeenCalled();
+
+		unbind();
+	});
+
+	it('does not cast once the duel is over', () => {
+		const view = fakeView(true);
+		const unbind = bindLoomInput(view);
+
+		keydown({ key: '3' });
+		expect(view.castSlot).not.toHaveBeenCalled();
+
+		unbind();
+	});
+
+	it('ends a held Reflex on a pointer release or cancel anywhere', () => {
+		const view = fakeView();
+		const unbind = bindLoomInput(view);
+
+		window.dispatchEvent(new Event('pointerup'));
+		expect(view.setReflex).toHaveBeenLastCalledWith(false);
+
+		window.dispatchEvent(new Event('pointercancel'));
+		expect(view.setReflex).toHaveBeenLastCalledWith(false);
+
+		unbind();
+	});
+
+	it('removes every listener on teardown', () => {
+		const view = fakeView();
+		bindLoomInput(view)();
+
+		keydown({ code: 'Space' });
+		window.dispatchEvent(new Event('pointerup'));
+		expect(view.setReflex).not.toHaveBeenCalled();
+	});
+});

--- a/UI/src/tests/routes/game/screens/challenges/RewardAffordance.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/RewardAffordance.test.ts
@@ -43,7 +43,7 @@ const skillReward = (revealed: boolean): ResolvedReward => ({
 	revealed,
 	rarity: ERarity.Common,
 	accent: 'var(--accent-light)',
-	glow: '0',
+	glow: null,
 	name: 'Firebolt',
 	sub: 'Skill',
 	skill: sampleSkill

--- a/UI/src/tests/routes/game/screens/challenges/RewardTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/RewardTooltip.test.ts
@@ -77,7 +77,7 @@ const skillReward = (revealed: boolean): ResolvedReward =>
 		revealed,
 		rarity: ERarity.Common,
 		accent: 'var(--accent-light)',
-		glow: '0',
+		glow: null,
 		name: 'Firebolt',
 		sub: 'Skill',
 		skill: previewSkill()


### PR DESCRIPTION
Works through the frontend tech-debt triage list in #714. Each item was independently small, so they're handled together here; the one genuinely larger item (a generic bar primitive) is split out into its own follow-up, #753, exactly as the triage issue anticipated.

## Single-source / reactivity
- **Stats category labels** were declared twice — `STAT_CATEGORIES` now derives its labels from `statCategoryLabel` (the same source the category accents use), so the tab labels and accents can't drift.
- **`ByEntityView` `kindTabs`** is now `$derived` instead of a plain `const`, so the per-kind counts track live `staticData` changes — matching its sibling `ByStatisticView`.
- **`modifierLabel` / `traceLabel`** (two near-identical switches) now share one `contributionLabel(line, base, statPoints)` helper. I deliberately did **not** fold these into `source-display.ts`'s `SOURCE_LABEL`: that constant labels the source *chips* with different phrasing ("Base value", "Stat points"), a separate display surface from a contribution line's full/short label ("Engine base value" / "Base"). Coupling them would change displayed text and conflate the two surfaces.
- **Options dirty predicate** (`draft[id] !== baseline[id]`) was written three times; it now lives only in `isDirtyId`, which both `dirtyIds` and `changedPreferences` call. The comment on `changedPreferences` still holds — `isDirtyId` is a plain method over plain state, not a `$derived` getter.
- **`SkillsView.applyToPlayer`** now clears an unequipped skill's `order` (`undefined`) instead of pinning it to `0`, which conflated "unequipped" with "first slot". `selectedSkills` filters on `selected` before sorting, so this is invariant-only, no behaviour change.

## Dead code / typing
- Removed the unreachable `if (e.cancelled)` guard in `LoomGame.resolvePlayerStrike` (a cancelled channel is marked `resolved`, so `resolveCrossings` skips it before the handler ever runs) and the dead `if (hook)` in `ApiSocket` (`getOrCreateHook` always returns a hook).
- Dropped the unread `SettingsCatDef.blurb`.
- **`ResolvedReward.glow`** is now `string | null` (`null` for the rarity-less skill) instead of a magic `'0'` string interpolated into `calc()`. `RewardIcon` handles `null` as the flat base glow, so skill rewards render identically (`--rarity-common-glow` is `0`).
- Replaced the two `e.resolve as number` assertions by threading the already-null-checked `resolve` tick from `resolveCrossings` into the resolve handlers.

## DRY / perf
- **`comparisonFor`** takes an optional precomputed `Map`, built once per rebuild in `ChallengesView.all`, instead of scanning the challenge-type list once per challenge. Direct callers (tests) still use the single-lookup path.
- Extracted the duplicated **`safeLocalStorage`** guard (was copy-pasted in `token-store`, `reference-cache`, `device-fingerprint`) into `$lib/common/local-storage`, and **`NavigatorWithCapabilities`** (was in both device collectors) into `$lib/api/navigator`. The storage helper is deep-imported to avoid a `common`↔`api` barrel cycle.
- Split `CardGame.svelte`'s overloaded `onMount` into `runLoomLoop` (the RAF driver) and `bindLoomInput` (global hotkeys + reflex pointer teardown) in a colocated `loom-input.ts`, with unit tests.

## Deferred
- **Generic progress/HP bar primitive** → #753 (sub-issue of #714). It needs a shared-primitive API design plus a cross-component migration with visual-regression risk, so it's tracked separately rather than bundled with these one-liners.

## Testing
- `npm run check` (svelte-check): 0 errors.
- `eslint` on all changed files: clean.
- Full unit suite: **1802 passed**, including a new `loom-input.test.ts` and updated skill-reward `glow` fixtures.

Closes #714

https://claude.ai/code/session_015MGM4D3zXgP43RDPr9YhDR

---
_Generated by [Claude Code](https://claude.ai/code/session_015MGM4D3zXgP43RDPr9YhDR)_