### PR TITLE
Record actual post-mitigation damage in per-skill stats (#835)

### DIFF
--- a/Game.Core.Tests/Battle/BattleSkillTests.cs
+++ b/Game.Core.Tests/Battle/BattleSkillTests.cs
@@ -4,6 +4,7 @@ using Game.Core.Players;
 using Game.Core.Players.Inventories;
 using Game.Core.Skills;
 using Xunit;
+using static Game.Core.EAttribute;
 
 namespace Game.Core.Tests.Battle
 {
@@ -132,6 +133,52 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(0, allocatedBytes);
         }
 
+        // ── Per-skill stats reconcile with global stats (#835) ───────────────
+
+        [Fact]
+        public void Update_PlayerCrit_RecordsActualDamagePerSkill_ReconcilingWithGlobal()
+        {
+            // A crit makes the raw pre-mitigation value understate the real hit: BaseDamage 20, crit
+            // ×2 ⇒ 40, then −2 enemy Defense ⇒ 38 actual. The per-skill stat must book 38 (not the raw
+            // 20) so it reconciles with the global stat DamageTarget books from the same hit.
+            var skill = MakeSkill(cooldownMs: 100, baseDamage: 20);
+            var battleSkill = new BattleSkill(skill);
+
+            // CriticalChance 1 always crits; CriticalDamage base 1.5 + 0.5 = 2.0.
+            var player = MakeBattlerWith((CriticalChance, 1), (CriticalDamage, 0.5));
+            var enemy = MakeBattlerWith((Endurance, 0)); // MaxHealth 50, Defense 2
+            var context = new BattleContext(player, enemy, timeDelta: 200, new Mulberry32(0));
+
+            battleSkill.Update(context);
+
+            var skillStats = context.Stats.SkillStats[skill.Id];
+            Assert.Equal(38.0, skillStats.TotalDamage, 0.001);
+            Assert.NotEqual(20.0, skillStats.TotalDamage, 0.001); // not the raw pre-crit/pre-defense value
+            Assert.Equal(context.Stats.PlayerDamageDealt, skillStats.TotalDamage, 0.001);
+            Assert.Equal(context.Stats.HighestPlayerAttack, skillStats.HighestSingleAttack, 0.001);
+        }
+
+        [Fact]
+        public void Update_EnemyDefenseClamp_RecordsActualDamagePerSkill_ReconcilingWithGlobal()
+        {
+            // High enemy Defense makes the raw value overstate the real hit (the other direction of the
+            // bug): BaseDamage 20 − 12 Defense ⇒ 8 actual. The per-skill stat must book 8, not 20.
+            var skill = MakeSkill(cooldownMs: 100, baseDamage: 20);
+            var battleSkill = new BattleSkill(skill);
+
+            var player = MakeBattlerWith((CriticalChance, 0)); // never crits
+            var enemy = MakeBattlerWith((Endurance, 10));      // Defense = 2 + 10 = 12, MaxHealth 250
+            var context = new BattleContext(player, enemy, timeDelta: 200, new Mulberry32(0));
+
+            battleSkill.Update(context);
+
+            var skillStats = context.Stats.SkillStats[skill.Id];
+            Assert.Equal(8.0, skillStats.TotalDamage, 0.001);
+            Assert.NotEqual(20.0, skillStats.TotalDamage, 0.001); // not the raw pre-defense value
+            Assert.Equal(context.Stats.PlayerDamageDealt, skillStats.TotalDamage, 0.001);
+            Assert.Equal(context.Stats.HighestPlayerAttack, skillStats.HighestSingleAttack, 0.001);
+        }
+
         // ── Helpers ──────────────────────────────────────────────────────────
 
         private static Skill MakeSkill(int cooldownMs, double baseDamage, List<DamageMultiplier>? multipliers = null) => new()
@@ -176,6 +223,27 @@ namespace Game.Core.Tests.Battle
                 CurrentZoneId = 0,
                 StatPoints = new PlayerStatPoints
                 { StatAllocations = statAllocations, StatPointsGained = 50, StatPointsUsed = 50 },
+                Inventory = new Inventory(),
+                SelectedSkills = [],
+                Skills = [],
+                LogPreferences = [],
+            };
+            return new Battler(player);
+        }
+
+        private static Battler MakeBattlerWith(params (EAttribute Attribute, double Amount)[] attributes)
+        {
+            var statAllocations = attributes
+                .Select(a => new StatAllocation { Attribute = a.Attribute, Amount = a.Amount })
+                .ToList();
+            var player = new Player
+            {
+                Id = 0,
+                Name = "t",
+                Level = 1,
+                Exp = 0,
+                CurrentZoneId = 0,
+                StatPoints = new PlayerStatPoints { StatAllocations = statAllocations, StatPointsGained = 0, StatPointsUsed = 0 },
                 Inventory = new Inventory(),
                 SelectedSkills = [],
                 Skills = [],

--- a/Game.Core/Battle/BattleContext.cs
+++ b/Game.Core/Battle/BattleContext.cs
@@ -101,13 +101,18 @@ namespace Game.Core.Battle
         /// Enemies never crit/dodge/block: the gating reads the rolls only on the player's side, leaving a clean
         /// seam for later enemy parity.
         /// </summary>
-        public void DamageTarget(double rawDamage)
+        /// <returns>
+        /// The actual damage applied after crit, Defense, and block — the same value booked into the battle
+        /// stats — so the caller can record a reconciling per-skill total instead of the raw pre-mitigation hit.
+        /// </returns>
+        public double DamageTarget(double rawDamage)
         {
+            double actualDamage;
             if (_isPlayerActive)
             {
                 var isCrit = _rng.Next() < _activeBattler.GetAttributeValue(CriticalChance);
                 var damage = isCrit ? rawDamage * _activeBattler.GetAttributeValue(CriticalDamage) : rawDamage;
-                var actualDamage = _targetBattler.TakeDamage(damage);
+                actualDamage = _targetBattler.TakeDamage(damage);
 
                 Stats.PlayerDamageDealt += actualDamage;
                 if (actualDamage > Stats.HighestPlayerAttack)
@@ -122,7 +127,6 @@ namespace Game.Core.Battle
                 var isDodge = _rng.Next() < _targetBattler.GetAttributeValue(DodgeChance);
                 var isBlock = _rng.Next() < _targetBattler.GetAttributeValue(BlockChance);
 
-                double actualDamage;
                 if (isDodge)
                 {
                     actualDamage = 0;
@@ -138,6 +142,8 @@ namespace Game.Core.Battle
 
                 Stats.PlayerDamageTaken += actualDamage;
             }
+
+            return actualDamage;
         }
 
         public void RecordSkillUse(int skillId, double damage)

--- a/Game.Core/Battle/BattleSkill.cs
+++ b/Game.Core/Battle/BattleSkill.cs
@@ -27,8 +27,11 @@ namespace Game.Core.Battle
                 // applied — so a self damage-buff never boosts the hit that carries it, and an earlier
                 // loadout slot's effect does influence a later slot firing on the same tick.
                 var damage = CalculateDamage(context);
-                context.RecordSkillUse(Skill.Id, damage);
-                context.DamageTarget(damage);
+                // Record the actual post-crit/post-defense/block damage DamageTarget returns, so per-skill
+                // stats reconcile with the global stats (which DamageTarget also books) rather than the raw
+                // pre-mitigation value. Recording therefore has to follow the hit, not precede it.
+                var actualDamage = context.DamageTarget(damage);
+                context.RecordSkillUse(Skill.Id, actualDamage);
                 ApplyEffects(context);
             }
         }


### PR DESCRIPTION
## Summary

Fixes the per-skill vs. global damage-statistic divergence (#835).

`BattleSkill.Update` recorded the **raw** `CalculateDamage` result per skill *before* the hit, while `DamageTarget` booked the **actual** post-crit/post-defense/block value into the global stats. The two were sourced from different values for the same hit and could never reconcile:

- A **crit** made the per-skill total *understate* real damage (raw is pre-multiplier).
- High enemy **Defense** made it *overstate* it (raw is pre-mitigation).
- A per-entity challenge keyed to a specific skill (same `EStatisticType`, keyed by id — e.g. `DamageDealt`) was evaluated against raw, un-mitigated, non-crit damage, which is simply wrong.

## What changed

- **`BattleContext.DamageTarget`** now returns the actual damage it applies (the same value it books into `PlayerDamageDealt` / `HighestPlayerAttack`).
- **`BattleSkill.Update`** deals the hit first and feeds the returned actual damage to `RecordSkillUse`, instead of recording the raw `CalculateDamage` result up front. Recording necessarily follows the hit now, since crit/defense are computed inside `DamageTarget`. `RecordSkillUse`'s own contract is unchanged (it still records whatever value it's handed), so its existing unit tests stand.

## How it addresses the issue

Picks the **actual** post-crit/post-defense definition of "damage dealt" — matching the global stat — and records that per skill, exactly the suggested direction. Block/dodge only apply to enemy→player hits, which aren't per-skill recorded (player-only), so the per-skill-relevant clamp is the enemy's Defense on the player's outgoing hit; both that and the crit case are covered.

Stats are server-only (the frontend computes no per-skill stats), so nothing mirrors on the frontend and no parity surface is touched.

## Test plan

- [x] `dotnet build` — clean, 0 warnings.
- [x] `dotnet test` — all backend suites green (Core 578, Application 281, Api 502, Infrastructure 37).
- [x] New `BattleSkillTests` reconciliation pair — asserts per-skill `TotalDamage`/`HighestSingleAttack` equal the global stats (and differ from the raw value) under both a **crit** (understate) and an **enemy-Defense clamp** (overstate).
- [x] `dotnet format --verify-no-changes` — clean.

Closes #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012KWfNF3eRb8VtDarCjA1ow)_