### PR TITLE
Fix misleading 0 progress for "at most" challenge with no statistic data

### DIFF
--- a/Game.Core.Tests/Progress/PlayerChallengeTests.cs
+++ b/Game.Core.Tests/Progress/PlayerChallengeTests.cs
@@ -105,6 +105,18 @@ namespace Game.Core.Tests.Progress
         }
 
         [Fact]
+        public void UpdateProgress_AtMost_NoData_LeavesProgressUntouched()
+        {
+            // The 0 placeholder for an absent statistic must not be stored: for an "at most" goal a 0
+            // reads as the best possible progress, so writing it would surface a misleading 0 best.
+            var playerChallenge = MakePlayerChallenge(goal: 10, type: EChallengeType.TimeTrial, initialProgress: 42m);
+
+            playerChallenge.UpdateProgress(0m, hasData: false);
+
+            Assert.Equal(42m, playerChallenge.Progress);
+        }
+
+        [Fact]
         public void UpdateProgress_AtMost_GenuineZeroValue_Completes()
         {
             // A recorded 0 (e.g. an instant victory) is a legitimate value at or below the goal, so it
@@ -117,7 +129,7 @@ namespace Game.Core.Tests.Progress
             Assert.NotNull(playerChallenge.CompletedAt);
         }
 
-        private static PlayerChallenge MakePlayerChallenge(decimal goal, EChallengeType type = EChallengeType.EnemiesKilled)
+        private static PlayerChallenge MakePlayerChallenge(decimal goal, EChallengeType type = EChallengeType.EnemiesKilled, decimal initialProgress = 0m)
         {
             var challenge = new Challenge
             {
@@ -128,7 +140,7 @@ namespace Game.Core.Tests.Progress
                 ProgressGoal = goal,
             };
 
-            return new PlayerChallenge(challenge, progress: 0m, completed: false);
+            return new PlayerChallenge(challenge, initialProgress, completed: false);
         }
     }
 }

--- a/Game.Core/Progress/PlayerChallenge.cs
+++ b/Game.Core/Progress/PlayerChallenge.cs
@@ -20,8 +20,9 @@ namespace Game.Core.Progress
 
         /// <param name="hasData">
         /// Whether the tracked statistic has a recorded value. "At most" goals only count when there is
-        /// data: with none, the goal is unmet regardless of the 0 placeholder <paramref name="value"/>,
-        /// while a genuine 0 (<paramref name="hasData"/> true) can satisfy it.
+        /// data: with none, neither <see cref="Progress"/> nor completion is touched (the 0 placeholder
+        /// <paramref name="value"/> is not a real best), while a genuine 0 (<paramref name="hasData"/> true)
+        /// can satisfy the goal.
         /// </param>
         public void UpdateProgress(decimal value, bool hasData)
         {
@@ -33,12 +34,16 @@ namespace Game.Core.Progress
             if (Challenge.Type.GoalComparison is EChallengeGoalComparison.AtMost)
             {
                 // "At most" goals (e.g. time trials) are met by reaching a value at or below the goal.
-                // Completion keys off whether the statistic has data, never off a magic 0 — see hasData.
-                Progress = value;
-                if (hasData && value <= Challenge.ProgressGoal)
+                // With no data the 0 placeholder is not a real best, so Progress is left untouched —
+                // storing it would surface a misleading 0 (the best possible) to the client.
+                if (hasData)
                 {
-                    Completed = true;
-                    CompletedAt = DateTime.UtcNow;
+                    Progress = value;
+                    if (value <= Challenge.ProgressGoal)
+                    {
+                        Completed = true;
+                        CompletedAt = DateTime.UtcNow;
+                    }
                 }
             }
             else


### PR DESCRIPTION
## Summary
`PlayerChallenge.UpdateProgress` wrote `Progress = value` unconditionally on the `AtMost` branch, so when the backing statistic had no data the `0m` placeholder from `TryGetStatisticValue` was stored as `Progress`. For an "at most" goal (e.g. a `FastestVictory` time trial — "win within N seconds") a `0` reads as the *best possible* progress, so the client showed a 0-second best for a player who had never won a qualifying battle. Completion was already correctly gated on `hasData`, so only the stored value was wrong.

The fix guards the `Progress` assignment (and the completion check) behind `if (hasData)` so progress is left untouched when there is no recorded statistic. The `AtLeast` branch was already correct and is unchanged.

Closes #903

## Testing
- `dotnet build Game.Core/Game.Core.csproj` — succeeded, 0 warnings/errors
- `dotnet test Game.Core.Tests/Game.Core.Tests.csproj` — 631 passed, 0 failed
- Added `UpdateProgress_AtMost_NoData_LeavesProgressUntouched`, asserting the placeholder `0` does not overwrite an existing `Progress` (seeds an initial progress of `42m` so the assertion distinguishes "untouched" from a coincidental default `0`). Existing no-data, with-data, and genuine-`0` paths remain covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNEKedmVgmmg6H9jAu7yxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNEKedmVgmmg6H9jAu7yxm)_