### PR TITLE
Add keyboard focus indicators and pager accessible names (#844)

### DIFF
--- a/UI/src/routes/+page.svelte
+++ b/UI/src/routes/+page.svelte
@@ -238,5 +238,10 @@ const handleSubmit = async () => {
 	cursor: pointer;
 	padding: 6px;
 	display: flex;
+
+	&:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
 }
 </style>

--- a/UI/src/routes/game/screens/inventory/InventoryGrid.svelte
+++ b/UI/src/routes/game/screens/inventory/InventoryGrid.svelte
@@ -34,12 +34,16 @@
 		{:else}
 			<span class="mono-label">{view.visible.length} items</span>
 			<div class="pager">
-				<button class="page-btn" disabled={pageClamped === 0} onclick={() => (view.page = Math.max(0, pageClamped - 1))}
-					>‹</button
+				<button
+					class="page-btn"
+					aria-label="Previous page"
+					disabled={pageClamped === 0}
+					onclick={() => (view.page = Math.max(0, pageClamped - 1))}>‹</button
 				>
 				<span class="page-indicator">{pageClamped + 1} / {pages}</span>
 				<button
 					class="page-btn"
+					aria-label="Next page"
 					disabled={pageClamped === pages - 1}
 					onclick={() => (view.page = Math.min(pages - 1, pageClamped + 1))}>›</button
 				>
@@ -145,6 +149,11 @@ const handleHoverLeave = () => tooltip?.hide();
 	&:disabled {
 		opacity: 0.3;
 		cursor: default;
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
 	}
 }
 

--- a/UI/src/routes/game/screens/inventory/InventoryToolbar.svelte
+++ b/UI/src/routes/game/screens/inventory/InventoryToolbar.svelte
@@ -83,6 +83,11 @@ const sortKeys = Object.keys(SORTS) as SortKey[];
 		background: color-mix(in srgb, var(--white) 6%, transparent);
 	}
 
+	&:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+
 	&.active {
 		background: color-mix(in srgb, var(--accent) 16%, transparent);
 		color: var(--text-primary);
@@ -134,6 +139,13 @@ const sortKeys = Object.keys(SORTS) as SortKey[];
 
 	&:not(:first-child) {
 		border-left: 1px solid var(--border-subtle);
+	}
+
+	// Inset the ring: the .sort-toggle wrapper clips overflow, so a positive
+	// offset would be cut off and the focus indicator would vanish.
+	&:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: -2px;
 	}
 
 	&.active {

--- a/UI/src/routes/game/screens/skills/SkillRow.svelte
+++ b/UI/src/routes/game/screens/skills/SkillRow.svelte
@@ -80,6 +80,11 @@ const gated = $derived(!metrics.unlocked && metrics.source != null);
 		background: color-mix(in srgb, var(--white) 4%, transparent);
 	}
 
+	&:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+
 	&.sel {
 		background: color-mix(in srgb, var(--accent) 12%, transparent);
 		border-color: color-mix(in srgb, var(--accent) 40%, transparent);

--- a/UI/src/routes/login/ModeToggle.svelte
+++ b/UI/src/routes/login/ModeToggle.svelte
@@ -36,5 +36,10 @@ const { mode, onToggle }: Props = $props();
 	font-family: inherit;
 	font-size: inherit;
 	letter-spacing: inherit;
+
+	&:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
 }
 </style>

--- a/UI/src/tests/routes/game/screens/inventory/InventoryGrid.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/InventoryGrid.test.ts
@@ -132,6 +132,14 @@ describe('InventoryGrid', () => {
 		const { container } = render(InventoryGrid, { props: { view: makeView(items, { page: 1 }) } });
 		expect(container.querySelector('.page-indicator')!.textContent).toBe('2 / 2');
 	});
+
+	it('exposes accessible names on the icon-only pager buttons', () => {
+		const items = Array.from({ length: 50 }, (_, i) => makeGridItem(i + 1));
+		const { getByRole } = render(InventoryGrid, { props: { view: makeView(items) } });
+		// The glyphs (‹/›) carry no accessible name, so screen readers rely on the aria-labels.
+		expect(getByRole('button', { name: 'Previous page' })).toBeTruthy();
+		expect(getByRole('button', { name: 'Next page' })).toBeTruthy();
+	});
 });
 
 describe('InventoryGrid — tooltip suppression', () => {


### PR DESCRIPTION
Closes #844

Several real `<button>`s carried hover styling but **no visible keyboard focus indicator**, so keyboard users couldn't see where focus was. The icon-only inventory pager arrows (`‹`/`›`) also exposed **no accessible name** to screen readers.

## What changed

Added a consistent `:focus-visible` ring to each affected button, matching the established treatment already used by `AttributesRadar`, `RewardAffordance`, and `ZoneNav`:

```scss
outline: 2px solid var(--accent);
outline-offset: 2px;
```

The semantic token used is **`var(--accent)`** (declared in `+layout.svelte`) — the same token the existing focus rings use. No colours are hardcoded.

### Buttons fixed
| File | Selector | Notes |
| --- | --- | --- |
| `InventoryGrid.svelte` | `.page-btn` | + `aria-label="Previous page"` / `"Next page"` on the icon-only `‹`/`›` arrows |
| `InventoryToolbar.svelte` | `.chip` | filter chips |
| `InventoryToolbar.svelte` | `.sort-option` | sort toggle — uses `outline-offset: -2px` because the `.sort-toggle` wrapper clips overflow, so an inset ring stays visible |
| `SkillRow.svelte` | `.row` | skill list row |
| `+page.svelte` | `.eye-button` | password reveal toggle |
| `login/ModeToggle.svelte` | `.mode-link` | login/signup mode toggle |

Scope was limited strictly to the focus-visible/aria concerns — no inventory page/filter logic was touched.

## Testing
- Added a focused test to `InventoryGrid.test.ts` asserting the pager buttons expose the `Previous page` / `Next page` accessible names via `getByRole`.
- `npm run check` (svelte-check + a11y): 0 errors, 0 warnings.
- `npx eslint` + `npx prettier --check` on all changed files: clean.
- Full `npx vitest run`: 1934 tests pass across 197 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_