### PR TITLE
Add shared PlayerBuilder to lean Game.Core.TestInfrastructure (#817)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,6 +44,7 @@ jobs:
             - 'Game.Application/**'
             - 'Game.Application.Tests/**'
             - 'Game.Core/**'
+            - 'Game.Core.TestInfrastructure/**'
             - 'Game.Core.Tests/**'
             - 'Game.DataAccess/**'
             - 'Game.Infrastructure/**'

--- a/Game.Api.Tests/Unit/PlayerDataMappingTests.cs
+++ b/Game.Api.Tests/Unit/PlayerDataMappingTests.cs
@@ -1,8 +1,8 @@
 using Game.Core;
 using Game.Core.Items;
-using Game.Core.Players;
 using Game.Core.Players.Inventories;
 using Game.Core.Skills;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 using CorePlayer = Game.Core.Players.Player;
 using PlayerDataModel = Game.Api.Models.Player.PlayerData;
@@ -82,19 +82,15 @@ namespace Game.Api.Tests.Unit
             Assert.Null(unequippedHelm.EquipmentSlotId);
         }
 
-        private static CorePlayer MakePlayer(List<Skill> skills, List<Skill> selectedSkills, Inventory? inventory = null) => new()
+        private static CorePlayer MakePlayer(List<Skill> skills, List<Skill> selectedSkills, Inventory? inventory = null)
         {
-            Id = 1,
-            Name = "Test",
-            Level = 1,
-            Exp = 0,
-            CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
-            Inventory = inventory ?? new Inventory(),
-            Skills = skills,
-            SelectedSkills = selectedSkills,
-            LogPreferences = [],
-        };
+            var builder = new PlayerBuilder().WithSkills(skills).WithSelectedSkills(selectedSkills);
+            if (inventory is not null)
+            {
+                builder.WithInventory(inventory);
+            }
+            return builder.Build();
+        }
 
         private static Skill MakeSkill(int id) => new()
         {

--- a/Game.Api.Tests/Unit/SessionServiceTests.cs
+++ b/Game.Api.Tests/Unit/SessionServiceTests.cs
@@ -1,7 +1,7 @@
 using Game.Abstractions.DataAccess;
 using Game.Api.Services;
 using Game.Core.Players;
-using Game.Core.Players.Inventories;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 
 namespace Game.Api.Tests.Unit
@@ -101,7 +101,7 @@ namespace Game.Api.Tests.Unit
         public void Player_AfterSetPlayer_ReturnsSameInstance()
         {
             var session = new SessionService(new FakeSessionStore());
-            var player = MakePlayer(7);
+            var player = new PlayerBuilder().WithId(7).Build();
 
             session.SetPlayer(player);
 
@@ -112,7 +112,7 @@ namespace Game.Api.Tests.Unit
         public void ClearSession_ResetsLoadedPlayer()
         {
             var session = new SessionService(new FakeSessionStore());
-            session.SetPlayer(MakePlayer(7));
+            session.SetPlayer(new PlayerBuilder().WithId(7).Build());
 
             session.ClearSession();
 
@@ -158,20 +158,6 @@ namespace Game.Api.Tests.Unit
 
             Assert.Empty(store.Cleared);
         }
-
-        private static Player MakePlayer(int id) => new()
-        {
-            Id = id,
-            Name = "Test",
-            Level = 1,
-            Exp = 0,
-            CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
-            Inventory = new Inventory(),
-            SelectedSkills = [],
-            Skills = [],
-            LogPreferences = [],
-        };
 
         // An in-memory session store that serves a single optional cached session and records writes, so
         // the cache-hit/miss and rehydration paths can be exercised without Redis.

--- a/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
@@ -4,8 +4,8 @@ using Game.Core.Battle;
 using Game.Core.Enemies;
 using Game.Core.Events;
 using Game.Core.Players;
-using Game.Core.Players.Inventories;
 using Game.Core.Progress;
+using Game.Core.TestInfrastructure.Builders;
 using Game.DataAccess;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Base;
@@ -255,18 +255,6 @@ namespace Game.Application.Tests.DataAccess
             return player.Id;
         }
 
-        private static Player MakeDomainPlayer(int id) => new()
-        {
-            Id = id,
-            Name = "Test",
-            Level = 1,
-            Exp = 0,
-            CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
-            Inventory = new Inventory(),
-            SelectedSkills = [],
-            Skills = [],
-            LogPreferences = [],
-        };
+        private static Player MakeDomainPlayer(int id) => new PlayerBuilder().WithId(id).Build();
     }
 }

--- a/Game.Application.Tests/Events/LoggingEventHandlerTests.cs
+++ b/Game.Application.Tests/Events/LoggingEventHandlerTests.cs
@@ -3,7 +3,7 @@ using Game.Core.Battle.Events;
 using Game.Core.Enemies;
 using Game.Core.Events;
 using Game.Core.Players;
-using Game.Core.Players.Inventories;
+using Game.Core.TestInfrastructure.Builders;
 using Game.TestInfrastructure.Helpers;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -55,7 +55,7 @@ namespace Game.Application.Tests.Events
         public async Task BattleCompletedEvent_LogsCuratedIds_AndNeverSerializesThePlayerAggregate()
         {
             var (handler, capturing) = CreateHandler();
-            var player = MakePlayer(id: 7, name: "SecretPlayerName");
+            var player = new PlayerBuilder().WithId(7).WithName("SecretPlayerName").Build();
             var enemy = MakeEnemy(id: 5, name: "SecretEnemyName");
             var evt = new BattleCompletedEvent(
                 player, enemy, Victory: true, PlayerDied: false, TotalMs: 3200,
@@ -99,20 +99,6 @@ namespace Game.Application.Tests.Events
         {
             public IReadOnlyList<KeyValuePair<string, object?>> GetLogProperties() => Properties;
         }
-
-        private static Player MakePlayer(int id, string name) => new()
-        {
-            Id = id,
-            Name = name,
-            Level = 1,
-            Exp = 0,
-            CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
-            Inventory = new Inventory(),
-            SelectedSkills = [],
-            Skills = [],
-            LogPreferences = [],
-        };
 
         private static Enemy MakeEnemy(int id, string name) => new()
         {

--- a/Game.Core.TestInfrastructure/Builders/PlayerBuilder.cs
+++ b/Game.Core.TestInfrastructure/Builders/PlayerBuilder.cs
@@ -1,0 +1,107 @@
+using Game.Core.Players;
+using Game.Core.Players.Inventories;
+using Game.Core.Skills;
+
+namespace Game.Core.TestInfrastructure.Builders
+{
+    /// <summary>
+    /// Fluent builder for the <see cref="Player"/> aggregate in tests. Supplies sensible defaults for
+    /// every required member so a test specifies only the fields it cares about, and is the single place
+    /// that knows the full <see cref="Player"/> graph — adding a required member to <see cref="Player"/>
+    /// becomes a one-line change here instead of an edit across every test.
+    /// </summary>
+    public sealed class PlayerBuilder
+    {
+        private int _id = 1;
+        private string _name = "Test";
+        private int _level = 1;
+        private int _exp = 0;
+        private int _currentZoneId = 0;
+        private List<StatAllocation> _statAllocations = [];
+        private int _statPointsGained = 0;
+        private int _statPointsUsed = 0;
+        private Inventory _inventory = new();
+        private List<Skill> _skills = [];
+        private List<Skill> _selectedSkills = [];
+        private List<LogPreference> _logPreferences = [];
+
+        public PlayerBuilder WithId(int id)
+        {
+            _id = id;
+            return this;
+        }
+
+        public PlayerBuilder WithName(string name)
+        {
+            _name = name;
+            return this;
+        }
+
+        public PlayerBuilder WithLevel(int level)
+        {
+            _level = level;
+            return this;
+        }
+
+        public PlayerBuilder WithExp(int exp)
+        {
+            _exp = exp;
+            return this;
+        }
+
+        public PlayerBuilder WithStatAllocations(IEnumerable<StatAllocation> allocations)
+        {
+            _statAllocations = allocations.ToList();
+            return this;
+        }
+
+        public PlayerBuilder WithStatPointsGained(int gained)
+        {
+            _statPointsGained = gained;
+            return this;
+        }
+
+        public PlayerBuilder WithStatPointsUsed(int used)
+        {
+            _statPointsUsed = used;
+            return this;
+        }
+
+        public PlayerBuilder WithInventory(Inventory inventory)
+        {
+            _inventory = inventory;
+            return this;
+        }
+
+        public PlayerBuilder WithSkills(IEnumerable<Skill> skills)
+        {
+            _skills = skills.ToList();
+            return this;
+        }
+
+        public PlayerBuilder WithSelectedSkills(IEnumerable<Skill> selectedSkills)
+        {
+            _selectedSkills = selectedSkills.ToList();
+            return this;
+        }
+
+        public Player Build() => new()
+        {
+            Id = _id,
+            Name = _name,
+            Level = _level,
+            Exp = _exp,
+            CurrentZoneId = _currentZoneId,
+            StatPoints = new PlayerStatPoints
+            {
+                StatAllocations = _statAllocations,
+                StatPointsGained = _statPointsGained,
+                StatPointsUsed = _statPointsUsed,
+            },
+            Inventory = _inventory,
+            SelectedSkills = _selectedSkills,
+            Skills = _skills,
+            LogPreferences = _logPreferences,
+        };
+    }
+}

--- a/Game.Core.TestInfrastructure/Game.Core.TestInfrastructure.csproj
+++ b/Game.Core.TestInfrastructure/Game.Core.TestInfrastructure.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Game.Core\Game.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Game.Core.Tests/Battle/BattleContextTests.cs
+++ b/Game.Core.Tests/Battle/BattleContextTests.cs
@@ -1,7 +1,7 @@
 using Game.Core;
 using Game.Core.Battle;
 using Game.Core.Players;
-using Game.Core.Players.Inventories;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 using static Game.Core.EAttribute;
 
@@ -197,19 +197,7 @@ namespace Game.Core.Tests.Battle
             var statAllocations = attributes
                 .Select(a => new StatAllocation { Attribute = a.Attribute, Amount = a.Amount })
                 .ToList();
-            var player = new Player
-            {
-                Id = 0,
-                Name = "t",
-                Level = 1,
-                Exp = 0,
-                CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints { StatAllocations = statAllocations, StatPointsGained = 0, StatPointsUsed = 0 },
-                Inventory = new Inventory(),
-                SelectedSkills = [],
-                Skills = [],
-                LogPreferences = [],
-            };
+            var player = new PlayerBuilder().WithStatAllocations(statAllocations).Build();
             return new Battler(player);
         }
     }

--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -6,6 +6,7 @@ using Game.Core.Items;
 using Game.Core.Players;
 using Game.Core.Players.Inventories;
 using Game.Core.Skills;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 
 namespace Game.Core.Tests.Battle
@@ -664,20 +665,13 @@ namespace Game.Core.Tests.Battle
             var totalUsed = (int)(strength + endurance + agility + dexterity);
             var defaultSkills = skills ?? [];
 
-            return new Player
-            {
-                Id = 1,
-                Name = "Test",
-                Level = 1,
-                Exp = 0,
-                CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints
-                { StatAllocations = allocations, StatPointsGained = totalUsed, StatPointsUsed = totalUsed },
-                Inventory = new Inventory(),
-                SelectedSkills = defaultSkills,
-                Skills = defaultSkills,
-                LogPreferences = [],
-            };
+            return new PlayerBuilder()
+                .WithStatAllocations(allocations)
+                .WithStatPointsGained(totalUsed)
+                .WithStatPointsUsed(totalUsed)
+                .WithSkills(defaultSkills)
+                .WithSelectedSkills(defaultSkills)
+                .Build();
         }
 
         /// <summary>
@@ -771,20 +765,13 @@ namespace Game.Core.Tests.Battle
             var totalUsed = (int)(strength + endurance + agility + dexterity);
             var defaultSkills = skills ?? [];
 
-            return new Player
-            {
-                Id = 1,
-                Name = "Test",
-                Level = 1,
-                Exp = 0,
-                CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints
-                { StatAllocations = allocations, StatPointsGained = totalUsed, StatPointsUsed = totalUsed },
-                Inventory = new Inventory(),
-                SelectedSkills = defaultSkills,
-                Skills = defaultSkills,
-                LogPreferences = [],
-            };
+            return new PlayerBuilder()
+                .WithStatAllocations(allocations)
+                .WithStatPointsGained(totalUsed)
+                .WithStatPointsUsed(totalUsed)
+                .WithSkills(defaultSkills)
+                .WithSelectedSkills(defaultSkills)
+                .Build();
         }
 
         private static Battler MakeEnemy(

--- a/Game.Core.Tests/Battle/BattleSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorTests.cs
@@ -3,8 +3,8 @@ using Game.Core.Attributes.Modifiers;
 using Game.Core.Battle;
 using Game.Core.Enemies;
 using Game.Core.Players;
-using Game.Core.Players.Inventories;
 using Game.Core.Skills;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 
 namespace Game.Core.Tests.Battle
@@ -132,20 +132,13 @@ namespace Game.Core.Tests.Battle
                 }
             ];
 
-            return new Player
-            {
-                Id = 1,
-                Name = "Test",
-                Level = 1,
-                Exp = 0,
-                CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints
-                { StatAllocations = allocations, StatPointsGained = totalUsed, StatPointsUsed = totalUsed },
-                Inventory = new Inventory(),
-                SelectedSkills = defaultSkills,
-                Skills = defaultSkills,
-                LogPreferences = [],
-            };
+            return new PlayerBuilder()
+                .WithStatAllocations(allocations)
+                .WithStatPointsGained(totalUsed)
+                .WithStatPointsUsed(totalUsed)
+                .WithSkills(defaultSkills)
+                .WithSelectedSkills(defaultSkills)
+                .Build();
         }
 
         private static Battler MakeEnemy(double statTotal, List<Skill>? skills = null)

--- a/Game.Core.Tests/Battle/BattleSkillTests.cs
+++ b/Game.Core.Tests/Battle/BattleSkillTests.cs
@@ -1,8 +1,8 @@
 using Game.Core.Attributes.Modifiers;
 using Game.Core.Battle;
 using Game.Core.Players;
-using Game.Core.Players.Inventories;
 using Game.Core.Skills;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 using static Game.Core.EAttribute;
 
@@ -123,20 +123,11 @@ namespace Game.Core.Tests.Battle
                 new() { Attribute = EAttribute.Dexterity, Amount = 0 },
                 new() { Attribute = EAttribute.Luck,      Amount = 0 },
             };
-            var attacker = new Battler(new Player
-            {
-                Id = 0,
-                Name = "t",
-                Level = 1,
-                Exp = 0,
-                CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints
-                { StatAllocations = statAllocations, StatPointsGained = 52, StatPointsUsed = 52 },
-                Inventory = new Inventory(),
-                SelectedSkills = [],
-                Skills = [],
-                LogPreferences = [],
-            });
+            var attacker = new Battler(new PlayerBuilder()
+                .WithStatAllocations(statAllocations)
+                .WithStatPointsGained(52)
+                .WithStatPointsUsed(52)
+                .Build());
             var defender = MakeBattler(strength: 0);
             var context = new BattleContext(attacker, defender, timeDelta: 0, new Mulberry32(0));
 
@@ -272,20 +263,11 @@ namespace Game.Core.Tests.Battle
                 new() { Attribute = EAttribute.Dexterity, Amount = 0 },
                 new() { Attribute = EAttribute.Luck,      Amount = 0 },
             };
-            var player = new Player
-            {
-                Id = 0,
-                Name = "t",
-                Level = 1,
-                Exp = 0,
-                CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints
-                { StatAllocations = statAllocations, StatPointsGained = 50, StatPointsUsed = 50 },
-                Inventory = new Inventory(),
-                SelectedSkills = [],
-                Skills = [],
-                LogPreferences = [],
-            };
+            var player = new PlayerBuilder()
+                .WithStatAllocations(statAllocations)
+                .WithStatPointsGained(50)
+                .WithStatPointsUsed(50)
+                .Build();
             return new Battler(player);
         }
 
@@ -294,19 +276,7 @@ namespace Game.Core.Tests.Battle
             var statAllocations = attributes
                 .Select(a => new StatAllocation { Attribute = a.Attribute, Amount = a.Amount })
                 .ToList();
-            var player = new Player
-            {
-                Id = 0,
-                Name = "t",
-                Level = 1,
-                Exp = 0,
-                CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints { StatAllocations = statAllocations, StatPointsGained = 0, StatPointsUsed = 0 },
-                Inventory = new Inventory(),
-                SelectedSkills = [],
-                Skills = [],
-                LogPreferences = [],
-            };
+            var player = new PlayerBuilder().WithStatAllocations(statAllocations).Build();
             return new Battler(player);
         }
     }

--- a/Game.Core.Tests/Battle/BattleSnapshotTests.cs
+++ b/Game.Core.Tests/Battle/BattleSnapshotTests.cs
@@ -4,6 +4,7 @@ using Game.Core.Items;
 using Game.Core.Players;
 using Game.Core.Players.Inventories;
 using Game.Core.Skills;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 
 namespace Game.Core.Tests.Battle
@@ -252,19 +253,13 @@ namespace Game.Core.Tests.Battle
         }
 
         private static Player MakePlayer(int level = 1, List<StatAllocation>? allocations = null,
-            List<Skill>? selectedSkills = null) => new()
-            {
-                Id = 1,
-                Name = "Test",
-                Level = level,
-                Exp = 0,
-                CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints { StatAllocations = allocations ?? [], StatPointsGained = 0, StatPointsUsed = 0 },
-                Inventory = new Inventory(),
-                SelectedSkills = selectedSkills ?? [],
-                Skills = selectedSkills ?? [],
-                LogPreferences = [],
-            };
+            List<Skill>? selectedSkills = null) =>
+            new PlayerBuilder()
+                .WithLevel(level)
+                .WithStatAllocations(allocations ?? [])
+                .WithSkills(selectedSkills ?? [])
+                .WithSelectedSkills(selectedSkills ?? [])
+                .Build();
 
         private static void Equip(Player player, Item item)
         {

--- a/Game.Core.Tests/Battle/DefeatRewardsTests.cs
+++ b/Game.Core.Tests/Battle/DefeatRewardsTests.cs
@@ -6,6 +6,7 @@ using Game.Core.Enemies;
 using Game.Core.Items;
 using Game.Core.Players;
 using Game.Core.Players.Inventories;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 using static Game.Core.EAttribute;
 
@@ -209,24 +210,12 @@ namespace Game.Core.Tests.Battle
 
         private static Player MakePlayer(
             (EAttribute Attribute, double Amount)[] allocations,
-            int statPointsGained = 0) => new()
-            {
-                Id = 1,
-                Name = "Test",
-                Level = 1,
-                Exp = 0,
-                CurrentZoneId = 0,
-                StatPoints = new PlayerStatPoints
-                {
-                    StatAllocations = allocations.Select(a => new StatAllocation { Attribute = a.Attribute, Amount = a.Amount }).ToList(),
-                    StatPointsGained = statPointsGained,
-                    StatPointsUsed = (int)allocations.Sum(a => a.Amount),
-                },
-                Inventory = new Inventory(),
-                SelectedSkills = [],
-                Skills = [],
-                LogPreferences = [],
-            };
+            int statPointsGained = 0) =>
+            new PlayerBuilder()
+                .WithStatAllocations(allocations.Select(a => new StatAllocation { Attribute = a.Attribute, Amount = a.Amount }))
+                .WithStatPointsGained(statPointsGained)
+                .WithStatPointsUsed((int)allocations.Sum(a => a.Amount))
+                .Build();
 
         private static void EquipAccessory(Player player, List<AttributeModifier> attributes)
         {

--- a/Game.Core.Tests/Events/LoggableDomainEventTests.cs
+++ b/Game.Core.Tests/Events/LoggableDomainEventTests.cs
@@ -3,7 +3,7 @@ using Game.Core.Battle.Events;
 using Game.Core.Enemies;
 using Game.Core.Players;
 using Game.Core.Players.Events;
-using Game.Core.Players.Inventories;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 
 namespace Game.Core.Tests.Events
@@ -18,7 +18,7 @@ namespace Game.Core.Tests.Events
         [Fact]
         public void BattleCompletedEvent_GetLogProperties_ReturnsOnlyCuratedSafeScalars()
         {
-            var player = MakePlayer(id: 7, name: "SecretPlayerName");
+            var player = new PlayerBuilder().WithId(7).WithName("SecretPlayerName").Build();
             var enemy = MakeEnemy(id: 5, name: "SecretEnemyName");
             var stats = new BattleStats { PlayerDamageDealt = 1234.5 };
             var evt = new BattleCompletedEvent(
@@ -47,7 +47,7 @@ namespace Game.Core.Tests.Events
         [Fact]
         public void PlayerLeveledUpEvent_GetLogProperties_ReturnsOnlyCuratedSafeScalars()
         {
-            var player = MakePlayer(id: 7, name: "SecretPlayerName");
+            var player = new PlayerBuilder().WithId(7).WithName("SecretPlayerName").Build();
             var evt = new PlayerLeveledUpEvent(player, NewLevel: 12, StatPointsGained: 60);
 
             var properties = evt.GetLogProperties().ToDictionary(p => p.Key, p => p.Value);
@@ -60,20 +60,6 @@ namespace Game.Core.Tests.Events
             var serialized = string.Join("|", properties.Select(p => $"{p.Key}={p.Value}"));
             Assert.DoesNotContain("SecretPlayerName", serialized);
         }
-
-        private static Player MakePlayer(int id, string name) => new()
-        {
-            Id = id,
-            Name = name,
-            Level = 1,
-            Exp = 0,
-            CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
-            Inventory = new Inventory(),
-            SelectedSkills = [],
-            Skills = [],
-            LogPreferences = [],
-        };
 
         private static Enemy MakeEnemy(int id, string name) => new()
         {

--- a/Game.Core.Tests/Game.Core.Tests.csproj
+++ b/Game.Core.Tests/Game.Core.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Game.Core\Game.Core.csproj" />
+    <ProjectReference Include="..\Game.Core.TestInfrastructure\Game.Core.TestInfrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Game.Core.Tests/Players/PlayerProgressionParityTests.cs
+++ b/Game.Core.Tests/Players/PlayerProgressionParityTests.cs
@@ -1,5 +1,5 @@
 using Game.Core.Players;
-using Game.Core.Players.Inventories;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 
 namespace Game.Core.Tests.Players
@@ -67,19 +67,11 @@ namespace Game.Core.Tests.Players
             Assert.Equal(scenario.ExpectedStatPoints, player.StatPoints.StatPointsGained);
         }
 
-        private static Player MakePlayer(int level, int exp, int statPointsGained) => new()
-        {
-            Id = 1,
-            Name = "Test",
-            Level = level,
-            Exp = exp,
-            CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints
-            { StatAllocations = [], StatPointsGained = statPointsGained, StatPointsUsed = 0 },
-            Inventory = new Inventory(),
-            SelectedSkills = [],
-            Skills = [],
-            LogPreferences = [],
-        };
+        private static Player MakePlayer(int level, int exp, int statPointsGained) =>
+            new PlayerBuilder()
+                .WithLevel(level)
+                .WithExp(exp)
+                .WithStatPointsGained(statPointsGained)
+                .Build();
     }
 }

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -7,6 +7,7 @@ using Game.Core.Players;
 using Game.Core.Players.Events;
 using Game.Core.Players.Inventories;
 using Game.Core.Skills;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 
 namespace Game.Core.Tests.Players
@@ -668,19 +669,8 @@ namespace Game.Core.Tests.Players
 
         // ── Helpers ──────────────────────────────────────────────────────────
 
-        private static Player MakePlayer(int level = 1, int exp = 0) => new()
-        {
-            Id = 1,
-            Name = "Test",
-            Level = level,
-            Exp = exp,
-            CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
-            Inventory = new Inventory(),
-            SelectedSkills = [],
-            Skills = [],
-            LogPreferences = [],
-        };
+        private static Player MakePlayer(int level = 1, int exp = 0) =>
+            new PlayerBuilder().WithLevel(level).WithExp(exp).Build();
 
         /// <summary>Builds a player whose unlocked set contains a skill for each given id (none equipped).</summary>
         private static Player MakePlayerWithUnlockedSkills(params int[] skillIds)

--- a/Game.Core.Tests/Progress/ChallengeTests.cs
+++ b/Game.Core.Tests/Progress/ChallengeTests.cs
@@ -1,6 +1,6 @@
 using Game.Core.Players;
-using Game.Core.Players.Inventories;
 using Game.Core.Progress;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 
 namespace Game.Core.Tests.Progress
@@ -45,7 +45,7 @@ namespace Game.Core.Tests.Progress
         {
             var challenge = MakeChallenge(EChallengeType.LevelReached, goal: 8);
             var playerChallenge = new PlayerChallenge(challenge, progress: 0m, completed: false);
-            var progress = MakeProgress(player: MakePlayer(level: 8));
+            var progress = MakeProgress(player: new PlayerBuilder().WithLevel(8).Build());
 
             challenge.UpdateChallengeProgress(playerChallenge, progress);
 
@@ -77,20 +77,6 @@ namespace Game.Core.Tests.Progress
         };
 
         private static PlayerProgress MakeProgress(Player? player = null, IEnumerable<PlayerStatistic>? statistics = null) =>
-            new(player ?? MakePlayer(), statistics ?? [], []);
-
-        private static Player MakePlayer(int level = 1) => new()
-        {
-            Id = 1,
-            Name = "Test",
-            Level = level,
-            Exp = 0,
-            CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
-            Inventory = new Inventory(),
-            SelectedSkills = [],
-            Skills = [],
-            LogPreferences = [],
-        };
+            new(player ?? new PlayerBuilder().Build(), statistics ?? [], []);
     }
 }

--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -2,8 +2,8 @@ using Game.Core;
 using Game.Core.Battle;
 using Game.Core.Enemies;
 using Game.Core.Players;
-using Game.Core.Players.Inventories;
 using Game.Core.Progress;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 
 namespace Game.Core.Tests.Progress
@@ -538,7 +538,7 @@ namespace Game.Core.Tests.Progress
         public void EvaluateChallenges_LevelReached_UsesPlayerLevel()
         {
             var challenge = MakeChallenge(id: 0, EChallengeType.LevelReached, goal: 5);
-            var progress = MakeProgress(player: MakePlayer(level: 5));
+            var progress = MakeProgress(player: new PlayerBuilder().WithLevel(5).Build());
 
             var completed = progress.EvaluateChallenges([challenge]);
 
@@ -549,7 +549,7 @@ namespace Game.Core.Tests.Progress
         public void EvaluateChallenges_LevelReachedBelowGoal_DoesNotComplete()
         {
             var challenge = MakeChallenge(id: 0, EChallengeType.LevelReached, goal: 10);
-            var progress = MakeProgress(player: MakePlayer(level: 5));
+            var progress = MakeProgress(player: new PlayerBuilder().WithLevel(5).Build());
 
             var completed = progress.EvaluateChallenges([challenge]);
 
@@ -715,7 +715,7 @@ namespace Game.Core.Tests.Progress
             IEnumerable<PlayerStatistic>? statistics = null,
             IEnumerable<PlayerChallenge>? challenges = null)
         {
-            return new PlayerProgress(player ?? MakePlayer(), statistics ?? [], challenges ?? []);
+            return new PlayerProgress(player ?? new PlayerBuilder().Build(), statistics ?? [], challenges ?? []);
         }
 
         private static PlayerStatistic Stat(EStatisticType type, int? entityId, decimal value) =>
@@ -753,18 +753,5 @@ namespace Game.Core.Tests.Progress
             AvailableSkills = [],
         };
 
-        private static Player MakePlayer(int level = 1) => new()
-        {
-            Id = 1,
-            Name = "Test",
-            Level = level,
-            Exp = 0,
-            CurrentZoneId = 0,
-            StatPoints = new PlayerStatPoints { StatAllocations = [], StatPointsGained = 0, StatPointsUsed = 0 },
-            Inventory = new Inventory(),
-            SelectedSkills = [],
-            Skills = [],
-            LogPreferences = [],
-        };
     }
 }

--- a/Game.TestInfrastructure/Game.TestInfrastructure.csproj
+++ b/Game.TestInfrastructure/Game.TestInfrastructure.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\Game.Core\Game.Core.csproj" />
     <ProjectReference Include="..\Game.DataAccess\Game.DataAccess.csproj" />
     <ProjectReference Include="..\Game.Infrastructure\Game.Infrastructure.csproj" />
+    <ProjectReference Include="..\Game.Core.TestInfrastructure\Game.Core.TestInfrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Game.sln
+++ b/Game.sln
@@ -41,6 +41,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Game.Infrastructure.Tests", "Game.Infrastructure.Tests\Game.Infrastructure.Tests.csproj", "{91602D3C-BE00-461B-AE2D-B38B22F6207B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Game.Core.TestInfrastructure", "Game.Core.TestInfrastructure\Game.Core.TestInfrastructure.csproj", "{B92D8CD4-47F7-44E2-9D75-836DAB959AC2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -183,6 +185,18 @@ Global
 		{91602D3C-BE00-461B-AE2D-B38B22F6207B}.Release|x64.Build.0 = Release|Any CPU
 		{91602D3C-BE00-461B-AE2D-B38B22F6207B}.Release|x86.ActiveCfg = Release|Any CPU
 		{91602D3C-BE00-461B-AE2D-B38B22F6207B}.Release|x86.Build.0 = Release|Any CPU
+		{B92D8CD4-47F7-44E2-9D75-836DAB959AC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B92D8CD4-47F7-44E2-9D75-836DAB959AC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B92D8CD4-47F7-44E2-9D75-836DAB959AC2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B92D8CD4-47F7-44E2-9D75-836DAB959AC2}.Debug|x64.Build.0 = Debug|Any CPU
+		{B92D8CD4-47F7-44E2-9D75-836DAB959AC2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B92D8CD4-47F7-44E2-9D75-836DAB959AC2}.Debug|x86.Build.0 = Debug|Any CPU
+		{B92D8CD4-47F7-44E2-9D75-836DAB959AC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B92D8CD4-47F7-44E2-9D75-836DAB959AC2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B92D8CD4-47F7-44E2-9D75-836DAB959AC2}.Release|x64.ActiveCfg = Release|Any CPU
+		{B92D8CD4-47F7-44E2-9D75-836DAB959AC2}.Release|x64.Build.0 = Release|Any CPU
+		{B92D8CD4-47F7-44E2-9D75-836DAB959AC2}.Release|x86.ActiveCfg = Release|Any CPU
+		{B92D8CD4-47F7-44E2-9D75-836DAB959AC2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build/coverage.ps1
+++ b/build/coverage.ps1
@@ -45,7 +45,7 @@ try {
     -reports:$cobertura `
     -targetdir:coverage/backend-report `
     -reporttypes:"TextSummary;JsonSummary;Html" `
-    "-assemblyfilters:+Game.*;-Game.*.Tests;-Game.TestInfrastructure" `
+    "-assemblyfilters:+Game.*;-Game.*.Tests;-Game.TestInfrastructure;-Game.Core.TestInfrastructure" `
     "-classfilters:-System.Text.RegularExpressions.Generated*" `
     "-filefilters:-**/obj/**;-**/Migrations/**"
   if ($LASTEXITCODE -ne 0) { throw "ReportGenerator failed" }

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -28,6 +28,12 @@ The codegen also emits a small amount of **static domain data** that the fronten
 
 Because all of this lands under `UI/src/lib/api/types`, the existing CI codegen-drift check already guards it: a retune of a coefficient (or an enum value) that isn't regenerated fails the `git diff`, so the cross-implementation parity no longer rests on a human keeping the two files in step.
 
+## Shared domain-object test builders
+
+Domain aggregates like `Player` have many `required` members, so tests previously hand-rolled the full object graph in every file that needed one — adding a member meant editing every copy. Shared **fluent builders** (e.g. `PlayerBuilder`) now own that construction with sensible defaults, so a test specifies only the fields it cares about and adding a required member is a one-line change in the builder.
+
+These builders live in their own **`Game.Core.TestInfrastructure`** project that references **only `Game.Core`**, deliberately kept separate from the integration-heavy `Game.TestInfrastructure` (which pulls in EF/Redis/Testcontainers/ASP.NET). That keeps the pure unit-test projects (notably `Game.Core.Tests`) free of out-of-process dependencies, matching the [lean unit-test philosophy](backend.md#testing-guidelines). `Game.TestInfrastructure` references it, so the integration suites get the same builders. New domain-object builders belong here.
+
 ## Integration-Test Containers in Constrained Environments
 
 Integration tests get a real PostgreSQL + Redis via **Testcontainers** (`PostgresContainerFixture`, `RedisContainerFixture`, composed by `IntegrationTestContainers`). Testcontainers depends on Docker **bridge networking**, which is unavailable in constrained sandboxes such as the Claude Code web environment (old kernel, no iptables, no usable bridge). There, Testcontainers cannot create networks or map ports and every integration test fails before it runs. See [anthropics/claude-code#29515](https://github.com/anthropics/claude-code/issues/29515).


### PR DESCRIPTION
## Summary

The full `Player` aggregate graph was hand-rolled across the test suite because `Player` has many `required` members. Adding a required member forced edits in every copy, and the literals had already drifted. This PR introduces a single fluent **`PlayerBuilder`** (sensible defaults + fluent overrides) and migrates every hand-rolled `Player` literal to it.

## How it addresses the issue

- **`PlayerBuilder`** is now the single place that knows the full `Player` graph — adding a required member to `Player` is a one-line change in the builder instead of an edit across every test.
- All hand-rolled `new Player { … }` literals are gone. Helpers with real test-specific shaping (battle stat allocations, parity derived-stats, defeat-reward sums) are kept but delegate their `Player` construction to the builder; trivial scalar-only helpers were inlined and removed.

## Design decision: where the builder lives

The issue suggested adding it to `Game.TestInfrastructure`, but that project pulls in EF/Redis/Testcontainers/ASP.NET — and 10+ of the call sites live in `Game.Core.Tests`, a deliberately lean unit-test project referencing only `Game.Core`. Referencing `Game.TestInfrastructure` from there would drag the whole integration stack into the pure domain unit tests, contradicting the lean-unit-test philosophy in `docs/backend.md`.

Per a decision confirmed with the maintainer, the builder lives in a **new `Game.Core.TestInfrastructure` project that references only `Game.Core`**. `Game.TestInfrastructure` references it, so the integration suites (`Game.Api.Tests`, `Game.Application.Tests`) get the same builder transitively; `Game.Core.Tests` references it directly and stays free of out-of-process dependencies.

## Scope beyond the issue

The issue's `MakePlayer` grep missed three more copies of the same anti-pattern, which are migrated here for completeness:
- `Game.Core.Tests/Battle/BattleContextTests.cs`
- `Game.Core.Tests/Battle/BattleSkillTests.cs` (3 literals)
- `Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs` (`MakeDomainPlayer`)

## Other changes

- Excluded the new support assembly from coverage (`build/coverage.ps1`), consistent with how `Game.TestInfrastructure` is excluded.
- Added the new project to the backend CI path filter (`.github/workflows/run-tests.yml`).
- Documented the lean test-builder project convention in `docs/infrastructure.md`.

Net **−158 lines** across the suite.

## Test plan

- [x] `dotnet build Game.sln` — 0 warnings, 0 errors
- [x] `Game.Core.Tests` — 620 passed
- [x] `Game.Api.Tests` — 526 passed (container-backed integration)
- [x] `Game.Application.Tests` — 329 passed (container-backed integration)

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvzcRiqzUt4zkjFonW9zuu)_