### PR TITLE
Surface inventory persist failures with a toast (#842)

### DIFF
--- a/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
+++ b/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
@@ -1,7 +1,7 @@
 import { EItemCategory } from '$lib/api';
 import { EEquipmentSlot, getEquipmentSlotForCategory, inventoryManager } from '$lib/engine';
 import { BattleAttributes, type AttributeEntry, type Item, type ItemMod } from '$lib/battle';
-import { staticData } from '$stores';
+import { staticData, toastError } from '$stores';
 
 /* ─── Static config ─────────────────────────────────────────────────────
    Equipment slots are declared here (extensible): adding a second weapon
@@ -118,19 +118,25 @@ export class InventoryView {
 		this.selectedId = itemId;
 	}
 
-	equip(itemId: number, slotId: EEquipmentSlot) {
-		inventoryManager.equipItem(itemId, slotId);
+	// Inventory mutations apply optimistically and roll back on a persist error; await the manager's
+	// boolean and surface a toast on failure so the silent revert is reported, not swallowed.
+	async equip(itemId: number, slotId: EEquipmentSlot) {
+		if (!(await inventoryManager.equipItem(itemId, slotId))) {
+			toastError('Your equipment change could not be saved. Please try again.');
+		}
 	}
 
-	unequip(slotId: EEquipmentSlot) {
-		inventoryManager.unequipItem(slotId);
+	async unequip(slotId: EEquipmentSlot) {
+		if (!(await inventoryManager.unequipItem(slotId))) {
+			toastError('Your equipment change could not be saved. Please try again.');
+		}
 	}
 
-	toggleEquip(item: Item) {
+	async toggleEquip(item: Item) {
 		if (item.equipmentSlotId != null) {
-			this.unequip(item.equipmentSlotId);
+			await this.unequip(item.equipmentSlotId);
 		} else {
-			this.equip(item.itemId, getEquipmentSlotForCategory(item.itemCategoryId));
+			await this.equip(item.itemId, getEquipmentSlotForCategory(item.itemCategoryId));
 		}
 	}
 
@@ -151,11 +157,15 @@ export class InventoryView {
 			.map((m) => ({ ...m, itemModSlotId: -1 }));
 	}
 
-	applyMod(itemId: number, slotId: number, modId: number) {
-		inventoryManager.applyMod(itemId, modId, slotId);
+	async applyMod(itemId: number, slotId: number, modId: number) {
+		if (!(await inventoryManager.applyMod(itemId, modId, slotId))) {
+			toastError('Your modifier change could not be saved. Please try again.');
+		}
 	}
 
-	removeMod(itemId: number, slotId: number) {
-		inventoryManager.removeMod(itemId, slotId);
+	async removeMod(itemId: number, slotId: number) {
+		if (!(await inventoryManager.removeMod(itemId, slotId))) {
+			toastError('Your modifier change could not be saved. Please try again.');
+		}
 	}
 }

--- a/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
@@ -14,6 +14,7 @@ const {
 	setFavorite,
 	applyMod,
 	removeMod,
+	toastError,
 	unlockedMods,
 	sampleItems,
 	sampleSlots,
@@ -25,6 +26,7 @@ const {
 	setFavorite: vi.fn(),
 	applyMod: vi.fn(),
 	removeMod: vi.fn(),
+	toastError: vi.fn(),
 	unlockedMods: new Set<number>(),
 	sampleItems: [] as Item[],
 	sampleSlots: new Array(6).fill(undefined) as (Item | undefined)[],
@@ -62,7 +64,7 @@ vi.mock('$lib/engine', () => ({
 	}
 }));
 
-vi.mock('$stores', () => ({ staticData }));
+vi.mock('$stores', () => ({ staticData, toastError }));
 
 import { itemCategoryColor, itemCategoryName } from '$lib/common';
 import { InventoryView, SORTS, EQUIP_SLOTS } from '$routes/game/screens/inventory/inventory-view.svelte';
@@ -86,11 +88,13 @@ const makeItem = (itemId: number, name: string, cat: EItemCategory, rarity: ERar
 	}) as unknown as Item;
 
 beforeEach(() => {
-	equipItem.mockClear();
-	unequipItem.mockClear();
+	// Default the optimistic mutations to a successful persist; failure cases override per-test.
+	equipItem.mockReset().mockResolvedValue(true);
+	unequipItem.mockReset().mockResolvedValue(true);
+	applyMod.mockReset().mockResolvedValue(true);
+	removeMod.mockReset().mockResolvedValue(true);
 	setFavorite.mockClear();
-	applyMod.mockClear();
-	removeMod.mockClear();
+	toastError.mockClear();
 	unlockedMods.clear();
 	staticData.itemMods = [];
 	sampleSlots.fill(undefined);
@@ -245,6 +249,59 @@ describe('InventoryView delegation', () => {
 	it('removeMod delegates to the manager', () => {
 		new InventoryView().removeMod(2, 0);
 		expect(removeMod).toHaveBeenCalledWith(2, 0);
+	});
+});
+
+describe('InventoryView persist-failure feedback', () => {
+	it('toasts when an equip fails to persist', async () => {
+		equipItem.mockResolvedValue(false);
+		await new InventoryView().equip(2, 4);
+		expect(toastError).toHaveBeenCalledWith('Your equipment change could not be saved. Please try again.');
+	});
+
+	it('stays silent when an equip persists', async () => {
+		await new InventoryView().equip(2, 4);
+		expect(toastError).not.toHaveBeenCalled();
+	});
+
+	it('toasts when an unequip fails to persist', async () => {
+		unequipItem.mockResolvedValue(false);
+		await new InventoryView().unequip(4);
+		expect(toastError).toHaveBeenCalledWith('Your equipment change could not be saved. Please try again.');
+	});
+
+	it('toggleEquip surfaces the underlying equip failure', async () => {
+		equipItem.mockResolvedValue(false);
+		await new InventoryView().toggleEquip(sampleItems[1]); // unequipped weapon → equip path
+		expect(toastError).toHaveBeenCalledWith('Your equipment change could not be saved. Please try again.');
+	});
+
+	it('toggleEquip surfaces the underlying unequip failure', async () => {
+		unequipItem.mockResolvedValue(false);
+		const equippedWeapon = makeItem(2, 'Alpha Blade', EItemCategory.Weapon, ERarity.Legendary, {
+			equipped: true,
+			equipmentSlotId: 4
+		});
+		await new InventoryView().toggleEquip(equippedWeapon);
+		expect(toastError).toHaveBeenCalledWith('Your equipment change could not be saved. Please try again.');
+	});
+
+	it('toasts when applying a mod fails to persist', async () => {
+		applyMod.mockResolvedValue(false);
+		await new InventoryView().applyMod(2, 0, 7);
+		expect(toastError).toHaveBeenCalledWith('Your modifier change could not be saved. Please try again.');
+	});
+
+	it('toasts when removing a mod fails to persist', async () => {
+		removeMod.mockResolvedValue(false);
+		await new InventoryView().removeMod(2, 0);
+		expect(toastError).toHaveBeenCalledWith('Your modifier change could not be saved. Please try again.');
+	});
+
+	it('stays silent when a mod change persists', async () => {
+		await new InventoryView().applyMod(2, 0, 7);
+		await new InventoryView().removeMod(2, 0);
+		expect(toastError).not.toHaveBeenCalled();
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes the silent rollback of inventory equip/unequip/mod mutations (#842).

`InventoryManager` already applies these mutations optimistically and correctly rolls back on a persist error, returning `false`. But the inventory **view** fired the manager calls fire-and-forget and never inspected that boolean, so on a socket error/timeout the change would appear and then silently vanish a moment later with zero explanation — exactly the silent divergence the optimistic-apply design is meant to make visible, and contrary to the project's toast guidance that persist failures are *reported, not swallowed* (`docs/frontend-screens.md:9`).

## What changed

- **`inventory-view.svelte.ts`** — `equip`, `unequip`, `applyMod`, and `removeMod` now `await` the manager and `toastError(...)` when it returns `false`. `toggleEquip` awaits its delegated call so the failure still surfaces. This mirrors the established pattern in `attributes-view`, `skills-view`, and `options-view`. All call sites are fire-and-forget event handlers, so making the actions async is safe.
- Wording is per-action and concise, matching the existing toasts: `Your equipment change could not be saved. Please try again.` and `Your modifier change could not be saved. Please try again.`

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors/warnings.
- [x] `npx vitest --run inventory-view` — 33 passed (was 25). New `InventoryView persist-failure feedback` suite asserts a toast fires on each failed mutation (including both `toggleEquip` branches) and stays silent on success.

## Note for reviewer

I used distinct per-action wording (equipment vs. modifier) rather than the single generic `Your inventory change could not be saved.` the issue suggested as one option — it reads a touch clearer and the issue explicitly allowed "per-action wording". Happy to collapse it to one message if you'd prefer uniformity.

Closes #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxumGvzMwemhxxzm7pTwfA)_