### PR TITLE
Resume fights cleanly after navigating to admin and back (#881)

### DIFF
--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -76,6 +76,11 @@ export class BattleEngine {
 			this.logicalUnhook?.();
 			this.renderUnhook?.();
 			this.enemyLoadedUnhook?.();
+			// Tear down to the clean Idle baseline. Leaving a transient stage (e.g. the post-victory
+			// Loading cooldown, or Paused mid boss-swap) would strand the fight on the next start():
+			// the enemy manager only re-fetches from Idle/Victorious/Defeated, while Loading/Paused make
+			// no progress on their own. Resetting here lets a return from the admin screen resume cleanly.
+			this.setBattleStage(Idle);
 		}
 		// A loading countdown is driven by the render engine independently of `running`, so cancel it
 		// unconditionally — otherwise its render hook leaks and the awaiting getNewEnemy path hangs.

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -169,6 +169,28 @@ describe('BattleEngine', () => {
 			engine.stop();
 			expect(engine.running).toBe(false);
 		});
+
+		it('resets the stage to Idle on stop so a restart begins from a clean baseline (#881)', () => {
+			engine.start();
+			// Park in the post-victory Loading cooldown — the stage a navigation to the admin screen most
+			// often interrupts. Without the reset it would stay Loading, stranding the fight on the next start().
+			engine.startLoading(1000);
+			expect(engine.stage).toBe(BattleStage.Loading);
+
+			engine.stop();
+
+			expect(engine.stage).toBe(BattleStage.Idle);
+		});
+
+		it('resets a Paused stage to Idle on stop (a navigation mid boss-swap)', () => {
+			engine.start();
+			engine.pause();
+			expect(engine.stage).toBe(BattleStage.Paused);
+
+			engine.stop();
+
+			expect(engine.stage).toBe(BattleStage.Idle);
+		});
 	});
 
 	describe('battle state transitions', () => {

--- a/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
@@ -153,3 +153,26 @@ describe('EnemyManager.getNewEnemy', () => {
 		expect(manager.currentEnemy).toEqual(enemy);
 	});
 });
+
+describe('EnemyManager.start', () => {
+	let manager: EnemyManager;
+	let sendSocketCommand: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		manager = new EnemyManager();
+		vi.mocked(logMessage).mockClear();
+		sendSocketCommand = vi.spyOn(apiSocket, 'sendSocketCommand');
+		sendSocketCommand.mockReset();
+	});
+
+	it('re-kicks the idle loop from the Idle baseline, e.g. returning from the admin screen (#881)', async () => {
+		// The mocked battleEngine.stage is the Idle baseline that battleEngine.stop() leaves behind. start()
+		// reads it and fetches a fresh enemy rather than leaving the fight frozen on resume.
+		sendSocketCommand.mockResolvedValue(enemyResponse(makeEnemy(5)));
+
+		manager.start();
+
+		await vi.waitFor(() => expect(sendSocketCommand).toHaveBeenCalledWith('NewEnemy', { newZoneId: 3 }));
+		expect(manager.currentEnemy).toEqual(makeEnemy(5));
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #881 — navigating to the admin screen and back left fights frozen ("paused") until a boss was challenged.

## Root cause

Navigating to `/admin` destroys the game page (`routes/game/+page.svelte`), whose `onDestroy` stops the battle and enemy-manager loops. `BattleEngine.stop()` tears down its hooks and resolves any in-flight loading countdown, **but never resets `this.stage`**.

The common trigger is navigating away during the post-victory **`Loading`** cooldown:

1. `stop()` resolves the cooldown promise, but the `getNewEnemy()` that would follow is a no-op because the enemy manager is already stopped (`started = false`).
2. The stage is left at `Loading`.
3. On return, `enemyManager.start()` calls `watchBattleStage(Loading)`, which matches none of its recovery branches (it only re-fetches from `Idle`/`Victorious`/`Defeated`), and `logicalUpdate`/`renderUpdate` only run while `Active` — so the fight never progresses.

Challenging a boss "fixed" it because that path loads a new enemy → `reset()` → `resume()` → `Active`.

## Fix

`BattleEngine.stop()` now resets the stage to `Idle` when it tears the engine down, so the next `start()` always begins from a clean baseline and `enemyManager.start()` reliably re-kicks the idle loop. This also covers the rarer stuck stages (e.g. `Paused` mid boss-swap).

The change is confined to the live engine's lifecycle — it does not touch the shared `battleStep` arithmetic or the `BattleSimulator` parity surface, so backend parity is unaffected.

## Test plan

- [x] `battle-engine.test.ts`: new tests asserting `stop()` resets the stage to `Idle` from both `Loading` (the exact bug stage) and `Paused`.
- [x] `enemy-manager.test.ts`: new test asserting `start()` re-kicks the idle loop (fetches a fresh enemy) from the `Idle` baseline `stop()` leaves behind.
- [x] Full frontend unit suite: 1981 passed.
- [x] `npm run lint` (ESLint + svelte-check): clean, 0 errors / 0 warnings.

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141BzDMg3ysKm8CDamEaFEC

---
_Generated by [Claude Code](https://claude.ai/code/session_0141BzDMg3ysKm8CDamEaFEC)_