### PR TITLE
Enforce Zone level-range invariant at construction (#840)

### DIFF
--- a/Game.Core.Tests/Zones/ZoneTests.cs
+++ b/Game.Core.Tests/Zones/ZoneTests.cs
@@ -63,6 +63,83 @@ namespace Game.Core.Tests.Zones
             Assert.True(zone.IsUnlocked(new HashSet<int> { 6, 7, 8 }));
         }
 
+        [Fact]
+        public void Construct_ValidRange_Succeeds()
+        {
+            var zone = MakeZone(levelMin: 3, levelMax: 7);
+
+            Assert.Equal(3, zone.LevelMin);
+            Assert.Equal(7, zone.LevelMax);
+        }
+
+        [Fact]
+        public void Construct_EqualBounds_IsAllowed()
+        {
+            var zone = MakeZone(levelMin: 5, levelMax: 5);
+
+            Assert.Equal(5, zone.LevelMin);
+            Assert.Equal(5, zone.LevelMax);
+        }
+
+        [Fact]
+        public void Construct_LevelMinGreaterThanLevelMax_Throws()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => MakeZone(levelMin: 8, levelMax: 4));
+
+            Assert.Contains("8", ex.Message);
+            Assert.Contains("4", ex.Message);
+            Assert.Equal(nameof(Zone.LevelMin), ex.ParamName);
+        }
+
+        // The cross-field invariant must hold regardless of which bound the object initializer assigns
+        // first, so pin the inverted-assignment path too (LevelMax set before LevelMin).
+        [Fact]
+        public void Construct_LevelMinGreaterThanLevelMax_ThrowsWhenMaxAssignedFirst()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => new Zone
+            {
+                Id = 0,
+                LevelMax = 4,
+                LevelMin = 8,
+                BossEnemyId = null,
+                BossLevel = 1,
+                UnlockChallengeId = null,
+            });
+
+            Assert.Contains("8", ex.Message);
+            Assert.Contains("4", ex.Message);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void Construct_LevelMinBelowOne_Throws(int levelMin)
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => MakeZone(levelMin: levelMin, levelMax: 10));
+
+            Assert.Equal(nameof(Zone.LevelMin), ex.ParamName);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void Construct_LevelMaxBelowOne_Throws(int levelMax)
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => MakeZone(levelMin: 1, levelMax: levelMax));
+
+            Assert.Equal(nameof(Zone.LevelMax), ex.ParamName);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void Construct_BossLevelBelowOne_Throws(int bossLevel)
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => MakeZone(bossLevel: bossLevel));
+
+            Assert.Equal(nameof(Zone.BossLevel), ex.ParamName);
+        }
+
         private static Zone MakeZone(
             int levelMin = 1, int levelMax = 10, int? bossEnemyId = null, int bossLevel = 1,
             int? unlockChallengeId = null) => new()

--- a/Game.Core/Zones/Zone.cs
+++ b/Game.Core/Zones/Zone.cs
@@ -9,9 +9,47 @@ namespace Game.Core.Zones
     /// </summary>
     public class Zone
     {
+        private readonly int _levelMin;
+        private readonly int _levelMax;
+        private readonly int _bossLevel;
+
         public required int Id { get; init; }
-        public required int LevelMin { get; init; }
-        public required int LevelMax { get; init; }
+
+        /// <summary>The inclusive lower bound of the random idle encounter-level range. Must be at least 1
+        /// and no greater than <see cref="LevelMax"/>.</summary>
+        public required int LevelMin
+        {
+            get => _levelMin;
+            init
+            {
+                if (value < 1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(LevelMin), value,
+                        $"{nameof(LevelMin)} must be at least 1.");
+                }
+
+                _levelMin = value;
+                ValidateLevelRange();
+            }
+        }
+
+        /// <summary>The inclusive upper bound of the random idle encounter-level range. Must be at least 1
+        /// and no less than <see cref="LevelMin"/>.</summary>
+        public required int LevelMax
+        {
+            get => _levelMax;
+            init
+            {
+                if (value < 1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(LevelMax), value,
+                        $"{nameof(LevelMax)} must be at least 1.");
+                }
+
+                _levelMax = value;
+                ValidateLevelRange();
+            }
+        }
 
         /// <summary>The id of this zone's single dedicated boss, fought via the "Challenge Boss" action,
         /// or <c>null</c> when no boss has been authored.</summary>
@@ -19,8 +57,21 @@ namespace Game.Core.Zones
 
         /// <summary>The fixed level the dedicated boss is fought at, independent of the
         /// <see cref="LevelMin"/>/<see cref="LevelMax"/> idle range. Only meaningful when
-        /// <see cref="BossEnemyId"/> is set.</summary>
-        public required int BossLevel { get; init; }
+        /// <see cref="BossEnemyId"/> is set. Must be at least 1.</summary>
+        public required int BossLevel
+        {
+            get => _bossLevel;
+            init
+            {
+                if (value < 1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(BossLevel), value,
+                        $"{nameof(BossLevel)} must be at least 1.");
+                }
+
+                _bossLevel = value;
+            }
+        }
 
         /// <summary>The id of the challenge that gates entry to this zone, or <c>null</c> when the zone is
         /// always open (e.g. the starting zone). The zone unlocks once the player completes that challenge
@@ -48,6 +99,24 @@ namespace Game.Core.Zones
         public int RollEncounterLevel()
         {
             return Random.Shared.Next(LevelMin, LevelMax + 1);
+        }
+
+        /// <summary>
+        /// Enforces the <see cref="LevelMin"/> &lt;= <see cref="LevelMax"/> invariant. Called from both
+        /// bounds' <c>init</c> accessors so a mis-authored range is rejected at construction (with the
+        /// offending values named) rather than throwing mid-battle in <see cref="RollEncounterLevel"/>.
+        /// The check runs only once both bounds are assigned: a not-yet-set bound has its backing field at
+        /// the default <c>0</c>, which a valid level (always &gt;= 1) never is, so the first accessor is a
+        /// no-op and the second performs the comparison regardless of initializer order.
+        /// </summary>
+        private void ValidateLevelRange()
+        {
+            if (_levelMin > 0 && _levelMax > 0 && _levelMin > _levelMax)
+            {
+                throw new ArgumentException(
+                    $"{nameof(LevelMin)} ({_levelMin}) cannot be greater than {nameof(LevelMax)} ({_levelMax}).",
+                    nameof(LevelMin));
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

`Zone.RollEncounterLevel()` calls `Random.Shared.Next(LevelMin, LevelMax + 1)`, which throws `ArgumentOutOfRangeException` when `LevelMin > LevelMax`. The `Zone` aggregate (authored content from the admin Workbench) enforced no invariant on its level range — `LevelMin`/`LevelMax`/`BossLevel` were plain `required init` properties — so a mis-authored zone surfaced as a runtime throw deep inside `BattleFactory.CreateBattleEnemy` on a real idle battle start instead of being rejected at authoring time with a clear message.

## What changed

- **`Game.Core/Zones/Zone.cs`** — `LevelMin`, `LevelMax`, and `BossLevel` are now validated via `init`-accessor guards so an invalid `Zone` can never be constructed:
  - Each of `LevelMin`/`LevelMax`/`BossLevel` must be `>= 1` (throws `ArgumentOutOfRangeException` naming the property and value).
  - `LevelMin <= LevelMax` (throws `ArgumentException` naming both offending values). The cross-field check runs from *both* bounds' `init` accessors, so it holds regardless of which bound the object initializer assigns first.
  - Failing at construction means both the admin write path and the reference-cache load (`ZoneMapper.ToCore`) reject a bad range up front, rather than letting it reach the battle hot path.
- **`Game.Core.Tests/Zones/ZoneTests.cs`** — added domain unit tests: valid range constructs fine, equal bounds (`LevelMin == LevelMax`) is allowed, `LevelMin > LevelMax` throws a clear message naming both values (pinned for both initializer orders), and each of `LevelMin`/`LevelMax`/`BossLevel` below 1 throws.

The `init`-accessor guards keep the setters `init`-only, so the structural-immutability guard (`ReferenceDataImmutabilityTests`) still passes — verified alongside the new tests.

## Verification

- `dotnet build Game.Core/Game.Core.csproj` — succeeds, 0 warnings.
- `dotnet test Game.Core.Tests` filtered to `*ZoneTests*` (16 passed) and `*ReferenceDataImmutabilityTests*` (31 passed).

Closes #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_