### PR TITLE
Frontend reactivity/perf cleanups + dead code (Stats, Attributes, Skills, Challenges)

### DIFF
--- a/UI/src/lib/battle/attribute-collection.ts
+++ b/UI/src/lib/battle/attribute-collection.ts
@@ -151,11 +151,16 @@ export const SOURCE_ORDER: readonly EAttributeModifierSource[] = [
 	EAttributeModifierSource.Derived
 ];
 
+/** A computed attribute's additive lines bucketed by source (in {@link SOURCE_ORDER}),
+ *  with the multiplicative lines kept separate. */
+export interface GroupedBySource<T extends AttributeModifier = AttributeModifier> {
+	groups: SourceGroup<T>[];
+	mults: AppliedModifier<T>[];
+}
+
 /** Splits a computed attribute's additive lines into per-source groups (in
  *  {@link SOURCE_ORDER}) and returns the multiplicative lines separately. */
-export function groupBySource<T extends AttributeModifier>(
-	computed: ComputedAttribute<T>
-): { groups: SourceGroup<T>[]; mults: AppliedModifier<T>[] } {
+export function groupBySource<T extends AttributeModifier>(computed: ComputedAttribute<T>): GroupedBySource<T> {
 	const groups = new Map<EAttributeModifierSource, SourceGroup<T>>();
 	const mults: AppliedModifier<T>[] = [];
 	for (const line of computed.lines) {

--- a/UI/src/routes/game/screens/attribute-breakdown/BreakdownDetail.svelte
+++ b/UI/src/routes/game/screens/attribute-breakdown/BreakdownDetail.svelte
@@ -16,7 +16,7 @@
 		<div class="value">{fmtNum(computed.total, view.selectedMeta.dec, view.selectedMeta.pct)}</div>
 	</div>
 
-	<div class="bar"><StackBar {computed} height={18} /></div>
+	<div class="bar"><StackBar {computed} grouped={view.selectedGrouped} height={18} /></div>
 	<div class="legend"><SourceLegend sources={groups.map((g) => g.source)} /></div>
 
 	{#if computed.lines.length === 0}

--- a/UI/src/routes/game/screens/attribute-breakdown/StackBar.svelte
+++ b/UI/src/routes/game/screens/attribute-breakdown/StackBar.svelte
@@ -29,12 +29,15 @@
 </div>
 
 <script lang="ts">
-import { groupBySource, type ComputedAttribute } from '$lib/battle';
+import { groupBySource, type ComputedAttribute, type GroupedBySource } from '$lib/battle';
 import { sourceColor, sourceLabel } from './source-display';
 import { fmtSigned, type LabeledModifier } from './attribute-breakdown-view.svelte';
 
 interface Props {
 	computed: ComputedAttribute<LabeledModifier>;
+	/** Pre-grouped source decomposition; derived from `computed` when omitted. Pass
+	 *  the view-model's already-computed grouping to avoid re-running groupBySource. */
+	grouped?: GroupedBySource<LabeledModifier>;
 	height?: number;
 	radius?: number;
 	/** Width the full bar represents; defaults to this attribute's own total so
@@ -42,11 +45,11 @@ interface Props {
 	scaleMax?: number;
 }
 
-let { computed, height = 14, radius = 2, scaleMax }: Props = $props();
+let { computed, grouped, height = 14, radius = 2, scaleMax }: Props = $props();
 
-const grouped = $derived(groupBySource(computed));
-const groups = $derived(grouped.groups);
-const mults = $derived(grouped.mults);
+const resolved = $derived(grouped ?? groupBySource(computed));
+const groups = $derived(resolved.groups);
+const mults = $derived(resolved.mults);
 const scale = $derived(scaleMax || Math.max(computed.total, computed.additiveSubtotal) || 1);
 </script>
 

--- a/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
+++ b/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
@@ -30,7 +30,7 @@ import {
 	type ComputedAttribute
 } from '$lib/battle';
 import { attributeName } from '$lib/common';
-import { playerManager, inventoryManager, type EEquipmentSlot } from '$lib/engine';
+import { playerManager, inventoryManager } from '$lib/engine';
 import { staticData } from '$stores';
 
 /** An {@link AttributeModifier} carrying display-only provenance so the
@@ -41,8 +41,6 @@ export type LabeledModifier = AttributeModifier & {
 	/** The equipped item or applied mod name; absent for base/points/derived,
 	 *  which are labelled by their source. */
 	label?: string;
-	/** The equipment slot a gear/mod contribution came from. */
-	slot?: EEquipmentSlot;
 	/** The mod type (Component/Prefix/Suffix) for an `ItemMod` contribution. */
 	modType?: EItemModType;
 };
@@ -150,13 +148,6 @@ export function fmtSigned(n: number, dec?: number, pct = false): string {
 
 /* ── contribution-line labels ─────────────────────────────────────────────── */
 
-const SLOT_LABELS = ['Helm', 'Chest', 'Leg', 'Boot', 'Weapon', 'Accessory'];
-
-/** Short equipment-slot label (e.g. `Weapon`) for a gear/mod contribution. */
-export function slotLabel(slot: number | undefined): string {
-	return slot != null ? (SLOT_LABELS[slot] ?? '') : '';
-}
-
 /** Shared shape of a contribution-line label: both the full and the short variants resolve a derived
  *  line to its source attribute and any gear line to the item/mod name, differing only in the fixed
  *  phrasing used for the base-value and stat-point sources (`base`/`statPoints`). */
@@ -222,8 +213,7 @@ export function buildPlayerModifiers(): LabeledModifier[] {
 				amount: attr.amount,
 				type: EModifierType.Additive,
 				source: EAttributeModifierSource.Item,
-				label: item.name,
-				slot
+				label: item.name
 			});
 		}
 		for (const mod of item.appliedMods) {
@@ -234,8 +224,7 @@ export function buildPlayerModifiers(): LabeledModifier[] {
 					type: EModifierType.Additive,
 					source: EAttributeModifierSource.ItemMod,
 					label: mod.name,
-					modType: mod.itemModTypeId,
-					slot
+					modType: mod.itemModTypeId
 				});
 			}
 		}

--- a/UI/src/routes/game/screens/attribute-breakdown/source-display.ts
+++ b/UI/src/routes/game/screens/attribute-breakdown/source-display.ts
@@ -8,7 +8,6 @@
    itself is the domain enum `EAttributeModifierSource` from `$lib/battle`. */
 
 import { EAttributeModifierSource } from '$lib/battle';
-import { tintColor } from '$lib/common';
 
 /** Kebab key matching the `--source-*` custom properties (e.g. `points`). */
 const SOURCE_KEY: Record<EAttributeModifierSource, string> = {
@@ -36,10 +35,6 @@ const SOURCE_LABEL: Record<EAttributeModifierSource, string> = {
 
 /** Themeable source accent hue, e.g. `var(--source-points)`. */
 export const sourceColor = (source: EAttributeModifierSource): string => `var(--source-${SOURCE_KEY[source]})`;
-
-/** The source accent at a given opacity (themeable via `color-mix`). */
-export const sourceTint = (source: EAttributeModifierSource, alpha: number): string =>
-	tintColor(sourceColor(source), alpha);
 
 /** Human-readable label for a source ("Stat points", "Equipment", …). */
 export const sourceLabel = (source: EAttributeModifierSource): string => SOURCE_LABEL[source];

--- a/UI/src/routes/game/screens/attributes/DerivedPanel.svelte
+++ b/UI/src/routes/game/screens/attributes/DerivedPanel.svelte
@@ -6,7 +6,7 @@
 		{#each visibleGroups as group (group)}
 			<div class="group">
 				<div class="group-label">{group}</div>
-				{#each statsIn(group) as d (d.id)}
+				{#each STATS_BY_GROUP[group] as d (d.id)}
 					{@const from = view.savedDerived[d.id]}
 					{@const to = view.derived[d.id]}
 					{@const isChanged = from !== to}
@@ -44,12 +44,11 @@ import AttributeIcon from '$components/AttributeIcon.svelte';
 import {
 	DERIVED_GROUPS,
 	DERIVED_STATS,
-	CORE_ATTRIBUTES,
-	feedsFor,
+	contributorsFor,
 	type AttributesView,
-	type DerivedGroup
+	type DerivedGroup,
+	type DerivedStatDef
 } from './attributes-view.svelte';
-import type { EAttribute } from '$lib/api';
 
 interface Props {
 	view: AttributesView;
@@ -57,13 +56,16 @@ interface Props {
 
 const { view }: Props = $props();
 
-const statsIn = (group: DerivedGroup) => DERIVED_STATS.filter((d) => d.group === group);
-const visibleGroups = DERIVED_GROUPS.filter((g) => statsIn(g).length > 0);
-
-/** The core attributes that feed a derived stat — the live inverse of `feedsFor`,
- *  so the "fed by" line never goes stale. */
-const contributorsFor = (derivedId: EAttribute): EAttribute[] =>
-	CORE_ATTRIBUTES.filter((_, i) => feedsFor(i).includes(derivedId));
+// The derived stats grouped once (static reference data) so the panel doesn't
+// re-scan DERIVED_STATS on every reactive update.
+const STATS_BY_GROUP = DERIVED_GROUPS.reduce(
+	(map, group) => {
+		map[group] = DERIVED_STATS.filter((d) => d.group === group);
+		return map;
+	},
+	{} as Record<DerivedGroup, DerivedStatDef[]>
+);
+const visibleGroups = DERIVED_GROUPS.filter((g) => STATS_BY_GROUP[g].length > 0);
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -128,6 +128,24 @@ export function feedsFor(coreIndex: number): EAttribute[] {
 	return perPointYields(coreIndex).map((y) => y.id);
 }
 
+/** Inverse of {@link feedsFor}: the core attributes that feed each derived stat,
+ *  precomputed once from the constant per-point yields so the breakdown's "fed by"
+ *  line is an O(1) lookup rather than a per-render scan over every core attribute. */
+const CONTRIBUTORS_BY_DERIVED: Partial<Record<EAttribute, EAttribute[]>> = (() => {
+	const map: Partial<Record<EAttribute, EAttribute[]>> = {};
+	CORE_ATTRIBUTES.forEach((core, i) => {
+		for (const derivedId of feedsFor(i)) {
+			(map[derivedId] ??= []).push(core);
+		}
+	});
+	return map;
+})();
+
+/** The core attributes that feed a derived stat (inverse of {@link feedsFor}). */
+export function contributorsFor(derivedId: EAttribute): EAttribute[] {
+	return CONTRIBUTORS_BY_DERIVED[derivedId] ?? [];
+}
+
 /** Maps a pointer position (in the radar's SVG user space) to the attribute
  *  value its axis vertex would represent if dragged there: projects the pointer
  *  onto the axis direction (so sideways drift is ignored and only the radial
@@ -219,10 +237,6 @@ export class AttributesView {
 	 *  a fixed value for the duration of a drag so allocating points mid-gesture
 	 *  can't rescale the radar (see {@link lockScale}). */
 	readonly hexMax = $derived(this.#lockedHexMax ?? computeHexMax(this.draft, this.committed));
-
-	isDirtyIndex(i: number): boolean {
-		return this.draft[i] !== this.committed[i];
-	}
 
 	/** Whether any attribute can still be incremented (points remain). */
 	canInc(): boolean {

--- a/UI/src/routes/game/screens/challenges/RewardTooltip.svelte
+++ b/UI/src/routes/game/screens/challenges/RewardTooltip.svelte
@@ -25,5 +25,7 @@ interface Props {
 
 const { reward }: Props = $props();
 
-let container: HTMLDivElement;
+// Bound to the root element and relocated into the global tooltip container by
+// getBaseNode(); reactive so the relocation runs once this has mounted.
+let container = $state<HTMLDivElement>();
 </script>

--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -290,11 +290,11 @@ export class SkillsView {
 		return list.sort(sortMetrics(this.sort, this.defense));
 	});
 
-	/** Equipped rail rows, ordered by loadout slot (not by the active sort). */
+	/** Equipped rail rows, ordered by loadout slot (not by the active sort). Built from
+	 *  the unfiltered loadout so a search/attribute filter can't drop an equipped row while
+	 *  the header still counts it — filtering is reserved for {@link availableRail}. */
 	readonly equippedRail = $derived(
-		this.railList
-			.filter((m) => this.isEquipped(m.skill.id))
-			.sort((a, b) => this.slotOf(a.skill.id) - this.slotOf(b.skill.id))
+		this.equipped.map((id) => this.metricsById[id]).filter((m): m is SkillMetrics => m != null)
 	);
 
 	/** Available (unequipped) rail rows, in the active sort order. */

--- a/UI/src/routes/game/screens/stats/ByStatisticView.svelte
+++ b/UI/src/routes/game/screens/stats/ByStatisticView.svelte
@@ -5,7 +5,7 @@
 	<div class="scroll">
 		<div class="grid" data-testid="stat-card-grid">
 			{#each view.shownStats as stat (stat.id)}
-				<StatCard data={view.data} {stat} onPickEntity={(kind, id) => view.goEntity(kind, id)} />
+				<StatCard summary={view.data.summaryFor(stat.id)} {stat} onPickEntity={(kind, id) => view.goEntity(kind, id)} />
 			{/each}
 		</div>
 	</div>

--- a/UI/src/routes/game/screens/stats/DossierTile.svelte
+++ b/UI/src/routes/game/screens/stats/DossierTile.svelte
@@ -27,22 +27,22 @@
 import CategoryTag from './CategoryTag.svelte';
 import CompHint from './CompHint.svelte';
 import MiniBar from './MiniBar.svelte';
-import type { EntityStatInfo, StatisticsData, StatEntityKind } from './statistics-view.svelte';
+import type { EntityStatInfo, StatSummary, StatEntityKind } from './statistics-view.svelte';
 import { fmtValue, statKindColor } from './statistics-display';
 
 interface Props {
 	info: EntityStatInfo;
-	data: StatisticsData;
+	/** Memoised rows + bar max for this stat (computed on StatisticsData). */
+	summary: StatSummary;
 	kind: StatEntityKind;
 	selId: number;
 	onPickStat: (cat: EntityStatInfo['stat']['cat']) => void;
 }
 
-let { info, data, kind, selId, onPickStat }: Props = $props();
+let { info, summary, kind, selId, onPickStat }: Props = $props();
 
-const rows = $derived(data.rowsForStat(info.stat.id));
-const maxVal = $derived(Math.max(...rows.map((r) => r.value), 1));
-const top = $derived(rows[0]);
+const maxVal = $derived(summary.maxVal);
+const top = $derived(summary.rows[0]);
 const isTop = $derived(top?.entityId === selId);
 const kindColor = $derived(statKindColor(kind));
 </script>

--- a/UI/src/routes/game/screens/stats/EntityDossier.svelte
+++ b/UI/src/routes/game/screens/stats/EntityDossier.svelte
@@ -22,7 +22,7 @@
 			{#each view.entityStats as info (info.stat.id)}
 				<DossierTile
 					{info}
-					data={view.data}
+					summary={view.data.summaryFor(info.stat.id)}
 					kind={view.entKind}
 					selId={entity.id}
 					onPickStat={(cat) => view.goStat(cat)}

--- a/UI/src/routes/game/screens/stats/StatCard.svelte
+++ b/UI/src/routes/game/screens/stats/StatCard.svelte
@@ -35,22 +35,22 @@ import CategoryTag from './CategoryTag.svelte';
 import KindBadge from './KindBadge.svelte';
 import CompHint from './CompHint.svelte';
 import StatCardRow from './StatCardRow.svelte';
-import type { StatisticsData, StatType, StatEntityKind } from './statistics-view.svelte';
+import type { StatSummary, StatType, StatEntityKind } from './statistics-view.svelte';
 import { fmtValue, statKindPlural } from './statistics-display';
 
 interface Props {
-	data: StatisticsData;
+	/** Memoised rows + bar max + headline for this stat (computed on StatisticsData). */
+	summary: StatSummary;
 	stat: StatType;
 	onPickEntity: (kind: StatEntityKind, id: number) => void;
 }
 
-let { data, stat, onPickEntity }: Props = $props();
+let { summary, stat, onPickEntity }: Props = $props();
 
-const rows = $derived(data.rowsForStat(stat.id));
-const headline = $derived(data.statHeadline(stat.id));
-const maxVal = $derived(Math.max(...rows.map((r) => r.value), 1));
-const top = $derived(rows.slice(0, 4));
-const more = $derived(rows.length - top.length);
+const headline = $derived(summary.headline);
+const maxVal = $derived(summary.maxVal);
+const top = $derived(summary.rows.slice(0, 4));
+const more = $derived(summary.rows.length - top.length);
 // Safe to read only when kind !== 'none' (guarded in the template).
 const asKind = $derived(stat.kind as StatEntityKind);
 </script>

--- a/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
+++ b/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
@@ -157,6 +157,17 @@ export interface EntityStatInfo {
 	value: number;
 	rank: number;
 	of: number;
+}
+
+/** Memoised per-statistic display data, computed once on the immutable
+ *  {@link StatisticsData} so the stat cards and dossier tiles read it as a prop
+ *  rather than re-scanning every render. */
+export interface StatSummary {
+	/** Per-entity rows, resolved and sorted best-first (empty for `none` stats). */
+	rows: StatRow[];
+	/** Bar denominator — the leading row's value, floored at 1. */
+	maxVal: number;
+	/** Grand-total headline: the server's null-entity row, else the row aggregate. */
 	headline: number;
 }
 
@@ -180,18 +191,22 @@ export class StatisticsData {
 	readonly statTypes: StatType[];
 	readonly stats: IPlayerStatistic[];
 	readonly entities: Record<StatEntityKind, StatEntity[]>;
-	private readonly byId: Map<EStatisticType, StatType>;
+	/** Entity lookup per kind, built once so id resolution is O(1) (not Array.find per row). */
+	private readonly entityById: Record<StatEntityKind, Map<number, StatEntity>>;
+	/** Per-statistic display summaries, memoised once over the immutable inputs. */
+	private readonly summaries: Map<EStatisticType, StatSummary>;
 
 	constructor(statTypes: StatType[], stats: IPlayerStatistic[], entities: Record<StatEntityKind, StatEntity[]>) {
 		this.statTypes = statTypes;
 		this.stats = stats;
 		this.entities = entities;
-		// eslint-disable-next-line svelte/prefer-svelte-reactivity -- non-reactive lookup map
-		this.byId = new Map(statTypes.map((s) => [s.id, s]));
-	}
-
-	statType(type: EStatisticType): StatType | undefined {
-		return this.byId.get(type);
+		this.entityById = {
+			enemy: indexEntities(entities.enemy),
+			zone: indexEntities(entities.zone),
+			skill: indexEntities(entities.skill)
+		};
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity -- non-reactive memo map
+		this.summaries = new Map(statTypes.map((s) => [s.id, this.computeSummary(s)]));
 	}
 
 	/** Statistic types in the given category, in catalogue (display) order. */
@@ -204,20 +219,65 @@ export class StatisticsData {
 	}
 
 	entity(kind: StatEntityKind, id: number): StatEntity | undefined {
-		return this.entityList(kind).find((e) => e.id === id);
+		return this.entityById[kind]?.get(id);
+	}
+
+	/** The memoised display summary for a statistic (rows + bar max + headline). */
+	summaryFor(type: EStatisticType): StatSummary {
+		return this.summaries.get(type) ?? EMPTY_SUMMARY;
 	}
 
 	/** Per-entity rows for a statistic, resolved and sorted best-first (ascending
 	 *  for "min" aggregates, where lower is better). Empty for `none` stats. */
 	rowsForStat(type: EStatisticType): StatRow[] {
-		const stat = this.byId.get(type);
-		if (!stat || stat.kind === 'none') {
+		return this.summaryFor(type).rows;
+	}
+
+	/** The grand-total headline for a statistic: the backend's null-entity row if
+	 *  present, otherwise the aggregate of its per-entity rows. */
+	statHeadline(type: EStatisticType): number {
+		return this.summaryFor(type).headline;
+	}
+
+	/** Every statistic that references the given entity, with the entity's value
+	 *  and rank among peers. */
+	statsForEntity(kind: StatEntityKind, entityId: number): EntityStatInfo[] {
+		const out: EntityStatInfo[] = [];
+		for (const stat of this.statTypes) {
+			if (stat.kind !== kind) {
+				continue;
+			}
+			const rows = this.summaryFor(stat.id).rows;
+			const idx = rows.findIndex((r) => r.entityId === entityId);
+			if (idx < 0) {
+				continue;
+			}
+			out.push({ stat, value: rows[idx].value, rank: idx + 1, of: rows.length });
+		}
+		return out;
+	}
+
+	/** Whether the player has recorded any statistic values at all (new player). */
+	get isEmpty(): boolean {
+		return this.stats.length === 0;
+	}
+
+	/** Computes a statistic's display summary once (called from the constructor). */
+	private computeSummary(stat: StatType): StatSummary {
+		const rows = this.computeRows(stat);
+		const maxVal = Math.max(...rows.map((r) => r.value), 1);
+		return { rows, maxVal, headline: this.computeHeadline(stat, rows) };
+	}
+
+	/** Resolves and sorts a statistic's per-entity rows (empty for `none` stats). */
+	private computeRows(stat: StatType): StatRow[] {
+		if (stat.kind === 'none') {
 			return [];
 		}
 		const kind = stat.kind;
 		const rows: StatRow[] = [];
 		for (const s of this.stats) {
-			if (s.statisticTypeId !== type || s.entityId == null) {
+			if (s.statisticTypeId !== stat.id || s.entityId == null) {
 				continue;
 			}
 			const entity = this.entity(kind, s.entityId);
@@ -229,47 +289,25 @@ export class StatisticsData {
 		return rows;
 	}
 
-	/** The grand-total headline for a statistic: the backend's null-entity row if
-	 *  present, otherwise the aggregate of its per-entity rows. */
-	statHeadline(type: EStatisticType): number {
-		const totalRow = this.stats.find((s) => s.statisticTypeId === type && s.entityId == null);
+	private computeHeadline(stat: StatType, rows: StatRow[]): number {
+		const totalRow = this.stats.find((s) => s.statisticTypeId === stat.id && s.entityId == null);
 		if (totalRow) {
 			return totalRow.value;
 		}
-		const stat = this.byId.get(type);
 		return aggregate(
-			this.rowsForStat(type).map((r) => r.value),
-			stat?.agg ?? 'sum'
+			rows.map((r) => r.value),
+			stat.agg
 		);
 	}
-
-	statEntityCount(type: EStatisticType): number {
-		return this.rowsForStat(type).length;
-	}
-
-	/** Every statistic that references the given entity, with the entity's value,
-	 *  rank among peers, and the statistic's headline. */
-	statsForEntity(kind: StatEntityKind, entityId: number): EntityStatInfo[] {
-		const out: EntityStatInfo[] = [];
-		for (const stat of this.statTypes) {
-			if (stat.kind !== kind) {
-				continue;
-			}
-			const rows = this.rowsForStat(stat.id);
-			const idx = rows.findIndex((r) => r.entityId === entityId);
-			if (idx < 0) {
-				continue;
-			}
-			out.push({ stat, value: rows[idx].value, rank: idx + 1, of: rows.length, headline: this.statHeadline(stat.id) });
-		}
-		return out;
-	}
-
-	/** Whether the player has recorded any statistic values at all (new player). */
-	get isEmpty(): boolean {
-		return this.stats.length === 0;
-	}
 }
+
+/** Indexes an entity list by id for O(1) resolution. */
+function indexEntities(list: StatEntity[]): Map<number, StatEntity> {
+	return new Map((list ?? []).map((e) => [e.id, e]));
+}
+
+/** Shared empty summary for an unknown (off-catalogue) statistic id. */
+const EMPTY_SUMMARY: StatSummary = { rows: [], maxVal: 1, headline: 0 };
 
 /* ── reactive view-model ──────────────────────────────────────────────────── */
 

--- a/UI/src/tests/routes/game/screens/attribute-breakdown/attribute-breakdown-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attribute-breakdown/attribute-breakdown-view.test.ts
@@ -24,7 +24,6 @@ import {
 	fmtSigned,
 	hasNonCombatModifier,
 	modifierLabel,
-	slotLabel,
 	type LabeledModifier
 } from '$routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte';
 import { makeAttribute } from '../../../../fixtures/attributes';
@@ -133,7 +132,7 @@ describe('buildPlayerModifiers', () => {
 		];
 		const mods = buildPlayerModifiers();
 		const item = mods.find((m) => m.source === EAttributeModifierSource.Item);
-		expect(item).toMatchObject({ attribute: EAttribute.Defense, amount: 14, label: 'Aegis Greathelm', slot: 0 });
+		expect(item).toMatchObject({ attribute: EAttribute.Defense, amount: 14, label: 'Aegis Greathelm' });
 		const mod = mods.find((m) => m.source === EAttributeModifierSource.ItemMod);
 		expect(mod).toMatchObject({
 			attribute: EAttribute.Endurance,
@@ -298,6 +297,5 @@ describe('formatting + labels', () => {
 		expect(
 			modifierLabel({ source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Endurance } as never)
 		).toBe('Endurance');
-		expect(slotLabel(4)).toBe('Weapon');
 	});
 });

--- a/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
@@ -31,6 +31,7 @@ import {
 	deriveStats,
 	perPointYields,
 	feedsFor,
+	contributorsFor,
 	derivedShortLabel,
 	radarValueAtPointer
 } from '$routes/game/screens/attributes/attributes-view.svelte';
@@ -153,6 +154,19 @@ describe('feedsFor', () => {
 		expect(feedsFor(idx.dex)).toEqual([EAttribute.CooldownRecovery]);
 		expect(feedsFor(idx.int)).toEqual([]);
 		expect(feedsFor(idx.luk)).toEqual([]);
+	});
+});
+
+describe('contributorsFor', () => {
+	it('reports the core attributes feeding each derived stat (inverse of feedsFor)', () => {
+		expect(contributorsFor(EAttribute.MaxHealth)).toEqual([EAttribute.Strength, EAttribute.Endurance]);
+		expect(contributorsFor(EAttribute.Defense)).toEqual([EAttribute.Endurance, EAttribute.Agility]);
+		expect(contributorsFor(EAttribute.CooldownRecovery)).toEqual([EAttribute.Agility, EAttribute.Dexterity]);
+	});
+
+	it('returns no contributors for an attribute no core stat derives', () => {
+		expect(contributorsFor(EAttribute.Strength)).toEqual([]);
+		expect(contributorsFor(EAttribute.Luck)).toEqual([]);
 	});
 });
 

--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -417,12 +417,15 @@ describe('Skills screen', () => {
 		expect(screen.getByText('No attribute scaling.')).toBeTruthy();
 	});
 
-	it('filters the rail by search term', async () => {
+	it('filters the available rail by search term while keeping the equipped loadout visible', async () => {
 		const { container } = render(Skills);
 		const search = container.querySelector<HTMLInputElement>('.search input')!;
 		await fireEvent.input(search, { target: { value: 'delta' } });
-		expect(container.querySelectorAll('.row').length).toBe(1);
+		// The 3 equipped rows stay (the equipped rail is never filtered); the available
+		// rail narrows to the single matching skill, Delta — 4 rows in total.
+		expect(container.querySelectorAll('.row').length).toBe(4);
 		expect(rowByName(container, 'Delta')).toBeTruthy();
+		expect(rowByName(container, 'Alpha')).toBeTruthy();
 	});
 
 	it('surfaces the gating challenge tooltip when hovering a locked, challenge-gated skill', async () => {

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -321,6 +321,22 @@ describe('SkillsView — rail filtering & sorting', () => {
 		expect(view.equippedRail.map((m) => m.skill.id)).toEqual([0, 1, 2]);
 		expect(view.availableRail.map((m) => m.skill.id)).toEqual([3]);
 	});
+
+	it('keeps the full equipped loadout in the rail when a search filter excludes it', () => {
+		// 'delta' matches only the unequipped skill 3; the equipped rail must still show
+		// the whole loadout (the header counts it) while the available rail is filtered.
+		view.search = 'delta';
+		expect(view.equippedRail.map((m) => m.skill.id)).toEqual([0, 1, 2]);
+		expect(view.availableRail.map((m) => m.skill.id)).toEqual([3]);
+	});
+
+	it('keeps the equipped rail intact when an attribute filter matches no equipped skill', () => {
+		// No fixture skill scales on Luck, so the attribute filter empties railList — the
+		// equipped rail is built from the unfiltered loadout and must survive.
+		view.toggleAttributeFilter(EAttribute.Luck);
+		expect(view.equippedRail.map((m) => m.skill.id)).toEqual([0, 1, 2]);
+		expect(view.availableRail).toEqual([]);
+	});
 });
 
 describe('SkillsView — loadout edits persist the ordered loadout', () => {

--- a/UI/src/tests/routes/game/screens/stats/statistics-view.test.ts
+++ b/UI/src/tests/routes/game/screens/stats/statistics-view.test.ts
@@ -160,11 +160,32 @@ describe('StatisticsData.statHeadline', () => {
 	});
 });
 
+describe('StatisticsData.summaryFor', () => {
+	it('bundles the rows, bar max, and headline for a statistic', () => {
+		const summary = data().summaryFor(EStatisticType.EnemiesKilled);
+		expect(summary.rows.map((r) => r.entityId)).toEqual([0, 1]);
+		expect(summary.maxVal).toBe(100); // the leading row's value
+		expect(summary.headline).toBe(120); // null-entity grand total
+	});
+
+	it('returns an empty (rows-less) summary for a total-only statistic', () => {
+		const summary = data().summaryFor(EStatisticType.PlayerDeaths);
+		expect(summary.rows).toEqual([]);
+		expect(summary.maxVal).toBe(1);
+		expect(summary.headline).toBe(7);
+	});
+
+	it('memoises a single summary instance per statistic', () => {
+		const d = data();
+		expect(d.summaryFor(EStatisticType.EnemiesKilled)).toBe(d.summaryFor(EStatisticType.EnemiesKilled));
+	});
+});
+
 describe('StatisticsData.statsForEntity', () => {
-	it('lists every statistic referencing an entity with its rank and headline', () => {
+	it('lists every statistic referencing an entity with its rank', () => {
 		const infos = data().statsForEntity('enemy', 0);
 		const killed = infos.find((i) => i.stat.id === EStatisticType.EnemiesKilled)!;
-		expect(killed).toMatchObject({ value: 100, rank: 1, of: 2, headline: 120 });
+		expect(killed).toMatchObject({ value: 100, rank: 1, of: 2 });
 		const fastest = infos.find((i) => i.stat.id === EStatisticType.FastestVictory)!;
 		expect(fastest).toMatchObject({ value: 2.0, rank: 1, of: 2 });
 	});


### PR DESCRIPTION
Closes #914.

A grab-bag of frontend reactivity, performance, and dead-code cleanups surfaced during a codebase health review.

## Reactivity / behavior
1. **`RewardTooltip` container reactivity.** `container` was a plain `let`, so the global `Tooltip` (whose `$effect` only tracks `component`) could miss the relocation when the `bind:this` established after the effect's first run. Made it `let container = $state()` to match every sibling tooltip (`ItemTooltip`, `SkillTooltip`, `ChallengeTooltip`, `AttributeTooltip`).
2. **Equipped-skill rail no longer vanishes under a filter.** `equippedRail` now derives from the unfiltered loadout (`this.equipped` mapped through `metricsById`, already in slot order); a search/attribute filter narrows only `availableRail`. Previously, typing a term an equipped skill didn't match dropped it from the "Equipped" group while the header still showed the full `equipped.length/cap` count.

## Performance
3. **Statistics summaries memoised.** Added an O(1) per-kind entity lookup `Map` (was `Array.find` per row) and memoised a per-stat summary (`rows`/`maxVal`/`headline`) once on the immutable `StatisticsData`, exposed via `summaryFor()` and passed to `StatCard`/`DossierTile` as props. Removes the quadratic, fanned-out `rowsForStat` scans (≥3× per stat in the dossier path).
4. **Theorycraft per-point yields — already addressed.** The current code already memoises `perPointYields(i)` by index and `TheoryRow` reads it that way, so the issue's `perPointYields(i, view.values)` description is stale. No change needed; called out for transparency.
5. **DerivedPanel / StackBar static maps.** `DerivedPanel` precomputes the group→stats map and uses a precomputed static feeds inverse (`contributorsFor`, added to `attributes-view`) instead of re-scanning `DERIVED_STATS`/`CORE_ATTRIBUTES` per render. `StackBar` accepts an optional pre-grouped result so the breakdown detail doesn't re-run `groupBySource` on the already-grouped selection (`groupBySource` now returns a named `GroupedBySource<T>`).

## Dead code removed
- `statistics-view`: `statType()`, `statEntityCount()`, `EntityStatInfo.headline`.
- `attributes-view`: `isDirtyIndex()`.
- `attribute-breakdown-view`: `slotLabel()`/`SLOT_LABELS` and the unused `slot` field on `LabeledModifier` (plus the now-unused `EEquipmentSlot` import and its assignments in `buildPlayerModifiers`).
- `attribute-breakdown/source-display`: unused `sourceTint` export (and its `tintColor` import).

## Test plan
- Updated unit tests for the removed symbols (`slotLabel`, `EntityStatInfo.headline`) and the corrected equipped-rail filtering (view-model + `Skills.test.ts` component test, which previously asserted the buggy "filter empties the equipped rail" behavior).
- Added tests: `StatisticsData.summaryFor` (rows/maxVal/headline + memoisation), `contributorsFor` (inverse of `feedsFor`), and equipped-rail regressions (search + attribute filters keep the loadout visible).
- `npm run lint` (eslint + svelte-check): clean.
- `npm run test:unit:ci`: 2088 passed.

No backend changes (the `attribute-collection.ts` edit is in `$lib/battle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158nCmbxTxBG988oam3BTc4

---
_Generated by [Claude Code](https://claude.ai/code/session_0158nCmbxTxBG988oam3BTc4)_