### PR TITLE
Single-source the enemy loadout cap and strengthen the battle-attribute parity tests

### DIFF
--- a/Game.Core.Tests/Attributes/BattleAttributesParityTests.cs
+++ b/Game.Core.Tests/Attributes/BattleAttributesParityTests.cs
@@ -5,108 +5,134 @@ using Xunit;
 namespace Game.Core.Tests.Attributes
 {
     /// <summary>
-    /// Parity guard for the shared derived-stat formulas. These cases mirror,
-    /// with identical inputs and identical expected values, the
-    /// "derived stat computation" block of the frontend suite
-    /// <c>UI/src/tests/lib/battle/battle-attributes.test.ts</c>.
-    /// The formula constants live in two hand-maintained places —
-    /// <see cref="StaticAttributeModifiers"/> on the backend and
-    /// <c>STATIC_ATTRIBUTE_MODIFIERS</c> on the frontend — and the battle
-    /// simulation on both sides depends on them agreeing, so these assertions
-    /// exist to make any silent drift between the two fail a build.
+    /// Parity guard for the shared derived-stat formulas. Every scenario here MUST be mirrored —
+    /// with identical inputs (the same name and core-attribute allocations) — in the frontend suite
+    /// <c>UI/src/tests/lib/battle/battle-attributes.test.ts</c>, just as the battle-simulation and
+    /// progression parity suites share a single named scenario table row-for-row.
+    /// <para>
+    /// The expected derived value is NOT a re-hardcoded literal: it is computed from the single source
+    /// of truth — <see cref="StaticAttributeModifiers.All"/> on the backend, the codegen-generated
+    /// <c>STATIC_ATTRIBUTE_MODIFIERS</c> on the frontend — by <see cref="ExpectedValue"/>. So a coefficient
+    /// retune flows into both the production <see cref="AttributeCollection"/> path and the expectation,
+    /// and the test pins that the two agree rather than a second hand-maintained copy of the numbers that
+    /// could rot out of step.
+    /// </para>
     /// </summary>
     public class BattleAttributesParityTests
     {
-        [Fact]
-        public void MaxHealth_Is50Plus20EndurancePlus5Strength()
-        {
-            var collection = MakeCollection(
-                (EAttribute.Strength, 10),
-                (EAttribute.Endurance, 20));
+        /// <summary>
+        /// A single derived-stat scenario: the core-attribute allocations that feed the collection
+        /// and the derived attributes whose composed value is asserted against the single-sourced table.
+        /// </summary>
+        public sealed record DerivedStatScenario(
+            (EAttribute Attribute, double Amount)[] Allocations,
+            EAttribute[] DerivedAttributes);
 
-            Assert.Equal(50 + 20 * 20 + 5 * 10, collection[EAttribute.MaxHealth]);
+        /// <summary>
+        /// The shared scenario table, keyed by name so xUnit can drive a <see cref="TheoryAttribute"/>
+        /// over the names; the test resolves the full scenario by name. Mirrored row-for-row by the
+        /// frontend suite's <c>scenarios</c> table.
+        /// </summary>
+        public static readonly IReadOnlyDictionary<string, DerivedStatScenario> Scenarios =
+            new Dictionary<string, DerivedStatScenario>
+            {
+                // MaxHealth = 50 (base) + 20·Endurance + 5·Strength
+                ["maxHealth"] = new DerivedStatScenario(
+                    [(EAttribute.Strength, 10), (EAttribute.Endurance, 20)],
+                    [EAttribute.MaxHealth]),
+
+                // Defense = 2 (base) + 1·Endurance + 0.5·Agility
+                ["defense"] = new DerivedStatScenario(
+                    [(EAttribute.Endurance, 30), (EAttribute.Agility, 20)],
+                    [EAttribute.Defense]),
+
+                // CooldownRecovery = 1 (base) + 0.004·Agility + 0.001·Dexterity
+                ["cooldownRecovery"] = new DerivedStatScenario(
+                    [(EAttribute.Agility, 20), (EAttribute.Dexterity, 10)],
+                    [EAttribute.CooldownRecovery]),
+
+                // CriticalChance = 0.002·Dexterity + 0.001·Luck (no base)
+                ["criticalChance"] = new DerivedStatScenario(
+                    [(EAttribute.Dexterity, 20), (EAttribute.Luck, 10)],
+                    [EAttribute.CriticalChance]),
+
+                // CriticalDamage = 1.5 (base) + 0.0025·Luck
+                ["criticalDamage"] = new DerivedStatScenario(
+                    [(EAttribute.Luck, 20)],
+                    [EAttribute.CriticalDamage]),
+
+                // DodgeChance = 0.001·Agility (no base)
+                ["dodgeChance"] = new DerivedStatScenario(
+                    [(EAttribute.Agility, 20)],
+                    [EAttribute.DodgeChance]),
+
+                // BlockChance = 0.002·Endurance (no base)
+                ["blockChance"] = new DerivedStatScenario(
+                    [(EAttribute.Endurance, 20)],
+                    [EAttribute.BlockChance]),
+
+                // BlockReduction = 2 (base) + 0.5·Endurance
+                ["blockReduction"] = new DerivedStatScenario(
+                    [(EAttribute.Endurance, 20)],
+                    [EAttribute.BlockReduction]),
+
+                // With no allocations every derived stat collapses to just its base: the two with a base
+                // carry it (CriticalDamage 1.5, BlockReduction 2), the three pure-derived chances are 0.
+                ["zeroBaseStats"] = new DerivedStatScenario(
+                    [],
+                    [
+                        EAttribute.MaxHealth, EAttribute.Defense, EAttribute.CooldownRecovery,
+                        EAttribute.CriticalDamage, EAttribute.BlockReduction,
+                        EAttribute.CriticalChance, EAttribute.DodgeChance, EAttribute.BlockChance,
+                    ]),
+            };
+
+        public static IEnumerable<object[]> ScenarioNames =>
+            Scenarios.Keys.Select(name => new object[] { name });
+
+        [Theory]
+        [MemberData(nameof(ScenarioNames))]
+        public void Parity_Scenario_ComposesDerivedStatsFromSingleSourcedCoefficients(string scenarioName)
+        {
+            var scenario = Scenarios[scenarioName];
+            var collection = MakeCollection(scenario.Allocations);
+
+            foreach (var attribute in scenario.DerivedAttributes)
+            {
+                var expected = ExpectedValue(attribute, scenario.Allocations);
+                // Compared to 10 decimals: the static coefficients are fractional, so the additions
+                // accumulate the usual binary-float error the frontend's toBeCloseTo also tolerates.
+                Assert.Equal(expected, collection[attribute], 10);
+            }
         }
 
-        [Fact]
-        public void Defense_Is2PlusEndurancePlusHalfAgility()
+        /// <summary>
+        /// Composes the expected value of <paramref name="attribute"/> directly from
+        /// <see cref="StaticAttributeModifiers.All"/> (the single source of truth) under the given
+        /// core-attribute <paramref name="allocations"/>. Every static modifier is additive: a base value
+        /// contributes its raw amount, a derived modifier contributes <c>amount × allocation[source]</c>
+        /// (an allocated core attribute carries no further modifiers, so its final value is its raw amount).
+        /// This is the same reduction <see cref="AttributeCollection"/> performs, so it can't diverge from
+        /// the production path on a coefficient change.
+        /// </summary>
+        private static double ExpectedValue(EAttribute attribute, (EAttribute Attribute, double Amount)[] allocations)
         {
-            var collection = MakeCollection(
-                (EAttribute.Endurance, 30),
-                (EAttribute.Agility, 20));
+            var allocated = allocations.ToDictionary(a => a.Attribute, a => a.Amount);
+            var expected = 0.0;
+            foreach (var modifier in StaticAttributeModifiers.All)
+            {
+                if (modifier.Attribute != attribute)
+                {
+                    continue;
+                }
 
-            Assert.Equal(2 + 30 + 0.5 * 20, collection[EAttribute.Defense]);
-        }
+                Assert.Equal(EModifierType.Additive, modifier.Type);
+                expected += modifier.Source is EAttributeModifierSource.Derived
+                    ? modifier.Amount * allocated.GetValueOrDefault(modifier.DerivedSource)
+                    : modifier.Amount;
+            }
 
-        [Fact]
-        public void CooldownRecovery_IsOnePlusFourThousandthsAgilityPlusOneThousandthDexterity()
-        {
-            var collection = MakeCollection(
-                (EAttribute.Agility, 20),
-                (EAttribute.Dexterity, 10));
-
-            Assert.Equal(1 + 0.004 * 20 + 0.001 * 10, collection[EAttribute.CooldownRecovery], 10);
-        }
-
-        [Fact]
-        public void CriticalChance_IsTwoThousandthsDexterityPlusOneThousandthLuck()
-        {
-            var collection = MakeCollection(
-                (EAttribute.Dexterity, 20),
-                (EAttribute.Luck, 10));
-
-            Assert.Equal(0.002 * 20 + 0.001 * 10, collection[EAttribute.CriticalChance], 10);
-        }
-
-        [Fact]
-        public void CriticalDamage_IsBaseOneAndHalfPlusQuarterPercentLuck()
-        {
-            var collection = MakeCollection(
-                (EAttribute.Luck, 20));
-
-            Assert.Equal(1.5 + 0.0025 * 20, collection[EAttribute.CriticalDamage], 10);
-        }
-
-        [Fact]
-        public void DodgeChance_IsOneThousandthAgility()
-        {
-            var collection = MakeCollection(
-                (EAttribute.Agility, 20));
-
-            Assert.Equal(0.001 * 20, collection[EAttribute.DodgeChance], 10);
-        }
-
-        [Fact]
-        public void BlockChance_IsTwoThousandthsEndurance()
-        {
-            var collection = MakeCollection(
-                (EAttribute.Endurance, 20));
-
-            Assert.Equal(0.002 * 20, collection[EAttribute.BlockChance], 10);
-        }
-
-        [Fact]
-        public void BlockReduction_IsTwoPlusHalfEndurance()
-        {
-            var collection = MakeCollection(
-                (EAttribute.Endurance, 20));
-
-            Assert.Equal(2 + 0.5 * 20, collection[EAttribute.BlockReduction]);
-        }
-
-        [Fact]
-        public void ZeroBaseStats_StillHaveDerivedBaseValues()
-        {
-            var collection = MakeCollection();
-
-            Assert.Equal(50, collection[EAttribute.MaxHealth]);
-            Assert.Equal(2, collection[EAttribute.Defense]);
-            Assert.Equal(1, collection[EAttribute.CooldownRecovery]);
-            // CriticalDamage and BlockReduction carry a base; the three chances have none, so they are 0.
-            Assert.Equal(1.5, collection[EAttribute.CriticalDamage]);
-            Assert.Equal(2, collection[EAttribute.BlockReduction]);
-            Assert.Equal(0, collection[EAttribute.CriticalChance]);
-            Assert.Equal(0, collection[EAttribute.DodgeChance]);
-            Assert.Equal(0, collection[EAttribute.BlockChance]);
+            return expected;
         }
 
         private static AttributeCollection MakeCollection(params (EAttribute Attribute, double Amount)[] allocations)

--- a/Game.Core.Tests/Battle/BattleFactoryTests.cs
+++ b/Game.Core.Tests/Battle/BattleFactoryTests.cs
@@ -53,7 +53,7 @@ namespace Game.Core.Tests.Battle
             var enemy = _factory.CreateBattleEnemy(
                 MakeZone(levelMin: 1, levelMax: 1), resolveEnemy: level => MakeEnemyAtLevel(level, skillCount: 6));
 
-            // The random idle encounter caps the loadout at the MaxBattleSkills limit (4).
+            // The random idle encounter caps the loadout at the MaxSelectedSkills limit (4).
             Assert.Equal(4, enemy.BattleSkills.Count);
         }
 

--- a/Game.Core.Tests/Enemies/EnemyTests.cs
+++ b/Game.Core.Tests/Enemies/EnemyTests.cs
@@ -103,7 +103,7 @@ namespace Game.Core.Tests.Enemies
         [Fact]
         public void SelectAllBattleSkills_KeepsEveryAvailableSkillInAuthoredOrder()
         {
-            // The dedicated-boss loadout is the full authored set — neither capped at MaxBattleSkills (4)
+            // The dedicated-boss loadout is the full authored set — neither capped at MaxSelectedSkills (4)
             // nor shuffled — so a 6-skill boss brings all 6 in order.
             var enemy = MakeEnemy(Skills(6));
 

--- a/Game.Core/Enemies/Enemy.cs
+++ b/Game.Core/Enemies/Enemy.cs
@@ -9,9 +9,6 @@ namespace Game.Core.Enemies
     /// </summary>
     public class Enemy
     {
-        /// <summary>The maximum number of skills an enemy brings into a battle.</summary>
-        private const int MaxBattleSkills = 4;
-
         private List<Skill>? _battleSkills;
 
         public required int Id { get; init; }
@@ -35,18 +32,19 @@ namespace Game.Core.Enemies
         }
 
         /// <summary>
-        /// Randomly selects this enemy's loadout for a new encounter: up to <see cref="MaxBattleSkills"/>
-        /// skills drawn from its available skills. The chosen loadout is the source of truth — it is
-        /// snapshotted and sent to the client — so the selection deliberately uses ambient randomness
-        /// rather than the battle seed, keeping that seed reserved as the battle simulation's RNG source
-        /// (identical on client and server).
+        /// Randomly selects this enemy's loadout for a new encounter: up to
+        /// <see cref="GameConstants.MaxSelectedSkills"/> skills drawn from its available skills (the same
+        /// cap the player's loadout uses, for player/enemy symmetry). The chosen loadout is the source of
+        /// truth — it is snapshotted and sent to the client — so the selection deliberately uses ambient
+        /// randomness rather than the battle seed, keeping that seed reserved as the battle simulation's
+        /// RNG source (identical on client and server).
         /// </summary>
         public void SelectBattleSkills()
         {
             // Partial Fisher–Yates: draw an unbiased, uniformly-distributed sample (and ordering) of the
             // available skills, rather than the biased OrderBy(random) sort it replaces.
             var pool = AvailableSkills.ToArray();
-            var take = Math.Min(MaxBattleSkills, pool.Length);
+            var take = Math.Min(GameConstants.MaxSelectedSkills, pool.Length);
             for (var i = 0; i < take; i++)
             {
                 var swap = Random.Shared.Next(i, pool.Length);
@@ -59,7 +57,7 @@ namespace Game.Core.Enemies
         /// <summary>
         /// Selects this enemy's <em>full</em> authored loadout — every available skill, in authored order —
         /// for a deterministic encounter (the dedicated-boss challenge). Unlike <see cref="SelectBattleSkills"/>
-        /// this neither caps the count at <see cref="MaxBattleSkills"/> nor shuffles, so the loadout is fixed.
+        /// this neither caps the count at <see cref="GameConstants.MaxSelectedSkills"/> nor shuffles, so the loadout is fixed.
         /// The chosen loadout is the source of truth — it is snapshotted and sent to the client — so both
         /// sides simulate the boss with the identical skill set.
         /// </summary>

--- a/UI/src/tests/lib/battle/battle-attributes.test.ts
+++ b/UI/src/tests/lib/battle/battle-attributes.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EAttribute, type IAttribute } from '$lib/api';
 import { BattleAttributes } from '$lib/battle/battle-attributes';
-import { EModifierType, EAttributeModifierSource, type AttributeModifier } from '$lib/battle/attribute-modifier';
+import {
+	STATIC_ATTRIBUTE_MODIFIERS,
+	EModifierType,
+	EAttributeModifierSource,
+	type AttributeModifier
+} from '$lib/battle/attribute-modifier';
 
 // The projection resolves names through `attributeName(id, staticData.attributes)`, so mock the
 // store to drive that reference set. Empty by default → names fall back to the normalised enum.
@@ -54,57 +59,125 @@ describe('BattleAttributes', () => {
 		});
 	});
 
-	describe('derived stat computation', () => {
-		it('calculates MaxHealth = 50 + 20*End + 5*Str', () => {
-			const ba = new BattleAttributes(makeAttrs([EAttribute.Strength, 10], [EAttribute.Endurance, 20]));
-			expect(ba.getValue(EAttribute.MaxHealth)).toBe(50 + 20 * 20 + 5 * 10);
-		});
+	// Parity guard for the shared derived-stat formulas. Every scenario here MUST be mirrored — with
+	// identical inputs (the same name and core-attribute allocations) — in the backend suite
+	// Game.Core.Tests/Attributes/BattleAttributesParityTests.cs, just as the battle-simulation parity
+	// suite shares its scenario table row-for-row. The expected value is NOT a re-hardcoded literal: it
+	// is composed from the single source of truth — STATIC_ATTRIBUTE_MODIFIERS (generated from the
+	// backend's StaticAttributeModifiers.All) — by expectedValue, so a coefficient retune flows into both
+	// the production BattleAttributes path and the expectation rather than a second copy that could rot.
+	describe('derived stat computation (parity)', () => {
+		type Allocation = [EAttribute, number];
+		interface DerivedStatScenario {
+			allocations: Allocation[];
+			derivedAttributes: EAttribute[];
+		}
 
-		it('calculates Defense = 2 + End + 0.5*Agi', () => {
-			const ba = new BattleAttributes(makeAttrs([EAttribute.Endurance, 30], [EAttribute.Agility, 20]));
-			expect(ba.getValue(EAttribute.Defense)).toBe(2 + 30 + 0.5 * 20);
-		});
+		const scenarios: Record<string, DerivedStatScenario> = {
+			// MaxHealth = 50 (base) + 20*Endurance + 5*Strength
+			maxHealth: {
+				allocations: [
+					[EAttribute.Strength, 10],
+					[EAttribute.Endurance, 20]
+				],
+				derivedAttributes: [EAttribute.MaxHealth]
+			},
 
-		it('calculates CooldownRecovery = 1 (base) + 0.004*Agi + 0.001*Dex', () => {
-			const ba = new BattleAttributes(makeAttrs([EAttribute.Agility, 20], [EAttribute.Dexterity, 10]));
-			expect(ba.getValue(EAttribute.CooldownRecovery)).toBeCloseTo(1 + 0.004 * 20 + 0.001 * 10, 10);
-		});
+			// Defense = 2 (base) + 1*Endurance + 0.5*Agility
+			defense: {
+				allocations: [
+					[EAttribute.Endurance, 30],
+					[EAttribute.Agility, 20]
+				],
+				derivedAttributes: [EAttribute.Defense]
+			},
 
-		it('calculates CriticalChance = 0.002*Dex + 0.001*Luck', () => {
-			const ba = new BattleAttributes(makeAttrs([EAttribute.Dexterity, 20], [EAttribute.Luck, 10]));
-			expect(ba.getValue(EAttribute.CriticalChance)).toBeCloseTo(0.002 * 20 + 0.001 * 10, 10);
-		});
+			// CooldownRecovery = 1 (base) + 0.004*Agility + 0.001*Dexterity
+			cooldownRecovery: {
+				allocations: [
+					[EAttribute.Agility, 20],
+					[EAttribute.Dexterity, 10]
+				],
+				derivedAttributes: [EAttribute.CooldownRecovery]
+			},
 
-		it('calculates CriticalDamage = 1.5 (base) + 0.0025*Luck', () => {
-			const ba = new BattleAttributes(makeAttrs([EAttribute.Luck, 20]));
-			expect(ba.getValue(EAttribute.CriticalDamage)).toBeCloseTo(1.5 + 0.0025 * 20, 10);
-		});
+			// CriticalChance = 0.002*Dexterity + 0.001*Luck (no base)
+			criticalChance: {
+				allocations: [
+					[EAttribute.Dexterity, 20],
+					[EAttribute.Luck, 10]
+				],
+				derivedAttributes: [EAttribute.CriticalChance]
+			},
 
-		it('calculates DodgeChance = 0.001*Agi', () => {
-			const ba = new BattleAttributes(makeAttrs([EAttribute.Agility, 20]));
-			expect(ba.getValue(EAttribute.DodgeChance)).toBeCloseTo(0.001 * 20, 10);
-		});
+			// CriticalDamage = 1.5 (base) + 0.0025*Luck
+			criticalDamage: {
+				allocations: [[EAttribute.Luck, 20]],
+				derivedAttributes: [EAttribute.CriticalDamage]
+			},
 
-		it('calculates BlockChance = 0.002*End', () => {
-			const ba = new BattleAttributes(makeAttrs([EAttribute.Endurance, 20]));
-			expect(ba.getValue(EAttribute.BlockChance)).toBeCloseTo(0.002 * 20, 10);
-		});
+			// DodgeChance = 0.001*Agility (no base)
+			dodgeChance: {
+				allocations: [[EAttribute.Agility, 20]],
+				derivedAttributes: [EAttribute.DodgeChance]
+			},
 
-		it('calculates BlockReduction = 2 (base) + 0.5*End', () => {
-			const ba = new BattleAttributes(makeAttrs([EAttribute.Endurance, 20]));
-			expect(ba.getValue(EAttribute.BlockReduction)).toBe(2 + 0.5 * 20);
-		});
+			// BlockChance = 0.002*Endurance (no base)
+			blockChance: {
+				allocations: [[EAttribute.Endurance, 20]],
+				derivedAttributes: [EAttribute.BlockChance]
+			},
 
-		it('handles zero base stats (CriticalDamage base 1.5, BlockReduction base 2, chances 0)', () => {
-			const ba = new BattleAttributes([]);
-			expect(ba.getValue(EAttribute.MaxHealth)).toBe(50);
-			expect(ba.getValue(EAttribute.Defense)).toBe(2);
-			expect(ba.getValue(EAttribute.CooldownRecovery)).toBe(1);
-			expect(ba.getValue(EAttribute.CriticalDamage)).toBe(1.5);
-			expect(ba.getValue(EAttribute.BlockReduction)).toBe(2);
-			expect(ba.getValue(EAttribute.CriticalChance)).toBe(0);
-			expect(ba.getValue(EAttribute.DodgeChance)).toBe(0);
-			expect(ba.getValue(EAttribute.BlockChance)).toBe(0);
+			// BlockReduction = 2 (base) + 0.5*Endurance
+			blockReduction: {
+				allocations: [[EAttribute.Endurance, 20]],
+				derivedAttributes: [EAttribute.BlockReduction]
+			},
+
+			// With no allocations every derived stat collapses to just its base: the two with a base carry
+			// it (CriticalDamage 1.5, BlockReduction 2), the three pure-derived chances are 0.
+			zeroBaseStats: {
+				allocations: [],
+				derivedAttributes: [
+					EAttribute.MaxHealth,
+					EAttribute.Defense,
+					EAttribute.CooldownRecovery,
+					EAttribute.CriticalDamage,
+					EAttribute.BlockReduction,
+					EAttribute.CriticalChance,
+					EAttribute.DodgeChance,
+					EAttribute.BlockChance
+				]
+			}
+		};
+
+		// Composes the expected value of `attribute` directly from STATIC_ATTRIBUTE_MODIFIERS (the single
+		// source of truth) under the given allocations — the same reduction BattleAttributes performs.
+		// Every static modifier is additive: a base value contributes its raw amount, a derived modifier
+		// contributes amount * allocation[derivedSource] (an allocated core attribute carries no further
+		// modifiers, so its final value is its raw amount).
+		const expectedValue = (attribute: EAttribute, allocations: Allocation[]): number => {
+			const allocated = new Map(allocations);
+			return STATIC_ATTRIBUTE_MODIFIERS.filter((modifier) => modifier.attribute === attribute).reduce(
+				(sum, modifier) => {
+					expect(modifier.type).toBe(EModifierType.Additive);
+					return modifier.source === EAttributeModifierSource.Derived
+						? sum + modifier.amount * (allocated.get(modifier.derivedSource) ?? 0)
+						: sum + modifier.amount;
+				},
+				0
+			);
+		};
+
+		it.each(Object.keys(scenarios))('composes %s derived stats from the single-sourced coefficients', (name) => {
+			const { allocations, derivedAttributes } = scenarios[name];
+			const ba = new BattleAttributes(makeAttrs(...allocations));
+
+			for (const attribute of derivedAttributes) {
+				// toBeCloseTo to 10 decimals: the fractional coefficients accumulate the usual binary-float
+				// error, matching the backend's `Assert.Equal(expected, actual, 10)` tolerance.
+				expect(ba.getValue(attribute)).toBeCloseTo(expectedValue(attribute, allocations), 10);
+			}
 		});
 	});
 


### PR DESCRIPTION
Closes #819

Two related single-source-of-truth gaps around battle constants/parity.

## 1. Enemy loadout cap → `GameConstants.MaxSelectedSkills`

`MaxBattleSkills = 4` was a private literal on `Game.Core/Enemies/Enemy.cs`, outside the `[ClientMirrored]` `GameConstants` class that single-sources cross-boundary constants.

Rather than add a *new* `MaxBattleSkills` constant to `GameConstants`, `Enemy` now consumes the existing `GameConstants.MaxSelectedSkills`. The two values were both `4` and conceptually the **same** cap — the `MaxSelectedSkills` doc comment already states *"Enemies bring the same cap into battle for player/enemy symmetry."* Adding a second mirrored constant holding `4` would have replaced one duplication (a private literal) with another (two public constants to keep in sync), defeating the single-source goal. So the stray literal is folded into the constant that already represents this cap and is already mirrored to the client.

Because no new cross-boundary constant was introduced, the generated client (`UI/src/lib/api/types/game-constants.ts`) is unchanged — the codegen diff-check (#282) stays clean. (Two test comments that named the old constant were updated to match.)

## 2. `BattleAttributesParityTests` — shared scenario table, no re-hardcoded coefficients

`BattleAttributesParityTests.cs` and its frontend mirror `battle-attributes.test.ts` re-encoded the derived-stat coefficients as literals (`50 + 20*20 + 5*10`) on both sides — a second hand-maintained copy of numbers already single-sourced in `StaticAttributeModifiers.All` and generated to the frontend via `STATIC_ATTRIBUTE_MODIFIERS`.

Both suites are restructured into a single named `Scenarios` table (mirrored row-for-row, the same shape as the battle-simulation parity suite): each scenario carries input allocations + the derived attributes to check. The **expected value is composed from the single-sourced modifier table**, not a literal — every static modifier is additive, so a base value contributes its raw amount and a derived modifier contributes `amount × allocation[derivedSource]`, the same reduction the production `AttributeCollection` / `BattleAttributes` performs. A coefficient retune now flows into both the production path and the expectation, so the assertions can no longer rot out of step. Coefficient values themselves are unchanged.

The 9 scenarios (`maxHealth`, `defense`, `cooldownRecovery`, `criticalChance`, `criticalDamage`, `dodgeChance`, `blockChance`, `blockReduction`, `zeroBaseStats`) are identical on both sides.

## Verification

- Backend: `dotnet build` clean; full `Game.Core.Tests` 614/614 pass; `BattleAttributesParity` 9 theory cases pass; Enemy/BattleFactory tests pass; `dotnet format --verify-no-changes` clean on `Game.Core` and `Game.Core.Tests`.
- Codegen: `dotnet run --project Game.Api -- codegen` produces a clean `git diff` (no generated change).
- Frontend: `npm run check` 0 errors/0 warnings; `npm run lint` (eslint + check) clean; `battle-attributes` unit tests 31 pass (9 parity scenarios mirror the backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_