### PR TITLE
Defer subscribers added during a createHook dispatch (#747)

### DIFF
--- a/UI/src/lib/common/hooks.ts
+++ b/UI/src/lib/common/hooks.ts
@@ -21,11 +21,14 @@ export const createHook = <T extends unknown[] = []>() => {
 		promiseResolvers = [];
 
 		// Iterate by index without allocating a snapshot (this is one of the hottest
-		// game-loop paths). A subscriber that unhooks mid-dispatch only tombstones
-		// itself (`removed`) instead of splicing, so no sibling is shifted past the
-		// cursor and skipped; the tombstones are compacted out once after dispatch.
+		// game-loop paths). Removals and additions during dispatch are both deferred so
+		// the index walk isn't disturbed: an unhook only tombstones (`removed`) instead
+		// of splicing, and the snapshotted `count` excludes any subscriber a callback
+		// appends mid-dispatch — keeping it from firing on an event that predates it.
+		// Tombstones are compacted out once after dispatch; appends survive it.
 		dispatching = true;
-		for (let i = 0; i < trackers.length; i++) {
+		const count = trackers.length;
+		for (let i = 0; i < count; i++) {
 			const tracker = trackers[i];
 			if (!tracker.removed) {
 				tracker.callback(...data, tracker.unhook);

--- a/UI/src/tests/common/hooks.test.ts
+++ b/UI/src/tests/common/hooks.test.ts
@@ -193,4 +193,55 @@ describe('createHook', () => {
 
 		expect(cb).not.toHaveBeenCalled();
 	});
+
+	it('subscriber added during dispatch is deferred to the next notify', () => {
+		const hook = createHook<[number]>();
+		const added = vi.fn();
+
+		// A subscriber that registers another subscriber while handling the event.
+		// The new subscriber must not receive the in-progress notification (it
+		// subscribed after the event fired) but must receive subsequent ones.
+		hook.onNotified((value) => {
+			if (value === 1) {
+				hook.onNotified(added);
+			}
+		});
+
+		hook.notify(1);
+		expect(added).not.toHaveBeenCalled();
+
+		hook.notify(2);
+		expect(added).toHaveBeenCalledTimes(1);
+		expect(added).toHaveBeenCalledWith(2, expect.any(Function));
+	});
+
+	it('compaction after a deferred add keeps the new subscriber and drops the tombstoned one', () => {
+		const hook = createHook<[number]>();
+		const cbA = vi.fn();
+		const cbB = vi.fn();
+		const cbC = vi.fn();
+
+		// One callback both tombstones itself and appends a new subscriber in the
+		// same dispatch — the post-dispatch compaction must splice the tombstone yet
+		// preserve the appended subscriber so it fires on the following notify.
+		hook.onNotified((value, unhook) => {
+			cbA(value);
+			if (value === 1) {
+				unhook();
+				hook.onNotified(cbC);
+			}
+		});
+		hook.onNotified(cbB);
+
+		hook.notify(1);
+		expect(cbA).toHaveBeenCalledTimes(1);
+		expect(cbB).toHaveBeenCalledTimes(1);
+		expect(cbC).not.toHaveBeenCalled();
+
+		hook.notify(2);
+		expect(cbA).toHaveBeenCalledTimes(1);
+		expect(cbB).toHaveBeenCalledTimes(2);
+		expect(cbC).toHaveBeenCalledTimes(1);
+		expect(cbC).toHaveBeenCalledWith(2, expect.any(Function));
+	});
 });


### PR DESCRIPTION
## Summary

`createHook`'s `notify` loop re-read `trackers.length` on every iteration, so a subscriber appended by a callback **running inside the dispatch** was invoked within that same dispatch — receiving an event that fired *before* it subscribed. Removals mid-dispatch were already handled carefully (tombstone + deferred splice), but additions were not symmetric.

This matters because `createHook` backs the game loop and engine wiring (`onLogicalUpdate`, `onRenderUpdate`, `onNewEnemyLoaded`, `onBattleStageChanged`, every `apiSocket.listenCommand`). A handler that subscribes another handler in response to an event — plausible during stage/enemy transitions — would get a spurious extra invocation with stale data.

## Fix

Snapshot the subscriber count at dispatch start and loop to that bound, so an add during dispatch is deferred to the next `notify` — symmetric with how removals are deferred:

```ts
dispatching = true;
const count = trackers.length;
for (let i = 0; i < count; i++) { … }
```

This is safe because:
- Additions only ever **append** (`trackers.push`), so indices `< count` stay valid and `count <= trackers.length` holds throughout the loop (removals tombstone rather than splice mid-dispatch).
- The post-dispatch tombstone compaction iterates the **full** current length and only splices `removed` entries — a newly appended tracker has `removed: false`, so it survives and fires on the next `notify`.

## How it addresses the issue

A callback that subscribes a new handler mid-dispatch no longer triggers that handler within the in-progress notification; the new handler instead receives the *next* notification, matching how a subscriber added outside a dispatch behaves.

## Test plan

Added two tests to `UI/src/tests/common/hooks.test.ts`:
- **`subscriber added during dispatch is deferred to the next notify`** — pins the core bug: the added subscriber is not called during the in-progress `notify` but is called on the following one (with the correct data).
- **`compaction after a deferred add keeps the new subscriber and drops the tombstoned one`** — covers the subtle interaction the issue called out: a callback that both unhooks itself and appends a subscriber in the same dispatch; the tombstone is compacted out while the appended subscriber survives and fires next dispatch.

Verification (frontend):
- `npm run lint` — clean (0 errors, 0 warnings)
- `npx vitest run src/tests/common/hooks.test.ts` — 16/16 passing
- `npm run test:unit:ci` — full suite green

Closes #747

https://claude.ai/code/session_01DukAtCxFURcemJ3U47jQ3e

---
_Generated by [Claude Code](https://claude.ai/code/session_01DukAtCxFURcemJ3U47jQ3e)_