### PR TITLE
Make hook onDestroy cleanup opt-in

### DIFF
--- a/UI/src/components/nav-menu/NavSidebar.svelte
+++ b/UI/src/components/nav-menu/NavSidebar.svelte
@@ -70,7 +70,8 @@ let { screens, active, onNavigate, pinned = $bindable(false) }: Props = $props()
 
 let ping = $state(0);
 
-onPingMeasured((p) => (ping = p));
+// Subscribed during component init, so opt into the hook's onDestroy cleanup.
+onPingMeasured((p) => (ping = p), true);
 
 const groups = [
 	{ key: 'combat', label: 'Combat' },

--- a/UI/src/lib/api/api-socket.ts
+++ b/UI/src/lib/api/api-socket.ts
@@ -153,10 +153,15 @@ export class ApiSocket {
 		return await request.getResponse();
 	}
 
+	/**
+	 * Subscribes to a server-pushed command and returns an unsubscribe function. Mirrors the underlying
+	 * hook's lifecycle contract: `cleanupOnDestroy` defaults off, so only pass `true` from within Svelte
+	 * component init; callers outside it must call the returned unsubscribe themselves.
+	 */
 	public listenCommand<T extends ApiSocketCommand>(
 		commandName: T,
 		action: Action<[IApiSocketResponse<T>]>,
-		cleanupOnDestroy: boolean = true
+		cleanupOnDestroy: boolean = false
 	) {
 		const hook = this.getOrCreateHook(commandName);
 		return hook.onNotified((data: IApiSocketResponse<T>) => action(data), cleanupOnDestroy);

--- a/UI/src/lib/common/hooks.ts
+++ b/UI/src/lib/common/hooks.ts
@@ -46,7 +46,18 @@ export const createHook = <T extends unknown[] = []>() => {
 		}
 	};
 
-	const onNotified = (callback: Action<[...T, Action]>, cleanupOnDestroy: boolean = true) => {
+	/**
+	 * Subscribes `callback` to this hook and returns an unsubscribe function. The hook is a generic
+	 * pub/sub primitive with no framework coupling: by default it wires NO Svelte lifecycle cleanup,
+	 * so a module-level, async, or `setTimeout` caller can subscribe safely and is responsible for
+	 * calling the returned unsubscribe itself.
+	 *
+	 * @param cleanupOnDestroy Opt in to auto-unsubscribe via Svelte's `onDestroy`. ONLY pass `true`
+	 *   from within component initialization (a `.svelte` `<script>` top level or a function reached
+	 *   synchronously from it) — `onDestroy` throws/no-ops outside that window. Callers outside a
+	 *   component context must leave this off and manage teardown via the returned unsubscribe.
+	 */
+	const onNotified = (callback: Action<[...T, Action]>, cleanupOnDestroy: boolean = false) => {
 		const unhook = () => {
 			if (tracker.removed) {
 				return;

--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -41,6 +41,13 @@ export const startGame = () => {
 		socketReplacedUnhook = apiSocket.listenCommand('SocketReplaced', handleSocketReplaced);
 		challengeCompletedUnhook = apiSocket.listenCommand('ChallengeCompleted', handleChallengeCompleted);
 		serverCommandFailedUnhook = apiSocket.listenCommand('ServerCommandFailed', handleServerCommandFailed);
+		// startGame runs during the game page's component init, so unhook these server-pushed-command
+		// listeners on teardown (listenCommand no longer auto-wires onDestroy) — mirroring the engines above.
+		onDestroy(() => {
+			socketReplacedUnhook?.();
+			challengeCompletedUnhook?.();
+			serverCommandFailedUnhook?.();
+		});
 	}
 };
 

--- a/UI/src/routes/+layout.svelte
+++ b/UI/src/routes/+layout.svelte
@@ -35,9 +35,9 @@ onMount(() => {
 });
 
 // Surface otherwise-silent WebSocket failures to the player. Registered during
-// layout init (the root layout lives for the whole app session), so the hook's
-// onDestroy cleanup is valid and a single subscription covers every screen.
-onSocketError((message) => toastError(message));
+// layout init (the root layout lives for the whole app session), so we opt into
+// the hook's onDestroy cleanup; a single subscription covers every screen.
+onSocketError((message) => toastError(message), true);
 
 // Boot gate. On a fresh page load (refresh or deep link) the in-memory game state is gone, so we
 // attempt to restore the session and decide where to land — keeping a fully-restored session on the

--- a/UI/src/tests/common/hooks.test.ts
+++ b/UI/src/tests/common/hooks.test.ts
@@ -80,19 +80,29 @@ describe('createHook', () => {
 		expect(cb).not.toHaveBeenCalled();
 	});
 
-	it('registers onDestroy cleanup by default', () => {
+	it('does not wire onDestroy by default (safe outside component init)', () => {
+		const hook = createHook<[number]>();
+		const cb = vi.fn();
+
+		// Default subscribe must not touch the framework lifecycle, so a module-level / async
+		// caller can subscribe without onDestroy throwing — and still gets a working unsubscribe.
+		const unhook = hook.onNotified(cb);
+		expect(onDestroy).not.toHaveBeenCalled();
+
+		hook.notify(1);
+		expect(cb).toHaveBeenCalledTimes(1);
+
+		unhook();
+		hook.notify(2);
+		expect(cb).toHaveBeenCalledTimes(1);
+	});
+
+	it('wires onDestroy cleanup when opted in (component context)', () => {
 		const hook = createHook<[]>();
-		hook.onNotified(vi.fn());
+		hook.onNotified(vi.fn(), true);
 
 		expect(onDestroy).toHaveBeenCalledTimes(1);
 		expect(onDestroy).toHaveBeenCalledWith(expect.any(Function));
-	});
-
-	it('skips onDestroy when cleanupOnDestroy is false', () => {
-		const hook = createHook<[]>();
-		hook.onNotified(vi.fn(), false);
-
-		expect(onDestroy).not.toHaveBeenCalled();
 	});
 
 	it('nextNotification resolves on next notify', async () => {

--- a/UI/src/tests/lib/engine/engine.test.ts
+++ b/UI/src/tests/lib/engine/engine.test.ts
@@ -111,6 +111,7 @@ import {
 	inventoryManager
 } from '$lib/engine/engine';
 import { activeModal, clearModals, confirmActiveModal } from '$stores/modal.svelte';
+import { onDestroy } from 'svelte';
 import type { IApiSocketResponse } from '$lib/api';
 
 /** Builds a ChallengeCompleted push response with the given reward ids (defaults: no rewards). */
@@ -213,6 +214,19 @@ describe('startGame', () => {
 		void handleSocketReplaced();
 
 		expect(disconnect).toHaveBeenCalledTimes(1);
+	});
+
+	it('unregisters the command listeners on component destroy (listenCommand no longer auto-cleans)', () => {
+		startGame();
+
+		// startGame runs during the game page's init, so it registers an onDestroy that tears the
+		// command listeners down — invoke the captured callback to simulate the page being destroyed.
+		const destroyCallbacks = vi.mocked(onDestroy).mock.calls.map(([fn]) => fn);
+		destroyCallbacks.forEach((fn) => fn());
+
+		expect(unlistenSocketReplaced).toHaveBeenCalledTimes(1);
+		expect(unlistenChallengeCompleted).toHaveBeenCalledTimes(1);
+		expect(unlistenServerCommandFailed).toHaveBeenCalledTimes(1);
 	});
 });
 


### PR DESCRIPTION
Closes #814

## Problem

`createHook`'s `onNotified` (`UI/src/lib/common/hooks.ts`) called Svelte's `onDestroy` by default (`cleanupOnDestroy = true`), coupling a generic pub/sub primitive to the component lifecycle. `onDestroy` only works during component initialization, so any future caller subscribing from a plain module, a `setTimeout`, or an async continuation would silently fail to register cleanup (or throw). The current hot subscribers happen to wire up during component init, so it works today — but it's an implicit, undocumented constraint baked into a primitive that shouldn't know about a framework lifecycle.

## Change — new opt-in API

- `onNotified` now defaults `cleanupOnDestroy` to **`false`** and always **returns an unsubscribe function**. A module-level / async caller can subscribe safely and manages its own teardown via the returned unsubscribe; a component-context caller opts in explicitly by passing `true`.
- `ApiSocket.listenCommand` mirrors the same contract (its `cleanupOnDestroy` default is also flipped to `false`).
- Added a short doc comment on both spelling out the lifecycle expectation, so the constraint is self-documenting rather than implicit.

## Caller audit (no leaks introduced)

I audited **every** subscriber across `UI/src` — all 7 hooks created via `createHook` (`onLogicalUpdate`, `onRenderUpdate`, `onNewEnemyLoaded`, `onBattleStageChanged`, `onSocketError`, `onPingMeasured`, and the per-command `listenCommand` hooks) plus all production and test call sites. Each was handled per its context:

- **Two true component-init subscribers** that relied solely on auto-cleanup now opt in with `, true`: `onSocketError` in `routes/+layout.svelte` and `onPingMeasured` in `components/nav-menu/NavSidebar.svelte`.
- **`startGame` (`lib/engine/engine.ts`)** makes three `listenCommand` calls during the game page's init but had no covering `onDestroy` (it relied on the old `listenCommand` default), so it now registers one that calls the captured unhooks — mirroring the existing `start*Engine` helpers. Runtime behaviour is identical: the listeners are still torn down on page destroy.
- **Engine `start()` / `startLoading()` subscribers** (`battle-engine.ts`, `enemy-manager.ts`) already captured the unhook and tear down via their own `stop()` / `finishLoading` paths, so removing their now-redundant auto-`onDestroy` is behaviour-preserving (and removes a latent throw if those methods were ever called outside init).
- **Test call sites** already passed `false` explicitly, so they are unaffected.

## Tests

- `hooks.test.ts`: replaced the two old default-on lifecycle tests with ones asserting the new contract — default subscribe does **not** wire `onDestroy` (module-context-safe) and returns a working unsubscribe that stops notifications; opting in with `true` wires `onDestroy`.
- `engine.test.ts`: added a test that the command listeners are unregistered when the page's `onDestroy` fires.
- Verified: `npm run check` (0 errors), `eslint` + `prettier --check` on changed files clean, and the **full** `npx vitest run` suite green (197 files, 1934 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_011crtrXCCk4EPsZW5AAk7h4)_