### PR TITLE
Fix dropped boss-fallback enemy fetch racing an in-flight idle fetch (#971)

### DIFF
--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -55,6 +55,14 @@ export class EnemyManager {
 	 *  under a sustained outage can't keep spinning — nor later clobber the new fight with an enemy
 	 *  nobody is waiting for. */
 	private fetchGeneration = 0;
+	/** The generation the in-flight fetch loop captured at its start. Lets a fresh getNewEnemy tell a
+	 *  genuine re-entrant duplicate (same generation — the running loop will still spawn, so drop) apart
+	 *  from a superseded loop (older generation — it will abandon without spawning, so wait it out then
+	 *  fetch fresh rather than be dropped by the re-entrancy guard). */
+	private fetchingGeneration = 0;
+	/** The in-flight fetch loop, so a superseding caller (e.g. a failing boss-challenge falling back to
+	 *  the idle loop) can await its teardown before fetching afresh — keeping a single fetch in flight. */
+	private inFlightFetch?: Promise<void>;
 	/** Resolver that short-circuits an in-flight retry backoff so a stop / superseding transition need
 	 *  not wait out the full delay before the loop re-checks whether it should still be running. */
 	private cancelBackoff?: () => void;
@@ -78,16 +86,33 @@ export class EnemyManager {
 		}
 	}
 
-	public async getNewEnemy() {
-		// Single re-entrancy guard: overlapping stage handlers (e.g. an idle victory racing an Idle/
-		// Defeated change) can both reach here, and each would request-and-notify a new enemy —
-		// double-counting a spawn. Because the backend replays what the client reports, a double-spawn
-		// has anti-cheat consequences, so the second, re-entrant call drops; the first still spawns one.
-		if (this.fetchingEnemy) {
-			return;
-		}
-		this.fetchingEnemy = true;
+	public async getNewEnemy(): Promise<void> {
 		const generation = this.fetchGeneration;
+		if (this.fetchingEnemy) {
+			// A fetch is already running. If it captured this same generation it's a genuine re-entrant
+			// duplicate — overlapping stage handlers (e.g. an idle victory racing an Idle/Defeated change)
+			// each request-and-notify a spawn, and a double-spawn has anti-cheat consequences (the backend
+			// replays what the client reports). Drop it; the running fetch still spawns one.
+			if (this.fetchingGeneration === generation) {
+				return;
+			}
+			// Otherwise this call's generation is newer, so the running fetch has been superseded (a
+			// transition bumped the generation) and will abandon without spawning. Wait for it to tear
+			// down, then fall through and fetch fresh so this fallback spawn isn't dropped by the guard.
+			await this.inFlightFetch;
+			// The wait can overlap a stop or a further supersession; bail if either landed meanwhile.
+			if (!this.started || generation !== this.fetchGeneration) {
+				return;
+			}
+		}
+		const run = this.runFetchLoop(generation);
+		this.inFlightFetch = run;
+		await run;
+	}
+
+	private async runFetchLoop(generation: number): Promise<void> {
+		this.fetchingEnemy = true;
+		this.fetchingGeneration = generation;
 		try {
 			// Retry iteratively rather than via self-recursion: each attempt returns to a flat stack
 			// (a sustained outage no longer grows the async chain without bound). The loop ends as soon

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -203,6 +203,44 @@ describe('EnemyManager boss mode', () => {
 		expect(loaded).toEqual([bossInstance]);
 	});
 
+	it('falls back to a fresh idle enemy when a failing ChallengeBoss races an in-flight idle fetch', async () => {
+		// The #971 bug: an idle getNewEnemy is mid-flight (fetchingEnemy still true) when a *failing*
+		// ChallengeBoss falls back to getNewEnemy. The fallback must not be silently dropped by the
+		// re-entrancy guard — it waits for the superseded idle fetch to tear down, then spawns a fresh enemy.
+		let releaseIdle!: (r: IApiSocketResponse<'NewEnemy'>) => void;
+		const idleGate = new Promise<IApiSocketResponse<'NewEnemy'>>((resolve) => (releaseIdle = resolve));
+		let newEnemyCalls = 0;
+		send.mockImplementation((name: string) => {
+			if (name === 'ChallengeBoss') {
+				return Promise.resolve(challengeError);
+			}
+			if (name === 'NewEnemy') {
+				newEnemyCalls++;
+				// The first NewEnemy is the in-flight idle fetch (held); the fallback fetch is the second.
+				return newEnemyCalls === 1 ? idleGate : Promise.resolve(newEnemyResponse);
+			}
+			return Promise.resolve(newEnemyResponse);
+		});
+		const loaded: IEnemyInstance[] = [];
+		onNewEnemyLoaded((e) => loaded.push(e), false);
+
+		const idleFetch = manager.getNewEnemy();
+		await flush(); // park the idle fetch on its held NewEnemy request
+
+		// ChallengeBoss fails and falls back to getNewEnemy while the idle fetch is still in flight.
+		const challenge = manager.challengeBoss();
+		await flush(); // the fallback is now awaiting the superseded idle fetch's teardown
+
+		releaseIdle(newEnemyResponse); // the stale idle fetch resolves and abandons (generation moved on)
+		await Promise.all([idleFetch, challenge]);
+
+		// The fallback issued a second NewEnemy and spawned a fresh idle enemy rather than being dropped.
+		expect(manager.mode).toBe('idle');
+		expect(newEnemyCalls).toBe(2);
+		expect(manager.currentEnemy).toEqual(normalInstance);
+		expect(loaded).toEqual([normalInstance]);
+	});
+
 	it('on a boss victory: reports the defeat, clears the zone, then returns to idle (auto-fight off)', async () => {
 		await manager.challengeBoss();
 


### PR DESCRIPTION
## Summary

Fixes the compound edge case #963 called out and deferred: when an idle `getNewEnemy` is mid-flight (`fetchingEnemy === true`) and a **failing** `ChallengeBoss` falls back to `getNewEnemy()`, the re-entrancy guard (`if (this.fetchingEnemy) return;`) silently dropped that fallback fetch. The player was left without an enemy until the next `BattleStage` change recovered the state.

### Root cause
`challengeBoss` bumps the fetch generation (`interruptFetch`) before awaiting `ChallengeBoss`, superseding any in-flight idle fetch so it will abandon **without spawning**. But the superseded idle loop only clears `fetchingEnemy` in its `finally`, which can land *after* the failing `ChallengeBoss` resolves and reaches its fallback `await this.getNewEnemy()`. The fallback then hits the still-set re-entrancy guard and no-ops — so nobody spawns.

### Fix
`getNewEnemy` now distinguishes the two cases instead of blanket-dropping when a fetch is in flight:

- **Same generation** → a genuine re-entrant duplicate (two overlapping stage handlers). Still dropped, preserving the anti-cheat double-spawn protection.
- **Newer generation** → the running fetch has been superseded and won't spawn. Await its teardown (keeping a single fetch in flight), then fetch fresh so the fallback spawn is reliably produced.

The fetch loop is split into a public `getNewEnemy` entry and a private `runFetchLoop(generation)` that owns the loop and the `fetchingEnemy`/`fetchingGeneration` bookkeeping. This is the `await/supersede` direction the issue suggested.

## How it addresses the issue
- A failing `ChallengeBoss` now reliably produces a fallback enemy even when an idle fetch was mid-flight — meeting both acceptance criteria.
- The re-entrancy / single-in-flight guarantees the existing tests cover are preserved (same-generation re-entrant calls still drop; a superseded fetch still abandons without clobbering the new fight).

## Test plan
- [x] New unit test: a failing `ChallengeBoss` racing an in-flight idle fetch waits the superseded fetch out and spawns a fresh idle enemy (would drop on the old guard).
- [x] `npx vitest --run enemy-manager` — 38 passed (both boss + idle suites), including the re-entrancy and supersession cases.
- [x] `npm run lint` — clean (0 errors / 0 warnings).

No backend parity mirror needed — this is frontend `EnemyManager` orchestration, not the `battleStep` per-tick arithmetic the parity suite guards.

Closes #971

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGZQZvemLwN6PLiGRX6Joj)_