### PR TITLE
Add centralized exception-handling middleware (#727)

### DIFF
--- a/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
@@ -137,11 +137,15 @@ namespace Game.Api.Tests.Integration
                 }
             };
 
-            // The change set is rejected before anything is committed (the test host rethrows the
-            // action's exception), so the record is left untouched.
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                () => authClient.PostAsJsonAsync("/api/AdminTools/AddEditEnemies", changes, CancellationToken));
+            // The reference admin repo rejects a top-level delete by throwing, which the centralized
+            // exception handler converts into a consistent 500 envelope (with the generic message, since
+            // the test host is not the Development environment). Nothing is committed, so the record stays.
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/AddEditEnemies", changes, CancellationToken);
 
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Equal("Internal Server Error", result.ErrorMessage);
             Assert.Contains(GetEnemies(), e => e.Id == enemy.Id);
         }
 

--- a/Game.Api.Tests/Unit/ExceptionHandlingMiddlewareTests.cs
+++ b/Game.Api.Tests/Unit/ExceptionHandlingMiddlewareTests.cs
@@ -1,0 +1,226 @@
+using Game.Api.Middleware;
+using Game.Api.Models.Common;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+using Xunit;
+
+namespace Game.Api.Tests.Unit
+{
+    /// <summary>
+    /// Covers the centralized exception handler: an unhandled exception becomes a consistent 500
+    /// <see cref="ApiResponse"/> envelope, the exception is logged exactly once, internal details only leak
+    /// in Development, client aborts are not treated as errors, and an already-started response is left to
+    /// unwind. The final case composes it with <see cref="RequestLoggingMiddleware"/> to confirm the logged
+    /// end-event status reflects the handler's 500.
+    /// </summary>
+    public class ExceptionHandlingMiddlewareTests
+    {
+        private static readonly string LoggerCategory = typeof(ExceptionHandlingMiddleware).FullName!;
+
+        [Fact]
+        public async Task UnhandledException_Returns500_WithConsistentErrorEnvelope()
+        {
+            var (_, logger) = CreateLogger();
+            RequestDelegate next = _ => throw new InvalidOperationException("boom");
+            var middleware = new ExceptionHandlingMiddleware(next, logger, CreateEnvironment(Environments.Production));
+            var context = CreateContextWithResponseBody();
+
+            await middleware.InvokeAsync(context);
+
+            Assert.Equal(StatusCodes.Status500InternalServerError, context.Response.StatusCode);
+            Assert.NotNull(context.Response.ContentType);
+            Assert.StartsWith("application/json", context.Response.ContentType);
+            var body = await ReadErrorMessage(context);
+            Assert.Equal("Internal Server Error", body);
+        }
+
+        [Fact]
+        public async Task NonDevelopment_DoesNotLeakExceptionMessage()
+        {
+            var (_, logger) = CreateLogger();
+            RequestDelegate next = _ => throw new InvalidOperationException("secret internal detail");
+            var middleware = new ExceptionHandlingMiddleware(next, logger, CreateEnvironment(Environments.Production));
+            var context = CreateContextWithResponseBody();
+
+            await middleware.InvokeAsync(context);
+
+            var body = await ReadErrorMessage(context);
+            Assert.Equal("Internal Server Error", body);
+            Assert.DoesNotContain("secret internal detail", body);
+        }
+
+        [Fact]
+        public async Task Development_IncludesExceptionMessage()
+        {
+            var (_, logger) = CreateLogger();
+            RequestDelegate next = _ => throw new InvalidOperationException("helpful dev detail");
+            var middleware = new ExceptionHandlingMiddleware(next, logger, CreateEnvironment(Environments.Development));
+            var context = CreateContextWithResponseBody();
+
+            await middleware.InvokeAsync(context);
+
+            Assert.Equal(StatusCodes.Status500InternalServerError, context.Response.StatusCode);
+            var body = await ReadErrorMessage(context);
+            Assert.Equal("helpful dev detail", body);
+        }
+
+        [Fact]
+        public async Task UnhandledException_IsLoggedExactlyOnce_AtErrorLevel()
+        {
+            var (provider, logger) = CreateLogger();
+            RequestDelegate next = _ => throw new InvalidOperationException("boom");
+            var middleware = new ExceptionHandlingMiddleware(next, logger, CreateEnvironment(Environments.Production));
+            var context = CreateContextWithResponseBody();
+
+            await middleware.InvokeAsync(context);
+
+            var errorEntry = Assert.Single(MiddlewareEntries(provider), e => e.Level == LogLevel.Error);
+            Assert.Contains("Unhandled exception", errorEntry.Message);
+        }
+
+        [Fact]
+        public async Task ClientAbort_IsSwallowed_WithoutErrorLogOrErrorResponse()
+        {
+            var (provider, logger) = CreateLogger();
+            var middleware = new ExceptionHandlingMiddleware(
+                _ => throw new OperationCanceledException(),
+                logger,
+                CreateEnvironment(Environments.Production));
+            var context = CreateContextWithResponseBody();
+            context.RequestAborted = new CancellationToken(canceled: true);
+
+            // No exception escapes — the client disconnect is handled, not rethrown.
+            await middleware.InvokeAsync(context);
+
+            // The status was never overwritten to 500 and nothing is logged at Error level.
+            Assert.NotEqual(StatusCodes.Status500InternalServerError, context.Response.StatusCode);
+            Assert.DoesNotContain(MiddlewareEntries(provider), e => e.Level == LogLevel.Error);
+            Assert.Single(MiddlewareEntries(provider), e => e.Level == LogLevel.Debug);
+        }
+
+        [Fact]
+        public async Task ResponseAlreadyStarted_Rethrows()
+        {
+            var (provider, logger) = CreateLogger();
+            var thrown = new InvalidOperationException("after response started");
+            RequestDelegate next = _ => throw thrown;
+            var middleware = new ExceptionHandlingMiddleware(next, logger, CreateEnvironment(Environments.Production));
+
+            // A response feature reporting HasStarted = true models bytes already on the wire (e.g. an
+            // upgraded WebSocket), so the handler cannot replace the response and must let it unwind.
+            var features = new FeatureCollection();
+            features.Set<IHttpRequestFeature>(new HttpRequestFeature { Method = "GET", Path = "/socket" });
+            features.Set<IHttpResponseFeature>(new StartedResponseFeature());
+            features.Set<IHttpResponseBodyFeature>(new StreamResponseBodyFeature(Stream.Null));
+            var context = new DefaultHttpContext(features);
+
+            var caught = await Assert.ThrowsAsync<InvalidOperationException>(() => middleware.InvokeAsync(context));
+            Assert.Same(thrown, caught);
+            // It is still logged once before being rethrown.
+            Assert.Single(MiddlewareEntries(provider), e => e.Level == LogLevel.Error);
+        }
+
+        [Fact]
+        public async Task ComposedWithRequestLogging_LogsRequestEndedWith500_AndExceptionLoggedOnce()
+        {
+            var capturingProvider = new CapturingLoggerProvider();
+            using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(capturingProvider));
+
+            var thrown = new InvalidOperationException("downstream boom");
+            RequestDelegate terminal = _ => throw thrown;
+
+            // Build the real pipeline order: RequestLogging wraps ExceptionHandling wraps the throwing terminal.
+            var exceptionHandling = new ExceptionHandlingMiddleware(
+                terminal,
+                loggerFactory.CreateLogger<ExceptionHandlingMiddleware>(),
+                CreateEnvironment(Environments.Production));
+            var requestLogging = new RequestLoggingMiddleware(
+                ctx => exceptionHandling.InvokeAsync(ctx),
+                loggerFactory.CreateLogger<RequestLoggingMiddleware>());
+
+            var context = CreateContextWithResponseBody();
+            context.Request.Method = "GET";
+            context.Request.Path = "/api/boom";
+            var sessionService = new Game.Api.Services.SessionService(new NoOpSessionStore());
+
+            // The exception is fully handled, so nothing escapes the request-logging middleware.
+            await requestLogging.InvokeAsync(context, sessionService);
+
+            Assert.Equal(StatusCodes.Status500InternalServerError, context.Response.StatusCode);
+
+            var loggingCategory = typeof(RequestLoggingMiddleware).FullName!;
+            var endedEntry = Assert.Single(
+                capturingProvider.Entries.Where(e => e.Category == loggingCategory),
+                e => e.Message.StartsWith("Request Ended"));
+            var statusCode = (int)endedEntry.Properties.Single(p => p.Key == "StatusCode").Value!;
+            Assert.Equal(500, statusCode);
+
+            Assert.Single(capturingProvider.Entries, e => e.Category == LoggerCategory && e.Level == LogLevel.Error);
+        }
+
+        private static (CapturingLoggerProvider Provider, ILogger<ExceptionHandlingMiddleware> Logger) CreateLogger()
+        {
+            var provider = new CapturingLoggerProvider();
+            var logger = new LoggerFactory([provider]).CreateLogger<ExceptionHandlingMiddleware>();
+            return (provider, logger);
+        }
+
+        private static IReadOnlyList<CapturingEntry> MiddlewareEntries(CapturingLoggerProvider provider)
+        {
+            return provider.Entries.Where(e => e.Category == LoggerCategory).ToList();
+        }
+
+        private static IHostEnvironment CreateEnvironment(string environmentName)
+        {
+            return new FakeHostEnvironment { EnvironmentName = environmentName };
+        }
+
+        private static DefaultHttpContext CreateContextWithResponseBody()
+        {
+            var context = new DefaultHttpContext();
+            context.Response.Body = new MemoryStream();
+            return context;
+        }
+
+        private static async Task<string?> ReadErrorMessage(HttpContext context)
+        {
+            context.Response.Body.Position = 0;
+            var response = await JsonSerializer.DeserializeAsync<ApiResponse>(
+                context.Response.Body,
+                new JsonSerializerOptions(JsonSerializerDefaults.Web));
+            return response?.ErrorMessage;
+        }
+
+        private sealed class StartedResponseFeature : IHttpResponseFeature
+        {
+            public int StatusCode { get; set; } = StatusCodes.Status200OK;
+            public string? ReasonPhrase { get; set; }
+            public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+            public Stream Body { get; set; } = Stream.Null;
+            public bool HasStarted => true;
+            public void OnStarting(Func<object, Task> callback, object state) { }
+            public void OnCompleted(Func<object, Task> callback, object state) { }
+        }
+
+        private sealed class FakeHostEnvironment : IHostEnvironment
+        {
+            public string EnvironmentName { get; set; } = Environments.Production;
+            public string ApplicationName { get; set; } = nameof(ExceptionHandlingMiddlewareTests);
+            public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+            public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+                new Microsoft.Extensions.FileProviders.NullFileProvider();
+        }
+
+        private sealed class NoOpSessionStore : Game.Abstractions.DataAccess.ISessionStore
+        {
+            public Task<Game.Core.Players.PlayerState?> GetSession(int userId, CancellationToken cancellationToken = default)
+                => Task.FromResult<Game.Core.Players.PlayerState?>(null);
+            public void Update(Game.Core.Players.PlayerState sessionData, int userId) { }
+            public void Clear(int userId) { }
+        }
+    }
+}

--- a/Game.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/Game.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,70 @@
+using Game.Api.Models.Common;
+
+namespace Game.Api.Middleware
+{
+    /// <summary>
+    /// Catches unhandled exceptions from the downstream pipeline, logs each one exactly once, and writes a
+    /// consistent <see cref="ApiResponse"/> error envelope so clients receive the project's structured error
+    /// shape on a 500 instead of the host's default response. It is the single place that logs unhandled
+    /// exceptions, keeping <see cref="RequestLoggingMiddleware"/> focused on structured start/end events.
+    /// </summary>
+    public class ExceptionHandlingMiddleware(
+        RequestDelegate next,
+        ILogger<ExceptionHandlingMiddleware> logger,
+        IHostEnvironment environment)
+    {
+        private readonly RequestDelegate _next = next;
+        private readonly ILogger<ExceptionHandlingMiddleware> _logger = logger;
+        private readonly IHostEnvironment _environment = environment;
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+            {
+                // The client disconnected mid-request, so there is no one to respond to and the connection
+                // is gone. This is not a server error worth a 500 or an error-level log.
+                _logger.LogDebug("Request {Method} {Path} aborted by the client.",
+                    context.Request.Method, context.Request.Path.Value);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unhandled exception processing {Method} {Path}.",
+                    context.Request.Method, context.Request.Path.Value);
+
+                if (context.Response.HasStarted)
+                {
+                    // The response is already (partly) on the wire — e.g. an upgraded WebSocket — so it
+                    // cannot be replaced with the error envelope. Let it unwind to the host.
+                    throw;
+                }
+
+                context.Response.Clear();
+                context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                // Internal details (message, stack trace) are only safe to surface in Development; other
+                // environments get a generic message so nothing about the failure leaks to the client.
+                var message = _environment.IsDevelopment() ? ex.Message : "Internal Server Error";
+                await context.Response.WriteAsJsonAsync(ApiResponse.Error(message), context.RequestAborted);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extension methods for adding <see cref="ExceptionHandlingMiddleware"/> to the application pipeline.
+    /// </summary>
+    public static class ExceptionHandlingMiddlewareExtensions
+    {
+        /// <summary>
+        /// Adds middleware that converts unhandled exceptions into the project's consistent
+        /// <see cref="ApiResponse"/> error envelope and logs them exactly once. Must run inside
+        /// <c>UseRequestLogging</c> so the error status is set before the request-ended event is logged.
+        /// </summary>
+        public static IApplicationBuilder UseExceptionHandling(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<ExceptionHandlingMiddleware>();
+        }
+    }
+}

--- a/Game.Api/Startup.cs
+++ b/Game.Api/Startup.cs
@@ -170,6 +170,9 @@ namespace Game.Api
             app.UseAuthentication();
             app.UseSessionLoader();
             app.UseRequestLogging();
+            // Runs inside request logging so an unhandled exception is converted to a 500 (with the
+            // consistent error envelope) before the request-ended event logs the response status.
+            app.UseExceptionHandling();
             app.UseLoginTracking();
             app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(15) });
             app.UseSocketInterceptor();

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -145,6 +145,10 @@ At most one active account may hold a given username, enforced by a **partial un
 
 The browser CORS policy's allowed origins are **configuration-bound, not hardcoded** — they are deployment-specific. The list supports multiple origins and is validated at startup (must be non-empty), so a misconfigured environment fails fast rather than silently rejecting every browser request. The local dev origin ships in the Development config.
 
+## Unhandled exception handling
+
+A centralized exception-handling middleware is the **single place** unhandled exceptions are logged and turned into a response. It converts any exception escaping the downstream pipeline into the project's consistent `ApiResponse` error envelope with a 500 status, so clients get the same `{ errorMessage }` shape they get for business failures rather than the host's default response. Internal details (the exception message) are surfaced **only in Development**; other environments get a generic message so nothing leaks. A client-disconnect cancellation is not treated as a server error, and an already-started response (e.g. an upgraded WebSocket) is left to unwind rather than corrupted. It runs **inside `RequestLoggingMiddleware`** so the 500 is set before the "Request Ended" event logs the status; `RequestLoggingMiddleware` therefore stays focused on structured start/end events and never logs the exception itself.
+
 ## Access Roles and Admin Authorization
 
 Authenticated users are gated out of admin tooling unless they hold the `Admin` role. **Roles live in the signed auth token, not the session store** — the token is the source of truth for what a request is authorized to do, which keeps the check self-contained and avoids a second lookup; the trade-off is that a role change only takes effect on the user's next login. The admin authorization filter reads the role straight off the cryptographically validated principal, **never** off the gameplay session cache: that cache is a presentation concern decoupled from the token's validity, so keying off it would wrongly reject a valid admin whose session key happens to be absent (evicted, never established, or aged out).


### PR DESCRIPTION
## Summary

Closes #727.

There was **no exception-handling middleware** anywhere in the pipeline, so an unhandled exception propagated to the host default: clients got an unstructured response (not the project's `ApiResponse` envelope) and there was no single dedicated place that logged the exception.

This adds `ExceptionHandlingMiddleware`, which:

1. **Produces a consistent error response.** Any exception escaping the downstream pipeline is converted to the project's `ApiResponse` error envelope (`{ errorMessage }`) with a `500` status, so an unhandled failure looks the same to the client as a business failure.
2. **Is the single place unhandled exceptions are logged** (one `Error`-level entry), keeping `RequestLoggingMiddleware` focused on its structured start/end events — which is exactly the seam #695 (PR #724) deliberately left open.

### Design decisions

- **No detail leak outside Development.** The exception message is surfaced only when the host is the Development environment; every other environment gets a generic `"Internal Server Error"`.
- **Ordering.** Registered **inside** `UseRequestLogging` (right after it) so the handler sets the 500 *before* `RequestLoggingMiddleware`'s `finally` logs the "Request Ended" status — the logged status reflects the handler's response, not the framework default. (Addresses the ordering note in the issue.)
- **Client disconnects aren't server errors.** An `OperationCanceledException` raised because `RequestAborted` fired is logged at `Debug` and swallowed — no 500, no error log.
- **Already-started responses unwind.** If the response has started (e.g. an upgraded WebSocket on `/socket`), the handler logs and rethrows rather than corrupting the in-flight response.
- Reuses the existing `ApiResponse.Error(...)` envelope (serialized camelCase via `WriteAsJsonAsync`), so the frontend's existing `errorMessage` parsing handles it with no client change.

## Behavior change to an existing test

The reference admin **top-level-delete** rejection is implemented by *throwing* (`ChangeSetProcessor`). Previously that exception was rethrown to the test client / hit the host default; now it becomes the structured 500 envelope. Updated `AddEditEnemies_DeleteEnemy_IsRejectedAndLeavesRecordIntact` to assert the new behavior (500 + envelope, record untouched). That path arguably should be a graceful `400` like the unknown-edit path — filed as follow-up **#777** rather than expanded here.

## Test plan

- [x] `dotnet build` — clean, 0 warnings.
- [x] `dotnet test Game.Api.Tests` — **491 passed**, including the full integration suite against the Postgres/Redis containers.
- New `ExceptionHandlingMiddlewareTests` (7 cases): 500 + consistent envelope; no detail leak in non-Development; detail included in Development; exception logged exactly once at Error; client abort swallowed (Debug log, no 500); already-started response rethrows; and a **composed** test (RequestLogging → ExceptionHandling → throwing terminal) asserting the "Request Ended" event logs `500` and the exception is logged once.

## Note for reviewers

An end-to-end integration test (real pipeline, real HTTP) was not added because there is no throwing endpoint in the app and introducing test-only routing infra would be disproportionate; the composed unit test covers the cross-middleware interaction the issue calls out. The pipeline ordering itself is pinned by the code comment in `Startup.cs`.

---
https://claude.ai/code/session_01R3tQ6jT5ra3o9yxihkBikL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3tQ6jT5ra3o9yxihkBikL)_