### PR TITLE
CI workflow hygiene: concurrency, format --no-restore, Playwright CI server, e2e path filter

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,13 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# Cancel any in-progress run for the same ref (PR branch or main) when a newer push lands. The
+# heaviest path is the 3-browser test-e2e matrix, so superseding stale runs frees those minutes
+# for the run that actually matters.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   detect-changes:
@@ -44,8 +51,13 @@ jobs:
             - 'Game.TestInfrastructure/**'
             - 'Game.sln'
             - 'build/**'
+            # e2e-affecting inputs: the dockerized stack, its seed, the local/Desktop compose
+            # variant, the API image, and the Playwright config all gate the test-e2e job.
             - 'docker-compose.yml'
+            - 'docker-compose.local.yml'
+            - 'Game.Api/Dockerfile'
             - 'e2e-seed.sql'
+            - 'UI/playwright.config.ts'
             - '.dockerignore'
             - '.github/workflows/**'
             - 'UI/src/lib/api/types/**'
@@ -94,7 +106,9 @@ jobs:
         git diff --exit-code -- UI/src/lib/api/types
 
     - name: Run formatter (verify only)
-      run: dotnet format --verify-no-changes
+      # --no-restore reuses the restore/build from "Build solution" above; without it dotnet format
+      # triggers its own implicit restore + MSBuild evaluation (mirrors the codegen/coverage steps).
+      run: dotnet format --verify-no-changes --no-restore
 
     - name: Execute tests with coverage gate
       # build/coverage.ps1 restores the coverage tools, collects one merged Cobertura across the whole

--- a/UI/playwright.config.ts
+++ b/UI/playwright.config.ts
@@ -4,7 +4,8 @@ const config: PlaywrightTestConfig = {
 	webServer: {
 		command: 'npm run dev -- --port 4173',
 		port: 4173,
-		reuseExistingServer: true
+		// Reuse a server only for local dev; in CI always start a known-good server.
+		reuseExistingServer: !process.env.CI
 	},
 	testDir: 'e2e-tests',
 	testMatch: /(.+\.)?(test|spec)\.[jt]s/,


### PR DESCRIPTION
Closes #818

Four low-cost CI hygiene improvements to `.github/workflows/run-tests.yml` and `UI/playwright.config.ts`:

1. **Concurrency cancellation** — Added a top-level `concurrency` group keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. A newer push to a PR branch (or main) now supersedes the in-flight run, freeing minutes spent on the heavy 3-browser `test-e2e` matrix for stale commits.
2. **`dotnet format --no-restore`** — The `Run formatter (verify only)` step now passes `--no-restore` so it reuses the restore/build from the preceding `Build solution` step instead of triggering its own implicit restore + MSBuild evaluation, matching the neighbouring codegen (`--no-build --no-restore`) and coverage (`-NoBuild`) steps.
3. **Playwright `reuseExistingServer: !process.env.CI`** — CI now always starts a known-good dev server, while local dev still reuses an already-running one.
4. **Complete e2e path filter** — Added the e2e-unique inputs `docker-compose.local.yml`, `Game.Api/Dockerfile`, and `UI/playwright.config.ts` to the `detect-changes` `backend` filter group, alongside the existing `docker-compose.yml` / `e2e-seed.sql` entries. The `test-e2e` job triggers on `backend == 'true'` OR `frontend == 'true'`, so placing these in `backend` reliably triggers e2e for changes that were previously only caught incidentally (the Dockerfile via `Game.Api/**`) or not flagged as a dedicated e2e input.

### Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` confirms the workflow YAML parses and the `concurrency` block resolves as expected.
- `npm run check` (svelte-kit sync + svelte-check) passes with 0 errors / 0 warnings; the `!process.env.CI` usage mirrors the existing `process.env.CI` usages already in the config.
- The GitHub workflow itself cannot be executed locally; correctness rests on YAML validity plus careful review of the path-filter wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_