### PR TITLE
Add dedicated --block-color semantic token for loom board (#772)

### DIFF
--- a/UI/src/routes/+layout.svelte
+++ b/UI/src/routes/+layout.svelte
@@ -113,6 +113,7 @@ $effect(() => {
 	--health-missing-color: #{colors.$hp-red-bg};
 	--health-remaining-color: #{colors.$hp-green};
 	--health-remaining-dark: #{colors.$hp-green-dark};
+	--block-color: #{colors.$hp-green};
 	--health-disappearing-color: #{colors.$hp-red-disappearing};
 	--slot-background-color: #{colors.$white};
 	--surface: #{colors.$surface};

--- a/UI/src/routes/game/screens/card-game/loom/Board.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/Board.svelte
@@ -2,7 +2,7 @@
 	<div class="gridlayer" style:background-position-x="{view.tickToX(0.5)}px"></div>
 
 	<span class="lane-label" style="top:4px">
-		<b style="color:var(--log-enemy)">enemy strikes</b> <b style="color:var(--health-remaining-color)">· your blocks</b>
+		<b style="color:var(--log-enemy)">enemy strikes</b> <b style="color:var(--block-color)">· your blocks</b>
 	</span>
 	<span class="lane-label" style="top:96px">
 		<b style="color:var(--log-player)">your strikes</b> <b style="color:var(--log-enemy)">· enemy guard</b>
@@ -71,7 +71,7 @@ const PXT = PX_PER_TICK;
    keeps the enemy hue (--log-enemy); player blocks stay the board's block green. */
 const FLASH_LAYOUT: Record<FlashKind, { y: number; color: string }> = {
 	enemyHit: { y: 36, color: 'var(--enemy-accent)' },
-	block: { y: 36, color: 'var(--health-remaining-color)' },
+	block: { y: 36, color: 'var(--block-color)' },
 	guarded: { y: 92, color: 'var(--log-enemy)' },
 	crit: { y: 116, color: 'var(--gold)' },
 	strike: { y: 160, color: 'var(--log-player)' },
@@ -267,9 +267,9 @@ onMount(() => {
 	height: 76px;
 	align-items: flex-start;
 	padding-top: 3px;
-	border-color: color-mix(in srgb, var(--health-remaining-color) 70%, transparent);
-	background: color-mix(in srgb, var(--health-remaining-color) 10%, transparent);
-	color: color-mix(in srgb, var(--health-remaining-color) 35%, var(--white));
+	border-color: color-mix(in srgb, var(--block-color) 70%, transparent);
+	background: color-mix(in srgb, var(--block-color) 10%, transparent);
+	color: color-mix(in srgb, var(--block-color) 35%, var(--white));
 }
 
 .preview.attack {

--- a/UI/src/routes/game/screens/card-game/loom/BoardEntity.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/BoardEntity.svelte
@@ -160,10 +160,10 @@ const hasTip = $derived(
 	align-items: flex-start;
 	padding-top: 3px;
 	border-style: dashed;
-	border-color: color-mix(in srgb, var(--health-remaining-color) 50%, transparent);
-	background: color-mix(in srgb, var(--health-remaining-color) 12%, transparent);
-	box-shadow: inset 0 0 16px color-mix(in srgb, var(--health-remaining-color) 12%, transparent);
-	color: color-mix(in srgb, var(--health-remaining-color) 35%, var(--white));
+	border-color: color-mix(in srgb, var(--block-color) 50%, transparent);
+	background: color-mix(in srgb, var(--block-color) 12%, transparent);
+	box-shadow: inset 0 0 16px color-mix(in srgb, var(--block-color) 12%, transparent);
+	color: color-mix(in srgb, var(--block-color) 35%, var(--white));
 	font-size: 10px;
 	letter-spacing: 0.12em;
 }

--- a/UI/src/routes/game/screens/card-game/loom/CardFace.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/CardFace.svelte
@@ -151,14 +151,14 @@ const { card, index, slot, view }: Props = $props();
 
 /* block cards (Guard / Dodge) */
 .card.lane-b {
-	border-left-color: var(--health-remaining-color);
-	--card-glow: color-mix(in srgb, var(--health-remaining-color) 50%, transparent);
+	border-left-color: var(--block-color);
+	--card-glow: color-mix(in srgb, var(--block-color) 50%, transparent);
 
 	.type .d {
-		background: var(--health-remaining-color);
+		background: var(--block-color);
 	}
 	.t {
-		color: color-mix(in srgb, var(--health-remaining-color) 45%, var(--text-primary));
+		color: color-mix(in srgb, var(--block-color) 45%, var(--text-primary));
 	}
 }
 

--- a/UI/src/routes/game/screens/card-game/loom/Legend.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/Legend.svelte
@@ -63,9 +63,9 @@ const ITEMS = [
 	background: color-mix(in srgb, var(--rarity-epic) 20%, transparent);
 }
 .sw.bl {
-	border-color: var(--health-remaining-color);
+	border-color: var(--block-color);
 	border-style: dashed;
-	background: color-mix(in srgb, var(--health-remaining-color) 18%, transparent);
+	background: color-mix(in srgb, var(--block-color) 18%, transparent);
 }
 .sw.cr {
 	border-color: var(--gold);


### PR DESCRIPTION
## Summary

- Introduces `--block-color` in `+layout.svelte`, initially resolving to `#{colors.$hp-green}` (same value as `--health-remaining-color`) — no visual change intended
- Repoints all player-block surfaces on the loom board to `--block-color`:
  - Block flash (`FLASH_LAYOUT.block.color` in `Board.svelte`)
  - "your blocks" lane label (`Board.svelte`)
  - `.preview.block` span (`Board.svelte`)
  - `.ent.block` entity (`BoardEntity.svelte`)
  - Block card face / `.lane-b` (`CardFace.svelte`)
  - Legend swatch `.sw.bl` (`Legend.svelte`)
- `--health-remaining-color` is left in place on genuine health surfaces: HP bars (`Combatants.svelte`) and the win-outcome banner (`OutcomeBanner.svelte`), where green semantically means "health remaining / survived"

The semantic separation means a future theme can restyle block/shield surfaces independently of HP bars by overriding `--block-color` alone. This mirrors the `--change-added`/`-modified`/`-removed` pattern documented in `docs/frontend.md` → Styling.

## Test plan

- [x] `npm run lint` — passes (0 errors, 0 warnings)
- [x] `npm run test:unit:ci` — 1868 tests across 196 files, all pass
- [ ] Visual check: open the card-game screen and confirm the block lane, block entities, preview, flash, card faces, and legend swatch all still render in green (no visible change expected)

Closes #772

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7ZNyv6mzpf9HGSh2tpL8h)_