### PR TITLE
Enforce player Include contract via shared IncludePlayerGraph extension

### DIFF
--- a/Game.DataAccess/Repositories/PlayerQueryExtensions.cs
+++ b/Game.DataAccess/Repositories/PlayerQueryExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using EntityPlayer = Game.Infrastructure.Entities.Player;
+
+namespace Game.DataAccess.Repositories
+{
+    /// <summary>
+    /// The single sanctioned way to materialize a player entity for <see cref="Mapping.PlayerMapper.ToCore"/>.
+    /// <see cref="Mapping.PlayerMapper.ToCore"/> reads every navigation collection applied below; loading a
+    /// player without them would silently map an empty graph (no skills/items/preferences) since lazy loading
+    /// is off. Centralizing the includes here makes that contract structural — a new load path that routes
+    /// through this extension cannot accidentally omit one — rather than a comment on each query.
+    /// </summary>
+    internal static class PlayerQueryExtensions
+    {
+        /// <summary>
+        /// Applies the full include graph that <see cref="Mapping.PlayerMapper.ToCore"/> requires. The
+        /// reference-data portion (item/skill/mod definitions) is resolved from the in-memory cached catalogs
+        /// in the mapper, so only the player-specific relational data is included here.
+        /// </summary>
+        public static IQueryable<EntityPlayer> IncludePlayerGraph(this IQueryable<EntityPlayer> players)
+        {
+            return players
+                .Include(p => p.PlayerAttributes)
+                .Include(p => p.PlayerSkills)
+                .Include(p => p.UnlockedItems)
+                .Include(p => p.UnlockedMods)
+                .Include(p => p.AppliedMods)
+                .Include(p => p.LogPreferences)
+                .AsSplitQuery();
+        }
+    }
+}

--- a/Game.DataAccess/Repositories/PlayerRepository.cs
+++ b/Game.DataAccess/Repositories/PlayerRepository.cs
@@ -92,18 +92,12 @@ namespace Game.DataAccess.Repositories
 
         private async Task<Player?> GetPlayerFromDb(int playerId, CancellationToken cancellationToken)
         {
-            // Only the player-specific relational data is fetched here; the reference-data portion
-            // (item/skill/mod definitions and their attributes) is resolved from the in-memory cached
-            // catalogs in PlayerMapper.ToCore, avoiding redundant deep joins on every player load.
+            // IncludePlayerGraph applies the full navigation graph PlayerMapper.ToCore reads, so the contract
+            // is enforced structurally rather than per-query. The reference-data portion (item/skill/mod
+            // definitions) is resolved from the in-memory cached catalogs in the mapper, not joined here.
             var entity = await _context.Players
                 .AsNoTracking()
-                .Include(p => p.PlayerAttributes)
-                .Include(p => p.PlayerSkills)
-                .Include(p => p.UnlockedItems)
-                .Include(p => p.UnlockedMods)
-                .Include(p => p.AppliedMods)
-                .Include(p => p.LogPreferences)
-                .AsSplitQuery()
+                .IncludePlayerGraph()
                 .FirstOrDefaultAsync(p => p.Id == playerId, cancellationToken);
 
             return entity is null ? null : PlayerMapper.ToCore(entity, _items, _itemMods, _skills);


### PR DESCRIPTION
Closes #806

## Problem

`PlayerMapper.ToCore` iterates the player entity's navigation collections (`PlayerAttributes`, `PlayerSkills`, `UnlockedItems`, `UnlockedMods`, `AppliedMods`, `LogPreferences`) assuming the caller's query eagerly loaded them. With lazy loading off, a load path that forgets an `.Include` would silently map an empty graph — a player with no skills/items/preferences and no exception to localize the bug. The required-includes contract lived only in a repository comment, not in the type system.

## Change

- Added an internal `IncludePlayerGraph()` extension on `IQueryable<Player-entity>` (`Game.DataAccess/Repositories/PlayerQueryExtensions.cs`) that applies the full required include graph — every navigation `ToCore` reads, plus `AsSplitQuery()`.
- Routed the single load path (`PlayerRepository.GetPlayerFromDb`) through it, removing the inline include chain and the comment-only contract. A new load path that materializes a player for `ToCore` now opts into the full graph structurally rather than re-listing includes that can drift.
- The entity seam stays `internal` to the data tier (the extension is keyed on the `Game.Infrastructure.Entities.Player` alias and is not visible to `Game.Api`/`Game.Application`), per docs/backend.md.

Note: the `Player` entity's navigation getters already throw `NotLoadedException` when a backing field was never loaded, so a forgotten include also fails fast at runtime; the structural extension is the primary mechanism and that throw is a defensive backstop.

## Testing

No new DB infrastructure. The include graph is exercised end-to-end by the existing DI-resolved player-load integration tests (`AccountServiceIntegrationTests` — `Login_ValidCredentials_ReturnsTokensAndPlayer` and friends seed a player with a linked skill and assert it loads), which would surface a missing include as missing player data. The extension itself is a declarative `.Include` chain with no pure-logic seam worth a dedicated unit test, so none was added.

Verified locally (SDK 10.0.109): `dotnet build Game.DataAccess`, `AccountServiceIntegrationTests` (15 passed) and `PlayerMapperTests` (4 passed), and `dotnet format Game.DataAccess --verify-no-changes` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_