### PR TITLE
Frontend perf: memoize Attributes per-point yields and hoist Skills challenge lookup (#897)

### DIFF
--- a/UI/src/routes/game/screens/attributes/TheoryRow.svelte
+++ b/UI/src/routes/game/screens/attributes/TheoryRow.svelte
@@ -67,7 +67,8 @@ const attrTip = getAttributeTooltip();
 const value = $derived(view.values[i]);
 const saved = $derived(view.savedValues[i]);
 const changed = $derived(value !== saved);
-const yields = $derived(perPointYields(i, view.values));
+// O(1) lookup of the constant per-point yields, memoised by index in the view model.
+const yields = $derived(perPointYields(i));
 
 // Allocation bar segments are scaled against the same radar maximum so the bar
 // and the radar agree visually.

--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -94,12 +94,16 @@ export function deriveStats(coreValues: number[]): Record<number, number> {
 }
 
 /** The marginal change to each surfaced derived stat from +1 in the core
- *  attribute at `coreIndex`. Auto-derived by diffing the real formulas, so it
- *  stays correct if those formulas change. */
-export function perPointYields(coreIndex: number, coreValues: number[]): PerPointYield[] {
-	const bumped = [...coreValues];
-	bumped[coreIndex] = (bumped[coreIndex] ?? 0) + 1;
-	const before = deriveStats(coreValues);
+ *  attribute at `coreIndex`, computed by diffing the real formulas against a
+ *  neutral baseline. The surfaced derived stats are linear in the core
+ *  attributes (purely additive modifiers — see `STATIC_ATTRIBUTE_MODIFIERS`), so
+ *  this marginal delta is constant per index and independent of the current
+ *  allocation; it is auto-derived so it stays correct if those formulas change. */
+function computePerPointYields(coreIndex: number): PerPointYield[] {
+	const baseline = CORE_ATTRIBUTES.map(() => 0);
+	const bumped = [...baseline];
+	bumped[coreIndex] = 1;
+	const before = deriveStats(baseline);
 	const after = deriveStats(bumped);
 	const yields: PerPointYield[] = [];
 	for (const def of DERIVED_STATS) {
@@ -111,17 +115,17 @@ export function perPointYields(coreIndex: number, coreValues: number[]): PerPoin
 	return yields;
 }
 
-/** The derived stats a core attribute feeds — intrinsic to the formulas, so it
- *  is computed once from a neutral baseline. */
-const CORE_FEEDS: EAttribute[][] = CORE_ATTRIBUTES.map((_, i) =>
-	perPointYields(
-		i,
-		CORE_ATTRIBUTES.map(() => 1)
-	).map((y) => y.id)
-);
+/** Per-point yields memoised by core index, computed once from the (constant)
+ *  marginal formulas rather than re-derived per allocation change. */
+const PER_POINT_YIELDS: PerPointYield[][] = CORE_ATTRIBUTES.map((_, i) => computePerPointYields(i));
+
+/** The constant marginal yields for the core attribute at `coreIndex`. */
+export function perPointYields(coreIndex: number): PerPointYield[] {
+	return PER_POINT_YIELDS[coreIndex] ?? [];
+}
 
 export function feedsFor(coreIndex: number): EAttribute[] {
-	return CORE_FEEDS[coreIndex] ?? [];
+	return perPointYields(coreIndex).map((y) => y.id);
 }
 
 /** Maps a pointer position (in the radar's SVG user space) to the attribute

--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -193,7 +193,17 @@ export class SkillsView {
 	readonly metricsById = $derived.by(() => {
 		const attrs = this.battleAttributes;
 		const cdMultiplier = cooldownMultiplier(attrs);
-		const challenges = staticData.challenges ?? [];
+		// Index the rewarding challenge by skill id once, so the per-skill source
+		// lookup stays O(1) rather than scanning every challenge per skill.
+		// A transient memo local to the derivation, not reactive state.
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const challengeBySkillId = new Map<number, IChallenge>();
+		for (const challenge of staticData.challenges ?? []) {
+			// First-match wins, mirroring the previous `find`, when two challenges reward the same skill.
+			if (challenge.rewardSkillId != null && !challengeBySkillId.has(challenge.rewardSkillId)) {
+				challengeBySkillId.set(challenge.rewardSkillId, challenge);
+			}
+		}
 		const byId: Record<number, SkillMetrics> = {};
 		for (const skill of this.catalogue) {
 			byId[skill.id] = {
@@ -202,7 +212,7 @@ export class SkillsView {
 				rawDamage: calculateSkillDamage(skill, attrs),
 				cooldown: cdMultiplier > 0 ? skill.cooldownMs / 1000 / cdMultiplier : skill.cooldownMs / 1000,
 				contributions: skillContributions(skill, attrs),
-				source: challenges.find((c) => c.rewardSkillId === skill.id)
+				source: challengeBySkillId.get(skill.id)
 			};
 		}
 		return byId;

--- a/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
@@ -88,33 +88,60 @@ describe('deriveStats', () => {
 });
 
 describe('perPointYields', () => {
-	const base = CORE_ATTRIBUTES.map(() => 5);
-
 	it('STR yields +5 Max Health per point', () => {
-		expect(perPointYields(idx.str, base)).toEqual([{ id: EAttribute.MaxHealth, delta: 5 }]);
+		expect(perPointYields(idx.str)).toEqual([{ id: EAttribute.MaxHealth, delta: 5 }]);
 	});
 
 	it('END yields +20 Max Health and +1 Defense per point', () => {
-		expect(perPointYields(idx.end, base)).toEqual([
+		expect(perPointYields(idx.end)).toEqual([
 			{ id: EAttribute.MaxHealth, delta: 20 },
 			{ id: EAttribute.Defense, delta: 1 }
 		]);
 	});
 
 	it('AGI yields +0.5 Defense and +0.004 Cooldown Recovery per point', () => {
-		expect(perPointYields(idx.agi, base)).toEqual([
+		expect(perPointYields(idx.agi)).toEqual([
 			{ id: EAttribute.Defense, delta: 0.5 },
 			{ id: EAttribute.CooldownRecovery, delta: 0.004 }
 		]);
 	});
 
 	it('DEX yields +0.001 Cooldown Recovery per point (a small multiplier increment, not rounded away)', () => {
-		expect(perPointYields(idx.dex, base)).toEqual([{ id: EAttribute.CooldownRecovery, delta: 0.001 }]);
+		expect(perPointYields(idx.dex)).toEqual([{ id: EAttribute.CooldownRecovery, delta: 0.001 }]);
 	});
 
 	it('INT and LUK have no surfaced derived yield yet', () => {
-		expect(perPointYields(idx.int, base)).toEqual([]);
-		expect(perPointYields(idx.luk, base)).toEqual([]);
+		expect(perPointYields(idx.int)).toEqual([]);
+		expect(perPointYields(idx.luk)).toEqual([]);
+	});
+
+	it('is constant per index — the marginal yield does not depend on the current allocation', () => {
+		// The surfaced derived stats are linear (purely additive modifiers), so a point's marginal
+		// yield is invariant to how many points are already allocated. This is what lets the per-point
+		// line be memoised once instead of re-derived on every stepper click / radar drag.
+		expect(perPointYields(idx.end)).toEqual(perPointYields(idx.end));
+		const allocations = [
+			[0, 0, 0, 0, 0, 0],
+			[5, 5, 5, 5, 5, 5],
+			[99, 3, 17, 42, 8, 61]
+		];
+		for (const values of allocations) {
+			for (let i = 0; i < CORE_ATTRIBUTES.length; i++) {
+				const bumped = [...values];
+				bumped[i] += 1;
+				const before = deriveStats(values);
+				const after = deriveStats(bumped);
+				const expected = DERIVED_STATS.flatMap((def) => {
+					const delta = Math.round((after[def.id] - before[def.id]) * 1e6) / 1e6;
+					return delta !== 0 ? [{ id: def.id, delta }] : [];
+				});
+				expect(perPointYields(i)).toEqual(expected);
+			}
+		}
+	});
+
+	it('returns the same memoised array reference across calls (no per-call rebuild)', () => {
+		expect(perPointYields(idx.agi)).toBe(perPointYields(idx.agi));
 	});
 });
 

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -259,6 +259,15 @@ describe('SkillsView — initial state', () => {
 		expect(view.maxDamage).toBe(100); // skill 4 base damage
 	});
 
+	it('resolves each skill metric to the challenge that rewards it (by rewardSkillId)', () => {
+		// Challenge 0 rewards skill 3, challenge 1 rewards skill 4; skills with no rewarding
+		// challenge have no source. The lookup is hoisted into a Map keyed by rewardSkillId,
+		// so resolution stays O(1) per skill rather than scanning every challenge.
+		expect(view.metric(3)?.source?.name).toBe('Slay Ten');
+		expect(view.metric(4)?.source?.name).toBe('Clear the Vale');
+		expect(view.metric(0)?.source).toBeUndefined();
+	});
+
 	it('resolves metrics through the shared battle formulas and the derived attribute composition', () => {
 		// Strength feeds Alpha's 1× multiplier directly; Agility derives CooldownRecovery (0.004/pt).
 		mockPlayerManager.attributes = [


### PR DESCRIPTION
## Summary
Two hot frontend derivations were rebuilding far more than they needed:

- **Attributes Theorycraft** — `perPointYields` re-derived the entire derived-stat vector on every allocation change, constructing ~12 full `BattleAttributes` compositions per stepper click and per radar `pointermove`. The surfaced derived stats are linear in the core attributes (purely additive modifiers in `STATIC_ATTRIBUTE_MODIFIERS`, no multiplicative steps), so a point's marginal yield is **constant per core index and independent of the current allocation**. The per-point yields are now computed once per index from a neutral baseline and memoized into `PER_POINT_YIELDS`; `perPointYields(coreIndex)` is an O(1) lookup and `feedsFor` reads from the same table (the old separate `CORE_FEEDS` was collapsed into it). `TheoryRow.svelte` drops the now-redundant `view.values` argument.
- **Skills `metricsById`** — replaced the per-skill `challenges.find(c => c.rewardSkillId === skill.id)` (O(skills × challenges)) with a `Map` keyed by `rewardSkillId` built once outside the loop, keeping first-match semantics. The derivation is now linear.

Pure perf refactor — derived output values and behavior are unchanged.

Closes #897

## Testing
- `npm run check` — 0 errors / 0 warnings
- `npm run lint` — clean
- `npm run test:unit -- --run` — 2033 passed (204 files). Extended `attributes-view` tests (single-arg signature; new tests asserting the marginal yield is constant across three allocations × all six indices, and that the memoized array reference is stable) and added a `skills-view` test asserting `source` still resolves via the hoisted Map.

## Note
The linearity assumption is documented in code and guarded by a test comparing the memoized yields against a full re-derivation across varied allocations, so a future multiplicative/cross-attribute formula change fails the test rather than silently serving stale yields. Stayed within the Theorycraft + Skills paths; did not touch the equipment-spawn/inventory memoization covered by sibling issue #811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNEKedmVgmmg6H9jAu7yxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNEKedmVgmmg6H9jAu7yxm)_