### PR TITLE
Fix HP bar text jitter by anchoring current HP value in its own slot (#882)

### DIFF
--- a/UI/src/components/HpBar.svelte
+++ b/UI/src/components/HpBar.svelte
@@ -17,7 +17,10 @@
 	{#each phasePips as pip (pip)}
 		<div class="phase-pip" style:left="{pip}%" aria-hidden="true"></div>
 	{/each}
-	<div class="hp-text">{healthText}</div>
+	<div class="hp-text" aria-hidden="true">
+		<span class="hp-current">{formatNum(currentHealth)}</span>
+		<span class="hp-max">/ {formatNum(maxHealth)}</span>
+	</div>
 </div>
 
 <script lang="ts">
@@ -37,6 +40,8 @@ type Props = {
 
 const { currentHealth, maxHealth, ariaLabel, tall = false, phasePips = [], testId }: Props = $props();
 
+// Full "current / max" string carried only by aria-valuetext; the visible text renders
+// current/max in separate elements so the current value's changing width can't shift the rest.
 const healthText = $derived(`${formatNum(currentHealth)} / ${formatNum(maxHealth)}`);
 const healthPerc = $derived(maxHealth ? formatNum(Math.max((currentHealth * 100) / maxHealth, 0)) : 100);
 </script>
@@ -84,11 +89,27 @@ const healthPerc = $derived(maxHealth ? formatNum(Math.max((currentHealth * 100)
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	gap: 0.25em;
 	font-family: var(--mono);
 	font-size: 11px;
 	color: var(--white);
 	text-shadow: 0 1px 2px color-mix(in srgb, var(--black) 70%, transparent);
 	letter-spacing: 0.3px;
+	// Tabular figures keep digit width constant so a value gaining/losing a decimal under DoT
+	// changes only within its own slot.
+	font-variant-numeric: tabular-nums;
+}
+
+// Right-align the current value in a reserved slot: its width can grow/shrink (decimal toggling)
+// without nudging the "/ max" beside it, eliminating the centered-text jitter.
+.hp-current {
+	min-width: 5ch;
+	text-align: right;
+}
+
+.hp-max {
+	text-align: left;
+	white-space: nowrap;
 }
 
 .tall .hp-text {

--- a/UI/src/tests/components/HpBar.test.ts
+++ b/UI/src/tests/components/HpBar.test.ts
@@ -26,6 +26,24 @@ describe('HpBar', () => {
 		expect(container.querySelector('.hp-text')?.textContent).toContain('412.55 / 523.5');
 	});
 
+	it('anchors the current value in its own slot so its width changes do not shift the max', () => {
+		const { container } = render(HpBar, {
+			props: { currentHealth: 80.6, maxHealth: 100, ariaLabel: 'Aelara health' }
+		});
+
+		// The current value renders in a dedicated element, separate from the stable "/ max",
+		// so its changing width (a decimal appearing/disappearing under DoT) stays in its own slot.
+		const current = container.querySelector('.hp-current') as HTMLElement;
+		const max = container.querySelector('.hp-max') as HTMLElement;
+		expect(current.textContent).toBe('80.6');
+		expect(max.textContent).toBe('/ 100');
+
+		// The visible split text is hidden from the a11y tree; aria-valuetext carries the full string.
+		const text = container.querySelector('.hp-text') as HTMLElement;
+		expect(text.getAttribute('aria-hidden')).toBe('true');
+		expect((container.querySelector('.hp-bar') as HTMLElement).getAttribute('aria-valuetext')).toBe('80.6 / 100');
+	});
+
 	it('sizes the remaining bar to the health percentage', () => {
 		const { container } = render(HpBar, {
 			props: { currentHealth: 50, maxHealth: 200, ariaLabel: 'health' }


### PR DESCRIPTION
## Summary
The fight-screen HP bar (shared `HpBar.svelte`) centered a single `current / max` string, so the whole string shifted horizontally whenever the current-health number gained or lost a decimal place — very noticeable under DoT ticks.

This applies the owner-approved **anchored-value** design: the visible text is split into a right-aligned current-value element in a reserved-width slot using tabular figures (`font-variant-numeric: tabular-nums`), with a stable `/ {max}` beside it. As the current value's decimal appears/disappears, the number changes within its own slot **without shifting the "/" and max** — no more jitter.

Accessibility is preserved: the visible split text is `aria-hidden`, while `aria-valuetext` still carries the full `current / max` string, and `aria-valuenow`/`min`/`max` are unchanged. `formatNum` and the `tall`/boss variant are untouched.

Closes #882

## Testing
- `npm run check` — 0 errors
- `npm run lint` — clean
- `npm run test:unit -- --run` — 204 files / 2035 tests pass (added a structural test asserting the current value lives in its own `.hp-current` element, the `/ max` in `.hp-max`, the visible block is `aria-hidden`, and `aria-valuetext` is unchanged).

## Note
Lightly overlaps #898, which owns the `healthPerc` bar-fill geometry in this same file. This PR stays strictly in the text lane (`healthText`/current/max rendering + `.hp-text`/`.hp-current`/`.hp-max` CSS) and does not touch `healthPerc`/`style:width`/the fill elements, so the two should not collide. `BossHpBar` consumes `HpBar` and inherits the fix automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNEKedmVgmmg6H9jAu7yxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNEKedmVgmmg6H9jAu7yxm)_