### PR TITLE
Harden socket command/IO layer robustness (#712)

### DIFF
--- a/Game.Api.Tests/CodeGen/SocketCommandMetadataTests.cs
+++ b/Game.Api.Tests/CodeGen/SocketCommandMetadataTests.cs
@@ -87,9 +87,9 @@ namespace Game.Api.Tests.CodeGen
     {
         public override string Name { get; set; } = "TestWithResponse";
 
-        public override ApiSocketResponse<SimpleModel> HandleExecute(SocketContext context)
+        public override Task<ApiSocketResponse<SimpleModel>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
-            return Success(new SimpleModel());
+            return Task.FromResult(Success(new SimpleModel()));
         }
     }
 
@@ -97,9 +97,9 @@ namespace Game.Api.Tests.CodeGen
     {
         public override string Name { get; set; } = "TestWithParams";
 
-        public override ApiSocketResponse Execute(SocketContext context)
+        public override Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
-            return Success();
+            return Task.FromResult(Success());
         }
     }
 
@@ -107,9 +107,9 @@ namespace Game.Api.Tests.CodeGen
     {
         public override string Name { get; set; } = "TestFull";
 
-        public override ApiSocketResponse<SimpleModel> HandleExecute(SocketContext context)
+        public override Task<ApiSocketResponse<SimpleModel>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
-            return Success(new SimpleModel());
+            return Task.FromResult(Success(new SimpleModel()));
         }
     }
 
@@ -117,9 +117,9 @@ namespace Game.Api.Tests.CodeGen
     {
         public override string Name { get; set; } = "TestBasic";
 
-        public override ApiSocketResponse Execute(SocketContext context)
+        public override Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
-            return Success();
+            return Task.FromResult(Success());
         }
     }
 
@@ -131,7 +131,7 @@ namespace Game.Api.Tests.CodeGen
     }
 
     // A basic command (no params/response generic base) that nonetheless declares members named
-    // "Parameters" and "HandleExecute". Resolving by raw member name would mis-extract these; gating on
+    // "Parameters" and "HandleExecuteAsync". Resolving by raw member name would mis-extract these; gating on
     // the typed generic base means neither descriptor is set.
     public class TestSocketCommandWithDecoyMembers : AbstractSocketCommand
     {
@@ -139,14 +139,14 @@ namespace Game.Api.Tests.CodeGen
 
         public string Parameters { get; set; } = "";
 
-        public int HandleExecute(SocketContext context)
+        public int HandleExecuteAsync(SocketContext context)
         {
             return 0;
         }
 
-        public override ApiSocketResponse Execute(SocketContext context)
+        public override Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
-            return Success();
+            return Task.FromResult(Success());
         }
     }
 }

--- a/Game.Api.Tests/Unit/GetReferenceDataVersionsTests.cs
+++ b/Game.Api.Tests/Unit/GetReferenceDataVersionsTests.cs
@@ -15,7 +15,7 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
-        public void HandleExecute_ReturnsOneVersionPerReferenceDataCommand()
+        public async Task HandleExecuteAsync_ReturnsOneVersionPerReferenceDataCommand()
         {
             var command = new GetReferenceDataVersions(
             [
@@ -24,7 +24,7 @@ namespace Game.Api.Tests.Unit
             ]);
 
             // The command ignores the socket context entirely.
-            var response = command.HandleExecute(null!);
+            var response = await command.HandleExecuteAsync(null!, CancellationToken.None);
 
             Assert.Null(response.Error);
             Assert.NotNull(response.Data);
@@ -34,7 +34,7 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
-        public void HandleExecute_OrdersVersionsByCommandName()
+        public async Task HandleExecuteAsync_OrdersVersionsByCommandName()
         {
             var command = new GetReferenceDataVersions(
             [
@@ -43,7 +43,7 @@ namespace Game.Api.Tests.Unit
                 new StubReferenceDataCommand { Name = "GetItems", Version = "i" }
             ]);
 
-            var response = command.HandleExecute(null!);
+            var response = await command.HandleExecuteAsync(null!, CancellationToken.None);
 
             Assert.Equal(
                 ["GetAttributes", "GetItems", "GetZones"],
@@ -51,11 +51,11 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
-        public void HandleExecute_ReturnsEmptyWhenNoReferenceDataCommands()
+        public async Task HandleExecuteAsync_ReturnsEmptyWhenNoReferenceDataCommands()
         {
             var command = new GetReferenceDataVersions([]);
 
-            var response = command.HandleExecute(null!);
+            var response = await command.HandleExecuteAsync(null!, CancellationToken.None);
 
             Assert.Null(response.Error);
             Assert.Empty(response.Data);

--- a/Game.Api.Tests/Unit/SocketContextTests.cs
+++ b/Game.Api.Tests/Unit/SocketContextTests.cs
@@ -5,6 +5,7 @@ using Game.Api.Sockets;
 using Game.Core.Players;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Net.WebSockets;
+using System.Text;
 using Xunit;
 
 namespace Game.Api.Tests.Unit
@@ -104,10 +105,194 @@ namespace Game.Api.Tests.Unit
             await context.WaitSocketClosed().WaitAsync(WaitTimeout, cancellationToken);
         }
 
+        [Fact]
+        public async Task SendData_MidFrameCancellation_CompletesTheFrameRatherThanLeavingItHalfSent()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var socket = new ScriptedWebSocket();
+            var context = CreateContext(socket);
+
+            // A payload larger than one frame, so it is sent as multiple chunks under the send lock.
+            var payload = new string('x', SocketContextTests.MaxFrameSize + 1000);
+            using var cts = new CancellationTokenSource();
+            // Cancel the moment the first (non-final) chunk has gone out — mid-frame.
+            socket.AfterSendChunk = isFinal =>
+            {
+                if (!isFinal)
+                {
+                    cts.Cancel();
+                }
+            };
+
+            var sent = await context.SendData(payload, cts.Token).WaitAsync(WaitTimeout, cancellationToken);
+
+            // The frame is written to completion despite the mid-frame cancellation, so the next writer can't
+            // interleave into a half-sent frame.
+            Assert.True(sent);
+            Assert.True(socket.SentFrameEndFlags is [false, true]);
+            Assert.Equal(payload, Assert.Single(socket.SentMessages));
+        }
+
+        [Fact]
+        public async Task SendData_CancelledBeforeAcquiringSendLock_ReturnsFalseAndSendsNothing()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var socket = new ScriptedWebSocket();
+            var context = CreateContext(socket);
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // The cancellation is handled locally (returns false), not allowed to escape as an exception.
+            var sent = await context.SendData("hello", cts.Token).WaitAsync(WaitTimeout, cancellationToken);
+
+            Assert.False(sent);
+            Assert.Empty(socket.SentMessages);
+        }
+
+        [Fact]
+        public async Task ReadMessage_ReassemblesMultiFrameTextMessage()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var socket = new ScriptedWebSocket();
+            var context = CreateContext(socket);
+
+            socket.QueueData("hel", endOfMessage: false);
+            socket.QueueData("lo", endOfMessage: true);
+
+            var message = await context.ReadMessage(cancellationToken).WaitAsync(WaitTimeout, cancellationToken);
+
+            Assert.Equal("hello", message);
+        }
+
+        [Fact]
+        public async Task ReadMessage_CloseFrame_StopsReadingAndReturnsEmpty()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var socket = new ScriptedWebSocket();
+            var context = CreateContext(socket);
+
+            socket.QueueClose();
+
+            // The Close frame is honoured (the read returns promptly instead of looping), leaving the socket in
+            // CloseReceived for the read loop to complete the handshake.
+            var message = await context.ReadMessage(cancellationToken).WaitAsync(WaitTimeout, cancellationToken);
+
+            Assert.Equal("", message);
+            Assert.Equal(WebSocketState.CloseReceived, socket.State);
+        }
+
+        [Fact]
+        public async Task ReadMessage_ZeroLengthFrameFlood_IsBoundedAndClosesAsMessageTooBig()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var socket = new ScriptedWebSocket();
+            var context = CreateContext(socket);
+
+            // A malformed peer streaming endless zero-length continuation frames must not spin forever: every
+            // frame counts toward the cap, so the read trips the size limit and closes.
+            socket.StreamZeroLengthFramesForever();
+
+            await Assert.ThrowsAsync<WebSocketException>(
+                () => context.ReadMessage(cancellationToken).WaitAsync(WaitTimeout, cancellationToken));
+
+            Assert.True(socket.CloseAsyncCalled);
+            Assert.Equal(WebSocketCloseStatus.MessageTooBig, socket.CloseStatusUsed);
+        }
+
         private static SocketContext CreateContext(WebSocket socket)
         {
             var session = new SessionService(new NoOpSessionStore());
             return new SocketContext(socket, playerId: 1, session, NullLogger<SocketContext>.Instance);
+        }
+
+        /// <summary>The frame chunk size <see cref="SocketContext"/> splits outbound sends at (4 KB).</summary>
+        private const int MaxFrameSize = 1024 * 4;
+
+        /// <summary>
+        /// A <see cref="WebSocket"/> stand-in that scripts receives (data / close / a zero-length flood) and
+        /// records outbound frame chunks, so the read-message and send-atomicity contracts can be exercised
+        /// deterministically.
+        /// </summary>
+        private sealed class ScriptedWebSocket : WebSocket
+        {
+            private readonly Queue<ReceiveStep> _receives = new();
+            private bool _floodZeroLengthFrames;
+            private readonly List<byte> _pendingSend = [];
+            private readonly List<string> _sentMessages = [];
+            private WebSocketState _state = WebSocketState.Open;
+
+            /// <summary>The endOfMessage flag of each sent chunk, in order.</summary>
+            public List<bool> SentFrameEndFlags { get; } = [];
+            public IReadOnlyList<string> SentMessages => _sentMessages;
+            public bool CloseAsyncCalled { get; private set; }
+            public WebSocketCloseStatus? CloseStatusUsed { get; private set; }
+
+            /// <summary>Invoked after each chunk is sent, with its endOfMessage flag.</summary>
+            public Action<bool>? AfterSendChunk { get; set; }
+
+            public void QueueData(string text, bool endOfMessage)
+                => _receives.Enqueue(new ReceiveStep(Encoding.UTF8.GetBytes(text), WebSocketMessageType.Text, endOfMessage));
+
+            public void QueueClose()
+                => _receives.Enqueue(new ReceiveStep([], WebSocketMessageType.Close, EndOfMessage: true));
+
+            public void StreamZeroLengthFramesForever() => _floodZeroLengthFrames = true;
+
+            public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (_receives.Count == 0 && _floodZeroLengthFrames)
+                {
+                    return Task.FromResult(new WebSocketReceiveResult(0, WebSocketMessageType.Text, endOfMessage: false));
+                }
+
+                var step = _receives.Dequeue();
+                if (step.Payload.Length > 0)
+                {
+                    Array.Copy(step.Payload, 0, buffer.Array!, buffer.Offset, step.Payload.Length);
+                }
+
+                if (step.Type is WebSocketMessageType.Close)
+                {
+                    _state = WebSocketState.CloseReceived;
+                }
+
+                return Task.FromResult(new WebSocketReceiveResult(step.Payload.Length, step.Type, step.EndOfMessage));
+            }
+
+            public override async Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+            {
+                await Task.Yield();
+                _pendingSend.AddRange(buffer.ToArray());
+                SentFrameEndFlags.Add(endOfMessage);
+                if (endOfMessage)
+                {
+                    _sentMessages.Add(Encoding.UTF8.GetString(_pendingSend.ToArray()));
+                    _pendingSend.Clear();
+                }
+
+                AfterSendChunk?.Invoke(endOfMessage);
+            }
+
+            public override Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
+            {
+                CloseAsyncCalled = true;
+                CloseStatusUsed = closeStatus;
+                _state = WebSocketState.Closed;
+                return Task.CompletedTask;
+            }
+
+            public override WebSocketState State => _state;
+            public override WebSocketCloseStatus? CloseStatus => null;
+            public override string? CloseStatusDescription => null;
+            public override string? SubProtocol => null;
+            public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken) => Task.CompletedTask;
+            public override void Abort() { }
+            public override void Dispose() { }
+
+            private sealed record ReceiveStep(byte[] Payload, WebSocketMessageType Type, bool EndOfMessage);
         }
 
         /// <summary>

--- a/Game.Api/CodeGen/Data/SocketCommandMetadata.cs
+++ b/Game.Api/CodeGen/Data/SocketCommandMetadata.cs
@@ -19,8 +19,12 @@ namespace Game.Api.CodeGen.Data
             // member, and the generic argument is read with a guarded index.
             if (socketCommand.GetClosedGenericBase(typeof(AbstractSocketCommandWithResponseData<>)) is not null)
             {
-                var method = socketCommand.GetMethod(nameof(AbstractSocketCommandWithResponseData<>.HandleExecute));
-                if (method is not null && method.ReturnParameter.GetNullabilityInfo().GenericTypeArguments is [var responseArg, ..])
+                // HandleExecuteAsync returns Task<ApiSocketResponse<T>>; peel the Task and the response
+                // envelope to reach T (the data type the generated client surfaces).
+                var method = socketCommand.GetMethod(nameof(AbstractSocketCommandWithResponseData<>.HandleExecuteAsync));
+                if (method is not null
+                    && method.ReturnParameter.GetNullabilityInfo().GenericTypeArguments is [var responseEnvelope]
+                    && responseEnvelope.GenericTypeArguments is [var responseArg, ..])
                 {
                     ResponseDescriptor = new CodeGenTypeDescriptor(responseArg);
                 }

--- a/Game.Api/Sockets/Commands/AbstractReferenceDataCommand.cs
+++ b/Game.Api/Sockets/Commands/AbstractReferenceDataCommand.cs
@@ -11,14 +11,14 @@ namespace Game.Api.Sockets.Commands
     /// <typeparam name="TModel">The API model type returned in the collection.</typeparam>
     public abstract class AbstractReferenceDataCommand<TModel> : AbstractSocketCommandWithResponseData<IEnumerable<TModel>>, IReferenceDataCommand
     {
-        public override ApiSocketResponse<IEnumerable<TModel>> HandleExecute(SocketContext context)
+        public override Task<ApiSocketResponse<IEnumerable<TModel>>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
-            return Success(GetReferenceData());
+            return Task.FromResult(Success(GetReferenceData()));
         }
 
         /// <summary>
         /// Hashes this set's current data so the frontend can detect a stale cache. Computed from
-        /// the same models <see cref="HandleExecute"/> returns, so the version tracks exactly what
+        /// the same models <see cref="HandleExecuteAsync"/> returns, so the version tracks exactly what
         /// a client would download.
         /// </summary>
         public string ComputeVersion()

--- a/Game.Api/Sockets/Commands/AbstractSocketCommand.cs
+++ b/Game.Api/Sockets/Commands/AbstractSocketCommand.cs
@@ -8,16 +8,10 @@ namespace Game.Api.Sockets.Commands
         public string? Id { get; set; }
         public abstract string Name { get; set; }
 
-        public virtual Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
-        {
-            var result = Execute(context);
-            return Task.FromResult(result);
-        }
-
-        public virtual ApiSocketResponse Execute(SocketContext context)
-        {
-            throw new NotImplementedException();
-        }
+        // The single execution entry point. Abstract (rather than a virtual with a sync companion that
+        // throws) so the compiler forces every command to implement exactly this one method — there is no
+        // wrong-override-at-runtime path. A synchronous handler returns Task.FromResult(...).
+        public abstract Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken);
 
         public virtual void SetParameters(string? parameters) { }
 
@@ -64,26 +58,14 @@ namespace Game.Api.Sockets.Commands
 
     public abstract class AbstractSocketCommandWithResponseData<T> : AbstractSocketCommand
     {
+        // Seals the base entry point onto the typed handler so commands implement only HandleExecuteAsync,
+        // whose ApiSocketResponse<T> return is what the codegen reads to type the client response.
         public sealed override async Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
             return await HandleExecuteAsync(context, cancellationToken);
         }
 
-        public sealed override ApiSocketResponse Execute(SocketContext context)
-        {
-            return base.Execute(context);
-        }
-
-        public virtual Task<ApiSocketResponse<T>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
-        {
-            var result = HandleExecute(context);
-            return Task.FromResult(result);
-        }
-
-        public virtual ApiSocketResponse<T> HandleExecute(SocketContext context)
-        {
-            throw new NotImplementedException();
-        }
+        public abstract Task<ApiSocketResponse<T>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken);
     }
 
     public class SocketCommandInfo

--- a/Game.Api/Sockets/Commands/GetReferenceDataVersions.cs
+++ b/Game.Api/Sockets/Commands/GetReferenceDataVersions.cs
@@ -23,7 +23,7 @@ namespace Game.Api.Sockets.Commands
             _referenceDataCommands = referenceDataCommands;
         }
 
-        public override ApiSocketResponse<IEnumerable<ReferenceDataVersion>> HandleExecute(SocketContext context)
+        public override Task<ApiSocketResponse<IEnumerable<ReferenceDataVersion>>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
             var versions = _referenceDataCommands
                 .Select(command => new ReferenceDataVersion
@@ -34,7 +34,7 @@ namespace Game.Api.Sockets.Commands
                 .OrderBy(version => version.Command, StringComparer.Ordinal)
                 .ToList();
 
-            return Success<IEnumerable<ReferenceDataVersion>>(versions);
+            return Task.FromResult(Success<IEnumerable<ReferenceDataVersion>>(versions));
         }
     }
 }

--- a/Game.Api/Sockets/SocketContext.cs
+++ b/Game.Api/Sockets/SocketContext.cs
@@ -10,6 +10,12 @@ namespace Game.Api.Sockets
     public class SocketContext
     {
         private const short MAX_MESSAGE_SIZE = 1024 * 4;
+
+        // Caps a single inbound message at MAX_FRAMES_PER_MESSAGE * MAX_MESSAGE_SIZE (~4 MB). Every received
+        // frame counts toward it — including empty ones — so a peer streaming zero-length frames is bounded
+        // rather than spinning the read loop until cancellation.
+        private const int MAX_FRAMES_PER_MESSAGE = 1024;
+
         private readonly byte[] _buffer = new byte[MAX_MESSAGE_SIZE];
 
         private readonly TaskCompletionSource<ESocketCloseReason> _socketClosedSource = new();
@@ -46,29 +52,35 @@ namespace Game.Api.Sockets
 
             _logger.LogDebug("Sending data to playerId ({PlayerId}) from socket ({Id}): {Data}", PlayerId, SocketId, data);
             var dataBytes = Encoding.UTF8.GetBytes(data);
-            await _sendLock.WaitAsync(cancellationToken);
+
+            try
+            {
+                await _sendLock.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancelled while waiting for the send lock — no frame was started, so there is nothing to
+                // unwind. Report the send as not delivered rather than letting the cancellation escape.
+                return false;
+            }
+
             try
             {
                 for (int i = 0; i < dataBytes.Length; i += MAX_MESSAGE_SIZE)
                 {
-                    if (dataBytes.Length - i <= MAX_MESSAGE_SIZE)
-                    {
-                        await _socket.SendAsync(
-                            buffer: new ArraySegment<byte>(dataBytes, i, dataBytes.Length - i),
-                            messageType: WebSocketMessageType.Text,
-                            endOfMessage: true,
-                            cancellationToken
-                        );
-                    }
-                    else
-                    {
-                        await _socket.SendAsync(
-                            buffer: new ArraySegment<byte>(dataBytes, i, MAX_MESSAGE_SIZE),
-                            messageType: WebSocketMessageType.Text,
-                            endOfMessage: false,
-                            cancellationToken
-                        );
-                    }
+                    var isFinalChunk = dataBytes.Length - i <= MAX_MESSAGE_SIZE;
+                    var chunkSize = isFinalChunk ? dataBytes.Length - i : MAX_MESSAGE_SIZE;
+
+                    // Send each chunk with CancellationToken.None: once a multi-chunk frame has begun it must
+                    // be written to completion under the lock. Cancelling mid-frame would release the lock on a
+                    // half-sent frame and let the next writer interleave into it, corrupting the stream.
+                    // Cancellation is honoured before the frame starts (the lock wait above), not during it.
+                    await _socket.SendAsync(
+                        buffer: new ArraySegment<byte>(dataBytes, i, chunkSize),
+                        messageType: WebSocketMessageType.Text,
+                        endOfMessage: isFinalChunk,
+                        CancellationToken.None
+                    );
                 }
             }
             catch (Exception ex)
@@ -93,19 +105,29 @@ namespace Game.Api.Sockets
         {
             var message = new StringBuilder();
             WebSocketReceiveResult result;
-            var buffersRead = 0;
+            var framesRead = 0;
             do
             {
                 result = await _socket.ReceiveAsync(new ArraySegment<byte>(_buffer), cancellationToken);
+
+                // A Close frame ends the message stream; stop reading and let the read loop run the closing
+                // handshake off the CloseReceived state. It carries no data, so don't append or count it.
+                if (result.MessageType is WebSocketMessageType.Close)
+                {
+                    break;
+                }
+
+                framesRead++;
                 if (result.Count > 0)
                 {
                     message.Append(Encoding.UTF8.GetString(_buffer, 0, result.Count));
-                    buffersRead++;
                 }
             }
-            while (!result.EndOfMessage && buffersRead < 1024);
+            while (!result.EndOfMessage && framesRead < MAX_FRAMES_PER_MESSAGE);
 
-            if (buffersRead >= 1024)
+            // Only a message that hit the frame cap without completing is over-size; a message that ends
+            // exactly on the cap is whole and accepted.
+            if (framesRead >= MAX_FRAMES_PER_MESSAGE && !result.EndOfMessage)
             {
                 await Close(ESocketCloseReason.MessageTooBig);
                 throw new WebSocketException("Socket message exceeded maximum allowed size.");


### PR DESCRIPTION
## Summary

Closes #712. Addresses the three robustness gaps the socket command/IO layer health review found.

### 1. `AbstractSocketCommand` no longer uses `NotImplementedException` as control flow

The base command exposed a sync/async pair where overriding the wrong one (or neither) **compiled** but threw `NotImplementedException` at runtime. The execution entry point is now the **single abstract** `ExecuteAsync` (and, for the typed variant, the abstract `HandleExecuteAsync`), so the compiler forces exactly one correct override — the wrong-override-at-runtime path is gone.

- The two synchronous reference-data commands (`AbstractReferenceDataCommand`, `GetReferenceDataVersions`) now return `Task.FromResult(...)`.
- **Codegen:** the response-type extraction in `SocketCommandMetadata` previously anchored on the now-removed sync `HandleExecute` (whose `ApiSocketResponse<T>` return gave it `T`). It now reads `HandleExecuteAsync`, peeling `Task<ApiSocketResponse<T>>` down to `T`. The generated client output is **unchanged** (verified — no tracked generated files drifted after a build).

### 2. `SocketContext.SendData` frame atomicity + cancellation handling

Cancellation could release `_sendLock` after a **partial** multi-chunk (>4 KB) frame, letting the next writer interleave into a half-sent frame and corrupt the stream; the lock-wait `OperationCanceledException` also escaped uncaught.

- Each chunk is now sent with `CancellationToken.None`, so once a frame begins it is written to completion under the lock (atomic). Cancellation is honoured **before** the frame starts (the lock wait) and handled locally — a cancelled send now returns `false` instead of throwing. The two send branches were also DRY'd into one.

### 3. `SocketContext.ReadMessage` honours `MessageType` and bounds zero-length frames

`ReadMessage` ignored `result.MessageType` and only counted non-empty buffers toward the ~4 MB cap, so a malformed peer streaming zero-length frames looped until cancellation.

- A `Close` frame now stops the read (leaving the socket in `CloseReceived` for the read loop's existing handshake) instead of being treated as data.
- **Every** received frame counts toward the cap (`MAX_FRAMES_PER_MESSAGE`), so a zero-length-frame flood trips the size limit and closes. A message that ends exactly on the cap is now correctly accepted as whole (previously rejected).

## Test plan

- [x] `dotnet build` (full solution) — clean.
- [x] `dotnet test Game.Api.Tests` — **489 passed**, including the integration suites (socket drain, command timeout) against the Postgres/Redis containers.
- New unit tests in `SocketContextTests`:
  - `SendData` completes a multi-chunk frame despite a mid-frame cancellation, and returns `false` (no throw, nothing sent) when cancelled before acquiring the send lock.
  - `ReadMessage` reassembles a multi-frame message, stops on a `Close` frame, and bounds a zero-length-frame flood into a `MessageTooBig` close.
- Codegen + reference-data command tests updated to the new abstract override points (`SocketCommandMetadataTests`, `GetReferenceDataVersionsTests`).

## Note for reviewers

Item #1 necessarily touches the codegen response-type extraction (it was anchored on the removed sync method). This is the only ripple beyond the files the issue named, and it produces identical generated output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G89Cw2xhLfrqdRdmujgvHv)_