### PR TITLE
Re-guard boss-victory resolution across mid-await transitions

### DIFF
--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -164,6 +164,13 @@ export class EnemyManager {
 		this.bossUnlockedNextZone = false;
 	}
 
+	/** Whether the boss loop is still the active, settled context — false once a stop / retreat / handoff
+	 *  has transitioned us away. A boss-victory resolution re-checks this after each await so a transition
+	 *  landing mid-resolution abandons it instead of clobbering the new state. */
+	private get bossLoopActive(): boolean {
+		return this.started && this.mode === 'boss' && !this.transitioning;
+	}
+
 	private async watchBattleStage(stage: BattleStage) {
 		// While swapping the active battle, ignore the outgoing battle's resolving stage changes.
 		if (this.transitioning) {
@@ -205,8 +212,18 @@ export class EnemyManager {
 	}
 
 	private async resolveBossVictory() {
-		await this.claimVictory();
+		// Snapshot the boss's zone up front: it identifies the zone being cleared and the gate this clear
+		// may unlock, and must stay fixed even if currentZone shifts (a zone-change / retreat) during the
+		// awaits below — otherwise the clear and the "next zone unlocked" check could target the wrong zone.
 		const clearedZoneId = playerManager.currentZone;
+
+		await this.claimVictory();
+		// A stop / retreat that landed during the victory claim has already transitioned us out of the boss
+		// loop; abandon the resolution so we don't resurrect the cleared overlay over the new state.
+		if (!this.bossLoopActive) {
+			return;
+		}
+
 		// A dedicated-boss victory clears its zone; surface the "Cleared" seal immediately while the
 		// authoritative per-zone statistic is reconciled on the next statistics load.
 		statistics.markZoneCleared(clearedZoneId);
@@ -220,6 +237,11 @@ export class EnemyManager {
 		const nextWasLocked = nextZone != null && !isZoneUnlocked(nextZone, completed);
 		if (nextWasLocked) {
 			await playerChallenges.load(true);
+			// Re-guard after the reload for the same reason — a stop / retreat may have landed while the
+			// challenge refresh was in flight.
+			if (!this.bossLoopActive) {
+				return;
+			}
 		}
 		this.bossUnlockedNextZone = nextWasLocked && nextZone != null && isZoneUnlocked(nextZone, completed);
 
@@ -227,7 +249,7 @@ export class EnemyManager {
 
 		await delay(BOSS_VICTORY_OVERLAY_MS);
 		// A retreat / stop during the overlay window already transitioned us elsewhere.
-		if (!this.started || this.mode !== 'boss') {
+		if (!this.bossLoopActive) {
 			return;
 		}
 		this.bossOutcome = undefined;

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -93,6 +93,8 @@ describe('EnemyManager boss mode', () => {
 		h.statistics.markZoneCleared.mockClear();
 		// Default: no zones authored ⇒ no "next zone" to unlock; the unlock tests opt in.
 		h.staticData.zones = undefined;
+		// Reset the current zone (a mid-claim zone-change test mutates it).
+		h.playerManager.currentZone = 3;
 		// Restore the enemy reference record (a missing-id test clears it).
 		h.staticData.enemies = [{ id: 0, name: 'Catacomb Lich', isBoss: true }];
 		h.playerChallenges.isChallengeCompleted.mockReset();
@@ -109,6 +111,21 @@ describe('EnemyManager boss mode', () => {
 	});
 
 	const fireStage = async (stage: number) => h.holder.stageCb?.(stage);
+
+	// Drain the microtask queue (a macrotask boundary) so an in-flight victory handler settles up to its
+	// next awaited point — used to park it on a gated claim/reload before interleaving a transition.
+	const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+	// A DefeatEnemy (claimVictory) response gated on a manual release, so a stop / retreat / zone-change
+	// can be interleaved while the victory claim is still in flight.
+	const gateDefeat = () => {
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => (release = resolve));
+		send.mockImplementation((name: string) =>
+			name === 'DefeatEnemy' ? gate.then(() => defeatResponse) : Promise.resolve(newEnemyResponse)
+		);
+		return release;
+	};
 
 	const zone = (id: number, order: number, unlockChallengeId?: number): IZone => ({
 		id,
@@ -230,6 +247,96 @@ describe('EnemyManager boss mode', () => {
 
 		expect(h.playerChallenges.load).not.toHaveBeenCalled();
 		expect(unlock.value).toBe(false);
+	});
+
+	it('abandons the boss victory when stop() lands during the victory claim', async () => {
+		await manager.challengeBoss();
+		const releaseDefeat = gateDefeat();
+
+		const handled = fireStage(h.BattleStage.Victorious);
+		await flush(); // park the handler on the awaited claim
+
+		manager.stop();
+		releaseDefeat();
+		await handled;
+
+		// The resolution bailed right after the claim: no zone clear, no overlay, no re-challenge.
+		expect(h.statistics.markZoneCleared).not.toHaveBeenCalled();
+		expect(manager.bossOutcome).toBeUndefined();
+		expect(manager.bossUnlockedNextZone).toBe(false);
+		expect(manager.mode).toBe('idle');
+		expect(send).not.toHaveBeenCalledWith('NewEnemy', expect.anything());
+	});
+
+	it('abandons the boss victory when a retreat lands during the victory claim', async () => {
+		await manager.challengeBoss();
+		const releaseDefeat = gateDefeat();
+
+		const handled = fireStage(h.BattleStage.Victorious);
+		await flush();
+
+		const retreated = manager.retreatFromBoss();
+		releaseDefeat();
+		await Promise.all([handled, retreated]);
+
+		// The retreat won: idle loop with a fresh normal enemy, and the victory resolution bailed.
+		expect(manager.mode).toBe('idle');
+		expect(manager.bossOutcome).toBeUndefined();
+		expect(h.statistics.markZoneCleared).not.toHaveBeenCalled();
+		expect(manager.currentEnemy).toEqual(normalInstance);
+	});
+
+	it("clears and unlocks the boss's own zone even if currentZone changes during the victory claim", async () => {
+		// Cleared zone 3; zone 4 (next by order) is gated behind challenge 7 and flips open on the refetch.
+		h.staticData.zones = [zone(3, 0), zone(4, 1, 7)];
+		let gateComplete = false;
+		h.playerChallenges.isChallengeCompleted.mockImplementation((id: number) => id === 7 && gateComplete);
+		h.playerChallenges.load.mockImplementation(() => {
+			gateComplete = true;
+			return Promise.resolve();
+		});
+		const unlock = captureUnlockAtOverlay();
+
+		await manager.challengeBoss();
+		const releaseDefeat = gateDefeat();
+
+		const handled = fireStage(h.BattleStage.Victorious);
+		await flush();
+
+		// Navigate to a different zone while the claim is still resolving.
+		h.playerManager.currentZone = 4;
+		releaseDefeat();
+		await handled;
+
+		// The clear and unlock target zone 3 (the boss that was fought), not the zone navigated to.
+		expect(h.statistics.markZoneCleared).toHaveBeenCalledWith(3);
+		expect(h.statistics.markZoneCleared).not.toHaveBeenCalledWith(4);
+		expect(unlock.value).toBe(true);
+	});
+
+	it('abandons the unlock and overlay when a retreat lands during the challenge reload', async () => {
+		// Zone 4 is gated behind challenge 7 (incomplete), so the victory triggers the challenge reload.
+		h.staticData.zones = [zone(3, 0), zone(4, 1, 7)];
+		h.playerChallenges.isChallengeCompleted.mockReturnValue(false);
+		let releaseLoad!: () => void;
+		const loadGate = new Promise<void>((resolve) => (releaseLoad = resolve));
+		h.playerChallenges.load.mockImplementation(() => loadGate);
+
+		await manager.challengeBoss();
+
+		const handled = fireStage(h.BattleStage.Victorious);
+		await flush(); // the claim settles; the handler parks on the gated challenge reload
+
+		const retreated = manager.retreatFromBoss();
+		releaseLoad();
+		await Promise.all([handled, retreated]);
+
+		// The zone was still marked cleared (the boss died), but the retreat abandoned the unlock + overlay.
+		expect(h.statistics.markZoneCleared).toHaveBeenCalledWith(3);
+		expect(manager.bossUnlockedNextZone).toBe(false);
+		expect(manager.bossOutcome).toBeUndefined();
+		expect(manager.mode).toBe('idle');
+		expect(manager.currentEnemy).toEqual(normalInstance);
 	});
 
 	it('on a boss loss: records it, turns auto-fight off, and returns to the idle loop honoring the cooldown', async () => {


### PR DESCRIPTION
## Summary

`EnemyManager.resolveBossVictory` awaited `claimVictory`, an optional `playerChallenges.load(true)`, then the overlay `delay`, but only re-checked `started`/`mode` **after** the final delay. A `stop()` / retreat / zone-change that landed *during* the victory claim or the challenge reload was left unguarded:

- the resolution could resurrect the Zone-Cleared overlay (`bossOutcome = 'victory'`) over state a stop/retreat had already torn down, and
- `bossUnlockedNextZone` was computed against `currentZone` snapshotted *between* two awaits, so a mid-resolution zone-change could set the "next zone unlocked" gate against the wrong zone.

## How it addresses the issue (#812)

- **Snapshot the cleared zone up front**, before `claimVictory`, so the zone-clear and the unlock check always target the boss that was actually fought — even if `currentZone` shifts during the awaits.
- **Re-guard after each await** (the victory claim and the challenge reload), not only after the final delay, via a new `bossLoopActive` getter (`started && mode === 'boss' && !transitioning`) that mirrors the existing idle-path guard. A transition landing mid-resolution now abandons it instead of clobbering the new state.

## Test plan

New tests in `enemy-manager-boss.test.ts`, each verified to fail against the pre-change implementation and pass after:

- [x] `stop()` lands during the victory claim → resolution bails (no zone clear, no overlay, no re-challenge)
- [x] a retreat lands during the victory claim → idle loop wins with a fresh enemy, resolution bails
- [x] `currentZone` changes during the victory claim → the clear and unlock still target the boss's own zone (snapshot)
- [x] a retreat lands during the challenge reload → unlock + overlay abandoned (zone still marked cleared)
- [x] full frontend unit suite green; lint + prettier clean

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)