### PR TITLE
Minor frontend consistency & robustness cleanups (#898)

### DIFF
--- a/UI/src/components/HpBar.svelte
+++ b/UI/src/components/HpBar.svelte
@@ -38,7 +38,9 @@ type Props = {
 const { currentHealth, maxHealth, ariaLabel, tall = false, phasePips = [], testId }: Props = $props();
 
 const healthText = $derived(`${formatNum(currentHealth)} / ${formatNum(maxHealth)}`);
-const healthPerc = $derived(maxHealth ? formatNum(Math.max((currentHealth * 100) / maxHealth, 0)) : 100);
+// Bar fill geometry is a clamped number (0–100), independent of the display formatter — a transient
+// currentHealth > maxHealth can't overflow the bar, and a zero/NaN maxHealth resolves to full.
+const healthPerc = $derived(maxHealth ? Math.min(100, Math.max(0, (currentHealth * 100) / maxHealth)) : 100);
 </script>
 
 <style lang="scss">

--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -92,11 +92,12 @@ export class EnemyManager {
 
 				// No enemy this time: either the zone is on cooldown (wait it out) or the request failed
 				// (`data` is absent — note the optional chaining; an error response carries no data).
-				// Back off in both cases, then retry.
+				// `||` (not `??`) so a no-enemy response with `cooldown: 0` still backs off rather than
+				// tight-looping; an explicit positive cooldown is honored.
 				if (result.error) {
 					logMessage(ELogType.Debug, 'There was an error loading a new enemy: ' + result.error);
 				}
-				await delay(result.data?.cooldown ?? NEW_ENEMY_RETRY_DELAY_MS);
+				await delay(result.data?.cooldown || NEW_ENEMY_RETRY_DELAY_MS);
 			}
 		} finally {
 			this.fetchingEnemy = false;

--- a/UI/src/routes/+layout.svelte
+++ b/UI/src/routes/+layout.svelte
@@ -101,7 +101,7 @@ $effect(() => {
 	user-select: none;
 	background: colors.$dark-light-gray-grad;
 	color: colors.$text-primary;
-	font-family: Geist, Arial, Helvetica, sans-serif;
+	font-family: var(--sans);
 
 	--border-radius: 3px;
 	--default-glow-color: #{colors.$accent};

--- a/UI/src/routes/game/screens/challenges/Challenges.svelte
+++ b/UI/src/routes/game/screens/challenges/Challenges.svelte
@@ -119,7 +119,7 @@ onMount(async () => {
 	flex-direction: column;
 	position: relative;
 	color: var(--text-primary);
-	font-family: Geist, Arial, Helvetica, sans-serif;
+	font-family: var(--sans);
 	overflow: hidden;
 }
 

--- a/UI/src/routes/game/screens/challenges/SortControl.svelte
+++ b/UI/src/routes/game/screens/challenges/SortControl.svelte
@@ -49,7 +49,7 @@ const { value, onChange }: Props = $props();
 
 .sort-option {
 	padding: 4px 11px;
-	font-family: Geist, sans-serif;
+	font-family: var(--sans);
 	font-size: 11px;
 	cursor: pointer;
 	border: none;

--- a/UI/src/routes/game/screens/inventory/EquipSlot.svelte
+++ b/UI/src/routes/game/screens/inventory/EquipSlot.svelte
@@ -39,6 +39,7 @@
 			{/if}
 			<OverlayButton label={item.name} onActivate={() => onSelect?.(item)} />
 			<button
+				type="button"
 				class="unequip"
 				class:show={hover}
 				title="Unequip"

--- a/UI/src/routes/game/screens/inventory/EquippedRail.svelte
+++ b/UI/src/routes/game/screens/inventory/EquippedRail.svelte
@@ -33,7 +33,7 @@
 	</div>
 
 	<div class="loadout-footer">
-		<button class="loadout-button" title="Saved loadouts — coming soon" disabled>+ Save loadout</button>
+		<button type="button" class="loadout-button" title="Saved loadouts — coming soon" disabled>+ Save loadout</button>
 	</div>
 </div>
 
@@ -128,7 +128,7 @@ const handleDrop = (slotId: number) => {
 .loadout-button {
 	width: 100%;
 	padding: 7px 0;
-	font-family: Geist, sans-serif;
+	font-family: var(--sans);
 	font-size: 11.5px;
 	color: var(--text-muted);
 	background: transparent;

--- a/UI/src/routes/game/screens/inventory/GridSlot.svelte
+++ b/UI/src/routes/game/screens/inventory/GridSlot.svelte
@@ -40,6 +40,7 @@
 	/>
 
 	<button
+		type="button"
 		class="fav-star"
 		class:on={item.favorite}
 		class:show={hover}

--- a/UI/src/routes/game/screens/inventory/Inventory.svelte
+++ b/UI/src/routes/game/screens/inventory/Inventory.svelte
@@ -63,7 +63,7 @@ setItemTooltip(tip.controller);
 	flex-direction: column;
 	position: relative;
 	color: var(--text-primary);
-	font-family: Geist, Arial, Helvetica, sans-serif;
+	font-family: var(--sans);
 	overflow: hidden;
 }
 

--- a/UI/src/routes/game/screens/inventory/InventoryToolbar.svelte
+++ b/UI/src/routes/game/screens/inventory/InventoryToolbar.svelte
@@ -1,11 +1,17 @@
 <div class="toolbar">
 	<div class="chips">
-		<button class="chip" class:active={view.filterCat == null && !view.favOnly} onclick={() => view.showAll()}>
+		<button
+			type="button"
+			class="chip"
+			class:active={view.filterCat == null && !view.favOnly}
+			onclick={() => view.showAll()}
+		>
 			All <span class="chip-count">{view.counts.all}</span>
 		</button>
 
 		{#each FILTER_CATEGORIES as cat (cat)}
 			<button
+				type="button"
 				class="chip"
 				class:active={view.filterCat === cat}
 				style:--chip-accent={itemCategoryColor(cat)}
@@ -17,6 +23,7 @@
 		{/each}
 
 		<button
+			type="button"
 			class="chip fav"
 			class:active={view.favOnly}
 			title="Show favorites only"
@@ -31,7 +38,7 @@
 		<span class="mono-label">Sort</span>
 		<div class="sort-toggle">
 			{#each sortKeys as key (key)}
-				<button class="sort-option" class:active={view.sort === key} onclick={() => view.setSort(key)}>
+				<button type="button" class="sort-option" class:active={view.sort === key} onclick={() => view.setSort(key)}>
 					{SORTS[key].label}
 				</button>
 			{/each}
@@ -68,7 +75,7 @@ const sortKeys = Object.keys(SORTS) as SortKey[];
 	align-items: center;
 	gap: 6px;
 	padding: 4px 10px;
-	font-family: Geist, sans-serif;
+	font-family: var(--sans);
 	font-size: 11.5px;
 	line-height: 1.2;
 	background: transparent;
@@ -129,7 +136,7 @@ const sortKeys = Object.keys(SORTS) as SortKey[];
 
 .sort-option {
 	padding: 4px 11px;
-	font-family: Geist, sans-serif;
+	font-family: var(--sans);
 	font-size: 11.5px;
 	cursor: pointer;
 	border: none;

--- a/UI/src/routes/game/screens/inventory/ItemDrawer.svelte
+++ b/UI/src/routes/game/screens/inventory/ItemDrawer.svelte
@@ -7,7 +7,7 @@
 	>
 		{#snippet trailing()}
 			<RarityTag rarityId={item.rarityId} style="margin-left: auto" />
-			<button class="close" onclick={() => view.select(null)} aria-label="Close">×</button>
+			<button type="button" class="close" onclick={() => view.select(null)} aria-label="Close">×</button>
 		{/snippet}
 	</TooltipTitle>
 </div>
@@ -31,7 +31,7 @@
 </div>
 
 <div class="drawer-footer">
-	<button class="equip-button" class:equipped onclick={() => view.toggleEquip(item)}>
+	<button type="button" class="equip-button" class:equipped onclick={() => view.toggleEquip(item)}>
 		{equipped ? 'Unequip' : 'Equip'}
 		<span class="equip-hint">{equipped ? '⌘·click' : 'or drag'}</span>
 	</button>
@@ -91,7 +91,7 @@ const attributeMap = $derived(item.totalAttributes?.getAttributeMap());
 .equip-button {
 	width: 100%;
 	padding: 8px 16px;
-	font-family: Geist, sans-serif;
+	font-family: var(--sans);
 	font-size: 12.5px;
 	font-weight: 500;
 	cursor: pointer;

--- a/UI/src/routes/game/screens/inventory/ModSlots.svelte
+++ b/UI/src/routes/game/screens/inventory/ModSlots.svelte
@@ -33,6 +33,7 @@
 							<div class="picker-options">
 								{#each options as mod (mod.id)}
 									<button
+										type="button"
 										class="picker-option"
 										style:border-left-color={accent}
 										onclick={() => {
@@ -76,6 +77,7 @@
 
 	{#if applied}
 		<button
+			type="button"
 			class="mod-remove"
 			title="Remove mod"
 			aria-label="Remove {applied.name}"

--- a/UI/src/tests/components/HpBar.test.ts
+++ b/UI/src/tests/components/HpBar.test.ts
@@ -41,6 +41,29 @@ describe('HpBar', () => {
 		expect((container.querySelector('.hp-remaining') as HTMLElement).getAttribute('style')).toContain('width: 100%');
 	});
 
+	it('clamps the bar to 100% when current health transiently exceeds max', () => {
+		const { container } = render(HpBar, {
+			props: { currentHealth: 150, maxHealth: 100, ariaLabel: 'health' }
+		});
+		expect((container.querySelector('.hp-remaining') as HTMLElement).getAttribute('style')).toContain('width: 100%');
+	});
+
+	it('clamps the bar to 0% for negative current health', () => {
+		const { container } = render(HpBar, {
+			props: { currentHealth: -50, maxHealth: 100, ariaLabel: 'health' }
+		});
+		expect((container.querySelector('.hp-remaining') as HTMLElement).getAttribute('style')).toContain('width: 0%');
+	});
+
+	it('renders NaN health without throwing (geometry is numeric, not a throwing formatter)', () => {
+		// The old `formatNum`-based geometry threw on NaN; the numeric clamp must render instead.
+		expect(() =>
+			render(HpBar, {
+				props: { currentHealth: Number.NaN, maxHealth: 100, ariaLabel: 'health' }
+			})
+		).not.toThrow();
+	});
+
 	it('overlays a phase pip for each provided percentage', () => {
 		const { container } = render(HpBar, {
 			props: { currentHealth: 50, maxHealth: 100, ariaLabel: 'Boss health', phasePips: [25, 50, 75] }

--- a/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
@@ -99,6 +99,18 @@ describe('EnemyManager.getNewEnemy', () => {
 		expect(logMessage).not.toHaveBeenCalled();
 	});
 
+	it('backs off by the default retry delay on a no-enemy response with cooldown 0 (no tight loop)', async () => {
+		// A no-enemy response carrying `cooldown: 0` must still wait out the default retry delay rather
+		// than spinning the loop with zero backoff; the explicit retry delay applies whenever there is no enemy.
+		sendSocketCommand.mockResolvedValueOnce(cooldownResponse(0)).mockResolvedValueOnce(enemyResponse(makeEnemy(8)));
+
+		await manager.getNewEnemy();
+
+		expect(delay).toHaveBeenCalledWith(1000);
+		expect(delay).not.toHaveBeenCalledWith(0);
+		expect(manager.currentEnemy).toEqual(makeEnemy(8));
+	});
+
 	it('does not throw on an error response, but logs it and retries after a backoff', async () => {
 		sendSocketCommand.mockResolvedValueOnce(errorResponse('boom')).mockResolvedValueOnce(enemyResponse(makeEnemy(4)));
 


### PR DESCRIPTION
## Summary
A grab-bag of small, low-risk frontend cleanups (tech debt):

1. **Font tokens** — Replaced hard-coded `font-family` literals (`Geist, Arial, Helvetica, sans-serif` / `Geist, sans-serif`) with `var(--sans)` across `inventory/EquippedRail`, `ItemDrawer`, `Inventory`, `InventoryToolbar` (×2), `challenges/Challenges`, `challenges/SortControl`, and `.page-base` in `+layout.svelte`, so the `--sans` token is the single source.
2. **HpBar bar geometry** — `healthPerc` is now a clamped plain number `maxHealth ? Math.min(100, Math.max(0, (currentHealth*100)/maxHealth)) : 100` instead of a `formatNum` string, so the fill can't overflow past 100% on a transient `currentHealth > maxHealth` and won't throw on NaN. `formatNum` is reserved for the text only.
3. **Enemy-manager backoff** — `getNewEnemy` now uses `result.data?.cooldown || NEW_ENEMY_RETRY_DELAY_MS` (was `??`), so a no-enemy response with `cooldown: 0` backs off by the retry delay instead of tight-looping.
4. **Button type** — Added `type="button"` to the inventory `<button>`s in `InventoryToolbar`, `ItemDrawer`, `GridSlot`, `EquippedRail`, `EquipSlot`, and `ModSlots`.

Closes #898

## Testing
`npm run check`, `npm run lint`, and `npm run test:unit -- --run` all pass (204 files, 2034 tests). Extended the HpBar tests (>max clamps to 100%, negative clamps to 0%, NaN renders without throwing) and the enemy-manager tests (a `cooldown: 0` no-enemy response still backs off by the default delay).

## Scope notes
- **#882 overlap (HpBar.svelte):** changed only the `healthPerc` derivation; `healthText` and the `.hp-text` markup/CSS (now merged from #882) were left untouched — separate lanes.
- **#908 overlap (Challenges.svelte):** touched only the `font-family` CSS line; the script/reactivity is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNEKedmVgmmg6H9jAu7yxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNEKedmVgmmg6H9jAu7yxm)_