### PR TITLE
Test coverage for socket transport, timeout/close races, and session parse-error (#810)

### DIFF
--- a/UI/src/lib/api/api-socket-request.ts
+++ b/UI/src/lib/api/api-socket-request.ts
@@ -1,4 +1,4 @@
-import { ApiSocketCommand, ApiSocketCommandWithRequest, ApiSocketResponseTypes } from './types/api-socket-type-map';
+import { ApiSocketCommand, ApiSocketCommandWithRequest, ApiSocketRequestTypes } from './types/api-socket-type-map';
 import { IApiSocketResponse } from './api-socket';
 
 export class ApiSocketRequest<T extends ApiSocketCommand | void = void> {
@@ -6,12 +6,12 @@ export class ApiSocketRequest<T extends ApiSocketCommand | void = void> {
 	private promiseResolver: (value: IApiSocketResponse<T>) => void;
 	id: string;
 	commandName: T;
-	parameters?: T extends ApiSocketCommandWithRequest ? ApiSocketResponseTypes[T] : never;
+	parameters?: T extends ApiSocketCommandWithRequest ? ApiSocketRequestTypes[T] : never;
 
 	constructor(
 		id: string,
 		commandName: T,
-		parameters?: T extends ApiSocketCommandWithRequest ? ApiSocketResponseTypes[T] : never
+		parameters?: T extends ApiSocketCommandWithRequest ? ApiSocketRequestTypes[T] : never
 	) {
 		this.id = id;
 		this.commandName = commandName;

--- a/UI/src/tests/lib/api/api-socket-request.test.ts
+++ b/UI/src/tests/lib/api/api-socket-request.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ApiSocketRequest } from '$lib/api/api-socket-request';
+import type { IApiSocketResponse } from '$lib/api/api-socket';
+
+// ApiSocketRequest is the pure transport primitive the socket client builds on: it wraps a single
+// command's pending promise and exposes the resolve-with-error contract the docs lean on (every
+// failure resolves the promise with an `error` field, never rejects). It has no DOM/WebSocket
+// dependencies, so it is exercised directly here rather than only indirectly through ApiSocket mocks.
+describe('ApiSocketRequest', () => {
+	describe('getCommandInfo', () => {
+		it('serializes the parameters to a JSON string alongside the id and command name', () => {
+			const request = new ApiSocketRequest('7', 'DefeatEnemy', { timestamp: 42 });
+
+			expect(request.getCommandInfo()).toEqual({
+				id: '7',
+				name: 'DefeatEnemy',
+				parameters: JSON.stringify({ timestamp: 42 })
+			});
+		});
+
+		it('serializes a no-request command with undefined parameters', () => {
+			// A no-request command (GetZones) carries no parameters; JSON.stringify(undefined) yields undefined.
+			const request = new ApiSocketRequest('0', 'GetZones');
+
+			const info = request.getCommandInfo();
+			expect(info.id).toBe('0');
+			expect(info.name).toBe('GetZones');
+			expect(info.parameters).toBeUndefined();
+		});
+	});
+
+	describe('resolve', () => {
+		it('settles getResponse with the full success response', async () => {
+			const request = new ApiSocketRequest('1', 'DefeatEnemy', { timestamp: 1 });
+			const response: IApiSocketResponse<'DefeatEnemy'> = { id: '1', name: 'DefeatEnemy', data: { cooldown: 100 } };
+
+			request.resolve(response);
+
+			await expect(request.getResponse()).resolves.toBe(response);
+		});
+	});
+
+	describe('settleWithError', () => {
+		it('settles getResponse through the resolve-with-error contract (error field, no data)', async () => {
+			const request = new ApiSocketRequest('2', 'DefeatEnemy', { timestamp: 1 });
+
+			request.settleWithError('Connection lost. Please try again.');
+
+			const response = await request.getResponse();
+			expect(response.id).toBe('2');
+			expect(response.name).toBe('DefeatEnemy');
+			expect(response.error).toBe('Connection lost. Please try again.');
+			// The error response carries no data, matching how the server signals errors so callers fall
+			// through their existing `response.error` guard rather than reading a partial payload.
+			expect(response.data).toBeUndefined();
+		});
+
+		it('resolves rather than rejects, so callers never need a try/catch around getResponse', async () => {
+			const request = new ApiSocketRequest('3', 'DefeatEnemy', { timestamp: 1 });
+			const onRejected = vi.fn();
+
+			request.settleWithError('boom');
+			await request.getResponse().catch(onRejected);
+
+			expect(onRejected).not.toHaveBeenCalled();
+		});
+	});
+
+	// Backed by Promise.withResolvers, so only the first settle takes effect. This is the request-level
+	// backstop the socket client relies on when a request can be settled by two paths — e.g. a per-request
+	// timeout firing and then a socket close also iterating the in-flight map (see ApiSocket).
+	describe('single settlement (first settle wins)', () => {
+		it('keeps the first success when a later error settle arrives', async () => {
+			const request = new ApiSocketRequest('4', 'DefeatEnemy', { timestamp: 1 });
+			const success: IApiSocketResponse<'DefeatEnemy'> = { id: '4', name: 'DefeatEnemy', data: { cooldown: 5 } };
+
+			request.resolve(success);
+			request.settleWithError('too late');
+
+			await expect(request.getResponse()).resolves.toBe(success);
+		});
+
+		it('keeps the first error when a later success settle arrives', async () => {
+			const request = new ApiSocketRequest('5', 'DefeatEnemy', { timestamp: 1 });
+
+			request.settleWithError('first');
+			request.resolve({ id: '5', name: 'DefeatEnemy', data: { cooldown: 9 } });
+
+			const response = await request.getResponse();
+			expect(response.error).toBe('first');
+			expect(response.data).toBeUndefined();
+		});
+	});
+});

--- a/UI/src/tests/lib/api/api-socket.test.ts
+++ b/UI/src/tests/lib/api/api-socket.test.ts
@@ -355,6 +355,70 @@ describe('ApiSocket', () => {
 		});
 	});
 
+	// The hardest orderings: a request settled by one path must never be re-settled by the other. The
+	// guard is two-sided — timeoutRequest prunes the in-flight entry, and settleInFlightRequests clears
+	// each request's timer — so whichever fires first leaves nothing for the other to settle again.
+	describe('timeout-then-close double-settle guard', () => {
+		const inFlightSize = (s: ApiSocket) =>
+			(s as unknown as { inFlightRequests: Map<string, unknown> }).inFlightRequests.size;
+
+		it('keeps the timeout error and does not re-settle when the socket later closes', async () => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			vi.useFakeTimers();
+			try {
+				// No tokens (localStorage cleared in beforeEach) so the later close only settles — no reconnect.
+				const promise = apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: 1 });
+				await flushMicrotasks();
+				const ws = lastWs();
+				expect(inFlightSize(apiSocket)).toBe(1);
+
+				// The request times out first: it is settled with the timeout error and pruned from the map.
+				vi.advanceTimersByTime(30000);
+				expect(inFlightSize(apiSocket)).toBe(0);
+
+				// A later close now finds nothing pending to settle a second time, so the promise keeps its
+				// original timeout error rather than being overwritten with the connection-lost one.
+				ws.readyState = ws.CLOSED;
+				ws.onclose?.({ code: 1006 });
+
+				const response = await promise;
+				expect(response.error).toBe('Timed out waiting for the server.');
+				expect(inFlightSize(apiSocket)).toBe(0);
+			} finally {
+				vi.useRealTimers();
+				warnSpy.mockRestore();
+			}
+		});
+
+		it('clears the request timer on close, so a later timer tick cannot re-settle it', async () => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			vi.useFakeTimers();
+			try {
+				const promise = apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: 1 });
+				await flushMicrotasks();
+				const ws = lastWs();
+				expect(inFlightSize(apiSocket)).toBe(1);
+
+				// The socket closes first: the in-flight request is settled with the connection-lost error and
+				// its timer cleared, pruning the entry.
+				ws.readyState = ws.CLOSED;
+				ws.onclose?.({ code: 1006 });
+				expect(inFlightSize(apiSocket)).toBe(0);
+
+				const response = await promise;
+				expect(response.error).toBe('Connection lost. Please try again.');
+
+				// Advancing past the timeout cap must not re-settle (timer cleared) or warn (entry pruned).
+				vi.advanceTimersByTime(60000);
+				expect(warnSpy).not.toHaveBeenCalled();
+				expect(inFlightSize(apiSocket)).toBe(0);
+			} finally {
+				vi.useRealTimers();
+				warnSpy.mockRestore();
+			}
+		});
+	});
+
 	describe('listenCommand', () => {
 		it('calls listener when matching command arrives', async () => {
 			const listener = vi.fn();
@@ -826,6 +890,27 @@ describe('ApiSocket', () => {
 			} finally {
 				vi.useRealTimers();
 			}
+		});
+
+		it('arms the stability timer on open and clears it on a pre-stable close (the flap-refill guard)', async () => {
+			// Read the refill timer handle directly: the budget-stability tests above assert the counter
+			// side-effect, but the flap guard the issue calls out is the connectionStableTimer being armed
+			// in onStart and torn down in handleClose so a brief open can't schedule a stale refill.
+			const stableTimer = (s: ApiSocket) =>
+				(s as unknown as { connectionStableTimer: ReturnType<typeof setTimeout> | null }).connectionStableTimer;
+
+			setTokens({ accessToken: 'a', refreshToken: 'r' });
+			apiSocket.sendSocketCommand('DefeatEnemy', { timestamp: 1 });
+			await flushMicrotasks();
+			const ws = lastWs();
+
+			ws.onopen?.(); // onStart arms the "connection is now stable" refill timer
+			expect(stableTimer(apiSocket)).not.toBeNull();
+
+			// A flap (closes before the stability window elapses) cancels the pending refill.
+			ws.readyState = ws.CLOSED;
+			ws.onclose?.({ code: 1006 });
+			expect(stableTimer(apiSocket)).toBeNull();
 		});
 	});
 });

--- a/UI/src/tests/lib/engine/session.test.ts
+++ b/UI/src/tests/lib/engine/session.test.ts
@@ -53,6 +53,19 @@ describe('resumeSession', () => {
 		expect(playerInitialize).not.toHaveBeenCalled();
 	});
 
+	it('returns "login" when restoring the player from a 200 response throws', async () => {
+		// A 200 response whose body can't be turned into a player (e.g. an unparseable/malformed payload):
+		// the throw originates after the status check, so the catch must still route to login, not crash boot.
+		// mockImplementationOnce keeps the throw scoped to restorePlayer's single call (clearAllMocks in the
+		// shared beforeEach resets call records but not a persistent implementation).
+		playerInitialize.mockImplementationOnce(() => {
+			throw new Error('bad player payload');
+		});
+
+		expect(await resumeSession()).toBe('login');
+		expect(hydrateAllFromCache).not.toHaveBeenCalled();
+	});
+
 	it('restores the player and returns "game" when the whole reference cache is current', async () => {
 		expect(await resumeSession()).toBe('game');
 		expect(playerInitialize).toHaveBeenCalledWith(PLAYER);


### PR DESCRIPTION
## Summary

Fills the frontend critical-path test-coverage gaps called out in #810. At the time the issue was filed, `session.ts` and `render-engine.ts` had no direct tests — those suites now exist on `main` and already cover the routing branches and start/stop/idempotency, so this PR targets the parts that were still genuinely uncovered plus a related correctness fix surfaced along the way.

## Changes

- **New `api-socket-request.test.ts`** — the transport primitive had zero direct tests. Covers the resolve-with-error contract (every failure resolves with an `error` field and no `data`, never rejects), `getCommandInfo` parameter serialization, and the **first-settle-wins** guard (`Promise.withResolvers`), which is the request-level backstop the socket client relies on when two paths could settle the same request.
- **`api-socket.test.ts`** — adds the hardest orderings the existing breadth tests skipped:
  - the **timeout-then-close double-settle guard** in both directions (timeout fires → entry pruned → later close is a no-op and keeps the timeout error; close fires → timer cleared → a later timer tick can't re-settle);
  - a direct assertion of the **`connectionStableTimer` flap-refill guard** handle (armed in `onStart`, cleared on a pre-stable close), complementing the existing counter-side-effect tests.
- **`session.test.ts`** — adds the **parse-error branch**: a 200 response whose player processing throws routes to `login` rather than crashing boot.
- **Fix (latent type bug):** `ApiSocketRequest` typed its outgoing `parameters` as `ApiSocketResponseTypes[T]` (the *response* shape) instead of `ApiSocketRequestTypes[T]` (the *request* shape). It was masked because the only caller (`sendSocketCommand`) passes `any`; the new direct-construction tests exposed it under `svelte-check`. One-line fix in the module under test.

## How it addresses the issue

Directly adds the focused unit tests #810 asks for in the still-uncovered modules/paths (`api-socket-request.ts` settle-with-error contract, the timeout-then-close and flap-refill orderings in `api-socket.ts`, and the session parse-error route), and corrects the type bug those tests revealed.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npx vitest --run` — full suite: **2050 passed / 205 files**
- [x] New/changed tests verified green individually

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012StvAj9meQa8v9S5PfqhzG)_