### PR TITLE
Fix flaky Redis-read cancellation test in Game.Application.Tests

### DIFF
--- a/Game.Infrastructure/Cache/Redis/RedisService.cs
+++ b/Game.Infrastructure/Cache/Redis/RedisService.cs
@@ -31,6 +31,10 @@ namespace Game.Infrastructure.Cache.Redis
 
         public async Task<string?> Get(string key, CancellationToken cancellationToken = default)
         {
+            // Honour an already-cancelled budget before issuing the read: WaitAsync alone is racy because it
+            // returns the inner task unchanged when that task is already complete (it checks IsCompleted before
+            // the token), so a command that finished first would silently swallow the cancellation.
+            cancellationToken.ThrowIfCancellationRequested();
             return await Redis.StringGetAsync(key).WaitAsync(cancellationToken);
         }
 


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure of `DataAccessCancellationTests.GetSession_WhenTokenAlreadyCancelled_ThrowsOperationCanceled` in `Game.Application.Tests` (passes locally, fails on loaded CI runners).

## Root cause

The issue body's "likely culprits" pointed at the debounce-timing tests, but the **EDIT** confirmed the actual failing test was `GetSession_WhenTokenAlreadyCancelled_ThrowsOperationCanceled`. That test asserts that an already-cancelled budget throws `OperationCanceledException`. The path is:

`SessionStore.GetSession` → `ICacheService.Get<PlayerState>` → `RedisService.Get` → `await Redis.StringGetAsync(key).WaitAsync(cancellationToken)`

`Task.WaitAsync(CancellationToken)` checks `IsCompleted` **before** it checks the token. So if the underlying `StringGetAsync` task is already complete (or synchronously faulted) at the instant `WaitAsync` runs, it returns that task unchanged and the cancellation is silently swallowed — no exception, failed assertion. Normally the network round-trip is still pending so cancellation wins (passes locally); under CI scheduling jitter the inner task occasionally wins the race, so the test flakes. This same race affected every read-path cancellation test, not just this one.

## The fix

Throw eagerly via `cancellationToken.ThrowIfCancellationRequested()` at the top of `RedisService.Get`, before issuing the read. An exhausted budget now unwinds deterministically instead of racing the I/O, and we avoid issuing a Redis command we already know is past its budget. This aligns the implementation with the documented "honour the token cooperatively" contract (`docs/backend.md`) and de-flakes all read-path cancellation tests (`GetSession`, `GetPlayer`, `GetCompletedChallengeIds`, `CacheService_AsyncGet`).

The write path (`ObserveWrite`) shares the same theoretical race, but it has no cancellation test and an early throw there would skip the fault-observation continuation it exists to attach; its current cooperative-best-effort behaviour is acceptable, so it is left unchanged. The EF/Npgsql-backed write tests honour the token natively and were never flaky.

## Test plan

- [x] `dotnet build Game.sln` — clean
- [x] `Game.Application.Tests` — 285/285 passing (includes the previously flaky `DataAccessCancellationTests`)
- [x] `Game.Infrastructure.Tests` — 38/38 passing (covers the changed `RedisService`)

No new test is added: `CacheService_AsyncGet_WhenTokenAlreadyCancelled_ThrowsOperationCanceled` already exercises `RedisService.Get` with an already-cancelled token directly, and that coverage is now deterministic.

Closes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uRcTm1zxh2Vc9M2oNJhna)_