### PR TITLE
Throw from ApiResponse.data whenever an errorMessage is present (#895)

### DIFF
--- a/UI/src/lib/api/api-response.ts
+++ b/UI/src/lib/api/api-response.ts
@@ -38,8 +38,14 @@ export class ApiResponse<T extends ApiResponseType> {
 		return this.status >= 200 && this.status < 300 && !this.responseJson.errorMessage;
 	}
 
+	/**
+	 * The parsed response payload. Throws whenever the body carries an `errorMessage` — regardless of
+	 * whether `data` is also populated — so the throw-on-error `ApiRequest.get`/`post` helpers can never
+	 * treat a business failure as success. This keys off `errorMessage` alone, matching `ok` and the
+	 * socket layer's `fetchSocketData`.
+	 */
 	public get data(): T {
-		if (!this.responseJson.data && this.responseJson.errorMessage) {
+		if (this.responseJson.errorMessage) {
 			throw new Error(this.error);
 		} else {
 			return this.responseJson.data;

--- a/UI/src/tests/lib/api/api-response.test.ts
+++ b/UI/src/tests/lib/api/api-response.test.ts
@@ -39,6 +39,15 @@ describe('ApiResponse', () => {
 			expect(() => response.data).toThrow('Not found');
 		});
 
+		it('throws when both data and errorMessage are present (business failure is not swallowed)', () => {
+			const raw = makeRaw({
+				responseText: JSON.stringify({ data: { id: 1, name: 'Test' }, errorMessage: 'Not found' })
+			});
+			const response = new ApiResponse(raw);
+
+			expect(() => response.data).toThrow('Not found');
+		});
+
 		it('returns null data when no errorMessage', () => {
 			const raw = makeRaw({
 				responseText: JSON.stringify({ data: null })


### PR DESCRIPTION
## Summary

Fixes #895. In `UI/src/lib/api/api-response.ts`, the `data` getter only threw when `data` was falsy **and** an `errorMessage` was present:

```ts
if (!this.responseJson.data && this.responseJson.errorMessage) {
```

So a response carrying **both** a populated `data` and an `errorMessage` returned the data and never threw — letting the throw-on-error static `ApiRequest.get`/`post` helpers silently treat a business failure as success. This also disagreed with the sibling `ok` accessor (which keys off `errorMessage` alone) and the socket layer's `fetchSocketData` (which throws on any `response.error`).

## How it addresses the issue

Takes the issue's suggested direction: key the guard off `errorMessage` alone, so `data` throws whenever an error message is present regardless of `data` truthiness. This brings `data` in line with `ok` and the socket path. The existing `null data + errorMessage` and `null data + no errorMessage` behaviors are unchanged; only the previously-swallowed both-present case now throws.

As noted in the issue, the backend's `ApiResponse` envelope returns null data alongside an error in practice, so this was a latent inconsistency rather than an actively-firing bug — the fix makes the contract robust if that ever changes.

## Changes

- `UI/src/lib/api/api-response.ts` — guard `data` on `errorMessage` alone; add a doc comment explaining the throw-on-error contract.
- `UI/src/tests/lib/api/api-response.test.ts` — regression test asserting `data` throws when both `data` and `errorMessage` are present.

## Test plan

- [x] `npx vitest run src/tests/lib/api/api-response.test.ts` — 18 passed (17 existing + 1 new).
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.

Closes #895.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ugPNGbS2zZUtY9xRgers8)_