### PR TITLE
Make device fingerprint stable across DST and browser updates (#749)

### DIFF
--- a/UI/src/lib/api/device-fingerprint.ts
+++ b/UI/src/lib/api/device-fingerprint.ts
@@ -14,8 +14,42 @@ let cached: string | undefined;
 let pending: Promise<string | undefined> | null = null;
 
 /**
- * The stable client-side signals that make up the fingerprint. Kept deterministic (no
- * timestamps/randomness) so the same device produces the same hash across sessions.
+ * A coarse, update-stable platform descriptor (e.g. `Windows`, `macOS`, `Android`). Prefers the
+ * standardized UA Client Hints `platform`; otherwise derives the OS family from the `userAgent`,
+ * excluding the version numbers — so a browser auto-update no longer rotates the fingerprint.
+ */
+const platformToken = (nav: NavigatorWithCapabilities): string => {
+	const hinted = nav.userAgentData?.platform;
+	if (hinted) {
+		return hinted;
+	}
+
+	const userAgent = nav.userAgent ?? '';
+	// Ordered: families whose UA token nests another (Android/ChromeOS UAs contain `Linux`, iOS UAs
+	// contain `Mac OS X`) must be tested first so the most specific match wins.
+	const families: ReadonlyArray<[RegExp, string]> = [
+		[/Android/i, 'Android'],
+		[/iPhone|iPad|iPod/i, 'iOS'],
+		[/CrOS/i, 'ChromeOS'],
+		[/Windows/i, 'Windows'],
+		[/Mac OS X|Macintosh/i, 'macOS'],
+		[/Linux/i, 'Linux']
+	];
+
+	for (const [pattern, family] of families) {
+		if (pattern.test(userAgent)) {
+			return family;
+		}
+	}
+
+	return '';
+};
+
+/**
+ * The stable client-side signals that make up the fingerprint. Every signal is chosen to stay
+ * invariant for one physical device across sessions: no timestamps/randomness, a coarse platform
+ * token rather than the auto-updating `userAgent`, and the DST-stable IANA time-zone string rather
+ * than the numeric offset.
  */
 const fingerprintSignals = (): string => {
 	const nav = navigator as NavigatorWithCapabilities;
@@ -28,7 +62,7 @@ const fingerprintSignals = (): string => {
 	})();
 
 	return [
-		nav.userAgent,
+		platformToken(nav),
 		nav.language,
 		(nav.languages ?? []).join(','),
 		nav.hardwareConcurrency ?? '',
@@ -36,8 +70,7 @@ const fingerprintSignals = (): string => {
 		screen.width,
 		screen.height,
 		screen.colorDepth,
-		timeZone,
-		new Date().getTimezoneOffset()
+		timeZone
 	].join('|');
 };
 

--- a/UI/src/lib/api/navigator.ts
+++ b/UI/src/lib/api/navigator.ts
@@ -1,7 +1,9 @@
 /**
- * Augments the standard `Navigator` with the optional Device Memory API field (`deviceMemory`), which
- * the DOM lib types don't model. Shared by the device fingerprint and the device-info collector.
+ * Augments the standard `Navigator` with optional capability fields the DOM lib types don't model:
+ * the Device Memory API's `deviceMemory` and the UA Client Hints `userAgentData` (we only read its
+ * stable `platform`). Shared by the device fingerprint and the device-info collector.
  */
 export interface NavigatorWithCapabilities extends Navigator {
 	deviceMemory?: number;
+	userAgentData?: { platform?: string };
 }

--- a/UI/src/tests/lib/api/device-fingerprint.test.ts
+++ b/UI/src/tests/lib/api/device-fingerprint.test.ts
@@ -6,6 +6,54 @@ const loadModule = async () => {
 	return import('$lib/api/device-fingerprint');
 };
 
+// A representative desktop-Chrome UA, parameterized on the volatile version so tests can vary it.
+const chromeUserAgent = (version: string): string =>
+	`Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${version} Safari/537.36`;
+
+const ANDROID_UA =
+	'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36';
+
+/**
+ * Computes a fresh fingerprint with the given navigator/Date signals overridden, restoring the
+ * globals afterwards. `userAgentData` is always overridden (to `undefined` when omitted) so the
+ * platform token derives from `userAgent` rather than any value jsdom might expose by default.
+ */
+const fingerprintWith = async (overrides: {
+	userAgent?: string;
+	userAgentData?: { platform?: string };
+	timezoneOffset?: number;
+}): Promise<string | undefined> => {
+	const restores: Array<() => void> = [];
+	const override = (target: object, key: string, value: unknown) => {
+		const prior = Object.getOwnPropertyDescriptor(target, key);
+		Object.defineProperty(target, key, { configurable: true, value });
+		restores.push(() => {
+			if (prior) {
+				Object.defineProperty(target, key, prior);
+			} else {
+				delete (target as Record<string, unknown>)[key];
+			}
+		});
+	};
+
+	if (overrides.userAgent !== undefined) {
+		override(navigator, 'userAgent', overrides.userAgent);
+	}
+	override(navigator, 'userAgentData', overrides.userAgentData);
+	if (overrides.timezoneOffset !== undefined) {
+		override(Date.prototype, 'getTimezoneOffset', () => overrides.timezoneOffset);
+	}
+
+	try {
+		localStorage.clear();
+		const { ensureDeviceFingerprint } = await loadModule();
+		return await ensureDeviceFingerprint();
+	} finally {
+		restores.forEach((restore) => restore());
+		localStorage.clear();
+	}
+};
+
 describe('device-fingerprint', () => {
 	beforeEach(() => {
 		localStorage.clear();
@@ -50,5 +98,51 @@ describe('device-fingerprint', () => {
 		expect(getDeviceFingerprint()).toBeUndefined();
 
 		Object.defineProperty(globalThis.crypto, 'subtle', { configurable: true, value: original });
+	});
+
+	// Regression for #749: the fingerprint must not rotate on a browser auto-update.
+	it('is stable across browser auto-updates (userAgent version changes)', async () => {
+		const before = await fingerprintWith({ userAgent: chromeUserAgent('120.0.0.0') });
+		const after = await fingerprintWith({ userAgent: chromeUserAgent('121.0.6167.85') });
+
+		expect(before).toMatch(/^[0-9a-f]{64}$/);
+		expect(before).toBe(after);
+	});
+
+	// Regression for #749: a DST shift changes getTimezoneOffset() but must not change the hash.
+	it('is stable across DST shifts (timezone offset is not a signal)', async () => {
+		const winter = await fingerprintWith({ timezoneOffset: 300 });
+		const summer = await fingerprintWith({ timezoneOffset: 240 });
+
+		expect(winter).toMatch(/^[0-9a-f]{64}$/);
+		expect(winter).toBe(summer);
+	});
+
+	it('produces different fingerprints for different platforms', async () => {
+		const windows = await fingerprintWith({ userAgent: chromeUserAgent('120.0.0.0') });
+		const android = await fingerprintWith({ userAgent: ANDROID_UA });
+
+		expect(windows).not.toBe(android);
+	});
+
+	it('prefers the UA Client Hints platform over the userAgent string', async () => {
+		// An Android UA whose client hint claims Windows must resolve to the same platform token as a
+		// genuine Windows UA — the hint wins — so (all else equal) the two fingerprints match.
+		const fromUserAgent = await fingerprintWith({ userAgent: chromeUserAgent('120.0.0.0') });
+		const fromClientHint = await fingerprintWith({
+			userAgent: ANDROID_UA,
+			userAgentData: { platform: 'Windows' }
+		});
+
+		expect(fromUserAgent).toBe(fromClientHint);
+	});
+
+	it('falls back to an empty platform token for an unrecognized userAgent', async () => {
+		// An unknown UA hits no family branch (token ''); a known one differs, proving the token varies.
+		const unknown = await fingerprintWith({ userAgent: 'TotallyUnknownAgent/1.0' });
+		const windows = await fingerprintWith({ userAgent: chromeUserAgent('120.0.0.0') });
+
+		expect(unknown).toMatch(/^[0-9a-f]{64}$/);
+		expect(unknown).not.toBe(windows);
 	});
 });


### PR DESCRIPTION
## Summary

`UI/src/lib/api/device-fingerprint.ts` documents its hash as "stable across sessions," but `fingerprintSignals()` folded in two signals that rotate for the **same physical device**, contradicting that contract:

- `new Date().getTimezoneOffset()` — the numeric offset **shifts with DST** (twice a year for most users), *and* it was redundant with the IANA time-zone string (`Intl.DateTimeFormat().resolvedOptions().timeZone`) already collected.
- `nav.userAgent` — the full UA string **changes on every browser auto-update**.

Because the fingerprint feeds the backend's per-device connection tracking (#29), an id that silently rotates undermines the feature.

## Changes

- **Dropped `getTimezoneOffset()`** — DST-variant and redundant with the DST-stable IANA `timeZone` string.
- **Replaced the raw `userAgent`** with a coarse, update-stable `platformToken`: prefer the standardized UA Client Hints `platform`, otherwise derive the OS family (`Windows`/`macOS`/`Linux`/`Android`/`iOS`/`ChromeOS`) from the userAgent with version numbers excluded. This keeps meaningful platform entropy while no longer rotating on a browser update. (Chosen over fully dropping the signal so device differentiation is preserved.)
- Added the optional `userAgentData` field to `NavigatorWithCapabilities` (TS's DOM lib doesn't model it).

The signal set now agrees with the "stable across sessions" contract; the doc comment on `fingerprintSignals` spells out *why* each signal is stable.

## Test plan

Added unit tests (regression-tagged for #749) in `device-fingerprint.test.ts`:

- ✅ Stable across browser auto-updates (two Chrome UAs differing only in version → same hash).
- ✅ Stable across DST shifts (`getTimezoneOffset()` varied → same hash).
- ✅ Different platforms produce different fingerprints.
- ✅ UA Client Hints `platform` is preferred over the userAgent string.
- ✅ Unrecognized userAgent falls back to an empty platform token.

Verification (all green):

- `npm run lint` (eslint + svelte-check) — 0 errors.
- `npm run test:unit:ci` — 1836 tests pass; `src/lib/api/**` coverage 97.4% stmts / 93.0% branches / 100% funcs, above the area floors.

Closes #749

https://claude.ai/code/session_01M7TyYmhgADUt3GPwDp12PJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7TyYmhgADUt3GPwDp12PJ)_