### PR TITLE
A11y: convert inventory grid/equip tiles to an accessible card pattern

### DIFF
--- a/UI/src/routes/game/screens/inventory/EquipSlot.svelte
+++ b/UI/src/routes/game/screens/inventory/EquipSlot.svelte
@@ -1,14 +1,15 @@
 <div class="equip-row">
 	<div class="row-label">{slot.label}</div>
 
+	<!-- The tile is a presentational drop target; only a filled slot carries an interactive
+	     (focusable) select button, so empty slots stay out of the tab order. -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
 		class="equip-tile"
 		class:filled
 		class:over
 		class:selected
 		class:can-accept={canAccept}
-		role="button"
-		tabindex="0"
 		style:border-color={tileBorder}
 		style:background={over
 			? tintColor('var(--accent)', 0.14)
@@ -18,13 +19,6 @@
 		ondragover={handleDragOver}
 		ondragleave={() => (over = false)}
 		ondrop={handleDrop}
-		onclick={() => item && onSelect?.(item)}
-		onkeydown={(e) => {
-			if (item && (e.key === 'Enter' || e.key === ' ')) {
-				e.preventDefault();
-				onSelect?.(item);
-			}
-		}}
 		onmouseenter={(e) => {
 			hover = true;
 			if (item) {
@@ -39,16 +33,14 @@
 	>
 		{#if item}
 			{#if item.iconPath}
-				<img class="item-icon" src={item.iconPath} alt={item.name} />
+				<img class="item-icon" src={item.iconPath} alt="" />
 			{:else}
 				<CategoryGlyph cat={item.itemCategoryId} color={itemCategoryColor(item.itemCategoryId)} size={40} />
 			{/if}
+			<OverlayButton label={item.name} onActivate={() => onSelect?.(item)} />
 			{#if hover}
-				<button
-					class="unequip"
-					title="Unequip"
-					aria-label="Unequip {item.name}"
-					onclick={stopPropagation(() => onUnequip?.(slot.id))}>×</button
+				<button class="unequip" title="Unequip" aria-label="Unequip {item.name}" onclick={() => onUnequip?.(slot.id)}
+					>×</button
 				>
 			{/if}
 			{#if item.appliedMods.length}
@@ -76,8 +68,8 @@
 <script lang="ts">
 import type { Item } from '$lib/battle';
 import { itemCategoryColor, rarityColor, rarityLabel, rarityTint, tintColor } from '$lib/common';
-import { stopPropagation } from '$lib/common/event-wrappers';
 import CategoryGlyph from './CategoryGlyph.svelte';
+import OverlayButton from './OverlayButton.svelte';
 import { type EquipSlotDef } from './inventory-view.svelte';
 
 interface Props {
@@ -185,6 +177,8 @@ const handleDrop = (e: DragEvent) => {
 	position: absolute;
 	top: 2px;
 	right: 2px;
+	// Above the full-bleed select button so it stays clickable.
+	z-index: 2;
 	width: 16px;
 	height: 16px;
 	border-radius: 2px;

--- a/UI/src/routes/game/screens/inventory/GridSlot.svelte
+++ b/UI/src/routes/game/screens/inventory/GridSlot.svelte
@@ -1,20 +1,13 @@
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
 	class="grid-slot"
 	class:selected
-	role="button"
-	tabindex="0"
-	draggable="true"
 	style:width="{size}px"
 	style:height="{size}px"
 	style:background={bg}
 	style:border-color={borderColor}
 	style:box-shadow={boxShadow}
 	style:transform={hover ? 'translateY(-1px)' : 'none'}
-	ondragstart={handleDragStart}
-	ondragend={() => onDragEnd?.()}
-	onclick={handleClick}
-	ondblclick={() => onToggleEquip?.(item)}
-	onkeydown={handleKeydown}
 	onmouseenter={(e) => {
 		hover = true;
 		onHoverEnter?.(item, e);
@@ -26,7 +19,7 @@
 	}}
 >
 	{#if item.iconPath}
-		<img class="item-icon" src={item.iconPath} alt={item.name} />
+		<img class="item-icon" src={item.iconPath} alt="" />
 	{:else}
 		<CategoryGlyph
 			cat={item.itemCategoryId}
@@ -35,13 +28,24 @@
 		/>
 	{/if}
 
+	<!-- Full-bleed primary action: plain activate selects, modifier/double activate equips.
+	     A real <button> gives native keyboard activation (modifier state rides the click). -->
+	<OverlayButton
+		label={item.name}
+		draggable
+		onActivate={handleActivate}
+		onDoubleClick={() => onToggleEquip?.(item)}
+		onDragStart={handleDragStart}
+		onDragEnd={() => onDragEnd?.()}
+	/>
+
 	<button
 		class="fav-star"
 		class:on={item.favorite}
 		class:show={hover}
 		title={item.favorite ? 'Unfavorite' : 'Favorite'}
 		aria-label={item.favorite ? 'Unfavorite' : 'Favorite'}
-		onclick={stopPropagation(() => onToggleFav?.(item))}
+		onclick={() => onToggleFav?.(item)}
 	>
 		<FavoriteStar
 			filled={item.favorite}
@@ -65,9 +69,9 @@
 <script lang="ts">
 import type { Item } from '$lib/battle';
 import { itemCategoryColor, rarityColor, rarityGlow, rarityLevel, rarityTint, tintColor } from '$lib/common';
-import { stopPropagation } from '$lib/common/event-wrappers';
 import CategoryGlyph from './CategoryGlyph.svelte';
 import FavoriteStar from './FavoriteStar.svelte';
+import OverlayButton from './OverlayButton.svelte';
 
 interface Props {
 	item: Item;
@@ -124,24 +128,13 @@ const boxShadow = $derived(
 			: glowShadow
 );
 
-const handleClick = (e: MouseEvent) => {
+// A modifier-held activate (⌘/Ctrl-click, or ⌘/Ctrl + keyboard activation, since the modifier
+// state rides the native button's click) equips; a plain activate selects.
+const handleActivate = (e: MouseEvent) => {
 	if (e.metaKey || e.ctrlKey) {
 		onToggleEquip?.(item);
 	} else {
 		onSelect?.(item);
-	}
-};
-
-const handleKeydown = (e: KeyboardEvent) => {
-	if (e.key === 'Enter' || e.key === ' ') {
-		e.preventDefault();
-		// Mirror the pointer affordances: a modifier+activate equips (like ⌘/Ctrl-click and
-		// double-click), a plain activate selects — so the equip path has a keyboard equivalent.
-		if (e.metaKey || e.ctrlKey) {
-			onToggleEquip?.(item);
-		} else {
-			onSelect?.(item);
-		}
 	}
 };
 

--- a/UI/src/routes/game/screens/inventory/OverlayButton.svelte
+++ b/UI/src/routes/game/screens/inventory/OverlayButton.svelte
@@ -1,0 +1,51 @@
+<button
+	type="button"
+	class="overlay-button"
+	{draggable}
+	aria-label={label}
+	onclick={onActivate}
+	ondblclick={onDoubleClick}
+	ondragstart={onDragStart}
+	ondragend={onDragEnd}
+></button>
+
+<script lang="ts">
+interface Props {
+	/** Accessible name for the action — the card has no visible button text of its own. */
+	label: string;
+	draggable?: boolean;
+	onActivate?: (e: MouseEvent) => void;
+	onDoubleClick?: (e: MouseEvent) => void;
+	onDragStart?: (e: DragEvent) => void;
+	onDragEnd?: (e: DragEvent) => void;
+}
+
+const { label, draggable = false, onActivate, onDoubleClick, onDragStart, onDragEnd }: Props = $props();
+</script>
+
+<style lang="scss">
+// A full-bleed primary action that turns a presentational card into an accessible control:
+// it stretches over the whole card beneath any sibling action buttons, giving the card real
+// <button> semantics (native keyboard + focus) without nesting interactive elements.
+.overlay-button {
+	position: absolute;
+	inset: 0;
+	z-index: 1;
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	padding: 0;
+	border: none;
+	border-radius: inherit;
+	background: transparent;
+	appearance: none;
+	// Inherit the card's cursor (grab on the grid, pointer on an equip slot).
+	cursor: inherit;
+
+	// Drawn inset so the ring stays visible inside the card's `overflow: hidden` clip.
+	&:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: -2px;
+	}
+}
+</style>

--- a/UI/src/tests/routes/game/screens/inventory/EquipSlot.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/EquipSlot.test.ts
@@ -51,6 +51,14 @@ describe('EquipSlot — empty state', () => {
 		const { container } = render(EquipSlot, { props: { slot: helmSlot } });
 		expect(container.querySelector('.equip-tile')!.classList.contains('filled')).toBe(false);
 	});
+
+	it('is not focusable when empty — no overlay button, and no role/tabindex on the tile', () => {
+		const { container } = render(EquipSlot, { props: { slot: helmSlot } });
+		expect(container.querySelector('.overlay-button')).toBeNull();
+		const tile = container.querySelector('.equip-tile')!;
+		expect(tile.getAttribute('role')).toBeNull();
+		expect(tile.getAttribute('tabindex')).toBeNull();
+	});
 });
 
 describe('EquipSlot — filled state', () => {
@@ -77,11 +85,11 @@ describe('EquipSlot — filled state', () => {
 });
 
 describe('EquipSlot — interactions', () => {
-	it('calls onSelect with the item when the filled tile is clicked', async () => {
+	it('calls onSelect with the item when the filled tile is activated', async () => {
 		const onSelect = vi.fn();
 		const item = makeItem();
 		const { container } = render(EquipSlot, { props: { slot: helmSlot, item, onSelect } });
-		await fireEvent.click(container.querySelector('.equip-tile')!);
+		await fireEvent.click(container.querySelector('.overlay-button')!);
 		expect(onSelect).toHaveBeenCalledWith(item);
 	});
 
@@ -90,6 +98,13 @@ describe('EquipSlot — interactions', () => {
 		const { container } = render(EquipSlot, { props: { slot: helmSlot, onSelect } });
 		await fireEvent.click(container.querySelector('.equip-tile')!);
 		expect(onSelect).not.toHaveBeenCalled();
+	});
+
+	it('exposes the filled tile select action as a real <button> labelled with the item name', () => {
+		const { container } = render(EquipSlot, { props: { slot: helmSlot, item: makeItem({ name: 'Iron Helm' }) } });
+		const overlay = container.querySelector('.overlay-button');
+		expect(overlay?.tagName).toBe('BUTTON');
+		expect(overlay!.getAttribute('aria-label')).toBe('Iron Helm');
 	});
 
 	it('shows the unequip button on mouse enter', async () => {

--- a/UI/src/tests/routes/game/screens/inventory/GridSlot.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/GridSlot.test.ts
@@ -76,31 +76,35 @@ describe('GridSlot — rendering', () => {
 	});
 });
 
-describe('GridSlot — click interactions', () => {
-	it('calls onSelect with the item on a plain click', async () => {
+// The primary action is a real <button> overlay, so pointer and keyboard share one activation
+// path: pressing Enter/Space on the focused button dispatches a click carrying the same modifier
+// state as a mouse click. jsdom doesn't synthesize that click from a keydown, so these fire the
+// click directly — the faithful representation of both a mouse click and a keyboard activation.
+describe('GridSlot — activation (pointer + keyboard share one path)', () => {
+	it('selects on a plain activate (click / Enter / Space)', async () => {
 		const onSelect = vi.fn();
 		const item = makeItem();
 		const { container } = render(GridSlot, { props: { item, onSelect } });
-		await fireEvent.click(container.querySelector('.grid-slot')!);
+		await fireEvent.click(container.querySelector('.overlay-button')!);
 		expect(onSelect).toHaveBeenCalledWith(item);
 	});
 
-	it('calls onToggleEquip instead of onSelect on a ctrl+click', async () => {
+	it('equips (not selects) on a Ctrl-modified activate — Ctrl-click or Ctrl+Enter', async () => {
 		const onSelect = vi.fn();
 		const onToggleEquip = vi.fn();
 		const item = makeItem();
 		const { container } = render(GridSlot, { props: { item, onSelect, onToggleEquip } });
-		await fireEvent.click(container.querySelector('.grid-slot')!, { ctrlKey: true });
+		await fireEvent.click(container.querySelector('.overlay-button')!, { ctrlKey: true });
 		expect(onToggleEquip).toHaveBeenCalledWith(item);
 		expect(onSelect).not.toHaveBeenCalled();
 	});
 
-	it('calls onToggleEquip instead of onSelect on a meta+click', async () => {
+	it('equips (not selects) on a Meta-modified activate — ⌘-click or ⌘+Space', async () => {
 		const onSelect = vi.fn();
 		const onToggleEquip = vi.fn();
 		const item = makeItem();
 		const { container } = render(GridSlot, { props: { item, onSelect, onToggleEquip } });
-		await fireEvent.click(container.querySelector('.grid-slot')!, { metaKey: true });
+		await fireEvent.click(container.querySelector('.overlay-button')!, { metaKey: true });
 		expect(onToggleEquip).toHaveBeenCalledWith(item);
 		expect(onSelect).not.toHaveBeenCalled();
 	});
@@ -109,11 +113,11 @@ describe('GridSlot — click interactions', () => {
 		const onToggleEquip = vi.fn();
 		const item = makeItem();
 		const { container } = render(GridSlot, { props: { item, onToggleEquip } });
-		await fireEvent.dblClick(container.querySelector('.grid-slot')!);
+		await fireEvent.dblClick(container.querySelector('.overlay-button')!);
 		expect(onToggleEquip).toHaveBeenCalledWith(item);
 	});
 
-	it('calls onToggleFav when the fav-star button is clicked and does not bubble to onSelect', async () => {
+	it('favoriting via the fav-star button does not also select', async () => {
 		const onToggleFav = vi.fn();
 		const onSelect = vi.fn();
 		const item = makeItem();
@@ -124,49 +128,22 @@ describe('GridSlot — click interactions', () => {
 	});
 });
 
-describe('GridSlot — keyboard interactions', () => {
-	it('calls onSelect on Enter key', async () => {
-		const onSelect = vi.fn();
-		const item = makeItem();
-		const { container } = render(GridSlot, { props: { item, onSelect } });
-		await fireEvent.keyDown(container.querySelector('.grid-slot')!, { key: 'Enter' });
-		expect(onSelect).toHaveBeenCalledWith(item);
+describe('GridSlot — accessibility semantics', () => {
+	it('exposes the primary action as a real <button>, not a tile with role/tabindex', () => {
+		const { container } = render(GridSlot, { props: { item: makeItem() } });
+		const overlay = container.querySelector('.overlay-button');
+		expect(overlay?.tagName).toBe('BUTTON');
+
+		// The card container is presentational — it must not carry button semantics or focus.
+		const tile = container.querySelector('.grid-slot')!;
+		expect(tile.getAttribute('role')).toBeNull();
+		expect(tile.getAttribute('tabindex')).toBeNull();
 	});
 
-	it('calls onSelect on Space key', async () => {
-		const onSelect = vi.fn();
-		const item = makeItem();
-		const { container } = render(GridSlot, { props: { item, onSelect } });
-		await fireEvent.keyDown(container.querySelector('.grid-slot')!, { key: ' ' });
-		expect(onSelect).toHaveBeenCalledWith(item);
-	});
-
-	it('does not call onSelect for other keys', async () => {
-		const onSelect = vi.fn();
-		const item = makeItem();
-		const { container } = render(GridSlot, { props: { item, onSelect } });
-		await fireEvent.keyDown(container.querySelector('.grid-slot')!, { key: 'ArrowRight' });
-		expect(onSelect).not.toHaveBeenCalled();
-	});
-
-	it('equips (not selects) on Ctrl+Enter — the keyboard equivalent of ⌘/Ctrl-click', async () => {
-		const onSelect = vi.fn();
-		const onToggleEquip = vi.fn();
-		const item = makeItem();
-		const { container } = render(GridSlot, { props: { item, onSelect, onToggleEquip } });
-		await fireEvent.keyDown(container.querySelector('.grid-slot')!, { key: 'Enter', ctrlKey: true });
-		expect(onToggleEquip).toHaveBeenCalledWith(item);
-		expect(onSelect).not.toHaveBeenCalled();
-	});
-
-	it('equips (not selects) on Meta+Space', async () => {
-		const onSelect = vi.fn();
-		const onToggleEquip = vi.fn();
-		const item = makeItem();
-		const { container } = render(GridSlot, { props: { item, onSelect, onToggleEquip } });
-		await fireEvent.keyDown(container.querySelector('.grid-slot')!, { key: ' ', metaKey: true });
-		expect(onToggleEquip).toHaveBeenCalledWith(item);
-		expect(onSelect).not.toHaveBeenCalled();
+	it('labels the primary action and the fav-star button for assistive tech', () => {
+		const { container } = render(GridSlot, { props: { item: makeItem({ name: 'Iron Sword' }) } });
+		expect(container.querySelector('.overlay-button')!.getAttribute('aria-label')).toBe('Iron Sword');
+		expect(container.querySelector('.fav-star')!.getAttribute('aria-label')).toBe('Favorite');
 	});
 });
 
@@ -212,7 +189,7 @@ describe('GridSlot — drag interactions', () => {
 		const item = makeItem({ itemId: 42 });
 		const { container } = render(GridSlot, { props: { item } });
 		const dt = { setData: vi.fn(), effectAllowed: '' };
-		await fireEvent.dragStart(container.querySelector('.grid-slot')!, { dataTransfer: dt });
+		await fireEvent.dragStart(container.querySelector('.overlay-button')!, { dataTransfer: dt });
 		expect(dt.setData).toHaveBeenCalledWith('text/plain', '42');
 	});
 
@@ -220,7 +197,7 @@ describe('GridSlot — drag interactions', () => {
 		const item = makeItem();
 		const { container } = render(GridSlot, { props: { item } });
 		const dt = { setData: vi.fn(), effectAllowed: '' };
-		await fireEvent.dragStart(container.querySelector('.grid-slot')!, { dataTransfer: dt });
+		await fireEvent.dragStart(container.querySelector('.overlay-button')!, { dataTransfer: dt });
 		expect(dt.effectAllowed).toBe('move');
 	});
 
@@ -228,7 +205,7 @@ describe('GridSlot — drag interactions', () => {
 		const onDragStart = vi.fn();
 		const item = makeItem();
 		const { container } = render(GridSlot, { props: { item, onDragStart } });
-		await fireEvent.dragStart(container.querySelector('.grid-slot')!, {
+		await fireEvent.dragStart(container.querySelector('.overlay-button')!, {
 			dataTransfer: { setData: vi.fn(), effectAllowed: '' }
 		});
 		expect(onDragStart).toHaveBeenCalledWith(item);
@@ -237,7 +214,12 @@ describe('GridSlot — drag interactions', () => {
 	it('calls onDragEnd on drag end', async () => {
 		const onDragEnd = vi.fn();
 		const { container } = render(GridSlot, { props: { item: makeItem(), onDragEnd } });
-		await fireEvent.dragEnd(container.querySelector('.grid-slot')!);
+		await fireEvent.dragEnd(container.querySelector('.overlay-button')!);
 		expect(onDragEnd).toHaveBeenCalled();
+	});
+
+	it('makes the primary action the drag handle (draggable)', () => {
+		const { container } = render(GridSlot, { props: { item: makeItem() } });
+		expect(container.querySelector('.overlay-button')!.getAttribute('draggable')).toBe('true');
 	});
 });

--- a/UI/src/tests/routes/game/screens/inventory/InventoryGrid.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/InventoryGrid.test.ts
@@ -164,7 +164,7 @@ describe('InventoryGrid — drag interactions', () => {
 		const items = [makeGridItem(1)];
 		const view = makeView(items);
 		const { container } = render(InventoryGrid, { props: { view } });
-		await fireEvent.dragStart(container.querySelector('.grid-slot')!, {
+		await fireEvent.dragStart(container.querySelector('.overlay-button')!, {
 			dataTransfer: { setData: vi.fn(), effectAllowed: '' }
 		});
 		expect(hideTooltip).toHaveBeenCalled();
@@ -174,7 +174,7 @@ describe('InventoryGrid — drag interactions', () => {
 		const items = [makeGridItem(7)];
 		const view = makeView(items);
 		const { container } = render(InventoryGrid, { props: { view } });
-		await fireEvent.dragStart(container.querySelector('.grid-slot')!, {
+		await fireEvent.dragStart(container.querySelector('.overlay-button')!, {
 			dataTransfer: { setData: vi.fn(), effectAllowed: '' }
 		});
 		expect(view.dragItemId).toBe(7);
@@ -184,7 +184,7 @@ describe('InventoryGrid — drag interactions', () => {
 		const items = [makeGridItem(7)];
 		const view = makeView(items, { dragItemId: 7 });
 		const { container } = render(InventoryGrid, { props: { view } });
-		await fireEvent.dragEnd(container.querySelector('.grid-slot')!);
+		await fireEvent.dragEnd(container.querySelector('.overlay-button')!);
 		expect(view.dragItemId).toBeNull();
 	});
 });

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -98,6 +98,12 @@ Blocking confirmation dialogs are the toast system's counterpart, from the same 
 
 **Non-blocking overlays compose `Popover` (`components/Popover.svelte`), not a hand-rolled backdrop.** It is the `ModalHost` counterpart for overlays that aren't a blocking confirm — driven by a plain `open` boolean + `onClose` rather than the promise queue — and owns the same chrome: backdrop/Escape dismissal, a focus trap, focus capture+restore, and a body scroll lock, with the content passed as a snippet. The layer is absolutely positioned, so it overlays its nearest positioned ancestor (mount it inside a `position: relative` container) rather than the whole viewport.
 
+## Accessibility
+
+Interactive controls are real elements, not `role="button"` divs — convert clickable `div`/`span`s to `<button>` (the app is mid-conversion; some `role="button"` tiles remain, e.g. `skills/EquippedBand.svelte`).
+
+**Accessible card pattern.** When a tile must host its own nested actions (favorite/unequip) and/or be a drag source, it can't itself be a `<button>` — nesting interactive elements is invalid HTML. Instead it uses a presentational container with a full-bleed primary-action `<button>` (`inventory/OverlayButton.svelte`) stretched beneath the secondary action buttons, which sit at a higher `z-index` so they stay clickable. The overlay carries the drag handle and gets native keyboard activation — modifier state rides the synthesized click, so a ⌘/Ctrl-activate can branch (e.g. select vs. equip) without a manual `keydown`. A card with no primary action (an empty equip slot) renders no overlay, so it stays out of the tab order while remaining a drop target. Hover-only affordances on the presentational container (tooltips, drop highlighting) carry a `<!-- svelte-ignore a11y_no_static_element_interactions -->`.
+
 ## Styling
 
 Most styling lives in each component's scoped scss; global styles and theming live in `UI/src/styles`. **All colours are CSS variables, used by semantic intent — never hard-coded.** Core colours are declared in `+layout.svelte` (pulled from `_colors.scss`); the palette is intentionally limited for consistency and contrast. The frontend is built for future custom themes that override those variables, so any colour must be a variable (added to `+layout.svelte`) and used according to its semantic meaning, even when two roles happen to share a hue.


### PR DESCRIPTION
## Summary

Reworks `inventory/GridSlot.svelte` and `inventory/EquipSlot.svelte` from `role="button"` tiles that **nested real `<button>`s** into an **accessible card pattern**, the design fork deliberately deferred from #596.

Both tiles were `role="button"` + `tabindex="0"` divs that contained nested interactive `<button>`s (favorite / unequip) — invalid HTML (`<button>`-in-`<button>`) with hand-rolled keyboard semantics — and `GridSlot` also doubled as a drag source. `EquipSlot` additionally left **empty** slots focusable, so keyboard users tabbed onto inert tiles.

## How it addresses the issue

- **New shared primitive `inventory/OverlayButton.svelte`** — a full-bleed, transparent primary-action `<button>` that turns a presentational card into a real control without nesting interactives. It stretches over the whole card *beneath* the secondary buttons (which carry higher `z-index`, so favorite/unequip stay clickable), owns the focus ring (`outline-offset: -2px`, drawn inside the card's `overflow: hidden` clip), and inherits the card's cursor.
- **Primary "select" action is now a real `<button>`**, dropping the manual `role`/`tabindex`/`keydown`. Native button activation means keyboard Enter/Space works for free, and because the modifier state rides the synthesized click, ⌘/Ctrl-activate (and double-click) still **equip** through the single `onclick` path — the keyboard-equip parity from #596 is preserved without a custom keydown handler.
- **`GridSlot`**: the overlay carries `draggable` + the drag handlers (it's the drag handle); the favorite star is a higher-`z-index` sibling.
- **`EquipSlot`**: the overlay renders **only when the slot is filled**, so empty slots are non-focusable while the presentational container remains a drop target (drag/drop + hover handlers stay on it, with the codebase's standard `<!-- svelte-ignore a11y_no_static_element_interactions -->`).
- Decorative tile icons are now `alt=""` (the button carries the accessible name), and the now-dead `stopPropagation` wrapping on the sibling action buttons is removed (they no longer share a click path with the primary action).
- Documented the pattern in `docs/frontend.md` (new **Accessibility** section).

## Test plan

- [x] `GridSlot.test.ts` / `EquipSlot.test.ts` updated to the new structure — activation/drag now target `.overlay-button`; added assertions that the primary action is a real `<button>` with an `aria-label`, that the tile carries no `role`/`tabindex`, and that an **empty** equip slot renders no overlay (the focusability bug fix). Modifier-activate-to-equip parity retained.
- [x] `InventoryGrid.test.ts` drag tests updated (drag handlers moved to the overlay).
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.
- [x] `npm run test:unit:ci` — full suite green, per-area coverage floors met.
- [ ] Visual verification recommended (overlay z-index vs. drag, favorite/unequip clickability, focus-ring placement) per the issue's note.

## Follow-up

- `skills/EquippedBand.svelte` has the same `role="button"` + nested-`<button>` + drag anti-pattern (out of scope here) — filed as #762, which also proposes promoting `OverlayButton` to `components/` when adopted there.

Closes #685

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAsztcCFbSECTtb4jHWY1F)_