### PR TITLE
Keep the loom engine DOM-free & de-duplicate the tick↔pixel projection (#706)

### DIFF
--- a/UI/src/lib/card-game/loom-game.ts
+++ b/UI/src/lib/card-game/loom-game.ts
@@ -57,13 +57,16 @@ export interface CritMark {
 	used: boolean;
 }
 
+/** Semantic kind of a resolution flash. The Board maps each to a board
+ *  position and themeable colour, so the engine stays free of pixels and CSS. */
+export type FlashKind = 'block' | 'enemyHit' | 'interrupt' | 'crit' | 'guarded' | 'strike' | 'channel';
+
 export interface FlashFx {
 	id: number;
-	/** Vertical position within the board (px); flashes always sit on the NOW line. */
-	y: number;
+	/** What resolved; the Board resolves this to a board y-position and colour. */
+	kind: FlashKind;
+	/** Display text for the flash (a damage number or an outcome label). */
 	text: string;
-	/** Themeable CSS colour token. */
-	color: string;
 	/** Remaining lifetime in seconds. */
 	ttl: number;
 }
@@ -76,24 +79,6 @@ export interface HandCard {
 }
 
 export type Outcome = 'win' | 'lose' | null;
-
-/** Lane-relative board y-positions (px) where resolution flashes appear. */
-const FLASH_Y = {
-	topImpact: 36,
-	crit: 116,
-	guarded: 92,
-	bottomImpact: 160
-} as const;
-
-const FLASH_COLOR = {
-	block: 'var(--health-remaining-color)',
-	enemyHit: 'var(--enemy-accent)',
-	interrupt: 'var(--rarity-epic)',
-	crit: 'var(--gold)',
-	guarded: 'var(--log-enemy)',
-	strike: 'var(--log-enemy)',
-	channel: 'var(--rarity-epic)'
-} as const;
 
 export class LoomGame {
 	/* ── timeline ──────────────────────────────────────────────────────── */
@@ -408,17 +393,17 @@ export class LoomGame {
 	private resolveEnemyHit(e: Entity, resolve: number): void {
 		e.resolved = true;
 		if (spanActiveAt(this.blockLane, resolve)) {
-			this.flash(FLASH_Y.topImpact, 'BLOCK', FLASH_COLOR.block);
+			this.flash('block', 'BLOCK');
 			return;
 		}
 		this.playerHP = Math.max(0, this.playerHP - (e.dmg ?? 0));
-		this.flash(FLASH_Y.topImpact, `-${e.dmg}`, FLASH_COLOR.enemyHit);
+		this.flash('enemyHit', `-${e.dmg}`);
 		// An unblocked hit interrupts a player Channel mid-wind-up.
 		for (const ch of this.ents) {
 			if (ch.type === 'channel' && !ch.resolved && resolve >= ch.start && resolve < ch.end) {
 				ch.resolved = true;
 				ch.cancelled = true;
-				this.flash(FLASH_Y.bottomImpact, 'interrupted', FLASH_COLOR.interrupt);
+				this.flash('interrupt', 'interrupted');
 			}
 		}
 	}
@@ -431,17 +416,13 @@ export class LoomGame {
 			if (mark) {
 				mark.used = true;
 			}
-			this.flash(FLASH_Y.crit, 'CRIT ×2', FLASH_COLOR.crit);
+			this.flash('crit', 'CRIT ×2');
 		}
 		if (outcome.guarded) {
-			this.flash(FLASH_Y.guarded, 'GUARDED', FLASH_COLOR.guarded);
+			this.flash('guarded', 'GUARDED');
 		}
 		this.enemyHP = Math.max(0, this.enemyHP - outcome.dmg);
-		this.flash(
-			FLASH_Y.bottomImpact,
-			`-${outcome.dmg}`,
-			e.type === 'channel' ? FLASH_COLOR.channel : FLASH_COLOR.strike
-		);
+		this.flash(e.type === 'channel' ? 'channel' : 'strike', `-${outcome.dmg}`);
 	}
 
 	/* ── reflex ────────────────────────────────────────────────────────── */
@@ -455,8 +436,8 @@ export class LoomGame {
 	}
 
 	/* ── housekeeping ──────────────────────────────────────────────────── */
-	private flash(y: number, text: string, color: string): void {
-		this.flashes.push({ id: this.nextFlashId++, y, text, color, ttl: 0.6 });
+	private flash(kind: FlashKind, text: string): void {
+		this.flashes.push({ id: this.nextFlashId++, kind, text, ttl: 0.6 });
 	}
 
 	private decayFlashes(dt: number): void {

--- a/UI/src/routes/game/screens/card-game/card-game-view.svelte.ts
+++ b/UI/src/routes/game/screens/card-game/card-game-view.svelte.ts
@@ -49,6 +49,21 @@ export class CardGameView {
 		return this.boardWidth * NOW_FRACTION;
 	}
 
+	/* ── tick ↔ pixel projection ───────────────────────────────────────────
+	   The single source for the scrolling timeline's tick→pixel mapping; the
+	   Board, the placement preview, and the pointer math all project through
+	   this pair so the board and preview can never desync. */
+
+	/** Board-local x (px) of a timeline `tick` at the current scroll position. */
+	tickToX(tick: number): number {
+		return this.nowX + (tick - this.game.playTick) * PX_PER_TICK;
+	}
+
+	/** Inverse of {@link tickToX}: the (fractional) tick at a board-local x. */
+	xToTick(boardX: number): number {
+		return (boardX - this.nowX) / PX_PER_TICK + this.game.playTick;
+	}
+
 	/** Where a card would land if cast right now — an active drag aim, else the
 	 *  hover hint at the lane tail. Null when nothing is hovered/dragged. */
 	get preview(): PlacementPreview | null {
@@ -57,7 +72,7 @@ export class CardGameView {
 		}
 		const d = this.drag;
 		if (d?.started) {
-			const desired = Math.round((d.pointerX - this.boardLeft - this.nowX) / PX_PER_TICK + this.game.playTick);
+			const desired = this.tickAtClientX(d.pointerX);
 			const p = this.game.aimPlacement(d.key, desired);
 			return { key: d.key, kind: p.kind, start: p.start, dur: p.dur, hint: false };
 		}
@@ -110,9 +125,10 @@ export class CardGameView {
 		this.hoverKey = null;
 	}
 
-	/** Convert a client x-coordinate to a board tick (for the aimed cast). */
+	/** Convert a client x-coordinate to a board tick (for the aimed cast),
+	 *  snapped to the nearest tick. */
 	tickAtClientX(clientX: number): number {
-		return Math.round((clientX - this.boardLeft - this.nowX) / PX_PER_TICK + this.game.playTick);
+		return Math.round(this.xToTick(clientX - this.boardLeft));
 	}
 
 	/* ── hover hint ────────────────────────────────────────────────────── */

--- a/UI/src/routes/game/screens/card-game/loom/Board.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/Board.svelte
@@ -1,11 +1,11 @@
 <div class="board" bind:this={boardEl} bind:clientWidth={view.boardWidth}>
-	<div class="gridlayer" style:background-position-x="{view.nowX + (0.5 - game.playTick) * PXT}px"></div>
+	<div class="gridlayer" style:background-position-x="{view.tickToX(0.5)}px"></div>
 
 	<span class="lane-label" style="top:4px">
 		<b style="color:var(--log-enemy)">enemy strikes</b> <b style="color:var(--health-remaining-color)">· your blocks</b>
 	</span>
 	<span class="lane-label" style="top:96px">
-		<b style="color:var(--log-enemy)">your strikes</b> <b style="color:var(--log-enemy)">· enemy guard</b>
+		<b style="color:var(--log-player)">your strikes</b> <b style="color:var(--log-enemy)">· enemy guard</b>
 	</span>
 	<div class="lanediv" style="top:92px"></div>
 
@@ -28,9 +28,7 @@
 			class="preview {preview.kind === 'block' ? 'block' : 'attack'}"
 			class:pvhint={preview.hint}
 			style:width="{preview.dur * PXT}px"
-			style:transform="translateX({view.nowX +
-				(preview.start - game.playTick) * PXT -
-				(preview.kind === 'block' ? PXT / 2 : 0)}px)"
+			style:transform="translateX({view.tickToX(preview.start - (preview.kind === 'block' ? 0.5 : 0))}px)"
 		>
 			{CARDS[preview.key].label}
 		</div>
@@ -38,7 +36,14 @@
 
 	<!-- resolution flashes -->
 	{#each game.flashes as f (f.id)}
-		<div class="flash" style:left="{view.nowX}px" style:top="{f.y}px" style:color={f.color}>{f.text}</div>
+		<div
+			class="flash"
+			style:left="{view.nowX}px"
+			style:top="{FLASH_LAYOUT[f.kind].y}px"
+			style:color={FLASH_LAYOUT[f.kind].color}
+		>
+			{f.text}
+		</div>
 	{/each}
 
 	{#if game.over && game.outcome}
@@ -48,7 +53,7 @@
 
 <script lang="ts">
 import { onMount } from 'svelte';
-import { CARDS, PX_PER_TICK, type CritMark, type Entity, type EntityType } from '$lib/card-game';
+import { CARDS, PX_PER_TICK, type CritMark, type Entity, type EntityType, type FlashKind } from '$lib/card-game';
 import type { CardGameView } from '../card-game-view.svelte';
 import BoardEntity from './BoardEntity.svelte';
 import OutcomeBanner from './OutcomeBanner.svelte';
@@ -60,13 +65,29 @@ const { view }: Props = $props();
 const game = $derived(view.game);
 const PXT = PX_PER_TICK;
 
+/* Board placement (y px) + themeable colour for each semantic flash kind — the
+   loom engine emits the kind; the presentation (pixels + CSS tokens) lives here.
+   Player strikes use the player combat-log hue (--log-player); the enemy's guard
+   keeps the enemy hue (--log-enemy); player blocks stay the board's block green. */
+const FLASH_LAYOUT: Record<FlashKind, { y: number; color: string }> = {
+	enemyHit: { y: 36, color: 'var(--enemy-accent)' },
+	block: { y: 36, color: 'var(--health-remaining-color)' },
+	guarded: { y: 92, color: 'var(--log-enemy)' },
+	crit: { y: 116, color: 'var(--gold)' },
+	strike: { y: 160, color: 'var(--log-player)' },
+	channel: { y: 160, color: 'var(--rarity-epic)' },
+	interrupt: { y: 160, color: 'var(--rarity-epic)' }
+};
+
 let boardEl: HTMLDivElement;
 
 const isCover = (type: EntityType) => type === 'block' || type === 'enemyblock';
 
-const entX = (e: Entity) => view.nowX + (e.start - game.playTick) * PXT - (isCover(e.type) ? PXT / 2 : 0);
+// Cover spans (blocks/guards) and crit columns sit half a tick earlier so they
+// visually centre on the cell their half-open coverage rule occupies.
+const entX = (e: Entity) => view.tickToX(e.start - (isCover(e.type) ? 0.5 : 0));
 const entW = (e: Entity) => Math.max((e.end - e.start) * PXT, 30);
-const critX = (c: CritMark) => view.nowX + (c.tick - game.playTick) * PXT - PXT / 2;
+const critX = (c: CritMark) => view.tickToX(c.tick - 0.5);
 
 // A derived local so `{#if preview}` narrows it to non-null inside the block.
 const preview = $derived(view.preview);
@@ -253,7 +274,7 @@ onMount(() => {
 
 .preview.attack {
 	top: 118px;
-	border-color: color-mix(in srgb, var(--log-enemy) 60%, transparent);
+	border-color: color-mix(in srgb, var(--log-player) 60%, transparent);
 }
 
 /* ── flashes ───────────────────────────────────────────────────────────── */

--- a/UI/src/routes/game/screens/card-game/loom/BoardEntity.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/BoardEntity.svelte
@@ -118,18 +118,18 @@ const hasTip = $derived(
 
 .ent.attack {
 	top: 118px;
-	border-color: color-mix(in srgb, var(--log-enemy) 88%, transparent);
+	border-color: color-mix(in srgb, var(--log-player) 88%, transparent);
 	background: linear-gradient(
 		180deg,
-		color-mix(in srgb, var(--log-enemy) 46%, var(--surface)),
-		color-mix(in srgb, var(--log-enemy) 30%, var(--surface))
+		color-mix(in srgb, var(--log-player) 46%, var(--surface)),
+		color-mix(in srgb, var(--log-player) 30%, var(--surface))
 	);
-	color: color-mix(in srgb, var(--log-enemy) 12%, var(--white));
+	color: color-mix(in srgb, var(--log-player) 12%, var(--white));
 	box-shadow: 0 2px 10px color-mix(in srgb, var(--black) 45%, transparent);
 
 	.tip {
-		background: color-mix(in srgb, var(--log-enemy) 60%, var(--white));
-		box-shadow: 0 0 8px color-mix(in srgb, var(--log-enemy) 70%, transparent);
+		background: color-mix(in srgb, var(--log-player) 60%, var(--white));
+		box-shadow: 0 0 8px color-mix(in srgb, var(--log-player) 70%, transparent);
 	}
 }
 

--- a/UI/src/routes/game/screens/card-game/loom/Legend.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/Legend.svelte
@@ -55,8 +55,8 @@ const ITEMS = [
 	);
 }
 .sw.at {
-	border-color: color-mix(in srgb, var(--log-enemy) 60%, transparent);
-	background: color-mix(in srgb, var(--log-enemy) 14%, transparent);
+	border-color: color-mix(in srgb, var(--log-player) 60%, transparent);
+	background: color-mix(in srgb, var(--log-player) 14%, transparent);
 }
 .sw.ch {
 	border-color: var(--rarity-epic);

--- a/UI/src/tests/lib/card-game/loom-game.test.ts
+++ b/UI/src/tests/lib/card-game/loom-game.test.ts
@@ -119,6 +119,63 @@ describe('LoomGame — resolution', () => {
 	});
 });
 
+describe('LoomGame — resolution flashes', () => {
+	/* The engine emits presentation-free semantic flash kinds; the Board maps
+	   each to a board position + themeable colour. These pin the kind each
+	   resolution path emits. */
+	const kinds = (game: LoomGame) => game.flashes.map((f) => f.kind);
+
+	it('emits an "enemyHit" flash when an enemy strike lands unblocked', () => {
+		const game = new LoomGame(zeroRng);
+		advanceTo(game, 10); // first enemy strike resolves unblocked at tick 9
+		expect(kinds(game)).toContain('enemyHit');
+	});
+
+	it('emits a "block" flash (and no others on that hit) when a strike is blocked', () => {
+		const game = new LoomGame(zeroRng);
+		game.hand = [{ id: 1, key: 'guard' }];
+		game.castSlot(0, 7); // [7,14) covers the enemy resolve at 9
+		advanceTo(game, 10);
+		expect(kinds(game)).toContain('block');
+		expect(kinds(game)).not.toContain('enemyHit');
+	});
+
+	it('emits "crit" and "strike" flashes when a strike doubles on a crit tick', () => {
+		const game = new LoomGame(zeroRng);
+		game.hand = [{ id: 1, key: 'slash' }];
+		game.castSlot(0, 8); // [8,11], resolves on the crit mark at tick 11
+		advanceTo(game, 12);
+		expect(kinds(game)).toEqual(expect.arrayContaining(['crit', 'strike']));
+	});
+
+	it('emits a "guarded" flash when a strike resolves inside the boss guard', () => {
+		const game = new LoomGame(zeroRng);
+		game.hand = [{ id: 1, key: 'slash' }];
+		game.castSlot(0, 14); // [14,17], resolves at 17 inside enemy guard [16,20)
+		advanceTo(game, 18);
+		expect(kinds(game)).toEqual(expect.arrayContaining(['guarded', 'strike']));
+	});
+
+	it('emits a "channel" flash when a player Channel resolves', () => {
+		const game = new LoomGame(zeroRng);
+		game.hand = [{ id: 1, key: 'channel' }];
+		game.castSlot(0); // quick-cast [0,9]; resolves at 9 before any enemy hit can interrupt it
+		advanceTo(game, 10);
+		expect(kinds(game)).toContain('channel');
+		expect(game.enemyHP).toBe(74); // 120 - 46
+	});
+
+	it('emits an "interrupt" flash and cancels the Channel when an unblocked hit lands mid-wind-up', () => {
+		const game = new LoomGame(zeroRng);
+		game.hand = [{ id: 1, key: 'channel' }];
+		game.castSlot(0, 3); // [3,12], still winding up when the enemy strike resolves at 9
+		advanceTo(game, 10);
+		expect(kinds(game)).toContain('interrupt');
+		const channel = game.ents.find((e) => e.type === 'channel');
+		expect(channel?.cancelled).toBe(true);
+	});
+});
+
 describe('LoomGame — deck economy', () => {
 	it('draws over time to refill the hand toward the cap', () => {
 		const game = new LoomGame(zeroRng); // hand 4, deck 10, drawInterval 1.95s

--- a/UI/src/tests/routes/game/screens/card-game/card-game-view.test.ts
+++ b/UI/src/tests/routes/game/screens/card-game/card-game-view.test.ts
@@ -27,6 +27,36 @@ describe('CardGameView — board geometry', () => {
 	});
 });
 
+describe('CardGameView — tick ↔ pixel projection', () => {
+	beforeEach(() => {
+		view.boardWidth = 200; // nowX = 60
+	});
+
+	it('projects a tick to its board-local x at the current scroll position', () => {
+		expect(view.tickToX(0)).toBeCloseTo(60, 5); // playTick 0 → NOW line
+		expect(view.tickToX(5)).toBeCloseTo(60 + 5 * PX_PER_TICK, 5);
+		view.game.playTick = 3; // scroll forward: tick 3 now sits on the NOW line
+		expect(view.tickToX(3)).toBeCloseTo(60, 5);
+	});
+
+	it('xToTick is the exact inverse of tickToX (round-trips at any scroll)', () => {
+		for (const playTick of [0, 3.5, 42]) {
+			view.game.playTick = playTick;
+			for (const tick of [-2, 0, 1.5, 7, 100]) {
+				expect(view.xToTick(view.tickToX(tick))).toBeCloseTo(tick, 5);
+			}
+		}
+	});
+
+	it('tickAtClientX is xToTick (offset by the board left edge) snapped to the nearest tick', () => {
+		view.boardLeft = 20;
+		view.game.playTick = 3;
+		const clientX = 20 + 60 + 5 * PX_PER_TICK; // boardLeft + nowX + 5 ticks of pixels
+		expect(view.tickAtClientX(clientX)).toBe(Math.round(view.xToTick(clientX - 20)));
+		expect(view.tickAtClientX(clientX)).toBe(8); // 5 + playTick 3
+	});
+});
+
 describe('CardGameView — pointer→tick conversion', () => {
 	beforeEach(() => {
 		view.boardWidth = 200; // nowX = 60

--- a/UI/src/tests/routes/game/screens/card-game/loom/Board.test.ts
+++ b/UI/src/tests/routes/game/screens/card-game/loom/Board.test.ts
@@ -100,3 +100,23 @@ describe('Board — pointer drag wiring', () => {
 		expect(view.game.hand).toHaveLength(1);
 	});
 });
+
+describe('Board — flash rendering', () => {
+	it('maps a semantic flash kind to its board y-position and themeable colour', () => {
+		const view = new CardGameView();
+		view.game.flashes = [
+			{ id: 1, kind: 'strike', text: '-16', ttl: 0.6 },
+			{ id: 2, kind: 'enemyHit', text: '-8', ttl: 0.6 }
+		];
+		const { container } = render(Board, { props: { view } });
+		const flashes = Array.from(container.querySelectorAll('.flash')) as HTMLElement[];
+
+		const strike = flashes.find((f) => f.textContent?.includes('-16'));
+		expect(strike?.style.top).toBe('160px'); // player-strike row
+		expect(strike?.style.color).toBe('var(--log-player)'); // player combat-log hue
+
+		const enemyHit = flashes.find((f) => f.textContent?.includes('-8'));
+		expect(enemyHit?.style.top).toBe('36px'); // enemy-impact row
+		expect(enemyHit?.style.color).toBe('var(--enemy-accent)');
+	});
+});


### PR DESCRIPTION
## Summary

Closes #706. Two related presentation/mechanics-separation fixes in the card minigame ("Initiative Loom").

## Part 1 — the "pure mechanics" engine no longer embeds presentation

`lib/card-game/loom-game.ts` was documented as DOM/CSS-free yet hardcoded board pixel y-positions (`FLASH_Y`) and CSS colour tokens (`FLASH_COLOR`).

- `LoomGame` now emits a **semantic `FlashKind`** (`block | enemyHit | interrupt | crit | guarded | strike | channel`); `FLASH_Y`/`FLASH_COLOR` are gone. The `flash()` helper takes a kind, not pixels/colour.
- `Board.svelte` owns the kind → `{ y, color }` mapping (`FLASH_LAYOUT`) — the one place pixels and CSS tokens live. The pixel positions are unchanged from the old `FLASH_Y`.

### Semantic-token corrections (the "pick correct tokens" part of the issue)

The issue flagged `--log-enemy` used for the **player's** strike, and the redundant `guarded`/`strike` duplicate. Resolved by giving the player strike the (previously **unused**, semantically-correct) `--log-player` hue:

- **strike** → `--log-player`. To keep the flash consistent with the card that produced it, I recoloured the whole player-strike concept from `--log-enemy` → `--log-player`: `BoardEntity` `.ent.attack`, the `.preview.attack` border, the "your strikes" lane label, and the `Legend` swatch. This also makes the player-strike lane visually distinct from the enemy (salmon) lanes, which reads more clearly.
- **guarded** → keeps `--log-enemy` (it signals the *enemy's* guard reducing your damage, matching the enemy-guard band) — now distinct from `strike`, resolving the duplicate.
- **block** → kept `--health-remaining-color`. The issue listed this as "misused", but player-block surfaces are themed with that green **board-wide** (lane label, `.ent.block`, `.preview.block`, `Legend`), and green correctly reads as "damage negated". Recolouring only the flash would desync it from the block lane, and there's no dedicated block/shield token. I left it consistent and am flagging it here rather than introducing an inconsistency — happy to add a dedicated token in a follow-up if you'd prefer.
- **enemyHit / crit / channel / interrupt** unchanged.

> ⚠️ The player-strike recolour (salmon → accent) is a visible change. If the salmon-for-player-strikes was intentional, say so and I'll revert just the hue while keeping the structural split.

## Part 2 — the tick→pixel projection was hand-written 5+ times

`nowX + (tick - playTick) * PX_PER_TICK` (plus the `±PXT/2` cover offset and its inverse) was duplicated across `Board.svelte` and `card-game-view.svelte.ts`, so the board and preview could desync if the scroll model changed.

- Added **`tickToX` / `xToTick`** to `CardGameView` as the single projection pair. The `±½-tick` cover offset is folded into tick-space (`tickToX(start - 0.5)`), so there's no separate offset constant.
- `Board` (`entX`, `critX`, gridlayer, preview transform) and the view-model's pointer math (`tickAtClientX`, the drag preview's `desired`) all route through them — the two pointer-math copies are now one.

## Test plan

- [x] **loom-game.test.ts** — new `resolution flashes` suite asserts the `FlashKind` each resolution path emits (`enemyHit`, `block`, `crit`+`strike`, `guarded`, `channel`, `interrupt`).
- [x] **card-game-view.test.ts** — `tickToX`/`xToTick` round-trip (inverse) across multiple scroll positions; `tickAtClientX` re-expressed via `xToTick`.
- [x] **Board.test.ts** — a flash kind maps to the expected board y-position and colour token.
- [x] `npm run lint` (eslint + svelte-check): clean.
- [x] `npm run test:unit:ci`: **1816 passed**, coverage gates green.

Closes #706.

https://claude.ai/code/session_01962dEexGxx4nnRnTps8ack

---
_Generated by [Claude Code](https://claude.ai/code/session_01962dEexGxx4nnRnTps8ack)_