### PR TITLE
Make AttributeDistribution & Challenge immutable; discovery-based immutability guard (#803)

### DIFF
--- a/Game.Core.Tests/Items/ReferenceDataImmutabilityTests.cs
+++ b/Game.Core.Tests/Items/ReferenceDataImmutabilityTests.cs
@@ -1,32 +1,56 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Game.Core.Attributes;
 using Game.Core.Attributes.Modifiers;
+using Game.Core.Enemies;
 using Game.Core.Items;
+using Game.Core.Progress;
 using Game.Core.Skills;
+using Game.Core.Zones;
 using Xunit;
 
 namespace Game.Core.Tests.Items
 {
     /// <summary>
-    /// Structural-immutability guard for the shared, cached reference-data domain models (#547) and the
-    /// <see cref="AttributeModifier"/> element type held inside their read-only collections (#603).
-    /// <c>GetItem</c>/<c>GetItemMod</c>/<c>GetSkill</c> hand the same pre-materialized instance to every
-    /// player straight from the reference cache, so these types must stay structurally immutable — every
-    /// property init-only and every collection an <see cref="IReadOnlyList{T}"/> — or a stray mutation would
-    /// silently corrupt the cache for every player. The compiler enforces "you can't mutate it"; this test
-    /// enforces "you can't quietly drop the immutability" (flip an <c>init</c> back to <c>set</c>, or a
-    /// read-only collection back to a mutable one), which the compiler alone would let pass.
+    /// Structural-immutability guard for the shared, cached reference-data domain models (#547) and every
+    /// value object reachable through their graphs (e.g. the <c>AttributeModifier</c>/<c>AttributeDistribution</c>
+    /// element types held inside their read-only collections, #603). The reference repos hand the same
+    /// pre-materialized instance to every player straight from the reference cache, so these types must stay
+    /// structurally immutable — every property init-only and every collection an <see cref="IReadOnlyList{T}"/> —
+    /// or a stray mutation would silently corrupt the cache for every player. The compiler enforces "you can't
+    /// mutate it"; this test enforces "you can't quietly drop the immutability" (flip an <c>init</c> back to
+    /// <c>set</c>, or a read-only collection back to a mutable one), which the compiler alone would let pass.
+    ///
+    /// The covered set is <b>discovered</b> by walking the public-property graph out from the cached aggregate
+    /// roots rather than hand-listed (#803): a nested model (or a brand-new field on an existing one) is picked
+    /// up automatically, so coverage can't silently lag behind the models the way a maintained list did when
+    /// <see cref="AttributeDistribution"/> and <see cref="Challenge"/> were added.
     /// </summary>
     public class ReferenceDataImmutabilityTests
     {
+        /// <summary>
+        /// The cached reference-data aggregate roots — the gameplay domain models handed out from the
+        /// reference caches (items, item mods, skills, enemies, zones, challenges; see
+        /// <c>docs/backend.md → Reference Data</c>). Every other covered type is reached by walking these.
+        /// <see cref="Enemy"/> is included alongside <see cref="EnemyTemplate"/> because it reuses the
+        /// template's shared collections by reference, so it is part of the same shared graph.
+        /// </summary>
+        private static readonly Type[] ReferenceDataRoots =
+        [
+            typeof(Item),
+            typeof(ItemMod),
+            typeof(Skill),
+            typeof(EnemyTemplate),
+            typeof(Enemy),
+            typeof(Zone),
+            typeof(Challenge),
+        ];
+
+        private static readonly Assembly CoreAssembly = typeof(Item).Assembly;
+
         public static IEnumerable<object[]> SharedReferenceDataModels()
         {
-            yield return new object[] { typeof(Item) };
-            yield return new object[] { typeof(ItemMod) };
-            yield return new object[] { typeof(ItemModSlot) };
-            yield return new object[] { typeof(Skill) };
-            yield return new object[] { typeof(SkillEffect) };
-            yield return new object[] { typeof(AttributeModifier) };
+            return DiscoverReferenceDataModels().Select(type => new object[] { type });
         }
 
         [Theory]
@@ -53,6 +77,78 @@ namespace Game.Core.Tests.Items
 
             Assert.True(mutableCollections.Count == 0,
                 $"{modelType.Name} exposes mutable collection properties: {string.Join(", ", mutableCollections)}");
+        }
+
+        /// <summary>
+        /// Sanity check on the discovery itself: the roots that started this guard (#547) must still be
+        /// reached, so a refactor that accidentally severs the graph (and thus the coverage) is caught.
+        /// </summary>
+        [Fact]
+        public void Discovery_CoversTheOriginalReferenceDataModels()
+        {
+            var discovered = DiscoverReferenceDataModels();
+
+            Type[] expected =
+            [
+                typeof(Item), typeof(ItemMod), typeof(ItemModSlot),
+                typeof(Skill), typeof(SkillEffect),
+                typeof(AttributeModifier), typeof(AttributeDistribution),
+                typeof(Challenge),
+            ];
+
+            Assert.All(expected, type => Assert.Contains(type, discovered));
+        }
+
+        /// <summary>
+        /// Breadth-first walk of the public-property graph from the <see cref="ReferenceDataRoots"/>,
+        /// collecting every reachable type defined in the <c>Game.Core</c> assembly. Collection/nullable
+        /// generic arguments are unwrapped so the element type of a read-only collection is covered, and a
+        /// visited set keeps the walk terminating on shared/back-referencing nodes.
+        /// </summary>
+        private static HashSet<Type> DiscoverReferenceDataModels()
+        {
+            var discovered = new HashSet<Type>();
+            var queue = new Queue<Type>(ReferenceDataRoots);
+
+            while (queue.Count > 0)
+            {
+                var current = queue.Dequeue();
+                if (!IsCoreModel(current) || !discovered.Add(current))
+                {
+                    continue;
+                }
+
+                foreach (var property in PublicInstanceProperties(current))
+                {
+                    foreach (var candidate in ModelTypesIn(property.PropertyType))
+                    {
+                        queue.Enqueue(candidate);
+                    }
+                }
+            }
+
+            return discovered;
+        }
+
+        /// <summary>
+        /// The model types carried by a property type: the type itself, or — for a constructed generic such as
+        /// <see cref="IReadOnlyList{T}"/> or <see cref="Nullable{T}"/> — its generic arguments, recursively.
+        /// </summary>
+        private static IEnumerable<Type> ModelTypesIn(Type propertyType)
+        {
+            if (propertyType.IsGenericType)
+            {
+                return propertyType.GetGenericArguments().SelectMany(ModelTypesIn);
+            }
+
+            return [propertyType];
+        }
+
+        /// <summary>A type counts as a reference-data model to walk/cover when it is a non-enum class or struct
+        /// authored in the <c>Game.Core</c> assembly (skipping primitives, strings, enums and framework types).</summary>
+        private static bool IsCoreModel(Type type)
+        {
+            return type.Assembly == CoreAssembly && !type.IsEnum && (type.IsClass || type.IsValueType) && type != typeof(string);
         }
 
         private static IEnumerable<PropertyInfo> PublicInstanceProperties(Type type)

--- a/Game.Core/Attributes/AttributeDistribution.cs
+++ b/Game.Core/Attributes/AttributeDistribution.cs
@@ -3,24 +3,26 @@
 namespace Game.Core.Attributes
 {
     /// <summary>
-    /// Represents the distribution of an attribute.
+    /// Represents the distribution of an attribute. Part of the shared, cached <see cref="Enemies.EnemyTemplate"/>
+    /// graph (reused by reference across every <see cref="Enemies.Enemy"/> produced from a template) and
+    /// therefore structurally immutable (init-only) so a consumer cannot corrupt the cache for every player (#547).
     /// </summary>
     public class AttributeDistribution
     {
         /// <summary>
         /// The attribute being distributed.
         /// </summary>
-        public EAttribute AttributeId { get; set; }
+        public EAttribute AttributeId { get; init; }
 
         /// <summary>
         /// The base amount of the attribute.
         /// </summary>
-        public decimal BaseAmount { get; set; }
+        public decimal BaseAmount { get; init; }
 
         /// <summary>
         /// The amount of the attribute per level.
         /// </summary>
-        public decimal AmountPerLevel { get; set; }
+        public decimal AmountPerLevel { get; init; }
 
         /// <summary>
         /// Creates a new <see cref="AttributeModifier"/> based on the given <paramref name="level"/>.

--- a/Game.Core/Progress/Challenge.cs
+++ b/Game.Core/Progress/Challenge.cs
@@ -1,23 +1,25 @@
 namespace Game.Core.Progress
 {
     /// <summary>
-    /// Represents a challenge that can be completed to unlock an item, modifier, and/or skill.
+    /// Represents a challenge that can be completed to unlock an item, modifier, and/or skill. Shared, cached
+    /// reference-data instance: structurally immutable (init-only) so the cached snapshot handed to every
+    /// battle's challenge evaluation cannot be corrupted (#547).
     /// </summary>
     public class Challenge
     {
-        public required int Id { get; set; }
-        public required string Name { get; set; }
-        public required string Description { get; set; }
-        public required ChallengeType Type { get; set; }
-        public int? TargetEntityId { get; set; }
-        public required decimal ProgressGoal { get; set; }
-        public int? RewardItemId { get; set; }
-        public int? RewardItemModId { get; set; }
-        public int? RewardSkillId { get; set; }
+        public required int Id { get; init; }
+        public required string Name { get; init; }
+        public required string Description { get; init; }
+        public required ChallengeType Type { get; init; }
+        public int? TargetEntityId { get; init; }
+        public required decimal ProgressGoal { get; init; }
+        public int? RewardItemId { get; init; }
+        public int? RewardItemModId { get; init; }
+        public int? RewardSkillId { get; init; }
 
         /// <summary>When set, the challenge is retired: out of circulation for new authoring but kept
         /// resolvable by id so existing references (and completions) stay valid. Null while active.</summary>
-        public DateTime? RetiredAt { get; set; }
+        public DateTime? RetiredAt { get; init; }
 
         public void UpdateChallengeProgress(PlayerChallenge playerChallenge, PlayerProgress playerProgress)
         {


### PR DESCRIPTION
## Summary

Closes the two shared reference-data models that violated the documented "structurally immutable value object" invariant (`docs/backend.md` → Reference Data), and reworks the immutability guard so coverage can't silently lag behind new models again (#803).

### What changed

- **`AttributeDistribution`** (`Game.Core/Attributes/AttributeDistribution.cs`) — `AttributeId` / `BaseAmount` / `AmountPerLevel` changed from `set;` → `init;`. The same `IReadOnlyList<AttributeDistribution>` instance is shared by reference across every `Enemy` produced from a cached `EnemyTemplate` (`ToEnemy` does not clone), so a stray write would have corrupted the shared graph for every concurrent battle.
- **`Challenge`** (`Game.Core/Progress/Challenge.cs`) — every property changed from `set;` → `init;`. `Challenges.All()` hands the cached snapshot back directly into `PlayerProgress.EvaluateChallenges` on every battle.
- **`EnemyTemplate` / `Enemy` audit** — both already expose only `init`-only public properties (`Enemy`'s only mutable state is the private per-encounter `_battleSkills` field, which is by design and not public). No change needed; both are now also covered by the guard.
- **`ReferenceDataImmutabilityTests`** — replaced the hand-maintained type list with **graph discovery**: a breadth-first walk of the public-property graph out from the cached aggregate roots (Item, ItemMod, Skill, EnemyTemplate, Enemy, Zone, Challenge), collecting every reachable `Game.Core` class/struct (unwrapping `IReadOnlyList<T>` / `Nullable<T>` generic args). Nested value objects — exactly how `AttributeDistribution` slipped through before — and any new field on an existing model are now picked up automatically. Added a `Discovery_CoversTheOriginalReferenceDataModels` sanity test so a refactor that severs the graph (and thus the coverage) is caught.

### How it addresses the issue

Both bullets of the suggested fix are done: the offending `set;` are now `init;` (with `EnemyTemplate`/`Enemy` audited), and the guard discovers the reference-data model types by reflection rather than a hand-maintained list.

### Design note

The discovery still has a small, stable list of *aggregate roots* (the cached snapshot element types — which the docs already enumerate). It can't derive them from the reference repos because those live in `Game.DataAccess` (internal) and `Game.Core.Tests` references only `Game.Core`; a namespace-based scan is also unworkable because `Game.Core.Progress` mixes the immutable `Challenge` with the mutable `PlayerChallenge`/`PlayerProgress`. The roots-plus-graph-walk approach directly fixes the actual failure mode (nested models escaping) while staying contained to the test project with no production marker types.

## Test plan

- [x] `dotnet build` — clean, 0 warnings.
- [x] `dotnet test --no-build --no-restore` — all backend suites green (Core 595, Application 281, Api 502, Infrastructure 37).
- [x] `dotnet format --verify-no-changes` — clean.

Closes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012TpvUrnno1WL37DvUCTSbR

---
_Generated by [Claude Code](https://claude.ai/code/session_012TpvUrnno1WL37DvUCTSbR)_