### PR TITLE
Add level/XP progress to the Attributes screen (#177)

### DIFF
--- a/UI/src/routes/game/screens/attributes/Attributes.svelte
+++ b/UI/src/routes/game/screens/attributes/Attributes.svelte
@@ -10,7 +10,10 @@
 
 	<!-- budget -->
 	<div class="budget-row">
-		<BudgetMeter remaining={view.remaining} budget={view.budget} />
+		<div class="meters">
+			<BudgetMeter remaining={view.remaining} budget={view.budget} />
+			<LevelMeter />
+		</div>
 		<span class="hint">
 			{view.mode === 'theory' ? 'Marginal yield shown per attribute' : 'Drag an axis or use − / + to spend'}
 		</span>
@@ -68,6 +71,7 @@ import AttributeTooltip from '$components/tooltip/AttributeTooltip.svelte';
 import { createAttributeTooltip, setAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
 import ModeToggle from './ModeToggle.svelte';
 import BudgetMeter from './BudgetMeter.svelte';
+import LevelMeter from './LevelMeter.svelte';
 import AttributesRadar from './AttributesRadar.svelte';
 import GuidedRow from './GuidedRow.svelte';
 import TheoryRow from './TheoryRow.svelte';
@@ -127,6 +131,14 @@ onDestroy(() => view.dispose());
 	gap: 20px;
 	padding: 0 28px 16px;
 	flex-shrink: 0;
+}
+
+// The points budget and the level/XP progress sit together as one progression dashboard.
+.meters {
+	display: flex;
+	align-items: flex-end;
+	gap: 32px;
+	min-width: 0;
 }
 
 .hint {

--- a/UI/src/routes/game/screens/attributes/LevelMeter.svelte
+++ b/UI/src/routes/game/screens/attributes/LevelMeter.svelte
@@ -1,0 +1,68 @@
+<!-- Character progression meter for the Attributes screen: the player's level plus a visible
+     current/total XP readout over the shared gold XpBar. Sits beside the points BudgetMeter and
+     mirrors its label/value layout, so the two read as one progression dashboard (XP → level →
+     stat points to spend). Reads the player manager directly, like the fight-screen card. -->
+<div class="level-meter">
+	<div class="row">
+		<span class="label">Level {playerManager.level}</span>
+		<span class="value">
+			{formatNum(playerManager.exp)}<span class="xp-total"
+				>&nbsp;/&nbsp;{formatNum(playerManager.nextLevelThreshold)} XP</span
+			>
+		</span>
+	</div>
+	<XpBar
+		level={playerManager.level}
+		exp={playerManager.exp}
+		nextLevelThreshold={playerManager.nextLevelThreshold}
+		ariaLabel="Experience progress"
+		testId="attributes-xp-bar"
+	/>
+</div>
+
+<script lang="ts">
+import { formatNum } from '$lib/common';
+import { playerManager } from '$lib/engine';
+import { XpBar } from '$components';
+</script>
+
+<style lang="scss">
+.level-meter {
+	display: flex;
+	flex-direction: column;
+	gap: 7px;
+	min-width: 210px;
+}
+
+.row {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 12px;
+	white-space: nowrap;
+}
+
+.label {
+	font-family: var(--mono);
+	font-size: 9.5px;
+	letter-spacing: 1.4px;
+	text-transform: uppercase;
+	color: var(--text-tertiary);
+}
+
+.value {
+	font-family: var(--sans);
+	font-size: 18px;
+	font-weight: 600;
+	letter-spacing: -0.3px;
+	white-space: nowrap;
+	color: var(--gold);
+	text-shadow: 0 0 12px color-mix(in srgb, var(--gold) 40%, transparent);
+}
+
+.xp-total {
+	font-size: 11px;
+	font-weight: 400;
+	color: var(--text-muted);
+}
+</style>

--- a/UI/src/tests/routes/game/screens/attributes/Attributes.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/Attributes.test.ts
@@ -7,7 +7,10 @@ const { mockPlayerManager, sendSocketCommand, toastError, staticData } = vi.hois
 	mockPlayerManager: {
 		attributes: [] as IBattlerAttribute[],
 		statPointsGained: 0,
-		statPointsUsed: 0
+		statPointsUsed: 0,
+		level: 0,
+		exp: 0,
+		nextLevelThreshold: 0
 	},
 	sendSocketCommand: vi.fn(),
 	toastError: vi.fn(),
@@ -50,6 +53,9 @@ beforeEach(() => {
 	];
 	mockPlayerManager.statPointsGained = 8;
 	mockPlayerManager.statPointsUsed = 0;
+	mockPlayerManager.level = 7;
+	mockPlayerManager.exp = 280;
+	mockPlayerManager.nextLevelThreshold = 700;
 	// The radar reads prefers-reduced-motion to decide whether to animate; force
 	// the snap path so no rAF runs during the test.
 	window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia;
@@ -65,6 +71,23 @@ describe('Attributes screen', () => {
 		// 8 unspent points available, none pending.
 		expect(screen.getByText('8')).toBeTruthy();
 		expect(screen.getByText('No changes')).toBeTruthy();
+	});
+
+	it('shows the player level and XP progress toward the next level', () => {
+		const { getByTestId, container } = render(Attributes);
+
+		const xpBar = getByTestId('attributes-xp-bar');
+		expect(xpBar.getAttribute('role')).toBe('progressbar');
+		expect(xpBar.getAttribute('aria-valuenow')).toBe('280');
+		expect(xpBar.getAttribute('aria-valuemax')).toBe('700');
+		// 280 / 700 = 40%.
+		expect((xpBar.querySelector('.xp-fill') as HTMLElement).getAttribute('style')).toContain('width: 40%');
+
+		// The visible level and current/total XP readout beside the bar.
+		const meter = container.querySelector('.level-meter') as HTMLElement;
+		expect(meter.querySelector('.label')?.textContent).toContain('7');
+		expect(meter.querySelector('.value')?.textContent).toContain('280');
+		expect(meter.querySelector('.value')?.textContent).toContain('700');
 	});
 
 	it('spends a point when an attribute stepper is clicked', async () => {


### PR DESCRIPTION
## Summary

Completes the second half of [#177](https://github.com/ginderjeremiah/GameServer/issues/177) — the fight-screen XP bar was already shipped; this adds level/XP progress to the **Attributes** (build) screen.

A new `LevelMeter` sits beside the points `BudgetMeter` in the budget row and renders the player's **level** plus a visible **current / total XP** readout over the shared gold `XpBar` primitive. Grouping the two meters reads as one progression dashboard — XP → level → stat points to spend — and `LevelMeter` mirrors `BudgetMeter`'s label/value layout (just gold instead of the points accent).

## Design notes

- **Reuses the existing `XpBar`** primitive (the same gold, shimmering, level-up-flashing bar used on the fight screen) rather than hand-rolling a new bar — per the "extend an existing primitive" guideline.
- **Reads `playerManager` directly** (level/exp/threshold), like the fight-screen `BattlerCard`, since XP progression is global player state and unrelated to the screen's point-buy `AttributesView` model.
- All colours go through existing CSS variables (`--gold`, `--text-tertiary`, `--text-muted`); no hard-coded hex.

## Testing

- New unit test in `Attributes.test.ts` renders the real screen and asserts the XP bar's `progressbar` role, `aria-valuenow`/`aria-valuemax`, the 40% fill, and the visible level + current/total readout.
- `vitest` (14 passed), `svelte-check` (0 errors), ESLint, and Prettier all pass.

> Note: a live in-browser walkthrough wasn't done — the Attributes screen only renders behind the full backend stack (Postgres + Redis + API + auth + a websocket-loaded session), which the Vite dev server can't exercise on its own. Verification is via the unit tests above plus reuse of the already-shipped `XpBar`/`BudgetMeter` surfaces.

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)