### PR TITLE
Thread CancellationToken through LoginTrackingService and SessionStore.GetSession (#708)

### DIFF
--- a/Game.Abstractions/DataAccess/ISessionStore.cs
+++ b/Game.Abstractions/DataAccess/ISessionStore.cs
@@ -5,7 +5,7 @@ namespace Game.Abstractions.DataAccess
     // Sessions are keyed by the user/account id (not PlayerState.PlayerId, which is a distinct value).
     public interface ISessionStore
     {
-        public Task<PlayerState?> GetSession(int userId);
+        public Task<PlayerState?> GetSession(int userId, CancellationToken cancellationToken = default);
         public void Update(PlayerState sessionData, int userId);
         public void Clear(int userId);
     }

--- a/Game.Abstractions/DataAccess/IUserLogins.cs
+++ b/Game.Abstractions/DataAccess/IUserLogins.cs
@@ -21,7 +21,8 @@ namespace Game.Abstractions.DataAccess
             string userAgent,
             string? secChUa,
             string? secChUaMobile,
-            string? secChUaPlatform);
+            string? secChUaPlatform,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enriches (creating when new) the <c>Device</c> for the given fingerprint with the capabilities the
@@ -35,6 +36,7 @@ namespace Game.Abstractions.DataAccess
             string? secChUaMobile,
             string? secChUaPlatform,
             double? deviceMemory,
-            int? hardwareConcurrency);
+            int? hardwareConcurrency,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/Game.Api.Tests/Unit/RequestLoggingMiddlewareTests.cs
+++ b/Game.Api.Tests/Unit/RequestLoggingMiddlewareTests.cs
@@ -52,7 +52,7 @@ namespace Game.Api.Tests.Unit
 
         private sealed class NoOpSessionStore : ISessionStore
         {
-            public Task<PlayerState?> GetSession(int userId) => Task.FromResult<PlayerState?>(null);
+            public Task<PlayerState?> GetSession(int userId, CancellationToken cancellationToken = default) => Task.FromResult<PlayerState?>(null);
             public void Update(PlayerState sessionData, int userId) { }
             public void Clear(int userId) { }
         }

--- a/Game.Api.Tests/Unit/SessionServiceTests.cs
+++ b/Game.Api.Tests/Unit/SessionServiceTests.cs
@@ -45,6 +45,20 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
+        public async Task LoadPlayerState_ForwardsCancellationTokenToStore()
+        {
+            // The token (HttpContext.RequestAborted) must reach the session store so a cancelled request
+            // unwinds the cache read cooperatively rather than running it to completion.
+            var store = new FakeSessionStore();
+            var session = new SessionService(store);
+            using var cts = new CancellationTokenSource();
+
+            await session.LoadPlayerState(5, cts.Token);
+
+            Assert.Equal(cts.Token, store.LastGetSessionToken);
+        }
+
+        [Fact]
         public async Task RehydrateSession_EstablishesAndPersistsSession()
         {
             var store = new FakeSessionStore();
@@ -110,8 +124,14 @@ namespace Game.Api.Tests.Unit
         {
             public PlayerState? Session { get; set; }
             public List<(PlayerState State, int UserId)> Updates { get; } = [];
+            public CancellationToken LastGetSessionToken { get; private set; }
 
-            public Task<PlayerState?> GetSession(int userId) => Task.FromResult(Session);
+            public Task<PlayerState?> GetSession(int userId, CancellationToken cancellationToken = default)
+            {
+                LastGetSessionToken = cancellationToken;
+                return Task.FromResult(Session);
+            }
+
             public void Update(PlayerState sessionData, int userId) => Updates.Add((sessionData, userId));
             public void Clear(int userId) { }
         }

--- a/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
@@ -143,7 +143,7 @@ namespace Game.Api.Tests.Unit
 
         private sealed class NoOpSessionStore : ISessionStore
         {
-            public Task<PlayerState?> GetSession(int userId) => Task.FromResult<PlayerState?>(null);
+            public Task<PlayerState?> GetSession(int userId, CancellationToken cancellationToken = default) => Task.FromResult<PlayerState?>(null);
             public void Update(PlayerState sessionData, int playerId) { }
             public void Clear(int userId) { }
         }

--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -385,7 +385,7 @@ namespace Game.Api.Tests.Unit
 
         private sealed class NoOpSessionStore : ISessionStore
         {
-            public Task<PlayerState?> GetSession(int userId) => Task.FromResult<PlayerState?>(null);
+            public Task<PlayerState?> GetSession(int userId, CancellationToken cancellationToken = default) => Task.FromResult<PlayerState?>(null);
             public void Update(PlayerState sessionData, int playerId) { }
             public void Clear(int userId) { }
         }

--- a/Game.Api.Tests/Unit/SocketContextTests.cs
+++ b/Game.Api.Tests/Unit/SocketContextTests.cs
@@ -150,7 +150,7 @@ namespace Game.Api.Tests.Unit
 
         private sealed class NoOpSessionStore : ISessionStore
         {
-            public Task<PlayerState?> GetSession(int userId) => Task.FromResult<PlayerState?>(null);
+            public Task<PlayerState?> GetSession(int userId, CancellationToken cancellationToken = default) => Task.FromResult<PlayerState?>(null);
             public void Update(PlayerState sessionData, int playerId) { }
             public void Clear(int userId) { }
         }

--- a/Game.Api.Tests/Unit/SocketSerializationTests.cs
+++ b/Game.Api.Tests/Unit/SocketSerializationTests.cs
@@ -88,7 +88,7 @@ namespace Game.Api.Tests.Unit
 
         private sealed class NoOpSessionStore : ISessionStore
         {
-            public Task<PlayerState?> GetSession(int userId) => Task.FromResult<PlayerState?>(null);
+            public Task<PlayerState?> GetSession(int userId, CancellationToken cancellationToken = default) => Task.FromResult<PlayerState?>(null);
             public void Update(PlayerState sessionData, int playerId) { }
             public void Clear(int userId) { }
         }

--- a/Game.Api/Controllers/LoginController.cs
+++ b/Game.Api/Controllers/LoginController.cs
@@ -137,7 +137,8 @@ namespace Game.Api.Controllers
                 hints.SecChUaMobile,
                 hints.SecChUaPlatform,
                 request.DeviceMemory,
-                request.HardwareConcurrency);
+                request.HardwareConcurrency,
+                HttpContext.RequestAborted);
 
             return ApiResponse.Success();
         }

--- a/Game.Api/Middleware/LoginTrackingMiddleware.cs
+++ b/Game.Api/Middleware/LoginTrackingMiddleware.cs
@@ -32,7 +32,8 @@ namespace Game.Api.Middleware
                         hints.UserAgent,
                         hints.SecChUa,
                         hints.SecChUaMobile,
-                        hints.SecChUaPlatform);
+                        hints.SecChUaPlatform,
+                        context.RequestAborted);
                 }
                 catch (Exception ex)
                 {

--- a/Game.Api/Middleware/SessionLoaderMiddleware.cs
+++ b/Game.Api/Middleware/SessionLoaderMiddleware.cs
@@ -26,7 +26,7 @@ namespace Game.Api.Middleware
             if (principal.Identity?.IsAuthenticated == true
                 && int.TryParse(principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value, out var userId))
             {
-                await sessionService.LoadPlayerState(userId);
+                await sessionService.LoadPlayerState(userId, context.RequestAborted);
 
                 // A valid token whose session cache entry is gone (Redis flush, TTL lapse, or a session
                 // never established on this instance) is authenticated-but-uncached, not anonymous. Rebuild

--- a/Game.Api/Services/SessionService.cs
+++ b/Game.Api/Services/SessionService.cs
@@ -40,10 +40,10 @@ namespace Game.Api.Services
         /// <see cref="HasPlayerSession"/> false for the caller to rehydrate. Called by
         /// SessionLoaderMiddleware on every authenticated request.
         /// </summary>
-        public async Task LoadPlayerState(int userId)
+        public async Task LoadPlayerState(int userId, CancellationToken cancellationToken = default)
         {
             UserId = userId;
-            var sessionData = await _sessionStore.GetSession(userId);
+            var sessionData = await _sessionStore.GetSession(userId, cancellationToken);
             if (sessionData is not null)
             {
                 PlayerState = sessionData;

--- a/Game.Application.Tests/DataAccess/DataAccessCancellationTests.cs
+++ b/Game.Application.Tests/DataAccess/DataAccessCancellationTests.cs
@@ -77,6 +77,42 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task GetSession_WhenTokenAlreadyCancelled_ThrowsOperationCanceled()
+        {
+            using var scope = CreateScope();
+            var sessionStore = scope.ServiceProvider.GetRequiredService<ISessionStore>();
+
+            // The session read runs on every authenticated request; the token now reaches the wrapped cache
+            // read, so a cancelled budget unwinds it cooperatively (#708).
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => sessionStore.GetSession(1, AlreadyCancelled()));
+        }
+
+        [Fact]
+        public async Task RecordConnection_WhenTokenAlreadyCancelled_ThrowsOperationCanceled()
+        {
+            using var scope = CreateScope();
+            var userLogins = scope.ServiceProvider.GetRequiredService<IUserLogins>();
+
+            // The connection-recording device lookup is the first awaited EF read; Npgsql honours the token
+            // natively, so a pre-cancelled budget unwinds the tracking write rather than running it (#708).
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => userLogins.RecordConnection(
+                    1, "127.0.0.1", "fp-cancel", "ua", null, null, null, AlreadyCancelled()));
+        }
+
+        [Fact]
+        public async Task SaveDeviceInfo_WhenTokenAlreadyCancelled_ThrowsOperationCanceled()
+        {
+            using var scope = CreateScope();
+            var userLogins = scope.ServiceProvider.GetRequiredService<IUserLogins>();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => userLogins.SaveDeviceInfo(
+                    "fp-cancel", "ua", null, null, null, 8, 4, AlreadyCancelled()));
+        }
+
+        [Fact]
         public async Task CommitAsync_WithPendingChanges_WhenTokenAlreadyCancelled_ThrowsOperationCanceled()
         {
             using var scope = CreateScope();

--- a/Game.Application.Tests/Services/LoginTrackingServiceTests.cs
+++ b/Game.Application.Tests/Services/LoginTrackingServiceTests.cs
@@ -1,0 +1,88 @@
+using Game.Abstractions.DataAccess;
+using Game.Application;
+using Game.Application.Services;
+using Xunit;
+
+namespace Game.Application.Tests.Services
+{
+    /// <summary>
+    /// Unit tests for <see cref="LoginTrackingService"/>'s cancellation plumbing (#708): the connection-recording
+    /// and device-info paths run in middleware/controllers outside the per-action commit pipeline, so they must
+    /// forward the request's cancellation token to both the repository read/write and the unit-of-work commit.
+    /// </summary>
+    public class LoginTrackingServiceTests
+    {
+        [Fact]
+        public async Task RecordConnection_ForwardsCancellationTokenToRepoAndCommit()
+        {
+            var userLogins = new FakeUserLogins();
+            var unitOfWork = new FakeUnitOfWork();
+            var service = new LoginTrackingService(userLogins, unitOfWork);
+            using var cts = new CancellationTokenSource();
+
+            await service.RecordConnection(5, "127.0.0.1", "fp", "ua", null, null, null, cts.Token);
+
+            Assert.Equal(cts.Token, userLogins.LastRecordToken);
+            Assert.Equal(cts.Token, unitOfWork.LastCommitToken);
+        }
+
+        [Fact]
+        public async Task SaveDeviceInfo_ForwardsCancellationTokenToRepoAndCommit()
+        {
+            var userLogins = new FakeUserLogins();
+            var unitOfWork = new FakeUnitOfWork();
+            var service = new LoginTrackingService(userLogins, unitOfWork);
+            using var cts = new CancellationTokenSource();
+
+            await service.SaveDeviceInfo("fp", "ua", null, null, null, 8, 4, cts.Token);
+
+            Assert.Equal(cts.Token, userLogins.LastSaveToken);
+            Assert.Equal(cts.Token, unitOfWork.LastCommitToken);
+        }
+
+        private sealed class FakeUserLogins : IUserLogins
+        {
+            public CancellationToken LastRecordToken { get; private set; }
+            public CancellationToken LastSaveToken { get; private set; }
+
+            public Task RecordConnection(
+                int userId,
+                string ipAddress,
+                string deviceFingerprintHash,
+                string userAgent,
+                string? secChUa,
+                string? secChUaMobile,
+                string? secChUaPlatform,
+                CancellationToken cancellationToken = default)
+            {
+                LastRecordToken = cancellationToken;
+                return Task.CompletedTask;
+            }
+
+            public Task SaveDeviceInfo(
+                string deviceFingerprintHash,
+                string userAgent,
+                string? secChUa,
+                string? secChUaMobile,
+                string? secChUaPlatform,
+                double? deviceMemory,
+                int? hardwareConcurrency,
+                CancellationToken cancellationToken = default)
+            {
+                LastSaveToken = cancellationToken;
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class FakeUnitOfWork : IUnitOfWork
+        {
+            public CancellationToken LastCommitToken { get; private set; }
+
+            public Task CommitAsync(CancellationToken cancellationToken = default)
+            {
+                LastCommitToken = cancellationToken;
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/Game.Application/Services/LoginTrackingService.cs
+++ b/Game.Application/Services/LoginTrackingService.cs
@@ -20,11 +20,12 @@ namespace Game.Application.Services
             string userAgent,
             string? secChUa,
             string? secChUaMobile,
-            string? secChUaPlatform)
+            string? secChUaPlatform,
+            CancellationToken cancellationToken = default)
         {
             await _userLogins.RecordConnection(
-                userId, ipAddress, deviceFingerprintHash, userAgent, secChUa, secChUaMobile, secChUaPlatform);
-            await _unitOfWork.CommitAsync();
+                userId, ipAddress, deviceFingerprintHash, userAgent, secChUa, secChUaMobile, secChUaPlatform, cancellationToken);
+            await _unitOfWork.CommitAsync(cancellationToken);
         }
 
         public async Task SaveDeviceInfo(
@@ -34,12 +35,13 @@ namespace Game.Application.Services
             string? secChUaMobile,
             string? secChUaPlatform,
             double? deviceMemory,
-            int? hardwareConcurrency)
+            int? hardwareConcurrency,
+            CancellationToken cancellationToken = default)
         {
             await _userLogins.SaveDeviceInfo(
                 deviceFingerprintHash, userAgent, secChUa, secChUaMobile, secChUaPlatform,
-                deviceMemory, hardwareConcurrency);
-            await _unitOfWork.CommitAsync();
+                deviceMemory, hardwareConcurrency, cancellationToken);
+            await _unitOfWork.CommitAsync(cancellationToken);
         }
     }
 }

--- a/Game.DataAccess/Repositories/SessionStore.cs
+++ b/Game.DataAccess/Repositories/SessionStore.cs
@@ -32,10 +32,10 @@ namespace Game.DataAccess.Repositories
             _cache = cache;
         }
 
-        public async Task<PlayerState?> GetSession(int userId)
+        public async Task<PlayerState?> GetSession(int userId, CancellationToken cancellationToken = default)
         {
             var sessionKey = SessionKey(userId);
-            var session = await _cache.Get<PlayerState>(sessionKey);
+            var session = await _cache.Get<PlayerState>(sessionKey, cancellationToken);
             if (session is not null)
             {
                 // Sliding expiration: a read refreshes the idle TTL so an active session never ages out.

--- a/Game.DataAccess/Repositories/UserLogins.cs
+++ b/Game.DataAccess/Repositories/UserLogins.cs
@@ -21,11 +21,12 @@ namespace Game.DataAccess.Repositories
             string userAgent,
             string? secChUa,
             string? secChUaMobile,
-            string? secChUaPlatform)
+            string? secChUaPlatform,
+            CancellationToken cancellationToken = default)
         {
             ipAddress = Truncate(ipAddress, UserLogin.MaxIpAddressLength) ?? string.Empty;
 
-            var device = await GetOrCreateDevice(deviceFingerprintHash, userAgent, secChUa, secChUaMobile, secChUaPlatform);
+            var device = await GetOrCreateDevice(deviceFingerprintHash, userAgent, secChUa, secChUaMobile, secChUaPlatform, cancellationToken);
 
             // A brand-new device cannot have an existing login, so skip the lookup and rely on the
             // navigation to propagate the generated DeviceId onto the new login when saved.
@@ -42,7 +43,7 @@ namespace Game.DataAccess.Repositories
             }
 
             var login = await _context.UserLogins.FirstOrDefaultAsync(l =>
-                l.UserId == userId && l.IpAddress == ipAddress && l.DeviceId == device.Id);
+                l.UserId == userId && l.IpAddress == ipAddress && l.DeviceId == device.Id, cancellationToken);
 
             if (login is null)
             {
@@ -67,9 +68,10 @@ namespace Game.DataAccess.Repositories
             string? secChUaMobile,
             string? secChUaPlatform,
             double? deviceMemory,
-            int? hardwareConcurrency)
+            int? hardwareConcurrency,
+            CancellationToken cancellationToken = default)
         {
-            var device = await GetOrCreateDevice(deviceFingerprintHash, userAgent, secChUa, secChUaMobile, secChUaPlatform);
+            var device = await GetOrCreateDevice(deviceFingerprintHash, userAgent, secChUa, secChUaMobile, secChUaPlatform, cancellationToken);
 
             device.DeviceMemory = deviceMemory;
             device.HardwareConcurrency = hardwareConcurrency;
@@ -84,14 +86,15 @@ namespace Game.DataAccess.Repositories
             string userAgent,
             string? secChUa,
             string? secChUaMobile,
-            string? secChUaPlatform)
+            string? secChUaPlatform,
+            CancellationToken cancellationToken)
         {
             deviceFingerprintHash = Truncate(deviceFingerprintHash, Device.MaxFingerprintLength) ?? string.Empty;
 
-            var device = await _context.Devices.FirstOrDefaultAsync(d => d.DeviceFingerprintHash == deviceFingerprintHash);
+            var device = await _context.Devices.FirstOrDefaultAsync(d => d.DeviceFingerprintHash == deviceFingerprintHash, cancellationToken);
             if (device is null)
             {
-                var browserInfo = await GetOrCreateBrowserInfo(userAgent, secChUa, secChUaMobile, secChUaPlatform);
+                var browserInfo = await GetOrCreateBrowserInfo(userAgent, secChUa, secChUaMobile, secChUaPlatform, cancellationToken);
                 device = new Device
                 {
                     DeviceFingerprintHash = deviceFingerprintHash,
@@ -112,14 +115,15 @@ namespace Game.DataAccess.Repositories
             string userAgent,
             string? secChUa,
             string? secChUaMobile,
-            string? secChUaPlatform)
+            string? secChUaPlatform,
+            CancellationToken cancellationToken)
         {
             userAgent = Truncate(userAgent, BrowserInfo.MaxUserAgentLength) ?? string.Empty;
             secChUa = Truncate(secChUa, BrowserInfo.MaxClientHintLength);
             secChUaMobile = Truncate(secChUaMobile, BrowserInfo.MaxClientHintLength);
             secChUaPlatform = Truncate(secChUaPlatform, BrowserInfo.MaxClientHintLength);
 
-            var browserInfo = await _context.BrowserInfos.FirstOrDefaultAsync(b => b.UserAgent == userAgent);
+            var browserInfo = await _context.BrowserInfos.FirstOrDefaultAsync(b => b.UserAgent == userAgent, cancellationToken);
             if (browserInfo is null)
             {
                 browserInfo = new BrowserInfo


### PR DESCRIPTION
## Summary

Closes #708. Fills the two remaining gaps in the end-to-end cooperative-cancellation plumbing (#558 / #682) so an aborted/cancelled request no longer keeps these reads/writes running.

## What changed

**1. `LoginTrackingService.RecordConnection` / `SaveDeviceInfo`** (`Game.Application/Services/LoginTrackingService.cs`)
- Both now accept `CancellationToken cancellationToken = default` and forward it to the `IUserLogins` repo call **and** `IUnitOfWork.CommitAsync`.
- `IUserLogins` (interface + `UserLogins` impl) threads the token down to every awaited EF read (`FirstOrDefaultAsync` on devices, browser-infos, logins) via the `GetOrCreateDevice`/`GetOrCreateBrowserInfo` helpers — Npgsql honours it natively.
- Callers supply the request token: `LoginTrackingMiddleware` and `LoginController.DeviceInfo` pass `HttpContext.RequestAborted` (mirroring `CommitFilter`).

**2. `SessionStore.GetSession`** (`Game.DataAccess/Repositories/SessionStore.cs`)
- Accepts a token and forwards it to the wrapped `ICacheService.Get<PlayerState>` read (honoured cooperatively via `WaitAsync`, since StackExchange.Redis has no native token). The fire-and-forget `ExpireAndForget` slide stays tokenless by design (nothing to cancel).
- Threaded through `ISessionStore` → `SessionService.LoadPlayerState` → `SessionLoaderMiddleware`, which now supplies `context.RequestAborted` on every authenticated request.

No documented behavior changes — this completes the threading the rest of the layer already follows, so no doc update was warranted.

## How it addresses the issue

Both paths flagged in #708 now participate in the end-to-end token threading: an aborted HTTP request cancels the login-tracking DB write and the per-request session read instead of running them to completion.

## Test plan

- [x] **`LoginTrackingServiceTests`** (new unit) — `RecordConnection`/`SaveDeviceInfo` forward the token to both the repo and `CommitAsync`.
- [x] **`SessionServiceTests`** — added `LoadPlayerState_ForwardsCancellationTokenToStore`.
- [x] **`DataAccessCancellationTests`** (integration) — added pre-cancelled-token cases for `GetSession`, `RecordConnection`, and `SaveDeviceInfo`, asserting each throws `OperationCanceledException` (proving the token reaches the data-tier I/O), mirroring the existing suite.
- [x] Updated the no-op `ISessionStore` fakes in the affected Api unit tests to the new signature.
- [x] `dotnet build`: clean (0 warnings).
- [x] `dotnet test` Game.Api.Tests: 484 passed.
- [x] `dotnet test` Game.Application.Tests: 260 passed.

Closes #708.

https://claude.ai/code/session_015Pw9aEiaLZgYHXdiiTxe9J

---
_Generated by [Claude Code](https://claude.ai/code/session_015Pw9aEiaLZgYHXdiiTxe9J)_