### PR TITLE
Foundation: decimal percentage convention + CooldownRecovery base-1 multiplier rebase

### DIFF
--- a/Game.Api.Tests/Integration/ReferenceDataSocketTests.cs
+++ b/Game.Api.Tests/Integration/ReferenceDataSocketTests.cs
@@ -151,7 +151,7 @@ namespace Game.Api.Tests.Integration
 
             var cooldownRecovery = Assert.Single(response.Data, a => a.Id == EAttribute.CooldownRecovery);
             Assert.True(cooldownRecovery.IsPercentage);
-            Assert.Equal(2, cooldownRecovery.Decimals);
+            Assert.Equal(0, cooldownRecovery.Decimals);
 
             var damageTaken = Assert.Single(response.Data, a => a.Id == EAttribute.DamageTakenPerSecond);
             Assert.Equal(EAttributeType.Status, damageTaken.AttributeType);

--- a/Game.Core.Tests/Attributes/AttributeCollectionTests.cs
+++ b/Game.Core.Tests/Attributes/AttributeCollectionTests.cs
@@ -84,8 +84,8 @@ namespace Game.Core.Tests.Attributes
 
             var collection = new AttributeCollection(modifiers);
 
-            // CooldownRecovery = Agility(10)*0.4 + Dexterity(20)*0.1 = 4 + 2 = 6
-            Assert.Equal(6, collection[EAttribute.CooldownRecovery]);
+            // CooldownRecovery = 1 (base) + Agility(10)*0.004 + Dexterity(20)*0.001 = 1 + 0.04 + 0.02 = 1.06
+            Assert.Equal(1.06, collection[EAttribute.CooldownRecovery], 10);
         }
 
         [Fact]

--- a/Game.Core.Tests/Attributes/AttributeTests.cs
+++ b/Game.Core.Tests/Attributes/AttributeTests.cs
@@ -104,7 +104,7 @@ namespace Game.Core.Tests.Attributes
         }
 
         [Theory]
-        [InlineData(EAttribute.CooldownRecovery, true, 2)]
+        [InlineData(EAttribute.CooldownRecovery, true, 0)]
         [InlineData(EAttribute.CriticalChance, true, 0)]
         [InlineData(EAttribute.DodgeChance, true, 0)]
         [InlineData(EAttribute.BlockChance, true, 0)]

--- a/Game.Core.Tests/Attributes/BattleAttributesParityTests.cs
+++ b/Game.Core.Tests/Attributes/BattleAttributesParityTests.cs
@@ -38,13 +38,13 @@ namespace Game.Core.Tests.Attributes
         }
 
         [Fact]
-        public void CooldownRecovery_IsFourTenthsAgilityPlusOneTenthDexterity()
+        public void CooldownRecovery_IsOnePlusFourThousandthsAgilityPlusOneThousandthDexterity()
         {
             var collection = MakeCollection(
                 (EAttribute.Agility, 20),
                 (EAttribute.Dexterity, 10));
 
-            Assert.Equal(0.4 * 20 + 0.1 * 10, collection[EAttribute.CooldownRecovery]);
+            Assert.Equal(1 + 0.004 * 20 + 0.001 * 10, collection[EAttribute.CooldownRecovery], 10);
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace Game.Core.Tests.Attributes
 
             Assert.Equal(50, collection[EAttribute.MaxHealth]);
             Assert.Equal(2, collection[EAttribute.Defense]);
-            Assert.Equal(0, collection[EAttribute.CooldownRecovery]);
+            Assert.Equal(1, collection[EAttribute.CooldownRecovery]);
         }
 
         private static AttributeCollection MakeCollection(params (EAttribute Attribute, double Amount)[] allocations)

--- a/Game.Core.Tests/Attributes/StaticAttributeModifiersTests.cs
+++ b/Game.Core.Tests/Attributes/StaticAttributeModifiersTests.cs
@@ -17,9 +17,10 @@ namespace Game.Core.Tests.Attributes
         {
             var expected = new (EAttribute Attribute, double Amount, EModifierType Type, EAttributeModifierSource Source, EAttribute? DerivedSource)[]
             {
-                // CooldownRecovery = 0.4·Agility + 0.1·Dexterity
-                (EAttribute.CooldownRecovery, 0.4, EModifierType.Additive, EAttributeModifierSource.Derived, EAttribute.Agility),
-                (EAttribute.CooldownRecovery, 0.1, EModifierType.Additive, EAttributeModifierSource.Derived, EAttribute.Dexterity),
+                // CooldownRecovery = 1 (base) + 0.004·Agility + 0.001·Dexterity
+                (EAttribute.CooldownRecovery, 1.0, EModifierType.Additive, EAttributeModifierSource.BaseValue, null),
+                (EAttribute.CooldownRecovery, 0.004, EModifierType.Additive, EAttributeModifierSource.Derived, EAttribute.Agility),
+                (EAttribute.CooldownRecovery, 0.001, EModifierType.Additive, EAttributeModifierSource.Derived, EAttribute.Dexterity),
                 // Defense = 2 (base) + 1·Endurance + 0.5·Agility
                 (EAttribute.Defense, 2.0, EModifierType.Additive, EAttributeModifierSource.BaseValue, null),
                 (EAttribute.Defense, 1.0, EModifierType.Additive, EAttributeModifierSource.Derived, EAttribute.Endurance),

--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -42,7 +42,7 @@ namespace Game.Core.Tests.Battle
             new Dictionary<string, ParityScenario>
             {
                 // Single skill, CooldownRecovery > 0 — exercises the cdMultiplier path.
-                //   Player: MaxHealth=900, Def=42, CDR=9 → cdMult=1.09
+                //   Player: MaxHealth=900, Def=42, CDR=1.09 → cdMult=1.09
                 //     charge/tick = 40*1.09 = 43.6, fires every 28 ticks (28*43.6=1220.8≥1200)
                 //     damage = 10 + 50*1.5 = 85, after def = 85-17 = 68
                 //   Enemy:  MaxHealth=400, Def=17, CDR=0; damage = 5-42 = 0 (clamped)
@@ -147,7 +147,7 @@ namespace Game.Core.Tests.Battle
                 // one source changes the kill count; the item's Agility and the prefix's Dexterity
                 // additionally feed CooldownRecovery, so the whole merge is exercised end to end.
                 //   Allocations: Str=20, End=20.  Item: +10 Str, +20 Agi.  Prefix: +8 Str, +20 Dex.  Suffix: +7 Str.
-                //   Merged: Str=45, End=20, Agi=20, Dex=20 → MaxHealth=675, Def=32, CDR=10 → cdMult=1.10.
+                //   Merged: Str=45, End=20, Agi=20, Dex=20 → MaxHealth=675, Def=32, CDR=1.10 → cdMult=1.10.
                 //   Player skill: 10 + 45*1.5 = 77.5 raw, after enemy def 17 → 60.5, fires every 28 ticks
                 //     (charge/tick = 40*1.10 = 44, 44*28=1232 ≥ 1200).
                 //   Enemy: MaxHealth=400, Def=17; attack 5-32 clamps to 0, so the player never dies.
@@ -196,8 +196,8 @@ namespace Game.Core.Tests.Battle
 
                 // A self CooldownRecovery buff is read live each tick, so it shortens the fire interval after
                 // the first hit applies it — proving CDR buffs change fire ticks.
-                //   Player: Str=20, base CDR=0 (cdMult=1); skill = Str×1.0 raw, cooldown 400.
-                //     Effect: Self +100 CooldownRecovery (additive) → cdMult=2 once applied, effectively permanent.
+                //   Player: Str=20, base CDR=1 (cdMult=1); skill = Str×1.0 raw, cooldown 400.
+                //     Effect: Self +1.0 CooldownRecovery (additive) → cdMult=2 once applied (base 1 + 1), effectively permanent.
                 //   Enemy:  Str=10 → MaxHealth=100, Def=2, no skills. Each hit deals 20−2 = 18.
                 //   Hit 1 fires at 400 (cdMult=1) and applies the buff; thereafter charge/tick = 80, so the
                 //   skill fires every 200ms: hits at 400,600,800,1000,1200,1400 → enemy dies on hit 6 at 1400.
@@ -208,7 +208,7 @@ namespace Game.Core.Tests.Battle
                         skills:
                         [
                             MakeSkill(1, baseDamage: 0, cooldownMs: 400, mult: EAttribute.Strength, multAmount: 1.0,
-                                effects: [MakeEffect(101, ESkillEffectTarget.Self, EAttribute.CooldownRecovery, EModifierType.Additive, 100, Permanent)]),
+                                effects: [MakeEffect(101, ESkillEffectTarget.Self, EAttribute.CooldownRecovery, EModifierType.Additive, 1.0, Permanent)]),
                         ]),
                     Enemy: () => MakeEnemy(
                         strength: 10, endurance: 0,
@@ -267,7 +267,7 @@ namespace Game.Core.Tests.Battle
                 // Same-tick CDR ordering: slot 0's self CooldownRecovery buff (applied after it fires) speeds
                 // up slot 1's charge accrual ON THE SAME TICK, because each slot reads the cooldown multiplier
                 // live in loadout order — so an earlier slot's effect influences a later slot firing that tick.
-                //   Player: base CDR=0 (cdMult=1). slot0 = pure buffer (0 damage, cooldown 40, Self +100 CDR
+                //   Player: base CDR=1 (cdMult=1). slot0 = pure buffer (0 damage, cooldown 40, Self +1.0 CDR
                 //     permanent → cdMult=2 once applied); slot1 = baseDamage 27, cooldown 400, no multiplier.
                 //   Enemy:  Str=5 → MaxHealth=75, Def=2, no skills. Each slot1 hit deals 27−2 = 25.
                 //   The buff lifts slot1's accrual to 80/tick from the first tick, so slot1 fires every 200ms at
@@ -279,7 +279,7 @@ namespace Game.Core.Tests.Battle
                         skills:
                         [
                             MakeSkill(1, baseDamage: 0, cooldownMs: 40,
-                                effects: [MakeEffect(104, ESkillEffectTarget.Self, EAttribute.CooldownRecovery, EModifierType.Additive, 100, Permanent)]),
+                                effects: [MakeEffect(104, ESkillEffectTarget.Self, EAttribute.CooldownRecovery, EModifierType.Additive, 1.0, Permanent)]),
                             MakeSkill(2, baseDamage: 27, cooldownMs: 400),
                         ]),
                     Enemy: () => MakeEnemy(
@@ -431,9 +431,9 @@ namespace Game.Core.Tests.Battle
 
         /// <summary>
         /// Demonstrates what happens if the player's derived stats are double-counted
-        /// (the bug the frontend used to have). CooldownRecovery doubles from 9→18,
-        /// cdMultiplier goes from 1.09→1.18, skills fire every 26 ticks instead of 28,
-        /// so the same matchup as the <c>cooldownRecovery</c> scenario ends sooner.
+        /// (the bug the frontend used to have). CooldownRecovery doubles from 1.09→2.18
+        /// (the base-1 multiplier counted twice), so skills fire every 14 ticks instead of 28,
+        /// ending the same matchup as the <c>cooldownRecovery</c> scenario much sooner.
         /// Kept separate from the matrix because it builds the player from already-final
         /// attribute values rather than raw allocations.
         /// </summary>
@@ -452,9 +452,9 @@ namespace Game.Core.Tests.Battle
             var result = sim.Simulate();
 
             Assert.True(result.Victory);
-            // With doubled CDR (18 instead of 9), cdMult=1.18,
-            // charge/tick = 47.2, fires every 26 ticks → 6240ms
-            Assert.Equal(6240, result.TotalMs);
+            // With doubled CDR (2.18 instead of 1.09), cdMult=2.18,
+            // charge/tick = 87.2, fires every 14 ticks → 3360ms
+            Assert.Equal(3360, result.TotalMs);
             Assert.True(result.TotalMs < 6720, "Double-counted stats should end the battle sooner.");
         }
 
@@ -476,7 +476,7 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(20, player.GetAttributeValue(EAttribute.Dexterity));
             Assert.Equal(675, player.GetAttributeValue(EAttribute.MaxHealth));
             Assert.Equal(32, player.GetAttributeValue(EAttribute.Defense));
-            Assert.Equal(10, player.GetAttributeValue(EAttribute.CooldownRecovery));
+            Assert.Equal(1.10, player.GetAttributeValue(EAttribute.CooldownRecovery), 10);
             Assert.Equal(1.10, player.GetCooldownMultiplier(), 10);
         }
 
@@ -628,7 +628,7 @@ namespace Game.Core.Tests.Battle
             // First, compute the correct final values (as the API would send them).
             double maxHealth = 50 + 20 * endurance + 5 * strength;
             double defense = 2 + endurance + 0.5 * agility;
-            double cooldownRecovery = 0.4 * agility + 0.1 * dexterity;
+            double cooldownRecovery = 1 + 0.004 * agility + 0.001 * dexterity;
 
             // These allocations include both raw stats AND derived values,
             // mimicking what PlayerData.FromPlayer sends to the frontend.

--- a/Game.Core.Tests/Battle/BattlerTests.cs
+++ b/Game.Core.Tests/Battle/BattlerTests.cs
@@ -45,10 +45,11 @@ namespace Game.Core.Tests.Battle
         [Fact]
         public void GetCooldownMultiplier_CalculatedFromCooldownRecovery()
         {
-            // CooldownRecovery = Agility(20)*0.4 + Dexterity(10)*0.1 = 8 + 1 = 9.
+            // CooldownRecovery = 1 (base) + 0.004·Agility(20) + 0.001·Dexterity(10) = 1.09, read directly
+            // as the cooldown multiplier (no 1 + x/100 transform).
             var battler = MakeBattler((EAttribute.Agility, 20), (EAttribute.Dexterity, 10));
 
-            var expected = 1 + (0.4 * 20 + 0.1 * 10) / 100;
+            var expected = 1 + 0.004 * 20 + 0.001 * 10;
             Assert.Equal(expected, battler.GetCooldownMultiplier(), 10);
         }
 

--- a/Game.Core/Attributes/Attribute.cs
+++ b/Game.Core/Attributes/Attribute.cs
@@ -51,8 +51,9 @@ namespace Game.Core.Attributes
         public int DisplayOrder { get; }
 
         /// <summary>
-        /// The number of decimal places the value should be displayed with (e.g.
-        /// <see cref="EAttribute.CooldownRecovery"/> = 2, most = 0).
+        /// The number of decimal places the value should be displayed with in its natural display form
+        /// (the percentage value for <see cref="IsPercentage"/> attributes). All attributes render as
+        /// whole numbers today, but a fractional attribute would raise it.
         /// </summary>
         public int Decimals { get; }
 
@@ -120,7 +121,7 @@ namespace Game.Core.Attributes
                 Luck => new(EAttributeType.Primary, IsPercentage: false, IsHarmful: false, "LUK", 5, 0),
                 MaxHealth => new(EAttributeType.Secondary, IsPercentage: false, IsHarmful: false, "HP", 6, 0),
                 Defense => new(EAttributeType.Secondary, IsPercentage: false, IsHarmful: false, "DEF", 7, 0),
-                CooldownRecovery => new(EAttributeType.Secondary, IsPercentage: true, IsHarmful: false, "CDR", 8, 2),
+                CooldownRecovery => new(EAttributeType.Secondary, IsPercentage: true, IsHarmful: false, "CDR", 8, 0),
                 CriticalChance => new(EAttributeType.Secondary, IsPercentage: true, IsHarmful: false, "CRT", 9, 0),
                 CriticalDamage => new(EAttributeType.Secondary, IsPercentage: true, IsHarmful: false, "CRT DMG", 10, 0),
                 DodgeChance => new(EAttributeType.Secondary, IsPercentage: true, IsHarmful: false, "DOD", 11, 0),

--- a/Game.Core/Attributes/Modifiers/StaticAttributeModifiers.cs
+++ b/Game.Core/Attributes/Modifiers/StaticAttributeModifiers.cs
@@ -22,9 +22,13 @@ namespace Game.Core.Attributes.Modifiers
         /// </summary>
         public static IReadOnlyList<AttributeModifier> All { get; } =
         [
-            // CooldownRecovery = 0.4·Agility + 0.1·Dexterity
-            new() { Attribute = CooldownRecovery, Amount = 0.4, Source = Derived, DerivedSource = Agility, Type = Additive },
-            new() { Attribute = CooldownRecovery, Amount = 0.1, Source = Derived, DerivedSource = Dexterity, Type = Additive },
+            // CooldownRecovery = 1 (base) + 0.004·Agility + 0.001·Dexterity. The attribute is the cooldown
+            // multiplier read directly (a base-1 multiplier, so a ×2 modifier genuinely doubles charge speed),
+            // hence the base 1 and the derived coefficients scaled ÷100 from the legacy 1 + CDR/100 form
+            // (AGI 20, DEX 10 → 1.09, identical to before the rebase).
+            new() { Attribute = CooldownRecovery, Amount = 1.0, Source = BaseValue, Type = Additive },
+            new() { Attribute = CooldownRecovery, Amount = 0.004, Source = Derived, DerivedSource = Agility, Type = Additive },
+            new() { Attribute = CooldownRecovery, Amount = 0.001, Source = Derived, DerivedSource = Dexterity, Type = Additive },
 
             // Defense = 2 (base) + 1·Endurance + 0.5·Agility
             new() { Attribute = Defense, Amount = 2.0, Source = BaseValue, Type = Additive },

--- a/Game.Core/Battle/Battler.cs
+++ b/Game.Core/Battle/Battler.cs
@@ -59,7 +59,9 @@ namespace Game.Core.Battle
 
         public double GetCooldownMultiplier()
         {
-            return 1 + (_attributes[CooldownRecovery] / 100);
+            // CooldownRecovery is a base-1 multiplier read directly (1.0 = normal charge speed); see
+            // StaticAttributeModifiers for the base/derived formula.
+            return _attributes[CooldownRecovery];
         }
 
         public double GetAttributeValue(EAttribute attribute)

--- a/UI/src/lib/api/types/attribute-modifiers.ts
+++ b/UI/src/lib/api/types/attribute-modifiers.ts
@@ -4,8 +4,9 @@
 import { EAttribute, EAttributeModifierSource, EModifierType } from './enums.ts';
 
 export const STATIC_ATTRIBUTE_MODIFIERS = [
-	{ attribute: EAttribute.CooldownRecovery, amount: 0.4, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Agility },
-	{ attribute: EAttribute.CooldownRecovery, amount: 0.1, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Dexterity },
+	{ attribute: EAttribute.CooldownRecovery, amount: 1, type: EModifierType.Additive, source: EAttributeModifierSource.BaseValue },
+	{ attribute: EAttribute.CooldownRecovery, amount: 0.004, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Agility },
+	{ attribute: EAttribute.CooldownRecovery, amount: 0.001, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Dexterity },
 	{ attribute: EAttribute.Defense, amount: 2, type: EModifierType.Additive, source: EAttributeModifierSource.BaseValue },
 	{ attribute: EAttribute.Defense, amount: 1, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Endurance },
 	{ attribute: EAttribute.Defense, amount: 0.5, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Agility },

--- a/UI/src/lib/battle/battle-formulas.ts
+++ b/UI/src/lib/battle/battle-formulas.ts
@@ -44,7 +44,8 @@ export function applyDefense(rawDamage: number, defense: number): number {
 	return Math.max(rawDamage - defense, 0);
 }
 
-/** The CooldownRecovery-derived cooldown multiplier (`1 + CooldownRecovery / 100`). */
+/** The cooldown multiplier — the CooldownRecovery attribute read directly. It is a base-1 multiplier
+ *  (1.0 = normal charge speed, 1.09 = +9%), so a multiplicative buff scales it intuitively. */
 export function cooldownMultiplier(attributes: BattleAttributes): number {
-	return 1 + attributes.getValue(EAttribute.CooldownRecovery) / 100;
+	return attributes.getValue(EAttribute.CooldownRecovery);
 }

--- a/UI/src/lib/common/attribute-display.ts
+++ b/UI/src/lib/common/attribute-display.ts
@@ -1,5 +1,5 @@
 import { EAttribute, EAttributeType, type IAttribute } from '$lib/api';
-import { normalizeText } from './functions';
+import { formatNum, normalizeText } from './functions';
 
 /*
  * Frontend display helpers for attributes. The accent hues are declared as `--attr-*` custom
@@ -86,3 +86,26 @@ export const attributeIsHarmful = (id: EAttribute, attributes?: IAttribute[]): b
  *  out-of-range type (e.g. reference data not yet loaded) degrades to an empty label. */
 export const attributeTypeName = (type: EAttributeType | undefined): string =>
 	type != null ? (EAttributeType[type] ?? '') : '';
+
+/** Renders an attribute value in its display form, honoring the reference set's `isPercentage`/
+ *  `decimals`. A percentage attribute stores a decimal fraction (e.g. CooldownRecovery `1.09`) and
+ *  renders scaled ×100 with a `%` suffix to its `decimals` precision (`109%`); other attributes render
+ *  the plain number. The reference set is passed in (not read from `$stores`), mirroring the other
+ *  param-based `$lib/common` helpers. */
+export const formatAttributeValue = (value: number, id: EAttribute, attributes?: IAttribute[]): string => {
+	const attribute = attributes?.find((a) => a.id === id);
+	if (attribute?.isPercentage) {
+		return `${(value * 100).toFixed(attribute.decimals)}%`;
+	}
+	return formatNum(value);
+};
+
+/** Renders a signed attribute delta (e.g. a per-point yield or a build-to-build change), honoring the
+ *  reference set's `isPercentage` the same way as {@link formatAttributeValue}. Uses adaptive precision
+ *  (trailing zeroes dropped) rather than the attribute's `decimals` so a small percentage contribution
+ *  — e.g. CooldownRecovery's `+0.004` per Agility point → `+0.4%` — is not rounded away. */
+export const formatAttributeDelta = (value: number, id: EAttribute, attributes?: IAttribute[]): string => {
+	const isPercentage = attributes?.find((a) => a.id === id)?.isPercentage ?? false;
+	const scaled = isPercentage ? value * 100 : value;
+	return `${scaled < 0 ? '−' : '+'}${formatNum(Math.abs(scaled))}${isPercentage ? '%' : ''}`;
+};

--- a/UI/src/routes/game/screens/attribute-breakdown/ApplyOrderTrace.svelte
+++ b/UI/src/routes/game/screens/attribute-breakdown/ApplyOrderTrace.svelte
@@ -8,15 +8,15 @@
 			<span class="swatch-slot"></span>
 			<span class="label">Start</span>
 			<span class="op"></span>
-			<span class="value">{fmtNum(0, dec)}</span>
+			<span class="value">{fmtNum(0, dec, pct)}</span>
 		</div>
 
 		{#each adds as line, i (i)}
 			<div class="line">
 				<span class="swatch-slot"><span class="swatch" style:background={sourceColor(line.source)}></span></span>
 				<span class="label">{traceLabel(line)}</span>
-				<span class="op">{fmtSigned(line.applied)}</span>
-				<span class="value">{fmtNum(line.running, dec)}</span>
+				<span class="op">{fmtSigned(line.applied, undefined, pct)}</span>
+				<span class="value">{fmtNum(line.running, dec, pct)}</span>
 			</div>
 		{/each}
 
@@ -26,14 +26,14 @@
 				<span class="swatch-slot"></span>
 				<span class="label">Additive subtotal</span>
 				<span class="op"></span>
-				<span class="value">{fmtNum(computed.additiveSubtotal, dec)}</span>
+				<span class="value">{fmtNum(computed.additiveSubtotal, dec, pct)}</span>
 			</div>
 			{#each mults as line, i (i)}
 				<div class="line">
 					<span class="swatch-slot"><span class="swatch" style:background={sourceColor(line.source)}></span></span>
 					<span class="label">{traceLabel(line)} (mult)</span>
 					<span class="op">×{line.factor}</span>
-					<span class="value">{fmtNum(line.running, dec)}</span>
+					<span class="value">{fmtNum(line.running, dec, pct)}</span>
 				</div>
 			{/each}
 		{/if}
@@ -43,7 +43,7 @@
 			<span class="swatch-slot"></span>
 			<span class="label">Final</span>
 			<span class="op"></span>
-			<span class="value">{fmtNum(computed.total, dec)}</span>
+			<span class="value">{fmtNum(computed.total, dec, pct)}</span>
 		</div>
 	</div>
 </div>
@@ -56,9 +56,11 @@ import type { ComputedAttribute } from '$lib/battle';
 interface Props {
 	computed: ComputedAttribute<LabeledModifier>;
 	dec: number;
+	/** Whether the selected attribute renders as a percentage (scaled ×100 with a `%` suffix). */
+	pct: boolean;
 }
 
-let { computed, dec }: Props = $props();
+let { computed, dec, pct }: Props = $props();
 
 const adds = $derived(computed.lines.filter((l) => !l.multiplied));
 const mults = $derived(computed.lines.filter((l) => l.multiplied));

--- a/UI/src/routes/game/screens/attribute-breakdown/AttributeListRow.svelte
+++ b/UI/src/routes/game/screens/attribute-breakdown/AttributeListRow.svelte
@@ -16,7 +16,7 @@
 		</span>
 		<StackBar {computed} height={6} radius={1} />
 	</span>
-	<span class="total">{fmtNum(computed.total, meta.dec)}</span>
+	<span class="total">{fmtNum(computed.total, meta.dec, meta.pct)}</span>
 </button>
 
 <script lang="ts">

--- a/UI/src/routes/game/screens/attribute-breakdown/BreakdownDetail.svelte
+++ b/UI/src/routes/game/screens/attribute-breakdown/BreakdownDetail.svelte
@@ -13,7 +13,7 @@
 				<p class="desc">{description}</p>
 			{/if}
 		</div>
-		<div class="value">{fmtNum(computed.total, view.selectedMeta.dec)}</div>
+		<div class="value">{fmtNum(computed.total, view.selectedMeta.dec, view.selectedMeta.pct)}</div>
 	</div>
 
 	<div class="bar"><StackBar {computed} height={18} /></div>
@@ -25,8 +25,8 @@
 		</p>
 	{:else}
 		<div class="columns">
-			<BySourceBreakdown {groups} />
-			<ApplyOrderTrace {computed} dec={view.selectedMeta.dec} />
+			<BySourceBreakdown {groups} pct={view.selectedMeta.pct} />
+			<ApplyOrderTrace {computed} dec={view.selectedMeta.dec} pct={view.selectedMeta.pct} />
 		</div>
 	{/if}
 </div>

--- a/UI/src/routes/game/screens/attribute-breakdown/BySourceBreakdown.svelte
+++ b/UI/src/routes/game/screens/attribute-breakdown/BySourceBreakdown.svelte
@@ -9,7 +9,7 @@
 				<span class="swatch" style:background={sourceColor(group.source)}></span>
 				<span class="src-name">{sourceLabel(group.source)}</span>
 				<span class="rule"></span>
-				<span class="src-total">{fmtSigned(group.total, 1)}</span>
+				<span class="src-total">{fmtSigned(group.total, 1, pct)}</span>
 			</div>
 			{#each group.lines as line, i (i)}
 				<div class="line">
@@ -25,7 +25,7 @@
 							{modifierLabel(line)}
 						{/if}
 					</span>
-					<span class="line-amount" class:negative={line.applied < 0}>{fmtSigned(line.applied)}</span>
+					<span class="line-amount" class:negative={line.applied < 0}>{fmtSigned(line.applied, undefined, pct)}</span>
 				</div>
 			{/each}
 		</div>
@@ -41,9 +41,11 @@ import { fmtNum, fmtSigned, modifierLabel, type LabeledModifier } from './attrib
 
 interface Props {
 	groups: SourceGroup<LabeledModifier>[];
+	/** Whether the selected attribute renders as a percentage (scaled ×100 with a `%` suffix). */
+	pct: boolean;
 }
 
-let { groups }: Props = $props();
+let { groups, pct }: Props = $props();
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
+++ b/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
@@ -53,6 +53,8 @@ export interface BreakdownAttrMeta {
 	type: EAttributeType;
 	/** Decimal places to render the value with. */
 	dec: number;
+	/** Whether the value renders as a percentage (scaled ×100 with a `%` suffix). */
+	pct: boolean;
 }
 
 /** The display-taxonomy groups, in render order. Status normally stays empty here — its per-second
@@ -76,7 +78,8 @@ export function attributeMeta(id: EAttribute, attributes: IAttribute[] | undefin
 	return {
 		id,
 		type: attribute?.attributeType ?? EAttributeType.Secondary,
-		dec: attribute?.decimals ?? 0
+		dec: attribute?.decimals ?? 0,
+		pct: attribute?.isPercentage ?? false
 	};
 }
 
@@ -126,18 +129,23 @@ export function buildGroups(
 
 /* ── number formatting ────────────────────────────────────────────────────── */
 
-export function fmtNum(n: number, dec = 0): string {
+/** Formats a value to `dec` places. When `pct` is set the value is a decimal fraction rendered as a
+ *  percentage — scaled ×100 with a `%` suffix (e.g. CooldownRecovery `1.09` → `109%`). */
+export function fmtNum(n: number, dec = 0, pct = false): string {
+	const value = pct ? n * 100 : n;
 	const factor = 10 ** dec;
-	const rounded = dec > 0 ? Math.round(n * factor) / factor : Math.round(n);
-	return rounded.toLocaleString('en-US', { minimumFractionDigits: dec, maximumFractionDigits: dec });
+	const rounded = dec > 0 ? Math.round(value * factor) / factor : Math.round(value);
+	return rounded.toLocaleString('en-US', { minimumFractionDigits: dec, maximumFractionDigits: dec }) + (pct ? '%' : '');
 }
 
-/** Signed value with a typographic minus, e.g. `+12` / `−3`. When `dec` is
- *  omitted a fractional value under 10 is shown to one decimal so small derived
- *  contributions (e.g. `+0.5`) don't collapse to `+1`/`+0`. */
-export function fmtSigned(n: number, dec?: number): string {
-	const places = dec ?? (Math.abs(n) < 10 && !Number.isInteger(n) ? 1 : 0);
-	return (n < 0 ? '−' : '+') + fmtNum(Math.abs(n), places);
+/** Signed value with a typographic minus, e.g. `+12` / `−3` (or `+8%` for a percentage attribute).
+ *  When `dec` is omitted a fractional value under 10 is shown to one decimal so small contributions
+ *  (e.g. `+0.5`) don't collapse to `+1`/`+0`; the threshold is judged on the rendered (percentage-
+ *  scaled, when `pct`) magnitude. */
+export function fmtSigned(n: number, dec?: number, pct = false): string {
+	const scaled = pct ? n * 100 : n;
+	const places = dec ?? (Math.abs(scaled) < 10 && !Number.isInteger(scaled) ? 1 : 0);
+	return (scaled < 0 ? '−' : '+') + fmtNum(Math.abs(n), places, pct);
 }
 
 /* ── contribution-line labels ─────────────────────────────────────────────── */

--- a/UI/src/routes/game/screens/attributes/DerivedPanel.svelte
+++ b/UI/src/routes/game/screens/attributes/DerivedPanel.svelte
@@ -24,10 +24,12 @@
 						</div>
 						{#if isChanged}
 							<span class="stat-delta" class:up={to > from}>
-								{to > from ? '+' : ''}{formatNum(round1(to - from))}
+								{formatAttributeDelta(to - from, d.id, staticData.attributes)}
 							</span>
 						{/if}
-						<span class="stat-val" class:changed={isChanged}>{formatNum(to)}{derivedUnit(d.id)}</span>
+						<span class="stat-val" class:changed={isChanged}
+							>{formatAttributeValue(to, d.id, staticData.attributes)}</span
+						>
 					</div>
 				{/each}
 			</div>
@@ -36,14 +38,13 @@
 </div>
 
 <script lang="ts">
-import { formatNum, attributeColor, attributeCode, attributeName } from '$lib/common';
+import { formatAttributeValue, formatAttributeDelta, attributeColor, attributeCode, attributeName } from '$lib/common';
 import { staticData } from '$stores';
 import AttributeIcon from '$components/AttributeIcon.svelte';
 import {
 	DERIVED_GROUPS,
 	DERIVED_STATS,
 	CORE_ATTRIBUTES,
-	derivedUnit,
 	feedsFor,
 	type AttributesView,
 	type DerivedGroup
@@ -63,8 +64,6 @@ const visibleGroups = DERIVED_GROUPS.filter((g) => statsIn(g).length > 0);
  *  so the "fed by" line never goes stale. */
 const contributorsFor = (derivedId: EAttribute): EAttribute[] =>
 	CORE_ATTRIBUTES.filter((_, i) => feedsFor(i).includes(derivedId));
-
-const round1 = (n: number): number => Math.round(n * 10) / 10;
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/game/screens/attributes/TheoryRow.svelte
+++ b/UI/src/routes/game/screens/attributes/TheoryRow.svelte
@@ -14,7 +14,7 @@
 			{:else}
 				{#each yields as y (y.id)}
 					<span class="yield">
-						<span class="amt" style="color: {color}">+{formatNum(y.delta)}{derivedUnit(y.id)}</span>
+						<span class="amt" style="color: {color}">{formatAttributeDelta(y.delta, y.id, staticData.attributes)}</span>
 						{derivedShortLabel(y.id)}
 					</span>
 				{/each}
@@ -41,19 +41,13 @@
 </div>
 
 <script lang="ts">
-import { formatNum, attributeColor, attributeCode, attributeName } from '$lib/common';
+import { formatAttributeDelta, attributeColor, attributeCode, attributeName } from '$lib/common';
 import { staticData } from '$stores';
 import AttributeIcon from '$components/AttributeIcon.svelte';
 import { getAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
 import { attributeHover } from '$components/tooltip/attribute-hover';
 import Stepper from './Stepper.svelte';
-import {
-	CORE_ATTRIBUTES,
-	derivedShortLabel,
-	derivedUnit,
-	perPointYields,
-	type AttributesView
-} from './attributes-view.svelte';
+import { CORE_ATTRIBUTES, derivedShortLabel, perPointYields, type AttributesView } from './attributes-view.svelte';
 
 interface Props {
 	i: number;

--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -32,7 +32,10 @@ export type AttributeMode = 'guided' | 'theory';
 const MODE_STORAGE_KEY = 'ttf.attr.mode';
 
 const sum = (arr: number[]): number => arr.reduce((a, b) => a + b, 0);
-const round2 = (n: number): number => Math.round(n * 100) / 100;
+/** Rounds a per-point yield to clean floating-point noise while preserving the small increments a
+ *  base-1 multiplier attribute contributes (e.g. CooldownRecovery's +0.004 per Agility point), which a
+ *  coarser 2-decimal round would collapse to zero and drop from the surfaced yields. */
+const roundYield = (n: number): number => Math.round(n * 1e6) / 1e6;
 
 /** The six core attributes that accept stat-point allocation (EAttribute 0..5), in display order.
  *  This is the **allocation domain** (the frontend mirror of the backend `Attribute.CoreAttributes`
@@ -57,17 +60,16 @@ export const DERIVED_GROUPS: DerivedGroup[] = ['Survivability', 'Offense', 'Util
 export interface DerivedStatDef {
 	id: EAttribute;
 	group: DerivedGroup;
-	/** Optional unit suffix appended after the value (e.g. `%`). */
-	unit: string;
 }
 
 /** Derived stats the game actually computes today (see `BattleAttributes`). Kept
  *  deliberately minimal — adding a real formula there plus an entry here is all
- *  it takes to surface a new stat, and the panel scales by scrolling. */
+ *  it takes to surface a new stat, and the panel scales by scrolling. Value formatting
+ *  (including the `%` for percentage attributes) comes from the shared `formatAttributeValue`. */
 export const DERIVED_STATS: DerivedStatDef[] = [
-	{ id: EAttribute.MaxHealth, group: 'Survivability', unit: '' },
-	{ id: EAttribute.Defense, group: 'Survivability', unit: '' },
-	{ id: EAttribute.CooldownRecovery, group: 'Utility', unit: '' }
+	{ id: EAttribute.MaxHealth, group: 'Survivability' },
+	{ id: EAttribute.Defense, group: 'Survivability' },
+	{ id: EAttribute.CooldownRecovery, group: 'Utility' }
 ];
 
 /** Marginal yield of a single point in a core attribute on one derived stat. */
@@ -100,7 +102,7 @@ export function perPointYields(coreIndex: number, coreValues: number[]): PerPoin
 	const after = deriveStats(bumped);
 	const yields: PerPointYield[] = [];
 	for (const def of DERIVED_STATS) {
-		const delta = round2(after[def.id] - before[def.id]);
+		const delta = roundYield(after[def.id] - before[def.id]);
 		if (delta !== 0) {
 			yields.push({ id: def.id, delta });
 		}
@@ -151,11 +153,6 @@ const DERIVED_SHORT: Partial<Record<EAttribute, string>> = {
 
 export function derivedShortLabel(id: EAttribute): string {
 	return DERIVED_SHORT[id] ?? attributeName(id, staticData.attributes);
-}
-
-/** The unit suffix configured for a surfaced derived stat (empty if none). */
-export function derivedUnit(id: EAttribute): string {
-	return DERIVED_STATS.find((d) => d.id === id)?.unit ?? '';
 }
 
 /* ── reactive view-model ──────────────────────────────────────────────────

--- a/UI/src/tests/lib/battle/attribute-modifier.test.ts
+++ b/UI/src/tests/lib/battle/attribute-modifier.test.ts
@@ -35,17 +35,23 @@ describe('STATIC_ATTRIBUTE_MODIFIERS', () => {
 		// Each entry corresponds 1:1 to a property in the C# StaticAttributeModifiers,
 		// kept in the order AttributeCollection.AddStaticModifiers adds them.
 		expect(STATIC_ATTRIBUTE_MODIFIERS).toEqual([
-			// CooldownRecovery = 0.4·AGI + 0.1·DEX
+			// CooldownRecovery = base 1 + 0.004·AGI + 0.001·DEX
 			{
 				attribute: EAttribute.CooldownRecovery,
-				amount: 0.4,
+				amount: 1,
+				type: EModifierType.Additive,
+				source: EAttributeModifierSource.BaseValue
+			},
+			{
+				attribute: EAttribute.CooldownRecovery,
+				amount: 0.004,
 				type: EModifierType.Additive,
 				source: EAttributeModifierSource.Derived,
 				derivedSource: EAttribute.Agility
 			},
 			{
 				attribute: EAttribute.CooldownRecovery,
-				amount: 0.1,
+				amount: 0.001,
 				type: EModifierType.Additive,
 				source: EAttributeModifierSource.Derived,
 				derivedSource: EAttribute.Dexterity

--- a/UI/src/tests/lib/battle/battle-attributes.test.ts
+++ b/UI/src/tests/lib/battle/battle-attributes.test.ts
@@ -65,16 +65,16 @@ describe('BattleAttributes', () => {
 			expect(ba.getValue(EAttribute.Defense)).toBe(2 + 30 + 0.5 * 20);
 		});
 
-		it('calculates CooldownRecovery = 0.4*Agi + 0.1*Dex', () => {
+		it('calculates CooldownRecovery = 1 (base) + 0.004*Agi + 0.001*Dex', () => {
 			const ba = new BattleAttributes(makeAttrs([EAttribute.Agility, 20], [EAttribute.Dexterity, 10]));
-			expect(ba.getValue(EAttribute.CooldownRecovery)).toBe(0.4 * 20 + 0.1 * 10);
+			expect(ba.getValue(EAttribute.CooldownRecovery)).toBeCloseTo(1 + 0.004 * 20 + 0.001 * 10, 10);
 		});
 
-		it('handles zero base stats (MaxHealth still has base 50)', () => {
+		it('handles zero base stats (MaxHealth base 50, CooldownRecovery base 1)', () => {
 			const ba = new BattleAttributes([]);
 			expect(ba.getValue(EAttribute.MaxHealth)).toBe(50);
 			expect(ba.getValue(EAttribute.Defense)).toBe(2);
-			expect(ba.getValue(EAttribute.CooldownRecovery)).toBe(0);
+			expect(ba.getValue(EAttribute.CooldownRecovery)).toBe(1);
 		});
 	});
 

--- a/UI/src/tests/lib/battle/battle-formulas.test.ts
+++ b/UI/src/tests/lib/battle/battle-formulas.test.ts
@@ -127,17 +127,15 @@ describe('battle-formulas', () => {
 	});
 
 	describe('cooldownMultiplier', () => {
-		it('is 1 with no CooldownRecovery', () => {
-			expect(cooldownMultiplier(makeAttributes())).toBe(1);
+		// CooldownRecovery is a base-1 multiplier read directly, so the attribute value IS the multiplier
+		// (these raw attributes skip the static base; a real battler's base 1.0 is exercised in battler.test).
+		it('reads the CooldownRecovery attribute directly as the multiplier', () => {
+			expect(cooldownMultiplier(makeAttributes([[EAttribute.CooldownRecovery, 1.09]]))).toBeCloseTo(1.09, 10);
+			expect(cooldownMultiplier(makeAttributes([[EAttribute.CooldownRecovery, 2]]))).toBe(2);
 		});
 
-		it('adds 1% per point of CooldownRecovery', () => {
-			expect(cooldownMultiplier(makeAttributes([[EAttribute.CooldownRecovery, 9]]))).toBeCloseTo(1.09, 10);
-			expect(cooldownMultiplier(makeAttributes([[EAttribute.CooldownRecovery, 100]]))).toBe(2);
-		});
-
-		it('slows cooldowns below 1 for a negative CooldownRecovery', () => {
-			expect(cooldownMultiplier(makeAttributes([[EAttribute.CooldownRecovery, -50]]))).toBeCloseTo(0.5, 10);
+		it('slows cooldowns for a CooldownRecovery below 1', () => {
+			expect(cooldownMultiplier(makeAttributes([[EAttribute.CooldownRecovery, 0.5]]))).toBeCloseTo(0.5, 10);
 		});
 	});
 });

--- a/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
+++ b/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
@@ -58,7 +58,7 @@ interface ParityScenario {
 
 const scenarios: ParityScenario[] = [
 	// Single skill, CooldownRecovery > 0 — exercises the cdMultiplier path.
-	//   Player: MaxHealth=900, Def=42, CDR=9 → cdMult=1.09; damage 85, after def 68.
+	//   Player: MaxHealth=900, Def=42, CDR=1.09 → cdMult=1.09; damage 85, after def 68.
 	//   Enemy:  MaxHealth=400, Def=17; damage 5-42 clamped to 0.
 	//   6 hits at ticks 28,56,84,112,140,168 → 6720ms.
 	{
@@ -197,7 +197,7 @@ const scenarios: ParityScenario[] = [
 	// one source changes the kill count; the item's Agility and the prefix's Dexterity
 	// additionally feed CooldownRecovery, so the whole merge is exercised end to end.
 	//   Allocations: Str=20, End=20.  Item: +10 Str, +20 Agi.  Prefix: +8 Str, +20 Dex.  Suffix: +7 Str.
-	//   Merged: Str=45, End=20, Agi=20, Dex=20 → MaxHealth=675, Def=32, CDR=10 → cdMult=1.10.
+	//   Merged: Str=45, End=20, Agi=20, Dex=20 → MaxHealth=675, Def=32, CDR=1.10 → cdMult=1.10.
 	//   Player skill: 10 + 45*1.5 = 77.5 raw, after enemy def 17 → 60.5, fires every 28 ticks
 	//     (charge/tick = 40*1.10 = 44, 44*28=1232 ≥ 1200).
 	//   Enemy: MaxHealth=400, Def=17; attack 5-32 clamps to 0, so the player never dies.
@@ -269,8 +269,8 @@ const scenarios: ParityScenario[] = [
 
 	// A self CooldownRecovery buff is read live each tick, so it shortens the fire interval after the first
 	// hit applies it. Mirrors the backend `cdrBuffShortensFireInterval` scenario.
-	//   Player: Str=20, base CDR=0 (cdMult=1); skill = Str×1.0 raw, cooldown 400.
-	//     Effect: Self +100 CooldownRecovery → cdMult=2 once applied, permanent.
+	//   Player: Str=20, base CDR=1 (cdMult=1); skill = Str×1.0 raw, cooldown 400.
+	//     Effect: Self +1.0 CooldownRecovery → cdMult=2 once applied (base 1 + 1), permanent.
 	//   Enemy:  Str=10 → MaxHealth=100, Def=2, no skills. Each hit deals 18.
 	//   Hit 1 at 400 applies the buff; thereafter the skill fires every 200ms → hit 6 at 1400.
 	{
@@ -289,7 +289,7 @@ const scenarios: ParityScenario[] = [
 								ESkillEffectTarget.Self,
 								EAttribute.CooldownRecovery,
 								EModifierType.Additive,
-								100,
+								1,
 								PERMANENT
 							)
 						]
@@ -360,7 +360,7 @@ const scenarios: ParityScenario[] = [
 	// Same-tick CDR ordering: slot 0's self CooldownRecovery buff speeds up slot 1's accrual on the same
 	// tick, because each slot reads the cooldown multiplier live in loadout order. Mirrors the backend
 	// `cdrBuffSpeedsLaterSlotSameTick` scenario.
-	//   Player: base CDR=0. slot0 = pure buffer (0 dmg, cooldown 40, Self +100 CDR permanent → cdMult=2),
+	//   Player: base CDR=1. slot0 = pure buffer (0 dmg, cooldown 40, Self +1.0 CDR permanent → cdMult=2),
 	//     slot1 = baseDamage 27, cooldown 400. Enemy Str=5 → MaxHealth=75, Def=2, no skills (25/hit).
 	//   The boosted accrual makes slot1 fire at 200,400,600 → enemy dies on the 3rd hit at 600.
 	{
@@ -379,7 +379,7 @@ const scenarios: ParityScenario[] = [
 								ESkillEffectTarget.Self,
 								EAttribute.CooldownRecovery,
 								EModifierType.Additive,
-								100,
+								1,
 								PERMANENT
 							)
 						]
@@ -640,7 +640,7 @@ describe('Battle simulation parity with backend', () => {
 
 		expect(player.attributes.getValue(EAttribute.MaxHealth)).toBe(900);
 		expect(player.attributes.getValue(EAttribute.Defense)).toBe(42);
-		expect(player.attributes.getValue(EAttribute.CooldownRecovery)).toBe(9);
+		expect(player.attributes.getValue(EAttribute.CooldownRecovery)).toBeCloseTo(1.09, 10);
 		expect(player.cdMultiplier).toBeCloseTo(1.09, 10);
 
 		expect(enemy.attributes.getValue(EAttribute.MaxHealth)).toBe(400);
@@ -664,7 +664,7 @@ describe('Battle simulation parity with backend', () => {
 		expect(player.attributes.getValue(EAttribute.Dexterity)).toBe(20);
 		expect(player.attributes.getValue(EAttribute.MaxHealth)).toBe(675);
 		expect(player.attributes.getValue(EAttribute.Defense)).toBe(32);
-		expect(player.attributes.getValue(EAttribute.CooldownRecovery)).toBe(10);
+		expect(player.attributes.getValue(EAttribute.CooldownRecovery)).toBeCloseTo(1.1, 10);
 		expect(player.cdMultiplier).toBeCloseTo(1.1, 10);
 	});
 
@@ -680,7 +680,7 @@ describe('Battle simulation parity with backend', () => {
 			// The FINAL values including derived stats, re-fed into the derived pipeline:
 			{ id: EAttribute.MaxHealth, amount: 900 }, // 50 + 20*30 + 5*50
 			{ id: EAttribute.Defense, amount: 42 }, // 2 + 30 + 0.5*20
-			{ id: EAttribute.CooldownRecovery, amount: 9 } // 0.4*20 + 0.1*10
+			{ id: EAttribute.CooldownRecovery, amount: 1.09 } // 1 + 0.004*20 + 0.001*10
 		];
 		const player = makeBattler(playerFinalAttrs, [
 			makeSkill(10, 1200, [{ attributeId: EAttribute.Strength, multiplier: 1.5 }])
@@ -690,11 +690,11 @@ describe('Battle simulation parity with backend', () => {
 		// Derived stats are now DOUBLED.
 		expect(player.attributes.getValue(EAttribute.MaxHealth)).toBe(1800);
 		expect(player.attributes.getValue(EAttribute.Defense)).toBe(84);
-		expect(player.attributes.getValue(EAttribute.CooldownRecovery)).toBe(18);
-		expect(player.cdMultiplier).toBeCloseTo(1.18, 10);
+		expect(player.attributes.getValue(EAttribute.CooldownRecovery)).toBeCloseTo(2.18, 10);
+		expect(player.cdMultiplier).toBeCloseTo(2.18, 10);
 
 		const result = new BattleSimulator(player, enemy).simulate();
-		expect(result.totalMs).toBe(6240);
+		expect(result.totalMs).toBe(3360);
 		expect(result.totalMs).toBeLessThan(6720);
 	});
 });

--- a/UI/src/tests/lib/battle/battler.test.ts
+++ b/UI/src/tests/lib/battle/battler.test.ts
@@ -67,7 +67,7 @@ describe('Battler', () => {
 			expect(battler.currentHealth).toBe(expectedMaxHealth);
 		});
 
-		it('calculates cdMultiplier from CooldownRecovery', () => {
+		it('calculates cdMultiplier from CooldownRecovery (a base-1 multiplier read directly)', () => {
 			const battler = new Battler(
 				makeBattlerData({
 					attributes: [
@@ -77,17 +77,20 @@ describe('Battler', () => {
 				})
 			);
 
-			const cdRecovery = 0.4 * 20 + 0.1 * 10;
-			expect(battler.cdMultiplier).toBeCloseTo(1 + cdRecovery / 100, 10);
+			// CooldownRecovery = base 1 + 0.004·AGI + 0.001·DEX, read directly as the multiplier.
+			const cdRecovery = 1 + 0.004 * 20 + 0.001 * 10;
+			expect(battler.cdMultiplier).toBeCloseTo(cdRecovery, 10);
 		});
 
 		it('reads cdMultiplier live, reflecting a mid-battle CooldownRecovery change', () => {
 			const battler = new Battler(makeBattlerData({ attributes: [] }));
+			// No allocations, so CooldownRecovery is just the static base 1.0 → multiplier 1.0.
 			expect(battler.cdMultiplier).toBe(1);
 
+			// A +1.0 buff lands on the base 1.0, doubling the multiplier to 2.0.
 			battler.attributes.addModifier({
 				attribute: EAttribute.CooldownRecovery,
-				amount: 100,
+				amount: 1,
 				type: EModifierType.Additive,
 				source: EAttributeModifierSource.PlayerStatPoints
 			});

--- a/UI/src/tests/routes/game/screens/attribute-breakdown/attribute-breakdown-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attribute-breakdown/attribute-breakdown-view.test.ts
@@ -58,7 +58,7 @@ const refAttributes: IAttribute[] = [
 	makeAttribute(EAttribute.CooldownRecovery, 'Cooldown Recovery', {
 		attributeType: EAttributeType.Secondary,
 		displayOrder: 8,
-		decimals: 2,
+		decimals: 0,
 		isPercentage: true
 	}),
 	makeAttribute(EAttribute.DamageTakenPerSecond, 'Damage Taken Per Second', {
@@ -203,8 +203,10 @@ describe('AttributeBreakdownView', () => {
 			EAttribute.Defense,
 			EAttribute.CooldownRecovery
 		]);
-		// CooldownRecovery carries its reference-data precision (2 decimals).
-		expect(secondary?.attrs.find((a) => a.meta.id === EAttribute.CooldownRecovery)?.meta.dec).toBe(2);
+		// CooldownRecovery carries its reference-data precision (0 decimals) and percentage flag.
+		const cdrMeta = secondary?.attrs.find((a) => a.meta.id === EAttribute.CooldownRecovery)?.meta;
+		expect(cdrMeta?.dec).toBe(0);
+		expect(cdrMeta?.pct).toBe(true);
 	});
 
 	it('self-selects only attributes with a real (non-combat) contributor', () => {
@@ -261,6 +263,13 @@ describe('formatting + labels', () => {
 		expect(fmtSigned(12)).toBe('+12');
 		expect(fmtSigned(-3)).toBe('−3');
 		expect(fmtSigned(0.5)).toBe('+0.5'); // small fractional shown to 1 dp
+	});
+
+	it('renders a percentage attribute scaled ×100 with a % suffix', () => {
+		// CooldownRecovery stores a decimal fraction (1.09) and renders as a percentage (109%).
+		expect(fmtNum(1.09, 0, true)).toBe('109%');
+		expect(fmtSigned(1.0, undefined, true)).toBe('+100%'); // the base contribution
+		expect(fmtSigned(0.08, undefined, true)).toBe('+8%'); // Agility's +0.004·20 share
 	});
 
 	it('falls back to a normalised enum name when reference data is absent', () => {

--- a/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
@@ -32,7 +32,6 @@ import {
 	perPointYields,
 	feedsFor,
 	derivedShortLabel,
-	derivedUnit,
 	radarValueAtPointer
 } from '$routes/game/screens/attributes/attributes-view.svelte';
 
@@ -68,7 +67,7 @@ describe('deriveStats', () => {
 		const d = deriveStats([0, 0, 0, 0, 0, 0]);
 		expect(d[EAttribute.MaxHealth]).toBe(50);
 		expect(d[EAttribute.Defense]).toBe(2);
-		expect(d[EAttribute.CooldownRecovery]).toBe(0);
+		expect(d[EAttribute.CooldownRecovery]).toBe(1);
 	});
 
 	it('computes MaxHealth = 50 + 20*END + 5*STR', () => {
@@ -102,15 +101,15 @@ describe('perPointYields', () => {
 		]);
 	});
 
-	it('AGI yields +0.5 Defense and +0.4 Cooldown Recovery per point', () => {
+	it('AGI yields +0.5 Defense and +0.004 Cooldown Recovery per point', () => {
 		expect(perPointYields(idx.agi, base)).toEqual([
 			{ id: EAttribute.Defense, delta: 0.5 },
-			{ id: EAttribute.CooldownRecovery, delta: 0.4 }
+			{ id: EAttribute.CooldownRecovery, delta: 0.004 }
 		]);
 	});
 
-	it('DEX yields +0.1 Cooldown Recovery per point', () => {
-		expect(perPointYields(idx.dex, base)).toEqual([{ id: EAttribute.CooldownRecovery, delta: 0.1 }]);
+	it('DEX yields +0.001 Cooldown Recovery per point (a small multiplier increment, not rounded away)', () => {
+		expect(perPointYields(idx.dex, base)).toEqual([{ id: EAttribute.CooldownRecovery, delta: 0.001 }]);
 	});
 
 	it('INT and LUK have no surfaced derived yield yet', () => {
@@ -165,10 +164,9 @@ describe('radarValueAtPointer', () => {
 });
 
 describe('label helpers', () => {
-	it('provides compact labels and units for derived stats', () => {
+	it('provides compact labels for derived stats', () => {
 		expect(derivedShortLabel(EAttribute.MaxHealth)).toBe('HP');
 		expect(derivedShortLabel(EAttribute.CooldownRecovery)).toBe('CDR');
-		expect(derivedUnit(EAttribute.MaxHealth)).toBe('');
 	});
 
 	it('falls back to a normalised enum name when reference data is absent', () => {

--- a/UI/src/tests/routes/game/screens/fight/SkillTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/SkillTooltip.test.ts
@@ -21,7 +21,15 @@ let owner: Battler;
 let opponent: Battler;
 
 beforeEach(() => {
-	owner = makeBattler({ name: 'Aelara', attributes: [{ attributeId: EAttribute.Strength, amount: 20 }] });
+	// These raw fixtures skip the derived pass, so CooldownRecovery is supplied explicitly: 1 is the
+	// base-1 multiplier every real battler carries (cdMultiplier reads the attribute directly now).
+	owner = makeBattler({
+		name: 'Aelara',
+		attributes: [
+			{ attributeId: EAttribute.Strength, amount: 20 },
+			{ attributeId: EAttribute.CooldownRecovery, amount: 1 }
+		]
+	});
 	opponent = makeBattler({ name: 'Dire Wolf', attributes: [{ attributeId: EAttribute.Defense, amount: 5 }] });
 	mockBattleEngine.getOpponent.mockReturnValue(opponent);
 	staticData.attributes = [];
@@ -88,12 +96,12 @@ describe('SkillTooltip', () => {
 	});
 
 	it('derives cooldown and DPS, shortening the cooldown for a faster battler', () => {
-		// cdMultiplier is a live read of CooldownRecovery: 1 + 100/100 = 2 (fixtures skip the
-		// derived pass, so CooldownRecovery is taken verbatim from the supplied attributes).
+		// cdMultiplier is the CooldownRecovery attribute read directly — a base-1 multiplier, so 2 = double
+		// speed (fixtures skip the derived pass, so CooldownRecovery is taken verbatim from the supplied attributes).
 		const fast = makeBattler({
 			attributes: [
 				{ attributeId: EAttribute.Strength, amount: 20 },
-				{ attributeId: EAttribute.CooldownRecovery, amount: 100 }
+				{ attributeId: EAttribute.CooldownRecovery, amount: 2 }
 			]
 		});
 		const skill = makeSkill(fast, {

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -260,14 +260,15 @@ describe('SkillsView — initial state', () => {
 	});
 
 	it('resolves metrics through the shared battle formulas and the derived attribute composition', () => {
-		// Strength feeds Alpha's 1× multiplier directly; Agility derives CooldownRecovery (0.4/pt).
+		// Strength feeds Alpha's 1× multiplier directly; Agility derives CooldownRecovery (0.004/pt).
 		mockPlayerManager.attributes = [
 			{ attributeId: EAttribute.Strength, amount: 20 },
 			{ attributeId: EAttribute.Agility, amount: 10 }
 		];
 		const fresh = new SkillsView();
 		expect(fresh.rawDamage(0)).toBe(32); // 12 base + 20·1
-		expect(fresh.cooldown(0)).toBeCloseTo(1 / 1.04, 10); // 1s / (1 + 4 CDR / 100)
+		// CooldownRecovery = base 1 + 0.004·10 = 1.04, read directly as the cooldown multiplier.
+		expect(fresh.cooldown(0)).toBeCloseTo(1 / 1.04, 10);
 		expect(fresh.metric(0)?.contributions).toEqual([{ attributeId: EAttribute.Strength, multiplier: 1, value: 20 }]);
 	});
 });

--- a/docs/game-design.md
+++ b/docs/game-design.md
@@ -18,6 +18,15 @@ Attributes are somewhat of a work-in-progress feature, but the general idea is t
 
 The attribute system is the substrate for timed skill effects (see [Skills](#skills)): applying an effect adds a real attribute modifier to the target mid-battle and expiry removes it, so derived attributes cascade naturally (a temporary Strength buff also raises MaxHealth, exactly like a permanent one). Damage-over-time and heal-over-time are realized the same way, through two **per-second** attributes — `DamageTakenPerSecond` and `HealthRegenPerSecond` — that an end-of-tick simulator phase consumes (a poison is then pure data: a debuff that adds `DamageTakenPerSecond` to the opponent for a duration). See [Skill Effects](#skill-effects) for the DoT/HoT runtime rules.
 
+## Attribute value conventions
+
+Percentage- and multiplier-style attributes are stored so they are consumed **without transformation** in the battle math:
+
+- **Percentage attributes** are stored as decimal fractions (`0.05` = 5%) and used as-is — a chance is compared directly against a `[0,1)` RNG draw — and rendered scaled ×100 (`0.05` → `5%`).
+- **Multiplier attributes** carry a base ≥ 1 and are read directly as the multiplier. `CooldownRecovery` is a base-`1` cooldown multiplier: a static `1.0` base plus `0.004·Agility + 0.001·Dexterity` (a typical AGI 20 / DEX 10 build sits at `1.09` ≈ +9% charge speed). Reading the attribute directly means a multiplicative modifier scales intuitively — a `×2` `CooldownRecovery` buff genuinely doubles charge speed rather than nudging the old `1 + CDR/100` value. Like the percentage attributes, it renders scaled ×100 (`1.09` → `109%`).
+
+This convention is the foundation the (still-unimplemented) player crit/dodge/block attributes build on — see the [spike](./spikes/178-player-crit-dodge-block.md).
+
 ## Experience Rewards
 
 The XP a victory awards scales with how well the enemy is matched to the player's power, so fighting something around (or above) your level pays off and grinding trivial enemies does not. The reward (`DefeatRewards`, computed server-side and sent to the client) is the enemy's attribute power times a difficulty multiplier derived from the ratio of the enemy's power to the player's: within a ±20% band the multiplier is `1`, and outside it the reward scales quadratically with the ratio (over-level enemies pay out more, under-level enemies far less).


### PR DESCRIPTION
## Summary

Implements **#797** — area **A** (the foundation) of spike **#178** (player crit/dodge/block). This is a **behaviour-preserving** refactor with **no new mechanic**: it settles the percentage/multiplier attribute storage convention #528 deferred, and rebases `CooldownRecovery` to a base-`1` multiplier so multiplicative modifiers behave intuitively.

## What changed

**CooldownRecovery rebase (behaviour-preserving)**
- `StaticAttributeModifiers`: `CooldownRecovery` gains a `BaseValue` of `1.0`, and its derived coefficients are rescaled `÷100` → `+0.004·Agility + 0.001·Dexterity`. AGI 20 / DEX 10 still resolves to **`1.09`**, identical to today.
- `Battler.GetCooldownMultiplier()` (BE) and `cooldownMultiplier()` (FE, `battle-formulas.ts`) now `return attributes[CooldownRecovery]` — the `1 + x/100` transform is gone. Every consumer (the shared skills-page / skill-tooltip cooldown display) reads the same multiplier value and follows automatically. The base `1.0` applies to **enemies** too, so their cooldown multiplier stays `1.0`.

**Decimal / multiplier convention**
- Percentage- and multiplier-style attributes are stored to be consumed **without transformation**. `CooldownRecovery` is now a multiplier read directly (base `1`), so a `×2` buff genuinely doubles charge speed.

**Display** (per owner decision — render the multiplier as a percentage, `1.09 → 109%`)
- Wired the previously-unused `IsPercentage` flag through value rendering on the **attributes build screen** and the **attribute-breakdown** inspector; `CooldownRecovery` `Decimals` `2 → 0` so it reads `109%` (not `109.00%`).
- Added shared `formatAttributeValue` / `formatAttributeDelta` helpers in `attribute-display.ts`.
- Fixed an attributes-screen **per-point precision regression**: the rebased increments (`+0.004`/AGI, `+0.001`/DEX) fall below the old 2-decimal rounding and would have silently dropped (making DEX appear to "feed nothing"); they now surface as `+0.4%` / `+0.1%`.

**Parity vectors (kept in lockstep on both sides)**
- Non-buff CDR scenarios keep their expected `totalMs` (the multiplier value is unchanged).
- The CDR-*buff* scenarios re-author their effect amounts (`+100` additive → `+1.0` on the base `1`, still `cdMult = 2`).
- The double-derived-stats guard recomputed: doubled `cdMult` `2.18` → battle ends at **`3360ms`** (mirrored in `BattleSimulatorParityTests` ↔ `battle-simulation-parity.test.ts`).
- Regenerated the codegen'd `STATIC_ATTRIBUTE_MODIFIERS` frontend table.

## Design note

The **attribute-breakdown inspector** is made percentage-aware too (not just the build screen), so the same stat doesn't read `1.09` on one screen and `109%` on another — the inspector's literal apply-order trace renders in the same `%` units (`0% → +100% → +108% → +109%`).

## Test plan
- [x] Backend: `dotnet build` + `dotnet test Game.Core.Tests` (560 pass) and `Game.Api.Tests` (498 pass, incl. the codegen-drift and reference-data integration tests).
- [x] Frontend: `npm run test:unit:ci` (1868 pass) and `npm run lint` (eslint + svelte-check, 0 errors).
- [x] Battle-parity matrices verified row-for-row consistent across BE ↔ FE.

Closes #797

---
_Generated by [Claude Code](https://claude.ai/code/session_017pTjJkat2JtLpGD85ixsXL)_