### PR TITLE
Memoize reference-data version hash per cache snapshot (#836)

### DIFF
--- a/Game.Abstractions/DataAccess/IChallenges.cs
+++ b/Game.Abstractions/DataAccess/IChallenges.cs
@@ -11,5 +11,8 @@ namespace Game.Abstractions.DataAccess
         // The precomputed statistic -> challenges reverse index, bundled with (and swapped atomically
         // alongside) the cached list, so per-battle challenge evaluation is scoped without re-indexing.
         public ChallengeIndex Index();
+
+        /// <inheritdoc cref="IItems.VersionKey"/>
+        public object VersionKey { get; }
     }
 }

--- a/Game.Abstractions/DataAccess/IEnemies.cs
+++ b/Game.Abstractions/DataAccess/IEnemies.cs
@@ -13,5 +13,8 @@ namespace Game.Abstractions.DataAccess
 
         /// <inheritdoc cref="GetDomainEnemy"/>
         public CoreEnemy GetRandomDomainEnemy(int zoneId, int level);
+
+        /// <inheritdoc cref="IItems.VersionKey"/>
+        public object VersionKey { get; }
     }
 }

--- a/Game.Abstractions/DataAccess/IItemMods.cs
+++ b/Game.Abstractions/DataAccess/IItemMods.cs
@@ -9,5 +9,8 @@ namespace Game.Abstractions.DataAccess
         // Whether an item mod with the given id exists; lets callers validate before GetItemMod without touching the entity.
         public bool ValidateItemModId(int itemModId);
         public CoreItemMod GetItemMod(int itemModId);
+
+        /// <inheritdoc cref="IItems.VersionKey"/>
+        public object VersionKey { get; }
     }
 }

--- a/Game.Abstractions/DataAccess/IItems.cs
+++ b/Game.Abstractions/DataAccess/IItems.cs
@@ -7,5 +7,12 @@ namespace Game.Abstractions.DataAccess
     {
         public List<Contracts.Item> All();
         public CoreItem GetItem(int itemId);
+
+        /// <summary>
+        /// The current immutable snapshot instance, exposed only as an opaque identity token. Its reference
+        /// changes on every build-then-swap, so callers can key a memo (e.g. the content-version hash) on it
+        /// and have a cache swap invalidate the memo without exposing the cached entities.
+        /// </summary>
+        public object VersionKey { get; }
     }
 }

--- a/Game.Abstractions/DataAccess/ISkills.cs
+++ b/Game.Abstractions/DataAccess/ISkills.cs
@@ -7,5 +7,8 @@ namespace Game.Abstractions.DataAccess
     {
         public List<Contracts.Skill> AllSkills();
         public CoreSkill GetSkill(int skillId);
+
+        /// <inheritdoc cref="IItems.VersionKey"/>
+        public object VersionKey { get; }
     }
 }

--- a/Game.Abstractions/DataAccess/IZones.cs
+++ b/Game.Abstractions/DataAccess/IZones.cs
@@ -14,5 +14,8 @@ namespace Game.Abstractions.DataAccess
         public CoreZone GetDomainZone(int zoneId);
 
         public bool ValidateZoneId(int zoneId);
+
+        /// <inheritdoc cref="IItems.VersionKey"/>
+        public object VersionKey { get; }
     }
 }

--- a/Game.Api.Tests/Unit/ReferenceDataCommandVersioningTests.cs
+++ b/Game.Api.Tests/Unit/ReferenceDataCommandVersioningTests.cs
@@ -1,0 +1,84 @@
+using Game.Api.Sockets.Commands;
+using Xunit;
+
+namespace Game.Api.Tests.Unit
+{
+    /// <summary>
+    /// Pins the memoization wired into <see cref="AbstractReferenceDataCommand{TModel}"/>: the content version
+    /// is keyed on the command's <c>VersionKey</c> (the immutable cache snapshot), so it is serialized once per
+    /// cache swap rather than on every connect, and a swap (a new snapshot instance) recomputes from the fresh
+    /// data. A fake command stands in for the real Get* commands, with the snapshot reference under test control.
+    /// </summary>
+    public class ReferenceDataCommandVersioningTests
+    {
+        private sealed record SampleModel(int Id, string Name);
+
+        // A fake reference-data command whose data and version key are driven by a swappable snapshot, mirroring
+        // a real Get* command reading its cache holder's Current snapshot.
+        private sealed class FakeReferenceDataCommand : AbstractReferenceDataCommand<SampleModel>
+        {
+            private object _snapshot = new();
+            private SampleModel[] _data = [];
+
+            public override string Name { get; set; } = nameof(FakeReferenceDataCommand);
+
+            public int GetReferenceDataCalls { get; private set; }
+
+            // Publishes a new snapshot instance (and its data), exactly as a build-then-swap reload does.
+            public void Swap(params SampleModel[] data)
+            {
+                _snapshot = new object();
+                _data = data;
+            }
+
+            protected override IEnumerable<SampleModel> GetReferenceData()
+            {
+                GetReferenceDataCalls++;
+                return _data;
+            }
+
+            protected override object VersionKey => _snapshot;
+        }
+
+        [Fact]
+        public void ComputeVersion_SerializesOncePerSnapshot()
+        {
+            var command = new FakeReferenceDataCommand();
+            command.Swap(new SampleModel(0, "Alpha"));
+
+            var first = command.ComputeVersion();
+            var second = command.ComputeVersion();
+
+            Assert.Equal(first, second);
+            // The data is materialized once for the snapshot, then served from the memo on later connects.
+            Assert.Equal(1, command.GetReferenceDataCalls);
+        }
+
+        [Fact]
+        public void ComputeVersion_RecomputesAfterSwap()
+        {
+            var command = new FakeReferenceDataCommand();
+            command.Swap(new SampleModel(0, "Alpha"));
+            var before = command.ComputeVersion();
+
+            command.Swap(new SampleModel(0, "Beta"));
+            var after = command.ComputeVersion();
+
+            Assert.NotEqual(before, after);
+            // One materialization per snapshot: the original plus the post-swap one.
+            Assert.Equal(2, command.GetReferenceDataCalls);
+        }
+
+        [Fact]
+        public void ComputeVersion_MatchesDirectHashOfTheData()
+        {
+            var data = new[] { new SampleModel(0, "Alpha"), new SampleModel(1, "Beta") };
+            var command = new FakeReferenceDataCommand();
+            command.Swap(data);
+
+            // The memoized version must be identical to hashing the same models directly, so the client sees
+            // the same version string whether or not the memo was warm.
+            Assert.Equal(ReferenceDataVersioning.ComputeVersion(data), command.ComputeVersion());
+        }
+    }
+}

--- a/Game.Api.Tests/Unit/ReferenceDataVersioningTests.cs
+++ b/Game.Api.Tests/Unit/ReferenceDataVersioningTests.cs
@@ -58,5 +58,65 @@ namespace Game.Api.Tests.Unit
             // SHA-256 rendered as uppercase hex is always 64 characters.
             Assert.Equal(64, first.Length);
         }
+
+        [Fact]
+        public void GetOrComputeVersion_MatchesDirectComputeVersion()
+        {
+            var snapshot = SampleSet();
+
+            var memoized = ReferenceDataVersioning.GetOrComputeVersion<Sample>(snapshot, () => snapshot);
+
+            Assert.Equal(ReferenceDataVersioning.ComputeVersion(snapshot), memoized);
+        }
+
+        [Fact]
+        public void GetOrComputeVersion_ComputesOncePerSnapshotKey()
+        {
+            var snapshot = SampleSet();
+            var computeCount = 0;
+
+            string ComputeFor() => ReferenceDataVersioning.GetOrComputeVersion<Sample>(snapshot, () =>
+            {
+                computeCount++;
+                return snapshot;
+            });
+
+            var first = ComputeFor();
+            var second = ComputeFor();
+
+            // The hash is serialized once for the snapshot instance, then served from the memo.
+            Assert.Equal(1, computeCount);
+            Assert.Same(first, second);
+        }
+
+        [Fact]
+        public void GetOrComputeVersion_RecomputesForNewSnapshotInstance()
+        {
+            // A cache swap publishes a new snapshot instance; keying on it must recompute even when the
+            // underlying values are identical, because the memo is per-instance, not per-value.
+            var firstSnapshot = SampleSet();
+            var secondSnapshot = SampleSet();
+            var computeCount = 0;
+
+            ReferenceDataVersioning.GetOrComputeVersion<Sample>(firstSnapshot, () => { computeCount++; return firstSnapshot; });
+            ReferenceDataVersioning.GetOrComputeVersion<Sample>(secondSnapshot, () => { computeCount++; return secondSnapshot; });
+
+            Assert.Equal(2, computeCount);
+        }
+
+        [Fact]
+        public void GetOrComputeVersion_NewSnapshotReflectsChangedData()
+        {
+            // The new snapshot's hash must track its (changed) contents, mirroring a real cache swap.
+            var firstSnapshot = SampleSet();
+            var firstVersion = ReferenceDataVersioning.GetOrComputeVersion<Sample>(firstSnapshot, () => firstSnapshot);
+
+            var secondSnapshot = SampleSet();
+            secondSnapshot[1].Name = "Gamma";
+            var secondVersion = ReferenceDataVersioning.GetOrComputeVersion<Sample>(secondSnapshot, () => secondSnapshot);
+
+            Assert.NotEqual(firstVersion, secondVersion);
+            Assert.Equal(ReferenceDataVersioning.ComputeVersion(secondSnapshot), secondVersion);
+        }
     }
 }

--- a/Game.Api/Sockets/Commands/AbstractReferenceDataCommand.cs
+++ b/Game.Api/Sockets/Commands/AbstractReferenceDataCommand.cs
@@ -19,13 +19,24 @@ namespace Game.Api.Sockets.Commands
         /// <summary>
         /// Hashes this set's current data so the frontend can detect a stale cache. Computed from
         /// the same models <see cref="HandleExecuteAsync"/> returns, so the version tracks exactly what
-        /// a client would download.
+        /// a client would download. The hash is memoized against <see cref="VersionKey"/> so it is computed
+        /// once per cache swap rather than re-serialized on every connect (this is the first command the
+        /// loading screen issues, for every player).
         /// </summary>
         public string ComputeVersion()
         {
-            return ReferenceDataVersioning.ComputeVersion(GetReferenceData());
+            return ReferenceDataVersioning.GetOrComputeVersion(VersionKey, GetReferenceData);
         }
 
         protected abstract IEnumerable<TModel> GetReferenceData();
+
+        /// <summary>
+        /// The immutable instance the memoized version is keyed on; its reference identity must change exactly
+        /// when this set's client-visible data changes. For a database-backed set this is the cache holder's
+        /// current snapshot (a build-then-swap publishes a new instance), so a swap invalidates the cached
+        /// version automatically. For an intrinsic (enum-derived) set the data is fixed for the process
+        /// lifetime, so a stable per-set sentinel is the natural key — see <see cref="IntrinsicVersionKey"/>.
+        /// </summary>
+        protected abstract object VersionKey { get; }
     }
 }

--- a/Game.Api/Sockets/Commands/GetAttributes.cs
+++ b/Game.Api/Sockets/Commands/GetAttributes.cs
@@ -14,5 +14,8 @@ namespace Game.Api.Sockets.Commands
         {
             return Core.Attributes.Attribute.GetAllAttributes().To().Model<Attribute>();
         }
+
+        // Intrinsic (enum-derived) set: fixed for the process lifetime, so the version is memoized once.
+        protected override object VersionKey => IntrinsicVersionKey<GetAttributes>.Instance;
     }
 }

--- a/Game.Api/Sockets/Commands/GetChallengeTypes.cs
+++ b/Game.Api/Sockets/Commands/GetChallengeTypes.cs
@@ -14,5 +14,8 @@ namespace Game.Api.Sockets.Commands
         {
             return Core.Progress.ChallengeType.GetAll().To().Model<ChallengeType>();
         }
+
+        // Intrinsic (enum-derived) set: fixed for the process lifetime, so the version is memoized once.
+        protected override object VersionKey => IntrinsicVersionKey<GetChallengeTypes>.Instance;
     }
 }

--- a/Game.Api/Sockets/Commands/GetChallenges.cs
+++ b/Game.Api/Sockets/Commands/GetChallenges.cs
@@ -25,6 +25,8 @@ namespace Game.Api.Sockets.Commands
             return _challenges.All().Select(ToContract);
         }
 
+        protected override object VersionKey => _challenges.VersionKey;
+
         // The domain challenge carries the rich ChallengeType; the read contract flattens it to the
         // type id plus the statistic/entity dimensions the type derives. Kept here because the
         // gameplay domain (IChallenges.All) intentionally serves the domain model — see backend.md.

--- a/Game.Api/Sockets/Commands/GetEnemies.cs
+++ b/Game.Api/Sockets/Commands/GetEnemies.cs
@@ -22,5 +22,7 @@ namespace Game.Api.Sockets.Commands
         {
             return _enemies.All();
         }
+
+        protected override object VersionKey => _enemies.VersionKey;
     }
 }

--- a/Game.Api/Sockets/Commands/GetItemMods.cs
+++ b/Game.Api/Sockets/Commands/GetItemMods.cs
@@ -22,5 +22,7 @@ namespace Game.Api.Sockets.Commands
         {
             return _itemMods.All();
         }
+
+        protected override object VersionKey => _itemMods.VersionKey;
     }
 }

--- a/Game.Api/Sockets/Commands/GetItems.cs
+++ b/Game.Api/Sockets/Commands/GetItems.cs
@@ -22,5 +22,7 @@ namespace Game.Api.Sockets.Commands
         {
             return _items.All();
         }
+
+        protected override object VersionKey => _items.VersionKey;
     }
 }

--- a/Game.Api/Sockets/Commands/GetSkills.cs
+++ b/Game.Api/Sockets/Commands/GetSkills.cs
@@ -22,5 +22,7 @@ namespace Game.Api.Sockets.Commands
         {
             return _skills.AllSkills();
         }
+
+        protected override object VersionKey => _skills.VersionKey;
     }
 }

--- a/Game.Api/Sockets/Commands/GetStatisticTypes.cs
+++ b/Game.Api/Sockets/Commands/GetStatisticTypes.cs
@@ -14,5 +14,8 @@ namespace Game.Api.Sockets.Commands
         {
             return Core.Progress.StatisticType.GetAll().To().Model<StatisticType>();
         }
+
+        // Intrinsic (enum-derived) set: fixed for the process lifetime, so the version is memoized once.
+        protected override object VersionKey => IntrinsicVersionKey<GetStatisticTypes>.Instance;
     }
 }

--- a/Game.Api/Sockets/Commands/GetZones.cs
+++ b/Game.Api/Sockets/Commands/GetZones.cs
@@ -22,5 +22,7 @@ namespace Game.Api.Sockets.Commands
         {
             return _zones.All();
         }
+
+        protected override object VersionKey => _zones.VersionKey;
     }
 }

--- a/Game.Api/Sockets/Commands/IntrinsicVersionKey.cs
+++ b/Game.Api/Sockets/Commands/IntrinsicVersionKey.cs
@@ -1,0 +1,16 @@
+namespace Game.Api.Sockets.Commands
+{
+    /// <summary>
+    /// A process-stable version key for an intrinsic (enum-derived) reference-data command. Intrinsic sets
+    /// have no cache holder to swap — their data is fixed for the process lifetime — so they cannot key the
+    /// memoized version on a snapshot instance. Each command type instead reuses a single sentinel, so its
+    /// version is computed once and then served from the memo for the life of the process, while staying
+    /// distinct from every other set's key.
+    /// </summary>
+    /// <typeparam name="TCommand">The intrinsic command type, ensuring one distinct sentinel per set.</typeparam>
+    internal static class IntrinsicVersionKey<TCommand>
+    {
+        /// <summary>The per-set sentinel; identical for every instance of <typeparamref name="TCommand"/>.</summary>
+        public static object Instance { get; } = new();
+    }
+}

--- a/Game.Api/Sockets/Commands/ReferenceDataVersioning.cs
+++ b/Game.Api/Sockets/Commands/ReferenceDataVersioning.cs
@@ -1,4 +1,5 @@
 using Game.Core;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -10,6 +11,14 @@ namespace Game.Api.Sockets.Commands
     /// </summary>
     internal static class ReferenceDataVersioning
     {
+        // Memoizes each set's computed hash against the immutable snapshot instance it was computed from, so
+        // the expensive serialize-and-hash runs once per cache swap rather than once per connect (the version
+        // is the first thing the loading screen pulls). Keying on the snapshot reference makes invalidation
+        // automatic: a build-then-swap publishes a new snapshot object, which is a cache miss, while the old
+        // entry is collected once no caller holds the prior snapshot. ConditionalWeakTable is itself
+        // thread-safe, and GetValue computes the value at most once per key under concurrent connects.
+        private static readonly ConditionalWeakTable<object, string> _versions = new();
+
         /// <summary>
         /// Hashes a reference-data set's serialized models. The set is serialized through its
         /// concrete <typeparamref name="TModel"/> (not <c>object</c>), so every model property is
@@ -21,6 +30,18 @@ namespace Game.Api.Sockets.Commands
             var json = models.Serialize();
             var hash = SHA256.HashData(Encoding.UTF8.GetBytes(json));
             return Convert.ToHexString(hash);
+        }
+
+        /// <summary>
+        /// Returns the cached version for <paramref name="snapshotKey"/>, computing it from
+        /// <paramref name="models"/> only on the first request for that snapshot. <paramref name="snapshotKey"/>
+        /// must be the immutable snapshot instance the data is drawn from: its reference identity changes on a
+        /// cache swap, which is exactly when the version must change, so a swap naturally invalidates the entry.
+        /// <paramref name="models"/> is evaluated lazily so the serialization is skipped entirely on a cache hit.
+        /// </summary>
+        public static string GetOrComputeVersion<TModel>(object snapshotKey, Func<IEnumerable<TModel>> models)
+        {
+            return _versions.GetValue(snapshotKey, _ => ComputeVersion(models()));
         }
     }
 }

--- a/Game.Application.Tests/Mapping/PlayerMapperTests.cs
+++ b/Game.Application.Tests/Mapping/PlayerMapperTests.cs
@@ -187,10 +187,13 @@ namespace Game.Application.Tests.Mapping
 
             public bool ValidateItemModId(int itemModId) => true;
 
-            // ToCore never reads the full contract lists, only the per-id resolvers above.
+            // ToCore never reads the full contract lists or the version key, only the per-id resolvers above.
             List<Item> IItems.All() => throw new NotSupportedException();
             List<ItemMod> IItemMods.All() => throw new NotSupportedException();
             List<Skill> ISkills.AllSkills() => throw new NotSupportedException();
+            object IItems.VersionKey => throw new NotSupportedException();
+            object IItemMods.VersionKey => throw new NotSupportedException();
+            object ISkills.VersionKey => throw new NotSupportedException();
         }
     }
 }

--- a/Game.DataAccess/Repositories/Challenges.cs
+++ b/Game.DataAccess/Repositories/Challenges.cs
@@ -6,6 +6,9 @@ namespace Game.DataAccess.Repositories
 {
     internal class Challenges(ChallengesCacheHolder holder) : IChallenges
     {
+        // The snapshot instance changes on every build-then-swap, so it doubles as the content-version key.
+        public object VersionKey => holder.Current;
+
         public IReadOnlyList<Challenge> All()
         {
             // The snapshot's list is already immutable, so return it directly rather than copying it on

--- a/Game.DataAccess/Repositories/Enemies.cs
+++ b/Game.DataAccess/Repositories/Enemies.cs
@@ -11,6 +11,9 @@ namespace Game.DataAccess.Repositories
     {
         private EnemySnapshot Snapshot => holder.Current;
 
+        // The snapshot instance changes on every build-then-swap, so it doubles as the content-version key.
+        public object VersionKey => Snapshot;
+
         public List<Contracts.Enemy> All()
         {
             return [.. Snapshot.Enemies.Select(EnemyMapper.ToContract)];

--- a/Game.DataAccess/Repositories/ItemMods.cs
+++ b/Game.DataAccess/Repositories/ItemMods.cs
@@ -11,6 +11,9 @@ namespace Game.DataAccess.Repositories
     {
         private IReadOnlyList<ItemMod> Entities => holder.Current.Entities;
 
+        // The snapshot instance changes on every build-then-swap, so it doubles as the content-version key.
+        public object VersionKey => holder.Current;
+
         public List<Contracts.ItemMod> All()
         {
             return [.. Entities.Select(ItemMapper.ModToContract)];

--- a/Game.DataAccess/Repositories/Items.cs
+++ b/Game.DataAccess/Repositories/Items.cs
@@ -11,6 +11,9 @@ namespace Game.DataAccess.Repositories
     {
         private IReadOnlyList<Item> Entities => holder.Current.Entities;
 
+        // The snapshot instance changes on every build-then-swap, so it doubles as the content-version key.
+        public object VersionKey => holder.Current;
+
         public List<Contracts.Item> All()
         {
             return [.. Entities.Select(ItemMapper.ToContract)];

--- a/Game.DataAccess/Repositories/Skills.cs
+++ b/Game.DataAccess/Repositories/Skills.cs
@@ -11,6 +11,9 @@ namespace Game.DataAccess.Repositories
     {
         private IReadOnlyList<Skill> Entities => holder.Current.Entities;
 
+        // The snapshot instance changes on every build-then-swap, so it doubles as the content-version key.
+        public object VersionKey => holder.Current;
+
         public List<Contracts.Skill> AllSkills()
         {
             return [.. Entities.Select(SkillMapper.ToContract)];

--- a/Game.DataAccess/Repositories/Zones.cs
+++ b/Game.DataAccess/Repositories/Zones.cs
@@ -10,6 +10,9 @@ namespace Game.DataAccess.Repositories
     {
         private IReadOnlyList<Zone> Entities => holder.Current;
 
+        // The snapshot instance changes on every build-then-swap, so it doubles as the content-version key.
+        public object VersionKey => holder.Current;
+
         public List<Contracts.Zone> All()
         {
             return [.. Entities.Select(ZoneMapper.ToContract)];

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -107,7 +107,9 @@ A stopping instance drains its live sockets cleanly rather than leaving them to 
 
 ## Reference-data caching and versioning
 
-The frontend caches each reference-data set in the browser and re-downloads only the sets that changed (see `frontend.md`). The `GetReferenceDataVersions` socket command supports this by returning a **content hash per set** in one round-trip. The hash is computed on demand by hashing the same serialized models the client actually receives (SHA-256 over the camelCase JSON), so the version changes if and only if the client-visible data changes — there is no separate version counter to maintain or invalidate. The versioned set is exactly the set of reference-data socket commands (discovered by assembly scan), so a newly-added one is versioned automatically.
+The frontend caches each reference-data set in the browser and re-downloads only the sets that changed (see `frontend.md`). The `GetReferenceDataVersions` socket command supports this by returning a **content hash per set** in one round-trip. The hash is computed by hashing the same serialized models the client actually receives (SHA-256 over the camelCase JSON), so the version changes if and only if the client-visible data changes — there is no separate version counter to maintain or invalidate. The versioned set is exactly the set of reference-data socket commands (discovered by assembly scan), so a newly-added one is versioned automatically.
+
+`GetReferenceDataVersions` is the **first** command the loading screen issues on every connect, so the hash is **memoized per set, keyed on the immutable cache snapshot it was computed from** — the serialize-and-hash runs once per cache swap rather than once per connect. Keying on the snapshot instance makes invalidation automatic: a build-then-swap publishes a new snapshot object (a memo miss), so an admin write can never serve a stale hash. Intrinsic (enum-derived) sets have no holder to swap, so they key on a process-stable sentinel and hash once for the process lifetime.
 
 ## Battle (setup, runtime & skill effects)
 


### PR DESCRIPTION
Closes #836

## Problem

`GetReferenceDataVersions` is the first command the loading screen issues on **every** connect, for **every** player. For each registered reference-data command it called `ComputeVersion()`, which fully JSON-serializes the entire set and SHA-256-hashes it. So all catalogs (items, item-mods, skills, enemies, zones, challenges, attributes, statistic/challenge types) were re-serialized and re-hashed from scratch on every connect — even though the underlying data is an immutable in-memory snapshot that only changes on an admin write / cache swap. The hash is a pure function of a rarely-changing snapshot, yet it was recomputed per connect.

## Change

Memoize the computed version, keyed on the immutable snapshot instance, so the serialize-and-hash runs **once per cache swap** rather than once per connect.

- `ReferenceDataVersioning.GetOrComputeVersion(snapshotKey, lazyModels)` memoizes against a `ConditionalWeakTable<object, string>`. Keying on the snapshot reference makes invalidation automatic: a build-then-swap publishes a new snapshot object (a memo miss), so an admin write can never serve a stale hash; the old entry is collected once no caller holds the prior snapshot. The models are evaluated lazily, so serialization is skipped entirely on a cache hit. `ConditionalWeakTable` is thread-safe and computes once per key under concurrent connects.
- `AbstractReferenceDataCommand` now exposes a `VersionKey` and routes `ComputeVersion()` through the memoizer.
  - **Cache-backed** commands key on their holder's `Current` snapshot, surfaced as an opaque `object VersionKey` on the reference-data repo interfaces (no entity exposure — it is just an identity token).
  - **Intrinsic** (enum-derived) sets have no holder to swap, so they key on a process-stable per-set sentinel (`IntrinsicVersionKey<TCommand>`) and hash once for the process lifetime.
- The hash algorithm and output are **unchanged** — clients still see the same version string for the same data.

## Tests

- `ReferenceDataVersioningTests` — the memoization helper computes once per snapshot key, recomputes for a new snapshot instance (even with identical values), the new snapshot reflects changed data, and the memoized value matches a direct `ComputeVersion`.
- `ReferenceDataCommandVersioningTests` — end-to-end through the `AbstractReferenceDataCommand` seam: serializes once per snapshot, recomputes after a swap, and matches a direct hash of the data.

## Verification

- Built `Game.Abstractions`, `Game.DataAccess`, `Game.Api`, `Game.Api.Tests`, `Game.Application.Tests` (0 warnings/errors).
- Ran the affected unit tests (`ReferenceDataVersioningTests`, `ReferenceDataCommandVersioningTests`, `GetReferenceDataVersionsTests`, `PlayerMapperTests`) — all green.
- `dotnet format --verify-no-changes` clean on every changed project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_