### PR TITLE
Derive statistic aggregation direction from a single domain fact

### DIFF
--- a/Game.Core.Tests/Progress/ChallengeTypeTests.cs
+++ b/Game.Core.Tests/Progress/ChallengeTypeTests.cs
@@ -1,3 +1,4 @@
+using Game.Core;
 using Game.Core.Progress;
 using Xunit;
 
@@ -52,6 +53,39 @@ namespace Game.Core.Tests.Progress
             var challengeType = new ChallengeType(type);
 
             Assert.Equal(EChallengeGoalComparison.AtLeast, challengeType.GoalComparison);
+        }
+
+        [Fact]
+        public void GoalComparison_IsDerivedFromBackingStatisticAggregation()
+        {
+            // The single domain fact ("this statistic is minimized") must drive both the recording mutator
+            // and the challenge comparison. This pins the invariant the issue (#839) exists to enforce:
+            // a min-aggregated backing statistic yields AtMost; anything else (including a challenge with no
+            // backing statistic) yields AtLeast — so the two encodings can never silently disagree.
+            foreach (var challengeType in ChallengeType.GetAll())
+            {
+                var isMinAggregated = challengeType.StatisticType?.AggregationKind == EAggregationKind.Min;
+                var expected = isMinAggregated
+                    ? EChallengeGoalComparison.AtMost
+                    : EChallengeGoalComparison.AtLeast;
+
+                Assert.Equal(expected, challengeType.GoalComparison);
+            }
+        }
+
+        [Fact]
+        public void EveryMinAggregatedStatisticChallengeUsesAtMost()
+        {
+            // Stated directionally as the issue asks: every challenge backed by a minimized statistic must
+            // compare AtMost, and every AtMost challenge must be backed by a minimized statistic — there is
+            // no other source of an AtMost comparison.
+            foreach (var challengeType in ChallengeType.GetAll())
+            {
+                var isMinAggregated = challengeType.StatisticType?.AggregationKind == EAggregationKind.Min;
+                var isAtMost = challengeType.GoalComparison == EChallengeGoalComparison.AtMost;
+
+                Assert.Equal(isMinAggregated, isAtMost);
+            }
         }
 
         [Fact]

--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -332,6 +332,44 @@ namespace Game.Core.Tests.Progress
         }
 
         [Fact]
+        public void RecordBattleCompleted_MutatorMatchesStatisticAggregationKind()
+        {
+            // The mutator is now derived from StatisticType.AggregationKind, not chosen by hand per call.
+            // Recording two values across two battles must agree with that direction for each kind:
+            // Sum accumulates, Max keeps the larger, Min keeps the smaller.
+            var sumProgress = MakeProgress();
+            var maxProgress = MakeProgress();
+            var minProgress = MakeProgress();
+
+            // Sum: DamageDealt (40 then 60 → 100).
+            sumProgress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000,
+                new BattleStats { PlayerDamageDealt = 40.0 }, isBossBattle: false, zoneId: 0);
+            sumProgress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000,
+                new BattleStats { PlayerDamageDealt = 60.0 }, isBossBattle: false, zoneId: 0);
+
+            // Max: HighestSingleAttackDamage (30 then 20 → 30).
+            maxProgress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000,
+                new BattleStats { HighestPlayerAttack = 30.0 }, isBossBattle: false, zoneId: 0);
+            maxProgress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000,
+                new BattleStats { HighestPlayerAttack = 20.0 }, isBossBattle: false, zoneId: 0);
+
+            // Min: FastestVictory (7s then 5s → 5s).
+            minProgress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 7000,
+                new BattleStats(), isBossBattle: false, zoneId: 0);
+            minProgress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 5000,
+                new BattleStats(), isBossBattle: false, zoneId: 0);
+
+            Assert.Equal(EAggregationKind.Sum, StatisticType.GetAggregationKind(EStatisticType.DamageDealt));
+            Assert.Equal(100m, sumProgress.GetStatisticValue(EStatisticType.DamageDealt, null));
+
+            Assert.Equal(EAggregationKind.Max, StatisticType.GetAggregationKind(EStatisticType.HighestSingleAttackDamage));
+            Assert.Equal(30m, maxProgress.GetStatisticValue(EStatisticType.HighestSingleAttackDamage, null));
+
+            Assert.Equal(EAggregationKind.Min, StatisticType.GetAggregationKind(EStatisticType.FastestVictory));
+            Assert.Equal(5m, minProgress.GetStatisticValue(EStatisticType.FastestVictory, null));
+        }
+
+        [Fact]
         public void RecordBattleCompleted_FirstVictoryWithZeroDuration_RecordsZeroFastestVictory()
         {
             var progress = MakeProgress();

--- a/Game.Core.Tests/Progress/StatisticTypeTests.cs
+++ b/Game.Core.Tests/Progress/StatisticTypeTests.cs
@@ -51,6 +51,59 @@ namespace Game.Core.Tests.Progress
             }
         }
 
+        [Theory]
+        // Min-aggregated: only the lowest reported value is kept (lower is better).
+        [InlineData(EStatisticType.FastestVictory, EAggregationKind.Min)]
+        // Max-aggregated: only the highest reported value is kept.
+        [InlineData(EStatisticType.HighestSingleAttackDamage, EAggregationKind.Max)]
+        // Sum-aggregated: accumulating counters/totals (a representative sample of the rest).
+        [InlineData(EStatisticType.EnemiesKilled, EAggregationKind.Sum)]
+        [InlineData(EStatisticType.DamageDealt, EAggregationKind.Sum)]
+        [InlineData(EStatisticType.ZonesCleared, EAggregationKind.Sum)]
+        [InlineData(EStatisticType.TotalBattleTime, EAggregationKind.Sum)]
+        public void Statistics_MapToExpectedAggregationKind(EStatisticType type, EAggregationKind expected)
+        {
+            var statisticType = new StatisticType(type);
+
+            Assert.Equal(expected, statisticType.AggregationKind);
+            // The static accessor (used by the per-battle recording path) agrees with the instance property.
+            Assert.Equal(expected, StatisticType.GetAggregationKind(type));
+        }
+
+        [Fact]
+        public void FastestVictory_IsTheOnlyMinAggregatedStatistic()
+        {
+            // FastestVictory is the sole "lower is better" statistic. Asserted across every type so a
+            // future minimized statistic must update this expectation (and its challenge comparison)
+            // deliberately. Asserted across the whole set so the min set stays a single source of truth.
+            foreach (var statisticType in StatisticType.GetAll())
+            {
+                var isMin = statisticType.AggregationKind == EAggregationKind.Min;
+                Assert.Equal(statisticType.Id == EStatisticType.FastestVictory, isMin);
+            }
+        }
+
+        [Fact]
+        public void HighestSingleAttackDamage_IsTheOnlyMaxAggregatedStatistic()
+        {
+            foreach (var statisticType in StatisticType.GetAll())
+            {
+                var isMax = statisticType.AggregationKind == EAggregationKind.Max;
+                Assert.Equal(statisticType.Id == EStatisticType.HighestSingleAttackDamage, isMax);
+            }
+        }
+
+        [Fact]
+        public void EveryStatisticHasADefinedAggregationKind()
+        {
+            // Guards against an EStatisticType the aggregation mapping silently falls through on.
+            foreach (var type in Enum.GetValues<EStatisticType>())
+            {
+                Assert.Contains(StatisticType.GetAggregationKind(type),
+                    new[] { EAggregationKind.Sum, EAggregationKind.Max, EAggregationKind.Min });
+            }
+        }
+
         [Fact]
         public void Name_IsHumanReadableWithSpaces()
         {

--- a/Game.Core/Enums.cs
+++ b/Game.Core/Enums.cs
@@ -353,6 +353,32 @@ namespace Game.Core
     }
 
     /// <summary>
+    /// How a statistic's recorded value is aggregated across the battles that report it. A derived domain
+    /// fact of the statistic type (see <see cref="Progress.StatisticType"/>), so it is the single source of
+    /// truth for both the recording mutator and a challenge's <see cref="EChallengeGoalComparison"/>.
+    /// </summary>
+    public enum EAggregationKind
+    {
+        /// <summary>
+        /// Each report is added to a running total (e.g. kills, damage dealt). Higher is better, so a
+        /// backing challenge completes once the value is at least the goal.
+        /// </summary>
+        Sum = 1,
+
+        /// <summary>
+        /// Only the largest reported value is kept (e.g. highest single attack). Higher is better, so a
+        /// backing challenge completes once the value is at least the goal.
+        /// </summary>
+        Max = 2,
+
+        /// <summary>
+        /// Only the smallest reported value is kept (e.g. fastest victory). Lower is better, so a backing
+        /// challenge completes once the value is at or below the goal.
+        /// </summary>
+        Min = 3,
+    }
+
+    /// <summary>
     /// Represents a type of player statistic that is tracked over time.
     /// </summary>
     public enum EStatisticType

--- a/Game.Core/Progress/ChallengeType.cs
+++ b/Game.Core/Progress/ChallengeType.cs
@@ -11,25 +11,26 @@
         {
             Id = id;
             Name = id.ToString().SpaceWords();
-            GoalComparison = GetGoalComparison(id);
 
             var statisticType = GetStatisticType(id);
             if (statisticType.HasValue)
             {
                 StatisticType = new StatisticType(statisticType.Value);
             }
+
+            GoalComparison = GetGoalComparison(StatisticType);
         }
 
         public static IEnumerable<ChallengeType> GetAll() => Enum.GetValues<EChallengeType>().Select(id => new ChallengeType(id));
 
-        private static EChallengeGoalComparison GetGoalComparison(EChallengeType id)
+        private static EChallengeGoalComparison GetGoalComparison(StatisticType? statisticType)
         {
-            return id switch
-            {
-                // Time trials track the fastest victory time, where a lower value is better.
-                EChallengeType.TimeTrial => EChallengeGoalComparison.AtMost,
-                _ => EChallengeGoalComparison.AtLeast,
-            };
+            // The comparison direction follows the backing statistic's aggregation: a minimized statistic
+            // (lower is better, e.g. FastestVictory) completes "at or below" the goal, everything else "at
+            // least". A challenge with no backing statistic (e.g. LevelReached) accumulates, so AtLeast.
+            return statisticType?.AggregationKind == EAggregationKind.Min
+                ? EChallengeGoalComparison.AtMost
+                : EChallengeGoalComparison.AtLeast;
         }
 
         private static EStatisticType? GetStatisticType(EChallengeType id)

--- a/Game.Core/Progress/PlayerProgress.cs
+++ b/Game.Core/Progress/PlayerProgress.cs
@@ -44,21 +44,21 @@ namespace Game.Core.Progress
         public IReadOnlyCollection<(EStatisticType Type, int? EntityId)> RecordBattleCompleted(
             Enemy enemy, bool victory, bool playerDied, int totalMs, BattleStats stats, bool isBossBattle, int zoneId)
         {
-            Increment(EStatisticType.DamageDealt, null, (decimal)Math.Round(stats.PlayerDamageDealt, 3));
-            SetMax(EStatisticType.HighestSingleAttackDamage, null, (decimal)Math.Round(stats.HighestPlayerAttack, 3));
-            Increment(EStatisticType.DamageTaken, null, (decimal)Math.Round(stats.PlayerDamageTaken, 3));
-            Increment(EStatisticType.DamageHealed, null, (decimal)Math.Round(stats.PlayerDamageHealed, 3));
-            Increment(EStatisticType.EnemiesEncountered, null, 1);
-            Increment(EStatisticType.EnemiesEncountered, enemy.Id, 1);
+            Record(EStatisticType.DamageDealt, null, (decimal)Math.Round(stats.PlayerDamageDealt, 3));
+            Record(EStatisticType.HighestSingleAttackDamage, null, (decimal)Math.Round(stats.HighestPlayerAttack, 3));
+            Record(EStatisticType.DamageTaken, null, (decimal)Math.Round(stats.PlayerDamageTaken, 3));
+            Record(EStatisticType.DamageHealed, null, (decimal)Math.Round(stats.PlayerDamageHealed, 3));
+            Record(EStatisticType.EnemiesEncountered, null, 1);
+            Record(EStatisticType.EnemiesEncountered, enemy.Id, 1);
 
             if (victory)
             {
-                Increment(EStatisticType.BattlesWon, null, 1);
-                Increment(EStatisticType.BattlesWon, enemy.Id, 1);
-                SetMin(EStatisticType.FastestVictory, null, totalMs / 1000m);
-                SetMin(EStatisticType.FastestVictory, enemy.Id, totalMs / 1000m);
-                Increment(EStatisticType.EnemiesKilled, null, 1);
-                Increment(EStatisticType.EnemiesKilled, enemy.Id, 1);
+                Record(EStatisticType.BattlesWon, null, 1);
+                Record(EStatisticType.BattlesWon, enemy.Id, 1);
+                Record(EStatisticType.FastestVictory, null, totalMs / 1000m);
+                Record(EStatisticType.FastestVictory, enemy.Id, totalMs / 1000m);
+                Record(EStatisticType.EnemiesKilled, null, 1);
+                Record(EStatisticType.EnemiesKilled, enemy.Id, 1);
 
                 // A dedicated-boss victory both farms the boss and (on the first clear) clears its zone. The
                 // boss-ness comes from the explicit challenge marker (threaded from PlayerState), not the
@@ -69,47 +69,47 @@ namespace Game.Core.Progress
                     // BossesDefeated is the farm counter: it increments on every dedicated-boss victory,
                     // tracked globally and per-boss so challenges can target either "defeat any boss" or a
                     // specific boss repeatedly.
-                    Increment(EStatisticType.BossesDefeated, null, 1);
-                    Increment(EStatisticType.BossesDefeated, enemy.Id, 1);
+                    Record(EStatisticType.BossesDefeated, null, 1);
+                    Record(EStatisticType.BossesDefeated, enemy.Id, 1);
 
                     // ZonesCleared counts distinct zones ever cleared, not boss-victory events. The per-zone
                     // entry is a binary "cleared" flag, and the global counter only bumps on a zone's first
                     // clear (its 0 -> 1 transition), so re-farming a boss never re-counts the zone.
                     if (GetStatisticValue(EStatisticType.ZonesCleared, zoneId) == 0)
                     {
-                        Increment(EStatisticType.ZonesCleared, null, 1);
-                        Increment(EStatisticType.ZonesCleared, zoneId, 1);
+                        Record(EStatisticType.ZonesCleared, null, 1);
+                        Record(EStatisticType.ZonesCleared, zoneId, 1);
                     }
                 }
             }
             else if (playerDied)
             {
                 // The player died, so the battle was genuinely lost.
-                Increment(EStatisticType.BattlesLost, null, 1);
-                Increment(EStatisticType.BattlesLost, enemy.Id, 1);
+                Record(EStatisticType.BattlesLost, null, 1);
+                Record(EStatisticType.BattlesLost, enemy.Id, 1);
             }
             else
             {
                 // Neither combatant died — the battle was abandoned mid-fight (e.g. the player retreated
                 // from a boss or switched zones). Tracked separately from a loss so the two are distinct
                 // numbers (#202).
-                Increment(EStatisticType.BattlesAbandoned, null, 1);
-                Increment(EStatisticType.BattlesAbandoned, enemy.Id, 1);
+                Record(EStatisticType.BattlesAbandoned, null, 1);
+                Record(EStatisticType.BattlesAbandoned, enemy.Id, 1);
             }
 
             if (playerDied)
             {
-                Increment(EStatisticType.PlayerDeaths, null, 1);
+                Record(EStatisticType.PlayerDeaths, null, 1);
             }
 
-            Increment(EStatisticType.TotalBattleTime, null, totalMs / 1000m);
-            Increment(EStatisticType.SkillsUsed, null, stats.PlayerSkillsUsed);
+            Record(EStatisticType.TotalBattleTime, null, totalMs / 1000m);
+            Record(EStatisticType.SkillsUsed, null, stats.PlayerSkillsUsed);
 
             foreach (var (skillId, skillStats) in stats.SkillStats)
             {
-                Increment(EStatisticType.SkillsUsed, skillId, skillStats.Uses);
-                Increment(EStatisticType.DamageDealt, skillId, (decimal)Math.Round(skillStats.TotalDamage, 3));
-                SetMax(EStatisticType.HighestSingleAttackDamage, skillId, (decimal)Math.Round(skillStats.HighestSingleAttack, 3));
+                Record(EStatisticType.SkillsUsed, skillId, skillStats.Uses);
+                Record(EStatisticType.DamageDealt, skillId, (decimal)Math.Round(skillStats.TotalDamage, 3));
+                Record(EStatisticType.HighestSingleAttackDamage, skillId, (decimal)Math.Round(skillStats.HighestSingleAttack, 3));
             }
 
             // The mutated rows are exactly the statistics this battle touched (the aggregate was freshly
@@ -184,14 +184,40 @@ namespace Game.Core.Progress
             return exists;
         }
 
-        private decimal Increment(EStatisticType type, int? entityId, decimal amount)
+        /// <summary>
+        /// Records a reported value for a statistic, aggregating it according to the statistic type's
+        /// <see cref="StatisticType.AggregationKind"/>. This single dispatch is the one place a statistic's
+        /// aggregation direction is consumed — the same derived fact drives a challenge's goal comparison —
+        /// so adding a "lower is better" statistic needs no change here, only its mapping on
+        /// <see cref="StatisticType"/>.
+        /// </summary>
+        private void Record(EStatisticType type, int? entityId, decimal value)
+        {
+            var aggregationKind = StatisticType.GetAggregationKind(type);
+            switch (aggregationKind)
+            {
+                case EAggregationKind.Sum:
+                    Increment(type, entityId, value);
+                    break;
+                case EAggregationKind.Max:
+                    SetMax(type, entityId, value);
+                    break;
+                case EAggregationKind.Min:
+                    SetMin(type, entityId, value);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type),
+                        $"Statistic {type} has an unhandled aggregation kind {aggregationKind}.");
+            }
+        }
+
+        private void Increment(EStatisticType type, int? entityId, decimal amount)
         {
             var stat = GetOrCreate(type, entityId, out _);
             stat.Value += amount;
-            return stat.Value;
         }
 
-        private decimal SetMax(EStatisticType type, int? entityId, decimal value)
+        private void SetMax(EStatisticType type, int? entityId, decimal value)
         {
             var stat = GetOrCreate(type, entityId, out var created);
             // Record on the first write (created) or a strictly greater value, so the first recorded value
@@ -200,11 +226,9 @@ namespace Game.Core.Progress
             {
                 stat.Value = value;
             }
-
-            return stat.Value;
         }
 
-        private decimal SetMin(EStatisticType type, int? entityId, decimal value)
+        private void SetMin(EStatisticType type, int? entityId, decimal value)
         {
             var stat = GetOrCreate(type, entityId, out var created);
             // Record on the first write (created) or a strictly lesser value. Keying off the explicit
@@ -214,8 +238,6 @@ namespace Game.Core.Progress
             {
                 stat.Value = value;
             }
-
-            return stat.Value;
         }
 
         private PlayerStatistic GetOrCreate(EStatisticType type, int? entityId, out bool created)

--- a/Game.Core/Progress/StatisticType.cs
+++ b/Game.Core/Progress/StatisticType.cs
@@ -16,6 +16,15 @@ namespace Game.Core.Progress
         /// challenge editor's target-entity picker rather than each special-casing the type.
         /// </summary>
         public bool BossOnly { get; }
+
+        /// <summary>
+        /// How this statistic's value is aggregated across the battles that report it. A derived domain
+        /// fact, so a single source of truth drives both the recording mutator
+        /// (<see cref="PlayerProgress.RecordBattleCompleted"/>) and the goal comparison of a challenge that
+        /// tracks this statistic (<see cref="ChallengeType.GoalComparison"/>) rather than each hard-coding
+        /// the direction independently.
+        /// </summary>
+        public EAggregationKind AggregationKind { get; }
         public string Name { get; }
 
         public StatisticType(EStatisticType id)
@@ -23,10 +32,30 @@ namespace Game.Core.Progress
             Id = id;
             EntityType = GetEntityType(id);
             BossOnly = GetBossOnly(id);
+            AggregationKind = GetAggregationKind(id);
             Name = id.ToString().SpaceWords();
         }
 
         public static IEnumerable<StatisticType> GetAll() => Enum.GetValues<EStatisticType>().Select(id => new StatisticType(id));
+
+        /// <summary>
+        /// The aggregation direction for a statistic type, exposed statically so the per-battle recording
+        /// path can dispatch on it without allocating a full <see cref="StatisticType"/> per write.
+        /// </summary>
+        public static EAggregationKind GetAggregationKind(EStatisticType id)
+        {
+            return id switch
+            {
+                // FastestVictory keeps the lowest victory time — lower is better, so a TimeTrial challenge
+                // backed by it completes on an "at most" comparison.
+                FastestVictory => EAggregationKind.Min,
+                // HighestSingleAttackDamage keeps the single largest hit ever landed.
+                HighestSingleAttackDamage => EAggregationKind.Max,
+                // ZonesCleared's per-zone row is a binary "cleared" flag and the global counter a distinct
+                // count; both only ever move upward, so they sum like the rest of the accumulating stats.
+                _ => EAggregationKind.Sum,
+            };
+        }
 
         private static bool GetBossOnly(EStatisticType id)
         {


### PR DESCRIPTION
## Summary

Whether a statistic is **summed, maximized, or minimized** was hard-coded independently in two places that had to agree by hand:

1. `PlayerProgress.RecordBattleCompleted` chose the mutator per statistic (`FastestVictory` → `SetMin`, `HighestSingleAttackDamage` → `SetMax`, everything else → `Increment`).
2. `ChallengeType.GetGoalComparison` independently decided `AtMost` vs `AtLeast` (`TimeTrial`/`FastestVictory` → `AtMost`, else `AtLeast`).

These are two encodings of the same domain fact — *"this statistic is minimized; lower is better."* Adding a new "lower is better" statistic meant remembering to touch both, with nothing enforcing agreement.

## Changes

- Model aggregation direction as a derived domain fact on `StatisticType` via a new `EAggregationKind` enum (`Sum`/`Max`/`Min`), mirroring how `EntityType`/`BossOnly` are already derived there. Exposed both as an instance property and a static accessor (`GetAggregationKind`) so the per-battle recording path can dispatch without allocating a `StatisticType` per write.
- `RecordBattleCompleted` now records every statistic through a single `Record` dispatch that selects the mutator from the statistic's `AggregationKind` (`Sum`→`Increment`, `Max`→`SetMax`, `Min`→`SetMin`).
- `ChallengeType.GoalComparison` is now derived from the backing statistic's `AggregationKind` (`Min`→`AtMost`, otherwise `AtLeast`). A challenge with no backing statistic (e.g. `LevelReached`) accumulates, so `AtLeast`.

Behaviour is identical for every existing statistic — this is a pure domain-modeling consolidation, no semantic change. The aggregation kind stays internal to the domain (the client-facing `StatisticType` API model is unchanged), so the reference-data version hash is untouched.

## Tests

- `StatisticTypeTests`: each statistic maps to its expected aggregation kind; `FastestVictory` is the sole `Min` and `HighestSingleAttackDamage` the sole `Max`; every statistic has a defined kind; instance property and static accessor agree.
- `ChallengeTypeTests`: the consistency invariant — every min-aggregated statistic's challenge uses `AtMost` and every `AtMost` challenge is backed by a min-aggregated statistic; goal comparison is derived from the backing statistic's aggregation across all types.
- `PlayerProgressTests`: the recording mutator matches the statistic's aggregation kind (Sum accumulates, Max keeps the larger, Min keeps the smaller); existing Sum/Max/Min recording behaviour is preserved.

All 626 `Game.Core.Tests` pass; `dotnet format --verify-no-changes` is clean for both changed projects.

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_