### PR TITLE
Stop the "by entity" dossier from chasing the search box (#894)

### DIFF
--- a/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
+++ b/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
@@ -307,10 +307,12 @@ export class StatisticsView {
 		return q ? list.filter((e) => e.name.toLowerCase().includes(q)) : list;
 	});
 
-	/** The resolved selected entity (falls back to the first match / first item). */
+	/** The resolved selected entity. When `entId` doesn't resolve to a concrete
+	 *  entity it falls back to the head of the *unfiltered* list — never the
+	 *  search-filtered list — so typing in the picker narrows the list without
+	 *  moving the active dossier. */
 	readonly selectedEntity = $derived.by(
-		() =>
-			this.data.entity(this.entKind, this.entId) ?? this.filteredEntities[0] ?? this.data.entityList(this.entKind)[0]
+		() => this.data.entity(this.entKind, this.entId) ?? this.data.entityList(this.entKind)[0]
 	);
 
 	/** Every statistic referencing the selected entity. */

--- a/UI/src/tests/routes/game/screens/stats/statistics-view.test.ts
+++ b/UI/src/tests/routes/game/screens/stats/statistics-view.test.ts
@@ -228,6 +228,29 @@ describe('StatisticsView navigation', () => {
 		view.setQuery('gob');
 		expect(view.filteredEntities.map((e) => e.id)).toEqual([1]);
 	});
+
+	it('keeps the resolved selection stable while the search query narrows the list', () => {
+		const view = seededView();
+		view.goEntity('enemy', 1);
+		// A concrete selection must not move as the picker filters, even when the
+		// query excludes the selected entity from the filtered list.
+		view.setQuery('bat');
+		expect(view.filteredEntities.map((e) => e.id)).toEqual([0]);
+		expect(view.selectedEntity?.id).toBe(1);
+	});
+
+	it('falls back to the unfiltered list head (not the search box) when entId is unresolved', () => {
+		const view = seededView();
+		view.mode = 'entity';
+		// An entId that resolves to no concrete entity for the kind (e.g. initial
+		// state or a kind-switch landing on a missing id).
+		view.entId = 99;
+		expect(view.selectedEntity?.id).toBe(0);
+		// Narrowing the picker to a different entity must not drag the dossier along.
+		view.setQuery('gob');
+		expect(view.filteredEntities.map((e) => e.id)).toEqual([1]);
+		expect(view.selectedEntity?.id).toBe(0);
+	});
 });
 
 describe('StatisticsView data wiring', () => {


### PR DESCRIPTION
## Summary

Fixes #894. In `statistics-view.svelte.ts` the `selectedEntity` derivation fell back through `this.filteredEntities[0]`:

```ts
this.data.entity(this.entKind, this.entId) ?? this.filteredEntities[0] ?? this.data.entityList(this.entKind)[0]
```

`filteredEntities` depends on the search `query`, and the resolved fallback was never written back to `entId`. So whenever `entId` didn't resolve to a concrete entity (the initial state, or a `switchKind` landing on an id that doesn't exist for the new kind), the displayed dossier and the highlighted picker row re-pointed to a different entity on every keystroke as the filter narrowed — the dossier appeared to "chase" the search box.

## How it addresses the issue

Of the two directions the issue suggests, I took **fall back to the head of the unfiltered list** rather than writing the resolved fallback back into `entId`. The write-back option would require a side-effecting state mutation inside a `$derived`, which is a Svelte anti-pattern (derivations should be pure); dropping the query-dependent middle term keeps the derivation pure and is strictly simpler.

The final fallback `this.data.entityList(this.entKind)[0]` was already the unfiltered head, so the fix is just removing the `filteredEntities[0]` term. Now:

- A concrete selection stays put as the picker filters — even when the query excludes the selected entity from the list (the picker simply highlights no row, the dossier is unchanged).
- An unresolved `entId` falls back to the unfiltered head and stays there regardless of the query.

## Changes

- `UI/src/routes/game/screens/stats/statistics-view.svelte.ts` — drop the query-dependent `filteredEntities[0]` fallback from `selectedEntity`; update the doc comment.
- `UI/src/tests/routes/game/screens/stats/statistics-view.test.ts` — two regression tests: a concrete selection stays stable while a query narrows the list (even excluding it), and an unresolved `entId` falls back to the unfiltered head rather than the search box.

## Test plan

- [x] `npx vitest run` for `statistics-view.test.ts` — 25 passed (23 existing + 2 new). Full stats screen suite — 41 passed.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.

Closes #894.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4DWGV3Fj8E1HKhUgxpdSp)_