### PR TITLE
Challenges screen now reflects live ChallengeCompleted pushes (#908)

### DIFF
--- a/UI/src/routes/game/screens/challenges/Challenges.svelte
+++ b/UI/src/routes/game/screens/challenges/Challenges.svelte
@@ -105,9 +105,9 @@ onMount(async () => {
 		// Don't conflate a failed load with a genuine no-progress result — a
 		// dropped fetch would otherwise render every challenge as zero progress.
 		toastError('Your challenge progress could not be loaded. Please try again later.');
-	} else {
-		view.playerChallenges = playerChallenges.all;
 	}
+	// The view-model reads progress straight from the shared store, so a live `ChallengeCompleted`
+	// push (markCompleted) flips an open card reactively — no manual snapshot to keep in sync.
 	view.loading = false;
 });
 </script>

--- a/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
+++ b/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
@@ -18,7 +18,7 @@ import {
 	resolveUnlockReward,
 	zonesUnlockedBy
 } from '$lib/common';
-import { staticData } from '$stores';
+import { playerChallenges, staticData } from '$stores';
 import { challengeTypeUnit } from './challenge-meta';
 
 /* ─── Types ──────────────────────────────────────────────────────────── */
@@ -281,15 +281,15 @@ export class ChallengesView {
 	/** Selected rail entry: a type id, or `'all'` for the overview. */
 	selectedType = $state<EChallengeType | 'all'>('all');
 	sort = $state<SortKey>('progress');
-	playerChallenges = $state<IPlayerChallenge[]>([]);
 	loading = $state(true);
 	/** A failed `GetPlayerChallenges` load — kept distinct from a genuine
 	 *  no-progress result so it isn't shown as a wall of zero-progress cards. */
 	error = $state(false);
 
-	// Rebuilt from reactive deps on each change (a lookup, not mutable held state).
+	// Rebuilt from reactive deps on each change (a lookup, not mutable held state). Reads progress
+	// straight from the shared store so a live `markCompleted()` push flips a card without a remount.
 	// eslint-disable-next-line svelte/prefer-svelte-reactivity
-	readonly #progressById = $derived(new Map(this.playerChallenges.map((pc) => [pc.challengeId, pc])));
+	readonly #progressById = $derived(new Map(playerChallenges.all.map((pc) => [pc.challengeId, pc])));
 
 	readonly all = $derived.by<ChallengeVM[]>(() => {
 		// Build the type→comparison lookup once per rebuild instead of scanning the list per challenge.

--- a/UI/src/tests/routes/game/screens/challenges/challenges-view.svelte.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/challenges-view.svelte.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { flushSync } from 'svelte';
 import {
 	EAttribute,
 	EChallengeGoalComparison,
@@ -14,10 +15,11 @@ import {
 	type IPlayerChallenge
 } from '$lib/api';
 
-// The view-model reads everything from the reference-data store; mock it with a
-// small fixture (collections are indexed by id, matching the real store).
-// `vi.hoisted` keeps the object initialised before the hoisted vi.mock factory.
-const { staticData } = vi.hoisted(() => ({
+// The view-model reads the challenge catalogue from the reference-data store and the player's
+// progress from the playerChallenges store. Mock staticData with a small fixture, but keep the REAL
+// playerChallenges store (only its socket fetch stubbed) so the view-model is exercised against the
+// genuine reactive `$state` — a live `markCompleted()` push then re-runs its `$derived` chain.
+const { staticData, mockFetchSocket } = vi.hoisted(() => ({
 	staticData: {
 		challenges: [] as IChallenge[],
 		challengeTypes: [] as IChallengeType[],
@@ -26,10 +28,20 @@ const { staticData } = vi.hoisted(() => ({
 		enemies: [] as { id: number; name: string }[],
 		zones: [] as { id: number; name: string; order?: number; unlockChallengeId?: number }[],
 		skills: [] as { id: number; name: string }[]
-	}
+	},
+	mockFetchSocket: vi.fn()
 }));
 
-vi.mock('$stores', () => ({ staticData }));
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$lib/api')>();
+	return { ...actual, fetchSocketData: mockFetchSocket };
+});
+vi.mock('$stores', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$stores')>();
+	return { ...actual, staticData };
+});
+
+import { playerChallenges } from '$stores';
 
 import {
 	ChallengesView,
@@ -293,9 +305,15 @@ describe('ChallengesView', () => {
 		{ challengeId: 9, progress: 0, completed: false }
 	];
 
+	beforeEach(async () => {
+		// Seed the real store through its socket fetch so the view-model reads genuine reactive state.
+		playerChallenges.reset();
+		mockFetchSocket.mockResolvedValue(player.map((p) => ({ ...p })));
+		await playerChallenges.load(true);
+	});
+
 	it('builds the reactive view-model from store + player progress', () => {
 		const view = new ChallengesView();
-		view.playerChallenges = player;
 		expect(view.all).toHaveLength(3);
 		expect(view.summary).toMatchObject({ total: 3, done: 1 });
 		expect(view.groups.map((g) => g.typeId)).toEqual([EChallengeType.EnemiesKilled, EChallengeType.TimeTrial]);
@@ -303,7 +321,6 @@ describe('ChallengesView', () => {
 
 	it('switches the detail pane and resorts when selection/sort change', () => {
 		const view = new ChallengesView();
-		view.playerChallenges = player;
 
 		expect(view.selectedGroup).toBeNull(); // overview by default
 		view.select(EChallengeType.EnemiesKilled);
@@ -312,5 +329,33 @@ describe('ChallengesView', () => {
 
 		view.setSort('name');
 		expect(view.detail.map((c) => c.name)).toEqual(['First Blood', 'Goblin Bane']);
+	});
+
+	it('reflects a live markCompleted() push without re-seeding the view (issue #908)', () => {
+		const view = new ChallengesView();
+		view.select(EChallengeType.EnemiesKilled);
+
+		let detailIds: number[] = [];
+		let summaryDone = -1;
+		const cleanup = $effect.root(() => {
+			$effect(() => {
+				detailIds = view.detail.map((c) => c.id);
+				summaryDone = view.summary.done;
+			});
+		});
+
+		flushSync();
+		// Challenge 2 starts in progress (active) and sorts ahead of the completed challenge 1.
+		expect(detailIds).toEqual([2, 1]);
+		expect(summaryDone).toBe(1);
+
+		// A live ChallengeCompleted push on the shared store must flip the card without a remount.
+		playerChallenges.markCompleted(2);
+		flushSync();
+		expect(summaryDone).toBe(2);
+		// Now both are done; the progress sort moves the freshly-completed challenge to the done bucket.
+		expect(detailIds).toEqual([1, 2]);
+
+		cleanup();
 	});
 });


### PR DESCRIPTION
## Summary
The Challenges screen snapshotted `playerChallenges.all` into a plain `$state` field once on mount, so a live `ChallengeCompleted` server push — which calls `markCompleted()` on the global store — never flipped an open screen's cards until the user navigated away and back.

This derives the view-model's progress lookup straight from the reactive store getter (`playerChallenges.all`) and drops the one-shot `view.playerChallenges = ...` sync on the screen. A live completion now reveals the reward and re-sorts the card reactively, matching the documented "Completion arrives live, not just on reload" behavior in `docs/frontend-screens.md`. All sorting/filtering and the overview summary stay reactive since they derive off the same `#progressById` lookup.

Closes #908

## Testing
- `npm run check` — 0 errors / 0 warnings
- `npm run lint` — clean
- `npm run test:unit -- --run` — 204 files, 2031 tests passing (added a view-model test asserting a live `markCompleted()` push flips a card and re-sorts without remounting)

## Note
Lightly overlaps #898, which retokenizes hard-coded `font-family` literals in this same `Challenges.svelte`. This PR deliberately touches only the reactivity (a 3-line `onMount` edit + the view-model getter), so the two should conflict at most trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNEKedmVgmmg6H9jAu7yxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNEKedmVgmmg6H9jAu7yxm)_