### PR TITLE
Close battle parity & engine test-matrix gaps (#941)

### DIFF
--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -171,6 +171,28 @@ namespace Game.Core.Tests.Battle
                     ExpectedPlayerDied: false,
                     ExpectedTotalMs: 7840),
 
+                // Fractional enemy attribute distribution (#941): the only scenario whose enemy attribute is
+                // built from a FRACTIONAL per-level AttributeDistribution (BaseAmount 0 + 2.5/level at level 3
+                // → Strength 7.5) rather than an integer BaseAmount at level 1 — the production path
+                // EnemyInstance.FromSource serializes the resulting double to the client, which re-derives it.
+                // Strength feeds only MaxHealth here: 50 + 5×7.5 = 87.5, a fractional max with a TIGHT kill margin.
+                //   Player: skill baseDamage 31, no multiplier, cooldown 400 → 31−2 Def = 29/hit every 10 ticks.
+                //   Enemy:  MaxHealth 87.5, Def 2, no skills (the player never dies).
+                //   Cumulative 29,58,87 (the 87.5 survives the 87), 116 → dies on hit 4 at tick 160 → 1600ms. Had
+                //   the .5 been lost to a float roundtrip (MaxHealth 87) the enemy would die a hit earlier at 1200.
+                ["fractionalEnemyDistribution"] = new ParityScenario(
+                    Player: () => MakeBattler(
+                        strength: 0, endurance: 0,
+                        skills: [MakeSkill(1, baseDamage: 31, cooldownMs: 400)]),
+                    Enemy: () => MakeEnemy(
+                        strength: 0, endurance: 0,
+                        skills: [],
+                        level: 3,
+                        perLevelDistributions: [(EAttribute.Strength, 0m, 2.5m)]),
+                    ExpectedVictory: true,
+                    ExpectedPlayerDied: false,
+                    ExpectedTotalMs: 1600),
+
                 // A self Strength buff: the hit that CARRIES the effect uses the pre-effect attributes, and
                 // only subsequent hits see the boost (which also raises damage via the Strength→damage path)
                 // — and re-applying it every fire now STACKS (each fire adds another +10), so the buff
@@ -381,6 +403,29 @@ namespace Game.Core.Tests.Battle
                     ExpectedTotalMs: 3000,
                     MaxMs: 3000),
 
+                // Effect apply → expire → re-apply (#941): a periodic poison whose duration (80ms = 2 ticks) is
+                // shorter than its skill's cooldown (120ms = 3 ticks), so each application fully LAPSES for a
+                // tick before the skill fires again and re-applies — the cycle where the backend's absolute
+                // ExpiresAtMs clock and the frontend's decrementing remainingMs are most likely to drift by a
+                // tick. (Distinct from the refresh-while-active stacking and single-shot expiry rows.)
+                //   Player: skill baseDamage 0, cooldown 120, Opponent +250 DamageTakenPerSecond for 80ms → 10/tick.
+                //     Fires at ticks 120,240,360; each application deals DoT on its 2 active ticks, then lapses one.
+                //   Enemy:  MaxHealth 50, no skills.
+                //   Active ticks 120,160 (50→30), lapse 200, re-apply 240,280 (30→10), lapse 320, re-apply 360
+                //   (→0): dies at tick 360 → 360ms. (A non-lapsing constant 10/tick from tick 120 would kill at 280.)
+                ["effectExpiresThenReapplies"] = new ParityScenario(
+                    Player: () => MakeBattler(
+                        strength: 0, endurance: 0,
+                        skills:
+                        [
+                            MakeSkill(1, baseDamage: 0, cooldownMs: 120,
+                                effects: [MakeEffect(210, ESkillEffectTarget.Opponent, EAttribute.DamageTakenPerSecond, EModifierType.Additive, 250, 80)]),
+                        ]),
+                    Enemy: () => MakeEnemy(strength: 0, endurance: 0, skills: []),
+                    ExpectedVictory: true,
+                    ExpectedPlayerDied: false,
+                    ExpectedTotalMs: 360),
+
                 // DoT stacking: a poison re-applied every tick STACKS (each application adds another
                 // DamageTakenPerSecond debuff) instead of refreshing, so the per-tick damage ramps. The skill
                 // (cooldown 40) applies Opponent +25 DamageTakenPerSecond each tick; at tick n the enemy
@@ -525,6 +570,26 @@ namespace Game.Core.Tests.Battle
                     ExpectedVictory: true,
                     ExpectedPlayerDied: false,
                     ExpectedTotalMs: 2400),
+
+                // Fractional crit chance against a fixed seed (#941): unlike the forced-1/0 crit rows, CriticalChance
+                // is a real 0.5 fraction, so whether each player fire crits depends on the actual Mulberry32 [0,1)
+                // draw — validating that a fractional chance compared against a real draw lands identically on both
+                // ports (not just the draw ordering/math). With ParitySeed the first six crit draws are
+                // crit,crit,no,no,crit,crit.
+                //   Player: skill baseDamage 12, cooldown 400 (one crit draw per fire, every 10 ticks); CriticalDamage
+                //     base 1.5 + 0.5 = 2.0 → a crit deals 12×2−2 = 22, a non-crit 12−2 = 10.
+                //   Enemy:  Str 10 → MaxHealth 100, Def 2, no skills (no enemy draws, so the stream is crit draws only).
+                //   Hits 22,22,10,10,22 (cum 86) then the 6th draw's crit (+22 → 108 ≥ 100) kills on fire 6 → 2400ms.
+                //   The 6th hit being a crit is decisive: a non-crit there (+10 → 96) would push the kill to fire 7.
+                ["fractionalCritChance"] = new ParityScenario(
+                    Player: () => MakeBattler(
+                        strength: 0, endurance: 0,
+                        skills: [MakeSkill(1, baseDamage: 12, cooldownMs: 400)],
+                        extra: [(EAttribute.CriticalChance, 0.5), (EAttribute.CriticalDamage, 0.5)]),
+                    Enemy: () => MakeEnemy(strength: 10, endurance: 0, skills: []),
+                    ExpectedVictory: true,
+                    ExpectedPlayerDied: false,
+                    ExpectedTotalMs: 2400),
             };
 
         /// <summary>A duration long enough that an effect never expires within a battle (for "permanent" buffs).</summary>
@@ -606,6 +671,22 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(32, player.GetAttributeValue(EAttribute.Defense));
             Assert.Equal(1.10, player.GetAttributeValue(EAttribute.CooldownRecovery), 10);
             Assert.Equal(1.10, player.GetCooldownMultiplier(), 10);
+        }
+
+        /// <summary>
+        /// Pins the fractional enemy attributes for the <c>fractionalEnemyDistribution</c> scenario so a
+        /// divergence in the decimal→double per-level distribution (or the wire roundtrip the client mirrors)
+        /// is reported directly rather than only surfacing as a different battle outcome. Mirrors the frontend
+        /// "derives the fractionalEnemyDistribution enemy MaxHealth" expectation.
+        /// </summary>
+        [Fact]
+        public void Parity_FractionalEnemyDistribution_DerivesFractionalMaxHealth()
+        {
+            var enemy = Scenarios["fractionalEnemyDistribution"].Enemy();
+
+            // Strength 0 (base) + (0 + 2.5 × level 3) per-level distribution = 7.5 → MaxHealth 50 + 5×7.5 = 87.5.
+            Assert.Equal(7.5, enemy.GetAttributeValue(EAttribute.Strength));
+            Assert.Equal(87.5, enemy.GetAttributeValue(EAttribute.MaxHealth));
         }
 
         private static Skill MakeSkill(
@@ -795,7 +876,9 @@ namespace Game.Core.Tests.Battle
         private static Battler MakeEnemy(
             double strength, double endurance,
             List<Skill>? skills = null,
-            (EAttribute Attribute, double Amount)[]? extra = null)
+            (EAttribute Attribute, double Amount)[]? extra = null,
+            int level = 1,
+            (EAttribute Attribute, decimal BaseAmount, decimal AmountPerLevel)[]? perLevelDistributions = null)
         {
             var defaultSkills = skills ?? [];
 
@@ -820,12 +903,28 @@ namespace Game.Core.Tests.Battle
                 }
             }
 
+            // Fractional per-level distributions (#941): exercise the AmountPerLevel × level path of
+            // AttributeDistribution.GetDistributionModifier — every other scenario uses an integer BaseAmount
+            // at level 1, so this is the only place the decimal→double per-level derivation is covered.
+            if (perLevelDistributions is not null)
+            {
+                foreach (var (attribute, baseAmount, amountPerLevel) in perLevelDistributions)
+                {
+                    distributions.Add(new AttributeDistribution
+                    {
+                        AttributeId = attribute,
+                        BaseAmount = baseAmount,
+                        AmountPerLevel = amountPerLevel,
+                    });
+                }
+            }
+
             var enemy = new Enemy
             {
                 Id = 1,
                 Name = "Test Enemy",
                 IsBoss = false,
-                Level = 1,
+                Level = level,
                 AttributeDistributions = distributions,
                 AvailableSkills = defaultSkills,
             };

--- a/UI/src/lib/battle/battler.ts
+++ b/UI/src/lib/battle/battler.ts
@@ -171,7 +171,14 @@ export class Battler {
 
 	/** Advances every active effect by `timeDelta`, removing any whose duration has elapsed (its modifier
 	 *  is removed and the totals recomputed). Called at the start of each tick before any skill fires, so
-	 *  an effect influences exactly `durationMs / tickSize` ticks counting the one it was applied on. */
+	 *  an effect influences exactly `durationMs / tickSize` ticks counting the one it was applied on.
+	 *
+	 *  Parity note: this decrements `remainingMs` per tick where the backend (`Battler.AdvanceEffects`)
+	 *  instead keys expiry to an absolute `_elapsedMs` clock. The two are **value-equal only under the
+	 *  current fixed tick size** — they are not algebraically identical under any future variable-tick or
+	 *  fractional-accumulation change, so they must stay in lockstep (or the FE be converted to the
+	 *  backend's absolute-expiry model). The mirrored parity matrix covers the apply→expire→re-apply
+	 *  cycle where the two bookkeeping models are most likely to drift by a tick. */
 	public advanceEffects(timeDelta: number) {
 		if (this.activeEffects.length === 0) {
 			return;

--- a/UI/src/lib/engine/render-engine.ts
+++ b/UI/src/lib/engine/render-engine.ts
@@ -38,7 +38,11 @@ export class RenderEngine {
 		const newTime = performance.now();
 		const delta = newTime - this.time;
 		this.time = newTime;
-		this.logicalDelta = newTime - logicEngine.time;
+		// Floor at 0: the logical engine's tab-background catch-up branch advances logicEngine.time by the
+		// discarded excess, which can momentarily push it past the render clock. A negative logicalDelta
+		// would drive the render-only charge/effect interpolation backwards for a frame (purely cosmetic —
+		// logical state and battle parity are unaffected).
+		this.logicalDelta = Math.max(0, newTime - logicEngine.time);
 		notifyRenderUpdate(delta, this.logicalDelta);
 	};
 }

--- a/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
+++ b/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
@@ -248,6 +248,21 @@ const scenarios: ParityScenario[] = [
 		expected: { victory: true, playerDied: false, totalMs: 7840 }
 	},
 
+	// Fractional enemy attribute distribution (#941): the only scenario whose enemy attribute is a FRACTIONAL
+	// value (Strength 7.5, produced on the backend by a 2.5/level distribution at level 3 and serialized to the
+	// client, which re-derives MaxHealth from it). Strength feeds only MaxHealth: 50 + 5×7.5 = 87.5, a fractional
+	// max with a TIGHT kill margin. Mirrors the backend `fractionalEnemyDistribution` scenario.
+	//   Player: skill baseDamage 31, no multiplier, cooldown 400 → 31−2 Def = 29/hit every 10 ticks.
+	//   Enemy:  MaxHealth 87.5, Def 2, no skills.
+	//   Cumulative 29,58,87 (the 87.5 survives the 87), 116 → dies on hit 4 at tick 160 → 1600ms. Had the .5 been
+	//   lost to a float roundtrip (MaxHealth 87) the enemy would die a hit earlier at 1200.
+	{
+		name: 'fractionalEnemyDistribution',
+		player: () => makeBattler([], [makeSkill(31, 400)]),
+		enemy: () => makeBattler([{ id: EAttribute.Strength, amount: 7.5 }], []),
+		expected: { victory: true, playerDied: false, totalMs: 1600 }
+	},
+
 	// A self Strength buff: the carrying hit uses the pre-effect attributes and only subsequent hits see
 	// the boost (which also raises damage via the Strength→damage path); re-applying it each fire now STACKS
 	// (each fire adds another +10). Mirrors the backend `selfStrengthBuffStacksEachFire` scenario.
@@ -530,6 +545,41 @@ const scenarios: ParityScenario[] = [
 		expected: { victory: false, playerDied: false, totalMs: 3000 }
 	},
 
+	// Effect apply → expire → re-apply (#941): a periodic poison whose duration (80ms = 2 ticks) is shorter than
+	// its skill's cooldown (120ms = 3 ticks), so each application fully LAPSES for a tick before re-applying — the
+	// cycle where the frontend's decrementing remainingMs and the backend's absolute ExpiresAtMs clock are most
+	// likely to drift by a tick. Mirrors the backend `effectExpiresThenReapplies` scenario.
+	//   Player: skill baseDamage 0, cooldown 120, Opponent +250 DamageTakenPerSecond for 80ms → 10/tick. Fires at
+	//     ticks 120,240,360. Enemy: MaxHealth 50, no skills.
+	//   Active 120,160 (50→30), lapse 200, re-apply 240,280 (30→10), lapse 320, re-apply 360 (→0): dies at 360ms.
+	//   (A non-lapsing constant 10/tick from tick 120 would kill at 280.)
+	{
+		name: 'effectExpiresThenReapplies',
+		player: () =>
+			makeBattler(
+				[],
+				[
+					makeSkill(
+						0,
+						120,
+						[],
+						[
+							makeEffect(
+								210,
+								ESkillEffectTarget.Opponent,
+								EAttribute.DamageTakenPerSecond,
+								EModifierType.Additive,
+								250,
+								80
+							)
+						]
+					)
+				]
+			),
+		enemy: () => makeBattler([], []),
+		expected: { victory: true, playerDied: false, totalMs: 360 }
+	},
+
 	// DoT stacking: a poison re-applied every tick STACKS (each application adds another
 	// DamageTakenPerSecond debuff) instead of refreshing, so the per-tick damage ramps. The skill
 	// (cooldown 40) applies Opponent +25 DamageTakenPerSecond each tick; at tick n the enemy carries n
@@ -695,6 +745,27 @@ const scenarios: ParityScenario[] = [
 				[makeSkill(20, 400)]
 			),
 		expected: { victory: true, playerDied: false, totalMs: 2400 }
+	},
+
+	// Fractional crit chance against a fixed seed (#941): unlike the forced-1/0 crit rows, CriticalChance is a
+	// real 0.5 fraction, so whether each player fire crits depends on the actual Mulberry32 [0,1) draw. With
+	// PARITY_SEED the first six crit draws are crit,crit,no,no,crit,crit. Mirrors the backend `fractionalCritChance`.
+	//   Player: skill baseDamage 12, cooldown 400 (one crit draw per fire); CriticalDamage base 1.5 + 0.5 = 2.0 →
+	//     a crit deals 12×2−2 = 22, a non-crit 12−2 = 10. Enemy: Str 10 → MaxHealth 100, Def 2, no skills.
+	//   Hits 22,22,10,10,22 (cum 86) then the 6th draw's crit (+22 → 108 ≥ 100) kills on fire 6 → 2400ms; a
+	//   non-crit there (96) would push the kill to fire 7.
+	{
+		name: 'fractionalCritChance',
+		player: () =>
+			makeBattler(
+				[
+					{ id: EAttribute.CriticalChance, amount: 0.5 },
+					{ id: EAttribute.CriticalDamage, amount: 0.5 }
+				],
+				[makeSkill(12, 400)]
+			),
+		enemy: () => makeBattler([{ id: EAttribute.Strength, amount: 10 }], []),
+		expected: { victory: true, playerDied: false, totalMs: 2400 }
 	}
 ];
 
@@ -747,6 +818,22 @@ describe('Battle simulation parity with backend', () => {
 		expect(player.attributes.getValue(EAttribute.Defense)).toBe(32);
 		expect(player.attributes.getValue(EAttribute.CooldownRecovery)).toBeCloseTo(1.1, 10);
 		expect(player.cdMultiplier).toBeCloseTo(1.1, 10);
+	});
+
+	it('derives the fractionalEnemyDistribution enemy MaxHealth to the expected fractional value', () => {
+		// Pins the fractional enemy stat down so a divergence in the fractional value (the backend's
+		// decimal→double per-level distribution, or the wire roundtrip this side mirrors) is reported
+		// directly rather than only as a different outcome. Mirrors
+		// BattleSimulatorParityTests.Parity_FractionalEnemyDistribution_DerivesFractionalMaxHealth.
+		const scenario = scenarios.find((s) => s.name === 'fractionalEnemyDistribution');
+		if (!scenario) {
+			throw new Error('fractionalEnemyDistribution scenario is missing from the matrix');
+		}
+		const enemy = scenario.enemy();
+
+		// Strength 7.5 (the backend's 2.5/level distribution at level 3) → MaxHealth 50 + 5×7.5 = 87.5.
+		expect(enemy.attributes.getValue(EAttribute.Strength)).toBe(7.5);
+		expect(enemy.attributes.getValue(EAttribute.MaxHealth)).toBe(87.5);
 	});
 
 	it('ends sooner if the player double-counts derived stats (the historical bug)', () => {

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -404,6 +404,32 @@ describe('EnemyManager boss mode', () => {
 		expect(manager.currentEnemy).toEqual(normalInstance);
 	});
 
+	it('abandons the auto-fight re-challenge when a retreat lands during the victory overlay', async () => {
+		// The third resolveBossVictory await boundary: a retreat that lands while the handler is parked on the
+		// Zone-Cleared overlay delay (auto-fight on) must abandon at the overlay's bossLoopActive re-check
+		// rather than re-challenging the boss over the new idle fight.
+		await manager.challengeBoss();
+		manager.setAutoFight(true);
+		// Gate the (only) overlay delay so a retreat can interleave while the victory handler is parked on it.
+		let releaseOverlay!: () => void;
+		vi.mocked(delay).mockReturnValueOnce(new Promise<void>((resolve) => (releaseOverlay = resolve)));
+
+		const handled = fireStage(h.BattleStage.Victorious);
+		await flush(); // claim + zone clear settle; the handler parks on the overlay delay
+		const challengeCallsBefore = send.mock.calls.filter((c: unknown[]) => c[0] === 'ChallengeBoss').length;
+
+		const retreated = manager.retreatFromBoss();
+		releaseOverlay();
+		await Promise.all([handled, retreated]);
+
+		// The retreat transitioned to the idle loop; the parked victory resolution bailed instead of issuing
+		// another ChallengeBoss, and the idle enemy stands.
+		expect(manager.mode).toBe('idle');
+		expect(send.mock.calls.filter((c: unknown[]) => c[0] === 'ChallengeBoss').length).toBe(challengeCallsBefore);
+		expect(manager.bossOutcome).toBeUndefined();
+		expect(manager.currentEnemy).toEqual(normalInstance);
+	});
+
 	it('on a boss loss: records it, turns auto-fight off, and returns to the idle loop honoring the cooldown', async () => {
 		await manager.challengeBoss();
 		manager.setAutoFight(true);

--- a/UI/src/tests/lib/engine/logical-engine.test.ts
+++ b/UI/src/tests/lib/engine/logical-engine.test.ts
@@ -102,4 +102,25 @@ describe('LogicalEngine', () => {
 		expect(engine.time).toBe(0);
 		expect(engine.tickRate).toBe(0);
 	});
+
+	it('caps catch-up to 5 ticks but keeps the clock current on a long stall (tab background)', () => {
+		// Drive a single huge inter-poll gap (a backgrounded tab) by controlling performance.now directly,
+		// so one poll sees a > tickSizeX5 delta and exercises the catch-up branch.
+		let now = 0;
+		const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now);
+		const cb = vi.fn();
+		onLogicalUpdate(cb, false);
+
+		engine.start(); // reads performance.now() → lastTime = time = 0
+		now = 1000; // a 1000ms stall (well past tickSizeX5 = 5 ticks) before the next poll fires
+		vi.advanceTimersByTime(10); // fire exactly one polling interval → the loop sees a 1000ms delta
+
+		// The branch advances `time` by the discarded excess (1000 − 200) and processes only the capped
+		// 200ms = 5 logical ticks rather than 25 — yet the clock still reaches ~now, so it can momentarily
+		// reach/pass the render clock (which render-engine then clamps to a non-negative logicalDelta).
+		expect(cb).toHaveBeenCalledTimes(5);
+		expect(engine.time).toBe(1000);
+
+		nowSpy.mockRestore();
+	});
 });

--- a/UI/src/tests/lib/engine/render-engine.test.ts
+++ b/UI/src/tests/lib/engine/render-engine.test.ts
@@ -96,6 +96,18 @@ describe('RenderEngine', () => {
 			expect(renderUpdates[0][1]).toBe(40); // 2000 − 1960
 		});
 
+		it('floors logicalDelta at 0 when the logical clock runs ahead of the render clock', () => {
+			// The logical engine's tab-background catch-up branch advances logicEngine.time by the discarded
+			// excess, which can momentarily push it past the render clock. A negative logicalDelta would drive
+			// the render-only charge/effect interpolation backwards for a frame, so it is clamped to ≥ 0.
+			performanceNow = 1000;
+			logicEngineStub.time = 1080; // logical clock 80ms ahead of the render clock
+			engine.start();
+
+			expect(renderUpdates[0][1]).toBe(0);
+			expect(engine.logicalDelta).toBe(0);
+		});
+
 		it('updates the time property to the current performance timestamp each frame', () => {
 			performanceNow = 500;
 			engine.start();


### PR DESCRIPTION
## Summary

Closes the FE/BE battle parity-matrix and engine-test gaps called out in #941 — the spots clustered exactly where a future divergence is most likely to hide — and fixes the one real defect the review surfaced.

Every new parity scenario is added **row-for-row to both** suites (`Game.Core.Tests/Battle/BattleSimulatorParityTests.cs` ↔ `UI/src/tests/lib/battle/battle-simulation-parity.test.ts`) so the two simulators stay pinned tick-for-tick.

## Parity matrix (3 new mirrored scenarios)

| Scenario | What it pins |
| --- | --- |
| `fractionalEnemyDistribution` | Enemy Strength built from a **fractional per-level** `AttributeDistribution` (`2.5`/level at level 3 → `7.5` → `MaxHealth 87.5`) — every other row uses an integer `BaseAmount` at level 1. A **tight kill margin** (cum. damage `87` against a `87.5` max) means a float roundtrip that dropped the `.5` would change the kill tick (1600 → 1200ms). The backend `MakeEnemy` helper gains a `level` + per-level-distribution parameter; a mirrored focused test pins the `87.5` max on both sides. |
| `effectExpiresThenReapplies` | A periodic effect whose duration (80ms = 2 ticks) is shorter than its cooldown (120ms = 3 ticks), so it **fully lapses then re-applies** — the apply→expire→re-apply cycle where the backend's absolute `ExpiresAtMs` clock and the frontend's decrementing `remainingMs` are most likely to drift by a tick. |
| `fractionalCritChance` | A real `0.5` `CriticalChance` against the fixed parity seed, so each player fire's crit depends on the **actual `Mulberry32` `[0,1)` draw** (not a forced 1/0). The 6th draw being a crit is decisive for the kill tick (2400 vs 2800ms). |

## Engine fix + tests

- **`render-engine.ts`: floor `logicalDelta` at 0.** The logical engine's `tickSizeX5` tab-background catch-up branch advances its clock by the discarded excess, which can momentarily push `logicEngine.time` past the render clock, making `logicalDelta` negative and driving the render-only charge/effect interpolation **backwards for a frame** (`updateRenderCooldowns`/`updateRenderEffects` cap with `Math.min` but had no `Math.max(0, …)` floor). Purely cosmetic — logical state and battle parity are unaffected. Clamping at the source is DRY (covers both render-cooldown and render-effect consumers). Adds a render-engine clamp test and a logical-engine catch-up-branch test.
- **`enemy-manager-boss.test.ts`: the missing re-entrancy boundary.** `resolveBossVictory` re-checks `bossLoopActive` after each `await`; the `claimVictory` and challenge-reload boundaries were already covered, but the **victory-overlay-delay** boundary was not. Added a test asserting an auto-fight re-challenge is abandoned when a retreat lands during the overlay.

## Code-comment hardening

Documented on the frontend `Battler.advanceEffects` that the decrementing `remainingMs` and the backend's absolute `ExpiresAtMs` are **value-equal only under the current fixed tick size** and must stay in lockstep (the cheap option offered alongside scenario 2).

## Already-covered gap

The `CombatFloaters` unmount-during-pending-timer cleanup (#941 item 6) already has an explicit regression test (`clears pending removal timers and unsubscribes on unmount`) that passes, so no change was needed.

## Test plan

- [x] `dotnet build` + `dotnet test Game.Core.Tests` — **637 passed** (incl. the new parity scenarios and pin test)
- [x] `vitest run` over the affected battle/engine suites + CombatFloaters — **431 passed**
- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] Verified the three scenarios' `totalMs` independently and confirmed FE/BE agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zJFxXdDY2H5ayE5kRNVxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018zJFxXdDY2H5ayE5kRNVxJ)_