### PR TITLE
Add subscribe-failure rollback to plain-action Subscribe overload (#837)

### DIFF
--- a/Game.Infrastructure.Tests/RedisPubSubSubscribeRollbackTests.cs
+++ b/Game.Infrastructure.Tests/RedisPubSubSubscribeRollbackTests.cs
@@ -41,6 +41,13 @@ namespace Game.Infrastructure.Tests
                 service.Subscribe("rollback-channel", "rollback-queue", (Func<(IPubSubQueue queue, string channel), Task>)(_ => Task.CompletedTask), id));
         }
 
+        [Fact]
+        public async Task Subscribe_PlainActionWithIdOverload_WhenSubscribeAsyncFails_RollsBackIdForRetry()
+        {
+            await AssertFailedSubscribeFreesId((service, id) =>
+                service.Subscribe("rollback-channel", (Action<(string message, string channel)>)(_ => { }), id));
+        }
+
         // Subscribes the same id twice against a failing connection. Both attempts must fail at SubscribeAsync
         // (RedisConnectionException); a second attempt failing at the registry (InvalidOperationException) would
         // mean the first failure wedged the id — the leak this rolls back.

--- a/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
@@ -99,15 +99,25 @@ namespace Game.Infrastructure.PubSub.Redis
         public async Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null)
         {
             _logger.LogInformation("Creating redis subscriber on channel '{Channel}'.", channel);
-            if (id is not null)
+            if (id is not null && !_handles.TryAdd(id, (handle, null)))
             {
-                if (!_handles.TryAdd(id, (handle, null)))
-                {
-                    throw new InvalidOperationException($"Cannot create handle with id: {id} because one already exists.");
-                }
+                throw new InvalidOperationException($"Cannot create handle with id: {id} because one already exists.");
             }
 
-            await Subscriber.SubscribeAsync(RedisChannel.Literal(channel), handle);
+            // Keep registration and subscribe atomic: a SubscribeAsync failure rolls back the id so a transient
+            // Redis error can't wedge it permanently with "a handle already exists" while nothing is subscribed (#655).
+            try
+            {
+                await Subscriber.SubscribeAsync(RedisChannel.Literal(channel), handle);
+            }
+            catch
+            {
+                if (id is not null)
+                {
+                    _handles.TryRemove(id, out _);
+                }
+                throw;
+            }
 
             void handle(RedisChannel _, RedisValue message)
             {


### PR DESCRIPTION
## Summary

Closes the rollback gap in the plain-action `Subscribe(channel, action, id)` overload of `RedisPubSubService` (#837).

`SubscribeWithWorker` was rewritten for #655 to keep handle registration and `SubscribeAsync` atomic — if `SubscribeAsync` throws a transient Redis error, it rolls back the id (`_handles.TryRemove(id)`) so a blip can't permanently wedge the id with "a handle already exists" while nothing is actually subscribed. The sibling plain-action-with-id overload never got that fix: it added the id to the static `_handles` registry and then called `SubscribeAsync` with no try/catch, so a transient failure left the id stuck forever.

This overload **is** used in production with an id — `ReferenceCacheSynchronizer` subscribes the reference-data channel keyed by `InstanceId` — so a transient Redis error during reference-cache subscriber setup would wedge that instance's id, the exact failure mode #655 fixed for the worker overload.

## What changed

- **`RedisPubSubService.Subscribe(channel, action, id)`** — wrapped `SubscribeAsync` in the same `try/catch`-and-`TryRemove(id)` rollback used by `SubscribeWithWorker`. (No worker to dispose on this overload, so the rollback only frees the id.)
- **`RedisPubSubSubscribeRollbackTests`** — added `Subscribe_PlainActionWithIdOverload_WhenSubscribeAsyncFails_RollsBackIdForRetry`, reusing the existing dead-endpoint `AssertFailedSubscribeFreesId` helper so the plain-action overload now has the same rollback guard as the queue/worker overloads.

## Test plan

- [x] `dotnet build Game.Infrastructure.Tests` — clean, 0 warnings.
- [x] `dotnet test Game.Infrastructure.Tests --no-build --no-restore` — 38 passed (was 37; new rollback test included).
- [x] `dotnet format --verify-no-changes` on `Game.Infrastructure` and `Game.Infrastructure.Tests` — clean.

Closes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gkkgjszbw6HeQekiyNPoSz)_