### PR TITLE
Reset inventory page in view-model setters, not an effect

### DIFF
--- a/UI/src/routes/game/screens/inventory/InventoryGrid.svelte
+++ b/UI/src/routes/game/screens/inventory/InventoryGrid.svelte
@@ -63,14 +63,6 @@ const pages = $derived(Math.max(1, Math.ceil(view.visible.length / perPage)));
 const pageClamped = $derived(Math.min(view.page, pages - 1));
 const slice = $derived(view.visible.slice(pageClamped * perPage, pageClamped * perPage + perPage));
 
-// Reset to the first page whenever the filter/sort changes.
-$effect(() => {
-	void view.sort;
-	void view.filterCat;
-	void view.favOnly;
-	view.page = 0;
-});
-
 const tooltip = getItemTooltip();
 
 // Suppress the tooltip while an item is selected or being dragged — a rule the grid owns since the

--- a/UI/src/routes/game/screens/inventory/InventoryToolbar.svelte
+++ b/UI/src/routes/game/screens/inventory/InventoryToolbar.svelte
@@ -1,13 +1,6 @@
 <div class="toolbar">
 	<div class="chips">
-		<button
-			class="chip"
-			class:active={view.filterCat == null && !view.favOnly}
-			onclick={() => {
-				view.filterCat = null;
-				view.favOnly = false;
-			}}
-		>
+		<button class="chip" class:active={view.filterCat == null && !view.favOnly} onclick={() => view.showAll()}>
 			All <span class="chip-count">{view.counts.all}</span>
 		</button>
 
@@ -16,7 +9,7 @@
 				class="chip"
 				class:active={view.filterCat === cat}
 				style:--chip-accent={itemCategoryColor(cat)}
-				onclick={() => (view.filterCat = view.filterCat === cat ? null : cat)}
+				onclick={() => view.setFilterCat(view.filterCat === cat ? null : cat)}
 			>
 				<span class="chip-diamond" style:background={itemCategoryColor(cat)}></span>
 				{itemCategoryName(cat)} <span class="chip-count">{view.counts.cats[cat] ?? 0}</span>
@@ -27,7 +20,7 @@
 			class="chip fav"
 			class:active={view.favOnly}
 			title="Show favorites only"
-			onclick={() => (view.favOnly = !view.favOnly)}
+			onclick={() => view.setFavOnly(!view.favOnly)}
 		>
 			<FavoriteStar filled={view.favOnly} size={11} />
 			Favorites <span class="chip-count">{view.counts.fav}</span>
@@ -38,7 +31,7 @@
 		<span class="mono-label">Sort</span>
 		<div class="sort-toggle">
 			{#each sortKeys as key (key)}
-				<button class="sort-option" class:active={view.sort === key} onclick={() => (view.sort = key)}>
+				<button class="sort-option" class:active={view.sort === key} onclick={() => view.setSort(key)}>
 					{SORTS[key].label}
 				</button>
 			{/each}

--- a/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
+++ b/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
@@ -114,6 +114,31 @@ export class InventoryView {
 
 	/* ── actions ─────────────────────────────────────────────────────── */
 
+	// Filter/sort changes snap back to the first page here — where the user intent originates —
+	// so page-reset never lives in an effect that writes tracked state. `pageClamped` in the grid
+	// remains the out-of-range safety net (e.g. when the visible list shrinks for other reasons).
+	setSort(sort: SortKey) {
+		this.sort = sort;
+		this.page = 0;
+	}
+
+	setFilterCat(filterCat: EItemCategory | null) {
+		this.filterCat = filterCat;
+		this.page = 0;
+	}
+
+	setFavOnly(favOnly: boolean) {
+		this.favOnly = favOnly;
+		this.page = 0;
+	}
+
+	/** The "All" affordance clears both the category and favorites filters in one action. */
+	showAll() {
+		this.filterCat = null;
+		this.favOnly = false;
+		this.page = 0;
+	}
+
 	select(itemId: number | null) {
 		this.selectedId = itemId;
 	}

--- a/UI/src/tests/routes/game/screens/inventory/InventoryGrid.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/InventoryGrid.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { flushSync } from 'svelte';
 import { render, cleanup, fireEvent } from '@testing-library/svelte';
 import { EItemCategory, ERarity } from '$lib/api';
 import { BattleAttributes, type Item } from '$lib/battle';
@@ -185,37 +184,5 @@ describe('InventoryGrid — drag interactions', () => {
 		const { container } = render(InventoryGrid, { props: { view } });
 		await fireEvent.dragEnd(container.querySelector('.overlay-button')!);
 		expect(view.dragItemId).toBeNull();
-	});
-});
-
-describe('InventoryGrid — page reset on filter/sort change', () => {
-	it('resets view.page to 0 when filterCat changes', () => {
-		const view = new InventoryView();
-		render(InventoryGrid, { props: { view } });
-		flushSync();
-		view.page = 2;
-		view.filterCat = EItemCategory.Weapon;
-		flushSync();
-		expect(view.page).toBe(0);
-	});
-
-	it('resets view.page to 0 when sort changes', () => {
-		const view = new InventoryView();
-		render(InventoryGrid, { props: { view } });
-		flushSync();
-		view.page = 2;
-		view.sort = 'name';
-		flushSync();
-		expect(view.page).toBe(0);
-	});
-
-	it('resets view.page to 0 when favOnly changes', () => {
-		const view = new InventoryView();
-		render(InventoryGrid, { props: { view } });
-		flushSync();
-		view.page = 2;
-		view.favOnly = true;
-		flushSync();
-		expect(view.page).toBe(0);
 	});
 });

--- a/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
@@ -203,6 +203,57 @@ describe('InventoryView derivations', () => {
 	});
 });
 
+describe('InventoryView filter/sort setters reset the page', () => {
+	it('setSort changes the sort and snaps back to the first page', () => {
+		const view = new InventoryView();
+		view.page = 3;
+		view.setSort('name');
+		expect(view.sort).toBe('name');
+		expect(view.page).toBe(0);
+	});
+
+	it('setFilterCat changes the category filter and snaps back to the first page', () => {
+		const view = new InventoryView();
+		view.page = 3;
+		view.setFilterCat(EItemCategory.Weapon);
+		expect(view.filterCat).toBe(EItemCategory.Weapon);
+		expect(view.page).toBe(0);
+	});
+
+	it('setFavOnly toggles the favorites filter and snaps back to the first page', () => {
+		const view = new InventoryView();
+		view.page = 3;
+		view.setFavOnly(true);
+		expect(view.favOnly).toBe(true);
+		expect(view.page).toBe(0);
+	});
+
+	it('showAll clears both filters and snaps back to the first page', () => {
+		const view = new InventoryView();
+		view.filterCat = EItemCategory.Weapon;
+		view.favOnly = true;
+		view.page = 3;
+		view.showAll();
+		expect(view.filterCat).toBeNull();
+		expect(view.favOnly).toBe(false);
+		expect(view.page).toBe(0);
+	});
+
+	// The grid clamps an out-of-range page as a safety net even when page-reset doesn't fire (the
+	// visible list can shrink for reasons other than a filter/sort action). This mirrors the
+	// `pageClamped = Math.min(view.page, pages - 1)` derivation in InventoryGrid.svelte.
+	it('an out-of-range page still clamps into the last available page', () => {
+		const view = new InventoryView();
+		const perPage = 48;
+		view.page = 5;
+		const pages = Math.max(1, Math.ceil(view.visible.length / perPage));
+		const pageClamped = Math.min(view.page, pages - 1);
+		expect(view.visible.length).toBeLessThanOrEqual(perPage);
+		expect(pages).toBe(1);
+		expect(pageClamped).toBe(0);
+	});
+});
+
 describe('InventoryView delegation', () => {
 	it('equip delegates to the manager', () => {
 		new InventoryView().equip(2, 4);


### PR DESCRIPTION
Closes #845

## Problem

`InventoryGrid.svelte` reset `view.page = 0` from an `$effect` that read `view.sort`/`view.filterCat`/`view.favOnly` solely to write `view.page` — the Svelte 5 anti-pattern of writing tracked state from an effect that reads tracked state. It schedules an extra reactive pass, is fragile to maintain, and was partly redundant with the existing `pageClamped` derivation that already clamps an out-of-range page.

## Change

Page-reset now lives where the user intent originates — on the view-model:

- Added `setSort`, `setFilterCat`, `setFavOnly`, and a `showAll` convenience method to `InventoryView`. Each sets its field and resets `page = 0` in one action.
- `InventoryToolbar.svelte`'s chip/sort controls route through these setters instead of writing `$state` directly (the "All" chip uses `showAll`, which clears both the category and favorites filters together).
- Removed the `$effect` from `InventoryGrid.svelte` entirely. `pageClamped = $derived(Math.min(view.page, pages - 1))` stays as the out-of-range safety net for when the visible list shrinks for reasons other than a filter/sort action.

No behavior regression: changing sort/category/favorites still snaps back to page 0, and clamping still holds.

## Tests

Extended `inventory-view.test.ts` with a new block asserting each setter mutates its field and resets `page` to 0, that `showAll` clears both filters, and that the grid's out-of-range page-clamping math still holds.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run test:unit -- inventory-view` — 38 passed (incl. 5 new)
- `npx eslint` + `npx prettier --check` on all changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_