### PR TITLE
Treat socket auth-retry budget exhaustion as terminal (#888)

### DIFF
--- a/UI/src/lib/api/api-socket.ts
+++ b/UI/src/lib/api/api-socket.ts
@@ -334,6 +334,13 @@ export class ApiSocket {
 
 		if (this.socketAuthRetries >= MAX_SOCKET_AUTH_RETRIES) {
 			console.warn(`Socket auth retry limit (${MAX_SOCKET_AUTH_RETRIES}) reached; not refreshing again.`);
+			// Budget exhausted: repeated freshly-refreshed tokens are still being rejected at the handshake,
+			// so the session is effectively unrecoverable. Stop the keepalive and route to re-auth (mirroring
+			// the refresh-failure branch below) — otherwise the ping would keep calling ensureSocket on the
+			// still-present access token, reconnecting via a path that never increments socketAuthRetries and
+			// so bypassing this very bound.
+			this.stopPingInterval();
+			handleAuthFailure();
 			return;
 		}
 

--- a/UI/src/tests/lib/api/api-socket.test.ts
+++ b/UI/src/tests/lib/api/api-socket.test.ts
@@ -674,6 +674,39 @@ describe('ApiSocket', () => {
 			warnSpy.mockRestore();
 		});
 
+		it('stops the keepalive and routes to re-auth when the retry budget is exhausted', async () => {
+			vi.useFakeTimers();
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			try {
+				setTokens({ accessToken: 'a', refreshToken: 'r' });
+				vi.mocked(refreshTokens).mockResolvedValue({ accessToken: 'a2', refreshToken: 'r2' });
+
+				apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: 1 });
+				await flushMicrotasks();
+				expect(internals(apiSocket).pingIntervalId).not.toBeNull();
+
+				// Reject every reconnect pre-open so the budget is spent and the next close hits the cap.
+				for (let i = 0; i < 6; i++) {
+					rejectHandshake(lastWs());
+					await flushMicrotasks();
+				}
+
+				// Exhausting the budget is terminal: the keepalive is torn down and the user is routed to
+				// re-auth, rather than being left to silently reconnect.
+				expect(internals(apiSocket).pingIntervalId).toBeNull();
+				expect(handleAuthFailure).toHaveBeenCalled();
+
+				// With the interval cleared, the keepalive can no longer fire to resurrect a socket and
+				// bypass the bound: advancing past the ping cadence opens no new connection.
+				const socketsBefore = socketInstances.length;
+				await vi.advanceTimersByTimeAsync(30000);
+				expect(socketInstances.length).toBe(socketsBefore);
+			} finally {
+				vi.useRealTimers();
+				warnSpy.mockRestore();
+			}
+		});
+
 		it('refills the retry budget only after the connection stays open (stable), not on open', async () => {
 			vi.useFakeTimers();
 			try {

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -58,7 +58,7 @@ A **per-request timeout** (30s) backstops the one case the close handler can't: 
 The single module-singleton socket doubles as a background reconnect: a 10s keepalive ping (also used for latency) re-arms a dropped socket while idle. Because the singleton outlives any one connection, the lifecycle is torn down deliberately:
 
 - **The keepalive is owned, not fire-and-forget** — its handle is cleared on a clean close, an unrecoverable auth failure, and an explicit `disconnect()`, and the ping self-terminates if it fires with no stored token, so it can't resurrect a socket for a logged-out user. `disconnect()` is called from the `SocketReplaced` teardown (which navigates client-side without a reload, so the ping would otherwise reconnect and fight the session that just took over).
-- **Auth-rejection retries are bounded** (5 in a row) so a flapping server can't drive an unbounded refresh/reconnect loop that burns single-use refresh tokens. The budget refills only after a reconnect stays open a stable interval, so a socket that opens then is immediately closed doesn't reset the count every cycle.
+- **Auth-rejection retries are bounded** (5 in a row) so a flapping server can't drive an unbounded refresh/reconnect loop that burns single-use refresh tokens. The budget refills only after a reconnect stays open a stable interval, so a socket that opens then is immediately closed doesn't reset the count every cycle. Exhausting the budget is treated as terminal: the keepalive is torn down and the user is routed to re-auth, so the ping can't keep reconnecting (on the still-present access token) and bypass the bound.
 
 ## Reference Data
 


### PR DESCRIPTION
## Summary

Fixes #888. The socket keepalive ping could bypass the `MAX_SOCKET_AUTH_RETRIES` bound after it was exhausted.

When the handshake keeps being auth-rejected, `handleClose` refreshes the token pair and reconnects, but only `MAX_SOCKET_AUTH_RETRIES` (5) times in a row. On exhaustion it previously just logged and `return`ed **without stopping the keepalive interval**:

```ts
if (this.socketAuthRetries >= MAX_SOCKET_AUTH_RETRIES) {
    console.warn(...);
    return;   // <-- interval left running
}
```

Because the *refresh* succeeded (it's the *handshake* that keeps being rejected), the access token is still present, so `attemptPing` never self-terminates and keeps calling `ensureSocket()` → `openSocket()` every 10s. Those reconnects come from the ping path, which never increments `socketAuthRetries`, so the "5 in a row" cap is bypassed entirely and the unbounded refresh/reconnect loop the bound exists to prevent resumes — burning a single-use refresh token each cycle once the access token expires.

## How it addresses the issue

Treats budget exhaustion as **terminal**: on the cap, call `stopPingInterval()` and `handleAuthFailure()` (route the user to re-auth), mirroring the existing refresh-failure branch and the documented "unrecoverable auth failure tears down the keepalive" lifecycle. With the interval cleared, the keepalive can no longer resurrect a socket and bypass the bound.

This is the issue's recommended primary direction (stop the ping + route to re-auth) rather than the alternative of gating `attemptPing` on the remaining budget — it's consistent with how the sibling unrecoverable-auth paths already behave.

## Changes

- `UI/src/lib/api/api-socket.ts` — on budget exhaustion, stop the keepalive and route to re-auth.
- `UI/src/tests/lib/api/api-socket.test.ts` — new test: budget exhausted → keepalive interval cleared, `handleAuthFailure` invoked, and advancing past the ping cadence opens no new socket.
- `docs/frontend.md` — note that budget exhaustion is terminal in the socket-lifecycle section.

## Test plan

- [x] `npm run test:unit` (`api-socket.test.ts`) — 36 passed (35 existing + 1 new).
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.

Closes #888.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013DNM9w91Ljy9WjKdYk5BAG)_