### PR TITLE
Source crit/dodge/block from core attributes + verify gear authoring (#799)

### DIFF
--- a/Game.Core.Tests/Attributes/BattleAttributesParityTests.cs
+++ b/Game.Core.Tests/Attributes/BattleAttributesParityTests.cs
@@ -48,6 +48,52 @@ namespace Game.Core.Tests.Attributes
         }
 
         [Fact]
+        public void CriticalChance_IsTwoThousandthsDexterityPlusOneThousandthLuck()
+        {
+            var collection = MakeCollection(
+                (EAttribute.Dexterity, 20),
+                (EAttribute.Luck, 10));
+
+            Assert.Equal(0.002 * 20 + 0.001 * 10, collection[EAttribute.CriticalChance], 10);
+        }
+
+        [Fact]
+        public void CriticalDamage_IsBaseOneAndHalfPlusQuarterPercentLuck()
+        {
+            var collection = MakeCollection(
+                (EAttribute.Luck, 20));
+
+            Assert.Equal(1.5 + 0.0025 * 20, collection[EAttribute.CriticalDamage], 10);
+        }
+
+        [Fact]
+        public void DodgeChance_IsOneThousandthAgility()
+        {
+            var collection = MakeCollection(
+                (EAttribute.Agility, 20));
+
+            Assert.Equal(0.001 * 20, collection[EAttribute.DodgeChance], 10);
+        }
+
+        [Fact]
+        public void BlockChance_IsTwoThousandthsEndurance()
+        {
+            var collection = MakeCollection(
+                (EAttribute.Endurance, 20));
+
+            Assert.Equal(0.002 * 20, collection[EAttribute.BlockChance], 10);
+        }
+
+        [Fact]
+        public void BlockReduction_IsTwoPlusHalfEndurance()
+        {
+            var collection = MakeCollection(
+                (EAttribute.Endurance, 20));
+
+            Assert.Equal(2 + 0.5 * 20, collection[EAttribute.BlockReduction]);
+        }
+
+        [Fact]
         public void ZeroBaseStats_StillHaveDerivedBaseValues()
         {
             var collection = MakeCollection();
@@ -55,6 +101,12 @@ namespace Game.Core.Tests.Attributes
             Assert.Equal(50, collection[EAttribute.MaxHealth]);
             Assert.Equal(2, collection[EAttribute.Defense]);
             Assert.Equal(1, collection[EAttribute.CooldownRecovery]);
+            // CriticalDamage and BlockReduction carry a base; the three chances have none, so they are 0.
+            Assert.Equal(1.5, collection[EAttribute.CriticalDamage]);
+            Assert.Equal(2, collection[EAttribute.BlockReduction]);
+            Assert.Equal(0, collection[EAttribute.CriticalChance]);
+            Assert.Equal(0, collection[EAttribute.DodgeChance]);
+            Assert.Equal(0, collection[EAttribute.BlockChance]);
         }
 
         private static AttributeCollection MakeCollection(params (EAttribute Attribute, double Amount)[] allocations)

--- a/Game.Core.Tests/Attributes/StaticAttributeModifiersTests.cs
+++ b/Game.Core.Tests/Attributes/StaticAttributeModifiersTests.cs
@@ -29,6 +29,19 @@ namespace Game.Core.Tests.Attributes
                 (EAttribute.MaxHealth, 50.0, EModifierType.Additive, EAttributeModifierSource.BaseValue, null),
                 (EAttribute.MaxHealth, 20.0, EModifierType.Additive, EAttributeModifierSource.Derived, EAttribute.Endurance),
                 (EAttribute.MaxHealth, 5.0, EModifierType.Additive, EAttributeModifierSource.Derived, EAttribute.Strength),
+                // CriticalChance = 0.002·Dexterity + 0.001·Luck
+                (EAttribute.CriticalChance, 0.002, EModifierType.Additive, EAttributeModifierSource.Derived, EAttribute.Dexterity),
+                (EAttribute.CriticalChance, 0.001, EModifierType.Additive, EAttributeModifierSource.Derived, EAttribute.Luck),
+                // CriticalDamage = 1.5 (base) + 0.0025·Luck
+                (EAttribute.CriticalDamage, 1.5, EModifierType.Additive, EAttributeModifierSource.BaseValue, null),
+                (EAttribute.CriticalDamage, 0.0025, EModifierType.Additive, EAttributeModifierSource.Derived, EAttribute.Luck),
+                // DodgeChance = 0.001·Agility
+                (EAttribute.DodgeChance, 0.001, EModifierType.Additive, EAttributeModifierSource.Derived, EAttribute.Agility),
+                // BlockChance = 0.002·Endurance
+                (EAttribute.BlockChance, 0.002, EModifierType.Additive, EAttributeModifierSource.Derived, EAttribute.Endurance),
+                // BlockReduction = 2 (base) + 0.5·Endurance
+                (EAttribute.BlockReduction, 2.0, EModifierType.Additive, EAttributeModifierSource.BaseValue, null),
+                (EAttribute.BlockReduction, 0.5, EModifierType.Additive, EAttributeModifierSource.Derived, EAttribute.Endurance),
             };
 
             Assert.Equal(expected.Length, StaticAttributeModifiers.All.Count);

--- a/Game.Core.Tests/Battle/BattleContextTests.cs
+++ b/Game.Core.Tests/Battle/BattleContextTests.cs
@@ -83,8 +83,8 @@ namespace Game.Core.Tests.Battle
         [Fact]
         public void DamageTarget_PlayerCrit_MultipliesRawBeforeDefense()
         {
-            // CriticalChance 1 always succeeds; CriticalDamage 2 reads directly as the multiplier.
-            var player = MakeBattlerWith((CriticalChance, 1), (CriticalDamage, 2));
+            // CriticalChance 1 always succeeds; CriticalDamage is the base 1.5 + 0.5 = 2, read directly as the multiplier.
+            var player = MakeBattlerWith((CriticalChance, 1), (CriticalDamage, 0.5));
             var enemy = MakeBattlerWith((Endurance, 0)); // MaxHealth 50, Defense 2
             var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
 
@@ -126,7 +126,8 @@ namespace Game.Core.Tests.Battle
         [Fact]
         public void DamageTarget_PlayerBlocksEnemyHit_SubtractsDefenseAndBlockReduction()
         {
-            var player = MakeBattlerWith((BlockChance, 1), (BlockReduction, 10)); // Defense 2
+            // BlockReduction is the base 2 + 8 = 10; Defense 2.
+            var player = MakeBattlerWith((BlockChance, 1), (BlockReduction, 8));
             var enemy = MakeBattlerWith((Endurance, 0));
             var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
             context.SwapActiveAndTargetBattlers();

--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -413,14 +413,15 @@ namespace Game.Core.Tests.Battle
                 // taken in lockstep on both sides, so these pin the player-only crit/dodge/block math and draw
                 // order while staying hand-computable.
 
-                // A forced crit (CriticalChance 1) multiplies the raw damage by CriticalDamage BEFORE Defense:
-                // 20 raw × 2 = 40, −2 Def = 38/hit, so the 100-HP enemy dies on hit 3 at tick 30 → 1200ms (vs
-                // hit 6 / 2400ms at the un-critted 18/hit).
+                // A forced crit (CriticalChance 1) multiplies the raw damage by CriticalDamage BEFORE Defense.
+                // CriticalDamage is the base 1.5 (sourced by #799) plus a 0.5 allocation = 2.0 total: 20 raw × 2
+                // = 40, −2 Def = 38/hit, so the 100-HP enemy dies on hit 3 at tick 30 → 1200ms (vs hit 6 /
+                // 2400ms at the un-critted 18/hit).
                 ["forcedCrit"] = new ParityScenario(
                     Player: () => MakeBattler(
                         strength: 10, endurance: 0,
                         skills: [MakeSkill(1, baseDamage: 20, cooldownMs: 400)],
-                        extra: [(EAttribute.CriticalChance, 1.0), (EAttribute.CriticalDamage, 2.0)]),
+                        extra: [(EAttribute.CriticalChance, 1.0), (EAttribute.CriticalDamage, 0.5)]),
                     Enemy: () => MakeEnemy(strength: 10, endurance: 0, skills: []),
                     ExpectedVictory: true,
                     ExpectedPlayerDied: false,
@@ -441,15 +442,16 @@ namespace Game.Core.Tests.Battle
                     ExpectedPlayerDied: false,
                     ExpectedTotalMs: 2400),
 
-                // A forced block (BlockChance 1) flatly reduces each incoming hit by Defense + BlockReduction:
-                // 25 − 2 − 20 = 3/hit instead of 23/hit. At 23/hit the enemy (firing every 5 ticks) kills the
-                // 100-HP player on its 5th hit at tick 25; at 3/hit the player survives to kill the 200-HP enemy
-                // (48/hit every 10 ticks) on hit 5 at tick 50 → 2000ms. Block flips the loss into a win.
+                // A forced block (BlockChance 1) flatly reduces each incoming hit by Defense + BlockReduction.
+                // BlockReduction is the base 2 (sourced by #799) plus an 18 allocation = 20 total: 25 − 2 − 20
+                // = 3/hit instead of 23/hit. At 23/hit the enemy (firing every 5 ticks) kills the 100-HP player
+                // on its 5th hit at tick 25; at 3/hit the player survives to kill the 200-HP enemy (48/hit every
+                // 10 ticks) on hit 5 at tick 50 → 2000ms. Block flips the loss into a win.
                 ["forcedBlock"] = new ParityScenario(
                     Player: () => MakeBattler(
                         strength: 10, endurance: 0,
                         skills: [MakeSkill(1, baseDamage: 50, cooldownMs: 400)],
-                        extra: [(EAttribute.BlockChance, 1.0), (EAttribute.BlockReduction, 20.0)]),
+                        extra: [(EAttribute.BlockChance, 1.0), (EAttribute.BlockReduction, 18.0)]),
                     Enemy: () => MakeEnemy(
                         strength: 30, endurance: 0,
                         skills: [MakeSkill(2, baseDamage: 25, cooldownMs: 200)]),
@@ -459,9 +461,11 @@ namespace Game.Core.Tests.Battle
 
                 // Draw-order alignment over a multi-skill exchange: two player skills (two crit draws) and two
                 // enemy skills (two dodge+block draw pairs) fire on the same ticks, so a mis-ordered or
-                // mis-counted draw stream would diverge between the two simulators. The player crits both hits
-                // (10×2−2=18, 15×2−2=28 → 46/tick) and blocks both enemy hits (12−2−10=0, 14−2−10=2 → 2/tick).
-                // The 100-HP enemy dies on the player's tick-30 volley → 1200ms; the player ends at 96 HP.
+                // mis-counted draw stream would diverge between the two simulators. CriticalDamage and
+                // BlockReduction each fold in the #799 base (1.5 + 0.5 = 2 multiplier; 2 + 8 = 10 reduction).
+                // The player crits both hits (10×2−2=18, 15×2−2=28 → 46/tick) and blocks both enemy hits
+                // (12−2−10=0, 14−2−10=2 → 2/tick). The 100-HP enemy dies on the player's tick-30 volley →
+                // 1200ms; the player ends at 96 HP.
                 ["drawOrderMultiSkill"] = new ParityScenario(
                     Player: () => MakeBattler(
                         strength: 10, endurance: 0,
@@ -472,8 +476,8 @@ namespace Game.Core.Tests.Battle
                         ],
                         extra:
                         [
-                            (EAttribute.CriticalChance, 1.0), (EAttribute.CriticalDamage, 2.0),
-                            (EAttribute.BlockChance, 1.0), (EAttribute.BlockReduction, 10.0),
+                            (EAttribute.CriticalChance, 1.0), (EAttribute.CriticalDamage, 0.5),
+                            (EAttribute.BlockChance, 1.0), (EAttribute.BlockReduction, 8.0),
                         ]),
                     Enemy: () => MakeEnemy(
                         strength: 10, endurance: 0,
@@ -646,8 +650,9 @@ namespace Game.Core.Tests.Battle
                 new() { Attribute = EAttribute.Luck,      Amount = 0 },
             };
 
-            // Extra non-core attributes (e.g. forced crit/dodge/block chances) ride in as additive allocations,
-            // since the static derivations that will eventually feed them are a later sourcing concern (#799).
+            // Extra non-core attributes (e.g. forced crit/dodge/block chances) ride in as additive allocations
+            // layered on top of the static derivations that now source them (#799) — so injected CriticalDamage
+            // and BlockReduction amounts here are deltas over their derived bases (1.5 and 2).
             if (extra is not null)
             {
                 foreach (var (attribute, amount) in extra)

--- a/Game.Core/Attributes/Modifiers/StaticAttributeModifiers.cs
+++ b/Game.Core/Attributes/Modifiers/StaticAttributeModifiers.cs
@@ -39,6 +39,30 @@ namespace Game.Core.Attributes.Modifiers
             new() { Attribute = MaxHealth, Amount = 50.0, Source = BaseValue, Type = Additive },
             new() { Attribute = MaxHealth, Amount = 20.0, Source = Derived, DerivedSource = Endurance, Type = Additive },
             new() { Attribute = MaxHealth, Amount = 5.0, Source = Derived, DerivedSource = Strength, Type = Additive },
+
+            // The crit/dodge/block derivations make the mechanic live from raw allocations (the values are
+            // also grantable by gear/item-mods/skill-effects through the normal modifier path). All use the
+            // decimal convention — a chance is compared directly against the [0,1) battle RNG draw — and the
+            // coefficients are a conservative strawman expected to be tuned during balancing.
+
+            // CriticalChance = 0.002·Dexterity + 0.001·Luck (no base, so 0 until something feeds it).
+            new() { Attribute = CriticalChance, Amount = 0.002, Source = Derived, DerivedSource = Dexterity, Type = Additive },
+            new() { Attribute = CriticalChance, Amount = 0.001, Source = Derived, DerivedSource = Luck, Type = Additive },
+
+            // CriticalDamage = 1.5 (base) + 0.0025·Luck. A base-1.5 multiplier read directly (like
+            // CooldownRecovery), so a crit is worth ×1.5 before any crit-damage gear and a ×2 modifier doubles it.
+            new() { Attribute = CriticalDamage, Amount = 1.5, Source = BaseValue, Type = Additive },
+            new() { Attribute = CriticalDamage, Amount = 0.0025, Source = Derived, DerivedSource = Luck, Type = Additive },
+
+            // DodgeChance = 0.001·Agility (no base).
+            new() { Attribute = DodgeChance, Amount = 0.001, Source = Derived, DerivedSource = Agility, Type = Additive },
+
+            // BlockChance = 0.002·Endurance (no base).
+            new() { Attribute = BlockChance, Amount = 0.002, Source = Derived, DerivedSource = Endurance, Type = Additive },
+
+            // BlockReduction = 2 (base) + 0.5·Endurance. A flat reduction (like Defense), subtracted in the same clamp on a block.
+            new() { Attribute = BlockReduction, Amount = 2.0, Source = BaseValue, Type = Additive },
+            new() { Attribute = BlockReduction, Amount = 0.5, Source = Derived, DerivedSource = Endurance, Type = Additive },
         ];
     }
 }

--- a/UI/src/lib/api/types/attribute-modifiers.ts
+++ b/UI/src/lib/api/types/attribute-modifiers.ts
@@ -13,4 +13,12 @@ export const STATIC_ATTRIBUTE_MODIFIERS = [
 	{ attribute: EAttribute.MaxHealth, amount: 50, type: EModifierType.Additive, source: EAttributeModifierSource.BaseValue },
 	{ attribute: EAttribute.MaxHealth, amount: 20, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Endurance },
 	{ attribute: EAttribute.MaxHealth, amount: 5, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Strength },
+	{ attribute: EAttribute.CriticalChance, amount: 0.002, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Dexterity },
+	{ attribute: EAttribute.CriticalChance, amount: 0.001, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Luck },
+	{ attribute: EAttribute.CriticalDamage, amount: 1.5, type: EModifierType.Additive, source: EAttributeModifierSource.BaseValue },
+	{ attribute: EAttribute.CriticalDamage, amount: 0.0025, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Luck },
+	{ attribute: EAttribute.DodgeChance, amount: 0.001, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Agility },
+	{ attribute: EAttribute.BlockChance, amount: 0.002, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Endurance },
+	{ attribute: EAttribute.BlockReduction, amount: 2, type: EModifierType.Additive, source: EAttributeModifierSource.BaseValue },
+	{ attribute: EAttribute.BlockReduction, amount: 0.5, type: EModifierType.Additive, source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Endurance },
 ] as const;

--- a/UI/src/tests/lib/battle/attribute-modifier.test.ts
+++ b/UI/src/tests/lib/battle/attribute-modifier.test.ts
@@ -97,6 +97,65 @@ describe('STATIC_ATTRIBUTE_MODIFIERS', () => {
 				type: EModifierType.Additive,
 				source: EAttributeModifierSource.Derived,
 				derivedSource: EAttribute.Strength
+			},
+			// CriticalChance = 0.002·DEX + 0.001·LUK
+			{
+				attribute: EAttribute.CriticalChance,
+				amount: 0.002,
+				type: EModifierType.Additive,
+				source: EAttributeModifierSource.Derived,
+				derivedSource: EAttribute.Dexterity
+			},
+			{
+				attribute: EAttribute.CriticalChance,
+				amount: 0.001,
+				type: EModifierType.Additive,
+				source: EAttributeModifierSource.Derived,
+				derivedSource: EAttribute.Luck
+			},
+			// CriticalDamage = base 1.5 + 0.0025·LUK
+			{
+				attribute: EAttribute.CriticalDamage,
+				amount: 1.5,
+				type: EModifierType.Additive,
+				source: EAttributeModifierSource.BaseValue
+			},
+			{
+				attribute: EAttribute.CriticalDamage,
+				amount: 0.0025,
+				type: EModifierType.Additive,
+				source: EAttributeModifierSource.Derived,
+				derivedSource: EAttribute.Luck
+			},
+			// DodgeChance = 0.001·AGI
+			{
+				attribute: EAttribute.DodgeChance,
+				amount: 0.001,
+				type: EModifierType.Additive,
+				source: EAttributeModifierSource.Derived,
+				derivedSource: EAttribute.Agility
+			},
+			// BlockChance = 0.002·END
+			{
+				attribute: EAttribute.BlockChance,
+				amount: 0.002,
+				type: EModifierType.Additive,
+				source: EAttributeModifierSource.Derived,
+				derivedSource: EAttribute.Endurance
+			},
+			// BlockReduction = base 2 + 0.5·END
+			{
+				attribute: EAttribute.BlockReduction,
+				amount: 2.0,
+				type: EModifierType.Additive,
+				source: EAttributeModifierSource.BaseValue
+			},
+			{
+				attribute: EAttribute.BlockReduction,
+				amount: 0.5,
+				type: EModifierType.Additive,
+				source: EAttributeModifierSource.Derived,
+				derivedSource: EAttribute.Endurance
 			}
 		]);
 	});

--- a/UI/src/tests/lib/battle/battle-attributes.test.ts
+++ b/UI/src/tests/lib/battle/battle-attributes.test.ts
@@ -70,11 +70,41 @@ describe('BattleAttributes', () => {
 			expect(ba.getValue(EAttribute.CooldownRecovery)).toBeCloseTo(1 + 0.004 * 20 + 0.001 * 10, 10);
 		});
 
-		it('handles zero base stats (MaxHealth base 50, CooldownRecovery base 1)', () => {
+		it('calculates CriticalChance = 0.002*Dex + 0.001*Luck', () => {
+			const ba = new BattleAttributes(makeAttrs([EAttribute.Dexterity, 20], [EAttribute.Luck, 10]));
+			expect(ba.getValue(EAttribute.CriticalChance)).toBeCloseTo(0.002 * 20 + 0.001 * 10, 10);
+		});
+
+		it('calculates CriticalDamage = 1.5 (base) + 0.0025*Luck', () => {
+			const ba = new BattleAttributes(makeAttrs([EAttribute.Luck, 20]));
+			expect(ba.getValue(EAttribute.CriticalDamage)).toBeCloseTo(1.5 + 0.0025 * 20, 10);
+		});
+
+		it('calculates DodgeChance = 0.001*Agi', () => {
+			const ba = new BattleAttributes(makeAttrs([EAttribute.Agility, 20]));
+			expect(ba.getValue(EAttribute.DodgeChance)).toBeCloseTo(0.001 * 20, 10);
+		});
+
+		it('calculates BlockChance = 0.002*End', () => {
+			const ba = new BattleAttributes(makeAttrs([EAttribute.Endurance, 20]));
+			expect(ba.getValue(EAttribute.BlockChance)).toBeCloseTo(0.002 * 20, 10);
+		});
+
+		it('calculates BlockReduction = 2 (base) + 0.5*End', () => {
+			const ba = new BattleAttributes(makeAttrs([EAttribute.Endurance, 20]));
+			expect(ba.getValue(EAttribute.BlockReduction)).toBe(2 + 0.5 * 20);
+		});
+
+		it('handles zero base stats (CriticalDamage base 1.5, BlockReduction base 2, chances 0)', () => {
 			const ba = new BattleAttributes([]);
 			expect(ba.getValue(EAttribute.MaxHealth)).toBe(50);
 			expect(ba.getValue(EAttribute.Defense)).toBe(2);
 			expect(ba.getValue(EAttribute.CooldownRecovery)).toBe(1);
+			expect(ba.getValue(EAttribute.CriticalDamage)).toBe(1.5);
+			expect(ba.getValue(EAttribute.BlockReduction)).toBe(2);
+			expect(ba.getValue(EAttribute.CriticalChance)).toBe(0);
+			expect(ba.getValue(EAttribute.DodgeChance)).toBe(0);
+			expect(ba.getValue(EAttribute.BlockChance)).toBe(0);
 		});
 	});
 

--- a/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
+++ b/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
@@ -627,7 +627,8 @@ const scenarios: ParityScenario[] = [
 	// on both sides. Mirrors the backend `forcedCrit` / `forcedDodge` / `forcedBlock` / `drawOrderMultiSkill`
 	// / `enemyForcedChanceIgnored` scenarios.
 
-	// Forced crit: 20 raw × 2 CriticalDamage = 40, −2 def = 38/hit, so the 100-HP enemy dies on hit 3 at 1200ms.
+	// Forced crit: CriticalDamage is the base 1.5 (sourced by #799) + 0.5 = 2, so 20 raw × 2 = 40, −2 def =
+	// 38/hit, and the 100-HP enemy dies on hit 3 at 1200ms.
 	{
 		name: 'forcedCrit',
 		player: () =>
@@ -635,7 +636,7 @@ const scenarios: ParityScenario[] = [
 				[
 					{ id: EAttribute.Strength, amount: 10 },
 					{ id: EAttribute.CriticalChance, amount: 1 },
-					{ id: EAttribute.CriticalDamage, amount: 2 }
+					{ id: EAttribute.CriticalDamage, amount: 0.5 }
 				],
 				[makeSkill(20, 400)]
 			),
@@ -659,9 +660,9 @@ const scenarios: ParityScenario[] = [
 		expected: { victory: true, playerDied: false, totalMs: 2400 }
 	},
 
-	// Forced block: 25 − 2 def − 20 block = 3/hit instead of 23/hit, so the player survives the enemy's
-	// every-5-tick assault long enough to kill the 200-HP enemy (48/hit) on hit 5 at 2000ms. Block flips
-	// the loss (player would die at tick 25) into a win.
+	// Forced block: BlockReduction is the base 2 (sourced by #799) + 18 = 20, so 25 − 2 def − 20 block =
+	// 3/hit instead of 23/hit, and the player survives the enemy's every-5-tick assault long enough to kill
+	// the 200-HP enemy (48/hit) on hit 5 at 2000ms. Block flips the loss (player would die at tick 25) into a win.
 	{
 		name: 'forcedBlock',
 		player: () =>
@@ -669,7 +670,7 @@ const scenarios: ParityScenario[] = [
 				[
 					{ id: EAttribute.Strength, amount: 10 },
 					{ id: EAttribute.BlockChance, amount: 1 },
-					{ id: EAttribute.BlockReduction, amount: 20 }
+					{ id: EAttribute.BlockReduction, amount: 18 }
 				],
 				[makeSkill(50, 400)]
 			),
@@ -678,8 +679,9 @@ const scenarios: ParityScenario[] = [
 	},
 
 	// Draw-order alignment over a multi-skill exchange: two player skills (two crit draws) and two enemy
-	// skills (two dodge+block draw pairs) fire on the same ticks. Player crits both hits (18 + 28 = 46/tick)
-	// and blocks both enemy hits (0 + 2 = 2/tick); the 100-HP enemy dies on the player's tick-30 volley → 1200ms.
+	// skills (two dodge+block draw pairs) fire on the same ticks. CriticalDamage and BlockReduction each fold
+	// in the #799 base (1.5 + 0.5 = 2 multiplier; 2 + 8 = 10 reduction). Player crits both hits (18 + 28 =
+	// 46/tick) and blocks both enemy hits (0 + 2 = 2/tick); the 100-HP enemy dies on the player's tick-30 volley → 1200ms.
 	{
 		name: 'drawOrderMultiSkill',
 		player: () =>
@@ -687,9 +689,9 @@ const scenarios: ParityScenario[] = [
 				[
 					{ id: EAttribute.Strength, amount: 10 },
 					{ id: EAttribute.CriticalChance, amount: 1 },
-					{ id: EAttribute.CriticalDamage, amount: 2 },
+					{ id: EAttribute.CriticalDamage, amount: 0.5 },
 					{ id: EAttribute.BlockChance, amount: 1 },
-					{ id: EAttribute.BlockReduction, amount: 10 }
+					{ id: EAttribute.BlockReduction, amount: 8 }
 				],
 				[makeSkill(10, 400), makeSkill(15, 400)]
 			),

--- a/UI/src/tests/lib/battle/battle-step.test.ts
+++ b/UI/src/tests/lib/battle/battle-step.test.ts
@@ -170,10 +170,11 @@ describe('battleStep', () => {
 	// so the outcome is deterministic regardless of the seed; the draw-order test pins the per-fire counts.
 	describe('crit / dodge / block (player-only, seeded)', () => {
 		it('multiplies a player crit by CriticalDamage before defense', () => {
+			// CriticalDamage is the base 1.5 (sourced by #799) + 0.5 = 2, read directly as the multiplier.
 			const player = makeBattler(
 				[
 					{ id: EAttribute.CriticalChance, amount: 1 },
-					{ id: EAttribute.CriticalDamage, amount: 2 }
+					{ id: EAttribute.CriticalDamage, amount: 0.5 }
 				],
 				[makeSkill(20, 40)]
 			);
@@ -210,10 +211,11 @@ describe('battleStep', () => {
 		});
 
 		it('subtracts defense and BlockReduction on a blocked hit', () => {
+			// BlockReduction is the base 2 (sourced by #799) + 8 = 10.
 			const player = makeBattler(
 				[
 					{ id: EAttribute.BlockChance, amount: 1 },
-					{ id: EAttribute.BlockReduction, amount: 10 }
+					{ id: EAttribute.BlockReduction, amount: 8 }
 				],
 				[]
 			);

--- a/UI/src/tests/routes/admin/workbench/reference.test.ts
+++ b/UI/src/tests/routes/admin/workbench/reference.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
+	EAttribute,
 	EChallengeGoalComparison,
 	EEntityType,
 	EItemCategory,
@@ -75,6 +76,18 @@ describe('enum-backed select options', () => {
 		const opts = reference.attributeOptions();
 		expect(opts.find((o) => o.value === 0)?.text).toBe('Strength');
 		expect(opts.find((o) => o.value === 6)?.text).toBe('Max Health');
+	});
+
+	it('exposes the crit/dodge/block attributes for gear/item-mod authoring', () => {
+		// Now that crit/dodge/block are sourced (#799) rather than unused, the item/item-mod attribute
+		// pickers — which read this same enum-backed option set — must offer them.
+		const opts = reference.attributeOptions();
+		const byValue = (value: EAttribute) => opts.find((o) => o.value === value)?.text;
+		expect(byValue(EAttribute.CriticalChance)).toBe('Critical Chance');
+		expect(byValue(EAttribute.CriticalDamage)).toBe('Critical Damage');
+		expect(byValue(EAttribute.DodgeChance)).toBe('Dodge Chance');
+		expect(byValue(EAttribute.BlockChance)).toBe('Block Chance');
+		expect(byValue(EAttribute.BlockReduction)).toBe('Block Reduction');
 	});
 
 	it('builds item-category, rarity and mod-type options', () => {

--- a/UI/src/tests/routes/game/screens/attribute-breakdown/attribute-breakdown-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attribute-breakdown/attribute-breakdown-view.test.ts
@@ -197,11 +197,17 @@ describe('AttributeBreakdownView', () => {
 		const secondary = view.groups.find((g) => g.type === EAttributeType.Secondary);
 		// Only the allocated core attributes self-select into Primary.
 		expect(primary?.attrs.map((a) => a.meta.id)).toEqual([EAttribute.Strength, EAttribute.Endurance]);
-		// The engine base/derived aggregates always contribute, so they stay in Secondary.
+		// The engine base/derived aggregates always contribute, so they stay in Secondary — including the
+		// crit/dodge/block set, which now derives from the core attributes (#799).
 		expect(secondary?.attrs.map((a) => a.meta.id)).toEqual([
 			EAttribute.MaxHealth,
 			EAttribute.Defense,
-			EAttribute.CooldownRecovery
+			EAttribute.CooldownRecovery,
+			EAttribute.CriticalChance,
+			EAttribute.CriticalDamage,
+			EAttribute.DodgeChance,
+			EAttribute.BlockChance,
+			EAttribute.BlockReduction
 		]);
 		// CooldownRecovery carries its reference-data precision (0 decimals) and percentage flag.
 		const cdrMeta = secondary?.attrs.find((a) => a.meta.id === EAttribute.CooldownRecovery)?.meta;
@@ -210,15 +216,24 @@ describe('AttributeBreakdownView', () => {
 	});
 
 	it('self-selects only attributes with a real (non-combat) contributor', () => {
-		// No allocations or gear: only the engine base/derived formulas contribute, so just the
-		// Secondary aggregates surface — the obsolete/unimplemented attributes and the combat-only
-		// Status channels have no contributors and drop out, and no Primary group is shown.
+		// No allocations or gear: only the engine base/derived formulas contribute. The Secondary aggregates
+		// surface — MaxHealth/Defense/CooldownRecovery plus the crit/dodge/block set, which now derives from
+		// the core attributes (#799). The obsolete attribute and the combat-only Status channels have no
+		// contributors and drop out, and no Primary group is shown.
 		const view = new AttributeBreakdownView();
 		const ids = view.groups.flatMap((g) => g.attrs.map((a) => a.meta.id));
-		expect(ids).toEqual([EAttribute.MaxHealth, EAttribute.Defense, EAttribute.CooldownRecovery]);
+		expect(ids).toEqual([
+			EAttribute.MaxHealth,
+			EAttribute.Defense,
+			EAttribute.CooldownRecovery,
+			EAttribute.CriticalChance,
+			EAttribute.CriticalDamage,
+			EAttribute.DodgeChance,
+			EAttribute.BlockChance,
+			EAttribute.BlockReduction
+		]);
 		expect(view.groups.some((g) => g.type === EAttributeType.Primary)).toBe(false);
 		expect(ids).not.toContain(EAttribute.DropBonus);
-		expect(ids).not.toContain(EAttribute.CriticalChance);
 		expect(ids).not.toContain(EAttribute.DamageTakenPerSecond);
 	});
 

--- a/docs/game-design.md
+++ b/docs/game-design.md
@@ -35,7 +35,7 @@ Players can land **critical hits** (deal increased damage), **dodge** (fully avo
 - **Dodge** zeroes the incoming hit entirely.
 - **Block** subtracts a flat `BlockReduction` alongside Defense (`max(raw − Defense − BlockReduction, 0)`).
 
-`CriticalChance`/`DodgeChance`/`BlockChance` are decimal probabilities (`0.05` = 5%) compared directly against the RNG draw. The values currently come from **no source** — the core-attribute derivations and gear authoring that feed them, and the combat-log/display surfacing, are follow-up work, so the feature is inert until then.
+`CriticalChance`/`DodgeChance`/`BlockChance` are decimal probabilities (`0.05` = 5%) compared directly against the RNG draw. They are **sourced from the core attributes** so the mechanic is live from raw allocations — `Dexterity`/`Luck` feed crit, `Agility` feeds dodge, `Endurance` feeds block — and `CriticalDamage` (base `1.5`) and `BlockReduction` (base `2`) carry a base so a crit/block matters before any gear. Items, item-mods, and skill-effects can also grant any of them through the normal modifier path. The derivation coefficients are a conservative strawman expected to be tuned during balancing (the exact formulas live in `StaticAttributeModifiers`). Only the combat-log/display surfacing of crit/dodge/block remains follow-up work.
 
 ## Experience Rewards
 


### PR DESCRIPTION
## Summary

Area **C** of spike #178 — makes the player crit/dodge/block mechanic (#798) **live from raw allocations** by sourcing it from the core attributes, and verifies gear/item-mod authoring exposes the same attributes.

New `StaticAttributeModifiers` derivation rows (decimal convention; **strawman — tune during balancing**):

| Attribute | Derivation |
| --- | --- |
| `CriticalChance` | `0.002·Dexterity + 0.001·Luck` |
| `CriticalDamage` | base `1.5` + `0.0025·Luck` (read directly, like `CooldownRecovery`) |
| `DodgeChance` | `0.001·Agility` |
| `BlockChance` | `0.002·Endurance` |
| `BlockReduction` | base `2` + `0.5·Endurance` |

`CriticalDamage`'s base `1.5` and `BlockReduction`'s base `2` mean a crit/block is worth something before any gear. The rows mirror to the client via the `STATIC_ATTRIBUTE_MODIFIERS` codegen (regenerated, drift-clean).

## How it addresses the issue

- **Derivation rows** — added to `StaticAttributeModifiers.All`; codegen regenerated.
- **Gear authoring** — confirmed (no product code change needed): items/item-mods already carry arbitrary `EAttribute` modifiers, and the admin attribute picker is enum-backed (`enumPairs(EAttribute)`), so crit/dodge/block are exposed now that they're "real". Added a guard test asserting the picker offers them.
- **Tests** — unit-tested the derived composition on **both** sides (each attribute resolves from its core inputs; `CriticalChance`/`DodgeChance`/`BlockChance` have no base, `CriticalDamage`/`BlockReduction` bases present).

## Knock-on changes (consequences of "the values now do something")

- **#798 battle & parity scenarios** (`BattleContextTests`, `BattleSimulatorParityTests` ↔ `battle-step.test.ts`, `battle-simulation-parity.test.ts`): the new bases stack on the forced-crit/forced-block injections. To keep every hand-computed outcome identical, the scenarios now inject **deltas over the bases** (e.g. `CriticalDamage 0.5` over base `1.5` = ×2), with comments noting the base. Backend/frontend mirrors kept in lockstep.
- **Attribute-breakdown screen**: crit/dodge/block now **self-select** automatically (they have derived contributors) — no view-code change, only the stale test expectations updated. This is the automatic display consequence the spike flagged under area D.
- **`docs/game-design.md`**: the crit/dodge/block section no longer says the values "come from no source".

## Test plan

- [x] Backend: `dotnet build` + `dotnet test` — Game.Core (576), Game.Api (502), Game.Application (281), Game.Infrastructure (37) all green.
- [x] Codegen drift clean (`dotnet run --project Game.Api -- codegen` → only `attribute-modifiers.ts` changed).
- [x] `dotnet format --verify-no-changes` on changed files — clean.
- [x] Frontend: `vitest run` — 1904 passed; `npm run lint` (eslint + svelte-check) clean; Prettier clean.

## Follow-ups / notes

- Combat-log feedback and skill-tooltip display for crit/dodge/block remain area **D** (#800); icon art is a deferred follow-up (#801 / `docs/icon-art.md`).
- Minor pre-existing: the enum-backed admin attribute picker also lists the `[Obsolete]` `DropBonus` — out of scope here, flagging for potential cleanup.

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012g9AnvKiVtMgcooJGydULa)_