### PR TITLE
Map ApiResponse error categories to HTTP status codes (#911)

### DIFF
--- a/Game.Api.Tests/Integration/LoginControllerTests.cs
+++ b/Game.Api.Tests/Integration/LoginControllerTests.cs
@@ -196,12 +196,12 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
-        public async Task Status_AuthenticatedButPlayerNotLoadable_ReturnsGracefulError()
+        public async Task Status_AuthenticatedButPlayerNotLoadable_Returns404WithError()
         {
             // A still-valid token whose player can't be loaded (archived/deleted between requests; here a user
             // with no player at all) must return a structured error, not a 500 — mirroring how Login surfaces a
             // missing player. Rehydration finds no player, so the session's selected id stays unresolved and the
-            // player load comes back null.
+            // player load comes back null. The missing-resource semantics surface as 404, not a blanket 400.
             using var scope = CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
             var user = await TestDataSeeder.CreateUserAsync(context, "playerlessstatus", "pass");
@@ -211,7 +211,7 @@ namespace Game.Api.Tests.Integration
 
             var response = await client.GetAsync("/api/Login/Status", CancellationToken);
 
-            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<ApiResponse<Models.Player.PlayerData>>(CancellationToken);
             Assert.Null(result?.Data);
             Assert.NotNull(result?.ErrorMessage);

--- a/Game.Api.Tests/Unit/ErrorStatusFilterTests.cs
+++ b/Game.Api.Tests/Unit/ErrorStatusFilterTests.cs
@@ -1,3 +1,5 @@
+using Game.Abstractions;
+using Game.Api;
 using Game.Api.Filters;
 using Game.Api.Models.Common;
 using Microsoft.AspNetCore.Http;
@@ -10,8 +12,9 @@ using Xunit;
 namespace Game.Api.Tests.Unit
 {
     /// <summary>
-    /// Covers the 200→400 rewrite the whole error contract depends on: a success-status response
-    /// carrying an <see cref="IApiResponse"/> error is rewritten to 400, while every other shape
+    /// Covers the success-status → error-status rewrite the whole error contract depends on: a 200 response
+    /// carrying an <see cref="IApiResponse"/> error is rewritten to the status implied by its
+    /// <see cref="IApiResponse.ErrorCategory"/> (401/404, defaulting to 400), while every other shape
     /// (no error, non-response value, non-object result, already-non-200 status) is left untouched.
     /// </summary>
     public class ErrorStatusFilterTests
@@ -32,9 +35,45 @@ namespace Game.Api.Tests.Unit
         [Fact]
         public void RewritesTo400_WhenResponseCarriesAnError()
         {
+            // An uncategorised error defaults to BadRequest, preserving the original collapse-to-400 behaviour.
             var result = new ObjectResult(ApiResponse.Error("Something went wrong."));
 
             Assert.Equal(StatusCodes.Status400BadRequest, RunFilter(result));
+        }
+
+        [Fact]
+        public void RewritesTo401_WhenErrorCategoryIsUnauthorized()
+        {
+            var result = new ObjectResult(ApiResponse.Error("Not logged in", ApiErrorCategory.Unauthorized));
+
+            Assert.Equal(StatusCodes.Status401Unauthorized, RunFilter(result));
+        }
+
+        [Fact]
+        public void RewritesTo404_WhenErrorCategoryIsNotFound()
+        {
+            var result = new ObjectResult(ApiResponse.Error("Player data not found", ApiErrorCategory.NotFound));
+
+            Assert.Equal(StatusCodes.Status404NotFound, RunFilter(result));
+        }
+
+        [Fact]
+        public void RewritesTo400_WhenErrorCategoryIsBadRequest()
+        {
+            var result = new ObjectResult(ApiResponse.Error("Invalid input", ApiErrorCategory.BadRequest));
+
+            Assert.Equal(StatusCodes.Status400BadRequest, RunFilter(result));
+        }
+
+        [Fact]
+        public void RewritesTypedResponse_UsingErrorCategoryFromImplicitConversion()
+        {
+            // A categorised ApiResponse.Error implicitly converted to a typed ApiResponse<T> (the controller
+            // return shape) must carry the category through so the status is still mapped correctly.
+            ApiResponse<TestModel> typed = ApiResponse.Error("Not logged in", ApiErrorCategory.Unauthorized);
+            var result = new ObjectResult(typed);
+
+            Assert.Equal(StatusCodes.Status401Unauthorized, RunFilter(result));
         }
 
         [Fact]
@@ -77,5 +116,8 @@ namespace Game.Api.Tests.Unit
 
             Assert.Equal(StatusCodes.Status201Created, RunFilter(result, StatusCodes.Status201Created));
         }
+
+        // Minimal IModel payload for exercising the typed ApiResponse<T> conversion path.
+        private sealed class TestModel : IModel { }
     }
 }

--- a/Game.Api/Controllers/LoginController.cs
+++ b/Game.Api/Controllers/LoginController.cs
@@ -86,7 +86,7 @@ namespace Game.Api.Controllers
         {
             if (!_sessionService.Authenticated)
             {
-                return ApiResponse.Error("Not logged in");
+                return ApiResponse.Error("Not logged in", ApiErrorCategory.Unauthorized);
             }
 
             // Load (or rehydrate) the session so the selected player id resolves; the HTTP pipeline no
@@ -98,7 +98,7 @@ namespace Game.Api.Controllers
             var player = await _playerService.LoadPlayer(_sessionService.SelectedPlayerId);
             if (player is null)
             {
-                return ApiResponse.Error("Player data not found");
+                return ApiResponse.Error("Player data not found", ApiErrorCategory.NotFound);
             }
 
             return ApiResponse.Success(PlayerData.FromPlayer(player));
@@ -114,7 +114,7 @@ namespace Game.Api.Controllers
         {
             if (!_sessionService.Authenticated)
             {
-                return ApiResponse.Error("Not logged in");
+                return ApiResponse.Error("Not logged in", ApiErrorCategory.Unauthorized);
             }
 
             // Load (or rehydrate) the session so the selected player id resolves for the presence check;

--- a/Game.Api/Enums.cs
+++ b/Game.Api/Enums.cs
@@ -8,4 +8,19 @@
         MessageTooBig = 3,
         ServerShuttingDown = 4
     }
+
+    /// <summary>
+    /// The kind of business error an <see cref="Models.Common.IApiResponse"/> carries, mapped to an HTTP
+    /// status code by <see cref="Filters.ErrorStatusFilter"/>. Lets a controller declare the error's
+    /// semantics (auth, missing resource, validation) instead of every failure collapsing to a 400.
+    /// </summary>
+    public enum ApiErrorCategory
+    {
+        /// <summary>A validation or business-rule failure — the default, maps to 400 Bad Request.</summary>
+        BadRequest = 0,
+        /// <summary>The caller is not authenticated — maps to 401 Unauthorized.</summary>
+        Unauthorized = 1,
+        /// <summary>The requested resource does not exist — maps to 404 Not Found.</summary>
+        NotFound = 2
+    }
 }

--- a/Game.Api/Filters/ErrorStatusFilter.cs
+++ b/Game.Api/Filters/ErrorStatusFilter.cs
@@ -1,6 +1,7 @@
 ﻿using Game.Api.Models.Common;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Game.Api.Filters
 {
@@ -10,12 +11,17 @@ namespace Game.Api.Filters
     public class ErrorStatusFilter : IResultFilter
     {
         /// <inheritdoc/>
-        /// <remarks>Attempts to determine if the endpoint result contains a standard error response and updates the status code accordingly.</remarks>
+        /// <remarks>
+        /// Rewrites a success-status response carrying an <see cref="IApiResponse"/> error to the status
+        /// implied by its <see cref="IApiResponse.ErrorCategory"/> (defaulting to 400), preserving the
+        /// distinct HTTP semantics of auth (401) and missing-resource (404) failures.
+        /// </remarks>
         public void OnResultExecuting(ResultExecutingContext context)
         {
-            if (context.HttpContext.Response.StatusCode == StatusCodes.Status200OK && HasError(context.Result))
+            if (context.HttpContext.Response.StatusCode == StatusCodes.Status200OK
+                && TryGetError(context.Result, out var response))
             {
-                context.HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                context.HttpContext.Response.StatusCode = StatusForCategory(response.ErrorCategory);
             }
         }
 
@@ -23,16 +29,35 @@ namespace Game.Api.Filters
         /// <remarks>Does nothing here.</remarks>
         public void OnResultExecuted(ResultExecutedContext context) { }
 
-        /// <summary>
-        /// Checks if the given <paramref name="result"/> contains a <see cref="IApiResponse"/> and it contains an <see cref="IApiResponse.ErrorMessage"/>.
-        /// </summary>s
-        /// <param name="result"></param>
-        /// <returns>True if the <see cref="IActionResult"/> represents an <see cref="IApiResponse"/> with an error and false otherwise.</returns>
-        private static bool HasError(IActionResult result)
+        // Maps an error category to its HTTP status. An unrecognised category defaults to 400 so a newly
+        // added category fails safe rather than passing the failure through as a 200.
+        private static int StatusForCategory(ApiErrorCategory category)
         {
-            return result is ObjectResult objectResult
-                && objectResult.Value is IApiResponse response
-                && response.ErrorMessage is not null and not "";
+            return category switch
+            {
+                ApiErrorCategory.Unauthorized => StatusCodes.Status401Unauthorized,
+                ApiErrorCategory.NotFound => StatusCodes.Status404NotFound,
+                _ => StatusCodes.Status400BadRequest,
+            };
+        }
+
+        /// <summary>
+        /// Determines whether the given <paramref name="result"/> carries an <see cref="IApiResponse"/> with
+        /// a non-empty <see cref="IApiResponse.ErrorMessage"/>, surfacing the response so its category can
+        /// steer the status code.
+        /// </summary>
+        private static bool TryGetError(IActionResult result, [NotNullWhen(true)] out IApiResponse? response)
+        {
+            if (result is ObjectResult objectResult
+                && objectResult.Value is IApiResponse apiResponse
+                && apiResponse.ErrorMessage is not null and not "")
+            {
+                response = apiResponse;
+                return true;
+            }
+
+            response = null;
+            return false;
         }
     }
 }

--- a/Game.Api/Models/Common/ApiResponse.cs
+++ b/Game.Api/Models/Common/ApiResponse.cs
@@ -1,4 +1,5 @@
 ﻿using Game.Abstractions.DataAccess.Admin;
+using System.Text.Json.Serialization;
 
 namespace Game.Api.Models.Common
 {
@@ -7,11 +8,15 @@ namespace Game.Api.Models.Common
         public T? Data { get; set; }
         public string? ErrorMessage { get; set; }
 
+        [JsonIgnore]
+        public ApiErrorCategory ErrorCategory { get; set; }
+
         public static implicit operator ApiResponse<T>(ApiResponse result)
         {
             return new()
             {
                 ErrorMessage = result.ErrorMessage,
+                ErrorCategory = result.ErrorCategory,
             };
         }
     }
@@ -21,11 +26,15 @@ namespace Game.Api.Models.Common
         public IEnumerable<T>? Data { get; set; }
         public string? ErrorMessage { get; set; }
 
+        [JsonIgnore]
+        public ApiErrorCategory ErrorCategory { get; set; }
+
         public static implicit operator ApiEnumerableResponse<T>(ApiResponse result)
         {
             return new()
             {
                 ErrorMessage = result.ErrorMessage,
+                ErrorCategory = result.ErrorCategory,
             };
         }
     }
@@ -35,11 +44,15 @@ namespace Game.Api.Models.Common
         public IAsyncEnumerable<T>? Data { get; set; }
         public string? ErrorMessage { get; set; }
 
+        [JsonIgnore]
+        public ApiErrorCategory ErrorCategory { get; set; }
+
         public static implicit operator ApiAsyncEnumerableResponse<T>(ApiResponse result)
         {
             return new()
             {
                 ErrorMessage = result.ErrorMessage,
+                ErrorCategory = result.ErrorCategory,
             };
         }
     }
@@ -47,6 +60,9 @@ namespace Game.Api.Models.Common
     public class ApiResponse : IApiResponse
     {
         public string? ErrorMessage { get; set; }
+
+        [JsonIgnore]
+        public ApiErrorCategory ErrorCategory { get; set; }
 
         // Maps the admin data tier's unified write result to the API response once, so every admin
         // endpoint can hand its result back directly instead of re-deriving the success/error mapping.
@@ -84,11 +100,19 @@ namespace Game.Api.Models.Common
             };
         }
 
+        // The category defaults to BadRequest, so an unqualified Error stays a 400 — the overload below
+        // is only needed when an endpoint wants 401/404 (or another non-validation) semantics.
         public static ApiResponse Error(string message)
+        {
+            return Error(message, ApiErrorCategory.BadRequest);
+        }
+
+        public static ApiResponse Error(string message, ApiErrorCategory category)
         {
             return new ApiResponse
             {
-                ErrorMessage = message
+                ErrorMessage = message,
+                ErrorCategory = category,
             };
         }
     }
@@ -108,5 +132,13 @@ namespace Game.Api.Models.Common
     public interface IApiResponse
     {
         public string? ErrorMessage { get; set; }
+
+        /// <summary>
+        /// The intended error category for a failure response, mapped to an HTTP status by
+        /// <see cref="Filters.ErrorStatusFilter"/>. Not serialized — the wire contract stays the
+        /// <c>{ errorMessage }</c> envelope; the category only steers the status code.
+        /// </summary>
+        [JsonIgnore]
+        public ApiErrorCategory ErrorCategory { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
`ErrorStatusFilter` previously rewrote every `ApiResponse` carrying an `errorMessage` on a 200 to **400 Bad Request**, erasing the distinct semantics of auth and missing-resource failures.

This introduces an `ApiErrorCategory` enum (`BadRequest`/`Unauthorized`/`NotFound`) that an `ApiResponse` can carry via a non-serialized `ErrorCategory` property. The filter maps the category to the matching status (401/404), defaulting to **400** for genuine validation/business failures. The wire contract is unchanged — the category is `[JsonIgnore]`d, so the response body stays the `{ errorMessage }` envelope; the category only steers the status code.

`LoginController` now returns **401** for "Not logged in" (`Status`/`ActiveSession`) and **404** for "Player data not found" (`Status`). Other business errors keep defaulting to 400.

Closes #911

## Testing
`dotnet test Game.Api.Tests` — full suite green (513/513), including new filter unit tests for the category→status mapping and the updated `LoginController` integration test asserting 404 on a not-loadable player.

## Notes
- **Frontend impact (verified safe, no FE changes):** the API client only triggers the refresh/re-auth path on a **401**; the new **404** surfaces as a thrown error exactly like the old 400. The `Status`/`ActiveSession` 401 branches are effectively unreachable via HTTP (auth pipeline returns 401 first), so no logout-loop risk. `errorCategory` is `[JsonIgnore]`d (no FE references), so the generated TS client is unaffected.
- **#906 overlap:** touched only the three error-return lines in `LoginController`; the `Logout` body #906 edits is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNEKedmVgmmg6H9jAu7yxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNEKedmVgmmg6H9jAu7yxm)_