### PR TITLE
Make AttributeChip tooltip keyboard-reachable (#774)

### DIFF
--- a/UI/src/components/AttributeChip.svelte
+++ b/UI/src/components/AttributeChip.svelte
@@ -1,14 +1,15 @@
 <!-- A monospace attribute pill (icon + code) tinted by the attribute's colour. Opens the shared
-     attribute tooltip on hover whenever a screen provides a controller via `setAttributeTooltip`;
+     attribute tooltip on hover or focus whenever a screen provides a controller via `setAttributeTooltip`;
      otherwise it is purely presentational. -->
-<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <span
 	class="achip"
 	class:wide
+	role="img"
+	tabindex="0"
+	aria-label={attributeName(attributeId, staticData.attributes)}
 	style:--ac={attributeColor(attributeId)}
-	onmouseenter={(e) => attrTip?.show(attributeId, e)}
-	onmousemove={(e) => attrTip?.move(e)}
-	onmouseleave={() => attrTip?.hide()}
+	use:attributeHover={{ controller: attrTip, id: attributeId }}
 >
 	<AttributeIcon id={attributeId} size={iconSize} />
 	{attributeCode(attributeId, staticData.attributes)}
@@ -16,10 +17,11 @@
 
 <script lang="ts">
 import type { EAttribute } from '$lib/api';
-import { attributeCode, attributeColor } from '$lib/common';
+import { attributeCode, attributeColor, attributeName } from '$lib/common';
 import { staticData } from '$stores';
 import AttributeIcon from '$components/AttributeIcon.svelte';
 import { getAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
+import { attributeHover } from '$components/tooltip/attribute-hover';
 
 interface Props {
 	attributeId: EAttribute;
@@ -52,6 +54,11 @@ const attrTip = getAttributeTooltip();
 		justify-content: center;
 		min-width: 46px;
 		text-align: center;
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--ac);
+		outline-offset: 2px;
 	}
 }
 </style>

--- a/UI/src/tests/components/AttributeChip.test.ts
+++ b/UI/src/tests/components/AttributeChip.test.ts
@@ -6,7 +6,7 @@ import { EAttribute } from '$lib/api';
 const controller = { show: vi.fn(), move: vi.fn(), hide: vi.fn() };
 
 // The chip resolves the screen-level controller via context; the action/controller wiring is
-// covered elsewhere, so here we stub it to assert the chip drives it on hover.
+// covered elsewhere, so here we stub it to assert the chip drives it on hover and focus.
 vi.mock('$components/tooltip/attribute-tooltip.svelte', () => ({
 	getAttributeTooltip: () => controller
 }));
@@ -39,6 +39,14 @@ describe('AttributeChip', () => {
 		expect(wide.container.querySelector('.achip')?.classList.contains('wide')).toBe(true);
 	});
 
+	it('is keyboard-reachable with tabindex, role, and an aria-label', () => {
+		const { container } = render(AttributeChip, { props: { attributeId: EAttribute.Strength } });
+		const chip = container.querySelector('.achip') as HTMLElement;
+		expect(chip.getAttribute('tabindex')).toBe('0');
+		expect(chip.getAttribute('role')).toBe('img');
+		expect(chip.getAttribute('aria-label')).toBe('Strength');
+	});
+
 	it('drives the shared attribute tooltip across hover (enter/move/leave)', async () => {
 		const { container } = render(AttributeChip, { props: { attributeId: EAttribute.Strength } });
 		const chip = container.querySelector('.achip') as HTMLElement;
@@ -47,6 +55,15 @@ describe('AttributeChip', () => {
 		await fireEvent.mouseMove(chip);
 		expect(controller.move).toHaveBeenCalled();
 		await fireEvent.mouseLeave(chip);
+		expect(controller.hide).toHaveBeenCalled();
+	});
+
+	it('opens the tooltip on focus and closes on blur', async () => {
+		const { container } = render(AttributeChip, { props: { attributeId: EAttribute.Strength } });
+		const chip = container.querySelector('.achip') as HTMLElement;
+		await fireEvent.focus(chip);
+		expect(controller.show).toHaveBeenCalledWith(EAttribute.Strength, chip);
+		await fireEvent.blur(chip);
 		expect(controller.hide).toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

- Replaces the three inline mouse handlers (`onmouseenter`/`onmousemove`/`onmouseleave`) in `AttributeChip.svelte` with the shared `attributeHover` action, which already handles `focus`/`blur` in addition to mouse events
- Adds `tabindex="0"`, `role="img"`, and `aria-label` (full attribute name via `attributeName`) to make the chip focusable and screen-reader-friendly
- Adds a `focus-visible` outline using the chip's attribute accent colour so keyboard focus is visually distinguishable
- New tests verify the accessibility attributes and focus/blur tooltip wiring

## Test plan

- [x] `AttributeChip` unit tests all pass (5/5), including two new cases: keyboard-accessibility attributes and focus/blur tooltip behaviour
- [x] `attributeHover` action tests unchanged and green (4/4)
- [x] Full unit suite green (1870 tests across 196 files)
- [x] `npm run lint` — 0 errors, 0 warnings

Closes #774

---
_Generated by [Claude Code](https://claude.ai/code/session_01M233VB6Vxv1NELupwkKWkK)_