### PR TITLE
Fix BackgroundWorker loop catch log message

### DIFF
--- a/Game.Infrastructure/BackgroundWorker.cs
+++ b/Game.Infrastructure/BackgroundWorker.cs
@@ -146,7 +146,7 @@ namespace Game.Infrastructure
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "An error occured while creating the worker loop.");
+                    _logger.LogError(ex, "An error occurred while executing the worker loop for background worker '{Name}' ({UniqueId}).", Name, _uniqueId);
                 }
 
                 IsRunning = false;
@@ -164,7 +164,7 @@ namespace Game.Infrastructure
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "An error occured while creating the async worker loop.");
+                    _logger.LogError(ex, "An error occurred while executing the async worker loop for background worker '{Name}' ({UniqueId}).", Name, _uniqueId);
                 }
 
                 IsRunning = false;


### PR DESCRIPTION
## Summary

The catch blocks in `BackgroundWorker.CreateWorkerLoop` / `CreateAsyncWorkerLoop` wrap execution of the loop action (the operationally important work — pub/sub queue drains, reference-data invalidation), but logged:

> An error occured while creating the worker loop.

That message had three problems:
1. It described the wrong operation — the error happens while **executing** the loop action, not creating the loop.
2. It omitted `Name` / `_uniqueId` (both in scope), so an operator couldn't tell **which** worker failed.
3. Typo: "occured".

This change corrects the wording to describe executing the loop action and adds the structured `{Name}` / `{UniqueId}` placeholders, matching the style of the neighbouring `LogTrace("...background worker '{Name}' ({UniqueId})...")` calls. Applied to both the sync and async catch blocks.

This is a log-message-only change — no behavioural change — so per the issue's guidance and the project's testing approach (asserting on log text is low-value and there is no existing pattern for it), no test was added.

## Verification
- `dotnet build Game.Infrastructure/Game.Infrastructure.csproj` — succeeds, 0 warnings / 0 errors.
- `dotnet format Game.Infrastructure/Game.Infrastructure.csproj --verify-no-changes` — passes (no formatting changes).

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_