### PR TITLE
Fix CombatFloaters timer leak and duration drift (#893)

### DIFF
--- a/UI/src/routes/game/screens/fight/CombatFloaters.svelte
+++ b/UI/src/routes/game/screens/fight/CombatFloaters.svelte
@@ -2,7 +2,7 @@
      combat events and, for the events striking this card's side, spawns a short-lived number/label
      that pops and drifts up. Colour and label are coded by outcome (crit/dodge/block/hit). Purely
      presentational (aria-hidden) — the combat log is the accessible record of the same events. -->
-<div class="floaters" aria-hidden="true" data-testid={testId}>
+<div class="floaters" aria-hidden="true" data-testid={testId} style:--float-duration="{DURATION_MS}ms">
 	{#each floaters as floater (floater.id)}
 		<div
 			class="floater"
@@ -51,11 +51,16 @@ const FLOAT_ICON: Partial<Record<CombatFloatEvent['kind'], string>> = {
 	block: '/img/Block Reduction.png'
 };
 
-/** Matches the float animation length in `common.scss` (`dmg-rise`), with a small grace margin. */
+/** Drives both the JS removal timer and the CSS `dmg-rise` animation (via the `--float-duration`
+ *  custom property) so the two can't drift; the timer adds a small grace margin over the animation. */
 const DURATION_MS = 1500;
 
 let floaters = $state<Floater[]>([]);
 let nextId = 0;
+// Pending removal timers, tracked so they can be cleared on unmount (no write-after-destroy).
+// Plain Set — pure bookkeeping that's never read reactively (mirrors ToastContainer's removalTimers).
+// eslint-disable-next-line svelte/prefer-svelte-reactivity
+const removalTimers = new Set<ReturnType<typeof setTimeout>>();
 
 const colorFor = (event: CombatFloatEvent): string => {
 	switch (event.kind) {
@@ -100,13 +105,25 @@ const spawn = (event: CombatFloatEvent) => {
 		amount: event.amount === undefined ? '' : formatNum(event.amount),
 		label: labelFor(event.kind)
 	});
-	setTimeout(() => {
+	const timer = setTimeout(() => {
+		removalTimers.delete(timer);
 		floaters = floaters.filter((floater) => floater.id !== id);
 	}, DURATION_MS + 80);
+	removalTimers.add(timer);
 };
 
-// Subscribe client-side only (the engine emits nothing during SSR); onMount's return is the cleanup.
-onMount(() => onCombatFloat(spawn));
+// Subscribe client-side only (the engine emits nothing during SSR); the cleanup unsubscribes and
+// clears any pending removal timers so none fire (and write the array) after the component is gone.
+onMount(() => {
+	const unsubscribe = onCombatFloat(spawn);
+	return () => {
+		unsubscribe();
+		for (const timer of removalTimers) {
+			clearTimeout(timer);
+		}
+		removalTimers.clear();
+	};
+});
 </script>
 
 <style lang="scss">
@@ -125,7 +142,7 @@ onMount(() => onCombatFloat(spawn));
 	font-weight: 700;
 	white-space: nowrap;
 	text-shadow: 0 1px 4px color-mix(in srgb, var(--black) 85%, transparent);
-	animation: dmg-rise 1500ms cubic-bezier(0.18, 0.7, 0.28, 1) forwards;
+	animation: dmg-rise var(--float-duration) cubic-bezier(0.18, 0.7, 0.28, 1) forwards;
 
 	&.crit {
 		text-shadow:

--- a/UI/src/tests/routes/game/screens/fight/CombatFloaters.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/CombatFloaters.test.ts
@@ -6,12 +6,15 @@ import type { CombatFloatEvent } from '$lib/engine';
 // CombatFloaters subscribes to the engine's combat-float hook at init. Capture the registered
 // callback so the test can drive events directly; the real `$lib/common` formatNum is used.
 const { onCombatFloat, captured } = vi.hoisted(() => {
-	const captured = { emit: undefined as ((event: CombatFloatEvent) => void) | undefined };
+	const captured = {
+		emit: undefined as ((event: CombatFloatEvent) => void) | undefined,
+		unsubscribe: vi.fn()
+	};
 	return {
 		captured,
 		onCombatFloat: vi.fn((callback: (event: CombatFloatEvent) => void) => {
 			captured.emit = callback;
-			return () => {};
+			return captured.unsubscribe;
 		})
 	};
 });
@@ -28,6 +31,7 @@ const emit = (event: CombatFloatEvent) => {
 afterEach(() => {
 	cleanup();
 	captured.emit = undefined;
+	captured.unsubscribe.mockClear();
 	vi.useRealTimers();
 });
 
@@ -102,5 +106,31 @@ describe('CombatFloaters', () => {
 		vi.advanceTimersByTime(1600);
 		flushSync();
 		expect(getByTestId('enemy-floaters').querySelectorAll('.floater')).toHaveLength(0);
+	});
+
+	it('drives the CSS animation duration from the JS constant via a custom property', () => {
+		const { getByTestId } = render(CombatFloaters, { props: { side: 'enemy', testId: 'enemy-floaters' } });
+		// The removal timer (DURATION_MS) and the dmg-rise animation read one source so they can't drift.
+		expect(getByTestId('enemy-floaters').style.getPropertyValue('--float-duration')).toBe('1500ms');
+	});
+
+	it('clears pending removal timers and unsubscribes on unmount (no write-after-destroy)', () => {
+		vi.useFakeTimers();
+		const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+		const { unmount } = render(CombatFloaters, { props: { side: 'enemy', testId: 'enemy-floaters' } });
+		// Spawn a few floaters so there are pending removal timers, then tear the component down.
+		emit({ target: 'enemy', kind: 'hit', amount: 1 });
+		emit({ target: 'enemy', kind: 'crit', amount: 2 });
+
+		unmount();
+
+		expect(captured.unsubscribe).toHaveBeenCalledTimes(1);
+		// Both pending removal timers are cleared, so neither callback fires after the component is gone.
+		expect(clearSpy).toHaveBeenCalledTimes(2);
+		expect(() => {
+			vi.advanceTimersByTime(1600);
+			flushSync();
+		}).not.toThrow();
+		clearSpy.mockRestore();
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #893. `CombatFloaters.svelte` scheduled a `setTimeout` per spawned floater to remove it from the reactive array, but never tracked or cleared those handles — the `onMount` cleanup only returned the `onCombatFloat` unsubscribe. Since the layer spawns many floaters per second across up to three combatant cards, navigating away mid-fight left a burst of pending callbacks that fired after the component was destroyed, each writing the orphaned `$state` array (a timer leak + write-after-unmount). Separately, the floater lifetime was a magic number duplicated in two places that could silently desync: the JS `DURATION_MS = 1500` (removal) and the CSS `animation: dmg-rise 1500ms`.

## How it addresses the issue

- **Timer leak / write-after-unmount** — track each removal `setTimeout` handle in a `Set`; each timer removes its own handle when it fires (so the set stays bounded during a long fight), and the `onMount` cleanup now unsubscribes **and** clears every still-pending timer, so none fire after the component is gone. The `Set` is plain (not `SvelteSet`) because it's pure bookkeeping never read reactively — the same precedent as `ToastContainer`'s `removalTimers`, with the matching `eslint-disable` line.
- **Duration drift** — the `.floaters` container now sets a `--float-duration` custom property from `DURATION_MS`, and the `dmg-rise` animation consumes `var(--float-duration)`, so the JS removal timer and the CSS animation read one source and can't drift. The timer still adds its small grace margin (`DURATION_MS + 80`).

## Note for the reviewer

The issue's third bullet (remove the "placeholder empty `.floater-icon` box shipped on every combat number") looks **stale**: the icon is now a real, implemented feature — `FLOAT_ICON` maps crit/dodge/block to actual art and the template renders the `<img>` only `{#if floater.icon}`, so a plain hit ships no icon box (the existing test asserts exactly this). I left the icon rendering untouched rather than remove a working feature. Happy to revisit if you intended something different here.

## Changes

- `UI/src/routes/game/screens/fight/CombatFloaters.svelte` — track + clear removal timers on unmount; drive the CSS animation duration from `DURATION_MS` via `--float-duration`.
- `UI/src/tests/.../CombatFloaters.test.ts` — assert the `--float-duration` custom property mirrors the JS constant, and that unmount unsubscribes and clears every pending removal timer (so no callback fires after destroy). The shared mock now exposes the unsubscribe spy.

## Test plan

- [x] `npx vitest run` for `CombatFloaters.test.ts` — 9 passed (7 existing + 2 new).
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.

Closes #893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JummTpxjGZ3hRCbETDNzYv)_