### PR TITLE
Fix frontend a11y/interaction gaps (nested button, drag-only reorder, unnamed sliders, hidden focus)

### DIFF
--- a/UI/src/routes/game/screens/attributes/AttributesRadar.svelte
+++ b/UI/src/routes/game/screens/attributes/AttributesRadar.svelte
@@ -25,13 +25,13 @@
 			class:interactive
 			class:dragging={dragIndex === i}
 			role="button"
-			tabindex={clickable ? 0 : -1}
+			tabindex={interactive ? 0 : -1}
 			aria-label={clickable
-				? `Adjust ${attributeName(coreIds[i], staticData.attributes)} — drag to allocate or click to add a point`
-				: `Adjust ${attributeName(coreIds[i], staticData.attributes)} — drag to refund points`}
+				? `Adjust ${attributeName(coreIds[i], staticData.attributes)} — drag, or use arrow keys to allocate and refund points`
+				: `Adjust ${attributeName(coreIds[i], staticData.attributes)} — drag, or use arrow keys to refund points`}
 			onpointerdown={(e) => startDrag(e, i)}
 			onclick={() => onVertexClick(i)}
-			onkeydown={(e) => clickable && handleKey(e, i)}
+			onkeydown={(e) => interactive && handleKey(e, i)}
 		>
 			<circle cx={vertex[0]} cy={vertex[1]} r="11" fill="transparent" />
 			<circle cx={vertex[0]} cy={vertex[1]} r={big ? 4.5 : 3.5} class="dot" style="--c: {attributeColor(coreIds[i])}" />
@@ -148,9 +148,15 @@ const labels = $derived(
 );
 
 function handleKey(e: KeyboardEvent, i: number): void {
-	if (e.key === 'Enter' || e.key === ' ') {
+	// Enter/Space and Arrow-up/right allocate a point; Arrow-down/left refunds one. The view's
+	// inc/dec no-op past their bounds, so a keyboard user can refund even at max budget — the
+	// drag-inward affordance the aria-label advertised but the keyboard previously couldn't reach.
+	if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowUp' || e.key === 'ArrowRight') {
 		e.preventDefault();
 		view.inc(i);
+	} else if (e.key === 'ArrowDown' || e.key === 'ArrowLeft') {
+		e.preventDefault();
+		view.dec(i);
 	}
 }
 

--- a/UI/src/routes/game/screens/card-game/loom/SandboxStrip.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/SandboxStrip.svelte
@@ -10,6 +10,7 @@
 			type="range"
 			min="0"
 			max="300"
+			aria-label="Agility"
 			value={game.agi}
 			oninput={(e) => view.setStat('agi', +e.currentTarget.value)}
 		/>
@@ -23,6 +24,7 @@
 			type="range"
 			min="1"
 			max="500"
+			aria-label="Dexterity"
 			value={game.dex}
 			oninput={(e) => view.setStat('dex', +e.currentTarget.value)}
 		/>
@@ -36,6 +38,7 @@
 			type="range"
 			min="0"
 			max="60"
+			aria-label="Luck"
 			value={game.luck}
 			oninput={(e) => view.setStat('luck', +e.currentTarget.value)}
 		/>

--- a/UI/src/routes/game/screens/challenges/OverviewPane.svelte
+++ b/UI/src/routes/game/screens/challenges/OverviewPane.svelte
@@ -42,11 +42,11 @@
 					group.items.filter((c) => c.state !== 'done'),
 					'progress'
 				)[0]}
-				<button
-					class="type-card"
-					style:border-left="2px solid {tintColor(group.accent, 0.6)}"
-					onclick={() => onPick(group.typeId)}
-				>
+				<!-- Accessible card: a presentational container whose primary action is a full-bleed
+				     OverlayButton (open this challenge type), with the reward chip raised above it so
+				     its own tooltip trigger stays interactive — no nested <button>s. -->
+				<div class="type-card" style:border-left="2px solid {tintColor(group.accent, 0.6)}">
+					<OverlayButton label={`View ${group.label} challenges`} onActivate={() => onPick(group.typeId)} />
 					<div class="type-card-head">
 						<RingMeter {pct} accent={group.accent} size={34} stroke={3} done={complete}>
 							<TypeGlyph typeId={group.typeId} color={complete ? 'var(--success)' : group.accent} size={15} />
@@ -56,14 +56,14 @@
 							<div class="mono-label sm" class:done={complete}>{stats.done}/{stats.total} unlocked</div>
 						</div>
 					</div>
-					<div class="type-card-reward">
+					<div class="type-card-reward" class:raised={next2}>
 						{#if next2}
 							<RewardAffordance reward={next2.reward} variant="chip" />
 						{:else}
 							<span class="all-unlocked">All unlocked ✓</span>
 						{/if}
 					</div>
-				</button>
+				</div>
 			{/each}
 		</div>
 	</div>
@@ -79,6 +79,7 @@ import {
 	type OverallSummary,
 	type TypeGroup
 } from './challenges-view.svelte';
+import OverlayButton from '$components/OverlayButton.svelte';
 import ProgressBar from './ProgressBar.svelte';
 import ProgressReadout from './ProgressReadout.svelte';
 import RewardAffordance from './RewardAffordance.svelte';
@@ -185,6 +186,7 @@ const { summary, nextUp, groups, onPick }: Props = $props();
 }
 
 .type-card {
+	position: relative;
 	text-align: left;
 	cursor: pointer;
 	background: var(--panel);
@@ -212,6 +214,13 @@ const { summary, nextUp, groups, onPick }: Props = $props();
 
 .type-card-reward {
 	margin-top: 11px;
+
+	// Raised above the full-bleed overlay so the reward chip's own tooltip trigger stays clickable;
+	// the non-interactive "All unlocked" state stays flat so clicks fall through to the overlay.
+	&.raised {
+		position: relative;
+		z-index: 2;
+	}
 }
 
 .all-unlocked {

--- a/UI/src/routes/game/screens/inventory/GridSlot.svelte
+++ b/UI/src/routes/game/screens/inventory/GridSlot.svelte
@@ -202,6 +202,16 @@ const handleDragStart = (e: DragEvent) => {
 	&.on {
 		opacity: 1;
 	}
+
+	// Keyboard parity with hover: a focused star is fully visible, and tabbing onto the slot's
+	// primary action hints the star too — a keyboard user otherwise lands on an invisible control.
+	&:focus-visible {
+		opacity: 1;
+	}
+}
+
+.grid-slot:focus-within .fav-star {
+	opacity: 0.75;
 }
 
 .cat-corner {

--- a/UI/src/routes/game/screens/skills/EquippedBand.svelte
+++ b/UI/src/routes/game/screens/skills/EquippedBand.svelte
@@ -4,7 +4,7 @@
 		<div class="spacer"></div>
 		<button type="button" class="band-chip action" onclick={() => view.cancelSwap()}>Cancel</button>
 	{:else}
-		<span class="label">Equipped loadout — priority left → right · drag to reorder</span>
+		<span class="label">Equipped loadout — priority left → right · drag or use the arrows to reorder</span>
 		<div class="spacer"></div>
 		<span class="band-chip">{view.equipped.length}/{view.cap}</span>
 	{/if}
@@ -47,6 +47,26 @@
 						aria-label="Remove {metrics.skill.name} from loadout"
 						onclick={() => view.toggle(id)}>✕</button
 					>
+					<!-- Keyboard/touch reorder path: HTML5 drag-and-drop is mouse-only, so these real
+					     buttons give a focus- and touch-reachable way to change battle priority. -->
+					<div class="reorder">
+						<button
+							type="button"
+							class="mv"
+							title="Move earlier in priority"
+							aria-label="Move {metrics.skill.name} earlier in priority"
+							disabled={index === 0}
+							onclick={() => view.reorder(index, index - 1)}>‹</button
+						>
+						<button
+							type="button"
+							class="mv"
+							title="Move later in priority"
+							aria-label="Move {metrics.skill.name} later in priority"
+							disabled={index >= view.equipped.length - 1}
+							onclick={() => view.reorder(index, index + 1)}>›</button
+						>
+					</div>
 				{/if}
 				<span class="en">{metrics.skill.name}</span>
 				<div class="es">
@@ -266,6 +286,48 @@ const onDragEnd = () => {
 
 		&:hover {
 			color: var(--enemy-accent);
+		}
+	}
+
+	.reorder {
+		position: absolute;
+		top: 5px;
+		left: 50%;
+		transform: translateX(-50%);
+		display: flex;
+		gap: 3px;
+		// Above the full-bleed overlay button so the arrows stay clickable.
+		z-index: 2;
+		// Revealed on hover or keyboard focus so the card stays clean by default; tapping the card
+		// (focusing its overlay) reveals them on touch, where there is no hover.
+		opacity: 0;
+		transition: opacity 120ms;
+	}
+
+	&:hover .reorder,
+	&:focus-within .reorder {
+		opacity: 1;
+	}
+
+	.mv {
+		width: 16px;
+		height: 16px;
+		border: none;
+		border-radius: 2px;
+		background: color-mix(in srgb, var(--black) 45%, transparent);
+		color: var(--text-tertiary);
+		font-size: 13px;
+		line-height: 16px;
+		text-align: center;
+		cursor: pointer;
+
+		&:hover:not(:disabled) {
+			color: var(--accent);
+		}
+
+		&:disabled {
+			opacity: 0.3;
+			cursor: default;
 		}
 	}
 

--- a/UI/src/tests/routes/game/screens/attributes/AttributesRadar.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/AttributesRadar.test.ts
@@ -8,6 +8,7 @@ const makeView = (
 	overrides: Partial<{
 		canInc: () => boolean;
 		inc: (i: number) => void;
+		dec: (i: number) => void;
 		setValue: (i: number, v: number) => void;
 		lockScale: () => void;
 		unlockScale: () => void;
@@ -19,6 +20,7 @@ const makeView = (
 		hexMax: 20,
 		canInc: vi.fn(() => true),
 		inc: vi.fn(),
+		dec: vi.fn(),
 		setValue: vi.fn(),
 		lockScale: vi.fn(),
 		unlockScale: vi.fn(),
@@ -220,26 +222,65 @@ describe('AttributesRadar — keyboard interaction', () => {
 		expect(view.inc).toHaveBeenCalledWith(1);
 	});
 
-	it('does not call view.inc when a non-activation key is pressed', async () => {
+	it('calls view.inc(i) when ArrowUp or ArrowRight is pressed on a vertex', async () => {
+		const view = makeView({});
+		const { container } = render(AttributesRadar, { props: { view } });
+		const vertices = container.querySelectorAll('[role="button"]');
+		await fireEvent.keyDown(vertices[0], { key: 'ArrowUp' });
+		await fireEvent.keyDown(vertices[1], { key: 'ArrowRight' });
+		expect(view.inc).toHaveBeenCalledWith(0);
+		expect(view.inc).toHaveBeenCalledWith(1);
+	});
+
+	it('calls view.dec(i) when ArrowDown or ArrowLeft is pressed on a vertex', async () => {
+		const view = makeView({});
+		const { container } = render(AttributesRadar, { props: { view } });
+		const vertices = container.querySelectorAll('[role="button"]');
+		await fireEvent.keyDown(vertices[2], { key: 'ArrowDown' });
+		await fireEvent.keyDown(vertices[3], { key: 'ArrowLeft' });
+		expect(view.dec).toHaveBeenCalledWith(2);
+		expect(view.dec).toHaveBeenCalledWith(3);
+	});
+
+	it('still refunds via the arrow keys when canInc() is false (at max budget)', async () => {
+		const view = makeView({ canInc: vi.fn(() => false) });
+		const { container } = render(AttributesRadar, { props: { view } });
+		await fireEvent.keyDown(container.querySelectorAll('[role="button"]')[0], { key: 'ArrowDown' });
+		expect(view.dec).toHaveBeenCalledWith(0);
+	});
+
+	it('does not call inc or dec when a non-activation key is pressed', async () => {
 		const view = makeView({});
 		const { container } = render(AttributesRadar, { props: { view } });
 		const vertex = container.querySelectorAll('[role="button"]')[0];
 		await fireEvent.keyDown(vertex, { key: 'Tab' });
 		expect(view.inc).not.toHaveBeenCalled();
+		expect(view.dec).not.toHaveBeenCalled();
+	});
+
+	it('does not handle keys when interactive=false', async () => {
+		const view = makeView({});
+		const { container } = render(AttributesRadar, { props: { view, interactive: false } });
+		const vertex = container.querySelectorAll('[role="button"]')[0];
+		await fireEvent.keyDown(vertex, { key: 'ArrowDown' });
+		await fireEvent.keyDown(vertex, { key: 'Enter' });
+		expect(view.inc).not.toHaveBeenCalled();
+		expect(view.dec).not.toHaveBeenCalled();
 	});
 });
 
 describe('AttributesRadar — tabindex', () => {
-	it('sets tabindex=0 on all vertices when canInc() is true', () => {
-		const view = makeView({ canInc: vi.fn(() => true) });
+	it('keeps all vertices focusable (tabindex=0) when interactive, even at max budget', () => {
+		// Focusable regardless of canInc so a keyboard user can refund points when the budget is spent.
+		const view = makeView({ canInc: vi.fn(() => false) });
 		const { container } = render(AttributesRadar, { props: { view } });
 		const vertices = container.querySelectorAll('[role="button"]');
 		vertices.forEach((v) => expect(v.getAttribute('tabindex')).toBe('0'));
 	});
 
-	it('sets tabindex=-1 on all vertices when canInc() is false', () => {
-		const view = makeView({ canInc: vi.fn(() => false) });
-		const { container } = render(AttributesRadar, { props: { view } });
+	it('sets tabindex=-1 on all vertices when interactive=false', () => {
+		const view = makeView({});
+		const { container } = render(AttributesRadar, { props: { view, interactive: false } });
 		const vertices = container.querySelectorAll('[role="button"]');
 		vertices.forEach((v) => expect(v.getAttribute('tabindex')).toBe('-1'));
 	});

--- a/UI/src/tests/routes/game/screens/card-game/loom/SandboxStrip.test.ts
+++ b/UI/src/tests/routes/game/screens/card-game/loom/SandboxStrip.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import type { CardGameView } from '$routes/game/screens/card-game/card-game-view.svelte';
+
+import SandboxStrip from '$routes/game/screens/card-game/loom/SandboxStrip.svelte';
+
+afterEach(cleanup);
+
+// The strip only reads `view.game` for display and calls `view.setStat`, so a minimal stub stands in
+// for the full card-game engine.
+const makeView = (setStat = vi.fn()): CardGameView =>
+	({
+		game: { agi: 100, dex: 100, luck: 30, drawIntervalSec: 1.5, handCap: 5, critGap: 3 },
+		setStat
+	}) as unknown as CardGameView;
+
+const sliders = (container: HTMLElement) =>
+	Array.from(container.querySelectorAll<HTMLInputElement>('input[type="range"]'));
+
+describe('SandboxStrip — accessible slider names', () => {
+	it('gives each range slider an accessible name', () => {
+		const { container } = render(SandboxStrip, { props: { view: makeView() } });
+		expect(sliders(container).map((s) => s.getAttribute('aria-label'))).toEqual(['Agility', 'Dexterity', 'Luck']);
+	});
+
+	it('routes each slider input to setStat with its stat key', async () => {
+		const setStat = vi.fn();
+		const { container } = render(SandboxStrip, { props: { view: makeView(setStat) } });
+		const [agi, dex, luck] = sliders(container);
+		await fireEvent.input(agi, { target: { value: '120' } });
+		await fireEvent.input(dex, { target: { value: '200' } });
+		await fireEvent.input(luck, { target: { value: '40' } });
+		expect(setStat).toHaveBeenCalledWith('agi', 120);
+		expect(setStat).toHaveBeenCalledWith('dex', 200);
+		expect(setStat).toHaveBeenCalledWith('luck', 40);
+	});
+});

--- a/UI/src/tests/routes/game/screens/challenges/Challenges.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/Challenges.test.ts
@@ -92,8 +92,9 @@ describe('Challenges screen', () => {
 			const { container } = render(Challenges);
 			await screen.findByText('Overview');
 
-			// Click the overview's "Enemies Killed" type card → view.select(type).
-			const typeCard = container.querySelector('.type-card') as HTMLElement;
+			// Activate the overview's "Enemies Killed" type card (its full-bleed overlay button) →
+			// view.select(type).
+			const typeCard = container.querySelector('.type-card .overlay-button') as HTMLElement;
 			await fireEvent.click(typeCard);
 
 			// The detail grid now shows the type's challenge cards + the sort control.
@@ -116,7 +117,7 @@ describe('Challenges screen', () => {
 		it('switches the active sort via the SortControl', async () => {
 			const { container } = render(Challenges);
 			await screen.findByText('Overview');
-			await fireEvent.click(container.querySelector('.type-card') as HTMLElement);
+			await fireEvent.click(container.querySelector('.type-card .overlay-button') as HTMLElement);
 			await screen.findByText('First Blood');
 
 			const nameSort = screen.getByText('Name');

--- a/UI/src/tests/routes/game/screens/challenges/OverviewPane.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/OverviewPane.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { EChallengeType, ERarity, type ISkill } from '$lib/api';
+import OverviewPane from '$routes/game/screens/challenges/OverviewPane.svelte';
+import type {
+	ChallengeVM,
+	OverallSummary,
+	ResolvedReward,
+	TypeGroup
+} from '$routes/game/screens/challenges/challenges-view.svelte';
+
+afterEach(cleanup);
+
+const sampleSkill: ISkill = {
+	id: 5,
+	name: 'Firebolt',
+	baseDamage: 12,
+	description: 'Hurls a bolt of fire.',
+	damageMultipliers: [],
+	effects: [],
+	cooldownMs: 3000,
+	iconPath: ''
+};
+
+const reward: ResolvedReward = {
+	kind: 'skill',
+	revealed: true,
+	rarity: ERarity.Common,
+	accent: 'var(--accent-light)',
+	glow: null,
+	name: 'Firebolt',
+	sub: 'Skill',
+	skill: sampleSkill
+};
+
+const challenge = (over: Partial<ChallengeVM> & { id: number }): ChallengeVM =>
+	({
+		name: `Challenge ${over.id}`,
+		description: '',
+		typeId: EChallengeType.EnemiesKilled,
+		goal: 10,
+		progress: 1,
+		completed: false,
+		state: 'active',
+		prog: { percent: 10 },
+		unit: '',
+		typeAccent: 'var(--challenge-enemies-killed)',
+		reward,
+		...over
+	}) as unknown as ChallengeVM;
+
+const group: TypeGroup = {
+	typeId: EChallengeType.EnemiesKilled,
+	label: 'Enemies Killed',
+	accent: 'var(--challenge-enemies-killed)',
+	items: [challenge({ id: 0 })]
+};
+
+const summary: OverallSummary = { total: 1, done: 0, active: 1, pct: 0 };
+
+const renderPane = (onPick = vi.fn()) =>
+	render(OverviewPane, { props: { summary, nextUp: null, groups: [group], onPick } });
+
+describe('OverviewPane — accessible type-card (no nested buttons)', () => {
+	it('renders the type-card as a presentational container with a real <button> overlay', () => {
+		const { container } = renderPane();
+		const card = container.querySelector('.type-card')!;
+		expect(card.tagName).toBe('DIV');
+		expect(card.querySelector('.overlay-button')?.tagName).toBe('BUTTON');
+	});
+
+	it('keeps the reward chip a sibling of the overlay, never nested inside another button', () => {
+		const { container } = renderPane();
+		const card = container.querySelector('.type-card')!;
+		const chip = card.querySelector('.chip');
+		expect(chip?.tagName).toBe('BUTTON');
+		// A <button> inside the overlay <button> would be invalid HTML — the bug this fixes.
+		expect(card.querySelector('.overlay-button button')).toBeNull();
+		expect(card.querySelector('button button')).toBeNull();
+	});
+
+	it('picks the challenge type when the card overlay is activated', async () => {
+		const onPick = vi.fn();
+		const { container } = renderPane(onPick);
+		await fireEvent.click(container.querySelector('.type-card .overlay-button')!);
+		expect(onPick).toHaveBeenCalledWith(EChallengeType.EnemiesKilled);
+	});
+});

--- a/UI/src/tests/routes/game/screens/skills/EquippedBand.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/EquippedBand.test.ts
@@ -210,6 +210,50 @@ describe('EquippedBand — drag to reorder', () => {
 	});
 });
 
+// HTML5 drag-and-drop is mouse-only, so the move buttons give keyboard and touch users a real,
+// focusable path to change battle priority. The buttons are native <button>s, so a click here
+// faithfully represents both a pointer/touch tap and a keyboard activation.
+describe('EquippedBand — reorder via move buttons (keyboard/touch)', () => {
+	const moveButtons = (card: HTMLElement) => Array.from(card.querySelectorAll<HTMLButtonElement>('.reorder .mv'));
+
+	it('renders move-earlier and move-later buttons on each filled card, labelled for assistive tech', () => {
+		const { container } = render(EquippedBand, { props: { view } });
+		const [earlier, later] = moveButtons(filledCards(container)[1]);
+		expect(earlier.tagName).toBe('BUTTON');
+		expect(earlier.getAttribute('aria-label')).toBe('Move Bravo earlier in priority');
+		expect(later.getAttribute('aria-label')).toBe('Move Bravo later in priority');
+	});
+
+	it('disables move-earlier on the first slot and move-later on the last slot', () => {
+		const { container } = render(EquippedBand, { props: { view } });
+		const cards = filledCards(container);
+		expect(moveButtons(cards[0])[0].disabled).toBe(true); // first slot can't move earlier
+		expect(moveButtons(cards[0])[1].disabled).toBe(false);
+		expect(moveButtons(cards[2])[0].disabled).toBe(false);
+		expect(moveButtons(cards[2])[1].disabled).toBe(true); // last slot can't move later
+	});
+
+	it('moves a skill later in priority when its move-later button is activated', async () => {
+		const { container } = render(EquippedBand, { props: { view } });
+		await fireEvent.click(moveButtons(filledCards(container)[0])[1]);
+		expect(sendSocketCommand).toHaveBeenCalledWith('SetSelectedSkills', [1, 0, 2]);
+		expect(view.equipped).toEqual([1, 0, 2]);
+	});
+
+	it('moves a skill earlier in priority when its move-earlier button is activated', async () => {
+		const { container } = render(EquippedBand, { props: { view } });
+		await fireEvent.click(moveButtons(filledCards(container)[2])[0]);
+		expect(sendSocketCommand).toHaveBeenCalledWith('SetSelectedSkills', [0, 2, 1]);
+		expect(view.equipped).toEqual([0, 2, 1]);
+	});
+
+	it('hides the move buttons while a swap is pending', () => {
+		view.toggle(3); // full loadout → starts a swap
+		const { container } = render(EquippedBand, { props: { view } });
+		expect(container.querySelector('.reorder')).toBeNull();
+	});
+});
+
 describe('EquippedBand — empty slot', () => {
 	beforeEach(() => {
 		// Free a slot so the band renders one empty card.


### PR DESCRIPTION
## Summary

Closes #913. Addresses the five distinct accessibility/interaction gaps surfaced during the codebase health review (all frontend-only — no battle logic or backend touched).

| # | Gap | Fix |
|---|-----|-----|
| 1 | **Nested `<button>` in the challenge type-card** (the reward chip is a real button inside the card button — invalid HTML) | The `type-card` is now a presentational `<div>` with a full-bleed `OverlayButton` primary action (open the type), and the reward chip is raised above it so its own tooltip trigger stays interactive. This is the project's established *accessible-card pattern* (docs/frontend.md → Accessibility). |
| 2 | **Loadout reorder is drag-only** (HTML5 DnD is mouse-only; priority is battle-affecting) | Added explicit move-earlier/move-later buttons on each filled card — real `<button>`s that serve keyboard, touch, and mouse. They reveal on hover/`:focus-within`, sit above the overlay, and disable at the ends. Drag still works. |
| 3 | **Sandbox sliders have no accessible name** | Added `aria-label` (`Agility`/`Dexterity`/`Luck`) to each range input. |
| 4 | **Favorite star focusable but invisible while focused** | Reveal on `.fav-star:focus-visible` (opacity 1) and `.grid-slot:focus-within .fav-star` (opacity .75), in addition to the existing hover/favorited reveal. |
| 5 | **Radar vertex has no keyboard refund/decrement** | `handleKey` now maps Arrow up/right → `inc` and Arrow down/left → `dec`; vertices stay focusable (`tabindex=0`) whenever `interactive`, so a keyboard user can refund even at max budget (the affordance the aria-label already advertised). aria-labels updated to mention arrow keys. |

## How it addresses the issue

Each item maps 1:1 to the corresponding numbered point in #913, using the patterns the docs prescribe (presentational container + `OverlayButton`, real interactive elements over `role`-divs, focus-reveal over hover-only).

## Test plan

- **Unit/component tests** added or updated:
  - `OverviewPane.test.ts` (new) — type-card is a `<div>` with a `<button>` overlay; reward chip is never nested in another button; activation calls `onPick`.
  - `EquippedBand.test.ts` — move buttons present/labelled, disabled at ends, reorder via activation, hidden during swap.
  - `AttributesRadar.test.ts` — Arrow-key inc/dec, refund still works at max budget, focusable regardless of `canInc`, ignored when not interactive.
  - `SandboxStrip.test.ts` (new) — slider aria-labels + `setStat` wiring.
  - `Challenges.test.ts` — updated the two type-card click sites to target the new overlay button.
  - Fix #4 is CSS-only (`:focus-visible`/`:focus-within`); not unit-tested as jsdom doesn't resolve scoped-CSS computed opacity.
- `npm run lint` (ESLint + svelte-check): clean.
- `npm run test:unit:ci`: full suite green (2078 tests).

## Note for review

The move-button reorder (item 2) was chosen over an Alt+Arrow-on-card keyboard handler because explicit buttons cover **both** the keyboard and touch gaps the issue calls out with a single discoverable affordance, and keep the "real interactive elements" philosophy. Happy to revisit if you'd prefer a keyboard modifier path instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011t1Aud3HkbdiQ8ZLbuzcH1)_