### PR TITLE
Harden SocketManagerService registration/teardown robustness (#909)

### DIFF
--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -143,6 +143,54 @@ namespace Game.Api.Tests.Unit
             Assert.Contains("42", release.Key);
         }
 
+        [Fact]
+        public async Task Processor_PersistentDequeueFault_AbandonsAfterCeilingInsteadOfHotSpinning()
+        {
+            var commands = new CapturingCommandFactory(throwOn: _ => null);
+            var (processor, _) = BuildProcessor(commands);
+
+            // Every dequeue throws (Redis down, or a throw before the pop). Without a ceiling the loop would
+            // hot-spin for the life of the connection, hammering Redis and the log (#909); it must back off
+            // and give up after a bounded number of consecutive failures, returning rather than looping.
+            var queue = new AlwaysThrowingQueue(new InvalidOperationException("dequeue boom"));
+
+            await processor(queue);
+
+            // The processor stopped after exactly the consecutive-failure ceiling rather than spinning, and
+            // it logged the abandonment so the give-up is observable.
+            Assert.Equal(SocketManagerService.MaxConsecutiveDequeueFailures, queue.Attempts);
+            Assert.Contains(_logs.Entries, e => e.Level == LogLevel.Error && e.Message.Contains("Abandoning"));
+        }
+
+        [Fact]
+        public async Task UnRegisterSocket_UnsubscribeThrows_StillReleasesPresenceKey()
+        {
+            // The clean-disconnect teardown runs the same guarded best-effort steps as a rollback: even when
+            // the unsubscribe throws, the presence-key release must still run so the key can't survive its
+            // full TTL reporting a ghost session that makes HasActiveSocket lie until expiry (#909).
+            var cache = new RecordingCacheService();
+            var pubSub = new ThrowingUnsubscribePubSubService(new InvalidOperationException("unsubscribe boom"));
+            var scopeFactory = _provider.GetRequiredService<IServiceScopeFactory>();
+            var registry = new SocketConnectionRegistry(new NoOpHostLifetime(), NullLogger<SocketConnectionRegistry>.Instance);
+            var manager = new SocketManagerService(
+                pubSub, cache, new CapturingCommandFactory(_ => null), scopeFactory, _loggerFactory, registry);
+
+            var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
+            var session = new SessionService(new NoOpSessionStore());
+            session.CreateSession(userId: 1, playerId: 77);
+            var context = await manager.RegisterSocket(socket, session);
+
+            // The unsubscribe fault during teardown must be swallowed, not propagated...
+            await manager.UnRegisterSocket(context);
+
+            // ...and the presence key was still released via a compare-and-delete keyed on the socket's own
+            // id (so a newer owner's key would be left intact), on the player's presence key.
+            var release = Assert.Single(cache.CompareAndDeletes);
+            Assert.Contains("77", release.Key);
+            Assert.Equal(context.SocketId, release.DeleteIfValue);
+            Assert.Contains(_logs.Entries, e => e.Level == LogLevel.Error && e.Message.Contains("unsubscribe"));
+        }
+
         private (Func<IPubSubQueue, Task> Processor, CapturingPubSubService PubSub) BuildProcessor(CapturingCommandFactory commandFactory)
         {
             var capturingPubSub = new CapturingPubSubService();
@@ -234,6 +282,34 @@ namespace Game.Api.Tests.Unit
                 }
 
                 return Task.FromResult<T?>(default);
+            }
+
+            public Task<string?> GetNextAsync() => throw new NotSupportedException();
+            public Task<string?> ReserveNextAsync() => throw new NotSupportedException();
+            public Task AcknowledgeAsync(string value) => throw new NotSupportedException();
+            public Task<long> ReclaimProcessingAsync() => throw new NotSupportedException();
+            public Task<long> GetLengthAsync() => throw new NotSupportedException();
+            public Task<IReadOnlyList<string>> PeekAsync(long count) => throw new NotSupportedException();
+            public Task<bool> RemoveAsync(string value) => throw new NotSupportedException();
+            public string? GetNext() => throw new NotSupportedException();
+            public T? GetNext<T>() => throw new NotSupportedException();
+            public void AddToQueue(string value) => throw new NotSupportedException();
+            public void AddToQueue<T>(T value) => throw new NotSupportedException();
+            public Task AddToQueueAsync(string value) => throw new NotSupportedException();
+            public Task AddToQueueAsync<T>(T value) => throw new NotSupportedException();
+            public Task AddRangeToQueueAsync(IEnumerable<string> values) => throw new NotSupportedException();
+        }
+
+        /// <summary>An in-memory queue whose every dequeue throws, to drive the processor's consecutive-
+        /// failure ceiling. Counts the attempts so a test can assert it gave up rather than hot-spinning.</summary>
+        private sealed class AlwaysThrowingQueue(Exception toThrow) : IPubSubQueue
+        {
+            public int Attempts { get; private set; }
+
+            public Task<T?> GetNextAsync<T>()
+            {
+                Attempts++;
+                throw toThrow;
             }
 
             public Task<string?> GetNextAsync() => throw new NotSupportedException();
@@ -344,6 +420,23 @@ namespace Game.Api.Tests.Unit
             public Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task UnSubscribe(string channel) => Task.CompletedTask;
             public Task UnSubscribe(string channel, string id) => Task.CompletedTask;
+            public IPubSubQueue GetQueue(string queueName) => throw new NotSupportedException();
+        }
+
+        /// <summary>A pub/sub whose <c>Subscribe</c> succeeds but <c>UnSubscribe</c> throws, to drive the
+        /// guarded-teardown path where the presence-key release must still run after an unsubscribe fault.</summary>
+        private sealed class ThrowingUnsubscribePubSubService(Exception toThrow) : IPubSubService
+        {
+            public Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string? id = null) => Task.CompletedTask;
+            public Task UnSubscribe(string channel, string id) => throw toThrow;
+
+            public Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string? id = null) => throw new NotSupportedException();
+            public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => throw new NotSupportedException();
+            public Task Publish(string channel, string message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task Publish(string channel, string queueName, string queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task Publish<T>(string channel, string queueName, T queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task UnSubscribe(string channel) => throw new NotSupportedException();
             public IPubSubQueue GetQueue(string queueName) => throw new NotSupportedException();
         }
 

--- a/Game.Api/Services/SocketManagerService.cs
+++ b/Game.Api/Services/SocketManagerService.cs
@@ -48,11 +48,6 @@ namespace Game.Api.Services
             var oldSocketId = await _cache.GetSet(presenceKey, socketContext.SocketId, SocketPresenceTtl);
             try
             {
-                if (oldSocketId is not null)
-                {
-                    await EmitSocketCommand(new SocketReplacedInfo(), oldSocketId);
-                }
-
                 await RegisterSocketCommandListener(socketHandler);
                 // Register before starting the loops so the registry tracks the socket — and threads its
                 // shutdown tokens into Listen — for a graceful drain on host shutdown (#526). Awaited because
@@ -64,8 +59,25 @@ namespace Game.Api.Services
                 // A step after the presence-key write failed, so the key now points at a socket whose drain
                 // loops never started — a "registered but dead" presence that would block the player and never
                 // drain. Undo the partial registration before propagating.
-                await RollbackRegistration(socketContext);
+                await TeardownSocketRegistration(socketContext, "rolling back a failed registration");
                 throw;
+            }
+
+            // Signal the replaced connection to close only now that the new socket is fully established.
+            // Emitting it before the registration above would, on a transient fault there (which rolls the new
+            // registration back), leave the player with a closing old connection and no working new one. This
+            // is best-effort: a failure here just leaves the old socket to its own inactivity teardown rather
+            // than tearing down the live new connection over a notification the old socket no longer needs.
+            if (oldSocketId is not null)
+            {
+                try
+                {
+                    await EmitSocketCommand(new SocketReplacedInfo(), oldSocketId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to notify replaced socket {OldSocketId} for player {PlayerId}; it will be cleaned up by its own inactivity teardown.", oldSocketId, playerId);
+                }
             }
 
             _logger.LogDebug("Initiated socket for player: ({Id}), with Id: {SocketId}", playerId, socketContext.SocketId);
@@ -73,12 +85,15 @@ namespace Game.Api.Services
         }
 
         /// <summary>
-        /// Undoes a partially-completed <see cref="RegisterSocket"/> after the presence key was written but a
-        /// later step threw: drop our presence claim (only if it is still ours) and tear down any subscription
-        /// and registry tracking. Each step is best-effort and guarded so a cleanup fault can't mask the
-        /// original registration exception that is about to propagate.
+        /// Best-effort teardown of a socket's registration — used both for a clean disconnect
+        /// (<see cref="UnRegisterSocket"/>) and to roll back a partially-completed <see cref="RegisterSocket"/>.
+        /// Drops registry tracking, unsubscribes the command listener, and releases the presence claim (only
+        /// if it is still ours). Each awaited step is guarded so a fault in one can't skip the others — most
+        /// importantly the presence-key release, which a ghost session would otherwise survive on until its
+        /// TTL — and so a cleanup fault on the rollback path can't mask the registration exception about to
+        /// propagate. <paramref name="reason"/> labels the teardown in the failure logs.
         /// </summary>
-        private async Task RollbackRegistration(SocketContext context)
+        private async Task TeardownSocketRegistration(SocketContext context, string reason)
         {
             _socketRegistry.Unregister(context.SocketId);
             try
@@ -87,18 +102,18 @@ namespace Game.Api.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to unsubscribe socket {SocketId} while rolling back a failed registration.", context.SocketId);
+                _logger.LogError(ex, "Failed to unsubscribe socket {SocketId} while {Reason}.", context.SocketId, reason);
             }
 
             try
             {
                 // Compare-and-delete so we only release the key while it is still ours — a newer connection may
-                // have taken it over between our write and this rollback, and that key must be left intact.
+                // have taken it over, and that key must be left intact.
                 await _cache.CompareAndDelete(CurrentSocketKey(context.PlayerId), context.SocketId);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to release the presence key for socket {SocketId} while rolling back a failed registration.", context.SocketId);
+                _logger.LogError(ex, "Failed to release the presence key for socket {SocketId} while {Reason}.", context.SocketId, reason);
             }
         }
 
@@ -123,11 +138,12 @@ namespace Game.Api.Services
             await _cache.Expire(CurrentSocketKey(playerId), SocketPresenceTtl);
         }
 
-        public async Task UnRegisterSocket(SocketContext context)
+        public Task UnRegisterSocket(SocketContext context)
         {
-            _socketRegistry.Unregister(context.SocketId);
-            await UnRegisterSocketCommandListener(context.SocketId);
-            await _cache.CompareAndDelete(CurrentSocketKey(context.PlayerId), context.SocketId);
+            // A clean disconnect shares the same guarded best-effort steps as a registration rollback: if the
+            // unsubscribe throws, the presence-key release must still run so the key can't survive its full
+            // TTL reporting a ghost session that makes HasActiveSocket lie until it expires.
+            return TeardownSocketRegistration(context, "tearing down the socket");
         }
 
         public async Task EmitSocketCommand(SocketCommandInfo commandInfo, string socketId)
@@ -161,10 +177,22 @@ namespace Game.Api.Services
             await _pubSub.Subscribe(channel, queueName, async args => await processor(args.queue), handler.Id);
         }
 
+        /// <summary>
+        /// The number of consecutive dequeue failures after which the command processor abandons its drain
+        /// loop rather than hot-spinning. A sustained fault (Redis unreachable, or a throw before the pop)
+        /// would otherwise tight-loop hammering Redis and the log for the life of the connection; the socket
+        /// re-establishes its subscription on reconnect.
+        /// </summary>
+        internal const int MaxConsecutiveDequeueFailures = 5;
+
+        /// <summary>Base backoff between consecutive dequeue failures, scaled by the failure streak.</summary>
+        private static readonly TimeSpan DequeueFailureBackoff = TimeSpan.FromMilliseconds(100);
+
         private Func<IPubSubQueue, Task> GetSocketCommandProcessor(SocketHandler socket)
         {
             return async (queue) =>
             {
+                var consecutiveFailures = 0;
                 while (true)
                 {
                     SocketCommandInfo? nextCommandInfo;
@@ -180,8 +208,21 @@ namespace Game.Api.Services
                         // GetNextAsync before deserialization throws, so skipping it advances the queue; a
                         // transient blip is retried on the next pass.
                         _logger.LogError(ex, "An error occurred while dequeuing a socket command on socket: {Id}, playerId: {PlayerId}.", socket.Id, socket.PlayerId);
+
+                        // Bound a persistent fault: a hot retry loop would hammer Redis and the log for the
+                        // life of the connection. Back off (scaled by the streak) and give up past a ceiling —
+                        // the socket re-establishes its subscription on reconnect.
+                        if (++consecutiveFailures >= MaxConsecutiveDequeueFailures)
+                        {
+                            _logger.LogError("Abandoning the command processor for socket: {Id}, playerId: {PlayerId} after {FailureCount} consecutive dequeue failures; it will re-establish on reconnect.", socket.Id, socket.PlayerId, consecutiveFailures);
+                            break;
+                        }
+
+                        await Task.Delay(DequeueFailureBackoff * consecutiveFailures);
                         continue;
                     }
+
+                    consecutiveFailures = 0;
 
                     if (nextCommandInfo is null)
                     {


### PR DESCRIPTION
## Summary

Closes #909. Three low-likelihood-but-worth-hardening robustness gaps on the socket connection lifecycle in `Game.Api/Services/SocketManagerService.cs`.

### 1. `SocketReplaced` is now sent only after the new socket is established
`RegisterSocket` previously notified the old socket (`EmitSocketCommand(SocketReplacedInfo)`) **before** the steps that can throw (Redis `Subscribe`, registry `Register`). On a transient failure the new registration rolled back but the old socket had already been told to disconnect — leaving the player with a closing old connection and no working new one.

Now the subscribe + register happen first; the replace-notification is emitted only once the new socket is guaranteed established. The notify is **best-effort** (guarded + logged): if it fails, the old socket is left to its own inactivity-watchdog teardown rather than tearing down the live new connection over a notification the old socket no longer needs.

### 2. The pub/sub command processor no longer hot-spins on a persistent dequeue fault
`GetSocketCommandProcessor` previously logged-and-`continue`d on any `GetNextAsync` exception with no backoff or ceiling, so a sustained fault (Redis down, or a throw before the pop) became a tight loop hammering Redis and the log for the life of the connection.

It now applies a backoff scaled by the consecutive-failure streak and gives up past a ceiling (`MaxConsecutiveDequeueFailures = 5`); the socket re-establishes its subscription on reconnect. The streak resets on any successful dequeue.

### 3. `UnRegisterSocket` clean-teardown is now fault-guarded
The normal teardown ran three awaited ops unguarded, so if `UnRegisterSocketCommandListener` threw, the `CompareAndDelete` presence-key release never ran — leaving the key to survive its full TTL reporting a ghost session (`HasActiveSocket` would lie until expiry).

Each step is now best-effort guarded, mirroring the rollback path. Because that made the clean-teardown and rollback paths identical, both now share a single `TeardownSocketRegistration(context, reason)` helper (the old `RollbackRegistration` is folded in), keeping the teardown logic DRY.

## How it addresses the issue
Each numbered fix maps directly to the three points in the issue.

## Test plan
- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] New unit tests in `SocketCommandProcessorTests`:
  - `Processor_PersistentDequeueFault_AbandonsAfterCeilingInsteadOfHotSpinning` — a persistently-throwing queue makes the processor give up after exactly the ceiling (not loop forever) and log the abandonment.
  - `UnRegisterSocket_UnsubscribeThrows_StillReleasesPresenceKey` — a throwing unsubscribe is swallowed and the presence key is still compare-and-deleted on the socket's own id.
- [x] Existing socket processor / rollback / presence-lifecycle tests still pass (the `RegisterSocket` reorder + best-effort emit and the shared teardown helper).
- [x] Full `Game.Api.Tests` suite green (534 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvJqinF9BdBxR6MByKskXP)_