### PR TITLE
Make equipped-rail Unequip button keyboard/touch-reachable (#892)

### DIFF
--- a/UI/src/routes/game/screens/inventory/EquipSlot.svelte
+++ b/UI/src/routes/game/screens/inventory/EquipSlot.svelte
@@ -38,11 +38,13 @@
 				<CategoryGlyph cat={item.itemCategoryId} color={itemCategoryColor(item.itemCategoryId)} size={40} />
 			{/if}
 			<OverlayButton label={item.name} onActivate={() => onSelect?.(item)} />
-			{#if hover}
-				<button class="unequip" title="Unequip" aria-label="Unequip {item.name}" onclick={() => onUnequip?.(slot.id)}
-					>×</button
-				>
-			{/if}
+			<button
+				class="unequip"
+				class:show={hover}
+				title="Unequip"
+				aria-label="Unequip {item.name}"
+				onclick={() => onUnequip?.(slot.id)}>×</button
+			>
 			{#if item.appliedMods.length}
 				<span class="mod-count">{item.appliedMods.length}◈</span>
 			{/if}
@@ -188,6 +190,15 @@ const handleDrop = (e: DragEvent) => {
 	font-size: 11px;
 	line-height: 1;
 	padding: 0;
+	// Always in the DOM (so keyboard/touch can reach it); revealed on hover or keyboard focus,
+	// mirroring GridSlot's favorite star.
+	opacity: 0;
+	transition: opacity 120ms;
+
+	&.show,
+	&:focus-visible {
+		opacity: 1;
+	}
 }
 
 .mod-count {

--- a/UI/src/tests/routes/game/screens/inventory/EquipSlot.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/EquipSlot.test.ts
@@ -107,23 +107,31 @@ describe('EquipSlot — interactions', () => {
 		expect(overlay!.getAttribute('aria-label')).toBe('Iron Helm');
 	});
 
-	it('shows the unequip button on mouse enter', async () => {
-		const { container } = render(EquipSlot, { props: { slot: helmSlot, item: makeItem() } });
-		await fireEvent.mouseEnter(container.querySelector('.equip-tile')!);
-		expect(container.querySelector('.unequip')).toBeTruthy();
+	it('keeps the unequip button in the DOM as a real <button> so keyboard/touch can reach it', () => {
+		const { container } = render(EquipSlot, { props: { slot: helmSlot, item: makeItem({ name: 'Iron Helm' }) } });
+		const unequip = container.querySelector('.unequip');
+		expect(unequip?.tagName).toBe('BUTTON');
+		expect(unequip!.getAttribute('aria-label')).toBe('Unequip Iron Helm');
 	});
 
-	it('hides the unequip button after mouse leave', async () => {
+	it('reveals the unequip button (adds "show" class) on mouse enter', async () => {
+		const { container } = render(EquipSlot, { props: { slot: helmSlot, item: makeItem() } });
+		await fireEvent.mouseEnter(container.querySelector('.equip-tile')!);
+		expect(container.querySelector('.unequip')!.classList.contains('show')).toBe(true);
+	});
+
+	it('hides the unequip button ("show" removed) on mouse leave but keeps it in the DOM', async () => {
 		const { container } = render(EquipSlot, { props: { slot: helmSlot, item: makeItem() } });
 		await fireEvent.mouseEnter(container.querySelector('.equip-tile')!);
 		await fireEvent.mouseLeave(container.querySelector('.equip-tile')!);
-		expect(container.querySelector('.unequip')).toBeNull();
+		const unequip = container.querySelector('.unequip')!;
+		expect(unequip.classList.contains('show')).toBe(false);
+		expect(unequip).toBeTruthy();
 	});
 
-	it('calls onUnequip with the slot id when the unequip button is clicked', async () => {
+	it('calls onUnequip with the slot id when the unequip button is activated without a prior hover', async () => {
 		const onUnequip = vi.fn();
 		const { container } = render(EquipSlot, { props: { slot: helmSlot, item: makeItem(), onUnequip } });
-		await fireEvent.mouseEnter(container.querySelector('.equip-tile')!);
 		await fireEvent.click(container.querySelector('.unequip')!);
 		expect(onUnequip).toHaveBeenCalledWith(helmSlot.id);
 	});

--- a/UI/src/tests/routes/game/screens/inventory/EquippedRail.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/EquippedRail.test.ts
@@ -140,9 +140,7 @@ describe('EquippedRail — drop handling', () => {
 		const item = makeItem();
 		const view = makeView({ equippedBySlot: { 4: item } as Record<number, Item> });
 		const { container } = render(EquippedRail, { props: { view } });
-		// Hover over the weapon tile to reveal the unequip button.
-		const tiles = container.querySelectorAll('.equip-tile');
-		await fireEvent.mouseEnter(tiles[4]);
+		// The unequip button is always in the DOM (keyboard/touch-reachable), no hover needed.
 		await fireEvent.click(container.querySelector('.unequip')!);
 		expect(view.unequip).toHaveBeenCalledWith(4);
 	});


### PR DESCRIPTION
## Summary

Fixes #892. In `UI/src/routes/game/screens/inventory/EquipSlot.svelte` the unequip control was rendered only while a `hover` flag was true, and `hover` is driven exclusively by `onmouseenter`/`onmouseleave`. Because the button only entered the DOM on mouse hover, **keyboard and touch users could never focus or activate it** from the equipped rail (they could still unequip via the item detail drawer, so it was a degraded affordance rather than a total block).

## How it addresses the issue

Mirror the sibling `GridSlot.svelte` favorite-star pattern, which the issue points to as the correct in-folder precedent:

- Render the `.unequip` button **unconditionally** so it's always in the DOM — tabbable and touch-tappable.
- Drive its appearance with a CSS class (`class:show={hover}`) for the hover-reveal visual, plus a `:focus-visible` reveal so keyboard users see it when it's focused.

This keeps the exact hover behavior for mouse users while making the rail's primary unequip path reachable by keyboard and touch. It also follows the project's documented **accessible card pattern** (`docs/frontend.md` → Accessibility): a presentational tile with a full-bleed `OverlayButton` and higher-`z` secondary action buttons that stay in the DOM.

## Changes

- `UI/src/routes/game/screens/inventory/EquipSlot.svelte` — render the unequip button unconditionally; reveal via `.show` (hover) and `:focus-visible` (keyboard).
- `UI/src/tests/.../EquipSlot.test.ts` — assert the button stays in the DOM as a real labelled `<button>`, is revealed via the `.show` class on hover (removed on leave), and is activatable without a prior hover (keyboard/touch).
- `UI/src/tests/.../EquippedRail.test.ts` — drop the now-unnecessary hover before clicking unequip and fix the stale comment.

## Test plan

- [x] `npx vitest run` for EquipSlot / EquippedRail / GridSlot — 58 passed.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.

## Note for the reviewer

I kept the button always-clickable (opacity-only hide) to match `GridSlot`'s fav-star precedent exactly. If you'd prefer the invisible state to be non-interactive for pointer users, I can add `pointer-events: none` when not `.show`/`:focus-visible` — but that would diverge from the established sibling pattern, so I left it consistent.

Closes #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSdkTs7czu3VGzFF6CLsBc)_