### PR TITLE
Add enemy-channel resolution test coverage for the loom card game (#709)

### DIFF
--- a/UI/src/tests/lib/card-game/loom-game.test.ts
+++ b/UI/src/tests/lib/card-game/loom-game.test.ts
@@ -119,6 +119,37 @@ describe('LoomGame — resolution', () => {
 	});
 });
 
+describe('LoomGame — enemy channel', () => {
+	/* The enemy's heavy Channel (windup 8, dmg 28 under zeroRng) winds up from
+	   tick 18 and resolves at tick 26 — far harder-hitting than a regular strike
+	   (dmg 8). Nothing else resolves in the [25,27) window, so the HP delta there
+	   isolates the channel. */
+
+	it('applies its full damage when it resolves unblocked', () => {
+		const game = new LoomGame(zeroRng);
+		const channel = () => game.ents.find((e) => e.type === 'enemychannel');
+		advanceTo(game, 25); // past the strikes at 9/16/23, still inside the channel wind-up
+		expect(channel()?.resolved).toBe(false);
+		const before = game.playerHP;
+		advanceTo(game, 27); // cross the channel resolve at tick 26
+		expect(channel()?.resolved).toBe(true);
+		expect(before - game.playerHP).toBe(28); // the channel's full hit, nothing else resolves in [25,27)
+	});
+
+	it('is negated when a block span covers its resolve', () => {
+		const game = new LoomGame(zeroRng);
+		game.hand = [{ id: 1, key: 'dodge' }];
+		game.castSlot(0, 24); // [24,27) covers the channel resolve at 26, but not the strike at 23
+		advanceTo(game, 25);
+		const before = game.playerHP;
+		advanceTo(game, 27);
+		const channel = game.ents.find((e) => e.type === 'enemychannel');
+		expect(channel?.resolved).toBe(true);
+		expect(game.playerHP).toBe(before); // channel fully blocked — no damage
+		expect(game.flashes.map((f) => f.kind)).toContain('block');
+	});
+});
+
 describe('LoomGame — resolution flashes', () => {
 	/* The engine emits presentation-free semantic flash kinds; the Board maps
 	   each to a board position + themeable colour. These pin the kind each


### PR DESCRIPTION
## Summary

Closes #709.

The "Initiative Loom" card minigame's **enemy Channel** — the heavy wind-up attack that resolves for 28–40 damage, the hardest-hitting enemy entity and the only one that can be blocked at its resolve — had no test coverage. The `loom-game.test.ts` header comment even describes the channel (`enemy channel: windup 8, dmg 28, from tick 18 → resolve at 26`) but nothing asserted it.

This adds a focused `LoomGame — enemy channel` describe block with two cases:

- **Unblocked channel applies its full damage.** Under `zeroRng` the channel resolves at tick 26 for 28 damage. Nothing else resolves in the `[25, 27)` window (strikes land at 9/16/23/30; crit ticks deal no player damage), so the player-HP delta across that crossing isolates the channel's hit exactly.
- **A block span covering the resolve negates it.** A `dodge` placed at `[24, 27)` covers the channel resolve at 26 but not the strike at 23, so the player takes no damage from the channel and a `block` flash is emitted.

## On the rest of issue #709

The issue listed two gaps plus a dead-code note. The other two items were **already resolved by PR #768** (`Keep the loom engine DOM-free…`), which landed after the issue was filed:

- the unblocked-hit-cancelling-a-player-Channel-mid-windup case is covered by the existing `emits an "interrupt" flash and cancels the Channel…` test, and
- the dead `if (e.cancelled)` guard the issue flagged is already gone from `loom-game.ts`.

So this PR completes the one remaining gap (enemy-channel resolution) rather than re-doing work already shipped.

## Test plan

- [x] `npx vitest run src/tests/lib/card-game/loom-game.test.ts` → 23 passed (21 existing + 2 new)
- [x] `npm run lint` (eslint + svelte-check) → 0 errors, 0 warnings
- [x] No production code changed — test-only addition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6hu8M3n66Q13hwi5AUKGV)_