### PR TITLE
Memoize equipmentStats/selectedSkills and skip redundant player re-derive (#811)

### DIFF
--- a/UI/src/lib/battle/battler.ts
+++ b/UI/src/lib/battle/battler.ts
@@ -221,6 +221,17 @@ export class Battler {
 			this.skills = this.fillSelectedSkills(battlerData);
 		}
 
+		// Re-arm every skill to the battle-start baseline. The data path's fillSelectedSkills already
+		// produced fresh (charge-0) skills; the data-less re-arm (an idle re-spawn with an unchanged
+		// loadout, #811) keeps the existing skills, so their charges must be zeroed here or the next
+		// fight would inherit the previous battle's accrued cooldowns.
+		for (const skill of this.skills) {
+			if (skill) {
+				skill.chargeTime = 0;
+				skill.renderChargeTime = 0;
+			}
+		}
+
 		this.currentHealth = this.attributes.getValue(EAttribute.MaxHealth);
 		this.isDead = false;
 	}

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -1,7 +1,7 @@
 import { Battler, battleStep, type BattleStepLog } from '$lib/battle';
 import { Mulberry32 } from '$lib/engine/mulberry32';
 import { staticData } from '$stores';
-import { ELogType, IEnemyInstance } from '$lib/api';
+import { ELogType, IBattlerAttribute, IEnemyInstance } from '$lib/api';
 import { logMessage, type LogOutcome } from '../log';
 import { formatNum, createHook, Action, effectLogMessage, attributeIsHarmful, attributeName } from '$lib/common';
 import { onLogicalUpdate } from '../logical-engine';
@@ -79,13 +79,24 @@ export class BattleEngine {
 	private readonly effectDamage = { enemyDot: 0, playerDot: 0, enemyHot: 0, playerHot: 0 };
 	private effectDamageElapsedMs = 0;
 
+	/** The inputs of the last *full* player attribute derive — the equipment stats, attribute
+	 *  distribution, loadout, and level. An idle farm re-spawns with all four unchanged, so the
+	 *  per-enemy reset can re-arm the existing player battler instead of rebuilding the whole attribute
+	 *  graph (and every Skill) from scratch on each cooldown (#811). The arrays are compared by
+	 *  reference — every producer reassigns rather than mutates in place, so a reference match means the
+	 *  inputs are unchanged. */
+	private lastEquipmentStats?: IBattlerAttribute[];
+	private lastPlayerAttributes?: IBattlerAttribute[];
+	private lastSelectedSkills?: number[];
+	private lastPlayerLevel?: number;
+
 	public start() {
 		if (!this.running) {
 			this.running = true;
 			this.logicalUnhook = onLogicalUpdate((delta) => this.logicalUpdate(delta));
 			this.renderUnhook = onRenderUpdate((_, logicalDelta) => this.renderUpdate(logicalDelta));
 			this.enemyLoadedUnhook = onNewEnemyLoaded((enemy) => this.reset(enemy));
-			this.player.reset(playerManager, inventoryManager.equipmentStats);
+			this.resetPlayer();
 		}
 	}
 
@@ -128,10 +139,34 @@ export class BattleEngine {
 		// so the crit/dodge/block draws stay in lockstep with the anti-cheat replay.
 		this.rng = new Mulberry32(enemyInstance.seed);
 		this.resetEffectDamage();
-		this.player.reset(playerManager, inventoryManager.equipmentStats);
+		this.resetPlayer();
 		this.enemy.reset({ ...enemyInstance, ...enemyData[enemyInstance.id] });
 		this.resume();
 	};
+
+	/** Resets the player battler for a new enemy, re-deriving the full attribute graph only when the
+	 *  equipment / attributes / loadout / level changed since the last derive; otherwise re-arms the
+	 *  existing battler (clears effects, resets health + skill charges) without the full rebuild (#811). */
+	private resetPlayer() {
+		const equipmentStats = inventoryManager.equipmentStats;
+		const attributes = playerManager.attributes;
+		const selectedSkills = playerManager.selectedSkills;
+		const level = playerManager.level;
+		if (
+			equipmentStats === this.lastEquipmentStats &&
+			attributes === this.lastPlayerAttributes &&
+			selectedSkills === this.lastSelectedSkills &&
+			level === this.lastPlayerLevel
+		) {
+			this.player.reset();
+			return;
+		}
+		this.player.reset(playerManager, equipmentStats);
+		this.lastEquipmentStats = equipmentStats;
+		this.lastPlayerAttributes = attributes;
+		this.lastSelectedSkills = selectedSkills;
+		this.lastPlayerLevel = level;
+	}
 
 	public getOpponent(battler: Battler) {
 		return battler.id === this.player.id ? this.enemy : this.player;

--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -50,6 +50,14 @@ export class InventoryManager {
 	 */
 	public items: Item[] = [];
 
+	/**
+	 * Memoised combined attributes of all equipped items + their applied mods. Rebuilt only on the
+	 * equip/unequip/mod mutations below (and their rollbacks), so the per-spawn battle reset and the
+	 * inventory/skills `$derived` chains read a stable array instead of re-flattening every equipped
+	 * item + mod on each access (#811).
+	 */
+	private equipmentStatsCache: IBattlerAttribute[] = [];
+
 	/** Tail of the optimistic-mutation queue; each mutation chains off it so rollback baselines never interleave. */
 	private lastOperation: Promise<unknown> = Promise.resolve();
 
@@ -82,14 +90,22 @@ export class InventoryManager {
 		}
 
 		this.publish();
+		this.refreshEquipmentStats();
 	}
 
 	public get unlockedItemList(): Item[] {
 		return this.items;
 	}
 
-	/** Computes combined attributes from all equipped items and their applied mods. */
+	/** Combined attributes from all equipped items and their applied mods (memoised — recomputed only
+	 *  by {@link refreshEquipmentStats} on an equip/unequip/mod change, so reads are O(1)). */
 	public get equipmentStats(): IBattlerAttribute[] {
+		return this.equipmentStatsCache;
+	}
+
+	/** Rebuilds the memoised {@link equipmentStats} from the currently equipped items + their mods.
+	 *  Called after every mutation that can change them (and after a rollback restores the prior state). */
+	private refreshEquipmentStats() {
 		const stats: IBattlerAttribute[] = [];
 		for (const item of this.equippedSlots) {
 			if (item) {
@@ -99,7 +115,7 @@ export class InventoryManager {
 				}
 			}
 		}
-		return stats;
+		this.equipmentStatsCache = stats;
 	}
 
 	public equipItem(itemId: number, slotId: EEquipmentSlot): Promise<boolean> {
@@ -124,6 +140,7 @@ export class InventoryManager {
 			});
 			if (response.error) {
 				rollback();
+				this.refreshEquipmentStats();
 				return false;
 			}
 
@@ -147,6 +164,7 @@ export class InventoryManager {
 			const slots = [...this.equippedSlots];
 			slots[slotId] = undefined;
 			this.equippedSlots = slots;
+			this.refreshEquipmentStats();
 
 			const response = await apiSocket.sendSocketCommand('UnequipItem', {
 				itemId: item.itemId,
@@ -154,6 +172,7 @@ export class InventoryManager {
 			});
 			if (response.error) {
 				rollback();
+				this.refreshEquipmentStats();
 				return false;
 			}
 
@@ -173,6 +192,7 @@ export class InventoryManager {
 			const rollback = snapshotFields(item, 'appliedMods', 'totalAttributes');
 			item.appliedMods = [...item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId), mod];
 			this.refreshItemAttributes(item);
+			this.refreshEquipmentStatsIfEquipped(item);
 
 			const response = await apiSocket.sendSocketCommand('ApplyMod', {
 				itemId,
@@ -181,6 +201,7 @@ export class InventoryManager {
 			});
 			if (response.error) {
 				rollback();
+				this.refreshEquipmentStatsIfEquipped(item);
 				return false;
 			}
 
@@ -199,6 +220,7 @@ export class InventoryManager {
 			const rollback = snapshotFields(item, 'appliedMods', 'totalAttributes');
 			item.appliedMods = item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId);
 			this.refreshItemAttributes(item);
+			this.refreshEquipmentStatsIfEquipped(item);
 
 			const response = await apiSocket.sendSocketCommand('RemoveMod', {
 				itemId,
@@ -206,6 +228,7 @@ export class InventoryManager {
 			});
 			if (response.error) {
 				rollback();
+				this.refreshEquipmentStatsIfEquipped(item);
 				return false;
 			}
 
@@ -306,12 +329,21 @@ export class InventoryManager {
 		slots[slotId] = item;
 
 		this.equippedSlots = slots;
+		this.refreshEquipmentStats();
 	}
 
 	/** Rebuilds an item's cached totalAttributes after its applied mods change. */
 	private refreshItemAttributes(item: Item) {
 		const allAttributes = [...item.attributes, ...item.appliedMods.flatMap((mod) => mod.attributes)];
 		item.totalAttributes = new BattleAttributes(allAttributes, false);
+	}
+
+	/** Refreshes the memoised equipmentStats only when the changed item is equipped — an unequipped
+	 *  item's mods don't contribute, so its mod edits must not churn the cache (or its consumers). */
+	private refreshEquipmentStatsIfEquipped(item: Item) {
+		if (item.equipped) {
+			this.refreshEquipmentStats();
+		}
 	}
 
 	/**

--- a/UI/src/lib/engine/player/player-manager.ts
+++ b/UI/src/lib/engine/player/player-manager.ts
@@ -24,15 +24,42 @@ export class PlayerManager implements IPlayerData {
 	#enabledByType = new Map<ELogType, boolean>();
 
 	/**
-	 * The equipped skill ids in loadout order, derived from the unlocked set. The wire payload
-	 * carries only the richer {@link unlockedSkills}; the ordered equipped list is its single
-	 * source of truth (parallel to deriving equipped items from inventoryData.unlockedItems).
+	 * Memoised equipped skill ids in loadout order, derived from {@link unlockedSkills}. The wire
+	 * payload carries only the richer unlocked set; this ordered list is its single source of truth
+	 * (parallel to deriving equipped items from inventoryData.unlockedItems). Rebuilt only on the
+	 * mutations that change the loadout ({@link initialize}/{@link setSelectedSkills}/
+	 * {@link addUnlockedSkill}), so the per-spawn battle reset and reactive consumers read a stable
+	 * array instead of re-running filter+sort+map on every access (#811).
 	 */
+	private selectedSkillsCache: number[] = [];
+
 	public get selectedSkills(): number[] {
-		return this.unlockedSkills
+		return this.selectedSkillsCache;
+	}
+
+	/** Recomputes the memoised {@link selectedSkills} from the current unlocked set's selected/order. */
+	private refreshSelectedSkills() {
+		this.selectedSkillsCache = this.unlockedSkills
 			.filter((skill) => skill.selected)
 			.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
 			.map((skill) => skill.skillId);
+	}
+
+	/**
+	 * Replaces the equipped loadout with `orderedIds` in priority order, updating each unlocked skill's
+	 * selected flag + slot order and refreshing the memoised {@link selectedSkills}. The single loadout
+	 * mutation path (mirroring how the inventory manager centralizes equipment changes), so battles and
+	 * other screens read the new equipped set/order without a reload.
+	 */
+	public setSelectedSkills(orderedIds: number[]) {
+		for (const unlockedSkill of this.unlockedSkills) {
+			const order = orderedIds.indexOf(unlockedSkill.skillId);
+			unlockedSkill.selected = order >= 0;
+			// An unequipped skill has no loadout slot, so clear its order rather than pinning it to 0
+			// (which would conflate "unequipped" with "first slot").
+			unlockedSkill.order = order >= 0 ? order : undefined;
+		}
+		this.refreshSelectedSkills();
 	}
 
 	/** The player's combat-log preferences. Assigning rebuilds the by-type enabled lookup. */
@@ -61,6 +88,7 @@ export class PlayerManager implements IPlayerData {
 		this.unlockedSkills = data.unlockedSkills;
 		this.logPreferences = data.logPreferences;
 		this.inventoryData = data.inventoryData;
+		this.refreshSelectedSkills();
 	}
 
 	/**
@@ -73,6 +101,9 @@ export class PlayerManager implements IPlayerData {
 			return;
 		}
 		this.unlockedSkills.push({ skillId, selected: false });
+		// A newly-unlocked skill is unselected, so the equipped loadout is unchanged — but refresh the
+		// memo so it stays consistent with the unlocked set rather than relying on that invariant.
+		this.refreshSelectedSkills();
 		logMessage(ELogType.ItemFound, 'New skill unlocked!');
 	}
 

--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -423,28 +423,17 @@ export class SkillsView {
 
 	/* ── persistence ─────────────────────────────────────────────────────────── */
 
-	/** Optimistically apply a new loadout, persist it atomically, and revert on failure. */
+	/** Optimistically apply a new loadout, persist it atomically, and revert on failure. The player
+	 *  manager owns the loadout mutation (so battles/other screens see it without a reload). */
 	private async commit(next: number[]): Promise<void> {
 		const previous = this.equipped;
 		this.equipped = next;
-		this.applyToPlayer(next);
+		playerManager.setSelectedSkills(next);
 		const response = await apiSocket.sendSocketCommand('SetSelectedSkills', next);
 		if (response.error) {
 			this.equipped = previous;
-			this.applyToPlayer(previous);
+			playerManager.setSelectedSkills(previous);
 			toastError('Your loadout could not be saved. Please try again.');
-		}
-	}
-
-	/** Mirror the loadout onto the player manager so battles and other screens read
-	 *  the new equipped set/order without a reload. */
-	private applyToPlayer(orderedIds: number[]): void {
-		for (const unlockedSkill of playerManager.unlockedSkills) {
-			const order = orderedIds.indexOf(unlockedSkill.skillId);
-			unlockedSkill.selected = order >= 0;
-			// An unequipped skill has no loadout slot, so clear its order rather than
-			// pinning it to 0 (which would conflate "unequipped" with "first slot").
-			unlockedSkill.order = order >= 0 ? order : undefined;
 		}
 	}
 }

--- a/UI/src/tests/lib/battle/battler.test.ts
+++ b/UI/src/tests/lib/battle/battler.test.ts
@@ -119,6 +119,18 @@ describe('Battler', () => {
 
 			expect(battler.attributes.getValue(EAttribute.Strength)).toBe(15);
 		});
+
+		it('re-arms skill charges on a data-less reset so an unchanged re-spawn starts at zero charge (#811)', () => {
+			const battler = new Battler(makeBattlerData({ selectedSkills: [0] }));
+			battler.skills[0]!.chargeTime = 300;
+			battler.skills[0]!.renderChargeTime = 300;
+
+			// A data-less re-arm keeps the existing skills, so their charges must be reset here.
+			battler.reset();
+
+			expect(battler.skills[0]!.chargeTime).toBe(0);
+			expect(battler.skills[0]!.renderChargeTime).toBe(0);
+		});
 	});
 
 	describe('advanceCooldowns', () => {

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -27,7 +27,7 @@ const { mockSkills, mockEnemies, mockAttributes, mockPlayerManager, mockInventor
 		]
 	};
 	const mockInventoryManager = {
-		equipmentStats: []
+		equipmentStats: [] as { attributeId: number; amount: number }[]
 	};
 
 	return { mockSkills, mockEnemies, mockAttributes, mockPlayerManager, mockInventoryManager };
@@ -679,6 +679,52 @@ describe('BattleEngine', () => {
 		it('returns player when given enemy', () => {
 			engine.start();
 			expect(engine.getOpponent(engine.enemy)).toBe(engine.player);
+		});
+	});
+
+	// An idle farm re-spawns with the player's equipment/attributes/loadout/level unchanged, so the
+	// per-enemy reset re-arms the existing battler instead of rebuilding its whole attribute graph.
+	describe('player reset optimization (#811)', () => {
+		const defaultAttributes = mockPlayerManager.attributes;
+		const defaultEquipmentStats = mockInventoryManager.equipmentStats;
+		const defaultLevel = mockPlayerManager.level;
+
+		afterEach(() => {
+			mockPlayerManager.attributes = defaultAttributes;
+			mockInventoryManager.equipmentStats = defaultEquipmentStats;
+			mockPlayerManager.level = defaultLevel;
+		});
+
+		it('re-arms the player without re-deriving when the inputs are unchanged between spawns', () => {
+			engine.start(); // the first reset fully derives the player and caches its inputs
+			const resetSpy = vi.spyOn(engine.player, 'reset');
+
+			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, selectedSkills: [0], attributes: [] });
+
+			// A data-less re-arm (no args) — the expensive attribute graph + skill rebuild is skipped.
+			expect(resetSpy).toHaveBeenCalledTimes(1);
+			expect(resetSpy).toHaveBeenCalledWith();
+		});
+
+		it('re-derives the player when the equipment stats change between spawns', () => {
+			engine.start();
+			const resetSpy = vi.spyOn(engine.player, 'reset');
+
+			const newStats = [{ attributeId: EAttribute.Strength, amount: 5 }];
+			mockInventoryManager.equipmentStats = newStats;
+			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, selectedSkills: [0], attributes: [] });
+
+			expect(resetSpy).toHaveBeenCalledWith(mockPlayerManager, newStats);
+		});
+
+		it('re-derives the player when the level changes between spawns (keeps the fight card level fresh)', () => {
+			engine.start();
+			const resetSpy = vi.spyOn(engine.player, 'reset');
+
+			mockPlayerManager.level = 6;
+			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, selectedSkills: [0], attributes: [] });
+
+			expect(resetSpy).toHaveBeenCalledWith(mockPlayerManager, mockInventoryManager.equipmentStats);
 		});
 	});
 });

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -231,6 +231,33 @@ describe('InventoryManager', () => {
 				{ attributeId: EAttribute.Agility, amount: 3 }
 			]);
 		});
+
+		it('memoizes the result, returning a stable reference until equipment changes', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+
+			const first = manager.equipmentStats;
+			// Re-reading without a mutation returns the same memoized array rather than re-flattening.
+			expect(manager.equipmentStats).toBe(first);
+
+			await manager.equipItem(1, EEquipmentSlot.WeaponSlot);
+
+			expect(manager.equipmentStats).not.toBe(first);
+			expect(manager.equipmentStats).toEqual([{ attributeId: EAttribute.Strength, amount: 5 }]);
+		});
+
+		it('restores the memoized stats when an equip is rolled back', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+			mockSendSocketCommand.mockResolvedValue({ error: 'nope' });
+
+			await manager.equipItem(1, EEquipmentSlot.WeaponSlot);
+
+			// The optimistic equip is reverted on the failed persist, so the cache must follow it back.
+			expect(manager.equipmentStats).toEqual([]);
+		});
 	});
 
 	describe('items (reactive published list)', () => {

--- a/UI/src/tests/lib/engine/player/player-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/player-manager.test.ts
@@ -93,6 +93,33 @@ describe('PlayerManager', () => {
 		});
 	});
 
+	describe('setSelectedSkills', () => {
+		it('replaces the loadout, updating each unlocked skill’s selected flag and slot order', () => {
+			manager.initialize(makePlayerData());
+
+			manager.setSelectedSkills([2, 0]);
+
+			expect(manager.selectedSkills).toEqual([2, 0]);
+			expect(manager.unlockedSkills.find((s) => s.skillId === 2)).toMatchObject({ selected: true, order: 0 });
+			expect(manager.unlockedSkills.find((s) => s.skillId === 0)).toMatchObject({ selected: true, order: 1 });
+			// A skill dropped from the loadout is unselected and loses its slot order.
+			expect(manager.unlockedSkills.find((s) => s.skillId === 1)).toMatchObject({ selected: false, order: undefined });
+		});
+
+		it('memoizes selectedSkills, returning a stable reference until the loadout changes', () => {
+			manager.initialize(makePlayerData());
+
+			const first = manager.selectedSkills;
+			// Re-reading without a mutation returns the same memoized array rather than re-deriving.
+			expect(manager.selectedSkills).toBe(first);
+
+			manager.setSelectedSkills([0]);
+
+			expect(manager.selectedSkills).not.toBe(first);
+			expect(manager.selectedSkills).toEqual([0]);
+		});
+	});
+
 	describe('grantExp', () => {
 		it('adds exp and logs the message', () => {
 			manager.initialize(makePlayerData({ level: 1, exp: 0 }));

--- a/UI/src/tests/routes/game/screens/skills/EquippedBand.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/EquippedBand.test.ts
@@ -15,6 +15,13 @@ const { mockPlayerManager, mockInventoryManager, sendSocketCommand, toastError, 
 				.filter((s) => s.selected)
 				.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
 				.map((s) => s.skillId);
+		},
+		setSelectedSkills(orderedIds: number[]) {
+			for (const unlockedSkill of playerManager.unlockedSkills) {
+				const order = orderedIds.indexOf(unlockedSkill.skillId);
+				unlockedSkill.selected = order >= 0;
+				unlockedSkill.order = order >= 0 ? order : undefined;
+			}
 		}
 	};
 	return {

--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -31,6 +31,13 @@ const {
 				.filter((s) => s.selected)
 				.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
 				.map((s) => s.skillId);
+		},
+		setSelectedSkills(orderedIds: number[]) {
+			for (const unlockedSkill of playerManager.unlockedSkills) {
+				const order = orderedIds.indexOf(unlockedSkill.skillId);
+				unlockedSkill.selected = order >= 0;
+				unlockedSkill.order = order >= 0 ? order : undefined;
+			}
 		}
 	};
 	return {

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EAttribute, type IChallenge, type IEnemy, type ISkill, type IZone } from '$lib/api';
 
 // Engine + stores are mocked so importing the view-model doesn't drag in the real
-// game engine. `playerManager.unlockedSkills` is a plain writable array (the view
-// reassigns it on persist) and `selectedSkills` derives the equipped order from it,
-// mirroring the real PlayerManager. `vi.hoisted` keeps these ready before the
-// hoisted vi.mock factories run.
+// game engine. `playerManager.unlockedSkills` is a plain writable array and
+// `setSelectedSkills`/`selectedSkills` mirror the real PlayerManager (the view now
+// routes loadout changes through the manager). `vi.hoisted` keeps these ready before
+// the hoisted vi.mock factories run.
 const { mockPlayerManager, mockInventoryManager, sendSocketCommand, toastError, staticData } = vi.hoisted(() => {
 	const playerManager = {
 		unlockedSkills: [] as { skillId: number; selected: boolean; order?: number }[],
@@ -16,6 +16,13 @@ const { mockPlayerManager, mockInventoryManager, sendSocketCommand, toastError, 
 				.filter((s) => s.selected)
 				.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
 				.map((s) => s.skillId);
+		},
+		setSelectedSkills(orderedIds: number[]) {
+			for (const unlockedSkill of playerManager.unlockedSkills) {
+				const order = orderedIds.indexOf(unlockedSkill.skillId);
+				unlockedSkill.selected = order >= 0;
+				unlockedSkill.order = order >= 0 ? order : undefined;
+			}
 		}
 	};
 	return {

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -36,6 +36,8 @@ The parity suite drives the production `BattleSimulator` (not a hand-rolled copy
 
 **Mid-battle attributes are a modifier graph, not a frozen snapshot.** `BattleAttributes` retains its modifier list instead of flattening to numbers at battle start, composing per-attribute totals through the same `computeAttributes` path the breakdown screen uses (memoised, recomputed only on add/remove). This mirrors the backend `AttributeCollection`, so both sides resolve derived attributes through one composition path even as values change mid-fight — the surface skill effects build on.
 
+**The per-spawn player reset skips redundant re-derivation.** An idle farm re-spawns enemies continuously, but the player's battler only needs its full attribute graph (and skill set) rebuilt when something actually changed. `BattleEngine` re-derives the player only when its inputs differ since the last derive — the memoised `InventoryManager.equipmentStats`, `PlayerManager.selectedSkills`, the attribute distribution, and the level — and otherwise cheaply re-arms the existing battler (clears effects, resets health + skill charges). Those getters are memoised on the managers and invalidated by the managers' own mutation methods (equip/unequip/mod, and `PlayerManager.setSelectedSkills` — the single loadout mutation path). The change-detection compares the inputs **by reference**, so every producer must **reassign** its cached array on change, never mutate it in place.
+
 ## Authentication
 
 The frontend authenticates against the backend's JWT scheme (see `backend.md` for the server side). All token handling lives in the API client layer (`lib/api`) so the rest of the app never touches tokens:


### PR DESCRIPTION
## Summary

The idle battle loop re-derived the player's **entire** attribute graph on **every** enemy spawn. `BattleEngine.reset` → `player.reset(playerManager, inventoryManager.equipmentStats)` runs each cooldown and:

- `InventoryManager.equipmentStats` re-flattened every equipped item + its mods into a fresh array on each access, and
- `Battler.reset` → `attributes.setData(...)` rebuilt the whole modifier graph and re-derived all player battle attributes from scratch (plus rebuilt every `Skill`) — even though the player's loadout/equipment didn't change between farm enemies.

The same flatten + derive also re-ran inside the inventory/skills `$derived` chains (`skills-view`'s `battleAttributes`, `inventory-view`'s `equippedTotals`).

This addresses **both halves** called out in the issue (the `equipmentStats` memo is necessary but not sufficient — the higher-value half is skipping the player attribute re-derive when nothing changed).

## How it addresses the issue

**1. Memoize the manager-side getters.**
- `InventoryManager.equipmentStats` is now a cached array, rebuilt only by the equip/unequip/mod mutations (and their rollbacks) the manager already centralizes. A mod edit on an *unequipped* item doesn't churn the cache.
- `PlayerManager.selectedSkills` is memoized the same way, rebuilt only on `initialize` / `addUnlockedSkill` / the new `setSelectedSkills`.
- **`PlayerManager.setSelectedSkills` is now the single loadout mutation path.** `SkillsView.commit` delegates to it instead of mutating `playerManager.unlockedSkills` directly (the old `applyToPlayer` is removed), so the loadout memo can be invalidated from one place — mirroring how the inventory manager owns equipment mutations.

**2. Skip the per-spawn player re-derive.** `BattleEngine` now re-derives the player only when its inputs — `equipmentStats`, attribute distribution, loadout, and level — actually changed since the last derive (compared **by reference**, which holds because every producer reassigns its cached array rather than mutating in place). Otherwise it cheaply re-arms the existing battler. `Battler.reset()` (the data-less re-arm) now also zeroes skill charges so an unchanged re-spawn still starts the fight clean. Level is included in the check so a level-up keeps the fight card's player level fresh.

No battle math changed, so frontend/backend parity is unaffected (the headless `BattleSimulator` always constructs battlers with data — the full-derive path).

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — **2047 passed**
- New/updated unit tests:
  - `InventoryManager` — `equipmentStats` returns a stable reference until equipment changes, and is restored on a rolled-back equip.
  - `PlayerManager` — `setSelectedSkills` updates selected/order + the memo; `selectedSkills` is memoized (stable reference until the loadout changes).
  - `Battler` — a data-less `reset()` re-arms skill charges.
  - `BattleEngine` — an unchanged re-spawn re-arms the player without re-deriving; an equipment-stats or level change re-derives.
  - Skills view/component mocks updated for the new `setSelectedSkills` path.

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCqeUcUChUyiofkrRhGmC4)_