### PR TITLE
Avoid fabricating Tag.Name on the admin tag delete (key-only delete)

### DIFF
--- a/Game.Application.Tests/DataAccess/AdminTagsIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminTagsIntegrationTests.cs
@@ -1,0 +1,129 @@
+using Game.Abstractions.Contracts.Admin;
+using Game.Abstractions.DataAccess;
+using Game.Abstractions.DataAccess.Admin;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Contracts = Game.Abstractions.Contracts;
+using Entities = Game.Infrastructure.Entities;
+
+namespace Game.Application.Tests.DataAccess
+{
+    /// <summary>
+    /// Exercises <see cref="IAdminTags"/> end-to-end through the entity store and unit of work. The focus is
+    /// the key-only hard delete: a tag carries a <c>required</c> Name yet is removed by key alone, the delete
+    /// stays in the change-tracker batch, and an in-use tag's assignment join rows cascade away (see
+    /// <c>docs/backend.md</c> → "Tags are the deliberate exception"). Seeding, the admin write, and the
+    /// assertion each use a separate DI scope so the write runs against an empty change tracker, mirroring the
+    /// per-request scope of a real admin call.
+    /// </summary>
+    [Collection("Integration")]
+    public class AdminTagsIntegrationTests : ApplicationIntegrationTestBase
+    {
+        public AdminTagsIntegrationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        private static Change<Contracts.Tag> Delete(Entities.Tag tag) =>
+            new()
+            {
+                ChangeType = EChangeType.Delete,
+                // The contract still carries Name (it's required), but the delete persists by key only.
+                Item = new Contracts.Tag { Id = tag.Id, Name = tag.Name, TagCategoryId = tag.TagCategoryId },
+            };
+
+        [Fact]
+        public async Task SaveTags_Delete_RemovesTagByKey()
+        {
+            int tagId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var tag = await TestDataSeeder.CreateTagAsync(context, "Doomed");
+                tagId = tag.Id;
+
+                using (var writeScope = CreateScope())
+                {
+                    var admin = writeScope.ServiceProvider.GetRequiredService<IAdminTags>();
+                    Assert.True(admin.SaveTags([Delete(tag)]).Succeeded);
+                    await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+                }
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                Assert.False(await context.Tags.AnyAsync(t => t.Id == tagId, CancellationToken));
+            }
+        }
+
+        [Fact]
+        public async Task SaveTags_Delete_InUseTag_CascadesAssignmentJoinRows()
+        {
+            int tagId, itemId, itemModId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var tag = await TestDataSeeder.CreateTagAsync(context, "Shared");
+                var item = await TestDataSeeder.CreateItemAsync(context, "Tagged Item");
+                var itemMod = await TestDataSeeder.CreateItemModAsync(context, "Tagged Mod");
+                tagId = tag.Id;
+                itemId = item.Id;
+                itemModId = itemMod.Id;
+
+                context.ItemTags.Add(new Entities.ItemTag { ItemId = itemId, TagId = tagId });
+                context.ItemModTags.Add(new Entities.ItemModTag { ItemModId = itemModId, TagId = tagId });
+                await context.SaveChangesAsync(CancellationToken);
+
+                using (var writeScope = CreateScope())
+                {
+                    var admin = writeScope.ServiceProvider.GetRequiredService<IAdminTags>();
+                    Assert.True(admin.SaveTags([Delete(tag)]).Succeeded);
+                    await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+                }
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                Assert.False(await context.Tags.AnyAsync(t => t.Id == tagId, CancellationToken));
+                Assert.False(await context.ItemTags.AnyAsync(it => it.TagId == tagId, CancellationToken));
+                Assert.False(await context.ItemModTags.AnyAsync(imt => imt.TagId == tagId, CancellationToken));
+                // The cascade is scoped to the deleted tag — the owning item and item mod survive.
+                Assert.True(await context.Items.AnyAsync(i => i.Id == itemId, CancellationToken));
+                Assert.True(await context.ItemMods.AnyAsync(im => im.Id == itemModId, CancellationToken));
+            }
+        }
+
+        [Fact]
+        public async Task SaveTags_Delete_LeavesUntargetedTagsIntact()
+        {
+            int doomedId, keptId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var doomed = await TestDataSeeder.CreateTagAsync(context, "Doomed");
+                var kept = await TestDataSeeder.CreateTagAsync(context, "Kept");
+                doomedId = doomed.Id;
+                keptId = kept.Id;
+
+                using (var writeScope = CreateScope())
+                {
+                    var admin = writeScope.ServiceProvider.GetRequiredService<IAdminTags>();
+                    Assert.True(admin.SaveTags([Delete(doomed)]).Succeeded);
+                    await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+                }
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                Assert.False(await context.Tags.AnyAsync(t => t.Id == doomedId, CancellationToken));
+                Assert.True(await context.Tags.AnyAsync(t => t.Id == keptId, CancellationToken));
+            }
+        }
+    }
+}

--- a/Game.Application.Tests/DataAccess/AdminTagsTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminTagsTests.cs
@@ -1,0 +1,70 @@
+using Game.Abstractions.Contracts.Admin;
+using Game.DataAccess.Repositories.Admin;
+using Xunit;
+using Contracts = Game.Abstractions.Contracts;
+using Entities = Game.Infrastructure.Entities;
+
+namespace Game.Application.Tests.DataAccess
+{
+    /// <summary>
+    /// Unit-tests the entity-store operations <see cref="AdminTags.SaveTags"/> stages for each change kind,
+    /// without a database. The delete path in particular must stage a key-only delete (no fabricated
+    /// <c>Name</c>), since <c>Tag.Name</c> is a required scalar the delete doesn't need.
+    /// </summary>
+    public class AdminTagsTests
+    {
+        private static Change<Contracts.Tag> Change(EChangeType type, int id, string name = "Tag", int categoryId = 0) =>
+            new() { ChangeType = type, Item = new Contracts.Tag { Id = id, Name = name, TagCategoryId = categoryId } };
+
+        [Fact]
+        public void SaveTags_Add_InsertsTagWithNameAndCategory()
+        {
+            var store = new RecordingEntityStore();
+            var adminTags = new AdminTags(store);
+
+            var result = adminTags.SaveTags([Change(EChangeType.Add, id: 0, name: "Fire", categoryId: 3)]);
+
+            Assert.True(result.Succeeded);
+            var inserted = Assert.IsType<Entities.Tag>(Assert.Single(store.Inserted));
+            Assert.Equal("Fire", inserted.Name);
+            Assert.Equal(3, inserted.TagCategoryId);
+            Assert.Empty(store.Updated);
+            Assert.Empty(store.DeletedByKey);
+        }
+
+        [Fact]
+        public void SaveTags_Edit_UpdatesTagByIdWithNewValues()
+        {
+            var store = new RecordingEntityStore();
+            var adminTags = new AdminTags(store);
+
+            var result = adminTags.SaveTags([Change(EChangeType.Edit, id: 7, name: "Ice", categoryId: 2)]);
+
+            Assert.True(result.Succeeded);
+            var updated = Assert.IsType<Entities.Tag>(Assert.Single(store.Updated));
+            Assert.Equal(7, updated.Id);
+            Assert.Equal("Ice", updated.Name);
+            Assert.Equal(2, updated.TagCategoryId);
+            Assert.Empty(store.Inserted);
+            Assert.Empty(store.DeletedByKey);
+        }
+
+        [Fact]
+        public void SaveTags_Delete_DeletesByKeyWithoutFabricatingName()
+        {
+            var store = new RecordingEntityStore();
+            var adminTags = new AdminTags(store);
+
+            var result = adminTags.SaveTags([Change(EChangeType.Delete, id: 42)]);
+
+            Assert.True(result.Succeeded);
+            var (entityType, keyValues) = Assert.Single(store.DeletedByKey);
+            Assert.Equal(typeof(Entities.Tag), entityType);
+            Assert.Equal([42], keyValues);
+            // The delete never materializes a full entity, so nothing is staged through the instance paths.
+            Assert.Empty(store.Deleted);
+            Assert.Empty(store.Inserted);
+            Assert.Empty(store.Updated);
+        }
+    }
+}

--- a/Game.Application.Tests/DataAccess/EntityStoreIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/EntityStoreIntegrationTests.cs
@@ -1,0 +1,89 @@
+using Game.Abstractions.DataAccess;
+using Game.DataAccess.Repositories;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Entities = Game.Infrastructure.Entities;
+
+namespace Game.Application.Tests.DataAccess
+{
+    /// <summary>
+    /// Exercises the generic key-only delete affordance on <see cref="IEntityStore"/> directly against EF, so
+    /// it is pinned independently of any one admin repository. A single-column key is the Tag case; a
+    /// composite key proves the affordance generalizes to any future required-scalar entity.
+    /// </summary>
+    [Collection("Integration")]
+    public class EntityStoreIntegrationTests : ApplicationIntegrationTestBase
+    {
+        public EntityStoreIntegrationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        [Fact]
+        public async Task DeleteByKey_SingleColumnKey_RemovesTheRowWithoutFabricatingScalars()
+        {
+            int tagId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                tagId = (await TestDataSeeder.CreateTagAsync(context, "Doomed")).Id;
+
+                using (var writeScope = CreateScope())
+                {
+                    var store = writeScope.ServiceProvider.GetRequiredService<IEntityStore>();
+                    store.DeleteByKey<Entities.Tag>(tagId);
+                    await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+                }
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                Assert.False(await context.Tags.AnyAsync(t => t.Id == tagId, CancellationToken));
+            }
+        }
+
+        [Fact]
+        public async Task DeleteByKey_CompositeKey_RemovesTheJoinRow()
+        {
+            int enemyId, skillId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+                var skill = await TestDataSeeder.CreateSkillAsync(context, "Linked");
+                await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, skill.Id);
+                enemyId = enemy.Id;
+                skillId = skill.Id;
+
+                using (var writeScope = CreateScope())
+                {
+                    var store = writeScope.ServiceProvider.GetRequiredService<IEntityStore>();
+                    // EnemySkill's key is { EnemyId, SkillId } — order follows the model's key definition.
+                    store.DeleteByKey<Entities.EnemySkill>(enemyId, skillId);
+                    await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+                }
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                Assert.False(await context.EnemySkills.AnyAsync(es => es.EnemyId == enemyId && es.SkillId == skillId, CancellationToken));
+            }
+        }
+
+        [Fact]
+        public void DeleteByKey_WrongKeyValueCount_Throws()
+        {
+            using var scope = CreateScope();
+            var store = scope.ServiceProvider.GetRequiredService<IEntityStore>();
+
+            // Tag has a single-column key, so supplying two values is a programming error, not a 0-row delete.
+            var ex = Assert.Throws<ArgumentException>(() => store.DeleteByKey<Entities.Tag>(1, 2));
+            Assert.Equal("keyValues", ex.ParamName);
+        }
+    }
+}

--- a/Game.Application.Tests/DataAccess/RecordingEntityStore.cs
+++ b/Game.Application.Tests/DataAccess/RecordingEntityStore.cs
@@ -14,9 +14,14 @@ namespace Game.Application.Tests.DataAccess
         public List<object> Deleted { get; } = [];
         public List<object> Tracked { get; } = [];
 
+        // Key-only deletes, each recorded as the entity type plus the supplied key values, in call order.
+        public List<(Type EntityType, object[] KeyValues)> DeletedByKey { get; } = [];
+
         public void Insert<TEntity>(TEntity entity) where TEntity : class => Inserted.Add(entity);
         public void Update<TEntity>(TEntity entity) where TEntity : class => Updated.Add(entity);
         public void Delete<TEntity>(TEntity entity) where TEntity : class => Deleted.Add(entity);
+        public void DeleteByKey<TEntity>(params object[] keyValues) where TEntity : class =>
+            DeletedByKey.Add((typeof(TEntity), keyValues));
         public void Track<TEntity>(TEntity entity) where TEntity : class => Tracked.Add(entity);
     }
 }

--- a/Game.DataAccess/Repositories/Admin/AdminTags.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminTags.cs
@@ -26,11 +26,7 @@ namespace Game.DataAccess.Repositories.Admin
                     Name = item.Name,
                     TagCategoryId = item.TagCategoryId,
                 }),
-                delete: item => _entityStore.Delete(new Entities.Tag
-                {
-                    Id = item.Id,
-                    Name = "",
-                }));
+                delete: item => _entityStore.DeleteByKey<Entities.Tag>(item.Id));
 
             // Tags carry their own identity and have no owner to miss, so a tag write never rejects — it
             // succeeds to share the unified result contract every admin write reports through.

--- a/Game.DataAccess/Repositories/EntityStore.cs
+++ b/Game.DataAccess/Repositories/EntityStore.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Game.Abstractions.DataAccess;
 using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
@@ -24,6 +25,11 @@ namespace Game.DataAccess.Repositories
             _context.Remove(entity);
         }
 
+        public void DeleteByKey<TEntity>(params object[] keyValues) where TEntity : class
+        {
+            Delete(BuildKeyOnlyStub<TEntity>(keyValues));
+        }
+
         public void Update<TEntity>(TEntity entity) where TEntity : class
         {
             // Mark just this entity as Modified rather than calling _context.Update, which would
@@ -38,6 +44,37 @@ namespace Game.DataAccess.Repositories
         public void Track<TEntity>(TEntity entity) where TEntity : class
         {
             _context.Entry(entity).State = EntityState.Unchanged;
+        }
+
+        // Builds a stub carrying only the primary key. The instance is created uninitialized — `required`
+        // is a compile-time guard the runtime doesn't enforce, the same way EF's own materializer
+        // constructs entities — so a key-only delete never has to fabricate a value for an unrelated
+        // required scalar. EF reads just the key for the resulting DELETE; the unset non-key columns
+        // (including any unset navigation) are never touched, mirroring the existing entity-instance Delete.
+        private TEntity BuildKeyOnlyStub<TEntity>(object[] keyValues) where TEntity : class
+        {
+            var entityType = _context.Model.FindEntityType(typeof(TEntity))
+                ?? throw new InvalidOperationException($"'{typeof(TEntity).Name}' is not a mapped entity type.");
+            var keyProperties = (entityType.FindPrimaryKey()
+                ?? throw new InvalidOperationException($"'{typeof(TEntity).Name}' has no primary key to delete by.")).Properties;
+
+            if (keyValues.Length != keyProperties.Count)
+            {
+                throw new ArgumentException(
+                    $"'{typeof(TEntity).Name}' has a {keyProperties.Count}-column primary key but {keyValues.Length} value(s) were supplied.",
+                    nameof(keyValues));
+            }
+
+            var stub = (TEntity)RuntimeHelpers.GetUninitializedObject(typeof(TEntity));
+            for (var i = 0; i < keyProperties.Count; i++)
+            {
+                var keyProperty = keyProperties[i].PropertyInfo
+                    ?? throw new InvalidOperationException(
+                        $"Key property '{keyProperties[i].Name}' on '{typeof(TEntity).Name}' has no CLR property to set.");
+                keyProperty.SetValue(stub, keyValues[i]);
+            }
+
+            return stub;
         }
     }
 }

--- a/Game.DataAccess/Repositories/IEntityStore.cs
+++ b/Game.DataAccess/Repositories/IEntityStore.cs
@@ -8,6 +8,14 @@ namespace Game.DataAccess.Repositories
     {
         void Insert<TEntity>(TEntity entity) where TEntity : class;
         void Delete<TEntity>(TEntity entity) where TEntity : class;
+
+        /// <summary>
+        /// Stages a delete for the row identified by <paramref name="keyValues"/> without an entity instance,
+        /// so a record whose only non-key state is a <c>required</c> scalar (e.g. <c>Tag.Name</c>) is removed
+        /// by key alone — no unrelated columns are fabricated to satisfy the initializer. The delete stays in
+        /// the change-tracker batch and is persisted with the rest of the set on <see cref="IUnitOfWork.CommitAsync"/>.
+        /// </summary>
+        void DeleteByKey<TEntity>(params object[] keyValues) where TEntity : class;
         void Update<TEntity>(TEntity entity) where TEntity : class;
         void Track<TEntity>(TEntity entity) where TEntity : class;
     }


### PR DESCRIPTION
Closes #756.

## Problem

`AdminTags.SaveTags` built a delete stub with a fabricated scalar to satisfy a required property:

```csharp
delete: item => _entityStore.Delete(new Entities.Tag
{
    Id = item.Id,
    Name = "",   // fabricated only to satisfy the required scalar
}));
```

`Entities.Tag.Name` is `required`, so the object initializer couldn't omit it even though the delete only needs the primary key. The `Name = ""` was harmless but misleading.

## Change

Added a key-only delete affordance to `IEntityStore`:

```csharp
void DeleteByKey<TEntity>(params object[] keyValues) where TEntity : class;
```

The implementation builds a stub carrying **only** the primary key (looked up from the EF model metadata) and routes it through the existing `Delete` path, so the delete stays inside the change-tracker batch and is persisted with the rest of the set on `IUnitOfWork.CommitAsync` — no immediate `ExecuteDelete`, no weakening of the entity's `required` insert/update validation.

The stub is created with `RuntimeHelpers.GetUninitializedObject` so a `required` non-key scalar never needs a fabricated value (`required` is a compile-time guard the runtime doesn't enforce — the same way EF's own materializer constructs entities). Only the key properties are set; the unset non-key columns and navigations are never touched, mirroring the existing entity-instance `Delete`.

The tag delete now reads:

```csharp
delete: item => _entityStore.DeleteByKey<Entities.Tag>(item.Id));
```

The affordance is generic, so any future required-scalar entity can delete by key without fabricating columns.

## Cascade + reload behavior

Confirmed the in-use-tag cascade still holds (see `docs/backend.md` → "Tags are the deliberate exception"): the DB-level cascade and the controller's reference-cache reload filter are unchanged — only the mechanism that stages the `DELETE` changed. An integration test deletes a tag that's assigned to both an item and an item mod and asserts the join rows cascade away while the owners survive.

## Tests

- **Unit** (`AdminTagsTests`) — verifies `SaveTags` stages Insert/Update for add/edit and a key-only `DeleteByKey` (no fabricated `Name`) for delete.
- **Integration** (`AdminTagsIntegrationTests`) — drives the real delete through the DI-resolved `IAdminTags` + `IUnitOfWork`: removes a tag by key, cascades an in-use tag's assignment join rows, and leaves untargeted tags intact.
- **Integration** (`EntityStoreIntegrationTests`) — pins the generic affordance directly: single-column key (Tag), composite key (EnemySkill), and the wrong-key-count guard.

Full solution builds with 0 warnings; full `Game.Application.Tests` suite (269 tests) passes.

https://claude.ai/code/session_01Dx7UFAaqiYtCq82Nnjg56s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dx7UFAaqiYtCq82Nnjg56s)_