### PR TITLE
Reject malformed socket frames missing "name" with a structured error (#935)

### DIFF
--- a/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
@@ -37,6 +37,20 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
+        public async Task HandleMessage_FrameMissingName_RejectsWithMalformedErrorInsteadOfThrowing()
+        {
+            // A structurally-valid frame that omits "name" deserializes to a SocketCommandInfo with a null
+            // Name. It must be rejected with a structured error the client can react to, not throw an
+            // unobserved exception that leaves the client hanging on its request id (#935).
+            var (socket, handler) = CreateHandler(_ => null);
+
+            await handler.HandleMessage("{\"id\":\"c1\",\"parameters\":null}");
+
+            Assert.Contains(socket.SentMessages, m => m.Contains("Malformed command.") && m.Contains("c1"));
+            Assert.Contains(_logs.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("no name"));
+        }
+
+        [Fact]
         public async Task ExecuteCommand_CommandFaults_SurfacesInternalServerErrorToTheClient()
         {
             var (socket, handler) = CreateHandler(name => name == "Boom" ? new InvalidOperationException("boom") : null);

--- a/Game.Api/Sockets/SocketHandler.cs
+++ b/Game.Api/Sockets/SocketHandler.cs
@@ -318,7 +318,7 @@ namespace Game.Api.Sockets
             }
         }
 
-        private async Task HandleMessage(string message)
+        internal async Task HandleMessage(string message)
         {
             if (message is "pong")
             {
@@ -336,6 +336,20 @@ namespace Game.Api.Sockets
                 var commandInfo = message.Deserialize<SocketCommandInfo>();
                 if (commandInfo is not null)
                 {
+                    if (string.IsNullOrEmpty(commandInfo.Name))
+                    {
+                        // A structurally-valid frame can omit "name" (System.Text.Json binds it null), so reject
+                        // it with a structured error instead of letting the null reach the command lookup — which
+                        // would throw an unobserved exception and leave the client hanging on its request id.
+                        _logger.LogWarning("Received socket command frame with no name: {Message} on socket: {Id}", message, Id);
+                        await _context.SendData(new ApiSocketResponse
+                        {
+                            Id = commandInfo.Id,
+                            Error = "Malformed command."
+                        });
+                        return;
+                    }
+
                     if (_commandFactory.IsServerInitiatedOnly(commandInfo.Name))
                     {
                         // Server-initiated commands (e.g. ChallengeCompleted, SocketReplaced) are only valid


### PR DESCRIPTION
## Summary

Closes #935.

A structurally-valid JSON socket frame that omits `"name"` (e.g. `{"id":"1","parameters":"..."}`) deserialized into a non-null `SocketCommandInfo` whose `Name` was `null`. The very next line — `IsServerInitiatedOnly(commandInfo.Name)` → `ConcurrentDictionary.ContainsKey(null)` — threw an `ArgumentNullException`. Because `HandleMessage`'s `catch` only handled `JsonException`, the exception escaped into the read loop's generic catch: the connection survived but **the client got no response for that command id and hung until its own 30s backstop fired**.

## How it addresses the issue

`HandleMessage` now guards for a missing/empty `Name` *before* the command lookup and returns the project's structured error response (`"Malformed command."`), mirroring the server-initiated rejection path immediately below it. A malformed-but-parseable frame is now rejected with an error the client can react to, instead of producing a swallowed server exception + client hang.

- `Game.Api/Sockets/SocketHandler.cs` — added the empty-`Name` guard; logs a warning and sends `ApiSocketResponse { Id, Error = "Malformed command." }`. `HandleMessage` changed from `private` to `internal` for direct unit-test access (consistent with the already-`internal` `ExecuteServerCommand`, which is exercised the same way under the existing `InternalsVisibleTo("Game.Api.Tests")`).

## Test plan

- Added `HandleMessage_FrameMissingName_RejectsWithMalformedErrorInsteadOfThrowing` to `SocketCommandExecutionTests` — feeds a structurally-valid frame missing `name`, asserts the client receives a `"Malformed command."` error (echoing the id) and a warning is logged, and that no exception escapes. This fills the test gap the issue calls out.
- `dotnet build` clean (0 warnings).
- Full `Game.Api.Tests` suite green (525 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTLDxf9dT7fHv1sBZp7Bk3)_