### PR TITLE
Source test frame-size from SocketContext.MAX_MESSAGE_SIZE (#780)

### DIFF
--- a/Game.Api.Tests/Unit/SocketContextTests.cs
+++ b/Game.Api.Tests/Unit/SocketContextTests.cs
@@ -113,7 +113,7 @@ namespace Game.Api.Tests.Unit
             var context = CreateContext(socket);
 
             // A payload larger than one frame, so it is sent as multiple chunks under the send lock.
-            var payload = new string('x', SocketContextTests.MaxFrameSize + 1000);
+            var payload = new string('x', SocketContext.MAX_MESSAGE_SIZE + 1000);
             using var cts = new CancellationTokenSource();
             // Cancel the moment the first (non-final) chunk has gone out — mid-frame.
             socket.AfterSendChunk = isFinal =>
@@ -205,9 +205,6 @@ namespace Game.Api.Tests.Unit
             var session = new SessionService(new NoOpSessionStore());
             return new SocketContext(socket, playerId: 1, session, NullLogger<SocketContext>.Instance);
         }
-
-        /// <summary>The frame chunk size <see cref="SocketContext"/> splits outbound sends at (4 KB).</summary>
-        private const int MaxFrameSize = 1024 * 4;
 
         /// <summary>
         /// A <see cref="WebSocket"/> stand-in that scripts receives (data / close / a zero-length flood) and

--- a/Game.Api/Sockets/SocketContext.cs
+++ b/Game.Api/Sockets/SocketContext.cs
@@ -9,7 +9,7 @@ namespace Game.Api.Sockets
 {
     public class SocketContext
     {
-        private const short MAX_MESSAGE_SIZE = 1024 * 4;
+        internal const short MAX_MESSAGE_SIZE = 1024 * 4;
 
         // Caps a single inbound message at MAX_FRAMES_PER_MESSAGE * MAX_MESSAGE_SIZE (~4 MB). Every received
         // frame counts toward it — including empty ones — so a peer streaming zero-length frames is bounded


### PR DESCRIPTION
## Summary

- Expose `SocketContext.MAX_MESSAGE_SIZE` as `internal` (the `InternalsVisibleTo` entry for `Game.Api.Tests` already exists in `Game.Api.csproj`)
- Remove the duplicate `private const int MaxFrameSize = 1024 * 4` from `SocketContextTests`
- Replace the reference in `SendData_MidFrameCancellation_...` with `SocketContext.MAX_MESSAGE_SIZE` so the test payload is derived from a single source of truth

Now if the chunk size ever changes, the test automatically tracks it — the multi-chunk assumption can't silently break.

## Test plan

- [ ] Existing `SocketContextTests` suite still passes (no logic change, only constant sourcing)
- [ ] CI green

Closes #780

---
_Generated by [Claude Code](https://claude.ai/code/session_0149VQafaDdGHQKe39YCFZsS)_