### PR TITLE
Harden admin content-authoring write-path validation (#951)

### DIFF
--- a/Game.Abstractions/DataAccess/Admin/IAdminItems.cs
+++ b/Game.Abstractions/DataAccess/Admin/IAdminItems.cs
@@ -16,7 +16,9 @@ namespace Game.Abstractions.DataAccess.Admin
         /// <summary>Applies a change set to an item's attributes. Fails if the item does not exist.</summary>
         AdminSaveResult SetAttributes(AddEditAttributesData data);
 
-        /// <summary>Applies an Add/Edit/Delete change set to an item's mod slots.</summary>
+        /// <summary>Applies an Add/Edit/Delete change set to item mod slots. Fails (applying nothing) if an
+        /// add targets an item that does not exist; an edit/delete of a slot the named item does not have is
+        /// a guarded no-op.</summary>
         AdminSaveResult SaveModSlots(IReadOnlyList<Change<ItemModSlot>> changes);
 
         /// <summary>Replaces an item's tag associations. Fails if the item does not exist.</summary>

--- a/Game.Application.Tests/DataAccess/AdminEnemiesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminEnemiesIntegrationTests.cs
@@ -174,6 +174,39 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SetAttributeDistributions_DuplicateDesiredKeys_ReturnsFailure()
+        {
+            int enemyId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+                enemyId = enemy.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // The same attribute named twice in the desired set would otherwise double-insert into a
+            // composite-PK violation at commit; it must reject up front instead.
+            var data = new SetEnemyAttributeDistributions
+            {
+                EnemyId = enemyId,
+                AttributeDistributions =
+                [
+                    new Contracts.AttributeDistribution { AttributeId = EAttribute.Intellect, BaseAmount = 1m, AmountPerLevel = 1m },
+                    new Contracts.AttributeDistribution { AttributeId = EAttribute.Intellect, BaseAmount = 2m, AmountPerLevel = 2m },
+                ],
+            };
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminEnemies>();
+
+            var result = admin.SetAttributeDistributions(data);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("The submitted attribute distribution set contains duplicate entries.", result.ErrorMessage);
+        }
+
+        [Fact]
         public void SetAttributeDistributions_UnknownEnemy_ReturnsNotFound()
         {
             using var scope = CreateScope();

--- a/Game.Application.Tests/DataAccess/AdminItemsIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminItemsIntegrationTests.cs
@@ -1,0 +1,203 @@
+using Game.Abstractions.Contracts.Admin;
+using Game.Abstractions.DataAccess.Admin;
+using Game.Core;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Contracts = Game.Abstractions.Contracts;
+using Entities = Game.Infrastructure.Entities;
+
+namespace Game.Application.Tests.DataAccess
+{
+    /// <summary>
+    /// Exercises <see cref="IAdminItems"/> write paths that guard malformed change sets before they reach the
+    /// database as a duplicate-key/FK violation or a silent 0-row update: the mod-slot existence/membership
+    /// validation and the attribute change-set upsert. Seeding, the admin write, and the assertion each use a
+    /// separate DI scope so the write runs against an empty change tracker, as a real admin call does.
+    /// </summary>
+    [Collection("Integration")]
+    public class AdminItemsIntegrationTests : ApplicationIntegrationTestBase
+    {
+        public AdminItemsIntegrationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        [Fact]
+        public void SaveModSlots_AddForUnknownItem_ReturnsNotFound()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminItems>();
+
+            var result = admin.SaveModSlots(
+            [
+                new Change<Contracts.ItemModSlot>
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = new Contracts.ItemModSlot { ItemId = 99999, ItemModSlotTypeId = EItemModType.Prefix },
+                },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Item not found.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SaveModSlots_AddsEditsAndDeletesAgainstItemMembership()
+        {
+            int itemId, editedSlotId, removedSlotId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var item = await TestDataSeeder.CreateItemAsync(context);
+                var editedSlot = await TestDataSeeder.AddItemModSlotAsync(context, item.Id, EItemModType.Prefix);
+                var removedSlot = await TestDataSeeder.AddItemModSlotAsync(context, item.Id, EItemModType.Suffix);
+
+                itemId = item.Id;
+                editedSlotId = editedSlot.Id;
+                removedSlotId = removedSlot.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // Add a new slot, retype the edited slot, and drop the removed slot.
+            var changes = new List<Change<Contracts.ItemModSlot>>
+            {
+                new()
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = new Contracts.ItemModSlot { ItemId = itemId, ItemModSlotTypeId = EItemModType.Suffix },
+                },
+                new()
+                {
+                    ChangeType = EChangeType.Edit,
+                    Item = new Contracts.ItemModSlot { Id = editedSlotId, ItemId = itemId, ItemModSlotTypeId = EItemModType.Suffix },
+                },
+                new()
+                {
+                    ChangeType = EChangeType.Delete,
+                    Item = new Contracts.ItemModSlot { Id = removedSlotId, ItemId = itemId },
+                },
+            };
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminItems>();
+                Assert.True(admin.SaveModSlots(changes).Succeeded);
+                await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var slots = await context.ItemModSlots
+                    .Where(s => s.ItemId == itemId)
+                    .ToListAsync(CancellationToken);
+
+                Assert.Equal(2, slots.Count);
+                Assert.DoesNotContain(slots, s => s.Id == removedSlotId);
+                Assert.Equal((int)EItemModType.Suffix, slots.Single(s => s.Id == editedSlotId).ItemModSlotTypeId);
+            }
+        }
+
+        [Fact]
+        public async Task SaveModSlots_EditAndDeleteOfNonMemberSlot_AreGuardedNoOps()
+        {
+            int itemId, slotId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var item = await TestDataSeeder.CreateItemAsync(context);
+                var slot = await TestDataSeeder.AddItemModSlotAsync(context, item.Id, EItemModType.Prefix);
+
+                itemId = item.Id;
+                slotId = slot.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // An edit/delete naming a slot id the item does not have must be reconciled away — not a silent
+            // EF 0-row update/delete — leaving the real slot untouched.
+            var changes = new List<Change<Contracts.ItemModSlot>>
+            {
+                new()
+                {
+                    ChangeType = EChangeType.Edit,
+                    Item = new Contracts.ItemModSlot { Id = 99999, ItemId = itemId, ItemModSlotTypeId = EItemModType.Suffix },
+                },
+                new()
+                {
+                    ChangeType = EChangeType.Delete,
+                    Item = new Contracts.ItemModSlot { Id = 88888, ItemId = itemId },
+                },
+            };
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminItems>();
+                Assert.True(admin.SaveModSlots(changes).Succeeded);
+                await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var slots = await context.ItemModSlots
+                    .Where(s => s.ItemId == itemId)
+                    .ToListAsync(CancellationToken);
+
+                var slot = Assert.Single(slots);
+                Assert.Equal(slotId, slot.Id);
+                Assert.Equal((int)EItemModType.Prefix, slot.ItemModSlotTypeId);
+            }
+        }
+
+        [Fact]
+        public async Task SetAttributes_AddOfAlreadyPresentAttribute_Upserts()
+        {
+            int itemId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                // CreateItemAsync seeds a single Strength attribute (amount 5).
+                var item = await TestDataSeeder.CreateItemAsync(context);
+                itemId = item.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // An Add of an attribute the item already has must upsert, not duplicate-insert into a
+            // composite-PK violation at commit.
+            var data = new AddEditAttributesData
+            {
+                Id = itemId,
+                Changes =
+                [
+                    new Change<Contracts.BattlerAttribute>
+                    {
+                        ChangeType = EChangeType.Add,
+                        Item = new Contracts.BattlerAttribute { AttributeId = EAttribute.Strength, Amount = 50m },
+                    },
+                ],
+            };
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminItems>();
+                Assert.True(admin.SetAttributes(data).Succeeded);
+                await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var attributes = await context.ItemAttributes
+                    .Where(a => a.ItemId == itemId)
+                    .ToListAsync(CancellationToken);
+
+                var attribute = Assert.Single(attributes);
+                Assert.Equal((int)EAttribute.Strength, attribute.AttributeId);
+                Assert.Equal(50m, attribute.Amount);
+            }
+        }
+    }
+}

--- a/Game.Application.Tests/DataAccess/AdminSkillsIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminSkillsIntegrationTests.cs
@@ -1,0 +1,233 @@
+using Game.Abstractions.Contracts.Admin;
+using Game.Abstractions.DataAccess.Admin;
+using Game.Core;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Contracts = Game.Abstractions.Contracts;
+using Entities = Game.Infrastructure.Entities;
+
+namespace Game.Application.Tests.DataAccess
+{
+    /// <summary>
+    /// Exercises <see cref="IAdminSkills"/> change-set write paths: the effect Edit/Delete membership guard
+    /// and the damage-multiplier change-set upsert. Seeding, the admin write, and the assertion each use a
+    /// separate DI scope so the write runs against an empty change tracker, as a real admin call does.
+    /// </summary>
+    [Collection("Integration")]
+    public class AdminSkillsIntegrationTests : ApplicationIntegrationTestBase
+    {
+        public AdminSkillsIntegrationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        [Fact]
+        public void SetEffects_UnknownSkill_ReturnsNotFound()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminSkills>();
+
+            var result = admin.SetEffects(new SetSkillEffectsData { Id = 99999, Changes = [] });
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Skill not found.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SetEffects_AddsEditsAndDeletes()
+        {
+            int skillId, editedEffectId, removedEffectId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var skill = await TestDataSeeder.CreateSkillAsync(context);
+                var editedEffect = await SeedEffectAsync(context, skill.Id, EAttribute.Strength, amount: 10m);
+                var removedEffect = await SeedEffectAsync(context, skill.Id, EAttribute.Endurance, amount: 20m);
+
+                skillId = skill.Id;
+                editedEffectId = editedEffect.Id;
+                removedEffectId = removedEffect.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            var data = new SetSkillEffectsData
+            {
+                Id = skillId,
+                Changes =
+                [
+                    new Change<Contracts.SkillEffect>
+                    {
+                        ChangeType = EChangeType.Add,
+                        Item = NewEffect(EAttribute.Intellect, amount: 30m),
+                    },
+                    new Change<Contracts.SkillEffect>
+                    {
+                        ChangeType = EChangeType.Edit,
+                        Item = NewEffect(EAttribute.Strength, amount: 99m, id: editedEffectId),
+                    },
+                    new Change<Contracts.SkillEffect>
+                    {
+                        ChangeType = EChangeType.Delete,
+                        Item = NewEffect(EAttribute.Endurance, amount: 20m, id: removedEffectId),
+                    },
+                ],
+            };
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminSkills>();
+                Assert.True(admin.SetEffects(data).Succeeded);
+                await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var effects = await context.SkillEffects
+                    .Where(e => e.SkillId == skillId)
+                    .ToListAsync(CancellationToken);
+
+                Assert.Equal(2, effects.Count);
+                Assert.DoesNotContain(effects, e => e.Id == removedEffectId);
+                Assert.Equal(99m, effects.Single(e => e.Id == editedEffectId).Amount);
+                Assert.Contains(effects, e => e.AttributeId == (int)EAttribute.Intellect && e.Amount == 30m);
+            }
+        }
+
+        [Fact]
+        public async Task SetEffects_EditAndDeleteOfUnknownEffect_AreGuardedNoOps()
+        {
+            int skillId, effectId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var skill = await TestDataSeeder.CreateSkillAsync(context);
+                var effect = await SeedEffectAsync(context, skill.Id, EAttribute.Strength, amount: 10m);
+
+                skillId = skill.Id;
+                effectId = effect.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // An edit/delete naming an effect id the skill does not have must reconcile away, leaving the
+            // real effect untouched — never a silent EF 0-row update/delete.
+            var data = new SetSkillEffectsData
+            {
+                Id = skillId,
+                Changes =
+                [
+                    new Change<Contracts.SkillEffect>
+                    {
+                        ChangeType = EChangeType.Edit,
+                        Item = NewEffect(EAttribute.Strength, amount: 999m, id: 99999),
+                    },
+                    new Change<Contracts.SkillEffect>
+                    {
+                        ChangeType = EChangeType.Delete,
+                        Item = NewEffect(EAttribute.Strength, amount: 10m, id: 88888),
+                    },
+                ],
+            };
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminSkills>();
+                Assert.True(admin.SetEffects(data).Succeeded);
+                await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var effects = await context.SkillEffects
+                    .Where(e => e.SkillId == skillId)
+                    .ToListAsync(CancellationToken);
+
+                var effect = Assert.Single(effects);
+                Assert.Equal(effectId, effect.Id);
+                Assert.Equal(10m, effect.Amount);
+            }
+        }
+
+        [Fact]
+        public async Task SetMultipliers_AddOfAlreadyPresentMultiplier_Upserts()
+        {
+            int skillId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                // CreateSkillAsync seeds a single Strength damage multiplier (1.0).
+                var skill = await TestDataSeeder.CreateSkillAsync(context);
+                skillId = skill.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // An Add of a multiplier the skill already has must upsert, not duplicate-insert into a
+            // composite-PK violation at commit.
+            var data = new AddEditAttributesData
+            {
+                Id = skillId,
+                Changes =
+                [
+                    new Change<Contracts.BattlerAttribute>
+                    {
+                        ChangeType = EChangeType.Add,
+                        Item = new Contracts.BattlerAttribute { AttributeId = EAttribute.Strength, Amount = 4m },
+                    },
+                ],
+            };
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminSkills>();
+                Assert.True(admin.SetMultipliers(data).Succeeded);
+                await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var multipliers = await context.SkillDamageMultipliers
+                    .Where(m => m.SkillId == skillId)
+                    .ToListAsync(CancellationToken);
+
+                var multiplier = Assert.Single(multipliers);
+                Assert.Equal((int)EAttribute.Strength, multiplier.AttributeId);
+                Assert.Equal(4m, multiplier.Multiplier);
+            }
+        }
+
+        private static async Task<Entities.SkillEffect> SeedEffectAsync(
+            GameContext context, int skillId, EAttribute attribute, decimal amount)
+        {
+            var effect = new Entities.SkillEffect
+            {
+                SkillId = skillId,
+                Target = (int)ESkillEffectTarget.Self,
+                AttributeId = (int)attribute,
+                ModifierType = (int)EModifierType.Additive,
+                Amount = amount,
+                DurationMs = 1000,
+            };
+            context.SkillEffects.Add(effect);
+            await context.SaveChangesAsync();
+            return effect;
+        }
+
+        private static Contracts.SkillEffect NewEffect(EAttribute attribute, decimal amount, int id = 0)
+        {
+            return new Contracts.SkillEffect
+            {
+                Id = id,
+                Target = ESkillEffectTarget.Self,
+                AttributeId = attribute,
+                ModifierTypeId = EModifierType.Additive,
+                Amount = amount,
+                DurationMs = 1000,
+            };
+        }
+    }
+}

--- a/Game.Application.Tests/DataAccess/AdminZonesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminZonesIntegrationTests.cs
@@ -78,6 +78,41 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SetEnemies_DuplicateDesiredKeys_ReturnsFailure()
+        {
+            int zoneId, enemyId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var zone = await TestDataSeeder.CreateZoneAsync(context);
+                var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+                zoneId = zone.Id;
+                enemyId = enemy.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // The same enemy named twice in the desired set would otherwise double-insert into a
+            // composite-PK violation at commit; it must reject up front instead.
+            var data = new SetZoneEnemiesData
+            {
+                ZoneId = zoneId,
+                ZoneEnemies =
+                [
+                    new Contracts.ZoneEnemy { EnemyId = enemyId, Weight = 1 },
+                    new Contracts.ZoneEnemy { EnemyId = enemyId, Weight = 2 },
+                ],
+            };
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminZones>();
+
+            var result = admin.SetEnemies(data);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("The submitted enemy set contains duplicate entries.", result.ErrorMessage);
+        }
+
+        [Fact]
         public void SetEnemies_UnknownZone_ReturnsNotFound()
         {
             using var scope = CreateScope();

--- a/Game.Application.Tests/DataAccess/AttributeChangeSetProcessorTests.cs
+++ b/Game.Application.Tests/DataAccess/AttributeChangeSetProcessorTests.cs
@@ -31,7 +31,7 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
-        public void Apply_Add_InsertsTheMappedEntity_RegardlessOfMembership()
+        public void Apply_AddOfAbsentAttribute_InsertsTheMappedEntity()
         {
             var store = new RecordingEntityStore();
 
@@ -41,6 +41,41 @@ namespace Game.Application.Tests.DataAccess
             Assert.Equal((int)EAttribute.Strength, inserted.AttributeId);
             Assert.Equal(5m, inserted.Amount);
             Assert.Empty(store.Updated);
+            Assert.Empty(store.Deleted);
+        }
+
+        [Fact]
+        public void Apply_AddOfAlreadyPresentAttribute_Upserts()
+        {
+            // An Add of an attribute the owner already has must update, not duplicate-insert into a
+            // composite-PK violation at commit.
+            var store = new RecordingEntityStore();
+            var existing = new[] { new TestEntity((int)EAttribute.Strength, 1m) };
+
+            Apply([Change(EChangeType.Add, EAttribute.Strength, 5m)], existing, store);
+
+            var updated = Assert.IsType<TestEntity>(Assert.Single(store.Updated));
+            Assert.Equal((int)EAttribute.Strength, updated.AttributeId);
+            Assert.Equal(5m, updated.Amount);
+            Assert.Empty(store.Inserted);
+            Assert.Empty(store.Deleted);
+        }
+
+        [Fact]
+        public void Apply_DuplicateAddInSameBatch_InsertsOnceThenUpdates()
+        {
+            // Two Adds of the same key in one batch must not both insert (which would duplicate-key at
+            // commit): the first inserts, the second sees the now-present key and updates.
+            var store = new RecordingEntityStore();
+
+            Apply(
+            [
+                Change(EChangeType.Add, EAttribute.Strength, 5m),
+                Change(EChangeType.Add, EAttribute.Strength, 7m),
+            ], existing: [], store);
+
+            Assert.Equal(5m, Assert.IsType<TestEntity>(Assert.Single(store.Inserted)).Amount);
+            Assert.Equal(7m, Assert.IsType<TestEntity>(Assert.Single(store.Updated)).Amount);
             Assert.Empty(store.Deleted);
         }
 

--- a/Game.Application.Tests/DataAccess/ChildCollectionReconcilerTests.cs
+++ b/Game.Application.Tests/DataAccess/ChildCollectionReconcilerTests.cs
@@ -1,3 +1,4 @@
+using Game.Abstractions.DataAccess.Admin;
 using Game.DataAccess.Repositories.Admin;
 using Xunit;
 
@@ -18,19 +19,20 @@ namespace Game.Application.Tests.DataAccess
             public List<string> Updated { get; } = [];
         }
 
-        private static void Reconcile(
+        private static AdminSaveResult Reconcile(
             IReadOnlyCollection<ExistingChild> existing,
             IReadOnlyCollection<DesiredChild> desired,
             Recorder recorder,
             bool withUpdate = true)
         {
-            ChildCollectionReconciler.Reconcile(
+            return ChildCollectionReconciler.Reconcile(
                 existing: existing,
                 desired: desired,
                 existingKey: e => e.Key,
                 desiredKey: d => int.Parse(d.Key),
                 delete: e => recorder.Deleted.Add(e.Key),
                 insert: d => recorder.Inserted.Add(d.Payload),
+                resourceName: "child",
                 update: withUpdate ? d => recorder.Updated.Add(d.Payload) : null);
         }
 
@@ -43,11 +45,32 @@ namespace Game.Application.Tests.DataAccess
             var existing = new[] { new ExistingChild(1), new ExistingChild(2) };
             var desired = new[] { new DesiredChild("2", "two"), new DesiredChild("3", "three") };
 
-            Reconcile(existing, desired, recorder);
+            var result = Reconcile(existing, desired, recorder);
 
+            Assert.True(result.Succeeded);
             Assert.Equal([1], recorder.Deleted);
             Assert.Equal(["two"], recorder.Updated);
             Assert.Equal(["three"], recorder.Inserted);
+        }
+
+        [Fact]
+        public void Reconcile_DuplicateDesiredKeys_ReturnsFailureAndInvokesNoHandlers()
+        {
+            // Two desired entries sharing a key would both miss the existing-membership check and
+            // double-insert (a unique violation at commit), so the malformed set is rejected up front and
+            // nothing is staged.
+            var recorder = new Recorder();
+
+            var existing = new[] { new ExistingChild(1) };
+            var desired = new[] { new DesiredChild("2", "two"), new DesiredChild("2", "two-again") };
+
+            var result = Reconcile(existing, desired, recorder);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("The submitted child set contains duplicate entries.", result.ErrorMessage);
+            Assert.Empty(recorder.Deleted);
+            Assert.Empty(recorder.Updated);
+            Assert.Empty(recorder.Inserted);
         }
 
         [Fact]
@@ -141,6 +164,7 @@ namespace Game.Application.Tests.DataAccess
                 desiredKey: d => int.Parse(d.Key),
                 delete: e => deletedChild = e,
                 insert: d => insertedItem = d,
+                resourceName: "child",
                 update: d => updatedItem = d);
 
             Assert.Equal(new ExistingChild(1), deletedChild);

--- a/Game.DataAccess/Repositories/Admin/AdminEnemies.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminEnemies.cs
@@ -49,7 +49,7 @@ namespace Game.DataAccess.Repositories.Admin
                 return AdminSaveResult.NotFound("Enemy");
             }
 
-            ChildCollectionReconciler.Reconcile(
+            return ChildCollectionReconciler.Reconcile(
                 existing: enemy.AttributeDistributions,
                 desired: data.AttributeDistributions,
                 existingKey: ad => ad.AttributeId,
@@ -66,6 +66,7 @@ namespace Game.DataAccess.Repositories.Admin
                     BaseAmount = ad.BaseAmount,
                     AmountPerLevel = ad.AmountPerLevel,
                 }),
+                resourceName: "attribute distribution",
                 update: ad => _entityStore.Update(new Entities.AttributeDistribution
                 {
                     EnemyId = enemy.Id,
@@ -73,8 +74,6 @@ namespace Game.DataAccess.Repositories.Admin
                     BaseAmount = ad.BaseAmount,
                     AmountPerLevel = ad.AmountPerLevel,
                 }));
-
-            return AdminSaveResult.Success;
         }
 
         public AdminSaveResult SetSkills(SetEnemySkillsData data)
@@ -87,7 +86,7 @@ namespace Game.DataAccess.Repositories.Admin
 
             // An EnemySkill is a pure join row (no payload beyond its key), so a skill present on both
             // sides needs no update — only deletes and inserts apply.
-            ChildCollectionReconciler.Reconcile(
+            return ChildCollectionReconciler.Reconcile(
                 existing: enemy.EnemySkills,
                 desired: data.SkillIds,
                 existingKey: es => es.SkillId,
@@ -101,9 +100,8 @@ namespace Game.DataAccess.Repositories.Admin
                 {
                     EnemyId = enemy.Id,
                     SkillId = id,
-                }));
-
-            return AdminSaveResult.Success;
+                }),
+                resourceName: "skill");
         }
 
         public AdminSaveResult SetSpawns(SetEnemySpawnsData data)
@@ -114,7 +112,7 @@ namespace Game.DataAccess.Repositories.Admin
                 return AdminSaveResult.NotFound("Enemy");
             }
 
-            ChildCollectionReconciler.Reconcile(
+            return ChildCollectionReconciler.Reconcile(
                 existing: enemy.ZoneEnemies,
                 desired: data.Spawns,
                 existingKey: ze => ze.ZoneId,
@@ -130,14 +128,13 @@ namespace Game.DataAccess.Repositories.Admin
                     EnemyId = enemy.Id,
                     Weight = s.Weight,
                 }),
+                resourceName: "spawn",
                 update: s => _entityStore.Update(new Entities.ZoneEnemy
                 {
                     ZoneId = s.ZoneId,
                     EnemyId = enemy.Id,
                     Weight = s.Weight,
                 }));
-
-            return AdminSaveResult.Success;
         }
     }
 }

--- a/Game.DataAccess/Repositories/Admin/AdminItems.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminItems.cs
@@ -75,22 +75,58 @@ namespace Game.DataAccess.Repositories.Admin
 
         public AdminSaveResult SaveModSlots(IReadOnlyList<Change<Contracts.ItemModSlot>> changes)
         {
+            // An Add must target an existing owning item — a bad ItemId would otherwise FK-fault at commit
+            // as an opaque 500. Reject the whole batch up front so the commit filter doesn't persist the
+            // rest alongside the invalid add (matching the identity-level saves' up-front validation).
+            if (changes.Any(c => c.ChangeType == EChangeType.Add && _items.LookupItem(c.Item.ItemId) is null))
+            {
+                return AdminSaveResult.NotFound("Item");
+            }
+
+            // Memoize each referenced item's current slot-id set so the Edit/Delete membership guard is an
+            // O(1) lookup, not a per-change linear scan over the item's slots.
+            var slotIdsByItem = new Dictionary<int, HashSet<int>>();
+            HashSet<int> SlotIds(int itemId)
+            {
+                if (!slotIdsByItem.TryGetValue(itemId, out var ids))
+                {
+                    ids = _items.LookupItem(itemId)?.ItemModSlots.Select(s => s.Id).ToHashSet() ?? [];
+                    slotIdsByItem[itemId] = ids;
+                }
+                return ids;
+            }
+
             return ChangeSetProcessor.Apply(changes,
                 add: item => _entityStore.Insert(new Entities.ItemModSlot
                 {
                     ItemId = item.ItemId,
                     ItemModSlotTypeId = (int)item.ItemModSlotTypeId,
                 }),
-                edit: item => _entityStore.Update(new Entities.ItemModSlot
+                // Edit/Delete are guarded by the slot's membership in its stated owning item (mirroring the
+                // other child-collection setters): a slot the item doesn't have is reconciled away, never a
+                // silent EF 0-row update/delete.
+                edit: item =>
                 {
-                    Id = item.Id,
-                    ItemId = item.ItemId,
-                    ItemModSlotTypeId = (int)item.ItemModSlotTypeId,
-                }),
-                delete: item => _entityStore.Delete(new Entities.ItemModSlot
+                    if (SlotIds(item.ItemId).Contains(item.Id))
+                    {
+                        _entityStore.Update(new Entities.ItemModSlot
+                        {
+                            Id = item.Id,
+                            ItemId = item.ItemId,
+                            ItemModSlotTypeId = (int)item.ItemModSlotTypeId,
+                        });
+                    }
+                },
+                delete: item =>
                 {
-                    Id = item.Id,
-                }));
+                    if (SlotIds(item.ItemId).Contains(item.Id))
+                    {
+                        _entityStore.Delete(new Entities.ItemModSlot
+                        {
+                            Id = item.Id,
+                        });
+                    }
+                });
         }
 
         public async Task<AdminSaveResult> SetTags(SetTagsData data, CancellationToken cancellationToken = default)

--- a/Game.DataAccess/Repositories/Admin/AdminSkills.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminSkills.cs
@@ -78,6 +78,11 @@ namespace Game.DataAccess.Repositories.Admin
                 return AdminSaveResult.NotFound("Skill");
             }
 
+            // Precompute the current effect-id set once so each Edit/Delete membership guard is an O(1)
+            // lookup rather than a per-change linear scan over the skill's effects (matching the other
+            // change-set guards in this layer).
+            var existingEffectIds = skill.SkillEffects.Select(se => se.Id).ToHashSet();
+
             return ChangeSetProcessor.Apply(data.Changes,
                 add: effect => _entityStore.Insert(new Entities.SkillEffect
                 {
@@ -92,7 +97,7 @@ namespace Game.DataAccess.Repositories.Admin
                 // the whole graph into the change tracker.
                 edit: effect =>
                 {
-                    if (skill.SkillEffects.Any(se => se.Id == effect.Id))
+                    if (existingEffectIds.Contains(effect.Id))
                     {
                         _entityStore.Update(new Entities.SkillEffect
                         {
@@ -108,7 +113,7 @@ namespace Game.DataAccess.Repositories.Admin
                 },
                 delete: effect =>
                 {
-                    if (skill.SkillEffects.Any(se => se.Id == effect.Id))
+                    if (existingEffectIds.Contains(effect.Id))
                     {
                         _entityStore.Delete(new Entities.SkillEffect
                         {

--- a/Game.DataAccess/Repositories/Admin/AdminZones.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminZones.cs
@@ -91,7 +91,7 @@ namespace Game.DataAccess.Repositories.Admin
                 return AdminSaveResult.NotFound("Zone");
             }
 
-            ChildCollectionReconciler.Reconcile(
+            return ChildCollectionReconciler.Reconcile(
                 existing: zone.ZoneEnemies,
                 desired: data.ZoneEnemies,
                 existingKey: ze => ze.EnemyId,
@@ -107,14 +107,13 @@ namespace Game.DataAccess.Repositories.Admin
                     EnemyId = ze.EnemyId,
                     Weight = ze.Weight,
                 }),
+                resourceName: "enemy",
                 update: ze => _entityStore.Update(new Entities.ZoneEnemy
                 {
                     ZoneId = data.ZoneId,
                     EnemyId = ze.EnemyId,
                     Weight = ze.Weight,
                 }));
-
-            return AdminSaveResult.Success;
         }
     }
 }

--- a/Game.DataAccess/Repositories/Admin/AttributeChangeSetProcessor.cs
+++ b/Game.DataAccess/Repositories/Admin/AttributeChangeSetProcessor.cs
@@ -6,19 +6,21 @@ namespace Game.DataAccess.Repositories.Admin
     /// <summary>
     /// Applies an attribute-keyed Add/Edit/Delete change set — an item's or item mod's attributes, or a
     /// skill's damage multipliers — to one owner's already-resolved child collection, building a fresh,
-    /// navigation-free entity per change. It owns the shape every such setter repeated: an Insert per Add and
-    /// a membership-guarded Update/Delete per Edit/Delete. The caller supplies only the part that differs
+    /// navigation-free entity per change. It owns the shape every such setter repeated: a membership-guarded
+    /// upsert per Add (insert when absent, update when the owner already has the attribute) and a
+    /// membership-guarded Update/Delete per Edit/Delete. The caller supplies only the part that differs
     /// across the three owners — how a desired <see cref="BattlerAttribute"/> maps to its persisted entity
     /// (the owner FK plus the <c>Amount</c>/<c>Multiplier</c> projection) — via <paramref name="toEntity"/>.
     /// This is an implementation detail of the Content Authoring persistence layer; it lives in
     /// <c>Game.DataAccess</c> alongside <see cref="ChangeSetProcessor"/> and the admin repositories.
     /// </summary>
     /// <remarks>
-    /// Edit and Delete are guarded by the owner's current attribute membership: a change targeting an
-    /// attribute the owner doesn't have is a no-op, never an EF 0-row update/delete that would throw. This is
-    /// deliberately distinct from the identity-level saves (which reject an edit of a missing record up
-    /// front): the change set here is a delta the client computed against a baseline it just read, so an
-    /// edit/delete of an absent attribute reconciles idempotently to the same end state — see
+    /// Add, Edit and Delete are all guarded by the owner's current attribute membership: an Add of an
+    /// already-present attribute upserts (rather than duplicate-inserting into a composite-PK violation),
+    /// and an Edit/Delete of an attribute the owner doesn't have is a no-op (never an EF 0-row update/delete
+    /// that would throw). This is deliberately distinct from the identity-level saves (which reject an edit
+    /// of a missing record up front): the change set here is a delta the client computed against a baseline
+    /// it just read, so it reconciles idempotently to the same end state — see
     /// <c>docs/backend-admin.md</c> → Admin Tools API surface. Ordering and dispatch are delegated to
     /// <see cref="ChangeSetProcessor"/>; the same fresh entity carries the key for a delete (its non-key
     /// payload is ignored once the row is staged as removed).
@@ -35,7 +37,21 @@ namespace Game.DataAccess.Repositories.Admin
             var existingKeys = existing.Select(existingKey).ToHashSet();
 
             ChangeSetProcessor.Apply(changes,
-                add: attribute => entityStore.Insert(toEntity(attribute)),
+                // An Add of an attribute the owner already has (or one added earlier in this same batch)
+                // is an upsert, not a duplicate composite-PK insert that violates at commit. Adds sort
+                // last (after Delete/Edit), so updating existingKeys here can't disturb the membership
+                // guards below — and a repeated Add then routes to Update rather than a second Insert.
+                add: attribute =>
+                {
+                    if (existingKeys.Add((int)attribute.AttributeId))
+                    {
+                        entityStore.Insert(toEntity(attribute));
+                    }
+                    else
+                    {
+                        entityStore.Update(toEntity(attribute));
+                    }
+                },
                 edit: attribute =>
                 {
                     if (existingKeys.Contains((int)attribute.AttributeId))

--- a/Game.DataAccess/Repositories/Admin/ChildCollectionReconciler.cs
+++ b/Game.DataAccess/Repositories/Admin/ChildCollectionReconciler.cs
@@ -1,3 +1,5 @@
+using Game.Abstractions.DataAccess.Admin;
+
 namespace Game.DataAccess.Repositories.Admin
 {
     /// <summary>
@@ -27,16 +29,29 @@ namespace Game.DataAccess.Repositories.Admin
         // The collections are typed IReadOnlyCollection rather than IEnumerable because each is enumerated
         // twice (once to build its key set, once to diff), so a deferred/lazy source would re-run — and could
         // yield a different sequence the second time. Requiring a materialized collection rules that out.
-        public static void Reconcile<TExisting, TDesired, TKey>(
+        public static AdminSaveResult Reconcile<TExisting, TDesired, TKey>(
             IReadOnlyCollection<TExisting> existing,
             IReadOnlyCollection<TDesired> desired,
             Func<TExisting, TKey> existingKey,
             Func<TDesired, TKey> desiredKey,
             Action<TExisting> delete,
             Action<TDesired> insert,
+            string resourceName,
             Action<TDesired>? update = null) where TKey : notnull
         {
-            var desiredKeys = desired.Select(desiredKey).ToHashSet();
+            // A full desired set must not name the same child twice: a duplicate key slips past the
+            // existing-membership check (both copies miss it) and double-inserts into a unique violation
+            // at commit — or, for an existing key, double-tracks the same entity as Modified, which EF
+            // rejects. The set is malformed input, so reject the whole write up front as a business error.
+            var desiredKeys = new HashSet<TKey>();
+            foreach (var item in desired)
+            {
+                if (!desiredKeys.Add(desiredKey(item)))
+                {
+                    return AdminSaveResult.Failure($"The submitted {resourceName} set contains duplicate entries.");
+                }
+            }
+
             var existingKeys = existing.Select(existingKey).ToHashSet();
 
             foreach (var child in existing)
@@ -58,6 +73,8 @@ namespace Game.DataAccess.Repositories.Admin
                     insert(item);
                 }
             }
+
+            return AdminSaveResult.Success;
         }
     }
 }

--- a/Game.DataAccess/Repositories/Admin/TagAssignmentReconciler.cs
+++ b/Game.DataAccess/Repositories/Admin/TagAssignmentReconciler.cs
@@ -21,13 +21,16 @@ namespace Game.DataAccess.Repositories.Admin
             var current = await currentTagIds.ToHashSetAsync(cancellationToken: cancellationToken);
             var desired = await desiredTagIds.ToHashSetAsync(cancellationToken: cancellationToken);
 
+            // The desired ids arrive as a HashSet, so duplicates are structurally impossible here and the
+            // reconciler's duplicate-key rejection can never fire — the result is always success.
             ChildCollectionReconciler.Reconcile(
                 existing: current,
                 desired: desired,
                 existingKey: id => id,
                 desiredKey: id => id,
                 delete: tagId => entityStore.Delete(toJoinRow(tagId)),
-                insert: tagId => entityStore.Insert(toJoinRow(tagId)));
+                insert: tagId => entityStore.Insert(toJoinRow(tagId)),
+                resourceName: "tag");
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes the four duplicate-key / missing-existence validation gaps called out in #951 on the Content Authoring admin write path, so a malformed `Set*`/`Save*` payload is rejected cleanly (a 400-mapped `AdminSaveResult` or a guarded no-op) instead of reaching the DB as a duplicate-key/FK violation (a 500 at commit) or a silent 0-row update.

### 1. `ChildCollectionReconciler.Reconcile` rejects duplicate desired keys
`existingKeys` was computed once and the insert loop iterated the raw `desired` collection, so two desired entries with the same key both missed `existingKeys` → two `Insert` calls for the same PK (unique violation), and on an existing key two `Update` calls double-track the same entity (which EF also rejects). The reconciler now scans the desired set for duplicate keys up front and returns a graceful business failure (`"The submitted {resource} set contains duplicate entries."`) before staging anything. Its signature changed from `void` to `AdminSaveResult` plus a `resourceName`; the five call sites (enemy attribute distributions / skills / spawns, zone enemies, tag assignments) propagate the result. The tag path passes a `HashSet`, so duplicates are structurally impossible there and the guard never fires.

### 2. `AttributeChangeSetProcessor.Apply` guards the Add path
`add` previously called `Insert` unconditionally, so an Add of an attribute the owner already has duplicate-inserted a composite-PK row. Add is now a membership-guarded **upsert**: insert when the key is absent, update when present. It mutates the `existingKeys` set as it inserts, so a duplicate Add **within the same batch** routes the second occurrence to Update instead of a second Insert. Adds sort last (after Delete/Edit), so this can't disturb the edit/delete membership guards.

### 3. `AdminItems.SaveModSlots` adds existence/membership validation
It now rejects the batch up front (`NotFound("Item")`) if any **Add** targets a non-existent owning item (a bad `ItemId` would otherwise FK-fault at commit), and guards **Edit/Delete** by the slot's membership in its stated owning item — a slot the item doesn't have is reconciled away rather than becoming a silent EF 0-row update/delete. Membership uses a memoized per-item slot-id set so each guard is O(1).

### 4. `AdminSkills.SetEffects` precomputes the membership set
The Edit/Delete guards did an `O(changes × effects)` `.Any(...)` linear scan per change; they now share a single precomputed `HashSet` of the skill's effect ids, matching every other guard in this layer.

## How it addresses the issue
Each of the four numbered points in #951 is implemented as specified, choosing the "upsert / reject up front" options most consistent with the documented admin write-path contract (identity/owner saves reject up front; child edits/deletes of a missing member are guarded no-ops). Docs/XML comments for the affected helpers and `IAdminItems.SaveModSlots` were updated to match.

## Out of scope (follow-up)
The issue's "Related" section suggests folding the copy-pasted Edit-existence guard into `ChangeSetProcessor` (so a repo *can't* omit it, as #3 did) and having `AdminChallenges` reuse `_challenges.ValidateChallengeId(...)` instead of its inline bounds check. That's a cross-repo refactor touching seven repositories, so I've left it for a follow-up issue rather than expanding this PR's scope.

## Test plan
- [x] `dotnet build` — clean (0 warnings / 0 errors)
- [x] Full backend suite green: Core 620, Infrastructure 42, Application 325, Api 525 — 0 failures
- New unit tests: reconciler duplicate-key rejection; attribute Add-of-present upsert and duplicate-Add-in-batch
- New integration tests: `AdminItems` mod-slot add-of-unknown-item rejection, add/edit/delete-against-membership, non-member edit/delete no-ops, and attribute upsert; `AdminSkills` effect add/edit/delete, unknown-effect no-ops, multiplier upsert; enemy & zone duplicate-key rejection

Closes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAsAGk8mfmdkoyTn4tTxuT)_