### PR TITLE
Plumb CancellationToken through admin tag-setting write paths

### DIFF
--- a/Game.Abstractions/DataAccess/Admin/IAdminItemMods.cs
+++ b/Game.Abstractions/DataAccess/Admin/IAdminItemMods.cs
@@ -17,6 +17,6 @@ namespace Game.Abstractions.DataAccess.Admin
         AdminSaveResult SetAttributes(AddEditAttributesData data);
 
         /// <summary>Replaces an item mod's tag associations. Fails if the item mod does not exist.</summary>
-        Task<AdminSaveResult> SetTags(SetTagsData data);
+        Task<AdminSaveResult> SetTags(SetTagsData data, CancellationToken cancellationToken = default);
     }
 }

--- a/Game.Abstractions/DataAccess/Admin/IAdminItems.cs
+++ b/Game.Abstractions/DataAccess/Admin/IAdminItems.cs
@@ -20,6 +20,6 @@ namespace Game.Abstractions.DataAccess.Admin
         AdminSaveResult SaveModSlots(IReadOnlyList<Change<ItemModSlot>> changes);
 
         /// <summary>Replaces an item's tag associations. Fails if the item does not exist.</summary>
-        Task<AdminSaveResult> SetTags(SetTagsData data);
+        Task<AdminSaveResult> SetTags(SetTagsData data, CancellationToken cancellationToken = default);
     }
 }

--- a/Game.Api/Controllers/Admin/AdminItemModsController.cs
+++ b/Game.Api/Controllers/Admin/AdminItemModsController.cs
@@ -35,7 +35,7 @@ namespace Game.Api.Controllers.Admin
         [HttpPost]
         public async Task<ApiResponse> SetTagsForItemMod([FromBody] SetTagsData setTagsData)
         {
-            return await _adminItemMods.SetTags(setTagsData);
+            return await _adminItemMods.SetTags(setTagsData, HttpContext.RequestAborted);
         }
     }
 }

--- a/Game.Api/Controllers/Admin/AdminItemsController.cs
+++ b/Game.Api/Controllers/Admin/AdminItemsController.cs
@@ -41,7 +41,7 @@ namespace Game.Api.Controllers.Admin
         [HttpPost]
         public async Task<ApiResponse> SetTagsForItem([FromBody] SetTagsData setTagsData)
         {
-            return await _adminItems.SetTags(setTagsData);
+            return await _adminItems.SetTags(setTagsData, HttpContext.RequestAborted);
         }
     }
 }

--- a/Game.Application.Tests/DataAccess/TagAssignmentReconcilerTests.cs
+++ b/Game.Application.Tests/DataAccess/TagAssignmentReconcilerTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Game.DataAccess.Repositories.Admin;
 using Xunit;
 
@@ -8,22 +9,26 @@ namespace Game.Application.Tests.DataAccess
         // Stands in for the two real join rows (ItemTag / ItemModTag), which differ only in their owner FK.
         private sealed record TestJoinRow(int TagId);
 
-        private static async IAsyncEnumerable<int> AsAsync(params int[] ids)
+        // Mirrors how EF's AsAsyncEnumerable honours the token ToHashSetAsync forwards via WithCancellation:
+        // the enumerator observes the token, so cancellation surfaces on materialization.
+        private static async IAsyncEnumerable<int> AsAsync(int[] ids, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             foreach (var id in ids)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 yield return id;
             }
 
             await Task.CompletedTask;
         }
 
-        private static Task Reconcile(int[] current, int[] desired, RecordingEntityStore store) =>
+        private static Task Reconcile(int[] current, int[] desired, RecordingEntityStore store, CancellationToken cancellationToken = default) =>
             TagAssignmentReconciler.ReconcileAsync(
                 AsAsync(current),
                 AsAsync(desired),
                 store,
-                tagId => new TestJoinRow(tagId));
+                tagId => new TestJoinRow(tagId),
+                cancellationToken);
 
         private static List<int> TagIds(IEnumerable<object> rows) =>
             rows.Cast<TestJoinRow>().Select(r => r.TagId).OrderBy(id => id).ToList();
@@ -68,6 +73,22 @@ namespace Game.Application.Tests.DataAccess
             var store = new RecordingEntityStore();
 
             await Reconcile(current: [1, 2], desired: [1, 2], store);
+
+            Assert.Empty(store.Inserted);
+            Assert.Empty(store.Deleted);
+        }
+
+        [Fact]
+        public async Task ReconcileAsync_AlreadyCancelledToken_ThrowsAndStagesNothing()
+        {
+            var store = new RecordingEntityStore();
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            // The token must reach the ToHashSetAsync materialization, so a pre-cancelled request unwinds
+            // before any join row is staged.
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => Reconcile(current: [1, 2], desired: [2, 3], store, cts.Token));
 
             Assert.Empty(store.Inserted);
             Assert.Empty(store.Deleted);

--- a/Game.DataAccess/Repositories/Admin/AdminItemMods.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminItemMods.cs
@@ -70,7 +70,7 @@ namespace Game.DataAccess.Repositories.Admin
             return AdminSaveResult.Success;
         }
 
-        public async Task<AdminSaveResult> SetTags(SetTagsData data)
+        public async Task<AdminSaveResult> SetTags(SetTagsData data, CancellationToken cancellationToken = default)
         {
             if (_itemMods.LookupItemMod(data.Id) is null)
             {
@@ -81,7 +81,8 @@ namespace Game.DataAccess.Repositories.Admin
                 _tags.GetTagIdsForItemMod(data.Id),
                 _tags.GetExistingTagIds(data.TagIds),
                 _entityStore,
-                tagId => new Entities.ItemModTag { ItemModId = data.Id, TagId = tagId });
+                tagId => new Entities.ItemModTag { ItemModId = data.Id, TagId = tagId },
+                cancellationToken);
 
             return AdminSaveResult.Success;
         }

--- a/Game.DataAccess/Repositories/Admin/AdminItems.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminItems.cs
@@ -93,7 +93,7 @@ namespace Game.DataAccess.Repositories.Admin
                 }));
         }
 
-        public async Task<AdminSaveResult> SetTags(SetTagsData data)
+        public async Task<AdminSaveResult> SetTags(SetTagsData data, CancellationToken cancellationToken = default)
         {
             if (_items.LookupItem(data.Id) is null)
             {
@@ -104,7 +104,8 @@ namespace Game.DataAccess.Repositories.Admin
                 _tags.GetTagIdsForItem(data.Id),
                 _tags.GetExistingTagIds(data.TagIds),
                 _entityStore,
-                tagId => new Entities.ItemTag { ItemId = data.Id, TagId = tagId });
+                tagId => new Entities.ItemTag { ItemId = data.Id, TagId = tagId },
+                cancellationToken);
 
             return AdminSaveResult.Success;
         }

--- a/Game.DataAccess/Repositories/Admin/TagAssignmentReconciler.cs
+++ b/Game.DataAccess/Repositories/Admin/TagAssignmentReconciler.cs
@@ -15,10 +15,11 @@ namespace Game.DataAccess.Repositories.Admin
             IAsyncEnumerable<int> currentTagIds,
             IAsyncEnumerable<int> desiredTagIds,
             IEntityStore entityStore,
-            Func<int, TJoin> toJoinRow) where TJoin : class
+            Func<int, TJoin> toJoinRow,
+            CancellationToken cancellationToken) where TJoin : class
         {
-            var current = await currentTagIds.ToHashSetAsync();
-            var desired = await desiredTagIds.ToHashSetAsync();
+            var current = await currentTagIds.ToHashSetAsync(cancellationToken: cancellationToken);
+            var desired = await desiredTagIds.ToHashSetAsync(cancellationToken: cancellationToken);
 
             ChildCollectionReconciler.Reconcile(
                 existing: current,


### PR DESCRIPTION
Closes #807

## Problem

`docs/backend.md` emphasizes that the per-command `CancellationToken` is plumbed down through the application services and the data tier so a wedged operation unwinds promptly. The admin item / item-mod `SetTags` paths broke that chain: the tag reconciler materialized its current/desired tag-id streams with `ToHashSetAsync()` and **no token**, so an abandoned or timed-out admin tag-setting request kept running that EF read work instead of cancelling.

## Change

Thread the request's `CancellationToken` from the controllers (`HttpContext.RequestAborted`, matching the existing `CommitFilter` convention) down to the actual EF call:

- `AdminItemsController.SetTagsForItem` / `AdminItemModsController.SetTagsForItemMod` now pass `HttpContext.RequestAborted`.
- `IAdminItems.SetTags` / `IAdminItemMods.SetTags` (and their implementations) take a `CancellationToken cancellationToken = default`, matching the gameplay repository convention (`= default` at the outermost boundary).
- `TagAssignmentReconciler.ReconcileAsync` takes the token (required — it is an internal helper always called with a real token) and forwards it to both `ToHashSetAsync(cancellationToken: …)` materializations, which is where the deferred `AsAsyncEnumerable()` `SELECT` queries actually execute.

The write side (`SaveChangesAsync` via `IUnitOfWork.CommitAsync`) already honoured the token through `CommitFilter`; this closes the read side of the same request.

### Scope note

The issue also references the attribute reconcilers. `AttributeChangeSetProcessor.Apply`, `ChangeSetProcessor.Apply`, and `ChildCollectionReconciler.Reconcile` are **fully synchronous** and touch no EF — they only stage entity-store operations on the change tracker — so there is no async call there to cancel. Only the tag reconciler's `ToHashSetAsync` materialization performs in-line async EF work, so it is the only reconciler that needed plumbing.

## Testing

Per `docs/backend.md`, these repository classes hold no unit-testable logic and the EF/cancellation behavior is covered by integration tests; no new Redis/DB infra was stood up. The reconciler already had a focused unit test with a `RecordingEntityStore` double and an `IAsyncEnumerable` helper, so I extended that existing pattern:

- The test `IAsyncEnumerable` helper now observes its `[EnumeratorCancellation]` token (mirroring how EF's `AsAsyncEnumerable` honours the token `ToHashSetAsync` forwards via `WithCancellation`).
- Added `ReconcileAsync_AlreadyCancelledToken_ThrowsAndStagesNothing`, asserting a pre-cancelled token unwinds before any join row is staged.

I verified the new test is meaningful by temporarily swapping the threaded token for `CancellationToken.None` and confirming the test fails, then restoring it.

- `dotnet build Game.sln` — succeeds, 0 warnings / 0 errors.
- `dotnet test Game.Application.Tests` — 286 passed (includes the 5 reconciler tests).
- `dotnet format --verify-no-changes` on every changed project (`Game.Abstractions`, `Game.DataAccess`, `Game.Api`, `Game.Application.Tests`) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_