### PR TITLE
Surface player crit/dodge/block in the combat log (#800)

### DIFF
--- a/UI/src/components/log-panel/LogGlyph.svelte
+++ b/UI/src/components/log-panel/LogGlyph.svelte
@@ -13,6 +13,12 @@
 		<path d="M10 1.5l2.5 2.5-7 7-2.5-2.5z M3 11l1.5 1.5" />
 	{:else if glyph === 'crit'}
 		<path d="M7 1.5l1.6 3.3 3.6.5-2.6 2.6.6 3.6L7 9.7 3.8 11.5l.6-3.6-2.6-2.6 3.6-.5z" />
+	{:else if glyph === 'dodge'}
+		<!-- Two motion chevrons suggesting an evasive slip aside. -->
+		<path d="M2.5 3.5l3 3.5-3 3.5M7 3.5l3 3.5-3 3.5" />
+	{:else if glyph === 'block'}
+		<!-- A guarding shield. -->
+		<path d="M7 1.8l4.3 1.7v3.4c0 3-1.9 4.6-4.3 5.8C4.6 11.5 2.7 9.9 2.7 6.9V3.5z" />
 	{:else if glyph === 'enemy'}
 		<path d="M3 11L11 3M11 11L3 3" />
 	{:else if glyph === 'loot'}

--- a/UI/src/components/log-panel/log-kind.ts
+++ b/UI/src/components/log-panel/log-kind.ts
@@ -1,7 +1,7 @@
 import { ELogType } from '$lib/api';
 import type { LogMessage } from '$lib/engine/log';
 
-export type GlyphKind = 'hit' | 'crit' | 'enemy' | 'loot' | 'system' | 'kill' | 'effect';
+export type GlyphKind = 'hit' | 'crit' | 'dodge' | 'block' | 'enemy' | 'loot' | 'system' | 'kill' | 'effect';
 
 export interface LogKind {
 	/** Accent color for the chip, message, and left bar. */
@@ -40,12 +40,23 @@ const EFFECT = logColors.effect;
  *
  * The log model only stores a flat `message` + `logType`, so player-vs-enemy
  * actions (both `ELogType.Damage`) are disambiguated by the message prefix the
- * battle engine produces ("You used …" / "You've been defeated!").
+ * battle engine produces ("You used …" / "You've been defeated!"). The player-only
+ * crit/dodge/block outcomes (#178) ride the same `ELogType.Damage` channel and are
+ * told apart by the distinctive phrasing `damageLogMessage` produces.
  */
 export function logKind(log: LogMessage): LogKind {
 	const fromPlayer = log.message.startsWith('You');
 	switch (log.logType) {
 		case ELogType.Damage:
+			if (log.message.startsWith('You landed a critical hit')) {
+				return { color: PLAYER, glyph: 'crit', label: 'Crit' };
+			}
+			if (log.message.startsWith('You dodged')) {
+				return { color: ENEMY, glyph: 'dodge', label: 'Dodge' };
+			}
+			if (log.message.startsWith('You blocked')) {
+				return { color: ENEMY, glyph: 'block', label: 'Block' };
+			}
 			return fromPlayer
 				? { color: PLAYER, glyph: 'hit', label: 'Hit' }
 				: { color: ENEMY, glyph: 'enemy', label: 'Hurt' };

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -137,18 +137,14 @@ export class BattleEngine {
 
 	private logicalUpdate(timeDelta: number) {
 		if (this.stage === Active) {
-			for (const { skill, damage, byPlayer } of battleStep(
+			for (const { skill, damage, byPlayer, crit, dodged, blocked } of battleStep(
 				this.player,
 				this.enemy,
 				timeDelta,
 				this.rng,
 				this.stepLog
 			)) {
-				if (byPlayer) {
-					logMessage(ELogType.Damage, `You used ${skill.name} and dealt ${formatNum(damage)} damage!`);
-				} else {
-					logMessage(ELogType.Damage, `${this.enemy.name} used ${skill.name} and dealt ${formatNum(damage)} damage!`);
-				}
+				logMessage(ELogType.Damage, this.damageLogMessage(skill.name, damage, byPlayer, crit, dodged, blocked));
 			}
 			this.logEffectApplications();
 			this.accumulateEffectDamage(timeDelta);
@@ -162,6 +158,33 @@ export class BattleEngine {
 			}
 		}
 		this.timeElapsed += timeDelta;
+	}
+
+	/** Builds the combat-log line for one skill activation, surfacing the player-only crit/dodge/block
+	 *  outcomes (#178). The crit/dodge/block flags are only ever set on the player's side of the
+	 *  exchange (crit on the player's own hit; dodge/block on an incoming enemy hit — a dodged hit is
+	 *  never also blocked), so the player-perspective phrasing is unambiguous. The "You"/enemy-name
+	 *  prefixes are what `logKind` keys the glyph off (see `log-kind.ts`). */
+	private damageLogMessage(
+		skillName: string,
+		damage: number,
+		byPlayer: boolean,
+		crit: boolean,
+		dodged: boolean,
+		blocked: boolean
+	): string {
+		if (byPlayer) {
+			return crit
+				? `You landed a critical hit with ${skillName} for ${formatNum(damage)} damage!`
+				: `You used ${skillName} and dealt ${formatNum(damage)} damage!`;
+		}
+		if (dodged) {
+			return `You dodged ${this.enemy.name}'s ${skillName}!`;
+		}
+		if (blocked) {
+			return `You blocked ${this.enemy.name}'s ${skillName}, taking only ${formatNum(damage)} damage!`;
+		}
+		return `${this.enemy.name} used ${skillName} and dealt ${formatNum(damage)} damage!`;
 	}
 
 	/** Logs a line for each effect freshly applied this tick (refreshes are skipped — the chip countdown

--- a/UI/src/tests/components/log-panel/log-kind.test.ts
+++ b/UI/src/tests/components/log-panel/log-kind.test.ts
@@ -23,6 +23,27 @@ describe('logKind', () => {
 			expect(result.glyph).toBe('enemy');
 			expect(result.label).toBe('Hurt');
 		});
+
+		it('returns the crit treatment for a player critical-hit line', () => {
+			const result = logKind(makeLog(ELogType.Damage, 'You landed a critical hit with Slash for 84 damage!'));
+			expect(result.color).toBe(logColors.player);
+			expect(result.glyph).toBe('crit');
+			expect(result.label).toBe('Crit');
+		});
+
+		it('returns the dodge treatment for a dodged incoming hit', () => {
+			const result = logKind(makeLog(ELogType.Damage, "You dodged Goblin's Slash!"));
+			expect(result.color).toBe(logColors.enemy);
+			expect(result.glyph).toBe('dodge');
+			expect(result.label).toBe('Dodge');
+		});
+
+		it('returns the block treatment for a blocked incoming hit', () => {
+			const result = logKind(makeLog(ELogType.Damage, "You blocked Goblin's Slash, taking only 12 damage!"));
+			expect(result.color).toBe(logColors.enemy);
+			expect(result.glyph).toBe('block');
+			expect(result.label).toBe('Block');
+		});
 	});
 
 	describe('ELogType.EnemyDefeated', () => {

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EAttribute, ELogType, EModifierType, ESkillEffectTarget } from '$lib/api';
 import type { ISkill, IEnemy, IEnemyInstance } from '$lib/api';
 
@@ -471,6 +471,61 @@ describe('BattleEngine', () => {
 			const effectCalls = vi.mocked(logMessage).mock.calls.filter(([type]) => type === ELogType.SkillEffect);
 			expect(effectCalls).toContainEqual([ELogType.SkillEffect, 'You took 6 damage over time.']);
 			expect(effectCalls).toContainEqual([ELogType.SkillEffect, 'Goblin recovered 5 health.']);
+		});
+
+		// The player-only crit/dodge/block outcomes (#178) surface through the combat log. Forcing a
+		// chance of 1 makes every [0,1) RNG draw succeed, so the outcome is deterministic without a seed.
+		describe('crit / dodge / block lines (#178)', () => {
+			const defaultAttributes = mockPlayerManager.attributes;
+			afterEach(() => {
+				mockPlayerManager.attributes = defaultAttributes;
+			});
+
+			const forcePlayerChance = (attributeId: EAttribute) => {
+				mockPlayerManager.attributes = [{ attributeId, amount: 1 }];
+			};
+			// A tanky enemy survives the player's opening hit and fires back, giving the player something
+			// to dodge/block.
+			const tankyEnemy = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				selectedSkills: [0],
+				attributes: [{ attributeId: EAttribute.Endurance, amount: 200 }]
+			};
+
+			it('logs a critical-hit line when the player crits', () => {
+				forcePlayerChance(EAttribute.CriticalChance);
+				engine.start();
+				enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, selectedSkills: [0], attributes: [] });
+
+				logicalUpdateCallbacks[0](500); // the player's 500ms skill fires and crits
+
+				expect(logMessage).toHaveBeenCalledWith(
+					ELogType.Damage,
+					expect.stringContaining('You landed a critical hit with Slash')
+				);
+			});
+
+			it('logs a dodge line when the player dodges an incoming enemy hit', () => {
+				forcePlayerChance(EAttribute.DodgeChance);
+				engine.start();
+				enemyLoadedCallbacks[0](tankyEnemy);
+
+				logicalUpdateCallbacks[0](500);
+
+				expect(logMessage).toHaveBeenCalledWith(ELogType.Damage, "You dodged Goblin's Slash!");
+			});
+
+			it('logs a block line when the player blocks an incoming enemy hit', () => {
+				forcePlayerChance(EAttribute.BlockChance);
+				engine.start();
+				enemyLoadedCallbacks[0](tankyEnemy);
+
+				logicalUpdateCallbacks[0](500);
+
+				expect(logMessage).toHaveBeenCalledWith(ELogType.Damage, expect.stringContaining("You blocked Goblin's Slash"));
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary

Area **D** of spike #178 — the UI surfacing of the player-only crit/dodge/block mechanic. The battle runtime (#798) added `crit`/`dodged`/`blocked` flags to `SkillActivation`; this wires them into the live combat log, the spike's stated V1 surface (*"V1 surfaces crit/dodge/block through the combat log only"*).

### What changed

- **Combat-log lines** (`battle-engine.ts`) — `logicalUpdate` now reads the crit/dodge/block flags off each activation and `damageLogMessage` produces a distinct line for each outcome:
  - crit → `You landed a critical hit with {skill} for {n} damage!`
  - dodge → `You dodged {enemy}'s {skill}!`
  - block → `You blocked {enemy}'s {skill}, taking only {n} damage!`
  - (normal player/enemy hits are unchanged.)
- **Glyphs** (`log-kind.ts`, `LogGlyph.svelte`) — crit reuses the existing star glyph; new `dodge` (evasion chevrons) and `block` (shield) glyphs + `Crit`/`Dodge`/`Block` chip labels so the three read distinctly in the manifest. Crit is player-accented; dodge/block keep the enemy accent (they mitigate an incoming enemy hit) with their own glyph.

Reuses `ELogType.Damage` rather than adding a new log type: crit/dodge/block are part of the damage exchange and don't warrant an independent toggle, and a new `ELogType` value would be a backend (codegen) change, outside this frontend-only issue. Consistent with the existing flat-message + prefix-keyed `logKind` design.

### Attribute-breakdown / stat surface

Already handled: the breakdown screen self-selects an attribute once it has a non-combat contributor, and #799's `StaticAttributeModifiers` derivations provide exactly that — so crit/dodge/block already appear there, with existing tests asserting it (`attribute-breakdown-view.test.ts`). No change needed.

### ⚠️ Deferred for a decision — the `CriticalDamage` `1.5×` display

The issue's third bullet asks for `CriticalDamage` to render as a multiplier (`1.5×`), *"the same treatment the CooldownRecovery rebase introduces in #797."* **But #797 actually shipped `CooldownRecovery` as `109%`** (`IsPercentage: true`), and `game-design.md` documents it as `109%`, not `1.09×`. `CriticalDamage` is currently `IsPercentage: true` too → it already renders `150%`.

So delivering `1.5×` would (a) contradict the just-shipped, documented `%` convention, (b) be inconsistent with `CooldownRecovery` unless that's also changed, and (c) likely need backend display-mode metadata to do cleanly (so it isn't purely frontend). Rather than silently reverse #797, I left the format as-is and **raised the question on the issue** (https://github.com/ginderjeremiah/GameServer/issues/800) — happy to do `1.5×` (and align `CooldownRecovery`) once the convention is confirmed.

## Test plan

- [x] `npm run test:unit:ci` — 1911 passed (197 files), incl. new combat-log tests (`battle-engine.test.ts`) and glyph-mapping tests (`log-kind.test.ts`).
- [x] `npm run lint` (eslint + svelte-check) — clean.

## Addresses #800

Combat-log surfacing + breakdown stat surface are done; the `CriticalDamage` display-format (`1.5×` vs `150%`) is pending the owner's call on the linked comment, so I've left the issue open rather than auto-closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoZskZeH2tDU6xMST2w8NK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoZskZeH2tDU6xMST2w8NK)_