### PR TITLE
Add last-admin guard to ArchiveUser/BanUser (#966)

### DIFF
--- a/Game.Abstractions/DataAccess/IUsers.cs
+++ b/Game.Abstractions/DataAccess/IUsers.cs
@@ -24,7 +24,8 @@ namespace Game.Abstractions.DataAccess
     /// <summary>
     /// Outcome of a single-user lifecycle action (<see cref="IUsers.ArchiveUser"/> /
     /// <see cref="IUsers.BanUser"/>), so the caller can surface the appropriate message. The data tier
-    /// rejects an admin targeting their own account to prevent a self-inflicted lockout.
+    /// enforces the admin-lockout rules: an admin cannot target their own account, nor take the last
+    /// usable admin out of circulation.
     /// </summary>
     public enum UserActionStatus
     {
@@ -33,6 +34,9 @@ namespace Game.Abstractions.DataAccess
 
         /// <summary>The acting admin attempted the action on their own account.</summary>
         SelfTarget,
+
+        /// <summary>The action would have taken the last usable admin out of circulation.</summary>
+        LastAdmin,
     }
 
     public interface IUsers
@@ -95,15 +99,18 @@ namespace Game.Abstractions.DataAccess
         Task<SetUserRolesStatus> SetUserRoles(int actingUserId, int targetUserId, IReadOnlyCollection<int> roleIds);
 
         /// <summary>
-        /// Archives (soft-deletes) the target user, freeing their username for reuse. Rejects an admin
-        /// archiving their own account (<see cref="UserActionStatus.SelfTarget"/>) and returns
-        /// <see cref="UserActionStatus.UserNotFound"/> if the user does not exist.
+        /// Archives (soft-deletes) the target user, freeing their username for reuse. Enforces the
+        /// admin-lockout rules: rejects an admin archiving their own account
+        /// (<see cref="UserActionStatus.SelfTarget"/>) and archiving the last usable admin
+        /// (<see cref="UserActionStatus.LastAdmin"/>). Returns <see cref="UserActionStatus.UserNotFound"/>
+        /// if the user does not exist.
         /// </summary>
         Task<UserActionStatus> ArchiveUser(int actingUserId, int targetUserId);
 
         /// <summary>
-        /// Bans the target user while keeping their username reserved. Rejects an admin banning their own
-        /// account (<see cref="UserActionStatus.SelfTarget"/>) and returns
+        /// Bans the target user while keeping their username reserved. Enforces the admin-lockout rules:
+        /// rejects an admin banning their own account (<see cref="UserActionStatus.SelfTarget"/>) and
+        /// banning the last usable admin (<see cref="UserActionStatus.LastAdmin"/>). Returns
         /// <see cref="UserActionStatus.UserNotFound"/> if the user does not exist.
         /// </summary>
         Task<UserActionStatus> BanUser(int actingUserId, int targetUserId);

--- a/Game.Api.Tests/Integration/AdminUsersControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminUsersControllerTests.cs
@@ -559,6 +559,155 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task ArchiveUser_ArchivingAnotherAdmin_WhileAdminsRemain_Succeeds()
+        {
+            var (authClient, _) = await SetupAdminClientWithIdAsync();
+            using var client = authClient;
+            int otherAdminId;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                var other = await TestDataSeeder.CreateUserAsync(context, "otheradmin", "pw");
+                otherAdminId = other.Id;
+                await TestDataSeeder.AssignRoleToUserAsync(context, other.Id, ERole.Admin);
+            }
+
+            // The acting admin remains usable, so archiving another admin is not a lockout.
+            var response = await client.PostAsJsonAsync(
+                "/api/AdminTools/ArchiveUser", new { UserId = otherAdminId }, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            using var scope2 = CreateScope();
+            var context2 = scope2.ServiceProvider.GetRequiredService<GameContext>();
+            var archived = await context2.Users.AsNoTracking().FirstAsync(u => u.Id == otherAdminId, CancellationToken);
+            Assert.NotNull(archived.ArchivedAt);
+        }
+
+        [Fact]
+        public async Task BanUser_BanningAnotherAdmin_WhileAdminsRemain_Succeeds()
+        {
+            var (authClient, _) = await SetupAdminClientWithIdAsync();
+            using var client = authClient;
+            int otherAdminId;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                var other = await TestDataSeeder.CreateUserAsync(context, "otheradmin", "pw");
+                otherAdminId = other.Id;
+                await TestDataSeeder.AssignRoleToUserAsync(context, other.Id, ERole.Admin);
+            }
+
+            // The acting admin remains usable, so banning another admin is not a lockout.
+            var response = await client.PostAsJsonAsync(
+                "/api/AdminTools/BanUser", new { UserId = otherAdminId }, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            using var scope2 = CreateScope();
+            var context2 = scope2.ServiceProvider.GetRequiredService<GameContext>();
+            var banned = await context2.Users.AsNoTracking().FirstAsync(u => u.Id == otherAdminId, CancellationToken);
+            Assert.NotNull(banned.BannedAt);
+        }
+
+        [Fact]
+        public async Task ArchiveUser_ArchivingLastAdmin_IsRejected()
+        {
+            // Driven through the repository so the actor is a valid-token admin who is no longer a usable
+            // admin (e.g. concurrently demoted), leaving the target as the last admin standing.
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var users = scope.ServiceProvider.GetRequiredService<IUsers>();
+
+            var soleAdmin = await TestDataSeeder.CreateUserAsync(context, "soleadmin", "pw");
+            await TestDataSeeder.AssignRoleToUserAsync(context, soleAdmin.Id, ERole.Admin);
+            var actor = await TestDataSeeder.CreateUserAsync(context, "ghostactor", "pw");
+
+            var status = await users.ArchiveUser(actor.Id, soleAdmin.Id);
+
+            Assert.Equal(UserActionStatus.LastAdmin, status);
+            var reloaded = await context.Users.AsNoTracking().FirstAsync(u => u.Id == soleAdmin.Id, CancellationToken);
+            Assert.Null(reloaded.ArchivedAt);
+        }
+
+        [Fact]
+        public async Task BanUser_BanningLastAdmin_IsRejected()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var users = scope.ServiceProvider.GetRequiredService<IUsers>();
+
+            var soleAdmin = await TestDataSeeder.CreateUserAsync(context, "soleadmin", "pw");
+            await TestDataSeeder.AssignRoleToUserAsync(context, soleAdmin.Id, ERole.Admin);
+            var actor = await TestDataSeeder.CreateUserAsync(context, "ghostactor", "pw");
+
+            var status = await users.BanUser(actor.Id, soleAdmin.Id);
+
+            Assert.Equal(UserActionStatus.LastAdmin, status);
+            var reloaded = await context.Users.AsNoTracking().FirstAsync(u => u.Id == soleAdmin.Id, CancellationToken);
+            Assert.Null(reloaded.BannedAt);
+        }
+
+        [Fact]
+        public async Task ArchiveUser_ConcurrentMutualArchives_LeaveOneAdminStanding()
+        {
+            // Two admins are the only admins; a ghost actor concurrently archives each. The atomic
+            // check-then-act must let at most one through so the system is never left admin-less.
+            var (firstAdminId, secondAdminId, actorId) = await SeedTwoAdminsAndGhostActorAsync();
+
+            async Task<UserActionStatus> ArchiveAsync(int targetId)
+            {
+                using var scope = CreateScope();
+                var users = scope.ServiceProvider.GetRequiredService<IUsers>();
+                return await users.ArchiveUser(actorId, targetId);
+            }
+
+            var results = await Task.WhenAll(ArchiveAsync(firstAdminId), ArchiveAsync(secondAdminId));
+
+            Assert.Equal(1, results.Count(r => r == UserActionStatus.Success));
+            Assert.Equal(1, results.Count(r => r == UserActionStatus.LastAdmin));
+            Assert.Equal(1, await CountUsableAdminsAsync());
+        }
+
+        [Fact]
+        public async Task BanUser_ConcurrentMutualBans_LeaveOneAdminStanding()
+        {
+            var (firstAdminId, secondAdminId, actorId) = await SeedTwoAdminsAndGhostActorAsync();
+
+            async Task<UserActionStatus> BanAsync(int targetId)
+            {
+                using var scope = CreateScope();
+                var users = scope.ServiceProvider.GetRequiredService<IUsers>();
+                return await users.BanUser(actorId, targetId);
+            }
+
+            var results = await Task.WhenAll(BanAsync(firstAdminId), BanAsync(secondAdminId));
+
+            Assert.Equal(1, results.Count(r => r == UserActionStatus.Success));
+            Assert.Equal(1, results.Count(r => r == UserActionStatus.LastAdmin));
+            Assert.Equal(1, await CountUsableAdminsAsync());
+        }
+
+        private async Task<(int FirstAdminId, int SecondAdminId, int ActorId)> SeedTwoAdminsAndGhostActorAsync()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var first = await TestDataSeeder.CreateUserAsync(context, "admin_a", "pw");
+            var second = await TestDataSeeder.CreateUserAsync(context, "admin_b", "pw");
+            var actor = await TestDataSeeder.CreateUserAsync(context, "ghostactor", "pw");
+            await TestDataSeeder.AssignRoleToUserAsync(context, first.Id, ERole.Admin);
+            await TestDataSeeder.AssignRoleToUserAsync(context, second.Id, ERole.Admin);
+            return (first.Id, second.Id, actor.Id);
+        }
+
+        private async Task<int> CountUsableAdminsAsync()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            return await context.Users.CountAsync(
+                u => u.ArchivedAt == null && u.BannedAt == null && u.Roles.Any(r => r.Id == (int)ERole.Admin),
+                CancellationToken);
+        }
+
+        [Fact]
         public async Task ArchiveUser_NonPositiveUserId_Returns400()
         {
             using var authClient = await SetupAdminClientAsync();

--- a/Game.Api/Controllers/Admin/AdminUsersController.cs
+++ b/Game.Api/Controllers/Admin/AdminUsersController.cs
@@ -79,23 +79,24 @@ namespace Game.Api.Controllers.Admin
         public async Task<ApiResponse> ArchiveUser([FromBody] UserActionData data)
         {
             var status = await _users.ArchiveUser(_session.UserId, data.UserId);
-            return MapUserAction(status, "You cannot archive your own account.");
+            return MapUserAction(status, "You cannot archive your own account.", "Cannot archive the last remaining admin.");
         }
 
         [HttpPost]
         public async Task<ApiResponse> BanUser([FromBody] UserActionData data)
         {
             var status = await _users.BanUser(_session.UserId, data.UserId);
-            return MapUserAction(status, "You cannot ban your own account.");
+            return MapUserAction(status, "You cannot ban your own account.", "Cannot ban the last remaining admin.");
         }
 
-        private static ApiResponse MapUserAction(UserActionStatus status, string selfTargetMessage)
+        private static ApiResponse MapUserAction(UserActionStatus status, string selfTargetMessage, string lastAdminMessage)
         {
             return status switch
             {
                 UserActionStatus.Success => ApiResponse.Success(),
                 UserActionStatus.UserNotFound => ApiResponse.Error("User not found."),
                 UserActionStatus.SelfTarget => ApiResponse.Error(selfTargetMessage),
+                UserActionStatus.LastAdmin => ApiResponse.Error(lastAdminMessage),
                 _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
             };
         }

--- a/Game.Core.Tests/Identity/AdminLockoutPolicyTests.cs
+++ b/Game.Core.Tests/Identity/AdminLockoutPolicyTests.cs
@@ -90,5 +90,61 @@ namespace Game.Core.Tests.Identity
 
             Assert.Equal(RoleChangeProtection.Allowed, result);
         }
+
+        [Theory]
+        // Self-target is rejected regardless of role or surviving-admin state.
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void CheckUserAction_TargetingSelf_IsSelfTarget(bool targetHasAdminRole, bool otherUsableAdminsRemain)
+        {
+            var result = AdminLockoutPolicy.CheckUserAction(
+                actingUserId: 7,
+                targetUserId: 7,
+                targetHasAdminRole,
+                otherUsableAdminsRemain);
+
+            Assert.Equal(UserActionProtection.SelfTarget, result);
+        }
+
+        [Theory]
+        // Acting on a non-admin never reduces the admin pool, so it is always allowed.
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CheckUserAction_NonAdminTarget_IsAllowed(bool otherUsableAdminsRemain)
+        {
+            var result = AdminLockoutPolicy.CheckUserAction(
+                actingUserId: 1,
+                targetUserId: 2,
+                targetHasAdminRole: false,
+                otherUsableAdminsRemain);
+
+            Assert.Equal(UserActionProtection.Allowed, result);
+        }
+
+        [Fact]
+        public void CheckUserAction_AdminTarget_WhileUsableAdminsRemain_IsAllowed()
+        {
+            var result = AdminLockoutPolicy.CheckUserAction(
+                actingUserId: 1,
+                targetUserId: 2,
+                targetHasAdminRole: true,
+                otherUsableAdminsRemain: true);
+
+            Assert.Equal(UserActionProtection.Allowed, result);
+        }
+
+        [Fact]
+        public void CheckUserAction_AdminTarget_WhenNoUsableAdminsRemain_IsLastAdmin()
+        {
+            var result = AdminLockoutPolicy.CheckUserAction(
+                actingUserId: 1,
+                targetUserId: 2,
+                targetHasAdminRole: true,
+                otherUsableAdminsRemain: false);
+
+            Assert.Equal(UserActionProtection.LastAdmin, result);
+        }
     }
 }

--- a/Game.Core/Identity/AdminLockoutPolicy.cs
+++ b/Game.Core/Identity/AdminLockoutPolicy.cs
@@ -16,6 +16,22 @@ namespace Game.Core.Identity
     }
 
     /// <summary>
+    /// The outcome of evaluating a single-user lifecycle action (archive/ban) against the admin-lockout
+    /// rules.
+    /// </summary>
+    public enum UserActionProtection
+    {
+        /// <summary>The action is safe to apply.</summary>
+        Allowed,
+
+        /// <summary>The action targets the acting admin's own account.</summary>
+        SelfTarget,
+
+        /// <summary>The action would take the last usable admin out of circulation.</summary>
+        LastAdmin,
+    }
+
+    /// <summary>
     /// Pure self-protection rules for privileged user-administration actions, guarding an admin from
     /// locking themselves — or everyone — out: banning/archiving their own account, dropping their own
     /// Admin role, or removing the Admin role from the last remaining admin. The rules take only plain
@@ -62,6 +78,34 @@ namespace Game.Core.Identity
             }
 
             return otherAdminsRemain ? RoleChangeProtection.Allowed : RoleChangeProtection.LastAdmin;
+        }
+
+        /// <summary>
+        /// Evaluates a single-user lifecycle action (archive or ban) for the lockout hazards: targeting the
+        /// acting admin's own account, or taking the last usable admin out of circulation. Acting on a
+        /// non-admin is always allowed, since it cannot reduce the pool of admins.
+        /// </summary>
+        /// <param name="actingUserId">The admin performing the action.</param>
+        /// <param name="targetUserId">The user being archived or banned.</param>
+        /// <param name="targetHasAdminRole">Whether the target currently holds the Admin role.</param>
+        /// <param name="otherUsableAdminsRemain">Whether any usable admin other than the target would remain afterwards.</param>
+        public static UserActionProtection CheckUserAction(
+            int actingUserId,
+            int targetUserId,
+            bool targetHasAdminRole,
+            bool otherUsableAdminsRemain)
+        {
+            if (IsSelfTarget(actingUserId, targetUserId))
+            {
+                return UserActionProtection.SelfTarget;
+            }
+
+            if (!targetHasAdminRole)
+            {
+                return UserActionProtection.Allowed;
+            }
+
+            return otherUsableAdminsRemain ? UserActionProtection.Allowed : UserActionProtection.LastAdmin;
         }
     }
 }

--- a/Game.DataAccess/Repositories/Users.cs
+++ b/Game.DataAccess/Repositories/Users.cs
@@ -234,18 +234,74 @@ namespace Game.DataAccess.Repositories
 
         private async Task<UserActionStatus> SetUserTimestamp(int actingUserId, int targetUserId, Action<UserEntity> setTimestamp)
         {
+            // Cheap self-target rejection before touching the database — an admin can never archive or ban
+            // their own account regardless of who else holds the role.
             if (AdminLockoutPolicy.IsSelfTarget(actingUserId, targetUserId))
             {
                 return UserActionStatus.SelfTarget;
             }
 
-            var user = await _context.Users.FirstOrDefaultAsync(u => u.Id == targetUserId);
+            var user = await _context.Users
+                .Include(u => u.Roles)
+                .FirstOrDefaultAsync(u => u.Id == targetUserId);
             if (user is null)
             {
                 return UserActionStatus.UserNotFound;
             }
 
+            // Only acting on an admin can trip the lockout rules; archiving/banning a non-admin carries no
+            // hazard and applies on the deferred unit-of-work path.
+            const int adminRoleId = (int)ERole.Admin;
+            var targetHasAdminRole = user.Roles.Any(r => r.Id == adminRoleId);
+            if (!targetHasAdminRole)
+            {
+                setTimestamp(user);
+                return UserActionStatus.Success;
+            }
+
+            return await ApplyLifecycleActionToAdminAtomically(actingUserId, user, setTimestamp, adminRoleId);
+        }
+
+        /// <summary>
+        /// Applies an archive/ban to an admin as an atomic check-then-act so the last-admin invariant holds
+        /// under concurrency. Without it, two simultaneous mutual archives/bans could each observe another
+        /// admin remaining and both commit, leaving the system with zero usable admins. A row lock on the
+        /// Admin role serializes every admin-membership change (here and in <see cref="SetUserRoles"/>)
+        /// through a single point; the surviving-admin fact the domain policy reads is gathered under that
+        /// lock, and the mutation commits in-tier (like <see cref="CreateAccount"/>) rather than deferring to
+        /// the request's unit of work — so the policy's check and the act it gates can't be split apart.
+        /// </summary>
+        private async Task<UserActionStatus> ApplyLifecycleActionToAdminAtomically(
+            int actingUserId,
+            UserEntity user,
+            Action<UserEntity> setTimestamp,
+            int adminRoleId)
+        {
+            await using var transaction = await _context.Database.BeginTransactionAsync();
+
+            // Lock the Admin role row; the lock is held until commit, serializing concurrent admin changes.
+            await _context.Database.ExecuteSqlInterpolatedAsync(
+                $"SELECT 1 FROM \"Roles\" WHERE \"Id\" = {adminRoleId} FOR UPDATE");
+
+            // Gather the surviving-admin fact under the lock. A "usable" admin can still log in to recover the
+            // instance, so it must be neither archived nor banned — both archiving and banning the target take
+            // it out of that pool, so the policy must reject the action that would empty it.
+            var otherUsableAdminsRemain = await _context.Users.AnyAsync(u =>
+                u.Id != user.Id && u.ArchivedAt == null && u.BannedAt == null && u.Roles.Any(r => r.Id == adminRoleId));
+
+            var protection = AdminLockoutPolicy.CheckUserAction(
+                actingUserId, user.Id, targetHasAdminRole: true, otherUsableAdminsRemain);
+            switch (protection)
+            {
+                case UserActionProtection.SelfTarget:
+                    return UserActionStatus.SelfTarget;
+                case UserActionProtection.LastAdmin:
+                    return UserActionStatus.LastAdmin;
+            }
+
             setTimestamp(user);
+            await _context.SaveChangesAsync();
+            await transaction.CommitAsync();
             return UserActionStatus.Success;
         }
 


### PR DESCRIPTION
## Summary

`ArchiveUser`/`BanUser` (both backed by `Users.SetUserTimestamp`) only guarded self-targeting — they had **no admin-count guard at all**. Because the actor can't target themselves, a *single* archive/ban can never empty the admin pool, but two **concurrent** actions can: admins A and B are the only admins, A archives/bans B *while* B archives/bans A, neither checks the count, both commit → **zero usable admins** and nobody can recover through the tooling.

This is the same lockout class #952 fixed for role removal, but `SetUserTimestamp` had none of that protection. This PR adds it, reusing the exact pattern #952 introduced.

Closes #966.

## How it addresses the issue

- **New pure policy rule.** `AdminLockoutPolicy.CheckUserAction(...)` mirrors `CheckRoleChange`: it takes plain facts (self-target, target-has-admin, whether another usable admin remains) and returns a new `UserActionProtection` enum. Kept free of data access and unit-tested.
- **Atomic check-then-act in the data tier.** An admin-targeted archive/ban now runs through `ApplyLifecycleActionToAdminAtomically`: begin a transaction, `SELECT … FOR UPDATE` the Admin role row (the same single serialization point `RemoveAdminRoleAtomically` locks), re-read the surviving-admin fact under that lock, let the policy decide, and commit **in-tier** (like `CreateAccount`) so the check and the act it gates can't be split by a concurrent action. Archiving/banning a non-admin keeps the cheap deferred-commit fast path.
- **Surviving-admin definition.** A *usable* admin must be **neither archived nor banned** — both actions take the target out of the recovery pool — so two mutual bans (or archives, or a mix) can leave at most one admin standing.
- **Controller + contract.** `UserActionStatus.LastAdmin` is mapped to "Cannot archive/ban the last remaining admin."; `IUsers` docs updated.

## Note for the reviewer (deliberate scoping)

To make the **ban** half of the issue's scenario a real lockout to prevent, the new guard treats a banned admin as not-usable. While implementing this I found that **ban is not actually enforced at login** — `Users.GetUser` filters only `ArchivedAt`, so a banned user can still authenticate today. That's a separate defect, filed as **#983**, which also tracks unifying `SetUserRoles`'s `otherAdminsRemain` check (still `ArchivedAt`-only, from #952) to the same "non-archived **and** non-banned" predicate once ban-at-login lands. I left `SetUserRoles` untouched here to keep this PR scoped to #966 and #952's shipped behavior intact.

## Test plan

- **Unit** (`AdminLockoutPolicyTests`): `CheckUserAction` self-target, non-admin target, admin-with-other-admins, and last-admin cases.
- **Integration** (`AdminUsersControllerTests`):
  - Archiving/banning another admin while admins remain → succeeds.
  - Archiving/banning the last admin (ghost actor, via repo) → `LastAdmin`, no mutation.
  - **Concurrent mutual archives** and **concurrent mutual bans** → exactly one `Success` + one `LastAdmin`, exactly one usable admin left in the DB.
- Full backend suite green locally: **1537 passed, 0 failed** (`dotnet build` + `dotnet test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpmjZ1C5g4NZaATn5hmEtk)_