### PR TITLE
Prune redundant InventoryManager.publish() rebuilds on field edits (#752)

### DIFF
--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -43,9 +43,10 @@ export class InventoryManager {
 	public equippedSlots: (Item | undefined)[] = new Array(6).fill(undefined);
 
 	/**
-	 * Reactive published view of `unlockedItems`. The manager is the single owner of the item
-	 * objects and the only place they are mutated; this snapshot is republished (`publish`) on every
-	 * change so reactive consumers (the inventory screen) re-derive without keeping their own copies.
+	 * Reactive published view of `unlockedItems`. The manager is the single owner of the item objects
+	 * and the only place they are mutated. `statify` makes each item's fields (and this array) reactive
+	 * in place, so the array is rebuilt (`publish`) only when the item *set* changes; in-place field
+	 * edits (equip, favorite, mods) propagate to consumers on their own without a rebuild.
 	 */
 	public items: Item[] = [];
 
@@ -116,7 +117,6 @@ export class InventoryManager {
 				...affected.map((it) => snapshotFields(it, 'equipped', 'equipmentSlotId'))
 			);
 			this.applyEquip(item, slotId);
-			this.publish();
 
 			const response = await apiSocket.sendSocketCommand('EquipItem', {
 				itemId,
@@ -124,7 +124,6 @@ export class InventoryManager {
 			});
 			if (response.error) {
 				rollback();
-				this.publish();
 				return false;
 			}
 
@@ -148,7 +147,6 @@ export class InventoryManager {
 			const slots = [...this.equippedSlots];
 			slots[slotId] = undefined;
 			this.equippedSlots = slots;
-			this.publish();
 
 			const response = await apiSocket.sendSocketCommand('UnequipItem', {
 				itemId: item.itemId,
@@ -156,7 +154,6 @@ export class InventoryManager {
 			});
 			if (response.error) {
 				rollback();
-				this.publish();
 				return false;
 			}
 
@@ -176,7 +173,6 @@ export class InventoryManager {
 			const rollback = snapshotFields(item, 'appliedMods', 'totalAttributes');
 			item.appliedMods = [...item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId), mod];
 			this.refreshItemAttributes(item);
-			this.publish();
 
 			const response = await apiSocket.sendSocketCommand('ApplyMod', {
 				itemId,
@@ -185,7 +181,6 @@ export class InventoryManager {
 			});
 			if (response.error) {
 				rollback();
-				this.publish();
 				return false;
 			}
 
@@ -204,7 +199,6 @@ export class InventoryManager {
 			const rollback = snapshotFields(item, 'appliedMods', 'totalAttributes');
 			item.appliedMods = item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId);
 			this.refreshItemAttributes(item);
-			this.publish();
 
 			const response = await apiSocket.sendSocketCommand('RemoveMod', {
 				itemId,
@@ -212,7 +206,6 @@ export class InventoryManager {
 			});
 			if (response.error) {
 				rollback();
-				this.publish();
 				return false;
 			}
 
@@ -234,7 +227,6 @@ export class InventoryManager {
 		}
 
 		item.favorite = favorite;
-		this.publish();
 		const response = await apiSocket.sendSocketCommand('SetItemFavorite', { itemId, favorite });
 		if (response.error) {
 			logMessage(ELogType.Debug, 'There was an error setting the item favorite: ' + response.error);
@@ -322,7 +314,11 @@ export class InventoryManager {
 		item.totalAttributes = new BattleAttributes(allAttributes, false);
 	}
 
-	/** Republishes the reactive item snapshot so consumers re-derive after a mutation. */
+	/**
+	 * Rebuilds the published `items` array from `unlockedItems`. Only needed when the item *set* changes
+	 * (initialize, addUnlockedItem): `statify` keeps in-place field edits reactive on their own, so pure
+	 * field mutations (equip, favorite, mods) propagate without a rebuild.
+	 */
 	private publish() {
 		this.items = [...this.unlockedItems.values()];
 	}

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -234,7 +234,7 @@ describe('InventoryManager', () => {
 	});
 
 	describe('items (reactive published list)', () => {
-		it('mirrors unlockedItemList and republishes a new array reference on mutation', async () => {
+		it('mirrors unlockedItemList and reflects an in-place field edit without rebuilding the array', async () => {
 			mockItems[1] = makeItem(1);
 			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
 			manager.initialize();
@@ -244,16 +244,21 @@ describe('InventoryManager', () => {
 
 			const before = manager.items;
 			await manager.equipItem(1, EEquipmentSlot.WeaponSlot);
-			// A mutation publishes a fresh array reference so reactive consumers re-derive.
-			expect(manager.items).not.toBe(before);
+			// A pure field edit mutates the item in place — statify keeps it reactive, so the array is not
+			// rebuilt and the same reference now reflects the change.
+			expect(manager.items).toBe(before);
+			expect(manager.items.find((i) => i.itemId === 1)?.equipped).toBe(true);
 		});
 
-		it('publishes a newly unlocked item into the list', () => {
+		it('rebuilds a fresh array when the item set grows (addUnlockedItem)', () => {
 			mockItems[3] = makeItem(3);
 			manager.initialize();
+			const before = manager.items;
 
 			manager.addUnlockedItem(makeInventoryItem({ itemId: 3 }));
 
+			// A set change has no statified field to signal it, so publish rebuilds a fresh array reference.
+			expect(manager.items).not.toBe(before);
 			expect(manager.items.map((i) => i.itemId)).toEqual([3]);
 		});
 	});


### PR DESCRIPTION
## Summary

Resolves the redundancy flagged in #752. After the `statify` rework made statified-array elements **field-reactive in place**, `InventoryManager.publish()` (which rebuilds the whole `items` array via `[...this.unlockedItems.values()]`) is no longer needed for mutations that only edit an existing item's fields — the field write itself is already reactive.

`publish()` now runs **only at the two sites where the item *set* grows** and no statified field/array can signal the change:

- `initialize()` — builds the array from the freshly-loaded map.
- `addUnlockedItem()` — a new key in `unlockedItems` has no in-array element to mutate.

Dropped the rebuild from every pure-field-edit path (both optimistic apply **and** rollback):

- `setFavorite` — `item.favorite` is reactive.
- `equipItem` / `unequipItem` — flip `item.equipped` / `item.equipmentSlotId` (reactive) and reassign `equippedSlots` (drives the equipment rail); `items` membership is unchanged (equipped items still appear in the grid).
- `applyMod` / `removeMod` — reassign `item.appliedMods` / `item.totalAttributes` (reactive).

### Note: this goes one step further than the issue

The issue assumed equip/unequip still needed the rebuild. They don't: `GridSlot.svelte` reads `item.equipped`/`favorite`/`appliedMods` directly off each statified `Item`, and the equipment panel derives from `equippedSlots`/`equipmentStats` — so equip state propagates without an `items` rebuild. This was confirmed with the repo owner before implementing.

### Optimistic rollback is unaffected

The snapshot/rollback baselines depend on the **field reassignments** (`equippedSlots`, `appliedMods`, `equipped`/`equipmentSlotId`) staying reassignments — those are untouched, and they are themselves reactive. The `items` array is never captured by `snapshotFields`, so removing its rebuild cannot corrupt a snapshot, and `rollback()`'s reassignments propagate to consumers on their own.

## How it addresses the issue

`publish()` rebuilds are pruned to the set-change call sites, and the remaining intent is documented on both the `items` field and the `publish()` method. The carve-outs in the issue (keep `equippedSlots`/`appliedMods`/`unlockedMods` as reassignments) are honored.

## Test plan

- [x] Updated the `items` test: a field edit (equip) no longer rebuilds the array (same reference) but the in-place change is visible; a set change (`addUnlockedItem`) still rebuilds a fresh array.
- [x] `npm run lint` — 0 errors, 0 warnings.
- [x] `npm run test:unit:ci` — 192 files / 1831 tests pass (inventory-manager: 50/50; inventory-view and other consumers green).

Closes #752

---
_Generated by [Claude Code](https://claude.ai/code/session_018j6nHLAh2pDafR9MPmY6D3)_