### PR TITLE
Fix decodeAccessTokenPayload base64url decode (re-pad + UTF-8 safe)

### DIFF
--- a/UI/src/lib/api/token-store.ts
+++ b/UI/src/lib/api/token-store.ts
@@ -47,6 +47,18 @@ export const getAccessToken = (): string | null => getTokens()?.accessToken ?? n
 export const getRefreshToken = (): string | null => getTokens()?.refreshToken ?? null;
 
 /**
+ * Decodes a base64url-encoded string (the JWT segment encoding) to a UTF-8 string. base64url swaps
+ * `+`/`/` for `-`/`_` and drops the `=` padding, so we restore both before `atob`, then UTF-8-decode
+ * the raw bytes — `atob` alone would mangle any multi-byte claim (e.g. an accented username).
+ */
+const decodeBase64Url = (value: string): string => {
+	const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+	const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+	const bytes = Uint8Array.from(atob(padded), (c) => c.charCodeAt(0));
+	return new TextDecoder().decode(bytes);
+};
+
+/**
  * Decodes the (unverified) payload of the stored JWT access token. Verifying the signature is the
  * server's job; the client only reads a couple of claims (expiry, roles) to drive pre-emptive
  * refresh and role-based UI gating. Returns null when there is no token, it is not a well-formed
@@ -64,8 +76,7 @@ const decodeAccessTokenPayload = (): Record<string, unknown> | null => {
 	}
 
 	try {
-		const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-		return JSON.parse(atob(base64)) as Record<string, unknown>;
+		return JSON.parse(decodeBase64Url(parts[1])) as Record<string, unknown>;
 	} catch {
 		return null;
 	}

--- a/UI/src/tests/lib/api/token-store.test.ts
+++ b/UI/src/tests/lib/api/token-store.test.ts
@@ -10,7 +10,11 @@ import {
 } from '$lib/api/token-store';
 
 function makeToken(payload: Record<string, unknown>): string {
-	const body = btoa(JSON.stringify(payload)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+	// Mirror how the backend serializes a JWT payload: UTF-8 encode the JSON, base64-encode the raw
+	// bytes (so multi-byte claims survive), then base64url-ify and strip the `=` padding.
+	const bytes = new TextEncoder().encode(JSON.stringify(payload));
+	const binary = Array.from(bytes, (b) => String.fromCharCode(b)).join('');
+	const body = btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 	return `header.${body}.signature`;
 }
 
@@ -112,5 +116,39 @@ describe('token-store', () => {
 		setTokens({ accessToken: makeToken({ role: ['Admin', 5, null] }), refreshToken: 'r' });
 
 		expect(getRoles()).toEqual(['Admin']);
+	});
+
+	it('decodes a payload whose base64url length is not a multiple of 4 (needs re-padding)', () => {
+		// `makeToken` strips `=` padding, so pick a payload whose base64url length isn't divisible by
+		// 4 to exercise the re-pad path before `atob`.
+		const token = makeToken({ role: 'Admin', sub: 'abc' });
+		const body = token.split('.')[1];
+		expect(body.length % 4).not.toBe(0);
+
+		setTokens({ accessToken: token, refreshToken: 'r' });
+
+		expect(getRoles()).toEqual(['Admin']);
+	});
+
+	it('round-trips a role claim containing multi-byte UTF-8 (accented + emoji)', () => {
+		const role = 'Admiñ-🛡';
+		setTokens({ accessToken: makeToken({ role }), refreshToken: 'r' });
+
+		expect(getRoles()).toEqual([role]);
+	});
+
+	it('decodes an expiry claim alongside a non-ASCII username claim', () => {
+		const exp = Math.floor(Date.now() / 1000) + 1000;
+		setTokens({ accessToken: makeToken({ exp, name: 'José 🎮' }), refreshToken: 'r' });
+
+		expect(getAccessTokenExpiry()).toBe(exp);
+	});
+
+	it('fails closed on a malformed (non-base64) payload segment', () => {
+		// A third segment is present so the split passes, but the payload isn't valid base64/JSON.
+		setTokens({ accessToken: 'header.@@not-base64@@.signature', refreshToken: 'r' });
+
+		expect(getAccessTokenExpiry()).toBeNull();
+		expect(getRoles()).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary

`decodeAccessTokenPayload` in `UI/src/lib/api/token-store.ts` decoded the JWT payload by swapping the base64url chars (`-`→`+`, `_`→`/`) and calling bare `atob` — but it never re-padded the segment to a multiple of 4 and never UTF-8-decoded the result. As a consequence:

- A payload whose base64url length isn't divisible by 4 could fail to decode.
- `atob` mangles multi-byte UTF-8, so a username/role claim containing non-ASCII (an accented name, an emoji) decoded to garbage.

Both cases failed closed via the existing try/catch (role gating returns `[]`, expiry returns `null` → forces a pre-emptive refresh), so this is **UX-only, not a security hole** — the backend still independently enforces every claim. But the symptoms are real: a spurious extra refresh, or the Admin sidebar entry being hidden from a legitimate admin.

## Changes

- Added a small, dependency-free `decodeBase64Url` helper that restores `+`/`/`, re-pads with `=` to a multiple of 4, and UTF-8-decodes the raw bytes via `TextDecoder` (instead of bare `atob`).
- `decodeAccessTokenPayload` now routes through it. **Public API of the module is unchanged** and the fail-closed `try/catch` is preserved.

## Tests

Added vitest cases to `UI/src/tests/lib/api/token-store.test.ts`:
- A payload whose base64url length is not a multiple of 4 (exercises re-padding) decodes correctly.
- A role claim and a username claim containing multi-byte UTF-8 (accented + emoji) round-trip correctly.
- A malformed (non-base64) payload segment still fails closed (`getRoles()` → `[]`, `getAccessTokenExpiry()` → `null`).

The test helper now UTF-8-encodes the JSON payload before base64-encoding, mirroring how the backend actually serializes a JWT (bare `btoa` throws on multi-byte input).

## Verification

- `npm run check` — svelte-check passes, 0 errors / 0 warnings.
- `npm run test:unit -- token-store` — 19/19 pass.

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_