### PR TITLE
Re-check fetch generation after NewEnemy await in EnemyManager (#969)

### DIFF
--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -98,6 +98,13 @@ export class EnemyManager {
 				const result = await apiSocket.sendSocketCommand('NewEnemy', {
 					newZoneId: playerManager.currentZone
 				});
+				// The loop condition only gates the top of each iteration, so a stop / superseding
+				// transition that lands while parked on the await above (not on the cancellable backoff)
+				// would otherwise still apply this response. Re-check before applying so a successful
+				// NewEnemy can't clobber the fight the supersession already moved on to.
+				if (!this.started || generation !== this.fetchGeneration) {
+					return;
+				}
 				if (result.data?.enemyInstance) {
 					this.currentEnemy = result.data.enemyInstance;
 					notifyNewEnemyLoaded(this.currentEnemy);

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -176,6 +176,33 @@ describe('EnemyManager boss mode', () => {
 		expect(logMessage).toHaveBeenCalledWith(ELogType.Debug, 'There was an error challenging the boss: no boss');
 	});
 
+	it('does not let a superseded idle fetch clobber the boss when its NewEnemy resolves mid-challenge', async () => {
+		// The exact issue scenario: an idle getNewEnemy is parked on its in-flight NewEnemy when
+		// challengeBoss supersedes it (bumping the generation) and loads the boss. When the stale idle
+		// NewEnemy then resolves with an enemy, it must not overwrite the boss the supersession moved to.
+		let releaseNewEnemy!: (r: IApiSocketResponse<'NewEnemy'>) => void;
+		const newEnemyGate = new Promise<IApiSocketResponse<'NewEnemy'>>((resolve) => (releaseNewEnemy = resolve));
+		send.mockImplementation((name: string) =>
+			name === 'NewEnemy' ? newEnemyGate : Promise.resolve(challengeResponse)
+		);
+		const loaded: IEnemyInstance[] = [];
+		onNewEnemyLoaded((e) => loaded.push(e), false);
+
+		const idleFetch = manager.getNewEnemy();
+		await flush(); // park the idle fetch on the held NewEnemy request
+
+		await manager.challengeBoss(); // supersedes the idle fetch and loads the boss
+		expect(manager.mode).toBe('boss');
+		expect(manager.currentEnemy).toEqual(bossInstance);
+
+		releaseNewEnemy(newEnemyResponse); // the superseded idle fetch resolves with a normal enemy
+		await idleFetch;
+
+		// The stale idle enemy was dropped: the boss remains, and only it was ever notified.
+		expect(manager.currentEnemy).toEqual(bossInstance);
+		expect(loaded).toEqual([bossInstance]);
+	});
+
 	it('on a boss victory: reports the defeat, clears the zone, then returns to idle (auto-fight off)', async () => {
 		await manager.challengeBoss();
 

--- a/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
@@ -170,6 +170,49 @@ describe('EnemyManager.getNewEnemy', () => {
 		releaseDelay(); // the real timer firing late is harmless (the backoff already settled)
 	});
 
+	it('does not apply a successful enemy when stop() lands while parked on the NewEnemy request', async () => {
+		// The narrow window the loop condition alone doesn't cover: the fetch is parked on the in-flight
+		// NewEnemy command (not the backoff) when stop() lands, and the command then resolves with an
+		// enemy. The post-await guard must drop it rather than spawn-and-notify over the stopped manager.
+		const enemy = makeEnemy(9);
+		let resolveSend!: (r: IApiSocketResponse<'NewEnemy'>) => void;
+		sendSocketCommand.mockReturnValueOnce(new Promise((resolve) => (resolveSend = resolve)));
+		const loaded: IEnemyInstance[] = [];
+		onNewEnemyLoaded((e) => loaded.push(e), false);
+
+		const fetch = manager.getNewEnemy();
+		await flush(); // park the loop on the in-flight NewEnemy request
+		manager.stop(); // supersede mid-request (clears started, bumps the generation)
+		resolveSend(enemyResponse(enemy));
+		await fetch;
+
+		expect(manager.currentEnemy).toBeUndefined();
+		expect(loaded).toEqual([]);
+	});
+
+	it('does not apply a successful enemy when the fetch is superseded while parked on the NewEnemy request', async () => {
+		// Same narrow window, but the supersession is a transition (generation bump) rather than a stop:
+		// the manager stays started, so only the generation re-check catches it. The enemy a superseded
+		// idle fetch receives must not overwrite the fight the transition moved on to.
+		const enemy = makeEnemy(11);
+		let resolveSend!: (r: IApiSocketResponse<'NewEnemy'>) => void;
+		sendSocketCommand.mockReturnValueOnce(new Promise((resolve) => (resolveSend = resolve)));
+		const loaded: IEnemyInstance[] = [];
+		onNewEnemyLoaded((e) => loaded.push(e), false);
+
+		const fetch = manager.getNewEnemy();
+		await flush(); // park the loop on the in-flight NewEnemy request
+		// Simulate a transition (e.g. challengeBoss) superseding this fetch via interruptFetch: the
+		// generation moves on while the manager stays started.
+		(manager as unknown as { interruptFetch(): void }).interruptFetch();
+		resolveSend(enemyResponse(enemy));
+		await fetch;
+
+		expect(manager.started).toBe(true);
+		expect(manager.currentEnemy).toBeUndefined();
+		expect(loaded).toEqual([]);
+	});
+
 	it('drops a concurrent re-entrant call so a stage-change race spawns a single enemy', async () => {
 		// Two overlapping stage handlers (e.g. an idle victory racing an Idle change) can both reach
 		// getNewEnemy; each would request-and-notify an enemy, double-counting the spawn. Since the


### PR DESCRIPTION
## Summary

Closes #969.

`EnemyManager.getNewEnemy`'s retry loop gated the active fetch only on the **loop condition** (`while (this.started && generation === this.fetchGeneration)`), which runs at the top of each iteration — not after the `await apiSocket.sendSocketCommand('NewEnemy', …)`. So if a stop or a superseding transition (e.g. `challengeBoss`, which bumps the generation via `interruptFetch`) landed while the loop was parked on the **in-flight `NewEnemy` command** (rather than on the cancellable backoff the PR #963 work already covered), and that command then resolved with an enemy, the loop would set `currentEnemy` and fire `notifyNewEnemyLoaded` *before* re-checking — clobbering the fight the supersession had already moved on to.

This is the narrow success-path window the generation bump in `challengeBoss` was meant to close, just via the successful-response path rather than the retry/backoff path.

## How it addresses the issue

Re-check `this.started` and the captured `generation` immediately after the `NewEnemy` await, before applying the enemy. A superseded success-path response is dropped (the loop returns) instead of spawning-and-notifying. This mirrors the protection the cancellable backoff already gives the retry window.

## Test plan

Added unit tests covering both halves of the post-await guard, each verified to **fail without the fix and pass with it**:

- `enemy-manager.test.ts`
  - stop() landing while parked on the in-flight `NewEnemy` request → the resolved enemy is not applied/notified (`started` re-check).
  - a generation bump (transition supersession) while parked on the request, manager still started → the resolved enemy is not applied/notified (generation re-check).
- `enemy-manager-boss.test.ts`
  - the exact issue scenario end-to-end: an idle fetch parked on its `NewEnemy` is superseded by a real `challengeBoss`, and when the stale idle `NewEnemy` later resolves it does **not** overwrite the loaded boss (`currentEnemy` stays the boss; only the boss was ever notified).

Verification run locally:
- `npx vitest run` on both enemy-manager test files → 37 passed.
- `npm run lint` (eslint + svelte-check) → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AToj92dJ5WDTDAxLNq6WUk)_