### PR TITLE
Backend tech-debt triage cleanup (#713)

### DIFF
--- a/Game.Abstractions/DataAccess/IChallenges.cs
+++ b/Game.Abstractions/DataAccess/IChallenges.cs
@@ -5,6 +5,8 @@ namespace Game.Abstractions.DataAccess
     public interface IChallenges
     {
         public IReadOnlyList<Challenge> All();
+        // Whether a challenge with the given id exists; an O(1) range check (challenges are zero-based-id reference data).
+        public bool ValidateChallengeId(int challengeId);
         public Challenge GetChallenge(int challengeId);
     }
 }

--- a/Game.Api.Tests/Integration/LoginControllerTests.cs
+++ b/Game.Api.Tests/Integration/LoginControllerTests.cs
@@ -195,6 +195,29 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task Status_AuthenticatedButPlayerNotLoadable_ReturnsGracefulError()
+        {
+            // A still-valid token whose player can't be loaded (archived/deleted between requests; here a user
+            // with no player at all) must return a structured error, not a 500 — mirroring how Login surfaces a
+            // missing player. Rehydration finds no player, so the session's selected id stays unresolved and the
+            // player load comes back null.
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context, "playerlessstatus", "pass");
+
+            var client = Factory.CreateClient();
+            TestAuthHelper.AddAuthHeader(client, user.Id);
+
+            var response = await client.GetAsync("/api/Login/Status", CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse<Models.Player.PlayerData>>(CancellationToken);
+            Assert.Null(result?.Data);
+            Assert.NotNull(result?.ErrorMessage);
+            client.Dispose();
+        }
+
+        [Fact]
         public async Task ActiveSession_Unauthenticated_Returns401()
         {
             var response = await Client.GetAsync("/api/Login/ActiveSession", CancellationToken);

--- a/Game.Api.Tests/Unit/PlayerDataMappingTests.cs
+++ b/Game.Api.Tests/Unit/PlayerDataMappingTests.cs
@@ -89,7 +89,7 @@ namespace Game.Api.Tests.Unit
             Level = 1,
             Exp = 0,
             CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints([]) { StatPointsGained = 0, StatPointsUsed = 0 },
+            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
             Inventory = inventory ?? new Inventory(),
             Skills = skills,
             SelectedSkills = selectedSkills,

--- a/Game.Api.Tests/Unit/SessionServiceTests.cs
+++ b/Game.Api.Tests/Unit/SessionServiceTests.cs
@@ -97,7 +97,7 @@ namespace Game.Api.Tests.Unit
             Level = 1,
             Exp = 0,
             CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints([]) { StatPointsGained = 0, StatPointsUsed = 0 },
+            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
             Inventory = new Inventory(),
             SelectedSkills = [],
             Skills = [],

--- a/Game.Api/Controllers/LoginController.cs
+++ b/Game.Api/Controllers/LoginController.cs
@@ -60,9 +60,14 @@ namespace Game.Api.Controllers
         public async Task<ApiResponse> CreateAccount([FromBody] LoginCredentials creds)
         {
             var status = await _accountService.CreateAccount(creds.Username, creds.Password);
-            return status == CreateAccountStatus.UsernameTaken
-                ? ApiResponse.Error("There is already an account with this username.")
-                : ApiResponse.Success();
+            // Exhaustive map (mirrors the login/role mappings) so a newly-added failure status is a build-time
+            // gap to fill rather than a silent success reported to the client.
+            return status switch
+            {
+                CreateAccountStatus.Success => ApiResponse.Success(),
+                CreateAccountStatus.UsernameTaken => ApiResponse.Error("There is already an account with this username."),
+                _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
+            };
         }
 
         [AllowAnonymous]
@@ -82,8 +87,14 @@ namespace Game.Api.Controllers
                 return ApiResponse.Error("Not logged in");
             }
 
-            var player = await _playerService.LoadPlayer(_sessionService.SelectedPlayerId)
-                ?? throw new InvalidOperationException("Player data not loaded.");
+            // A still-valid token whose player can't be loaded (deleted/archived between requests) is a
+            // graceful error, not a 500 — mirroring the structured ApiResponse.Error its sibling endpoints use.
+            var player = await _playerService.LoadPlayer(_sessionService.SelectedPlayerId);
+            if (player is null)
+            {
+                return ApiResponse.Error("Player data not found");
+            }
+
             return ApiResponse.Success(PlayerData.FromPlayer(player));
         }
 

--- a/Game.Api/Filters/AdminCacheReloadFilter.cs
+++ b/Game.Api/Filters/AdminCacheReloadFilter.cs
@@ -49,12 +49,12 @@ namespace Game.Api.Filters
                     logger.LogWarning(ex, "Failed to broadcast the reference-data change; other instances may serve stale reference data until the next notification.");
                 }
 
-                foreach (var cache in caches)
-                {
-                    // Not tied to the request's cancellation token: the write has committed, so the cache
-                    // must reflect it even if the client has disconnected.
-                    await cache.ReloadAsync();
-                }
+                // Reload all holders concurrently rather than back-to-back: each rebuilds its snapshot on its
+                // own DI-scoped context and swaps it atomically, and no holder depends on another's reload
+                // order, so a serial pass only adds latency and could leave some sets fresh and some stale if
+                // one query failed mid-list. Not tied to the request's cancellation token: the write has
+                // committed, so the caches must reflect it even if the client has disconnected.
+                await Task.WhenAll(caches.Select(cache => cache.ReloadAsync()));
             }
         }
     }

--- a/Game.Api/Startup.cs
+++ b/Game.Api/Startup.cs
@@ -189,7 +189,12 @@ namespace Game.Api
         private static void ConfigureAuth(WebApplicationBuilder builder)
         {
             var jwtSection = builder.Configuration.GetSection("Jwt");
-            builder.Services.AddOptions<JwtOptions>().Bind(jwtSection);
+            builder.Services.AddOptions<JwtOptions>()
+                .Bind(jwtSection)
+                // HMAC-SHA256 needs a key of at least its 256-bit output, so fail fast at startup (mirroring
+                // the pepper/CORS validation below) rather than only when the first token is issued.
+                .Validate(options => Encoding.UTF8.GetByteCount(options.SigningKey) >= 32, "Jwt:SigningKey must be at least 32 bytes for HMAC-SHA256")
+                .ValidateOnStart();
 
             var signingKey = jwtSection["SigningKey"] ?? throw new InvalidOperationException("Jwt:SigningKey not set");
             var issuer = jwtSection["Issuer"] ?? Constants.SERVER_PRINCIPAL;

--- a/Game.Application.Tests/DataAccess/ChildCollectionReconcilerTests.cs
+++ b/Game.Application.Tests/DataAccess/ChildCollectionReconcilerTests.cs
@@ -19,8 +19,8 @@ namespace Game.Application.Tests.DataAccess
         }
 
         private static void Reconcile(
-            IEnumerable<ExistingChild> existing,
-            IEnumerable<DesiredChild> desired,
+            IReadOnlyCollection<ExistingChild> existing,
+            IReadOnlyCollection<DesiredChild> desired,
             Recorder recorder,
             bool withUpdate = true)
         {

--- a/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
@@ -262,7 +262,7 @@ namespace Game.Application.Tests.DataAccess
             Level = 1,
             Exp = 0,
             CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints([]) { StatPointsGained = 0, StatPointsUsed = 0 },
+            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
             Inventory = new Inventory(),
             SelectedSkills = [],
             Skills = [],

--- a/Game.Application.Tests/DataAccess/PlayerUpdateRetryPolicyTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerUpdateRetryPolicyTests.cs
@@ -71,5 +71,31 @@ namespace Game.Application.Tests.DataAccess
             Assert.Equal(TimeSpan.Zero, policy.DelayAfterAttempt(1));
             Assert.Equal(TimeSpan.Zero, policy.DelayAfterAttempt(5));
         }
+
+        [Fact]
+        public void MaxDelay_DefaultsToOneMinute()
+        {
+            Assert.Equal(TimeSpan.FromMinutes(1), PlayerUpdateRetryPolicy.Default.MaxDelay);
+        }
+
+        [Fact]
+        public void DelayAfterAttempt_SaturatesAtMaxDelay_ForLargeAttempt()
+        {
+            // 200ms * 2^39 is days — far past MaxDelay — so the doubling must saturate at the cap rather
+            // than schedule an absurd wait.
+            var policy = new PlayerUpdateRetryPolicy(40, TimeSpan.FromMilliseconds(200));
+
+            Assert.Equal(policy.MaxDelay, policy.DelayAfterAttempt(40));
+        }
+
+        [Fact]
+        public void DelayAfterAttempt_PathologicalAttempt_ClampsWithoutOverflowing()
+        {
+            // A high enough exponent overflows the raw TimeSpan multiply (which throws); the clamp must
+            // saturate at MaxDelay instead of letting it overflow.
+            var policy = new PlayerUpdateRetryPolicy(3, TimeSpan.FromMilliseconds(200));
+
+            Assert.Equal(policy.MaxDelay, policy.DelayAfterAttempt(1000));
+        }
     }
 }

--- a/Game.Application.Tests/DataAccess/ReferenceDataBoundsCheckTests.cs
+++ b/Game.Application.Tests/DataAccess/ReferenceDataBoundsCheckTests.cs
@@ -62,5 +62,23 @@ namespace Game.Application.Tests.DataAccess
             Assert.Contains("challenge", ex.Message);
             Assert.Throws<ArgumentOutOfRangeException>(() => challenges.GetChallenge(-1));
         }
+
+        [Fact]
+        public void ValidateChallengeId_AcceptsInRangeRejectsOutOfRange()
+        {
+            using var scope = CreateScope();
+            var challenges = scope.ServiceProvider.GetRequiredService<IChallenges>();
+            var count = challenges.All().Count;
+
+            // The O(1) range check the admin zone validator relies on: an id is valid iff it indexes the
+            // zero-based snapshot.
+            Assert.False(challenges.ValidateChallengeId(-1));
+            Assert.False(challenges.ValidateChallengeId(count));
+            if (count > 0)
+            {
+                Assert.True(challenges.ValidateChallengeId(0));
+                Assert.True(challenges.ValidateChallengeId(count - 1));
+            }
+        }
     }
 }

--- a/Game.Application.Tests/Events/LoggingEventHandlerTests.cs
+++ b/Game.Application.Tests/Events/LoggingEventHandlerTests.cs
@@ -107,7 +107,7 @@ namespace Game.Application.Tests.Events
             Level = 1,
             Exp = 0,
             CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints([]) { StatPointsGained = 0, StatPointsUsed = 0 },
+            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
             Inventory = new Inventory(),
             SelectedSkills = [],
             Skills = [],

--- a/Game.Application/Services/PlayerService.cs
+++ b/Game.Application/Services/PlayerService.cs
@@ -16,57 +16,27 @@ namespace Game.Application.Services
 
         public async Task<bool> TryUpdateAttributes(Player player, IEnumerable<IAttributeUpdate> updates, CancellationToken cancellationToken = default)
         {
-            if (!player.TryUpdateAttributes(updates))
-            {
-                return false;
-            }
-
-            await _playerRepo.SavePlayer(player, cancellationToken);
-            return true;
+            return await SaveIf(player, player.TryUpdateAttributes(updates), cancellationToken);
         }
 
         public async Task<bool> EquipItem(Player player, int itemId, EEquipmentSlot slot, CancellationToken cancellationToken = default)
         {
-            if (!player.TryEquipItem(itemId, slot))
-            {
-                return false;
-            }
-
-            await _playerRepo.SavePlayer(player, cancellationToken);
-            return true;
+            return await SaveIf(player, player.TryEquipItem(itemId, slot), cancellationToken);
         }
 
         public async Task<bool> UnequipItem(Player player, EEquipmentSlot slot, CancellationToken cancellationToken = default)
         {
-            if (!player.TryUnequipItem(slot))
-            {
-                return false;
-            }
-
-            await _playerRepo.SavePlayer(player, cancellationToken);
-            return true;
+            return await SaveIf(player, player.TryUnequipItem(slot), cancellationToken);
         }
 
         public async Task<bool> SetFavorite(Player player, int itemId, bool favorite, CancellationToken cancellationToken = default)
         {
-            if (!player.TrySetFavorite(itemId, favorite))
-            {
-                return false;
-            }
-
-            await _playerRepo.SavePlayer(player, cancellationToken);
-            return true;
+            return await SaveIf(player, player.TrySetFavorite(itemId, favorite), cancellationToken);
         }
 
         public async Task<bool> SetSelectedSkills(Player player, IReadOnlyList<int> orderedSkillIds, CancellationToken cancellationToken = default)
         {
-            if (!player.TrySetSelectedSkills(orderedSkillIds))
-            {
-                return false;
-            }
-
-            await _playerRepo.SavePlayer(player, cancellationToken);
-            return true;
+            return await SaveIf(player, player.TrySetSelectedSkills(orderedSkillIds), cancellationToken);
         }
 
         public async Task SaveLogPreferences(Player player, IEnumerable<LogPreference> preferences, CancellationToken cancellationToken = default)
@@ -87,25 +57,25 @@ namespace Game.Application.Services
             }
 
             var mod = _itemMods.GetItemMod(itemModId);
-
-            if (!player.TryApplyMod(itemId, itemModId, itemModSlotId, mod))
-            {
-                return false;
-            }
-
-            await _playerRepo.SavePlayer(player, cancellationToken);
-            return true;
+            return await SaveIf(player, player.TryApplyMod(itemId, itemModId, itemModSlotId, mod), cancellationToken);
         }
 
         public async Task<bool> RemoveMod(Player player, int itemId, int itemModSlotId, CancellationToken cancellationToken = default)
         {
-            if (!player.TryRemoveMod(itemId, itemModSlotId))
+            return await SaveIf(player, player.TryRemoveMod(itemId, itemModSlotId), cancellationToken);
+        }
+
+        // Persists the player only when the domain mutation succeeded, returning whether it did — centralizing
+        // the guard/save/return boilerplate the anti-cheat mutation commands share. A rejected mutation
+        // (false) skips the save so it leaves no state change, matching the all-or-nothing contract.
+        private async Task<bool> SaveIf(Player player, bool mutated, CancellationToken cancellationToken)
+        {
+            if (mutated)
             {
-                return false;
+                await _playerRepo.SavePlayer(player, cancellationToken);
             }
 
-            await _playerRepo.SavePlayer(player, cancellationToken);
-            return true;
+            return mutated;
         }
     }
 }

--- a/Game.Core.Tests/Battle/BattleContextTests.cs
+++ b/Game.Core.Tests/Battle/BattleContextTests.cs
@@ -97,7 +97,7 @@ namespace Game.Core.Tests.Battle
                 Level = 1,
                 Exp = 0,
                 CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints(statAllocations) { StatPointsGained = 50, StatPointsUsed = 50 },
+                StatPoints = new PlayerStatPoints { StatAllocations = statAllocations, StatPointsGained = 50, StatPointsUsed = 50 },
                 Inventory = new Inventory(),
                 SelectedSkills = [],
                 Skills = [],

--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -548,8 +548,8 @@ namespace Game.Core.Tests.Battle
                 Level = 1,
                 Exp = 0,
                 CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints(allocations)
-                { StatPointsGained = totalUsed, StatPointsUsed = totalUsed },
+                StatPoints = new PlayerStatPoints
+                { StatAllocations = allocations, StatPointsGained = totalUsed, StatPointsUsed = totalUsed },
                 Inventory = new Inventory(),
                 SelectedSkills = defaultSkills,
                 Skills = defaultSkills,
@@ -657,8 +657,8 @@ namespace Game.Core.Tests.Battle
                 Level = 1,
                 Exp = 0,
                 CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints(allocations)
-                { StatPointsGained = totalUsed, StatPointsUsed = totalUsed },
+                StatPoints = new PlayerStatPoints
+                { StatAllocations = allocations, StatPointsGained = totalUsed, StatPointsUsed = totalUsed },
                 Inventory = new Inventory(),
                 SelectedSkills = defaultSkills,
                 Skills = defaultSkills,

--- a/Game.Core.Tests/Battle/BattleSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorTests.cs
@@ -141,8 +141,8 @@ namespace Game.Core.Tests.Battle
                 Level = 1,
                 Exp = 0,
                 CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints(allocations)
-                { StatPointsGained = totalUsed, StatPointsUsed = totalUsed },
+                StatPoints = new PlayerStatPoints
+                { StatAllocations = allocations, StatPointsGained = totalUsed, StatPointsUsed = totalUsed },
                 Inventory = new Inventory(),
                 SelectedSkills = defaultSkills,
                 Skills = defaultSkills,

--- a/Game.Core.Tests/Battle/BattleSkillTests.cs
+++ b/Game.Core.Tests/Battle/BattleSkillTests.cs
@@ -174,8 +174,8 @@ namespace Game.Core.Tests.Battle
                 Level = 1,
                 Exp = 0,
                 CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints(statAllocations)
-                { StatPointsGained = 50, StatPointsUsed = 50 },
+                StatPoints = new PlayerStatPoints
+                { StatAllocations = statAllocations, StatPointsGained = 50, StatPointsUsed = 50 },
                 Inventory = new Inventory(),
                 SelectedSkills = [],
                 Skills = [],

--- a/Game.Core.Tests/Battle/BattleSnapshotTests.cs
+++ b/Game.Core.Tests/Battle/BattleSnapshotTests.cs
@@ -259,7 +259,7 @@ namespace Game.Core.Tests.Battle
                 Level = level,
                 Exp = 0,
                 CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints(allocations ?? []) { StatPointsGained = 0, StatPointsUsed = 0 },
+                StatPoints = new PlayerStatPoints { StatAllocations = allocations ?? [], StatPointsGained = 0, StatPointsUsed = 0 },
                 Inventory = new Inventory(),
                 SelectedSkills = selectedSkills ?? [],
                 Skills = selectedSkills ?? [],

--- a/Game.Core.Tests/Battle/DefeatRewardsTests.cs
+++ b/Game.Core.Tests/Battle/DefeatRewardsTests.cs
@@ -188,9 +188,9 @@ namespace Game.Core.Tests.Battle
                 Level = 1,
                 Exp = 0,
                 CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints(
-                    allocations.Select(a => new StatAllocation { Attribute = a.Attribute, Amount = a.Amount }).ToList())
+                StatPoints = new PlayerStatPoints
                 {
+                    StatAllocations = allocations.Select(a => new StatAllocation { Attribute = a.Attribute, Amount = a.Amount }).ToList(),
                     StatPointsGained = statPointsGained,
                     StatPointsUsed = (int)allocations.Sum(a => a.Amount),
                 },

--- a/Game.Core.Tests/Events/LoggableDomainEventTests.cs
+++ b/Game.Core.Tests/Events/LoggableDomainEventTests.cs
@@ -68,7 +68,7 @@ namespace Game.Core.Tests.Events
             Level = 1,
             Exp = 0,
             CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints([]) { StatPointsGained = 0, StatPointsUsed = 0 },
+            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
             Inventory = new Inventory(),
             SelectedSkills = [],
             Skills = [],

--- a/Game.Core.Tests/Players/EquipmentSlotTests.cs
+++ b/Game.Core.Tests/Players/EquipmentSlotTests.cs
@@ -5,7 +5,7 @@ namespace Game.Core.Tests.Players
 {
     public class EquipmentSlotTests
     {
-        // ── Constructor derives Value, Name, and ItemCategory ───────────────
+        // ── Name and ItemCategory are computed get-only from Value ──────────
 
         [Theory]
         [InlineData(EEquipmentSlot.HelmSlot, "Helm Slot", EItemCategory.Helm)]
@@ -34,11 +34,40 @@ namespace Game.Core.Tests.Players
         }
 
         [Fact]
-        public void Constructor_UnmappedSlot_Throws()
+        public void NameAndCategory_TrackValue_NeverGoStale()
         {
-            // Every defined EEquipmentSlot maps to a category; an out-of-range value exercises the
-            // guard that prevents constructing a slot with no associated item category.
-            Assert.Throws<ArgumentException>(() => new EquipmentSlot((EEquipmentSlot)99));
+            // Name/ItemCategory are derived from Value rather than stored, so reassigning Value (e.g. a
+            // deserializer or a future caller) can never leave a stale category that would mis-gate slot
+            // compatibility.
+            var equipmentSlot = new EquipmentSlot(EEquipmentSlot.WeaponSlot)
+            {
+                Value = EEquipmentSlot.HelmSlot,
+            };
+
+            Assert.Equal("Helm Slot", equipmentSlot.Name);
+            Assert.Equal(EItemCategory.Helm, equipmentSlot.ItemCategory);
+        }
+
+        [Fact]
+        public void SerializationRoundTrip_DerivesCategoryFromValue()
+        {
+            // The player aggregate round-trips through Redis as JSON; the derived category must follow Value
+            // back out, not depend on a persisted Name/ItemCategory field.
+            var roundTripped = new EquipmentSlot(EEquipmentSlot.WeaponSlot).Serialize().Deserialize<EquipmentSlot>();
+
+            Assert.NotNull(roundTripped);
+            Assert.Equal(EEquipmentSlot.WeaponSlot, roundTripped.Value);
+            Assert.Equal(EItemCategory.Weapon, roundTripped.ItemCategory);
+        }
+
+        [Fact]
+        public void ItemCategory_UnmappedSlot_Throws()
+        {
+            // Every defined EEquipmentSlot maps to a category; deriving ItemCategory from an out-of-range
+            // value exercises the guard that prevents resolving a slot with no associated item category.
+            var equipmentSlot = new EquipmentSlot((EEquipmentSlot)99);
+
+            Assert.Throws<ArgumentException>(() => _ = equipmentSlot.ItemCategory);
         }
     }
 }

--- a/Game.Core.Tests/Players/PlayerStatPointsTests.cs
+++ b/Game.Core.Tests/Players/PlayerStatPointsTests.cs
@@ -135,7 +135,7 @@ namespace Game.Core.Tests.Players
             {
                 new() { Attribute = EAttribute.Strength, Amount = 0 },
             };
-            var stats = new PlayerStatPoints(allocations) { StatPointsGained = 10, StatPointsUsed = 0 };
+            var stats = new PlayerStatPoints { StatAllocations = allocations, StatPointsGained = 10, StatPointsUsed = 0 };
 
             var result = stats.TryUpdateAttributes([new Update(EAttribute.Luck, 3)]);
 
@@ -153,7 +153,7 @@ namespace Game.Core.Tests.Players
             {
                 new() { Attribute = EAttribute.Strength, Amount = 0 },
             };
-            var stats = new PlayerStatPoints(allocations) { StatPointsGained = 10, StatPointsUsed = 0 };
+            var stats = new PlayerStatPoints { StatAllocations = allocations, StatPointsGained = 10, StatPointsUsed = 0 };
 
             var result = stats.TryUpdateAttributes([
                 new Update(EAttribute.Strength, 2),
@@ -193,8 +193,9 @@ namespace Game.Core.Tests.Players
                 new() { Attribute = EAttribute.Dexterity, Amount = 0 },
                 new() { Attribute = EAttribute.Luck,      Amount = 0 },
             };
-            return new PlayerStatPoints(allocations)
+            return new PlayerStatPoints
             {
+                StatAllocations = allocations,
                 StatPointsGained = gained,
                 StatPointsUsed = used,
             };

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -675,7 +675,7 @@ namespace Game.Core.Tests.Players
             Level = level,
             Exp = exp,
             CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints([]) { StatPointsGained = 0, StatPointsUsed = 0 },
+            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
             Inventory = new Inventory(),
             SelectedSkills = [],
             Skills = [],

--- a/Game.Core.Tests/Players/StatAllocationTests.cs
+++ b/Game.Core.Tests/Players/StatAllocationTests.cs
@@ -27,7 +27,7 @@ namespace Game.Core.Tests.Players
                 new() { Attribute = EAttribute.Strength, Amount = 4 },
                 new() { Attribute = EAttribute.Agility, Amount = 6 },
             };
-            var statPoints = new PlayerStatPoints(allocations) { StatPointsGained = 10, StatPointsUsed = 10 };
+            var statPoints = new PlayerStatPoints { StatAllocations = allocations, StatPointsGained = 10, StatPointsUsed = 10 };
 
             var fromAllocations = allocations.Select(a => a.ToModifier()).ToList();
             var fromStatPoints = statPoints.ToAttributeModifiers().ToList();

--- a/Game.Core.Tests/Progress/ChallengeTests.cs
+++ b/Game.Core.Tests/Progress/ChallengeTests.cs
@@ -86,7 +86,7 @@ namespace Game.Core.Tests.Progress
             Level = level,
             Exp = 0,
             CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints([]) { StatPointsGained = 0, StatPointsUsed = 0 },
+            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
             Inventory = new Inventory(),
             SelectedSkills = [],
             Skills = [],

--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -702,7 +702,7 @@ namespace Game.Core.Tests.Progress
             Level = level,
             Exp = 0,
             CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints([]) { StatPointsGained = 0, StatPointsUsed = 0 },
+            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
             Inventory = new Inventory(),
             SelectedSkills = [],
             Skills = [],

--- a/Game.Core/Items/ItemMod.cs
+++ b/Game.Core/Items/ItemMod.cs
@@ -25,7 +25,7 @@ namespace Game.Core.Items
         public required string Description { get; init; }
 
         /// <inheritdoc cref="EItemModType" />
-        public EItemModType Type { get; init; }
+        public required EItemModType Type { get; init; }
 
         /// <inheritdoc cref="ERarity" />
         public required ERarity Rarity { get; init; }

--- a/Game.Core/Players/Inventories/EquipmentSlot.cs
+++ b/Game.Core/Players/Inventories/EquipmentSlot.cs
@@ -13,14 +13,14 @@ namespace Game.Core.Players.Inventories
         public EEquipmentSlot Value { get; set; }
 
         /// <summary>
-        /// The name of the equipment slot.
+        /// The name of the equipment slot, derived from <see cref="Value"/>.
         /// </summary>
-        public string Name { get; set; }
+        public string Name => Value.ToString().Capitalize().SpaceWords();
 
         /// <summary>
-        /// The item category that is allowed to be equipped.
+        /// The item category that is allowed to be equipped, derived from <see cref="Value"/>.
         /// </summary>
-        public EItemCategory ItemCategory { get; set; }
+        public EItemCategory ItemCategory => GetItemCategory(Value);
 
         /// <summary>
         /// The item ID of the equipped item, or null when the slot is empty.
@@ -39,8 +39,6 @@ namespace Game.Core.Players.Inventories
         public EquipmentSlot(EEquipmentSlot value)
         {
             Value = value;
-            Name = value.ToString().Capitalize().SpaceWords();
-            ItemCategory = GetItemCategory(value);
         }
 
         /// <summary>

--- a/Game.Core/Players/PlayerStatPoints.cs
+++ b/Game.Core/Players/PlayerStatPoints.cs
@@ -18,16 +18,7 @@ namespace Game.Core.Players
         public required int StatPointsUsed { get; set; }
 
         /// <inheritdoc cref="StatAllocation"/>
-        public List<StatAllocation> StatAllocations { get; set; }
-
-        /// <summary>
-        /// Creates a new instance of <see cref="PlayerStatPoints"/>.
-        /// </summary>
-        /// <param name="statAllocations"></param>
-        public PlayerStatPoints(List<StatAllocation> statAllocations)
-        {
-            StatAllocations = statAllocations;
-        }
+        public required List<StatAllocation> StatAllocations { get; set; }
 
         /// <summary>
         /// Attempts to apply the given <paramref name="changedAttributes"/> to the player's stat allocations.

--- a/Game.DataAccess/DataProviderSynchronizer.cs
+++ b/Game.DataAccess/DataProviderSynchronizer.cs
@@ -471,11 +471,13 @@ namespace Game.DataAccess
             // Batched like HandleAttributeAllocationsChanged: load the touched rows, set/insert, save once.
             if (evt.Statistics.Count > 0)
             {
-                // Constrain the load to the touched (type, entity) space, not every row of the touched
-                // types: a long-lived account accrues one row per enemy/skill, so filtering on typeIds alone
-                // would load hundreds to upsert the ~10-20 this battle changed (aggregate-DB-load concern,
-                // #548). The exact-key match still happens in memory below; this only bounds the fetch.
-                // entityIds includes null for the global rows — EF turns Contains over a List<int?> into
+                // Bound the load by the touched type id set AND the touched entity id set — their
+                // cross-product, which is a superset of the exact (type, entity) pairs changed. Filtering on
+                // typeIds alone would, for a long-lived account with one row per enemy/skill, load hundreds to
+                // upsert the ~10-20 this battle changed (aggregate-DB-load concern, #548). A value-tuple IN
+                // over the exact pairs isn't cleanly EF-translatable, so this cross-product bound is the
+                // pragmatic narrowing; the exact-key match still happens in memory below. entityIds includes
+                // null for the global rows — EF turns Contains over a List<int?> into
                 // "EntityId IN (...) OR EntityId IS NULL".
                 var typeIds = evt.Statistics.Select(s => s.StatisticTypeId).Distinct().ToList();
                 var entityIds = evt.Statistics.Select(s => s.EntityId).Distinct().ToList();

--- a/Game.DataAccess/Mapping/PlayerMapper.cs
+++ b/Game.DataAccess/Mapping/PlayerMapper.cs
@@ -156,8 +156,9 @@ namespace Game.DataAccess.Mapping
                 Level = entity.Level,
                 Exp = entity.Exp,
                 CurrentZoneId = entity.CurrentZoneId,
-                StatPoints = new PlayerStatPoints(statAllocations)
+                StatPoints = new PlayerStatPoints
                 {
+                    StatAllocations = statAllocations,
                     StatPointsGained = entity.StatPointsGained,
                     StatPointsUsed = entity.StatPointsUsed,
                 },

--- a/Game.DataAccess/Repositories/Admin/AdminZones.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminZones.cs
@@ -29,7 +29,6 @@ namespace Game.DataAccess.Repositories.Admin
             // must reference an existing challenge. An edit must also target an existing zone — a missing id
             // is a not-found rejection, not an EF 0-row update that throws. Validate the whole change set up
             // front so an invalid reference rejects the batch rather than partially applying.
-            var challengeCount = _challenges.All().Count;
             foreach (var change in changes)
             {
                 if (change.ChangeType == EChangeType.Delete)
@@ -48,9 +47,10 @@ namespace Game.DataAccess.Repositories.Admin
                     return "Boss enemy is invalid. A zone's boss must be an existing enemy marked as a boss.";
                 }
 
-                // Challenges are zero-based-id reference data, so a valid id is an in-range index.
+                // Challenges are zero-based-id reference data, so a valid id is an in-range index (an O(1)
+                // check, like the enemy/zone validators above).
                 if (change.Item.UnlockChallengeId is int unlockChallengeId
-                    && (unlockChallengeId < 0 || unlockChallengeId >= challengeCount))
+                    && !_challenges.ValidateChallengeId(unlockChallengeId))
                 {
                     return "Unlock challenge is invalid. A zone's unlock challenge must reference an existing challenge.";
                 }

--- a/Game.DataAccess/Repositories/Admin/ChildCollectionReconciler.cs
+++ b/Game.DataAccess/Repositories/Admin/ChildCollectionReconciler.cs
@@ -24,9 +24,12 @@ namespace Game.DataAccess.Repositories.Admin
     /// </remarks>
     internal static class ChildCollectionReconciler
     {
+        // The collections are typed IReadOnlyCollection rather than IEnumerable because each is enumerated
+        // twice (once to build its key set, once to diff), so a deferred/lazy source would re-run — and could
+        // yield a different sequence the second time. Requiring a materialized collection rules that out.
         public static void Reconcile<TExisting, TDesired, TKey>(
-            IEnumerable<TExisting> existing,
-            IEnumerable<TDesired> desired,
+            IReadOnlyCollection<TExisting> existing,
+            IReadOnlyCollection<TDesired> desired,
             Func<TExisting, TKey> existingKey,
             Func<TDesired, TKey> desiredKey,
             Action<TExisting> delete,

--- a/Game.DataAccess/Repositories/Caching/EnemiesCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/EnemiesCacheHolder.cs
@@ -39,9 +39,11 @@ namespace Game.DataAccess.Repositories.Caching
                 .ToListAsync(cancellationToken);
 
             // Map each enemy's available-skill loadout once here so the gameplay reads clone a pre-built
-            // template rather than re-mapping the skill graph per encounter (#584). Skills are loaded directly
-            // rather than read from the skill cache: holders reload independently and this one reloads before
-            // the skill holder, so a cross-cache read could observe a stale skill snapshot mid-reload-sweep.
+            // template rather than re-mapping the skill graph per encounter (#584). Skills are queried directly
+            // from this snapshot's own context rather than read from the skill cache so the build stays
+            // self-contained and order-independent: holders reload concurrently and independently (no holder
+            // depends on another's reload order), so reading the shared skill cache mid-sweep could observe a
+            // stale — or not-yet-loaded — skill snapshot.
             var skills = await context.Skills
                 .AsNoTracking()
                 .Include(s => s.SkillDamageMultipliers)

--- a/Game.DataAccess/Repositories/Challenges.cs
+++ b/Game.DataAccess/Repositories/Challenges.cs
@@ -13,6 +13,11 @@ namespace Game.DataAccess.Repositories
             return holder.Current;
         }
 
+        public bool ValidateChallengeId(int challengeId)
+        {
+            return challengeId >= 0 && challengeId < holder.Current.Count;
+        }
+
         public Challenge GetChallenge(int challengeId)
         {
             return holder.Current.GetById(challengeId, "challenge");

--- a/Game.DataAccess/Repositories/ITagAssignmentQueries.cs
+++ b/Game.DataAccess/Repositories/ITagAssignmentQueries.cs
@@ -16,7 +16,9 @@ namespace Game.DataAccess.Repositories
         IAsyncEnumerable<int> GetTagIdsForItemMod(int itemModId);
 
         /// <summary>The subset of the given ids that correspond to existing tags, so a join row is never
-        /// inserted for an unknown tag (which would violate the foreign key).</summary>
-        IAsyncEnumerable<int> GetExistingTagIds(IEnumerable<int> tagIds);
+        /// inserted for an unknown tag (which would violate the foreign key). Takes a materialized collection
+        /// (not a deferred <see cref="IEnumerable{T}"/>) so the ids captured in the translated query can't be a
+        /// re-evaluated/side-effecting source.</summary>
+        IAsyncEnumerable<int> GetExistingTagIds(IReadOnlyCollection<int> tagIds);
     }
 }

--- a/Game.DataAccess/Repositories/RefreshTokenStore.cs
+++ b/Game.DataAccess/Repositories/RefreshTokenStore.cs
@@ -1,5 +1,6 @@
 using Game.Abstractions.DataAccess;
 using Game.Abstractions.Infrastructure;
+using System.Buffers.Text;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -57,15 +58,8 @@ namespace Game.DataAccess.Repositories
 
         private static string GenerateToken()
         {
-            return Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
-        }
-
-        private static string Base64UrlEncode(byte[] bytes)
-        {
-            return Convert.ToBase64String(bytes)
-                .TrimEnd('=')
-                .Replace('+', '-')
-                .Replace('/', '_');
+            // Base64Url emits the URL-safe alphabet without padding, so no manual trim/replace is needed.
+            return Base64Url.EncodeToString(RandomNumberGenerator.GetBytes(32));
         }
     }
 }

--- a/Game.DataAccess/Repositories/Tags.cs
+++ b/Game.DataAccess/Repositories/Tags.cs
@@ -25,7 +25,7 @@ namespace Game.DataAccess.Repositories
             return _context.Tags.Select(ToContract).AsAsyncEnumerable();
         }
 
-        public IAsyncEnumerable<int> GetExistingTagIds(IEnumerable<int> tagIds)
+        public IAsyncEnumerable<int> GetExistingTagIds(IReadOnlyCollection<int> tagIds)
         {
             return _context.Tags.Where(t => tagIds.Contains(t.Id)).Select(t => t.Id).AsAsyncEnumerable();
         }

--- a/Game.DataAccess/RetryPolicy.cs
+++ b/Game.DataAccess/RetryPolicy.cs
@@ -3,11 +3,18 @@ namespace Game.DataAccess
     /// <summary>
     /// Base shape for an exponential-backoff retry policy: an operation is attempted up to
     /// <see cref="MaxAttempts"/> times, waiting <see cref="BaseDelay"/> after the first failed attempt and
-    /// doubling the wait after each subsequent one.
+    /// doubling the wait after each subsequent one, capped at <see cref="MaxDelay"/>.
     /// </summary>
     internal abstract record RetryPolicy
     {
-        protected RetryPolicy(int maxAttempts, TimeSpan baseDelay)
+        /// <summary>
+        /// A generous default cap so the exponential backoff can't overflow <see cref="TimeSpan"/> (its
+        /// multiply throws on overflow) or schedule an absurd wait for a policy configured with a high
+        /// <see cref="MaxAttempts"/>; chosen well above every configured policy's natural ceiling.
+        /// </summary>
+        private static readonly TimeSpan DefaultMaxDelay = TimeSpan.FromMinutes(1);
+
+        protected RetryPolicy(int maxAttempts, TimeSpan baseDelay, TimeSpan? maxDelay = null)
         {
             if (maxAttempts < 1)
             {
@@ -19,8 +26,15 @@ namespace Game.DataAccess
                 throw new ArgumentOutOfRangeException(nameof(baseDelay), baseDelay, "The backoff delay cannot be negative.");
             }
 
+            var resolvedMaxDelay = maxDelay ?? DefaultMaxDelay;
+            if (resolvedMaxDelay < baseDelay)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxDelay), maxDelay, "The maximum delay cannot be less than the base delay.");
+            }
+
             MaxAttempts = maxAttempts;
             BaseDelay = baseDelay;
+            MaxDelay = resolvedMaxDelay;
         }
 
         /// <summary>The total number of times an operation is attempted before giving up.</summary>
@@ -29,8 +43,12 @@ namespace Game.DataAccess
         /// <summary>The backoff delay after the first failed attempt; doubled for each subsequent attempt.</summary>
         public TimeSpan BaseDelay { get; }
 
+        /// <summary>The ceiling the doubling backoff saturates at, guarding against overflow and absurd waits.</summary>
+        public TimeSpan MaxDelay { get; }
+
         /// <summary>
-        /// The backoff delay to wait after <paramref name="failedAttempt"/> (1-based) before the next attempt.
+        /// The backoff delay to wait after <paramref name="failedAttempt"/> (1-based) before the next attempt,
+        /// saturating at <see cref="MaxDelay"/>.
         /// </summary>
         public TimeSpan DelayAfterAttempt(int failedAttempt)
         {
@@ -39,7 +57,13 @@ namespace Game.DataAccess
                 return TimeSpan.Zero;
             }
 
-            return BaseDelay * Math.Pow(2, failedAttempt - 1);
+            // Compute in double ticks and clamp before constructing the TimeSpan, so a large exponent
+            // saturates at MaxDelay instead of overflowing the TimeSpan multiply (which throws). A huge or
+            // infinite double still compares >= MaxDelay.Ticks, so it clamps cleanly.
+            var ticks = BaseDelay.Ticks * Math.Pow(2, failedAttempt - 1);
+            return ticks >= MaxDelay.Ticks
+                ? MaxDelay
+                : TimeSpan.FromTicks((long)ticks);
         }
     }
 }

--- a/Game.Infrastructure.Tests/CacheServiceFactoryTests.cs
+++ b/Game.Infrastructure.Tests/CacheServiceFactoryTests.cs
@@ -1,5 +1,6 @@
 using Game.Abstractions.Infrastructure;
 using Game.Infrastructure.Cache;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Game.Infrastructure.Tests
@@ -24,7 +25,7 @@ namespace Game.Infrastructure.Tests
             };
 
             var ex = Assert.Throws<InvalidOperationException>(
-                () => CacheServiceFactory.GetCacheService(options));
+                () => CacheServiceFactory.GetCacheService(options, NullLoggerFactory.Instance));
             Assert.Contains("CacheSystem", ex.Message);
         }
     }

--- a/Game.Infrastructure/Cache/CacheServiceFactory.cs
+++ b/Game.Infrastructure/Cache/CacheServiceFactory.cs
@@ -1,16 +1,17 @@
 ﻿using Game.Abstractions.Infrastructure;
 using Game.Infrastructure.Cache.Redis;
 using Game.Infrastructure.Redis;
+using Microsoft.Extensions.Logging;
 
 namespace Game.Infrastructure.Cache
 {
     internal static class CacheServiceFactory
     {
-        public static ICacheService GetCacheService(ICacheOptions config)
+        public static ICacheService GetCacheService(ICacheOptions config, ILoggerFactory loggerFactory)
         {
             return config.CacheSystem switch
             {
-                CacheSystem.Redis => CreateRedisService(config),
+                CacheSystem.Redis => CreateRedisService(config, loggerFactory),
                 // Fail loud on an unsupported value rather than silently defaulting to Redis (#453).
                 _ => throw new InvalidOperationException(
                     $"Unsupported CacheSystem '{config.CacheSystem}'. The application only supports "
@@ -18,9 +19,9 @@ namespace Game.Infrastructure.Cache
             };
         }
 
-        private static ICacheService CreateRedisService(ICacheOptions config)
+        private static ICacheService CreateRedisService(ICacheOptions config, ILoggerFactory loggerFactory)
         {
-            return new RedisService(RedisMultiplexerFactory.GetMultiplexer(config));
+            return new RedisService(RedisMultiplexerFactory.GetMultiplexer(config), loggerFactory.CreateLogger<RedisService>());
         }
     }
 }

--- a/Game.Infrastructure/Cache/Redis/RedisService.cs
+++ b/Game.Infrastructure/Cache/Redis/RedisService.cs
@@ -24,8 +24,10 @@ namespace Game.Infrastructure.Cache.Redis
         // zero-overhead no-op (it returns the same task), so the default-token callers pay nothing.
         //
         // For write operations the abandoned command's eventual fault would otherwise go unobserved — a silently
-        // failed write with no signal — so they route through ObserveWrite, which attaches a fault-logging
-        // continuation when (and only when) the await is cancelled.
+        // failed write with no signal — so every mutating call (including the read-modify-write GetSet/GetDelete)
+        // routes through ObserveWrite, which attaches a fault-logging continuation when (and only when) the await
+        // is cancelled. Pure reads (Get) are exempt: a post-cancellation fault there loses only an unobserved
+        // read, not a write.
 
         public async Task<string?> Get(string key, CancellationToken cancellationToken = default)
         {
@@ -40,7 +42,8 @@ namespace Game.Infrastructure.Cache.Redis
 
         public async Task<string?> GetDelete(string key, CancellationToken cancellationToken = default)
         {
-            return await Redis.StringGetDeleteAsync(key).WaitAsync(cancellationToken);
+            // Read-and-delete is a write (it removes the key), so it routes through ObserveWrite too.
+            return await ObserveWrite(Redis.StringGetDeleteAsync(key), cancellationToken);
         }
 
         public async Task<T?> GetDelete<T>(string key, CancellationToken cancellationToken = default)
@@ -51,7 +54,8 @@ namespace Game.Infrastructure.Cache.Redis
 
         public async Task<string?> GetSet(string key, string? value, CancellationToken cancellationToken = default)
         {
-            return await Redis.StringGetSetAsync(key, value).WaitAsync(cancellationToken);
+            // Read-and-set is a write (it stores the new value), so it routes through ObserveWrite too.
+            return await ObserveWrite(Redis.StringGetSetAsync(key, value), cancellationToken);
         }
 
         public async Task<T?> GetSet<T>(string key, T value, CancellationToken cancellationToken = default)

--- a/Game.Infrastructure/Cache/Redis/RedisService.cs
+++ b/Game.Infrastructure/Cache/Redis/RedisService.cs
@@ -1,5 +1,6 @@
 using Game.Abstractions.Infrastructure;
 using Game.Core;
+using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 
 namespace Game.Infrastructure.Cache.Redis
@@ -7,11 +8,13 @@ namespace Game.Infrastructure.Cache.Redis
     internal class RedisService : ICacheService
     {
         private ConnectionMultiplexer Multiplexer { get; }
+        private readonly ILogger<RedisService> _logger;
         public IDatabase Redis => Multiplexer.GetDatabase();
 
-        public RedisService(ConnectionMultiplexer multiplexer)
+        public RedisService(ConnectionMultiplexer multiplexer, ILogger<RedisService> logger)
         {
             Multiplexer = multiplexer;
+            _logger = logger;
         }
 
         // StackExchange.Redis exposes no CancellationToken on its database operations, so the token is honoured
@@ -19,6 +22,10 @@ namespace Game.Infrastructure.Cache.Redis
         // per-socket command lock without waiting out the dependency's own 5s timeout — #558), while the
         // underlying command keeps running to completion in the background. WaitAsync(CancellationToken.None) is a
         // zero-overhead no-op (it returns the same task), so the default-token callers pay nothing.
+        //
+        // For write operations the abandoned command's eventual fault would otherwise go unobserved — a silently
+        // failed write with no signal — so they route through ObserveWrite, which attaches a fault-logging
+        // continuation when (and only when) the await is cancelled.
 
         public async Task<string?> Get(string key, CancellationToken cancellationToken = default)
         {
@@ -58,9 +65,9 @@ namespace Game.Infrastructure.Cache.Redis
             // Read-old-then-write in one Lua script (atomic, mirroring CompareAndDelete) so the value and its
             // TTL land together — a separate StringGetSet + KeyExpire would leave the key without an expiry if
             // the process faulted between the two calls.
-            var result = await Redis.ScriptEvaluateAsync(
+            var result = await ObserveWrite(Redis.ScriptEvaluateAsync(
                 "local old = redis.call('get', KEYS[1]); redis.call('set', KEYS[1], ARGV[1], 'PX', ARGV[2]); return old",
-                [key], [(RedisValue)value, (RedisValue)(long)expiry.TotalMilliseconds]).WaitAsync(cancellationToken);
+                [key], [(RedisValue)value, (RedisValue)(long)expiry.TotalMilliseconds]), cancellationToken);
             return (string?)result;
         }
 
@@ -86,7 +93,7 @@ namespace Game.Infrastructure.Cache.Redis
 
         public async Task Expire(string key, TimeSpan expiry, CancellationToken cancellationToken = default)
         {
-            await Redis.KeyExpireAsync(key, expiry).WaitAsync(cancellationToken);
+            await ObserveWrite(Redis.KeyExpireAsync(key, expiry), cancellationToken);
         }
 
         public void ExpireAndForget(string key, TimeSpan expiry)
@@ -121,12 +128,12 @@ namespace Game.Infrastructure.Cache.Redis
 
         public async Task CompareAndDelete(string key, string deleteIfValue, CancellationToken cancellationToken = default)
         {
-            await Redis.ScriptEvaluateAsync("if redis.call('get', KEYS[1]) == ARGV[1] then redis.call('del', KEYS[1]) end", [key], [deleteIfValue]).WaitAsync(cancellationToken);
+            await ObserveWrite(Redis.ScriptEvaluateAsync("if redis.call('get', KEYS[1]) == ARGV[1] then redis.call('del', KEYS[1]) end", [key], [deleteIfValue]), cancellationToken);
         }
 
         public async Task Delete(string key, CancellationToken cancellationToken = default)
         {
-            await Redis.KeyDeleteAsync(key).WaitAsync(cancellationToken);
+            await ObserveWrite(Redis.KeyDeleteAsync(key), cancellationToken);
         }
 
         public void DeleteAndForget(string key)
@@ -141,7 +148,29 @@ namespace Game.Infrastructure.Cache.Redis
 
         private async Task StringSetAsync(string key, string? value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None, When when = When.Always, CancellationToken cancellationToken = default)
         {
-            await Redis.StringSetAsync(key, value, expiry: expiry, flags: flags, when: when).WaitAsync(cancellationToken);
+            await ObserveWrite(Redis.StringSetAsync(key, value, expiry: expiry, flags: flags, when: when), cancellationToken);
+        }
+
+        // Awaits a write command under the cancellation budget. On a non-cancelled await a fault surfaces here
+        // directly; on cancellation the await unwinds but the underlying command keeps running (StackExchange.Redis
+        // can't cancel it), so a fault-logging continuation is attached to the abandoned task before rethrowing —
+        // the write may have silently failed, and the next save self-heals the value but would otherwise leave no
+        // signal. ExecuteSynchronously + OnlyOnFaulted keeps it allocation-light and silent on success.
+        private async Task<T> ObserveWrite<T>(Task<T> command, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await command.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                _ = command.ContinueWith(
+                    faulted => _logger.LogError(faulted.Exception, "A Redis write faulted after its command budget was cancelled; the write may not have been applied."),
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+                throw;
+            }
         }
     }
 }

--- a/Game.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Game.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -36,7 +36,8 @@ namespace Game.Infrastructure.DependencyInjection
             return services.AddTransient(sp =>
             {
                 var options = sp.GetRequiredService<InfrastructureOptions>();
-                return CacheServiceFactory.GetCacheService(options);
+                var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+                return CacheServiceFactory.GetCacheService(options, loggerFactory);
             });
         }
 

--- a/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
@@ -29,9 +29,10 @@ namespace Game.Infrastructure.PubSub.Redis
         }
 
         // StackExchange.Redis exposes no CancellationToken on its operations, so the durable queue write is
-        // wrapped in WaitAsync (the same partial-honouring as RedisService): a cancelled per-command budget
+        // wrapped in ObserveWrite (the same partial-honouring as RedisService): a cancelled per-command budget
         // unwinds the await promptly rather than waiting out the dependency's own timeout (#558), while the
-        // underlying command settles in the background. The wake publish stays fire-and-forget, so it needs none.
+        // underlying command settles in the background — and a post-cancellation fault on the abandoned write is
+        // logged rather than lost. The wake publish stays fire-and-forget, so it needs none.
         public async Task Publish(string channel, string message, CancellationToken cancellationToken = default)
         {
             await Redis.PublishAsync(RedisChannel.Literal(channel), message, CommandFlags.FireAndForget).WaitAsync(cancellationToken);
@@ -49,7 +50,7 @@ namespace Game.Infrastructure.PubSub.Redis
             // signal for the queue consumer, and Redis pub/sub is already at-most-once (awaiting it confirms
             // the command was sent, not that any subscriber received it), so it is fire-and-forget: the data
             // is safely enqueued regardless, and the consumer drains the whole queue on its next wake (#552).
-            await queue.AddToQueueAsync(queueData).WaitAsync(cancellationToken);
+            await ObserveWrite(queue.AddToQueueAsync(queueData), cancellationToken);
             await Redis.PublishAsync(RedisChannel.Literal(channel), "", CommandFlags.FireAndForget);
         }
 
@@ -70,8 +71,29 @@ namespace Game.Infrastructure.PubSub.Redis
             // for the same reason as the per-event Publish above — the data is already enqueued and the consumer
             // drains the whole queue on its next wake (#559).
             var queue = GetQueue(queueName);
-            await queue.AddRangeToQueueAsync(values).WaitAsync(cancellationToken);
+            await ObserveWrite(queue.AddRangeToQueueAsync(values), cancellationToken);
             await Redis.PublishAsync(RedisChannel.Literal(channel), "", CommandFlags.FireAndForget);
+        }
+
+        // Mirrors RedisService.ObserveWrite for the durable queue writes: the underlying command keeps running
+        // after a cancelled await (StackExchange.Redis can't cancel it), so a post-cancellation fault — a
+        // silently-dropped enqueue, i.e. a lost player update — is surfaced via a fault-logging continuation
+        // rather than going unobserved. ExecuteSynchronously + OnlyOnFaulted keeps it light and silent on success.
+        private async Task ObserveWrite(Task command, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await command.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                _ = command.ContinueWith(
+                    faulted => _logger.LogError(faulted.Exception, "A Redis queue write faulted after its command budget was cancelled; the enqueued data may have been lost."),
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+                throw;
+            }
         }
 
         public async Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null)


### PR DESCRIPTION
## Summary

Works the backend tech-debt triage list in #713. Per the agreed scope, this PR implements the **14 clear, low-risk findings** and defers the **2 design-sensitive "consider" items** to focused follow-ups (#755, #756). Changes are split into three logically-grouped commits (reliability/correctness, hardening, DRY/perf/clarity).

## Findings addressed

### Reliability / correctness
- **Redis write-path faults go unobserved** — `Set`/`Delete`/`CompareAndDelete`/`Expire`/set-with-expiry now route through an `ObserveWrite` helper that attaches a fault-logging continuation to the abandoned command when (and only when) the await is cancelled; the same is applied to the durable queue writes in `RedisPubSubService`. (`RedisService`, `RedisPubSubService`, threaded an `ILogger` through `CacheServiceFactory`/DI.)
- **`AdminCacheReloadFilter` reloaded holders serially** → `Task.WhenAll`; each holder rebuilds on its own scoped context and no holder depends on another's reload order.
- **`EquipmentSlot.Name`/`ItemCategory` were publicly settable** and only derived in the constructor → made get-only computed from `Value`, so a deserialized slot can't carry a stale `ItemCategory` that mis-gates slot compatibility.
- **`ItemMod.Type` and `PlayerStatPoints.StatAllocations` weren't `required`** → made `required`, matching their sibling models (drops the now-redundant `PlayerStatPoints` constructor).

### Hardening
- **JWT signing key length not validated at startup** → `.Validate(... >= 32 bytes ...).ValidateOnStart()`, mirroring the pepper/CORS fail-fast, so a too-short HMAC-SHA256 key fails on boot.
- **`LoginController.CreateAccount` mapped every non-`UsernameTaken` status to success** → exhaustive `switch` with a throwing default.
- **`LoginController.Status` threw on a missing player (→ 500)** → returns a structured `ApiResponse.Error`, mirroring the sibling endpoints.

### DRY / perf / clarity
- **`PlayerService` mutation boilerplate** → extracted a `SaveIf` helper.
- **`AdminZones` validated `unlockChallengeId` via `All().Count`** → added an O(1) `IChallenges.ValidateChallengeId` (mirrors the enemy/zone validators).
- **`RetryPolicy.DelayAfterAttempt` unbounded exponential** → clamped at a `MaxDelay` so a high `MaxAttempts` can't overflow the `TimeSpan` multiply.
- **`IEnumerable` re-enumeration footguns** → `ChildCollectionReconciler.Reconcile` args and `Tags.GetExistingTagIds` parameter constrained to `IReadOnlyCollection`.
- **`RefreshTokenStore` hand-rolled Base64Url** → `System.Buffers.Text.Base64Url`.
- **Misleading comments corrected** — the `EnemiesCacheHolder` skill-ordering comment, and the over-stated progress-update over-fetch comment (a value-tuple `IN` isn't cleanly EF-translatable, so the comment now accurately describes the type×entity cross-product bound).

## Deferred (follow-up issues)
- #755 — skip the redundant per-request session read on the HTTP path (touches documented auth/session rehydration behavior; needs a design decision).
- #756 — key-only tag delete instead of fabricating `Tag.Name = ""` (needs a small `IEntityStore` abstraction decision).

## Test plan
- New unit/integration tests: `EquipmentSlot` derivation + JSON round-trip (the staleness concern), `RetryPolicy` `MaxDelay` saturation/no-overflow, `IChallenges.ValidateChallengeId` bounds, and `Status` graceful-error on an unloadable player. Updated `EquipmentSlot` guard test (throw moved to `ItemCategory` access) and all `PlayerStatPoints` construction sites for the `required` change.
- Full suite green locally: **Game.Core.Tests 549**, **Game.Application.Tests 244**, **Game.Api.Tests 477**, **Game.Infrastructure.Tests 37** — 0 failures, `dotnet build` clean (0 warnings).

Closes #713.

https://claude.ai/code/session_011R8MzPcG3pjPcv3Pik1HEC

---
_Generated by [Claude Code](https://claude.ai/code/session_011R8MzPcG3pjPcv3Pik1HEC)_