### PR TITLE
Extract shared presentational primitives (#705)

### DIFF
--- a/UI/src/components/AttributeChip.svelte
+++ b/UI/src/components/AttributeChip.svelte
@@ -1,0 +1,57 @@
+<!-- A monospace attribute pill (icon + code) tinted by the attribute's colour. Opens the shared
+     attribute tooltip on hover whenever a screen provides a controller via `setAttributeTooltip`;
+     otherwise it is purely presentational. -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<span
+	class="achip"
+	class:wide
+	style:--ac={attributeColor(attributeId)}
+	onmouseenter={(e) => attrTip?.show(attributeId, e)}
+	onmousemove={(e) => attrTip?.move(e)}
+	onmouseleave={() => attrTip?.hide()}
+>
+	<AttributeIcon id={attributeId} size={iconSize} />
+	{attributeCode(attributeId, staticData.attributes)}
+</span>
+
+<script lang="ts">
+import type { EAttribute } from '$lib/api';
+import { attributeCode, attributeColor } from '$lib/common';
+import { staticData } from '$stores';
+import AttributeIcon from '$components/AttributeIcon.svelte';
+import { getAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
+
+interface Props {
+	attributeId: EAttribute;
+	iconSize?: number;
+	/** Centred, min-width variant for chips that align in a column (the skill damage breakdown). */
+	wide?: boolean;
+}
+
+const { attributeId, iconSize = 12, wide = false }: Props = $props();
+
+const attrTip = getAttributeTooltip();
+</script>
+
+<style lang="scss">
+.achip {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 2px 8px;
+	border: 1px solid color-mix(in srgb, var(--ac) 38%, transparent);
+	border-radius: 3px;
+	background: color-mix(in srgb, var(--ac) 12%, transparent);
+	color: var(--ac);
+	font-family: var(--mono);
+	font-size: 10px;
+	letter-spacing: 0.5px;
+	white-space: nowrap;
+
+	&.wide {
+		justify-content: center;
+		min-width: 46px;
+		text-align: center;
+	}
+}
+</style>

--- a/UI/src/components/RarityTag.svelte
+++ b/UI/src/components/RarityTag.svelte
@@ -1,0 +1,42 @@
+<!-- A rarity pip + label (e.g. "● Common"), tinted by the item's rarity tier. Shared by the
+     inventory equip slots and the item drawer header; callers position it via passthrough props
+     (e.g. style="margin-left: auto"). -->
+<span class="rarity-tag" {...rest}>
+	<span class="rarity-dot" style:background={color} style:box-shadow="0 0 6px {rarityTint(rarityId, 0.65)}"></span>
+	<span class="rarity-label" style:color>{rarityLabel(rarityId)}</span>
+</span>
+
+<script lang="ts">
+import type { HTMLAttributes } from 'svelte/elements';
+import { rarityColor, rarityLabel, rarityTint } from '$lib/common';
+
+interface Props extends HTMLAttributes<HTMLSpanElement> {
+	rarityId: number;
+}
+
+const { rarityId, ...rest }: Props = $props();
+
+const color = $derived(rarityColor(rarityId));
+</script>
+
+<style lang="scss">
+.rarity-tag {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.rarity-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.rarity-label {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 1.6px;
+	text-transform: uppercase;
+}
+</style>

--- a/UI/src/components/tooltip/attribute-hover.ts
+++ b/UI/src/components/tooltip/attribute-hover.ts
@@ -1,0 +1,44 @@
+import type { EAttribute } from '$lib/api';
+import type { AttributeTooltipController } from './attribute-tooltip.svelte';
+
+export interface AttributeHoverParams {
+	/** The screen-level controller, resolved by the owning component via `getAttributeTooltip()`. */
+	controller: AttributeTooltipController | undefined;
+	id: EAttribute;
+}
+
+/**
+ * Opens the shared attribute tooltip for {@link AttributeHoverParams.id} while the element is
+ * hovered or focused — anchored at the cursor on hover and off the element's box on focus — and
+ * hides it on leave/blur. Replaces the per-row mouse/focus-handler boilerplate. The controller is
+ * passed in (rather than read here) because an action runs after init and can't call `getContext`;
+ * the owning component resolves it once via `getAttributeTooltip()`.
+ */
+export function attributeHover(node: HTMLElement, params: AttributeHoverParams) {
+	let { controller, id } = params;
+
+	const onEnter = (e: MouseEvent) => controller?.show(id, e);
+	const onMove = (e: MouseEvent) => controller?.move(e);
+	const onLeave = () => controller?.hide();
+	const onFocus = () => controller?.show(id, node);
+	const onBlur = () => controller?.hide();
+
+	node.addEventListener('mouseenter', onEnter);
+	node.addEventListener('mousemove', onMove);
+	node.addEventListener('mouseleave', onLeave);
+	node.addEventListener('focus', onFocus);
+	node.addEventListener('blur', onBlur);
+
+	return {
+		update(next: AttributeHoverParams) {
+			({ controller, id } = next);
+		},
+		destroy() {
+			node.removeEventListener('mouseenter', onEnter);
+			node.removeEventListener('mousemove', onMove);
+			node.removeEventListener('mouseleave', onLeave);
+			node.removeEventListener('focus', onFocus);
+			node.removeEventListener('blur', onBlur);
+		}
+	};
+}

--- a/UI/src/routes/game/screens/attribute-breakdown/AttributeListRow.svelte
+++ b/UI/src/routes/game/screens/attribute-breakdown/AttributeListRow.svelte
@@ -7,11 +7,7 @@
 	data-testid="attr-row-{meta.id}"
 	aria-pressed={active}
 	onclick={() => onSelect(meta.id)}
-	onmouseenter={(e) => attrTip?.show(meta.id, e)}
-	onmousemove={(e) => attrTip?.move(e)}
-	onmouseleave={() => attrTip?.hide()}
-	onfocus={(e) => attrTip?.show(meta.id, e.currentTarget)}
-	onblur={() => attrTip?.hide()}
+	use:attributeHover={{ controller: attrTip, id: meta.id }}
 >
 	<span class="info">
 		<span class="name-row">
@@ -29,6 +25,7 @@ import { attributeName } from '$lib/common';
 import { staticData } from '$stores';
 import AttributeIcon from '$components/AttributeIcon.svelte';
 import { getAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
+import { attributeHover } from '$components/tooltip/attribute-hover';
 import StackBar from './StackBar.svelte';
 import { fmtNum, type BreakdownAttrMeta, type LabeledModifier } from './attribute-breakdown-view.svelte';
 

--- a/UI/src/routes/game/screens/attributes/GuidedRow.svelte
+++ b/UI/src/routes/game/screens/attributes/GuidedRow.svelte
@@ -1,18 +1,10 @@
 <div class="row">
-	<span
-		class="attr-hit"
-		role="img"
-		aria-label={name}
-		onmouseenter={showTip}
-		onmousemove={moveTip}
-		onmouseleave={hideTip}
-	>
+	<span class="attr-hit" role="img" aria-label={name} use:attributeHover={{ controller: attrTip, id }}>
 		<AttributeIcon {id} size={40} />
 	</span>
 
 	<div class="info">
-		<!-- svelte-ignore a11y_no_static_element_interactions -->
-		<div class="head" onmouseenter={showTip} onmousemove={moveTip} onmouseleave={hideTip}>
+		<div class="head" use:attributeHover={{ controller: attrTip, id }}>
 			<span class="code" style="color: {color}">{code}</span>
 			<span class="name">{name}</span>
 		</div>
@@ -37,6 +29,7 @@ import { attributeColor, attributeCode, attributeName } from '$lib/common';
 import { staticData } from '$stores';
 import AttributeIcon from '$components/AttributeIcon.svelte';
 import { getAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
+import { attributeHover } from '$components/tooltip/attribute-hover';
 import Delta from './Delta.svelte';
 import Stepper from './Stepper.svelte';
 import { CORE_ATTRIBUTES, DERIVED_STATS, feedsFor, type AttributesView } from './attributes-view.svelte';
@@ -56,9 +49,6 @@ const feeds = $derived(feedsFor(i));
 
 // Hover explainer for the attribute, driven through the screen-level controller.
 const attrTip = getAttributeTooltip();
-const showTip = (e: MouseEvent) => attrTip?.show(id, e);
-const moveTip = (e: MouseEvent) => attrTip?.move(e);
-const hideTip = () => attrTip?.hide();
 
 // The set of derived stats whose value differs between the saved and pending
 // builds — used to light up the feed chips this attribute drives.

--- a/UI/src/routes/game/screens/attributes/TheoryRow.svelte
+++ b/UI/src/routes/game/screens/attributes/TheoryRow.svelte
@@ -1,17 +1,9 @@
 <div class="trow">
-	<span
-		class="attr-hit"
-		role="img"
-		aria-label={name}
-		onmouseenter={showTip}
-		onmousemove={moveTip}
-		onmouseleave={hideTip}
-	>
+	<span class="attr-hit" role="img" aria-label={name} use:attributeHover={{ controller: attrTip, id }}>
 		<AttributeIcon {id} size={40} />
 	</span>
 	<div class="attr">
-		<!-- svelte-ignore a11y_no_static_element_interactions -->
-		<div class="head" onmouseenter={showTip} onmousemove={moveTip} onmouseleave={hideTip}>
+		<div class="head" use:attributeHover={{ controller: attrTip, id }}>
 			<span class="code" style="color: {color}">{code}</span>
 			<span class="name">{name}</span>
 		</div>
@@ -53,6 +45,7 @@ import { formatNum, attributeColor, attributeCode, attributeName } from '$lib/co
 import { staticData } from '$stores';
 import AttributeIcon from '$components/AttributeIcon.svelte';
 import { getAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
+import { attributeHover } from '$components/tooltip/attribute-hover';
 import Stepper from './Stepper.svelte';
 import {
 	CORE_ATTRIBUTES,
@@ -76,9 +69,6 @@ const name = $derived(attributeName(id, staticData.attributes));
 
 // Hover explainer for the attribute, driven through the screen-level controller.
 const attrTip = getAttributeTooltip();
-const showTip = (e: MouseEvent) => attrTip?.show(id, e);
-const moveTip = (e: MouseEvent) => attrTip?.move(e);
-const hideTip = () => attrTip?.hide();
 
 const value = $derived(view.values[i]);
 const saved = $derived(view.savedValues[i]);

--- a/UI/src/routes/game/screens/challenges/Challenges.svelte
+++ b/UI/src/routes/game/screens/challenges/Challenges.svelte
@@ -153,22 +153,6 @@ onMount(async () => {
 	line-height: 1;
 }
 
-.mono-label {
-	font-family: var(--mono);
-	font-size: 9.5px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-
-	&.accent {
-		color: var(--accent-light);
-	}
-
-	&.sm {
-		font-size: 8.5px;
-	}
-}
-
 .chal-summary {
 	text-align: right;
 }

--- a/UI/src/routes/game/screens/challenges/OverviewPane.svelte
+++ b/UI/src/routes/game/screens/challenges/OverviewPane.svelte
@@ -107,22 +107,6 @@ const { summary, nextUp, groups, onPick }: Props = $props();
 	gap: 14px;
 }
 
-.mono-label {
-	font-family: var(--mono);
-	font-size: 9.5px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-
-	&.sm {
-		font-size: 8.5px;
-	}
-
-	&.done {
-		color: var(--success);
-	}
-}
-
 .summary-card {
 	flex: 1;
 	background: var(--panel);

--- a/UI/src/routes/game/screens/inventory/EquipSlot.svelte
+++ b/UI/src/routes/game/screens/inventory/EquipSlot.svelte
@@ -54,11 +54,7 @@
 	<div class="row-info">
 		{#if item}
 			<div class="item-name">{item.name}</div>
-			<div class="rarity-tag">
-				<span class="rarity-dot" style:background={rc} style:box-shadow="0 0 6px {rarityTint(item.rarityId, 0.65)}"
-				></span>
-				<span class="rarity-label" style:color={rc}>{rarityLabel(item.rarityId)}</span>
-			</div>
+			<RarityTag rarityId={item.rarityId} style="margin-top: 3px" />
 		{:else}
 			<div class="empty-label">Empty</div>
 		{/if}
@@ -67,7 +63,8 @@
 
 <script lang="ts">
 import type { Item } from '$lib/battle';
-import { itemCategoryColor, rarityColor, rarityLabel, rarityTint, tintColor } from '$lib/common';
+import { itemCategoryColor, rarityTint, tintColor } from '$lib/common';
+import RarityTag from '$components/RarityTag.svelte';
 import CategoryGlyph from './CategoryGlyph.svelte';
 import OverlayButton from './OverlayButton.svelte';
 import { type EquipSlotDef } from './inventory-view.svelte';
@@ -92,7 +89,6 @@ let over = $state(false);
 let hover = $state(false);
 
 const filled = $derived(!!item);
-const rc = $derived(item ? rarityColor(item.rarityId) : 'var(--accent)');
 const canAccept = $derived(!!dragItem && dragItem.itemCategoryId === slot.category);
 
 const tileBorder = $derived(
@@ -214,27 +210,6 @@ const handleDrop = (e: DragEvent) => {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-}
-
-.rarity-tag {
-	margin-top: 3px;
-	display: flex;
-	align-items: center;
-	gap: 6px;
-}
-
-.rarity-dot {
-	width: 6px;
-	height: 6px;
-	border-radius: 50%;
-	flex-shrink: 0;
-}
-
-.rarity-label {
-	font-family: var(--mono);
-	font-size: 9px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
 }
 
 .empty-label {

--- a/UI/src/routes/game/screens/inventory/EquippedRail.svelte
+++ b/UI/src/routes/game/screens/inventory/EquippedRail.svelte
@@ -102,14 +102,6 @@ const handleDrop = (slotId: number) => {
 	flex-shrink: 0;
 }
 
-.mono-label {
-	font-family: var(--mono);
-	font-size: 9.5px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-}
-
 .line {
 	flex: 1;
 	height: 1px;

--- a/UI/src/routes/game/screens/inventory/EquippedTotals.svelte
+++ b/UI/src/routes/game/screens/inventory/EquippedTotals.svelte
@@ -49,18 +49,6 @@ const { view }: { view: InventoryView } = $props();
 	flex-shrink: 0;
 }
 
-.mono-label {
-	font-family: var(--mono);
-	font-size: 9.5px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-
-	&.accent {
-		color: var(--accent-light);
-	}
-}
-
 .line {
 	flex: 1;
 	height: 1px;

--- a/UI/src/routes/game/screens/inventory/InventoryGrid.svelte
+++ b/UI/src/routes/game/screens/inventory/InventoryGrid.svelte
@@ -142,14 +142,6 @@ const handleHoverLeave = () => {
 	justify-content: space-between;
 }
 
-.mono-label {
-	font-family: var(--mono);
-	font-size: 9.5px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-}
-
 .pager {
 	display: flex;
 	align-items: center;

--- a/UI/src/routes/game/screens/inventory/InventoryToolbar.svelte
+++ b/UI/src/routes/game/screens/inventory/InventoryToolbar.svelte
@@ -122,14 +122,6 @@ const sortKeys = Object.keys(SORTS) as SortKey[];
 	margin-left: auto;
 }
 
-.mono-label {
-	font-family: var(--mono);
-	font-size: 9.5px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-}
-
 .sort-toggle {
 	display: flex;
 	border: 1px solid var(--border-subtle);

--- a/UI/src/routes/game/screens/inventory/ItemDrawer.svelte
+++ b/UI/src/routes/game/screens/inventory/ItemDrawer.svelte
@@ -6,11 +6,7 @@
 		labelColor={accent}
 	>
 		{#snippet trailing()}
-			<span class="rarity-tag">
-				<span class="rarity-dot" style:background={rc} style:box-shadow="0 0 6px {rarityTint(item.rarityId, 0.65)}"
-				></span>
-				<span class="rarity-label" style:color={rc}>{rarityLabel(item.rarityId)}</span>
-			</span>
+			<RarityTag rarityId={item.rarityId} style="margin-left: auto" />
 			<button class="close" onclick={() => view.select(null)} aria-label="Close">×</button>
 		{/snippet}
 	</TooltipTitle>
@@ -47,14 +43,14 @@ import TooltipTitle from '$components/tooltip/TooltipTitle.svelte';
 import TooltipSection from '$components/tooltip/TooltipSection.svelte';
 import TooltipStatsGrid from '$components/tooltip/TooltipStatsGrid.svelte';
 import TooltipDescription from '$components/tooltip/TooltipDescription.svelte';
+import RarityTag from '$components/RarityTag.svelte';
 import { type Item } from '$lib/battle';
-import { itemCategoryColor, itemCategoryName, rarityColor, rarityLabel, rarityTint } from '$lib/common';
+import { itemCategoryColor, itemCategoryName } from '$lib/common';
 import { type InventoryView } from './inventory-view.svelte';
 
 const { item, view }: { item: Item; view: InventoryView } = $props();
 
 const accent = $derived(itemCategoryColor(item.itemCategoryId));
-const rc = $derived(rarityColor(item.rarityId));
 const equipped = $derived(item.equipmentSlotId != null);
 
 // Merged item + applied-mod attributes, from the item's own source-of-truth
@@ -68,26 +64,6 @@ const attributeMap = $derived(item.totalAttributes?.getAttributeMap());
 // primitive; the drawer keeps only its category-coloured left-accent stripe.
 .drawer-header {
 	border-left: 3px solid;
-}
-
-.rarity-tag {
-	margin-left: auto;
-	display: flex;
-	align-items: center;
-	gap: 6px;
-}
-
-.rarity-dot {
-	width: 6px;
-	height: 6px;
-	border-radius: 50%;
-}
-
-.rarity-label {
-	font-family: var(--mono);
-	font-size: 9px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
 }
 
 .close {

--- a/UI/src/routes/game/screens/skills/EquippedBand.svelte
+++ b/UI/src/routes/game/screens/skills/EquippedBand.svelte
@@ -52,10 +52,7 @@
 				</div>
 				<div class="chips">
 					{#each metrics.skill.damageMultipliers as mult (mult.attributeId)}
-						<span class="achip" style:--ac={attributeColor(mult.attributeId)}>
-							<AttributeIcon id={mult.attributeId} size={12} />
-							{attributeCode(mult.attributeId, staticData.attributes)}
-						</span>
+						<AttributeChip attributeId={mult.attributeId} />
 					{/each}
 				</div>
 			</div>
@@ -69,9 +66,8 @@
 </div>
 
 <script lang="ts">
-import { attributeCode, attributeColor, formatNum } from '$lib/common';
-import { staticData } from '$stores';
-import AttributeIcon from '$components/AttributeIcon.svelte';
+import { formatNum } from '$lib/common';
+import AttributeChip from '$components/AttributeChip.svelte';
 import type { SkillsView } from './skills-view.svelte';
 
 type Props = {
@@ -342,20 +338,5 @@ const onDragEnd = () => {
 		text-transform: uppercase;
 		color: var(--text-muted);
 	}
-}
-
-.achip {
-	display: inline-flex;
-	align-items: center;
-	gap: 4px;
-	padding: 2px 8px;
-	border: 1px solid color-mix(in srgb, var(--ac) 38%, transparent);
-	border-radius: 3px;
-	background: color-mix(in srgb, var(--ac) 12%, transparent);
-	color: var(--ac);
-	font-family: var(--mono);
-	font-size: 10px;
-	letter-spacing: 0.5px;
-	white-space: nowrap;
 }
 </style>

--- a/UI/src/routes/game/screens/skills/SkillDamageBreakdown.svelte
+++ b/UI/src/routes/game/screens/skills/SkillDamageBreakdown.svelte
@@ -3,16 +3,7 @@
 	{#if metrics.contributions.length}
 		{#each metrics.contributions as contribution (contribution.attributeId)}
 			<div class="scale" style:--ac={attributeColor(contribution.attributeId)}>
-				<!-- svelte-ignore a11y_no_static_element_interactions -->
-				<span
-					class="achip"
-					onmouseenter={(e) => tip.controller.show(contribution.attributeId, e)}
-					onmousemove={(e) => tip.controller.move(e)}
-					onmouseleave={() => tip.controller.hide()}
-				>
-					<AttributeIcon id={contribution.attributeId} size={12} />
-					{attributeCode(contribution.attributeId, staticData.attributes)}
-				</span>
+				<AttributeChip attributeId={contribution.attributeId} wide />
 				<div class="bar"><i style:width="{Math.round((contribution.value / maxContribution) * 100)}%"></i></div>
 				<span class="contrib"
 					>{attributeName(contribution.attributeId, staticData.attributes)} ×{contribution.multiplier} = +{fmt(
@@ -32,15 +23,10 @@
 	</div>
 </div>
 
-<!-- One shared tooltip for the scaling chips, anchored to whichever chip is hovered. -->
-<AttributeTooltip bind:this={tooltip} attributeId={tip.attributeId} />
-
 <script lang="ts">
-import { attributeCode, attributeColor, attributeName, formatNum } from '$lib/common';
-import { staticData, type TooltipComponent } from '$stores';
-import AttributeIcon from '$components/AttributeIcon.svelte';
-import AttributeTooltip from '$components/tooltip/AttributeTooltip.svelte';
-import { createAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
+import { attributeColor, attributeName, formatNum } from '$lib/common';
+import { staticData } from '$stores';
+import AttributeChip from '$components/AttributeChip.svelte';
 import type { SkillMetrics, SkillsView } from './skills-view.svelte';
 
 type Props = {
@@ -49,9 +35,6 @@ type Props = {
 };
 
 const { view, metrics }: Props = $props();
-
-let tooltip = $state<TooltipComponent>();
-const tip = createAttributeTooltip(() => tooltip);
 
 const fmt = (n: number) => formatNum(Math.round(n));
 
@@ -82,24 +65,6 @@ const maxContribution = $derived(Math.max(metrics.skill.baseDamage, ...metrics.c
 	align-items: center;
 	gap: 11px;
 	margin-top: 8px;
-}
-
-.achip {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	gap: 4px;
-	min-width: 46px;
-	padding: 2px 8px;
-	border: 1px solid color-mix(in srgb, var(--ac) 38%, transparent);
-	border-radius: 3px;
-	background: color-mix(in srgb, var(--ac) 12%, transparent);
-	color: var(--ac);
-	font-family: var(--mono);
-	font-size: 10px;
-	letter-spacing: 0.5px;
-	text-align: center;
-	white-space: nowrap;
 }
 
 .bar {

--- a/UI/src/routes/game/screens/skills/Skills.svelte
+++ b/UI/src/routes/game/screens/skills/Skills.svelte
@@ -25,10 +25,17 @@
 	<EquippedBand {view} />
 
 	<SortFilterModal {view} />
+
+	<!-- Shared attribute tooltip for the scaling chips in the damage breakdown and the equipped
+	     loadout band, published via context so both surfaces hover the one panel. -->
+	<AttributeTooltip bind:this={tooltip} attributeId={tip.attributeId} />
 </div>
 
 <script lang="ts">
 import { formatNum } from '$lib/common';
+import { type TooltipComponent } from '$stores';
+import AttributeTooltip from '$components/tooltip/AttributeTooltip.svelte';
+import { createAttributeTooltip, setAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
 import { SkillsView } from './skills-view.svelte';
 import CompareBar from './CompareBar.svelte';
 import SkillRail from './SkillRail.svelte';
@@ -39,6 +46,10 @@ import SortFilterModal from './SortFilterModal.svelte';
 const view = new SkillsView();
 
 const fmt = (n: number) => formatNum(Math.round(n));
+
+let tooltip = $state<TooltipComponent>();
+const tip = createAttributeTooltip(() => tooltip);
+setAttributeTooltip(tip.controller);
 </script>
 
 <style lang="scss">

--- a/UI/src/styles/common.scss
+++ b/UI/src/styles/common.scss
@@ -96,6 +96,29 @@ h1 {
 	align-content: center;
 }
 
+// Monospaced uppercase eyebrow/label used across screens (section rules, footers, stat
+// captions). Promoted from ~10 byte-identical scoped copies. `.sm` is the compact variant;
+// `.accent`/`.done` recolour it for the highlighted/completed states that use it.
+.mono-label {
+	font-family: var(--mono);
+	font-size: 9.5px;
+	letter-spacing: 1.6px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+
+	&.sm {
+		font-size: 8.5px;
+	}
+
+	&.accent {
+		color: var(--accent-light);
+	}
+
+	&.done {
+		color: var(--success);
+	}
+}
+
 input::placeholder {
 	color: var(--text-tertiary);
 }

--- a/UI/src/tests/components/AttributeChip.test.ts
+++ b/UI/src/tests/components/AttributeChip.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { EAttribute } from '$lib/api';
+
+const controller = { show: vi.fn(), move: vi.fn(), hide: vi.fn() };
+
+// The chip resolves the screen-level controller via context; the action/controller wiring is
+// covered elsewhere, so here we stub it to assert the chip drives it on hover.
+vi.mock('$components/tooltip/attribute-tooltip.svelte', () => ({
+	getAttributeTooltip: () => controller
+}));
+
+vi.mock('$stores', () => ({
+	staticData: { attributes: [{ id: EAttribute.Strength, code: 'STR', name: 'Strength' }] }
+}));
+
+import AttributeChip from '$components/AttributeChip.svelte';
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe('AttributeChip', () => {
+	it('renders the attribute code, icon, and colour tint', () => {
+		const { container } = render(AttributeChip, { props: { attributeId: EAttribute.Strength } });
+		const chip = container.querySelector('.achip') as HTMLElement;
+		expect(chip.textContent).toContain('STR');
+		expect(chip.querySelector('img.attr-icon')).toBeTruthy();
+		expect(chip.style.getPropertyValue('--ac')).toBe('var(--attr-strength)');
+	});
+
+	it('applies the wide modifier only when requested', () => {
+		const plain = render(AttributeChip, { props: { attributeId: EAttribute.Strength } });
+		expect(plain.container.querySelector('.achip')?.classList.contains('wide')).toBe(false);
+		cleanup();
+		const wide = render(AttributeChip, { props: { attributeId: EAttribute.Strength, wide: true } });
+		expect(wide.container.querySelector('.achip')?.classList.contains('wide')).toBe(true);
+	});
+
+	it('drives the shared attribute tooltip across hover (enter/move/leave)', async () => {
+		const { container } = render(AttributeChip, { props: { attributeId: EAttribute.Strength } });
+		const chip = container.querySelector('.achip') as HTMLElement;
+		await fireEvent.mouseEnter(chip);
+		expect(controller.show).toHaveBeenCalledWith(EAttribute.Strength, expect.anything());
+		await fireEvent.mouseMove(chip);
+		expect(controller.move).toHaveBeenCalled();
+		await fireEvent.mouseLeave(chip);
+		expect(controller.hide).toHaveBeenCalled();
+	});
+});

--- a/UI/src/tests/components/RarityTag.test.ts
+++ b/UI/src/tests/components/RarityTag.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { ERarity } from '$lib/api';
+import RarityTag from '$components/RarityTag.svelte';
+
+afterEach(cleanup);
+
+describe('RarityTag', () => {
+	it('renders the rarity label tinted by the rarity colour', () => {
+		const { container, getByText } = render(RarityTag, { props: { rarityId: ERarity.Common } });
+		expect(getByText('Common')).toBeTruthy();
+		const dot = container.querySelector('.rarity-dot') as HTMLElement;
+		const label = container.querySelector('.rarity-label') as HTMLElement;
+		expect(dot.style.background).toBe('var(--rarity-common)');
+		expect(label.style.color).toBe('var(--rarity-common)');
+	});
+
+	it('forwards positioning props through to the root element', () => {
+		const { container } = render(RarityTag, {
+			props: { rarityId: ERarity.Common, style: 'margin-left: auto' }
+		});
+		const tag = container.querySelector('.rarity-tag') as HTMLElement;
+		expect(tag.style.marginLeft).toBe('auto');
+	});
+});

--- a/UI/src/tests/components/tooltip/attribute-hover.test.ts
+++ b/UI/src/tests/components/tooltip/attribute-hover.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { EAttribute } from '$lib/api';
+import { attributeHover } from '$components/tooltip/attribute-hover';
+
+const makeController = () => ({ show: vi.fn(), move: vi.fn(), hide: vi.fn() });
+
+describe('attributeHover action', () => {
+	it('shows anchored at the cursor on hover and hides on leave', () => {
+		const node = document.createElement('div');
+		const controller = makeController();
+		const action = attributeHover(node, { controller, id: EAttribute.Strength });
+
+		const enter = new MouseEvent('mouseenter');
+		node.dispatchEvent(enter);
+		expect(controller.show).toHaveBeenCalledWith(EAttribute.Strength, enter);
+
+		node.dispatchEvent(new MouseEvent('mousemove'));
+		expect(controller.move).toHaveBeenCalledTimes(1);
+
+		node.dispatchEvent(new MouseEvent('mouseleave'));
+		expect(controller.hide).toHaveBeenCalledTimes(1);
+
+		action.destroy();
+	});
+
+	it('shows anchored off the element on focus and hides on blur', () => {
+		const node = document.createElement('button');
+		const controller = makeController();
+		const action = attributeHover(node, { controller, id: EAttribute.Agility });
+
+		node.dispatchEvent(new FocusEvent('focus'));
+		expect(controller.show).toHaveBeenCalledWith(EAttribute.Agility, node);
+
+		node.dispatchEvent(new FocusEvent('blur'));
+		expect(controller.hide).toHaveBeenCalledTimes(1);
+
+		action.destroy();
+	});
+
+	it('tracks the latest controller/id after update and stops after destroy', () => {
+		const node = document.createElement('div');
+		const first = makeController();
+		const action = attributeHover(node, { controller: first, id: EAttribute.Strength });
+
+		const second = makeController();
+		action.update({ controller: second, id: EAttribute.Luck });
+
+		node.dispatchEvent(new MouseEvent('mouseenter'));
+		expect(first.show).not.toHaveBeenCalled();
+		expect(second.show).toHaveBeenCalledWith(EAttribute.Luck, expect.anything());
+
+		action.destroy();
+		node.dispatchEvent(new MouseEvent('mouseenter'));
+		expect(second.show).toHaveBeenCalledTimes(1);
+	});
+
+	it('no-ops safely when no controller is provided', () => {
+		const node = document.createElement('div');
+		const action = attributeHover(node, { controller: undefined, id: EAttribute.Strength });
+		expect(() => node.dispatchEvent(new MouseEvent('mouseenter'))).not.toThrow();
+		action.destroy();
+	});
+});


### PR DESCRIPTION
## Summary

Pulls the duplicated presentational widgets flagged in #705 into shared primitives, cutting real drift. Covers four of the five items; the fifth (centralizing the inventory `ItemTooltip`) is split to a focused follow-up — see _Scope note_ below.

## What changed

1. **`.mono-label` utility class** — the byte-identical mono/uppercase eyebrow style was re-declared in **6** components (challenges `Challenges`/`OverviewPane`, inventory `EquippedRail`/`EquippedTotals`/`InventoryGrid`/`InventoryToolbar`). Promoted to a single `.mono-label` utility in `styles/common.scss` (with the `.sm`/`.accent`/`.done` modifiers those copies used) and removed all 6 scoped copies. No template changes — the markup already used `class="mono-label"`.

2. **`RarityTag.svelte`** — new shared component for the rarity pip + label, replacing the inline copies in `inventory/EquipSlot.svelte` and `inventory/ItemDrawer.svelte`. Positioning stays with the caller via passthrough props (`style="margin-top: 3px"` / `margin-left: auto`).

3. **`AttributeChip.svelte`** — new shared component (attribute icon + code, colour tint, `wide` variant) replacing the two **drifted** `.achip` copies in `skills/EquippedBand.svelte` and `skills/SkillDamageBreakdown.svelte`. As the issue noted, one copy wired the attribute tooltip and the other didn't; consolidating **fixes that gap** — the skills screen's attribute-tooltip controller is lifted into `Skills.svelte` and published via `setAttributeTooltip` (mirroring the attribute-breakdown screen), so the equipped-loadout chips now get the same hover explainer the damage-breakdown chips have.

4. **`attributeHover` action** — new action in `components/tooltip/attribute-hover.ts` that wires the shared attribute-tooltip controller on hover (and focus) for an element, replacing the per-row `showTip`/`moveTip`/`hideTip` boilerplate in `attributes/GuidedRow.svelte`, `attributes/TheoryRow.svelte`, and `attribute-breakdown/AttributeListRow.svelte`. (An action can't call `getContext`, so the owning component resolves the controller once and passes it in.)

## How it addresses #705

Items 1–4 of #705 (mono-label, RarityTag, AttributeChip, attribute-hover) are implemented here, including the live `.achip` tooltip-drift fix the issue called out.

## Scope note — item 5 split to #766

#705's fifth item (lift the inventory `ItemTooltip` into one screen-level controller) is a **stateful** controller lift, not a presentational extraction: it makes `EquippedRail`/`InventoryGrid` depend on a context-provided controller and requires reworking their isolation tests (which currently assert on a per-component `registerTooltipComponent` mock). I split it into **#766** so it gets focused review rather than riding along here. Happy to fold it back in if you'd prefer it in one PR.

## Test plan

- [x] New unit tests: `RarityTag.test.ts`, `AttributeChip.test.ts` (renders code/icon/tint, `wide` variant, drives the tooltip on hover), `tooltip/attribute-hover.test.ts` (hover + focus anchoring, reactive update, destroy cleanup, no-controller no-op).
- [x] `npm run lint` (eslint + svelte-check): clean.
- [x] `npm run test:unit:ci`: **1815 passed**, coverage gates green (components area 97.4% stmts).

Closes #705.

https://claude.ai/code/session_01Un2v9jyodBxSj1UriFLhTg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Un2v9jyodBxSj1UriFLhTg)_