### PR TITLE
Match frontend skill-damage float grouping to the backend (#802)

### DIFF
--- a/Game.Core.Tests/Battle/BattleSkillTests.cs
+++ b/Game.Core.Tests/Battle/BattleSkillTests.cs
@@ -96,6 +96,64 @@ namespace Game.Core.Tests.Battle
         }
 
         [Fact]
+        public void CalculateDamage_FloatGrouping_MatchesBackend()
+        {
+            // Per-hit-damage parity guard (mirrors battle-formulas.test.ts "groups the multiplier sum like the
+            // backend"). Floating-point addition is not associative, so `base + (m1 + m2)` and a naive
+            // `(base + m1) + m2` can differ by a ULP at a kill boundary — a live-vs-replay desync (#802). Two
+            // contributions each below baseDamage's ULP vanish if added one at a time but survive when summed
+            // first, so the correct grouping lifts the result above baseDamage and the wrong one returns it
+            // unchanged — pinning the exact ordering, not just a coarse outcome.
+            const double tiny = 1e-16; // below the ULP of 1.0, so a single contribution is lost when added to base
+            var multipliers = new List<DamageMultiplier>
+            {
+                new() { Attribute = EAttribute.Strength, Amount = tiny },
+                new() { Attribute = EAttribute.Agility,  Amount = tiny },
+            };
+            var skill = MakeSkill(cooldownMs: 1000, baseDamage: 1, multipliers: multipliers);
+            var battleSkill = new BattleSkill(skill);
+
+            var statAllocations = new List<StatAllocation>
+            {
+                new() { Attribute = EAttribute.Strength,  Amount = 1 },
+                new() { Attribute = EAttribute.Agility,   Amount = 1 },
+                new() { Attribute = EAttribute.Endurance, Amount = 50 },
+                new() { Attribute = EAttribute.Intellect, Amount = 0 },
+                new() { Attribute = EAttribute.Dexterity, Amount = 0 },
+                new() { Attribute = EAttribute.Luck,      Amount = 0 },
+            };
+            var attacker = new Battler(new Player
+            {
+                Id = 0,
+                Name = "t",
+                Level = 1,
+                Exp = 0,
+                CurrentZoneId = 0,
+                StatPoints = new PlayerStatPoints
+                { StatAllocations = statAllocations, StatPointsGained = 52, StatPointsUsed = 52 },
+                Inventory = new Inventory(),
+                SelectedSkills = [],
+                Skills = [],
+                LogPreferences = [],
+            });
+            var defender = MakeBattler(strength: 0);
+            var context = new BattleContext(attacker, defender, timeDelta: 0, new Mulberry32(0));
+
+            const double c1 = 1 * tiny;
+            const double c2 = 1 * tiny;
+            const double correct = 1 + (c1 + c2); // base + (m1 + m2)
+            const double naive = 1 + c1 + c2;     // ((base + m1) + m2)
+            // Sanity: the inputs are ULP-sensitive — the two groupings genuinely differ.
+            Assert.NotEqual(correct, naive);
+            Assert.Equal(1.0, naive);
+
+            var damage = battleSkill.CalculateDamage(context);
+
+            Assert.Equal(correct, damage);
+            Assert.True(damage > skill.BaseDamage, "Correct grouping must lift the result above baseDamage.");
+        }
+
+        [Fact]
         public void CalculateDamage_OnHotPath_DoesNotAllocate()
         {
             // CalculateDamage runs on every skill fire, the hottest sub-path of the simulation, so it

--- a/UI/src/lib/battle/battle-formulas.ts
+++ b/UI/src/lib/battle/battle-formulas.ts
@@ -20,13 +20,16 @@ const contributionValue = (mult: IAttributeMultiplier, attributes: BattleAttribu
 	attributes.getValue(mult.attributeId) * mult.multiplier;
 
 /** Raw damage of a skill at the given attributes: base plus each multiplier applied to the
- *  attribute it scales. */
+ *  attribute it scales. Accumulate the multiplier bonus from zero and add baseDamage last, exactly
+ *  mirroring the backend grouping (`BattleSkill.CalculateDamage`): floating-point addition is not
+ *  associative, so this `base + (m1 + m2 + …)` order keeps the result bit-for-bit identical and the
+ *  anti-cheat replay in parity for skills with two or more damage multipliers. */
 export function calculateSkillDamage(skill: ISkill, attributes: BattleAttributes): number {
-	let damage = skill.baseDamage;
+	let multiplierBonus = 0;
 	for (const mult of skill.damageMultipliers) {
-		damage += contributionValue(mult, attributes);
+		multiplierBonus += contributionValue(mult, attributes);
 	}
-	return damage;
+	return skill.baseDamage + multiplierBonus;
 }
 
 /** Per-attribute breakdown of a skill's scaling at the given attributes — the decomposition of

--- a/UI/src/tests/lib/battle/battle-formulas.test.ts
+++ b/UI/src/tests/lib/battle/battle-formulas.test.ts
@@ -68,6 +68,38 @@ describe('battle-formulas', () => {
 
 			expect(calculateSkillDamage(skill, makeAttributes())).toBe(10);
 		});
+
+		// Per-hit-damage parity guard (mirrors BattleSkillTests.CalculateDamage_FloatGrouping_MatchesBackend).
+		// Floating-point addition is not associative, so the backend's `base + (m1 + m2)` and a naive
+		// `(base + m1) + m2` can differ by a ULP at a kill boundary — a live-vs-replay desync (#802). Two
+		// contributions each below baseDamage's ULP vanish if added one at a time but survive when summed
+		// first, so the correct grouping lifts the result above baseDamage and the wrong one returns it
+		// unchanged — pinning the exact ordering, not just a coarse outcome.
+		it('groups the multiplier sum like the backend (base added last) for ≥2 multipliers', () => {
+			const tiny = 1e-16; // below the ULP of 1.0, so a single contribution is lost when added to base
+			const skill = makeSkillData({
+				baseDamage: 1,
+				damageMultipliers: [
+					{ attributeId: EAttribute.Strength, multiplier: tiny },
+					{ attributeId: EAttribute.Agility, multiplier: tiny }
+				]
+			});
+			const attributes = makeAttributes([
+				[EAttribute.Strength, 1],
+				[EAttribute.Agility, 1]
+			]);
+
+			const c1 = 1 * tiny;
+			const c2 = 1 * tiny;
+			const correct = skill.baseDamage + (c1 + c2); // base + (m1 + m2)
+			const naive = skill.baseDamage + c1 + c2; // ((base + m1) + m2)
+			// Sanity: the inputs are ULP-sensitive — the two groupings genuinely differ.
+			expect(correct).not.toBe(naive);
+			expect(naive).toBe(skill.baseDamage);
+
+			expect(calculateSkillDamage(skill, attributes)).toBe(correct);
+			expect(calculateSkillDamage(skill, attributes)).toBeGreaterThan(skill.baseDamage);
+		});
 	});
 
 	describe('skillContributions', () => {


### PR DESCRIPTION
## Summary

Fixes the frontend/backend float-grouping divergence in the shared skill-damage formula (#802).

`calculateSkillDamage` (`UI/src/lib/battle/battle-formulas.ts`) added `baseDamage` **first** and then accumulated each multiplier contribution — computing `((base + m1) + m2)`. The backend (`BattleSkill.CalculateDamage`) accumulates the multiplier bonus from `0.0` and adds `BaseDamage` **last** — `base + (m1 + m2)`, with an explicit comment that this exact ordering is required for bit-for-bit parity.

Floating-point addition is not associative, so for a skill with **two or more** damage multipliers the two groupings can differ by a ULP, and at an exact HP/Defense boundary that sub-ULP difference can flip a kill — a live-vs-replay desync the anti-cheat replay depends on not happening.

## How it addresses the issue

- **Reordered `calculateSkillDamage`** to accumulate the multiplier bonus separately from zero and add `baseDamage` last, mirroring the backend grouping exactly. Identical for 0 or 1 multiplier (so existing scenarios are unaffected); now bit-for-bit for ≥2.
- **Added a mirrored per-hit-damage parity test** on both sides — `battle-formulas.test.ts` and `BattleSkillTests.cs` — driven by ULP-sensitive inputs (two contributions each below `baseDamage`'s ULP that vanish when added one at a time but survive when summed first). The correct grouping lifts the result above `baseDamage`; the naive grouping returns it unchanged. This pins the exact ordering rather than only the coarse battle outcomes the simulation-parity matrix asserts (which is why the existing suite never caught it).

The simulation-parity matrix asserts whole-battle `BattleResult`s (victory/playerDied/totalMs), which can't carry a per-hit value, so the guard lives as a dedicated mirrored test pair next to each formula, each cross-referencing the other.

## Test plan

- [x] `dotnet test Game.Core.Tests` — 577 passed (incl. new `CalculateDamage_FloatGrouping_MatchesBackend`).
- [x] `vitest run battle-formulas.test.ts battle-simulation-parity.test.ts` — 40 passed (incl. new grouping test).
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `dotnet format --verify-no-changes` — clean.

Closes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCTFjZnYhN71UME1JTkgfs

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCTFjZnYhN71UME1JTkgfs)_