### PR TITLE
Fix uncleared saved-flash timer in admin EntityStore

### DIFF
--- a/UI/src/routes/admin/workbench/Workbench.svelte
+++ b/UI/src/routes/admin/workbench/Workbench.svelte
@@ -34,7 +34,7 @@
 </div>
 
 <script lang="ts">
-import { onMount } from 'svelte';
+import { onMount, onDestroy } from 'svelte';
 import { Loading } from '$components';
 import './workbench.scss';
 import type { EntityConfig, Identified } from './entities/types';
@@ -61,6 +61,10 @@ onMount(async () => {
 	store = new EntityStore(entity, seed);
 	selId = seed[0]?.id ?? 0;
 });
+
+// Cancel any pending "saved" flash timer so a save that lands near unmount can't
+// write into a torn-down store.
+onDestroy(() => store?.dispose());
 
 const selected = $derived(store ? (store.items.find((it) => it.id === selId) ?? store.items[0]) : undefined);
 const selectedBaseline = $derived(store && selected ? store.baselineOf(selected.id) : undefined);

--- a/UI/src/routes/admin/workbench/entity-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/entity-store.svelte.ts
@@ -22,6 +22,7 @@ export class EntityStore<T extends Identified> {
 	saved = $state(false);
 	saving = $state(false);
 	private nextId = -1;
+	#flashTimer: ReturnType<typeof setTimeout> | undefined;
 
 	constructor(config: EntityConfig<T>, seed: T[]) {
 		this.config = config;
@@ -165,8 +166,7 @@ export class EntityStore<T extends Identified> {
 			this.items = fresh.map(clone);
 			this.base = fresh.map(clone);
 			this.deleted.clear();
-			this.saved = true;
-			setTimeout(() => (this.saved = false), 1900);
+			this.flashSaved();
 		} catch (ex) {
 			// Without this, a failed persist reset only the saving flag and the
 			// user was left with unsaved edits and no indication anything broke.
@@ -180,5 +180,24 @@ export class EntityStore<T extends Identified> {
 		this.items = this.base.map(clone);
 		this.deleted.clear();
 		this.saved = false;
+	}
+
+	/** Briefly flash the "Changes saved" confirmation. The timer handle is owned so a
+	 *  re-arm clears the prior one and {@link dispose} can cancel a pending flash — a save
+	 *  that lands just before the Workbench unmounts must not write into a dead store. */
+	private flashSaved() {
+		this.saved = true;
+		if (this.#flashTimer) {
+			clearTimeout(this.#flashTimer);
+		}
+		this.#flashTimer = setTimeout(() => {
+			this.saved = false;
+		}, 1900);
+	}
+
+	dispose() {
+		if (this.#flashTimer) {
+			clearTimeout(this.#flashTimer);
+		}
 	}
 }

--- a/UI/src/tests/routes/admin/workbench/entity-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entity-store.test.ts
@@ -142,7 +142,10 @@ describe('EntityStore', () => {
 		it('clears the saved flag after the flash interval elapses', async () => {
 			vi.useFakeTimers();
 			try {
-				const store = new EntityStore(makeConfig(async () => seed), seed);
+				const store = new EntityStore(
+					makeConfig(async () => seed),
+					seed
+				);
 				store.addItem();
 				await store.save();
 				expect(store.saved).toBe(true);
@@ -157,7 +160,10 @@ describe('EntityStore', () => {
 		it('dispose cancels a pending flash so saved is not flipped after teardown', async () => {
 			vi.useFakeTimers();
 			try {
-				const store = new EntityStore(makeConfig(async () => seed), seed);
+				const store = new EntityStore(
+					makeConfig(async () => seed),
+					seed
+				);
 				store.addItem();
 				await store.save();
 				expect(store.saved).toBe(true);
@@ -176,7 +182,10 @@ describe('EntityStore', () => {
 		it('re-arming the flash clears the prior timer (no early reset)', async () => {
 			vi.useFakeTimers();
 			try {
-				const store = new EntityStore(makeConfig(async () => seed), seed);
+				const store = new EntityStore(
+					makeConfig(async () => seed),
+					seed
+				);
 				store.addItem();
 				await store.save();
 

--- a/UI/src/tests/routes/admin/workbench/entity-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entity-store.test.ts
@@ -138,6 +138,66 @@ describe('EntityStore', () => {
 		expect(persist).not.toHaveBeenCalled();
 	});
 
+	describe('saved flash timer', () => {
+		it('clears the saved flag after the flash interval elapses', async () => {
+			vi.useFakeTimers();
+			try {
+				const store = new EntityStore(makeConfig(async () => seed), seed);
+				store.addItem();
+				await store.save();
+				expect(store.saved).toBe(true);
+
+				vi.advanceTimersByTime(1900);
+				expect(store.saved).toBe(false);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('dispose cancels a pending flash so saved is not flipped after teardown', async () => {
+			vi.useFakeTimers();
+			try {
+				const store = new EntityStore(makeConfig(async () => seed), seed);
+				store.addItem();
+				await store.save();
+				expect(store.saved).toBe(true);
+
+				// Teardown (Workbench unmount) before the flash fires must not leave a
+				// live timer that writes into the dead store.
+				store.dispose();
+				vi.advanceTimersByTime(1900);
+				expect(store.saved).toBe(true);
+				expect(vi.getTimerCount()).toBe(0);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('re-arming the flash clears the prior timer (no early reset)', async () => {
+			vi.useFakeTimers();
+			try {
+				const store = new EntityStore(makeConfig(async () => seed), seed);
+				store.addItem();
+				await store.save();
+
+				// A second save part-way through the first flash should restart, not stack.
+				vi.advanceTimersByTime(1000);
+				store.addItem();
+				await store.save();
+				expect(vi.getTimerCount()).toBe(1);
+
+				// The first timer would have fired here; the re-armed one must keep saved true.
+				vi.advanceTimersByTime(900);
+				expect(store.saved).toBe(true);
+
+				vi.advanceTimersByTime(1000);
+				expect(store.saved).toBe(false);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+	});
+
 	describe('retire', () => {
 		it('isRetired reflects the retiredAt field', () => {
 			const store = new EntityStore(makeConfig(), [


### PR DESCRIPTION
## Summary

The admin `EntityStore.save()` scheduled a "saved" flag reset with an untracked `setTimeout`:

```ts
this.saved = true;
setTimeout(() => (this.saved = false), 1900);
```

The handle wasn't stored or cleared on teardown, so a save that completed shortly before the Workbench unmounts fired a `$state` write into a dead store (and re-arming a save while a flash was still pending stacked timers).

## Changes

- Store the timer handle on the instance (`#flashTimer`).
- Extract the flash into a private `flashSaved()` that `clearTimeout`s the prior handle before re-arming.
- Add a `dispose()` that cancels a pending flash, wired through `Workbench.svelte`'s `onDestroy`.

This mirrors the established `OptionsView` / `AttributesView` flash-timer pattern (owned handle, clear-before-re-arm, clear on dispose via `onDestroy`).

## Testing

Added focused unit tests using vitest fake timers covering: the flash auto-clears after the interval, `dispose()` cancels a pending flash so `saved` isn't flipped after teardown (and no live timer remains), and re-arming clears the prior timer instead of stacking.

- `npm run check` — passes (0 errors, 0 warnings).
- `npm run test:unit -- entity-store` — 16 passed.

Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_