### PR TITLE
Make gate/lock tooltips keyboard & screen-reader reachable (ZoneNav, SkillRow)

### DIFF
--- a/UI/src/routes/game/screens/fight/ZoneNav.svelte
+++ b/UI/src/routes/game/screens/fight/ZoneNav.svelte
@@ -9,9 +9,12 @@
 		<button
 			class="zone-btn"
 			class:locked={leftLocked}
-			disabled={leftDisabled}
+			disabled={leftAbsent}
+			aria-disabled={leftLocked || undefined}
 			aria-label={leftLocked ? 'Previous zone locked' : 'Previous zone'}
 			onclick={handleClickLeft}
+			onfocus={(e) => focusLock(leftLocked, prevZone?.unlockChallengeId, e)}
+			onblur={hideLock}
 		>
 			{#if leftLocked}<LockGlyph />{:else}&#8249;{/if}
 		</button>
@@ -30,9 +33,12 @@
 		<button
 			class="zone-btn"
 			class:locked={rightLocked}
-			disabled={rightDisabled}
+			disabled={rightAbsent}
+			aria-disabled={rightLocked || undefined}
 			aria-label={rightLocked ? 'Next zone locked' : 'Next zone'}
 			onclick={handleClickRight}
+			onfocus={(e) => focusLock(rightLocked, nextZone?.unlockChallengeId, e)}
+			onblur={hideLock}
 		>
 			{#if rightLocked}<LockGlyph />{:else}&#8250;{/if}
 		</button>
@@ -43,7 +49,14 @@
 
 <script lang="ts">
 import type { IZone } from '$lib/api';
-import { staticData, playerChallenges, registerTooltipComponent, type TooltipComponent } from '$stores';
+import {
+	anchorPosition,
+	staticData,
+	playerChallenges,
+	registerTooltipComponent,
+	type TooltipAnchor,
+	type TooltipComponent
+} from '$stores';
 import { playerManager } from '$lib/engine';
 import { isZoneUnlocked, zonesByOrder } from '$lib/common';
 import { ChallengeTooltip } from '$components';
@@ -51,20 +64,28 @@ import LockGlyph from './LockGlyph.svelte';
 
 // A locked zone is always gated on a challenge (an ungated zone is never locked), so the lock
 // affordance shows that gating challenge — what it requires and what completing it unlocks —
-// rather than a static hint that wrongly assumed every gate was the zone's boss.
+// rather than a static hint that wrongly assumed every gate was the zone's boss. The explanation is
+// reachable by both mouse hover and keyboard focus (the locked arrow stays focusable via
+// `aria-disabled` rather than `disabled`).
 let tooltip = $state<TooltipComponent>();
 let challengeId = $state<number | undefined>();
 const { setTooltipPosition, showTooltip, hideTooltip } = registerTooltipComponent(() => tooltip);
 
-const showLock = (locked: boolean, gateChallengeId: number | undefined, ev: MouseEvent) => {
+// Anchor the lock tooltip at the cursor (mouse) or off the focused arrow's box (focus).
+const showLock = (locked: boolean, gateChallengeId: number | undefined, anchor: TooltipAnchor) => {
 	if (!locked) {
 		return;
 	}
 	challengeId = gateChallengeId;
-	setTooltipPosition({ x: ev.clientX, y: ev.clientY });
+	setTooltipPosition(anchorPosition(anchor));
 	showTooltip();
 };
-const moveLock = (ev: MouseEvent) => setTooltipPosition({ x: ev.clientX, y: ev.clientY });
+const moveLock = (ev: MouseEvent) => setTooltipPosition(anchorPosition(ev));
+const focusLock = (locked: boolean, gateChallengeId: number | undefined, ev: FocusEvent) => {
+	if (ev.currentTarget instanceof HTMLElement) {
+		showLock(locked, gateChallengeId, ev.currentTarget);
+	}
+};
 const hideLock = () => {
 	hideTooltip();
 	challengeId = undefined;
@@ -85,8 +106,10 @@ const completed = (id: number) => playerChallenges.isChallengeCompleted(id);
 // simply being at the first/last zone (no neighbour at all).
 const leftLocked = $derived(prevZone != null && !isZoneUnlocked(prevZone, completed));
 const rightLocked = $derived(nextZone != null && !isZoneUnlocked(nextZone, completed));
-const leftDisabled = $derived(prevZone == null || leftLocked);
-const rightDisabled = $derived(nextZone == null || rightLocked);
+// An arrow is hard-`disabled` (unfocusable) only when there is no neighbour to explain at all;
+// a locked-but-existing neighbour stays focusable with `aria-disabled` so its gate is reachable.
+const leftAbsent = $derived(prevZone == null);
+const rightAbsent = $derived(nextZone == null);
 
 const goToZone = (zone: IZone | undefined) => {
 	if (zone != null && isZoneUnlocked(zone, completed)) {
@@ -128,8 +151,13 @@ const handleClickRight = () => goToZone(nextZone);
 	font-size: 12px;
 	transition: background 140ms;
 
-	&:hover:not(:disabled) {
+	&:hover:not(:disabled):not(.locked) {
 		background: var(--border-subtle);
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
 	}
 
 	&:disabled {
@@ -138,12 +166,13 @@ const handleClickRight = () => goToZone(nextZone);
 	}
 
 	// A locked neighbour (gating challenge not yet completed) reads more clearly than a plain
-	// end-of-list disabled arrow, so the lock glyph stays legible. Disabling the button suppresses
-	// its own pointer events, so the wrapping span receives the hover that drives the lock tooltip.
-	&.locked:disabled {
+	// end-of-list disabled arrow, so the lock glyph stays legible. It stays focusable (not
+	// `disabled`, but `aria-disabled`) so the gate tooltip is keyboard-reachable; activation is a
+	// no-op because `goToZone` only navigates to an unlocked zone.
+	&.locked {
 		opacity: 0.6;
 		color: color-mix(in srgb, var(--text-primary) 65%, transparent);
-		pointer-events: none;
+		cursor: not-allowed;
 	}
 }
 

--- a/UI/src/routes/game/screens/skills/SkillRail.svelte
+++ b/UI/src/routes/game/screens/skills/SkillRail.svelte
@@ -30,7 +30,7 @@
 				<span>{view.equipped.length}/{view.cap}</span>
 			</div>
 			{#each view.equippedRail as metrics (metrics.skill.id)}
-				<SkillRow {metrics} {view} onGateEnter={showChallenge} onGateMove={moveChallenge} onGateLeave={hideChallenge} />
+				<SkillRow {metrics} {view} onGateShow={showChallenge} onGateMove={moveChallenge} onGateLeave={hideChallenge} />
 			{/each}
 		{/if}
 		<div class="grp">
@@ -39,7 +39,7 @@
 		</div>
 		{#if view.availableRail.length}
 			{#each view.availableRail as metrics (metrics.skill.id)}
-				<SkillRow {metrics} {view} onGateEnter={showChallenge} onGateMove={moveChallenge} onGateLeave={hideChallenge} />
+				<SkillRow {metrics} {view} onGateShow={showChallenge} onGateMove={moveChallenge} onGateLeave={hideChallenge} />
 			{/each}
 		{:else}
 			<div class="empty">none match the filter</div>
@@ -54,7 +54,13 @@ import { SKILL_SORTS, type SkillMetrics, type SkillsView } from './skills-view.s
 import SkillRow from './SkillRow.svelte';
 import { attributeCode } from '$lib/common';
 import { ChallengeTooltip } from '$components';
-import { registerTooltipComponent, staticData, type TooltipComponent } from '$stores';
+import {
+	anchorPosition,
+	registerTooltipComponent,
+	staticData,
+	type TooltipAnchor,
+	type TooltipComponent
+} from '$stores';
 
 type Props = {
 	view: SkillsView;
@@ -63,21 +69,22 @@ type Props = {
 const { view }: Props = $props();
 
 // A locked skill rewarded by a not-yet-completed challenge surfaces that gating challenge — its
-// requirement and everything completing it unlocks — through the shared ChallengeTooltip on hover,
-// exactly as the locked-zone arrow does. SkillRow fires these callbacks only for gated rows.
+// requirement and everything completing it unlocks — through the shared ChallengeTooltip, reachable
+// by both mouse hover and keyboard focus, exactly as the locked-zone arrow does. SkillRow fires
+// these callbacks only for gated rows.
 let tooltip = $state<TooltipComponent>();
 let challengeId = $state<number | undefined>();
 const { setTooltipPosition, showTooltip, hideTooltip } = registerTooltipComponent(() => tooltip);
 
-const showChallenge = (metrics: SkillMetrics, ev: MouseEvent) => {
+const showChallenge = (metrics: SkillMetrics, anchor: TooltipAnchor) => {
 	if (metrics.source == null) {
 		return;
 	}
 	challengeId = metrics.source.id;
-	setTooltipPosition({ x: ev.clientX, y: ev.clientY });
+	setTooltipPosition(anchorPosition(anchor));
 	showTooltip();
 };
-const moveChallenge = (ev: MouseEvent) => setTooltipPosition({ x: ev.clientX, y: ev.clientY });
+const moveChallenge = (ev: MouseEvent) => setTooltipPosition(anchorPosition(ev));
 const hideChallenge = () => {
 	hideTooltip();
 	challengeId = undefined;

--- a/UI/src/routes/game/screens/skills/SkillRow.svelte
+++ b/UI/src/routes/game/screens/skills/SkillRow.svelte
@@ -4,9 +4,11 @@
 	class:sel={view.selectedId === metrics.skill.id}
 	class:lock={!metrics.unlocked}
 	onclick={() => view.select(metrics.skill.id)}
-	onmouseenter={gated ? (e) => onGateEnter?.(metrics, e) : undefined}
+	onmouseenter={gated ? (e) => onGateShow?.(metrics, e) : undefined}
 	onmousemove={gated ? onGateMove : undefined}
 	onmouseleave={gated ? onGateLeave : undefined}
+	onfocus={gated ? onGateFocus : undefined}
+	onblur={gated ? onGateLeave : undefined}
 >
 	<SkillIcon skill={metrics.skill} locked={!metrics.unlocked} size={30} />
 	<span class="body">
@@ -24,22 +26,31 @@
 
 <script lang="ts">
 import { formatNum } from '$lib/common';
+import type { TooltipAnchor } from '$stores';
 import SkillIcon from './SkillIcon.svelte';
 import type { SkillMetrics, SkillsView } from './skills-view.svelte';
 
 type Props = {
 	metrics: SkillMetrics;
 	view: SkillsView;
-	/** Hover callbacks that surface a gated skill's gating challenge. Fired only when the row is
-	 *  gated (locked + rewarded by a challenge); unlocked rows never invoke them. */
-	onGateEnter?: (metrics: SkillMetrics, ev: MouseEvent) => void;
+	/** Callbacks that surface a gated skill's gating challenge, reachable by both mouse hover and
+	 *  keyboard focus. Fired only when the row is gated (locked + rewarded by a challenge); unlocked
+	 *  rows never invoke them. The anchor is a pointer event (cursor) or the row element (focus). */
+	onGateShow?: (metrics: SkillMetrics, anchor: TooltipAnchor) => void;
 	onGateMove?: (ev: MouseEvent) => void;
 	onGateLeave?: () => void;
 };
 
-const { metrics, view, onGateEnter, onGateMove, onGateLeave }: Props = $props();
+const { metrics, view, onGateShow, onGateMove, onGateLeave }: Props = $props();
 
 const fmt = (n: number) => formatNum(Math.round(n));
+
+// Anchor the gate tooltip off the focused row's box (focus has no cursor position).
+const onGateFocus = (ev: FocusEvent) => {
+	if (ev.currentTarget instanceof HTMLElement) {
+		onGateShow?.(metrics, ev.currentTarget);
+	}
+};
 
 // A locked skill that is some challenge's reward is gated behind that challenge — hovering it
 // surfaces the gate. Unlocked skills (and locked ones with no challenge source) show no tooltip.

--- a/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
@@ -26,7 +26,13 @@ const { mockPlayerManager, staticData, playerChallenges, registerTooltipComponen
 }));
 
 vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager }));
-vi.mock('$stores', () => ({ staticData, playerChallenges, registerTooltipComponent }));
+vi.mock('$stores', () => ({
+	staticData,
+	playerChallenges,
+	registerTooltipComponent,
+	// The tooltip content under test is driven by `challengeId`; position is irrelevant here.
+	anchorPosition: () => ({ x: 0, y: 0 })
+}));
 
 import ZoneNav from '$routes/game/screens/fight/ZoneNav.svelte';
 
@@ -112,7 +118,10 @@ describe('ZoneNav', () => {
 		render(ZoneNav);
 		const [, right] = screen.getAllByRole('button') as HTMLButtonElement[];
 
-		expect(right.disabled).toBe(true);
+		// A locked arrow stays focusable (not hard-`disabled`) so its gate is keyboard-reachable,
+		// signalling its non-navigability with `aria-disabled` instead.
+		expect(right.disabled).toBe(false);
+		expect(right.getAttribute('aria-disabled')).toBe('true');
 		expect(right.getAttribute('aria-label')).toBe('Next zone locked');
 		// A locked arrow shows the padlock glyph rather than the chevron.
 		expect(right.querySelector('svg')).not.toBeNull();
@@ -132,6 +141,7 @@ describe('ZoneNav', () => {
 		const [, right] = screen.getAllByRole('button') as HTMLButtonElement[];
 
 		expect(right.disabled).toBe(false);
+		expect(right.getAttribute('aria-disabled')).toBeNull();
 		expect(right.querySelector('svg')).toBeNull();
 
 		await fireEvent.click(right);
@@ -147,7 +157,8 @@ describe('ZoneNav', () => {
 		render(ZoneNav);
 		const [left] = screen.getAllByRole('button') as HTMLButtonElement[];
 
-		expect(left.disabled).toBe(true);
+		expect(left.disabled).toBe(false);
+		expect(left.getAttribute('aria-disabled')).toBe('true');
 		expect(left.getAttribute('aria-label')).toBe('Previous zone locked');
 		expect(left.querySelector('svg')).not.toBeNull();
 	});
@@ -174,6 +185,40 @@ describe('ZoneNav', () => {
 
 		// Leaving clears the tooltip's challenge so it no longer renders the gate.
 		await fireEvent.mouseLeave(wraps[1]);
+		expect(screen.queryByText('Cull the Swarm')).toBeNull();
+	});
+
+	it('surfaces the gating challenge on keyboard focus of a locked arrow and clears on blur', async () => {
+		staticData.zones = [zone(10, 1, 'Alpha'), zone(20, 2, 'Beta', 5)];
+		staticData.challenges = [];
+		staticData.challenges[5] = challenge(5, 'Cull the Swarm', 'Defeat 10 enemies');
+		mockPlayerManager.currentZone = 10;
+		playerChallenges.isChallengeCompleted.mockReturnValue(false);
+
+		render(ZoneNav);
+		const [, right] = screen.getAllByRole('button') as HTMLButtonElement[];
+
+		// Focusing the locked arrow (keyboard path, no cursor) surfaces the gate.
+		await fireEvent.focus(right);
+		expect(screen.getByText('Cull the Swarm')).toBeTruthy();
+		expect(screen.getByText('Defeat 10 enemies')).toBeTruthy();
+		expect(screen.getByText('Beta')).toBeTruthy();
+
+		// Blurring clears the gate so it no longer renders.
+		await fireEvent.blur(right);
+		expect(screen.queryByText('Cull the Swarm')).toBeNull();
+	});
+
+	it('does not surface a tooltip when focusing an unlocked (navigable) arrow', async () => {
+		staticData.zones = [zone(10, 1, 'Alpha'), zone(20, 2, 'Beta')];
+		staticData.challenges = [];
+		staticData.challenges[5] = challenge(5, 'Cull the Swarm', 'Defeat 10 enemies');
+		mockPlayerManager.currentZone = 10;
+
+		render(ZoneNav);
+		const [, right] = screen.getAllByRole('button') as HTMLButtonElement[];
+
+		await fireEvent.focus(right);
 		expect(screen.queryByText('Cull the Swarm')).toBeNull();
 	});
 

--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -60,7 +60,14 @@ const {
 });
 
 vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager, inventoryManager: mockInventoryManager }));
-vi.mock('$stores', () => ({ staticData, toastError, playerChallenges, registerTooltipComponent }));
+vi.mock('$stores', () => ({
+	staticData,
+	toastError,
+	playerChallenges,
+	registerTooltipComponent,
+	// The gate tooltip content under test is driven by `challengeId`; position is irrelevant here.
+	anchorPosition: () => ({ x: 0, y: 0 })
+}));
 vi.mock('$lib/api', async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, unknown>;
 	return { ...actual, apiSocket: { sendSocketCommand } };
@@ -431,6 +438,34 @@ describe('Skills screen', () => {
 
 		// Leaving the row clears the gate so it no longer renders.
 		await fireEvent.mouseLeave(echo);
+		expect(screen.queryByText('Slay Ten')).toBeNull();
+	});
+
+	it('surfaces the gating challenge tooltip on keyboard focus of a locked, challenge-gated skill', async () => {
+		staticData.challenges = [
+			{
+				id: 0,
+				name: 'Slay Ten',
+				description: 'Defeat 10 enemies',
+				challengeTypeId: 0,
+				progressGoal: 10,
+				rewardSkillId: 4
+			}
+		] as unknown as IChallenge[];
+		const { container } = render(Skills);
+
+		// Reveal locked skills so Echo (gated) appears in the rail.
+		await fireEvent.click(container.querySelector<HTMLButtonElement>('.filt-btn')!);
+		await fireEvent.click(container.querySelector<HTMLButtonElement>('.switch')!);
+		const echo = rowByName(container, 'Echo')!;
+
+		// The gated row is a focusable button; focusing it (keyboard path) surfaces the gate.
+		await fireEvent.focus(echo);
+		expect(screen.getByText('Slay Ten')).toBeTruthy();
+		expect(screen.getByText('Defeat 10 enemies')).toBeTruthy();
+
+		// Blurring the row clears the gate so it no longer renders.
+		await fireEvent.blur(echo);
 		expect(screen.queryByText('Slay Ten')).toBeNull();
 	});
 


### PR DESCRIPTION
## Summary

Closes #686.

The locked-zone arrow (`fight/ZoneNav.svelte`) and the gated-skill row (`skills/SkillRow.svelte`) only surfaced their "why is this gated/locked?" tooltip on **mouse hover**, so keyboard and screen-reader users couldn't reach the explanation. This adds a focus path to both, anchored off the control's box rather than the cursor.

The infrastructure for this already existed: `anchorPosition(MouseEvent | HTMLElement)` in `stores/tooltip.svelte.ts` (the element-rect-anchored path the issue calls for) and the established focus-reachable tooltip pattern in `fight/Skills.svelte`. This change applies that pattern to the two remaining hover-only gate/lock tooltips.

## How it addresses the issue

**Design fork resolved (ZoneNav locked-arrow focusability):** the issue offered "focusable + `aria-disabled`" vs. "keep `disabled` and expose the gate another way". I went with the former, since it's the minimal change that makes the gate keyboard-reachable while keeping the arrow non-navigating:

- A locked arrow is no longer hard-`disabled` (which removes it from the tab order); it stays focusable and signals non-navigability with `aria-disabled="true"`. Only a **truly-absent** neighbour (first/last zone, nothing to explain) stays `disabled`/unfocusable.
- Activation stays a no-op — `goToZone` already only navigates to an *unlocked* zone, so a click/Enter on a locked arrow does nothing, exactly as before.
- The gate tooltip is revealed on `focus` (anchored off the arrow's box) and cleared on `blur`; the existing mouse-hover path is unchanged.
- Added a `:focus-visible` outline so the now-focusable arrow has a visible focus ring.

**SkillRow:** the row is already a real `<button>` (focusable); it now reveals its gate tooltip on `focus`/`blur` in addition to hover. `SkillRow`'s gate callback was generalized from `(metrics, MouseEvent)` to `(metrics, TooltipAnchor)` and `SkillRail` resolves position through `anchorPosition` for both paths.

## Note on ARIA (one part I want a second opinion on)

The issue mentioned `aria-describedby` as a possible ARIA hook. I did **not** wire `aria-describedby` from the control to the dynamic tooltip content: the tooltip is a single shared global component positioned by the tooltip store, with no stable per-trigger id relationship — associating it would be a larger change, and it's inconsistent with how the rest of the app's tooltips work (e.g. `fight/Skills.svelte`, which relies on the focusable control + visible tooltip + accessible name). The locked state is instead conveyed via the existing `aria-label` ("… zone locked") plus `aria-disabled`. Happy to revisit if you'd prefer the full `aria-describedby` association — it would likely warrant a small shared "describedby tooltip" abstraction across all tooltip call sites rather than a one-off here.

## Test plan

- [x] `ZoneNav.test.ts`: updated the two "locks the arrow" cases to the new contract (`disabled === false` + `aria-disabled === 'true'`), confirmed the unlocked arrow has no `aria-disabled`, and added focus/blur coverage (gate surfaces on focus, clears on blur; navigable arrow shows nothing on focus). Clicking a locked arrow still doesn't navigate.
- [x] `Skills.test.ts`: added a focus/blur counterpart to the existing hover gate-tooltip test.
- [x] `npm run lint` (eslint + svelte-check): clean.
- [x] `npm run test:unit:ci`: 1809 passed, coverage gates green.

https://claude.ai/code/session_01JYvxwfAwhfPrnVrxgDCqNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYvxwfAwhfPrnVrxgDCqNK)_