### PR TITLE
Fix frontend optimistic-mutation races: serialize setFavorite, cancellable enemy backoff (#939)

### DIFF
--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -50,6 +50,14 @@ export class EnemyManager {
 	/** Re-entrancy guard for getNewEnemy: overlapping stage handlers must not both spawn-and-notify an
 	 *  enemy (a double-spawn the backend replay would flag as cheating). */
 	private fetchingEnemy = false;
+	/** Bumped whenever the active enemy-fetch loop is superseded (a stop, or a transition taking over).
+	 *  The running getNewEnemy captures this value and exits once it no longer matches, so a stale loop
+	 *  under a sustained outage can't keep spinning — nor later clobber the new fight with an enemy
+	 *  nobody is waiting for. */
+	private fetchGeneration = 0;
+	/** Resolver that short-circuits an in-flight retry backoff so a stop / superseding transition need
+	 *  not wait out the full delay before the loop re-checks whether it should still be running. */
+	private cancelBackoff?: () => void;
 
 	public start() {
 		if (!this.started) {
@@ -63,6 +71,9 @@ export class EnemyManager {
 		if (this.started) {
 			this.started = false;
 			this.battleStageUnhook?.();
+			// Cut short an in-flight retry backoff so a getNewEnemy parked under a sustained outage exits
+			// at once on the cleared `started` flag rather than after the full backoff window.
+			this.interruptFetch();
 			this.returnToIdle();
 		}
 	}
@@ -76,11 +87,14 @@ export class EnemyManager {
 			return;
 		}
 		this.fetchingEnemy = true;
+		const generation = this.fetchGeneration;
 		try {
 			// Retry iteratively rather than via self-recursion: each attempt returns to a flat stack
-			// (a sustained outage no longer grows the async chain without bound) and `stop()` cancels
-			// the loop by flipping `started`.
-			while (this.started) {
+			// (a sustained outage no longer grows the async chain without bound). The loop ends as soon
+			// as `stop()` flips `started` or a transition supersedes this fetch (bumping the generation);
+			// because the retry backoff is cancellable, either takes effect immediately rather than after
+			// the full delay — so the controls don't feel frozen while a backoff is parked.
+			while (this.started && generation === this.fetchGeneration) {
 				const result = await apiSocket.sendSocketCommand('NewEnemy', {
 					newZoneId: playerManager.currentZone
 				});
@@ -97,11 +111,45 @@ export class EnemyManager {
 				if (result.error) {
 					logMessage(ELogType.Debug, 'There was an error loading a new enemy: ' + result.error);
 				}
-				await delay(result.data?.cooldown || NEW_ENEMY_RETRY_DELAY_MS);
+				await this.backoff(result.data?.cooldown || NEW_ENEMY_RETRY_DELAY_MS);
 			}
 		} finally {
 			this.fetchingEnemy = false;
 		}
+	}
+
+	/**
+	 * A cancellable retry backoff: resolves after `ms`, or early if {@link interruptFetch} fires, so a
+	 * stop / superseding transition during a sustained outage need not wait out the full delay before
+	 * the fetch loop re-checks its run condition. Still delegates the actual sleep to `delay` (so a
+	 * positive cooldown is honored) rather than re-implementing the timer.
+	 */
+	private backoff(ms: number): Promise<void> {
+		return new Promise<void>((resolve) => {
+			let settled = false;
+			const finish = () => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				// Only clear the shared handle if it still points at this backoff — a later backoff may
+				// have already replaced it (e.g. the real timer firing after an early cancel).
+				if (this.cancelBackoff === finish) {
+					this.cancelBackoff = undefined;
+				}
+				resolve();
+			};
+			this.cancelBackoff = finish;
+			delay(ms).then(finish);
+		});
+	}
+
+	/** Supersedes any in-flight enemy fetch: the running getNewEnemy loop ends at its next check (the
+	 *  bumped generation no longer matches) and its retry backoff is cut short so the supersession takes
+	 *  effect immediately rather than after the parked delay. */
+	private interruptFetch() {
+		this.fetchGeneration++;
+		this.cancelBackoff?.();
 	}
 
 	/**
@@ -111,9 +159,15 @@ export class EnemyManager {
 	 */
 	public async challengeBoss() {
 		if (this.transitioning) {
+			// A rapid press while a prior transition is parked in its enemy-fetch backoff: cut that backoff
+			// short so the prior transition settles (releasing the guard) instead of holding the controls
+			// for the full retry window. This press is still dropped — the player presses again once freed.
+			this.interruptFetch();
 			return;
 		}
 		this.transitioning = true;
+		// Supersede any in-flight idle-loop fetch so its retry can't later overwrite the boss being loaded.
+		this.interruptFetch();
 		this.mode = 'boss';
 		this.bossOutcome = undefined;
 		this.bossUnlockedNextZone = false;
@@ -140,7 +194,13 @@ export class EnemyManager {
 
 	/** Retreat from an in-progress boss fight back to the normal idle farm loop. */
 	public async retreatFromBoss() {
-		if (this.mode !== 'boss' || this.transitioning) {
+		if (this.transitioning) {
+			// As in challengeBoss: a rapid press while a prior transition is parked in its backoff frees it
+			// (releasing the guard) rather than holding the controls for the full retry window.
+			this.interruptFetch();
+			return;
+		}
+		if (this.mode !== 'boss') {
 			return;
 		}
 		this.transitioning = true;

--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -242,19 +242,26 @@ export class InventoryManager {
 	 * updated optimistically; a failed send keeps the local state (it re-syncs on the next toggle or
 	 * on reload) rather than rolling back, since a favourite flag is low-stakes. The transport resolves
 	 * every failure with `response.error` (it never rejects), so the failure is observed and logged.
+	 *
+	 * Routed through {@link serialize} like the other optimistic mutations so its optimistic write can't
+	 * interleave with an in-flight item op's snapshot/rollback baseline — a favorite toggle resolving
+	 * between another op's snapshot and its rollback would otherwise race the rebuild. The no-rollback
+	 * policy lives inside the serialized closure (the toggle stays applied on a failed persist).
 	 */
-	public async setFavorite(itemId: number, favorite: boolean) {
-		const item = this.unlockedItems.get(itemId);
-		if (!item) {
-			return false;
-		}
+	public setFavorite(itemId: number, favorite: boolean): Promise<boolean> {
+		return this.serialize(async () => {
+			const item = this.unlockedItems.get(itemId);
+			if (!item) {
+				return false;
+			}
 
-		item.favorite = favorite;
-		const response = await apiSocket.sendSocketCommand('SetItemFavorite', { itemId, favorite });
-		if (response.error) {
-			logMessage(ELogType.Debug, 'There was an error setting the item favorite: ' + response.error);
-		}
-		return true;
+			item.favorite = favorite;
+			const response = await apiSocket.sendSocketCommand('SetItemFavorite', { itemId, favorite });
+			if (response.error) {
+				logMessage(ELogType.Debug, 'There was an error setting the item favorite: ' + response.error);
+			}
+			return true;
+		});
 	}
 
 	/** Called when the player unlocks a new item from a challenge reward. */
@@ -285,7 +292,7 @@ export class InventoryManager {
 	}
 
 	/**
-	 * Serializes the optimistic mutations (equip/unequip/applyMod/removeMod) so each one captures its
+	 * Serializes the optimistic mutations (equip/unequip/applyMod/removeMod/setFavorite) so each one captures its
 	 * rollback baseline only after the previous mutation has fully settled — persist and any rollback
 	 * included. Overlapping callers (a double-click equip, dragging a second item while the first
 	 * persist is still in flight) would otherwise interleave baselines: one operation's rollback could

--- a/UI/src/lib/engine/player/player-manager.ts
+++ b/UI/src/lib/engine/player/player-manager.ts
@@ -119,8 +119,12 @@ export class PlayerManager implements IPlayerData {
 	public grantExp(exp: number) {
 		logMessage(ELogType.Exp, `Earned ${formatNum(exp)} exp.`);
 		this.exp += exp;
-		while (this.exp >= this.nextLevelThreshold) {
+		let threshold = this.nextLevelThreshold;
+		// A non-positive threshold (a hypothetical EXP_PER_LEVEL constant regression) would spin this
+		// loop forever; guard it so a single bad constant can't lock up the game.
+		while (threshold > 0 && this.exp >= threshold) {
 			this.levelUp();
+			threshold = this.nextLevelThreshold;
 		}
 	}
 

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -390,6 +390,32 @@ describe('EnemyManager boss mode', () => {
 		expect(send).not.toHaveBeenCalledWith('NewEnemy', expect.anything());
 	});
 
+	it('a rapid second press frees a transition parked in its enemy-fetch backoff', async () => {
+		// ChallengeBoss fails, so the transition falls back to getNewEnemy; NewEnemy is also down, so that
+		// fetch parks in its (held-open) retry backoff with `transitioning` still set. A second press is
+		// dropped by the guard but cancels the parked backoff, so the first transition settles promptly
+		// instead of holding the controls for the full retry window.
+		let releaseDelay: () => void = () => {};
+		vi.mocked(delay).mockReturnValue(new Promise<void>((resolve) => (releaseDelay = resolve)));
+		send.mockImplementation((name: string) =>
+			name === 'ChallengeBoss'
+				? Promise.resolve(challengeError)
+				: Promise.resolve({ id: '1', name: 'NewEnemy', error: 'outage' } as IApiSocketResponse<'NewEnemy'>)
+		);
+
+		const first = manager.challengeBoss();
+		await flush(); // park the fallback fetch on its backoff while transitioning is held
+
+		// The second press is dropped (the guard still returns), but it interrupts the parked backoff.
+		await manager.challengeBoss();
+		// The first transition now settles — its fallback fetch loop exits on the superseded generation —
+		// even though the held delay never elapsed. Resolving at all is the proof it was short-circuited.
+		await first;
+
+		expect(manager.mode).toBe('idle');
+		releaseDelay();
+	});
+
 	it('toggles auto-fight', () => {
 		expect(manager.autoFight).toBe(false);
 		manager.setAutoFight(true);

--- a/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
@@ -50,6 +50,10 @@ const cooldownResponse = (cooldown: number): IApiSocketResponse<'NewEnemy'> => (
 const errorResponse = (error: string): IApiSocketResponse<'NewEnemy'> =>
 	({ id: '1', name: 'NewEnemy', error }) as IApiSocketResponse<'NewEnemy'>;
 
+/** Drains the microtask queue (a macrotask boundary) so an in-flight fetch settles up to its next
+ *  awaited point — used to park it on a retry backoff before interleaving a stop. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 describe('EnemyManager.getNewEnemy', () => {
 	let manager: EnemyManager;
 	let sendSocketCommand: ReturnType<typeof vi.spyOn>;
@@ -143,6 +147,27 @@ describe('EnemyManager.getNewEnemy', () => {
 
 		expect(sendSocketCommand).toHaveBeenCalledTimes(1);
 		expect(manager.currentEnemy).toBeUndefined();
+	});
+
+	it('short-circuits an in-flight retry backoff on stop() rather than waiting out the delay', async () => {
+		// Park the loop in its backoff: the first request fails, so it awaits the delay — hold that delay
+		// open so it can only be released by the cancellation path, not by the timer elapsing.
+		sendSocketCommand.mockResolvedValue(errorResponse('outage'));
+		let releaseDelay: () => void = () => {};
+		vi.mocked(delay).mockReturnValue(new Promise<void>((resolve) => (releaseDelay = resolve)));
+
+		const fetch = manager.getNewEnemy();
+		await flush(); // let the first request resolve and the loop park on the backoff
+		expect(sendSocketCommand).toHaveBeenCalledTimes(1);
+
+		// stop() cancels the backoff and clears `started`; the loop wakes and exits without a further
+		// request, even though the held delay never elapsed.
+		manager.stop();
+		await fetch;
+
+		expect(sendSocketCommand).toHaveBeenCalledTimes(1);
+		expect(manager.currentEnemy).toBeUndefined();
+		releaseDelay(); // the real timer firing late is harmless (the backoff already settled)
 	});
 
 	it('drops a concurrent re-entrant call so a stage-change race spawns a single enemy', async () => {

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -529,6 +529,30 @@ describe('InventoryManager', () => {
 			expect(manager.unlockedItems.get(1)?.equipped).toBe(true);
 			expect(manager.unlockedItems.get(1)?.appliedMods.map((m) => m.id)).toEqual([10]);
 		});
+
+		it('serializes setFavorite behind a pending equip so its optimistic write cannot interleave', async () => {
+			// A favorite toggle must wait out an in-flight item op rather than writing its flag between
+			// that op's snapshot and rollback — so it routes through the same chain as the other mutations.
+			let resolveEquip: (value: { error?: string }) => void = () => {};
+			mockSendSocketCommand.mockReturnValueOnce(new Promise((resolve) => (resolveEquip = resolve)));
+
+			const equip = manager.equipItem(1, EEquipmentSlot.WeaponSlot);
+			const fav = manager.setFavorite(1, true);
+
+			await flush();
+			// The equip applied optimistically and awaits its persist; the favorite toggle is still queued
+			// behind it — neither its flag write nor its socket call has happened yet.
+			expect(manager.unlockedItems.get(1)?.equipped).toBe(true);
+			expect(manager.unlockedItems.get(1)?.favorite).toBe(false);
+			expect(mockSendSocketCommand).toHaveBeenCalledTimes(1);
+
+			resolveEquip({});
+			await Promise.all([equip, fav]);
+
+			expect(mockSendSocketCommand).toHaveBeenCalledTimes(2);
+			expect(mockSendSocketCommand).toHaveBeenLastCalledWith('SetItemFavorite', { itemId: 1, favorite: true });
+			expect(manager.unlockedItems.get(1)?.favorite).toBe(true);
+		});
 	});
 
 	describe('unequipItem', () => {


### PR DESCRIPTION
## Summary

Addresses the two behavioral bugs (plus the minor guard) called out in #939, all in the frontend engine.

### 1. `setFavorite` is now serialized with the other optimistic inventory mutations
`InventoryManager.setFavorite` previously mutated `item.favorite` and persisted **outside** the `serialize()` chain that `equipItem`/`unequipItem`/`applyMod`/`removeMod` run through. A favorite toggle resolving between another op's snapshot and its rollback could race the publish/rebuild. It now routes through `serialize()` so its optimistic write can't interleave with an in-flight item mutation — its low-stakes, no-rollback-on-error policy is preserved inside the serialized closure.

### 2. Un-cancellable retry backoff no longer blocks boss-transition controls
`EnemyManager.getNewEnemy`'s retry loop awaited a bare, non-cancellable `delay`. During a sustained outage `transitioning` stayed `true` for the full backoff window, so rapid Challenge/Retreat presses were silently dropped by the `if (this.transitioning) return;` guards, and `stop()` couldn't take effect until the delay elapsed.

The backoff is now cancellable, coordinated by a `fetchGeneration` counter + a `cancelBackoff` handle:
- **`stop()`** cuts the parked backoff short so the loop exits immediately on the cleared `started` flag.
- **A rapid second `challengeBoss`/`retreatFromBoss` press** (still dropped by its guard) interrupts the prior transition's parked backoff so it settles promptly — releasing the guard — instead of holding the controls for the full retry window. The press itself is dropped; the player presses again once freed.
- **A proceeding boss transition** also supersedes any in-flight idle-loop fetch (via the generation bump) so a stale retry can't later overwrite the boss being loaded.

The actual sleep still delegates to `delay`, so explicit cooldowns are honored.

### 3. Minor: `grantExp` level-up loop guard
`PlayerManager.grantExp` now bails the level-up loop on a non-positive level threshold, so a hypothetical `EXP_PER_LEVEL` constant regression can't spin it forever.

## How it addresses the issue
Each of the three points in #939 is implemented as specified. The cancellation design keeps the existing re-entrancy/anti-cheat guarantees (single in-flight fetch, no double-spawn) intact.

## Note on a design choice worth a look
The guard-path interrupt means a rapid second press is still *dropped* (the player presses again once the prior transition frees the guard) rather than the new press *superseding* the in-flight one. Superseding would be a larger behavioral change touching the careful `transitioning`/boss-victory re-entrancy handling, so I kept it out of scope — happy to revisit if you'd prefer the new press to take over.

One compound edge case I left as-is (and didn't want to expand scope for): if an idle fetch is mid-flight (`fetchingEnemy` true) when a *failing* `ChallengeBoss` falls back to `getNewEnemy`, the re-entrancy guard can briefly drop that fallback fetch; it recovers on the next stage change. Let me know if you'd like a follow-up issue for it.

## Test plan
- [x] `npm run lint` — clean (0 errors / 0 warnings)
- [x] `npm run test:unit:ci` — full suite green (2081 passed)
- [x] New unit tests:
  - `setFavorite` is serialized behind a pending equip (optimistic write can't interleave)
  - `stop()` short-circuits an in-flight retry backoff without waiting out the delay
  - a rapid second boss press frees a transition parked in its enemy-fetch backoff

No backend parity mirror is needed — these changes are frontend engine/manager logic, not the `battleStep` per-tick arithmetic that the parity suite guards.

Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEKaRQJwQajNDaKfbSP2Qa)_