### PR TITLE
Dedupe safeLocalStorage guard in log-panel and attributes views

### DIFF
--- a/UI/src/components/log-panel/log-panel-view.svelte.ts
+++ b/UI/src/components/log-panel/log-panel-view.svelte.ts
@@ -11,6 +11,8 @@
    component; the clamping and persistence logic lives here so it stays
    unit-testable without a DOM. */
 
+import { safeLocalStorage } from '$lib/common/local-storage';
+
 /** Smallest the log panel itself is allowed to get. */
 export const MIN_LOG_PANEL_HEIGHT = 96;
 /** Default panel height — roughly the original fixed combat-log size. */
@@ -27,16 +29,6 @@ const STORAGE_KEY = 'gameserver.logPanelHeight';
 export const clampLogPanelHeight = (height: number, max: number): number => {
 	const upper = Math.max(MIN_LOG_PANEL_HEIGHT, max);
 	return Math.min(Math.max(height, MIN_LOG_PANEL_HEIGHT), upper);
-};
-
-/** Returns local storage when available (absent during SSR), or null otherwise.
- *  Access is wrapped because reading `localStorage` throws in some privacy modes. */
-const storage = (): Storage | null => {
-	try {
-		return typeof localStorage !== 'undefined' ? localStorage : null;
-	} catch {
-		return null;
-	}
 };
 
 export class LogPanelView {
@@ -72,7 +64,7 @@ export class LogPanelView {
 	 *  overflow a smaller one. */
 	hydrate(available?: number): void {
 		this.maxHeight = this.maxFor(available);
-		const raw = storage()?.getItem(STORAGE_KEY);
+		const raw = safeLocalStorage()?.getItem(STORAGE_KEY);
 		if (raw === null || raw === undefined) {
 			return;
 		}
@@ -141,7 +133,7 @@ export class LogPanelView {
 	/** Persist the current height (best-effort; ignore quota/availability errors). */
 	private persist(): void {
 		try {
-			storage()?.setItem(STORAGE_KEY, String(Math.round(this.height)));
+			safeLocalStorage()?.setItem(STORAGE_KEY, String(Math.round(this.height)));
 		} catch {
 			// Persistence is best-effort; ignore quota/availability errors.
 		}

--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -24,6 +24,7 @@
 import { apiSocket, EAttribute, type IAttributeUpdate, type IBattlerAttribute } from '$lib/api';
 import { BattleAttributes } from '$lib/battle';
 import { attributeName } from '$lib/common';
+import { safeLocalStorage } from '$lib/common/local-storage';
 import { playerManager } from '$lib/engine';
 import { staticData, toastError } from '$stores';
 
@@ -357,17 +358,13 @@ function computeHexMax(draft: number[], committed: number[]): number {
 }
 
 function readStoredMode(): AttributeMode {
-	try {
-		return localStorage.getItem(MODE_STORAGE_KEY) === 'theory' ? 'theory' : 'guided';
-	} catch {
-		// Storage can be unavailable (private mode / SSR); fall back to the default.
-		return 'guided';
-	}
+	// Storage may be null (private mode / SSR); fall back to the default.
+	return safeLocalStorage()?.getItem(MODE_STORAGE_KEY) === 'theory' ? 'theory' : 'guided';
 }
 
 function storeMode(mode: AttributeMode): void {
 	try {
-		localStorage.setItem(MODE_STORAGE_KEY, mode);
+		safeLocalStorage()?.setItem(MODE_STORAGE_KEY, mode);
 	} catch {
 		// Persisting the preference is best-effort; ignore storage failures.
 	}


### PR DESCRIPTION
## Summary

Two sites hand-rolled their own copy of the shared best-effort `localStorage` guard (the SSR-absent + privacy-mode try/catch) instead of importing the documented single source, `safeLocalStorage()` from `$lib/common/local-storage`:

- **`log-panel-view.svelte.ts`** — its local `storage()` helper was a byte-for-byte copy of `safeLocalStorage()`.
- **`attributes-view.svelte.ts`** — `readStoredMode`/`storeMode` wrapped raw `localStorage` in the same SSR/privacy try/catch.

Both now import and call the shared `safeLocalStorage()` and the local copies are deleted.

## Notes

- Uses the **deep import** path `$lib/common/local-storage` (not the `$lib/common` barrel), as the shared file documents: going through the barrel transitively pulls in `$lib/api` and would form an import cycle for api-layer consumers.
- Behavior is preserved exactly — same storage keys, same read/write semantics, same null/SSR handling. `safeLocalStorage()` returns `Storage | null`, so reads use optional chaining and fall through to the existing defaults when storage is unavailable. The best-effort write try/catch is kept (it guards `setItem` quota errors, which the access guard does not).

## Verification

- `npm run check` (svelte-check): 0 errors, 0 warnings — confirms no import cycle or type issues.
- `npm run test:unit` for `log-panel-view` and `attributes-view`: 65 tests pass.

Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_