### PR TITLE
Decouple combat-log glyph selection from message text (#849)

### DIFF
--- a/UI/src/components/log-panel/log-kind.ts
+++ b/UI/src/components/log-panel/log-kind.ts
@@ -1,5 +1,5 @@
 import { ELogType } from '$lib/api';
-import type { LogMessage } from '$lib/engine/log';
+import type { LogMessage, LogOutcome } from '$lib/engine/log';
 
 export type GlyphKind = 'hit' | 'crit' | 'dodge' | 'block' | 'enemy' | 'loot' | 'system' | 'kill' | 'effect';
 
@@ -36,30 +36,35 @@ const SYSTEM = logColors.system;
 const EFFECT = logColors.effect;
 
 /**
+ * Visual treatment per structured combat outcome. The `Damage` channel carries player-vs-enemy and
+ * the player-only crit/dodge/block outcomes (#178) on one `ELogType`; keying the glyph off the typed
+ * {@link LogOutcome} the engine sets keeps it stable when a message is reworded.
+ */
+const damageKinds: Record<LogOutcome, LogKind> = {
+	'player-hit': { color: PLAYER, glyph: 'hit', label: 'Hit' },
+	'player-crit': { color: PLAYER, glyph: 'crit', label: 'Crit' },
+	'player-dodge': { color: ENEMY, glyph: 'dodge', label: 'Dodge' },
+	'player-block': { color: ENEMY, glyph: 'block', label: 'Block' },
+	'enemy-hit': { color: ENEMY, glyph: 'enemy', label: 'Hurt' }
+};
+
+/**
  * Maps a {@link LogMessage} to its visual treatment for the sliding manifest.
  *
- * The log model only stores a flat `message` + `logType`, so player-vs-enemy
- * actions (both `ELogType.Damage`) are disambiguated by the message prefix the
- * battle engine produces ("You used …" / "You've been defeated!"). The player-only
- * crit/dodge/block outcomes (#178) ride the same `ELogType.Damage` channel and are
- * told apart by the distinctive phrasing `damageLogMessage` produces.
+ * `Damage` entries carry a structured {@link LogOutcome} (set by the battle engine at the log site),
+ * so the glyph is chosen from that typed value rather than the message text. Entries without one
+ * (e.g. the Options live-preview samples) and the `EnemyDefeated` channel still disambiguate
+ * player-vs-enemy by the "You" message prefix the engine produces.
  */
 export function logKind(log: LogMessage): LogKind {
 	const fromPlayer = log.message.startsWith('You');
 	switch (log.logType) {
 		case ELogType.Damage:
-			if (log.message.startsWith('You landed a critical hit')) {
-				return { color: PLAYER, glyph: 'crit', label: 'Crit' };
+			if (log.outcome) {
+				return damageKinds[log.outcome];
 			}
-			if (log.message.startsWith('You dodged')) {
-				return { color: ENEMY, glyph: 'dodge', label: 'Dodge' };
-			}
-			if (log.message.startsWith('You blocked')) {
-				return { color: ENEMY, glyph: 'block', label: 'Block' };
-			}
-			return fromPlayer
-				? { color: PLAYER, glyph: 'hit', label: 'Hit' }
-				: { color: ENEMY, glyph: 'enemy', label: 'Hurt' };
+			// No structured outcome (e.g. live-preview samples): fall back to the "You" prefix split.
+			return fromPlayer ? damageKinds['player-hit'] : damageKinds['enemy-hit'];
 		case ELogType.ItemFound:
 			return { color: LOOT, glyph: 'loot', label: 'Loot' };
 		case ELogType.Exp:

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -2,7 +2,7 @@ import { Battler, battleStep, type BattleStepLog } from '$lib/battle';
 import { Mulberry32 } from '$lib/engine/mulberry32';
 import { staticData } from '$stores';
 import { ELogType, IEnemyInstance } from '$lib/api';
-import { logMessage } from '../log';
+import { logMessage, type LogOutcome } from '../log';
 import { formatNum, createHook, Action, effectLogMessage, attributeIsHarmful, attributeName } from '$lib/common';
 import { onLogicalUpdate } from '../logical-engine';
 import { onRenderUpdate } from '../render-engine';
@@ -144,7 +144,8 @@ export class BattleEngine {
 				this.rng,
 				this.stepLog
 			)) {
-				logMessage(ELogType.Damage, this.damageLogMessage(skill.name, damage, byPlayer, crit, dodged, blocked));
+				const outcome = damageLogOutcome(byPlayer, crit, dodged, blocked);
+				logMessage(ELogType.Damage, this.damageLogMessage(skill.name, damage, outcome), outcome);
 			}
 			this.logEffectApplications();
 			this.accumulateEffectDamage(timeDelta);
@@ -161,30 +162,22 @@ export class BattleEngine {
 	}
 
 	/** Builds the combat-log line for one skill activation, surfacing the player-only crit/dodge/block
-	 *  outcomes (#178). The crit/dodge/block flags are only ever set on the player's side of the
-	 *  exchange (crit on the player's own hit; dodge/block on an incoming enemy hit — a dodged hit is
-	 *  never also blocked), so the player-perspective phrasing is unambiguous. The "You"/enemy-name
-	 *  prefixes are what `logKind` keys the glyph off (see `log-kind.ts`). */
-	private damageLogMessage(
-		skillName: string,
-		damage: number,
-		byPlayer: boolean,
-		crit: boolean,
-		dodged: boolean,
-		blocked: boolean
-	): string {
-		if (byPlayer) {
-			return crit
-				? `You landed a critical hit with ${skillName} for ${formatNum(damage)} damage!`
-				: `You used ${skillName} and dealt ${formatNum(damage)} damage!`;
+	 *  outcomes (#178). The message prose and the structured `outcome` are derived from the same
+	 *  {@link damageLogOutcome} decision, so a reworded line can no longer drift from the glyph
+	 *  `logKind` picks for it (the glyph now keys off `outcome`, not this text — see `log-kind.ts`). */
+	private damageLogMessage(skillName: string, damage: number, outcome: LogOutcome): string {
+		switch (outcome) {
+			case 'player-crit':
+				return `You landed a critical hit with ${skillName} for ${formatNum(damage)} damage!`;
+			case 'player-hit':
+				return `You used ${skillName} and dealt ${formatNum(damage)} damage!`;
+			case 'player-dodge':
+				return `You dodged ${this.enemy.name}'s ${skillName}!`;
+			case 'player-block':
+				return `You blocked ${this.enemy.name}'s ${skillName}, taking only ${formatNum(damage)} damage!`;
+			case 'enemy-hit':
+				return `${this.enemy.name} used ${skillName} and dealt ${formatNum(damage)} damage!`;
 		}
-		if (dodged) {
-			return `You dodged ${this.enemy.name}'s ${skillName}!`;
-		}
-		if (blocked) {
-			return `You blocked ${this.enemy.name}'s ${skillName}, taking only ${formatNum(damage)} damage!`;
-		}
-		return `${this.enemy.name} used ${skillName} and dealt ${formatNum(damage)} damage!`;
 	}
 
 	/** Logs a line for each effect freshly applied this tick (refreshes are skipped — the chip countdown
@@ -251,4 +244,21 @@ export class BattleEngine {
 		this.stage = stage;
 		notifyBattleStageChanged(stage);
 	}
+}
+
+/** Resolves the structured {@link LogOutcome} for one damage exchange from the battle-step flags.
+ *  The crit/dodge/block flags are only ever set on the player's side (crit on the player's own hit;
+ *  dodge/block on an incoming enemy hit — a dodged hit is never also blocked), so the mapping is
+ *  unambiguous. Drives both the log prose and the glyph, keeping them in lockstep. */
+function damageLogOutcome(byPlayer: boolean, crit: boolean, dodged: boolean, blocked: boolean): LogOutcome {
+	if (byPlayer) {
+		return crit ? 'player-crit' : 'player-hit';
+	}
+	if (dodged) {
+		return 'player-dodge';
+	}
+	if (blocked) {
+		return 'player-block';
+	}
+	return 'enemy-hit';
 }

--- a/UI/src/lib/engine/log.ts
+++ b/UI/src/lib/engine/log.ts
@@ -2,14 +2,24 @@ import { ELogType } from '$lib/api';
 import { playerManager } from './player/player-manager';
 import { addLog } from '$stores';
 
+/**
+ * Structured combat-outcome discriminator carried alongside a `Damage`-channel entry. The battle
+ * engine knows each hit's outcome explicitly (player vs enemy, crit/dodge/block) at the log site, so
+ * it sets this rather than encoding the outcome only in the prose — letting `logKind` pick the glyph
+ * from a typed value instead of sniffing the message text, which would silently drift on a reword.
+ */
+export type LogOutcome = 'player-hit' | 'player-crit' | 'player-dodge' | 'player-block' | 'enemy-hit';
+
 export interface LogMessage {
 	id: number;
 	logType: ELogType;
 	message: string;
+	/** Optional outcome for `Damage` entries; absent for every other channel. */
+	outcome?: LogOutcome;
 }
 
-export const logMessage = (logType: ELogType, message: string) => {
+export const logMessage = (logType: ELogType, message: string, outcome?: LogOutcome) => {
 	if (playerManager.logTypeEnabled(logType)) {
-		addLog(logType, message);
+		addLog(logType, message, outcome);
 	}
 };

--- a/UI/src/stores/logs.svelte.ts
+++ b/UI/src/stores/logs.svelte.ts
@@ -1,4 +1,4 @@
-import { LogMessage } from '$lib/engine/log';
+import { LogMessage, LogOutcome } from '$lib/engine/log';
 import { ELogType } from '$lib/api';
 
 const maxLogEntries = 40;
@@ -11,11 +11,11 @@ let lastId = 0;
 export const logs = () => logsData;
 
 /** Prepend a combat-log entry (newest-first), assigning its id and capping the list length. */
-export const addLog = (logType: ELogType, message: string) => {
+export const addLog = (logType: ELogType, message: string, outcome?: LogOutcome) => {
 	if (logsData.length >= maxLogEntries) {
 		logsData.pop();
 	}
-	logsData.unshift({ id: ++lastId, logType, message });
+	logsData.unshift({ id: ++lastId, logType, message, outcome });
 };
 
 /** Clear the combat log and its id counter (e.g. on logout / session replacement) so the

--- a/UI/src/tests/components/log-panel/log-kind.test.ts
+++ b/UI/src/tests/components/log-panel/log-kind.test.ts
@@ -1,48 +1,74 @@
 import { describe, it, expect } from 'vitest';
 import { ELogType } from '$lib/api';
+import type { LogOutcome } from '$lib/engine/log';
 import { logKind, formatLogTime, logColors } from '../../../components/log-panel/log-kind';
 
-type LogMessage = { id: number; logType: ELogType; message: string };
+type LogMessage = { id: number; logType: ELogType; message: string; outcome?: LogOutcome };
 
-function makeLog(logType: ELogType, message: string): LogMessage {
-	return { id: 1, logType, message };
+function makeLog(logType: ELogType, message: string, outcome?: LogOutcome): LogMessage {
+	return { id: 1, logType, message, outcome };
 }
 
 describe('logKind', () => {
 	describe('ELogType.Damage', () => {
-		it('returns the player-hit treatment when the message starts with "You"', () => {
-			const result = logKind(makeLog(ELogType.Damage, 'You used Slash for 42 damage.'));
+		// Glyph selection is driven by the structured `outcome`, not the message text — so the message
+		// passed here is deliberately empty/mismatched to prove the prose is no longer load-bearing.
+		it('returns the player-hit treatment for the "player-hit" outcome', () => {
+			const result = logKind(makeLog(ELogType.Damage, '', 'player-hit'));
 			expect(result.color).toBe(logColors.player);
 			expect(result.glyph).toBe('hit');
 			expect(result.label).toBe('Hit');
 		});
 
-		it('returns the enemy-hit treatment when the message does not start with "You"', () => {
-			const result = logKind(makeLog(ELogType.Damage, 'Goblin hit you for 15 damage.'));
+		it('returns the enemy-hit treatment for the "enemy-hit" outcome', () => {
+			const result = logKind(makeLog(ELogType.Damage, '', 'enemy-hit'));
 			expect(result.color).toBe(logColors.enemy);
 			expect(result.glyph).toBe('enemy');
 			expect(result.label).toBe('Hurt');
 		});
 
-		it('returns the crit treatment for a player critical-hit line', () => {
-			const result = logKind(makeLog(ELogType.Damage, 'You landed a critical hit with Slash for 84 damage!'));
+		it('returns the crit treatment for the "player-crit" outcome', () => {
+			const result = logKind(makeLog(ELogType.Damage, '', 'player-crit'));
 			expect(result.color).toBe(logColors.player);
 			expect(result.glyph).toBe('crit');
 			expect(result.label).toBe('Crit');
 		});
 
-		it('returns the dodge treatment for a dodged incoming hit', () => {
-			const result = logKind(makeLog(ELogType.Damage, "You dodged Goblin's Slash!"));
+		it('returns the dodge treatment for the "player-dodge" outcome', () => {
+			const result = logKind(makeLog(ELogType.Damage, '', 'player-dodge'));
 			expect(result.color).toBe(logColors.enemy);
 			expect(result.glyph).toBe('dodge');
 			expect(result.label).toBe('Dodge');
 		});
 
-		it('returns the block treatment for a blocked incoming hit', () => {
-			const result = logKind(makeLog(ELogType.Damage, "You blocked Goblin's Slash, taking only 12 damage!"));
+		it('returns the block treatment for the "player-block" outcome', () => {
+			const result = logKind(makeLog(ELogType.Damage, '', 'player-block'));
 			expect(result.color).toBe(logColors.enemy);
 			expect(result.glyph).toBe('block');
 			expect(result.label).toBe('Block');
+		});
+
+		it('keys the glyph off the outcome even when the message reads like a different outcome', () => {
+			// A reworded/misleading message must not flip the glyph: the outcome wins.
+			const result = logKind(makeLog(ELogType.Damage, 'You landed a critical hit!', 'player-hit'));
+			expect(result.glyph).toBe('hit');
+			expect(result.glyph).not.toBe('crit');
+		});
+
+		describe('without a structured outcome (e.g. Options live-preview samples)', () => {
+			it('falls back to the player-hit treatment when the message starts with "You"', () => {
+				const result = logKind(makeLog(ELogType.Damage, 'You used Slash for 42 damage.'));
+				expect(result.color).toBe(logColors.player);
+				expect(result.glyph).toBe('hit');
+				expect(result.label).toBe('Hit');
+			});
+
+			it('falls back to the enemy-hit treatment when the message does not start with "You"', () => {
+				const result = logKind(makeLog(ELogType.Damage, 'Goblin hit you for 15 damage.'));
+				expect(result.color).toBe(logColors.enemy);
+				expect(result.glyph).toBe('enemy');
+				expect(result.label).toBe('Hurt');
+			});
 		});
 	});
 

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -346,7 +346,7 @@ describe('BattleEngine', () => {
 
 			logicalUpdateCallbacks[0](500);
 
-			expect(logMessage).toHaveBeenCalledWith(ELogType.Damage, expect.stringContaining('Slash'));
+			expect(logMessage).toHaveBeenCalledWith(ELogType.Damage, expect.stringContaining('Slash'), 'player-hit');
 		});
 
 		it('does not process updates when not Active', () => {
@@ -503,7 +503,8 @@ describe('BattleEngine', () => {
 
 				expect(logMessage).toHaveBeenCalledWith(
 					ELogType.Damage,
-					expect.stringContaining('You landed a critical hit with Slash')
+					expect.stringContaining('You landed a critical hit with Slash'),
+					'player-crit'
 				);
 			});
 
@@ -514,7 +515,7 @@ describe('BattleEngine', () => {
 
 				logicalUpdateCallbacks[0](500);
 
-				expect(logMessage).toHaveBeenCalledWith(ELogType.Damage, "You dodged Goblin's Slash!");
+				expect(logMessage).toHaveBeenCalledWith(ELogType.Damage, "You dodged Goblin's Slash!", 'player-dodge');
 			});
 
 			it('logs a block line when the player blocks an incoming enemy hit', () => {
@@ -524,7 +525,11 @@ describe('BattleEngine', () => {
 
 				logicalUpdateCallbacks[0](500);
 
-				expect(logMessage).toHaveBeenCalledWith(ELogType.Damage, expect.stringContaining("You blocked Goblin's Slash"));
+				expect(logMessage).toHaveBeenCalledWith(
+					ELogType.Damage,
+					expect.stringContaining("You blocked Goblin's Slash"),
+					'player-block'
+				);
 			});
 		});
 	});

--- a/UI/src/tests/lib/engine/log.test.ts
+++ b/UI/src/tests/lib/engine/log.test.ts
@@ -35,10 +35,17 @@ describe('logMessage', () => {
 		];
 	});
 
-	it('forwards an enabled log type to the store', () => {
+	it('forwards an enabled log type to the store (no outcome by default)', () => {
 		logMessage(ELogType.Exp, 'Earned 50 exp.');
 
-		expect(addLog).toHaveBeenCalledWith(ELogType.Exp, 'Earned 50 exp.');
+		expect(addLog).toHaveBeenCalledWith(ELogType.Exp, 'Earned 50 exp.', undefined);
+	});
+
+	it('forwards a structured outcome through to the store', () => {
+		mockPlayerManager.logPreferences = [{ id: ELogType.Damage, enabled: true }];
+		logMessage(ELogType.Damage, 'You used Slash and dealt 10 damage!', 'player-hit');
+
+		expect(addLog).toHaveBeenCalledWith(ELogType.Damage, 'You used Slash and dealt 10 damage!', 'player-hit');
 	});
 
 	it('does not forward a disabled log type', () => {
@@ -50,6 +57,6 @@ describe('logMessage', () => {
 	it('forwards an unknown log type (defaults to enabled)', () => {
 		logMessage(ELogType.EnemyDefeated, 'Enemy defeated!');
 
-		expect(addLog).toHaveBeenCalledWith(ELogType.EnemyDefeated, 'Enemy defeated!');
+		expect(addLog).toHaveBeenCalledWith(ELogType.EnemyDefeated, 'Enemy defeated!', undefined);
 	});
 });


### PR DESCRIPTION
Closes #849

## Problem

`logKind` (`UI/src/components/log-panel/log-kind.ts`) picked a `Damage`-channel combat-log entry's glyph/colour/label by sniffing the message prose with `message.startsWith(...)` against four literals — `'You'` for the player-vs-enemy split plus `'You landed a critical hit'` / `'You dodged'` / `'You blocked'` for the crit/dodge/block outcomes. Those had to stay byte-for-byte in sync with the strings `BattleEngine.damageLogMessage` produces; reword a message and the glyph silently fell back to the generic hit/enemy treatment with no compile-time error. The pattern was originally one `'You'` prefix (the flat `{ id, logType, message }` model's player/enemy disambiguator) but #178 widened it to four fragile literals.

## Approach — structured discriminator (chosen over shared constants)

The issue offered two directions. I went with the **structured outcome discriminator** rather than shared message constants, because:

- The engine already knows each hit's outcome explicitly (`byPlayer`/`crit`/`dodged`/`blocked` booleans) at the log site — re-deriving it by string-sniffing is exactly the brittleness to remove. Shared constants would only stop the literals from drifting independently; they'd still couple the glyph to the message prose.
- The log model is tiny and only three places construct a `LogMessage` (the store's `addLog`, the Options live-preview feed, and tests), so an **optional, additive** field extends it with no ripple.

### What changed

- **`log.ts`** — added an optional `LogOutcome` (`'player-hit' | 'player-crit' | 'player-dodge' | 'player-block' | 'enemy-hit'`) to `LogMessage`, threaded through `logMessage`.
- **`logs.svelte.ts`** — `addLog` accepts and stores the optional `outcome`.
- **`battle-engine.ts`** — a single `damageLogOutcome(...)` derives the outcome from the battle-step flags; that same value drives **both** the message prose (`damageLogMessage` now switches on it) **and** the stored discriminator, so they cannot disagree. Edits are confined to the logging/message concern (no subscription-wiring touched).
- **`log-kind.ts`** — `Damage` glyph selection keys off the typed `outcome` via a `damageKinds` map. The `'You'`-prefix split is kept only as a fallback for entries **without** an outcome (the live-preview samples) and for the `EnemyDefeated` channel (the original single-prefix pattern, out of scope here).

The discriminator is optional/additive, so existing entries and the player-vs-enemy disambiguation still render unchanged.

## Display-only

No battle-parity or backend impact (confirmed by the issue). Glyph/label/colour treatments are byte-for-byte identical to before.

## Tests

- `log-kind.test.ts` now drives each `Damage` glyph off the `outcome` (with deliberately empty/mismatched message text to prove the prose is no longer load-bearing), including a case where a crit-worded message with a `player-hit` outcome still renders the hit glyph. The no-outcome `'You'`-prefix fallback is retained.
- `battle-engine.test.ts` asserts the engine sets the correct structured outcome on each crit/dodge/block/hit log call.
- `log.test.ts` verifies `logMessage` forwards the outcome through to the store.
- `npm run check` (0 errors), `eslint` + `prettier --check` clean on all changed files, and 75/75 affected unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_