### PR TITLE
Add Codex glossary screen (Enemies tab)

### DIFF
--- a/UI/src/components/nav-menu/SideGlyph.svelte
+++ b/UI/src/components/nav-menu/SideGlyph.svelte
@@ -18,6 +18,12 @@
 		<path d="M6.3 6.3v3.4M9.3 6.3v3.4" stroke-linecap="round" />
 	{:else if kind === 'stats'}
 		<path d="M2 13.5h12M3.5 13.5V8M7 13.5V4.5M10.5 13.5V10M14 13.5V6" stroke-linecap="round" />
+	{:else if kind === 'codex'}
+		<path
+			d="M8 3.4C6.4 2.4 4.3 2.2 2.5 2.6v9.2c1.8-.4 3.9-.2 5.5.8 1.6-1 3.7-1.2 5.5-.8V2.6c-1.8-.4-3.9-.2-5.5.8zM8 3.4v9.4"
+			stroke-linejoin="round"
+			stroke-linecap="round"
+		/>
 	{:else if kind === 'options'}
 		<circle cx="8" cy="8" r="2.2" />
 		<path

--- a/UI/src/routes/game/+page.svelte
+++ b/UI/src/routes/game/+page.svelte
@@ -20,6 +20,7 @@ import { NavSidebar, LogPanel } from '$components';
 import { GAME_SCREENS, visibleScreens } from './screens/screen-defs';
 import PlaceholderScreen from './screens/PlaceholderScreen.svelte';
 import { startGame } from '$lib/engine';
+import { navigation } from '$stores';
 import { getRoles } from '$lib/api';
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
@@ -65,6 +66,16 @@ const handleNavigate = (key: string) => {
 	}
 	currentScreen = key;
 };
+
+// Another screen can request a switch (carrying a one-shot payload the target consumes on mount) via
+// the navigation store — e.g. the Statistics screen deep-linking an enemy into the Codex dossier.
+$effect(() => {
+	const requested = navigation.requestedScreen;
+	if (requested) {
+		handleNavigate(requested);
+		navigation.clear();
+	}
+});
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/game/screens/codex/AttributesPanel.svelte
+++ b/UI/src/routes/game/screens/codex/AttributesPanel.svelte
@@ -1,0 +1,283 @@
+<!-- Attributes sub-tab: the enemy's attribute distribution scaled to a chosen level. A boss is a
+     fixed-level encounter; a normal enemy gets a live level slider. "Show scaling" reveals the
+     base + per-level breakdown. Primary bars come straight from the distribution; the derived
+     Max Health / Defense cards are computed through the real battle attribute composition. -->
+<div class="attributes">
+	<div class="section-head">
+		<span class="label">Attribute distribution</span>
+		<button
+			type="button"
+			class="scaling-toggle"
+			class:on={view.scaling}
+			aria-pressed={view.scaling}
+			data-testid="codex-scaling-toggle"
+			onclick={() => view.toggleScaling()}
+		>
+			Show scaling
+		</button>
+	</div>
+
+	{#if view.range}
+		{#if view.range.fixed}
+			<div class="fixed-level">
+				<span>FIXED ENCOUNTER</span>
+				<span class="rule"></span>
+				<span class="fixed-val">LVL {view.level}</span>
+			</div>
+		{:else}
+			<div class="level-control">
+				<span class="lvl-label">LVL</span>
+				<input
+					type="range"
+					class="level-range"
+					min={view.range.min}
+					max={view.range.max}
+					value={view.level}
+					aria-label="Level"
+					data-testid="codex-level-slider"
+					oninput={(e) => view.setLevel(+e.currentTarget.value)}
+				/>
+				<span class="lvl-val">{view.level}</span>
+			</div>
+		{/if}
+	{/if}
+
+	<div class="primary">
+		{#each view.attributes.primary as stat (stat.attributeId)}
+			<div class="stat">
+				<div class="stat-row">
+					<span class="code">{attributeCode(stat.attributeId, staticData.attributes)}</span>
+					<span class="bar-wrap" style:--bar-fill={attributeColor(stat.attributeId)}>
+						<Bar value={stat.value} max={view.maxPrimary} presentational />
+					</span>
+					<span class="val">{stat.value}</span>
+				</div>
+				{#if view.scaling}
+					<div class="scale-line">{stat.base} base + {stat.perLevel}/lvl × {view.level}</div>
+				{/if}
+			</div>
+		{/each}
+	</div>
+
+	<div class="secondary">
+		{#each view.attributes.secondary as stat (stat.attributeId)}
+			<div class="card">
+				<div class="card-label">{attributeName(stat.attributeId, staticData.attributes)}</div>
+				<div class="card-val" style:color={secondaryColor(stat.attributeId)}>{stat.value}</div>
+				{#if view.scaling}
+					<div class="card-scale">+{roundDelta(stat.perLevel)}/lvl</div>
+				{/if}
+			</div>
+		{/each}
+	</div>
+</div>
+
+<script lang="ts">
+import { Bar } from '$components';
+import { EAttribute } from '$lib/api';
+import { attributeCode, attributeColor, attributeName } from '$lib/common';
+import { staticData } from '$stores';
+import type { CodexView } from './codex-view.svelte';
+
+interface Props {
+	view: CodexView;
+}
+
+let { view }: Props = $props();
+
+// Derived secondaries have no themed `--attr-*` hue, so map the two surfaced ones to semantic tokens
+// (health → success/green, defense → accent/blue), matching the design's intent.
+const secondaryColor = (id: EAttribute): string => (id === EAttribute.MaxHealth ? 'var(--success)' : 'var(--accent)');
+
+// A derived stat's per-level slope can carry float noise; round it for the scaling readout.
+const roundDelta = (value: number): number => Math.round(value * 10) / 10;
+</script>
+
+<style lang="scss">
+.section-head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 11px;
+}
+
+.label {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 1.6px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+}
+
+.scaling-toggle {
+	font-family: var(--mono);
+	font-size: 8px;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	background: transparent;
+	border: 1px solid var(--border-light);
+	border-radius: 10px;
+	padding: 2px 9px;
+	color: var(--text-muted);
+	cursor: pointer;
+
+	&.on {
+		background: color-mix(in srgb, var(--accent) 16%, transparent);
+		border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+		color: var(--accent);
+	}
+}
+
+.fixed-level {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 14px;
+	font-family: var(--mono);
+	font-size: 9px;
+	color: var(--text-muted);
+}
+
+.rule {
+	height: 1px;
+	flex: 1;
+	background: var(--border-subtle);
+}
+
+.fixed-val {
+	color: var(--boss-accent);
+	font-size: 11px;
+}
+
+.level-control {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 14px;
+}
+
+.lvl-label {
+	font-family: var(--mono);
+	font-size: 9px;
+	color: var(--text-muted);
+}
+
+.lvl-val {
+	font-family: var(--mono);
+	font-size: 13px;
+	color: var(--enemy-accent);
+	font-weight: 500;
+	width: 26px;
+	text-align: right;
+}
+
+.level-range {
+	flex: 1;
+	-webkit-appearance: none;
+	appearance: none;
+	height: 3px;
+	border-radius: 3px;
+	background: var(--border-light);
+	outline: none;
+
+	&::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		appearance: none;
+		width: 14px;
+		height: 14px;
+		border-radius: 50%;
+		background: var(--enemy-accent);
+		cursor: pointer;
+		box-shadow: 0 0 8px color-mix(in srgb, var(--enemy-accent) 60%, transparent);
+		border: 2px solid var(--surface);
+	}
+
+	&::-moz-range-thumb {
+		width: 14px;
+		height: 14px;
+		border-radius: 50%;
+		background: var(--enemy-accent);
+		cursor: pointer;
+		border: 2px solid var(--surface);
+	}
+}
+
+.stat {
+	margin-bottom: 9px;
+}
+
+.stat-row {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+}
+
+.code {
+	font-family: var(--mono);
+	font-size: 9.5px;
+	width: 30px;
+	color: var(--text-tertiary);
+}
+
+.bar-wrap {
+	flex: 1;
+	--bar-height: 8px;
+	--bar-radius: 3px;
+	--bar-track-bg: color-mix(in srgb, var(--white) 6%, transparent);
+}
+
+.val {
+	font-family: var(--mono);
+	font-size: 11.5px;
+	width: 34px;
+	text-align: right;
+	color: var(--text-primary);
+	font-weight: 500;
+}
+
+.scale-line {
+	font-family: var(--mono);
+	font-size: 8.5px;
+	color: var(--text-muted);
+	padding-left: 39px;
+	margin-top: 2px;
+}
+
+.secondary {
+	display: flex;
+	gap: 10px;
+	margin-top: 14px;
+	padding-top: 13px;
+	border-top: 1px solid var(--border-subtle);
+}
+
+.card {
+	flex: 1;
+	background: var(--panel);
+	border: 1px solid var(--border-subtle);
+	border-radius: 4px;
+	padding: 9px 11px;
+}
+
+.card-label {
+	font-family: var(--mono);
+	font-size: 8px;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+}
+
+.card-val {
+	font-family: var(--mono);
+	font-size: 17px;
+	font-weight: 500;
+	margin-top: 2px;
+}
+
+.card-scale {
+	font-family: var(--mono);
+	font-size: 8px;
+	color: var(--text-muted);
+	margin-top: 2px;
+}
+</style>

--- a/UI/src/routes/game/screens/codex/Codex.svelte
+++ b/UI/src/routes/game/screens/codex/Codex.svelte
@@ -1,0 +1,87 @@
+<!-- Codex screen — a read-only reference glossary (bestiary / atlas / skill catalogue). Only the
+     Enemies tab is built; Zones and Skills are placeholders. Per-entity player statistics live in the
+     enemy dossier here, and the Statistics screen deep-links an enemy into it via the navigation store.
+     Ported from the `Glossary.dc.html` Claude Design handoff onto live reference/runtime data. -->
+<div class="codex" data-testid="codex-screen">
+	<div class="header">
+		<span class="diamond" aria-hidden="true"></span>
+		<h1 class="title">Codex</h1>
+	</div>
+
+	<CodexTabBar {view} />
+
+	<div class="content">
+		{#if view.tab === 'enemies'}
+			<EnemiesTab {view} />
+		{:else if view.tab === 'zones'}
+			<ComingSoonPanel label="Zones" accent="var(--accent)" />
+		{:else}
+			<ComingSoonPanel label="Skills" accent="var(--attr-intellect)" />
+		{/if}
+	</div>
+</div>
+
+<script lang="ts">
+import { onMount } from 'svelte';
+import { navigation, playerChallenges, statistics } from '$stores';
+import { CodexView, type CodexNavPayload } from './codex-view.svelte';
+import CodexTabBar from './CodexTabBar.svelte';
+import ComingSoonPanel from './ComingSoonPanel.svelte';
+import EnemiesTab from './EnemiesTab.svelte';
+
+// Consume any deep-link payload (e.g. an enemy handed over from the Statistics screen) once.
+const view = new CodexView(navigation.consumePayload<CodexNavPayload>());
+
+onMount(async () => {
+	// Force-refresh the player's statistics (the dossier's "your record"); challenge progress is
+	// loaded once at boot, so a plain load is enough.
+	await Promise.all([statistics.load(true), playerChallenges.load()]);
+	view.stats = statistics.stats;
+	view.statsError = statistics.error;
+	view.statsLoading = false;
+});
+</script>
+
+<style lang="scss">
+.codex {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	background: linear-gradient(180deg, var(--panel) 0%, var(--surface) 64%);
+	color: var(--text-primary);
+	font-family: var(--sans);
+	overflow: hidden;
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 24px 30px 16px;
+	flex: none;
+}
+
+.diamond {
+	width: 10px;
+	height: 10px;
+	transform: rotate(45deg);
+	background: var(--accent);
+	box-shadow: 0 0 8px color-mix(in srgb, var(--accent) 60%, transparent);
+	flex: none;
+}
+
+.title {
+	margin: 0;
+	font-size: 28px;
+	font-weight: 400;
+	letter-spacing: -0.4px;
+	line-height: 1;
+}
+
+.content {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+}
+</style>

--- a/UI/src/routes/game/screens/codex/CodexTabBar.svelte
+++ b/UI/src/routes/game/screens/codex/CodexTabBar.svelte
@@ -1,0 +1,106 @@
+<!-- The Codex's top-level tab bar: Enemies / Zones / Skills, each with a live count badge, section
+     accent dot and an active underline. -->
+<div class="tabs" role="tablist" aria-label="Codex sections">
+	{#each view.tabs as tab (tab.key)}
+		<button
+			type="button"
+			role="tab"
+			aria-selected={tab.active}
+			class="tab"
+			class:active={tab.active}
+			style:--tab-accent={tab.accent}
+			data-testid="codex-tab-{tab.key}"
+			onclick={() => view.selectTab(tab.key)}
+		>
+			<span class="dot"></span>
+			<span class="label">{tab.label}</span>
+			<span class="count">{tab.count}</span>
+			<span class="underline"></span>
+		</button>
+	{/each}
+</div>
+
+<script lang="ts">
+import type { CodexView } from './codex-view.svelte';
+
+interface Props {
+	view: CodexView;
+}
+
+let { view }: Props = $props();
+</script>
+
+<style lang="scss">
+.tabs {
+	display: flex;
+	gap: 6px;
+	border-bottom: 1px solid var(--border-subtle);
+	padding: 0 30px;
+	flex: none;
+}
+
+.tab {
+	position: relative;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	padding: 4px 14px 12px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.dot {
+	width: 8px;
+	height: 8px;
+	transform: rotate(45deg);
+	flex: none;
+	background: var(--text-muted);
+}
+
+.label {
+	font-size: 13.5px;
+	font-weight: 400;
+	color: var(--text-tertiary);
+}
+
+.count {
+	font-family: var(--mono);
+	font-size: 9.5px;
+	color: var(--text-muted);
+	border: 1px solid var(--border-light);
+	border-radius: 8px;
+	padding: 0 6px;
+	line-height: 15px;
+}
+
+.underline {
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: -1px;
+	height: 2px;
+	border-radius: 2px;
+	background: transparent;
+}
+
+.tab.active {
+	.dot {
+		background: var(--tab-accent);
+	}
+
+	.label {
+		color: var(--text-primary);
+		font-weight: 600;
+	}
+
+	.count {
+		color: var(--tab-accent);
+		border-color: color-mix(in srgb, var(--tab-accent) 45%, transparent);
+	}
+
+	.underline {
+		background: var(--tab-accent);
+	}
+}
+</style>

--- a/UI/src/routes/game/screens/codex/ComingSoonPanel.svelte
+++ b/UI/src/routes/game/screens/codex/ComingSoonPanel.svelte
@@ -1,0 +1,71 @@
+<!-- Placeholder body for a Codex tab that isn't built yet (Zones / Skills). Mirrors the global
+     PlaceholderScreen's dashed-diamond language, tinted with the tab's section accent. -->
+<div class="coming-soon" data-testid="codex-coming-soon" style:--cs-accent={accent}>
+	<div class="icon">
+		<div class="diamond"><div class="diamond-inner"></div></div>
+	</div>
+	<div class="title">{label}</div>
+	<div class="subtitle">Coming soon</div>
+</div>
+
+<script lang="ts">
+interface Props {
+	label: string;
+	/** Section accent for this tab (a themeable `var(--…)` token). */
+	accent?: string;
+}
+
+const { label, accent = 'var(--accent)' }: Props = $props();
+</script>
+
+<style lang="scss">
+.coming-soon {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 14px;
+	padding: 36px;
+}
+
+.icon {
+	width: 64px;
+	height: 64px;
+	border-radius: 2px;
+	border: 1px dashed color-mix(in srgb, var(--cs-accent) 35%, transparent);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.diamond {
+	width: 16px;
+	height: 16px;
+	transform: rotate(45deg);
+	border: 1px solid color-mix(in srgb, var(--cs-accent) 60%, transparent);
+	position: relative;
+}
+
+.diamond-inner {
+	position: absolute;
+	inset: 4px;
+	background: color-mix(in srgb, var(--cs-accent) 60%, transparent);
+}
+
+.title {
+	font-size: 18px;
+	color: var(--text-primary);
+	font-weight: 400;
+}
+
+.subtitle {
+	margin-top: 4px;
+	font-family: var(--mono);
+	font-size: 11px;
+	color: var(--text-muted);
+	letter-spacing: 1px;
+	text-transform: uppercase;
+}
+</style>

--- a/UI/src/routes/game/screens/codex/EnemiesTab.svelte
+++ b/UI/src/routes/game/screens/codex/EnemiesTab.svelte
@@ -1,0 +1,131 @@
+<!-- The Enemies tab: a toolbar (search + Normal/Boss filter) over the enemy table on the left, and
+     the selected enemy's dossier on the right. Search and sort are display-only in this slice. -->
+<div class="enemies">
+	<div class="list-col">
+		<div class="toolbar">
+			<div class="search" aria-hidden="true">
+				<span class="search-icon">⌕</span>
+				<span class="search-text">search {view.enemies.length} enemies</span>
+			</div>
+			<div class="chips">
+				{#each ENEMY_FILTERS as chip (chip.key)}
+					<button
+						type="button"
+						class="chip"
+						class:on={view.filter === chip.key}
+						data-testid="codex-filter-{chip.key}"
+						onclick={() => view.setFilter(chip.key)}
+					>
+						{chip.label}
+					</button>
+				{/each}
+			</div>
+			<span class="spacer"></span>
+			<span class="count">{view.shownCount} shown · sort: level ▾</span>
+		</div>
+
+		<EnemyTable {view} />
+	</div>
+
+	<EnemyDossier {view} />
+</div>
+
+<script lang="ts">
+import type { CodexView } from './codex-view.svelte';
+import { ENEMY_FILTERS } from './codex-display';
+import EnemyTable from './EnemyTable.svelte';
+import EnemyDossier from './EnemyDossier.svelte';
+
+interface Props {
+	view: CodexView;
+}
+
+let { view }: Props = $props();
+</script>
+
+<style lang="scss">
+.enemies {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+}
+
+.list-col {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	padding: 14px 0 14px 30px;
+}
+
+.toolbar {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 12px;
+	padding-right: 22px;
+}
+
+.search {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	background: var(--panel);
+	border: 1px solid var(--border-light);
+	border-radius: 3px;
+	padding: 6px 11px;
+	width: 190px;
+}
+
+.search-icon {
+	color: var(--text-muted);
+	font-size: 12px;
+}
+
+.search-text {
+	font-family: var(--mono);
+	font-size: 10.5px;
+	color: var(--text-muted);
+	letter-spacing: 0.5px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.chips {
+	display: flex;
+	gap: 5px;
+}
+
+.chip {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	background: transparent;
+	color: var(--text-tertiary);
+	border: 1px solid var(--border-light);
+	border-radius: 10px;
+	padding: 4px 11px;
+	cursor: pointer;
+
+	&.on {
+		background: var(--text-primary);
+		color: var(--text-on-accent);
+		border-color: var(--text-primary);
+	}
+}
+
+.spacer {
+	flex: 1;
+}
+
+.count {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+	white-space: nowrap;
+}
+</style>

--- a/UI/src/routes/game/screens/codex/EnemyChallengesPanel.svelte
+++ b/UI/src/routes/game/screens/codex/EnemyChallengesPanel.svelte
@@ -1,0 +1,85 @@
+<!-- Challenges sub-tab: the challenges scoped to this enemy, with the player's progress. -->
+<div class="challenges">
+	<div class="label">Related challenges · {view.challenges.length}</div>
+	<div class="list">
+		{#each view.challenges as challenge (challenge.id)}
+			<div class="challenge" style:--ch-accent={challenge.accent}>
+				<div class="text">
+					<div class="name">{challenge.name}</div>
+					<div class="type">{challenge.typeLabel}</div>
+				</div>
+				<span class="prog" class:done={challenge.completed}>{challenge.progressText}</span>
+			</div>
+		{/each}
+	</div>
+</div>
+
+<script lang="ts">
+import type { CodexView } from './codex-view.svelte';
+
+interface Props {
+	view: CodexView;
+}
+
+let { view }: Props = $props();
+</script>
+
+<style lang="scss">
+.label {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 1.6px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+	margin-bottom: 10px;
+}
+
+.list {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.challenge {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	background: var(--panel);
+	border: 1px solid var(--border-subtle);
+	border-left: 2px solid var(--ch-accent);
+	border-radius: 4px;
+	padding: 9px 11px;
+}
+
+.text {
+	flex: 1;
+	min-width: 0;
+}
+
+.name {
+	font-size: 12.5px;
+	color: var(--text-primary);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.type {
+	font-family: var(--mono);
+	font-size: 8.5px;
+	letter-spacing: 0.8px;
+	text-transform: uppercase;
+	color: var(--ch-accent);
+	margin-top: 2px;
+}
+
+.prog {
+	font-family: var(--mono);
+	font-size: 11px;
+	color: var(--text-secondary);
+
+	&.done {
+		color: var(--success);
+	}
+}
+</style>

--- a/UI/src/routes/game/screens/codex/EnemyDossier.svelte
+++ b/UI/src/routes/game/screens/codex/EnemyDossier.svelte
@@ -1,0 +1,151 @@
+<!-- The enemy dossier (right panel): a section-accented header (kind + name), a row of sub-tabs, and
+     the active sub-tab's body. Sub-tab content lives in its own small panel component. -->
+{#if view.selectedEnemy}
+	<div class="dossier" data-testid="codex-dossier" style:--dossier-accent={view.dossierAccent}>
+		<div class="head">
+			<div class="kind-line">
+				<span class="kind-dot"></span>
+				<span class="kind">{view.dossierKind}</span>
+			</div>
+			<div class="name">{view.selectedEnemy.name}</div>
+		</div>
+
+		<div class="sub-tabs" role="tablist" aria-label="Enemy detail">
+			{#each view.subTabs as tab (tab.key)}
+				<button
+					type="button"
+					role="tab"
+					aria-selected={view.sub === tab.key}
+					class="sub-tab"
+					class:active={view.sub === tab.key}
+					data-testid="codex-subtab-{tab.key}"
+					onclick={() => view.selectSub(tab.key)}
+				>
+					{tab.label}
+					<span class="underline"></span>
+				</button>
+			{/each}
+		</div>
+
+		<div class="body">
+			{#if view.sub === 'attributes'}
+				<AttributesPanel {view} />
+			{:else if view.sub === 'statistics'}
+				<StatisticsPanel {view} />
+			{:else if view.sub === 'skills'}
+				<EnemySkillsPanel {view} />
+			{:else if view.sub === 'spawns'}
+				<EnemySpawnsPanel {view} />
+			{:else if view.sub === 'challenges'}
+				<EnemyChallengesPanel {view} />
+			{/if}
+		</div>
+	</div>
+{/if}
+
+<script lang="ts">
+import type { CodexView } from './codex-view.svelte';
+import AttributesPanel from './AttributesPanel.svelte';
+import StatisticsPanel from './StatisticsPanel.svelte';
+import EnemySkillsPanel from './EnemySkillsPanel.svelte';
+import EnemySpawnsPanel from './EnemySpawnsPanel.svelte';
+import EnemyChallengesPanel from './EnemyChallengesPanel.svelte';
+
+interface Props {
+	view: CodexView;
+}
+
+let { view }: Props = $props();
+</script>
+
+<style lang="scss">
+.dossier {
+	width: 380px;
+	flex: none;
+	background: var(--surface);
+	border-left: 1px solid var(--border-subtle);
+	display: flex;
+	flex-direction: column;
+}
+
+.head {
+	border-left: 3px solid var(--dossier-accent);
+	padding: 18px 20px 14px;
+	flex: none;
+}
+
+.kind-line {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	margin-bottom: 6px;
+}
+
+.kind-dot {
+	width: 6px;
+	height: 6px;
+	transform: rotate(45deg);
+	background: var(--dossier-accent);
+	flex: none;
+}
+
+.kind {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 1.6px;
+	text-transform: uppercase;
+	color: var(--dossier-accent);
+}
+
+.name {
+	font-size: 21px;
+	font-weight: 500;
+	letter-spacing: -0.3px;
+	line-height: 1.05;
+}
+
+.sub-tabs {
+	display: flex;
+	gap: 2px;
+	padding: 0 18px;
+	border-bottom: 1px solid var(--border-subtle);
+	flex: none;
+}
+
+.sub-tab {
+	position: relative;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	padding: 3px 7px 10px;
+	font-family: var(--mono);
+	font-size: 8.5px;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+
+	&.active {
+		color: var(--text-primary);
+
+		.underline {
+			background: var(--dossier-accent);
+		}
+	}
+}
+
+.underline {
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: -1px;
+	height: 2px;
+	background: transparent;
+}
+
+.body {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 16px 20px 20px;
+}
+</style>

--- a/UI/src/routes/game/screens/codex/EnemySkillsPanel.svelte
+++ b/UI/src/routes/game/screens/codex/EnemySkillsPanel.svelte
@@ -1,0 +1,78 @@
+<!-- Skills sub-tab: the enemy's skill pool. Rows are display-only for now — they'll deep-link into
+     the Codex Skills tab once it's built (follow-up). -->
+<div class="skills">
+	<div class="label">Skill pool · {view.skillRows.length}</div>
+	<div class="list">
+		{#each view.skillRows as skill (skill.id)}
+			<div class="skill">
+				<span class="mark"></span>
+				<div class="text">
+					<div class="name">{skill.name}</div>
+					<div class="meta">{skill.meta}</div>
+				</div>
+			</div>
+		{/each}
+	</div>
+</div>
+
+<script lang="ts">
+import type { CodexView } from './codex-view.svelte';
+
+interface Props {
+	view: CodexView;
+}
+
+let { view }: Props = $props();
+</script>
+
+<style lang="scss">
+.label {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 1.6px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+	margin-bottom: 10px;
+}
+
+.list {
+	display: flex;
+	flex-direction: column;
+	gap: 7px;
+}
+
+.skill {
+	display: flex;
+	align-items: center;
+	gap: 11px;
+	background: var(--panel);
+	border: 1px solid var(--border-subtle);
+	border-radius: 5px;
+	padding: 9px 11px;
+}
+
+.mark {
+	width: 5px;
+	height: 5px;
+	transform: rotate(45deg);
+	background: var(--attr-intellect);
+	flex: none;
+}
+
+.text {
+	flex: 1;
+	min-width: 0;
+}
+
+.name {
+	font-size: 12.5px;
+	color: var(--text-primary);
+}
+
+.meta {
+	font-family: var(--mono);
+	font-size: 8.5px;
+	color: var(--text-muted);
+	margin-top: 1px;
+}
+</style>

--- a/UI/src/routes/game/screens/codex/EnemySpawnsPanel.svelte
+++ b/UI/src/routes/game/screens/codex/EnemySpawnsPanel.svelte
@@ -1,0 +1,87 @@
+<!-- Spawns sub-tab: the zones this enemy spawns in (with its share of each zone's spawn table), or a
+     single "Encounter" row for a boss. Rows are display-only for now — they'll deep-link into the
+     Codex Zones tab once it's built (follow-up). -->
+<div class="spawns">
+	<div class="label">{view.spawnHeading}</div>
+	<div class="list">
+		{#each view.spawns as spawn (spawn.zoneId)}
+			<div class="spawn">
+				<div class="top">
+					<span class="zone">{spawn.zoneName}</span>
+					<span class="share">{spawn.share}%</span>
+				</div>
+				<div class="bottom">
+					<span class="bar-wrap"><Bar value={spawn.share} presentational /></span>
+					<span class="weight">{spawn.weightLabel}</span>
+				</div>
+			</div>
+		{/each}
+	</div>
+</div>
+
+<script lang="ts">
+import { Bar } from '$components';
+import type { CodexView } from './codex-view.svelte';
+
+interface Props {
+	view: CodexView;
+}
+
+let { view }: Props = $props();
+</script>
+
+<style lang="scss">
+.label {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 1.6px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+	margin-bottom: 10px;
+}
+
+.list {
+	display: flex;
+	flex-direction: column;
+	gap: 11px;
+}
+
+.top {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 5px;
+}
+
+.zone {
+	font-size: 12.5px;
+	color: var(--text-primary);
+}
+
+.share {
+	font-family: var(--mono);
+	font-size: 10px;
+	color: var(--accent-light);
+}
+
+.bottom {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.bar-wrap {
+	flex: 1;
+	--bar-height: 6px;
+	--bar-radius: 3px;
+	--bar-fill: var(--accent);
+	--bar-track-bg: color-mix(in srgb, var(--white) 6%, transparent);
+}
+
+.weight {
+	font-family: var(--mono);
+	font-size: 8.5px;
+	color: var(--text-muted);
+	white-space: nowrap;
+}
+</style>

--- a/UI/src/routes/game/screens/codex/EnemyTable.svelte
+++ b/UI/src/routes/game/screens/codex/EnemyTable.svelte
@@ -1,0 +1,174 @@
+<!-- The enemy table: a column header over a scrollable list of selectable enemy rows. Each row shows
+     a mark (gold diamond for a boss, neutral dot otherwise), the name, a BOSS tag, the level band and
+     the zone / skill counts. -->
+<div class="table">
+	<div class="head">
+		<span class="c-name">Name</span>
+		<span class="c-num">Level</span>
+		<span class="c-num narrow">Zones</span>
+		<span class="c-num narrow">Skills</span>
+	</div>
+
+	<div class="rows" data-testid="codex-enemy-rows">
+		{#each view.enemyRows as row (row.id)}
+			<button
+				type="button"
+				class="row"
+				class:selected={row.selected}
+				class:boss={row.isBoss}
+				data-testid="codex-enemy-{row.id}"
+				onclick={() => view.selectEnemy(row.id)}
+			>
+				<span class="c-name name-cell">
+					<span class="mark"></span>
+					<span class="name">{row.name}</span>
+					{#if row.isBoss}
+						<span class="boss-tag">BOSS</span>
+					{/if}
+				</span>
+				<span class="c-num band">{row.band}</span>
+				<span class="c-num narrow muted">{row.zoneCount}</span>
+				<span class="c-num narrow muted">{row.skillCount}</span>
+			</button>
+		{/each}
+	</div>
+</div>
+
+<script lang="ts">
+import type { CodexView } from './codex-view.svelte';
+
+interface Props {
+	view: CodexView;
+}
+
+let { view }: Props = $props();
+</script>
+
+<style lang="scss">
+.table {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+}
+
+.head {
+	display: flex;
+	align-items: center;
+	font-family: var(--mono);
+	font-size: 8.5px;
+	letter-spacing: 1.4px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+	padding: 0 14px 8px;
+	border-bottom: 1px solid var(--border-subtle);
+	margin-right: 14px;
+}
+
+.c-name {
+	flex: 2.4;
+	min-width: 0;
+}
+
+.c-num {
+	flex: 1;
+	text-align: right;
+}
+
+.narrow {
+	flex: 0.9;
+}
+
+.rows {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding-right: 6px;
+}
+
+.row {
+	width: 100%;
+	text-align: left;
+	display: flex;
+	align-items: center;
+	padding: 9px 14px;
+	border: none;
+	border-left: 2px solid transparent;
+	border-bottom: 1px solid color-mix(in srgb, var(--white) 5%, transparent);
+	background: transparent;
+	cursor: pointer;
+	font-family: var(--sans);
+
+	&:hover {
+		background: color-mix(in srgb, var(--white) 3%, transparent);
+	}
+
+	&.selected {
+		border-left-color: var(--enemy-accent);
+		background: color-mix(in srgb, var(--enemy-accent) 10%, transparent);
+
+		.name {
+			color: var(--white);
+			font-weight: 600;
+		}
+	}
+
+	&.selected.boss {
+		border-left-color: var(--boss-accent);
+		background: color-mix(in srgb, var(--boss-accent) 10%, transparent);
+	}
+}
+
+.name-cell {
+	display: flex;
+	align-items: center;
+	gap: 11px;
+	min-width: 0;
+}
+
+.mark {
+	width: 9px;
+	height: 9px;
+	flex: none;
+	border-radius: 50%;
+	background: color-mix(in srgb, var(--white) 28%, transparent);
+}
+
+.row.boss .mark {
+	border-radius: 0;
+	transform: rotate(45deg);
+	background: var(--boss-accent);
+	box-shadow: 0 0 6px color-mix(in srgb, var(--boss-accent) 50%, transparent);
+}
+
+.name {
+	font-size: 13.5px;
+	color: var(--text-primary);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.boss-tag {
+	font-family: var(--mono);
+	font-size: 7.5px;
+	letter-spacing: 1px;
+	color: var(--boss-accent);
+	border: 1px solid color-mix(in srgb, var(--boss-accent) 40%, transparent);
+	border-radius: 3px;
+	padding: 1px 4px;
+	flex: none;
+}
+
+.band {
+	font-family: var(--mono);
+	font-size: 10.5px;
+	color: var(--text-secondary);
+}
+
+.muted {
+	font-family: var(--mono);
+	font-size: 10.5px;
+	color: var(--text-tertiary);
+}
+</style>

--- a/UI/src/routes/game/screens/codex/StatisticsPanel.svelte
+++ b/UI/src/routes/game/screens/codex/StatisticsPanel.svelte
@@ -1,0 +1,89 @@
+<!-- Statistics sub-tab: the player's tracked record against this enemy — every statistic that
+     references it, reusing the Statistics screen's per-entity query. Runtime progress, not part of
+     the enemy's reference data. -->
+<div class="statistics">
+	<div class="label">Your record</div>
+
+	{#if view.statsLoading}
+		<div class="note">Loading your record…</div>
+	{:else if view.statsError}
+		<div class="note">Your statistics could not be loaded.</div>
+	{:else if view.statistics.length === 0}
+		<div class="note">No battles recorded against this enemy yet.</div>
+	{:else}
+		<div class="grid" data-testid="codex-enemy-stats">
+			{#each view.statistics as stat (stat.label)}
+				<div class="card">
+					<div class="card-label">{stat.label}</div>
+					<div class="card-val">{stat.value}</div>
+				</div>
+			{/each}
+		</div>
+		<div class="caption">Tracked from your battles — runtime progress, not part of the enemy's reference data.</div>
+	{/if}
+</div>
+
+<script lang="ts">
+import type { CodexView } from './codex-view.svelte';
+
+interface Props {
+	view: CodexView;
+}
+
+let { view }: Props = $props();
+</script>
+
+<style lang="scss">
+.label {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 1.6px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+	margin-bottom: 11px;
+}
+
+.grid {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 9px;
+}
+
+.card {
+	background: var(--panel);
+	border: 1px solid var(--border-subtle);
+	border-radius: 4px;
+	padding: 9px 11px;
+}
+
+.card-label {
+	font-family: var(--mono);
+	font-size: 8px;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+}
+
+.card-val {
+	font-family: var(--mono);
+	font-size: 16px;
+	font-weight: 500;
+	color: var(--text-primary);
+	margin-top: 3px;
+}
+
+.caption {
+	font-size: 11px;
+	color: var(--text-muted);
+	font-style: italic;
+	line-height: 1.45;
+	margin-top: 12px;
+}
+
+.note {
+	font-size: 12px;
+	color: var(--text-tertiary);
+	font-style: italic;
+	line-height: 1.5;
+}
+</style>

--- a/UI/src/routes/game/screens/codex/codex-display.ts
+++ b/UI/src/routes/game/screens/codex/codex-display.ts
@@ -1,0 +1,44 @@
+/* Presentation helpers + shared string-literal types for the Codex screen. Colours reference the
+   themeable `var(--…)` tokens rather than hard-coding hex (per the theming rule), so the screen
+   restyles with the theme. Kept dependency-light (no store, no reactive state) so the view-model and
+   its tests import the types/formatters without a cycle. */
+
+import type { LevelRange } from './enemy-level';
+
+/** Top-level Codex tab. Only `enemies` is built today; `zones`/`skills` show a placeholder. */
+export type CodexTab = 'enemies' | 'zones' | 'skills';
+/** Enemy dossier sub-tab. `challenges` only appears when the enemy has related challenges. */
+export type EnemySubTab = 'attributes' | 'statistics' | 'skills' | 'spawns' | 'challenges';
+/** Enemy-table filter chip. */
+export type EnemyFilter = 'all' | 'normal' | 'boss';
+
+export const CODEX_TABS: CodexTab[] = ['enemies', 'zones', 'skills'];
+
+export const ENEMY_FILTERS: { key: EnemyFilter; label: string }[] = [
+	{ key: 'all', label: 'All' },
+	{ key: 'normal', label: 'Normal' },
+	{ key: 'boss', label: 'Boss' }
+];
+
+/** Accent hue per top-level tab — the section's themed colour (enemy / zone / skill). */
+export const tabAccent = (tab: CodexTab): string =>
+	tab === 'enemies' ? 'var(--enemy-accent)' : tab === 'zones' ? 'var(--accent)' : 'var(--attr-intellect)';
+
+/** Title-cased tab label. */
+export const tabLabel = (tab: CodexTab): string => tab[0].toUpperCase() + tab.slice(1);
+
+/** A normal enemy reads in salmon, a boss in gold. */
+export const enemyAccent = (isBoss: boolean): string => (isBoss ? 'var(--boss-accent)' : 'var(--enemy-accent)');
+
+export const enemyKindLabel = (isBoss: boolean): string => (isBoss ? 'Boss' : 'Enemy');
+
+/** A compact level band: `L18` for a fixed boss encounter, `18–28` for a ranged spawn. */
+export const formatBand = (range: LevelRange): string => (range.fixed ? `L${range.min}` : `${range.min}–${range.max}`);
+
+/** A cooldown in milliseconds as `—` (no cooldown / utility), `2s`, or `1.8s`. */
+export function formatCooldown(ms: number): string {
+	if (ms === 0) {
+		return '—';
+	}
+	return ms % 1000 === 0 ? `${ms / 1000}s` : `${(ms / 1000).toFixed(1)}s`;
+}

--- a/UI/src/routes/game/screens/codex/codex-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/codex-view.svelte.ts
@@ -1,0 +1,353 @@
+/* Codex screen — a read-only reference glossary of the game's enemies, zones and skills. Only the
+   Enemies tab is built today; Zones and Skills show a "coming soon" placeholder (filed as follow-ups).
+
+   The Enemies tab is a master/detail: a filterable enemy table beside a dossier with Attributes
+   (live level-scaled stats + a "show scaling" breakdown), Statistics (the player's per-enemy record),
+   Skills, Spawns and Challenges sub-tabs. The data is all live reference/runtime data — the screen
+   reuses the real `BattleAttributes` enemy build for stat scaling (`enemy-stats`), the Statistics
+   screen's per-entity query (`StatisticsData.statsForEntity`), and the challenge progress store —
+   rather than hard-coding any of it. Per-entity statistics live here now; the Statistics screen
+   deep-links an enemy into this dossier instead of rendering its own.
+
+   The view-model only wires reactive state to the pure helpers; the projection maths live in
+   `enemy-level` / `enemy-stats` (unit-tested directly). */
+
+import { EEntityType, type IEnemy, type IPlayerStatistic } from '$lib/api';
+import { challengeTypeColor, challengeTypeName } from '$lib/common';
+import { playerChallenges, staticData } from '$stores';
+import { fmtValue } from '../stats/statistics-display';
+import { StatisticsData, buildStatEntities, buildStatTypes } from '../stats/statistics-view.svelte';
+import {
+	type CodexTab,
+	type EnemyFilter,
+	type EnemySubTab,
+	CODEX_TABS,
+	enemyAccent,
+	enemyKindLabel,
+	formatBand,
+	formatCooldown,
+	tabAccent,
+	tabLabel
+} from './codex-display';
+import { type LevelRange, levelRange, spawnShare, zoneTotalWeight } from './enemy-level';
+import { type EnemyAttributes, enemyAttributesAtLevel } from './enemy-stats';
+
+/** A one-shot payload handed to the Codex via the navigation store (e.g. from the Statistics screen). */
+export interface CodexNavPayload {
+	tab?: CodexTab;
+	enemyId?: number;
+	sub?: EnemySubTab;
+}
+
+/* ── projected row/card view-models (presentational shapes the components render) ── */
+
+export interface CodexTabVM {
+	key: CodexTab;
+	label: string;
+	count: number;
+	accent: string;
+	active: boolean;
+}
+
+export interface EnemyRowVM {
+	id: number;
+	name: string;
+	isBoss: boolean;
+	band: string;
+	zoneCount: number;
+	skillCount: number;
+	selected: boolean;
+}
+
+export interface SubTabVM {
+	key: EnemySubTab;
+	label: string;
+}
+
+export interface EnemySkillVM {
+	id: number;
+	name: string;
+	meta: string;
+}
+
+export interface EnemySpawnVM {
+	zoneId: number;
+	zoneName: string;
+	share: number;
+	weightLabel: string;
+}
+
+export interface EnemyStatVM {
+	label: string;
+	value: string;
+	rank: number;
+	of: number;
+}
+
+export interface EnemyChallengeVM {
+	id: number;
+	name: string;
+	typeLabel: string;
+	accent: string;
+	progressText: string;
+	completed: boolean;
+}
+
+const SUB_TAB_DEFS: SubTabVM[] = [
+	{ key: 'attributes', label: 'Attributes' },
+	{ key: 'statistics', label: 'Statistics' },
+	{ key: 'skills', label: 'Skills' },
+	{ key: 'spawns', label: 'Spawns' }
+];
+
+/* ── reactive view-model ──────────────────────────────────────────────────── */
+
+export class CodexView {
+	/** Active top-level tab. */
+	tab = $state<CodexTab>('enemies');
+	/** Inspected enemy id (falls back to the head of the list when unresolved). */
+	selectedEnemyId = $state<number>(-1);
+	/** Active dossier sub-tab. */
+	sub = $state<EnemySubTab>('attributes');
+	/** Level the Attributes sub-tab scales the selected enemy to. */
+	level = $state<number>(1);
+	/** Whether the Attributes sub-tab reveals the base + per-level scaling breakdown. */
+	scaling = $state<boolean>(false);
+	/** Enemy-table filter chip. */
+	filter = $state<EnemyFilter>('all');
+
+	/** The player's statistic values (fetched on mount via the shared statistics store). */
+	stats = $state<IPlayerStatistic[]>([]);
+	statsLoading = $state(true);
+	statsError = $state(false);
+
+	constructor(payload?: CodexNavPayload) {
+		if (payload?.tab) {
+			this.tab = payload.tab;
+		}
+		if (payload?.sub) {
+			this.sub = payload.sub;
+		}
+		// Resolve the initial enemy (the deep-link target, else the head of the list) so the table
+		// highlights what the dossier shows. Reads stores directly to avoid touching a $derived here.
+		const initial = this.resolveEnemy(payload?.enemyId ?? -1);
+		if (initial) {
+			this.selectedEnemyId = initial.id;
+		}
+		this.level = this.levelFor(initial);
+	}
+
+	/* ── catalogue ───────────────────────────────────────────────────────────── */
+
+	/** Non-retired enemies — retirement keeps a slot resolvable but out of the glossary. */
+	readonly enemies = $derived((staticData.enemies ?? []).filter((e) => !e.retiredAt));
+
+	readonly filteredEnemies = $derived(
+		this.enemies.filter((e) => this.filter === 'all' || (this.filter === 'boss' ? e.isBoss : !e.isBoss))
+	);
+
+	/** Top-level tabs with live counts + section accents. */
+	readonly tabs = $derived.by<CodexTabVM[]>(() => {
+		const counts: Record<CodexTab, number> = {
+			enemies: this.enemies.length,
+			zones: (staticData.zones ?? []).filter((z) => !z.retiredAt).length,
+			skills: (staticData.skills ?? []).filter((s) => !s.retiredAt).length
+		};
+		return CODEX_TABS.map((key) => ({
+			key,
+			label: tabLabel(key),
+			count: counts[key],
+			accent: tabAccent(key),
+			active: key === this.tab
+		}));
+	});
+
+	/** Enemy table rows for the active filter. */
+	readonly enemyRows = $derived.by<EnemyRowVM[]>(() => {
+		const zones = staticData.zones ?? [];
+		return this.filteredEnemies.map((e) => ({
+			id: e.id,
+			name: e.name,
+			isBoss: e.isBoss,
+			band: formatBand(levelRange(e, zones)),
+			zoneCount: e.isBoss ? 1 : e.spawns.length,
+			skillCount: e.skillPool.length,
+			selected: e.id === this.selectedEnemyId
+		}));
+	});
+
+	/** Number of enemies shown under the active filter (the "N shown" readout). */
+	readonly shownCount = $derived(this.filteredEnemies.length);
+
+	/* ── selected enemy + dossier ──────────────────────────────────────────────── */
+
+	/** The inspected enemy, falling back to the head of the (filtered, then full) list. */
+	readonly selectedEnemy = $derived.by<IEnemy | undefined>(
+		() => this.enemies.find((e) => e.id === this.selectedEnemyId) ?? this.filteredEnemies[0] ?? this.enemies[0]
+	);
+
+	readonly range = $derived.by<LevelRange | undefined>(() => {
+		const e = this.selectedEnemy;
+		return e ? levelRange(e, staticData.zones ?? []) : undefined;
+	});
+
+	/** Header chrome for the dossier (kind label + section accent). */
+	readonly dossierAccent = $derived(
+		this.selectedEnemy ? enemyAccent(this.selectedEnemy.isBoss) : 'var(--enemy-accent)'
+	);
+	readonly dossierKind = $derived(this.selectedEnemy ? enemyKindLabel(this.selectedEnemy.isBoss) : '');
+
+	/** Primary + derived-secondary attribute values for the selected enemy at the current level. */
+	readonly attributes = $derived.by<EnemyAttributes>(() => {
+		const e = this.selectedEnemy;
+		return e ? enemyAttributesAtLevel(e, this.level) : { primary: [], secondary: [] };
+	});
+
+	/** Bar denominator for the primary stat bars (the leading value, floored at 1). */
+	readonly maxPrimary = $derived(Math.max(1, ...this.attributes.primary.map((p) => p.value)));
+
+	readonly skillRows = $derived.by<EnemySkillVM[]>(() => {
+		const e = this.selectedEnemy;
+		const skills = staticData.skills ?? [];
+		if (!e) {
+			return [];
+		}
+		return e.skillPool
+			.map((id) => skills[id])
+			.filter(Boolean)
+			.map((sk) => ({
+				id: sk.id,
+				name: sk.name,
+				meta: `${sk.baseDamage > 0 ? `base ${sk.baseDamage}` : 'utility'} · ${formatCooldown(sk.cooldownMs)} cd`
+			}));
+	});
+
+	readonly spawnHeading = $derived.by(() => {
+		const e = this.selectedEnemy;
+		if (!e) {
+			return '';
+		}
+		if (e.isBoss) {
+			return 'Encounter';
+		}
+		const n = e.spawns.length;
+		return `Spawns in ${n} ${n === 1 ? 'zone' : 'zones'}`;
+	});
+
+	readonly spawns = $derived.by<EnemySpawnVM[]>(() => {
+		const e = this.selectedEnemy;
+		const zones = staticData.zones ?? [];
+		if (!e) {
+			return [];
+		}
+		if (e.isBoss) {
+			const zone = zones.find((z) => z?.bossEnemyId === e.id);
+			return zone ? [{ zoneId: zone.id, zoneName: zone.name, share: 100, weightLabel: 'boss fight' }] : [];
+		}
+		return e.spawns
+			.map((sp) => ({
+				zoneId: sp.zoneId,
+				zoneName: zones[sp.zoneId]?.name ?? `Zone ${sp.zoneId}`,
+				share: spawnShare(sp.weight, zoneTotalWeight(sp.zoneId, this.enemies)),
+				weightLabel: `weight ${sp.weight}`
+			}))
+			.sort((a, b) => b.share - a.share);
+	});
+
+	/** The statistic query engine, rebuilt from the live reference data + fetched values. */
+	readonly statData = $derived(
+		new StatisticsData(buildStatTypes(staticData.statisticTypes ?? []), this.stats, buildStatEntities())
+	);
+
+	/** Every statistic that references the selected enemy (the dossier's "your record"). */
+	readonly statistics = $derived.by<EnemyStatVM[]>(() => {
+		const e = this.selectedEnemy;
+		if (!e) {
+			return [];
+		}
+		return this.statData.statsForEntity('enemy', e.id).map((info) => ({
+			label: info.stat.name,
+			value: fmtValue(info.value, info.stat.unit),
+			rank: info.rank,
+			of: info.of
+		}));
+	});
+
+	/** Challenges scoped to the selected enemy, with progress from the shared challenge store. */
+	readonly challenges = $derived.by<EnemyChallengeVM[]>(() => {
+		const e = this.selectedEnemy;
+		if (!e) {
+			return [];
+		}
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient lookup, not held state
+		const progressById = new Map(playerChallenges.all.map((pc) => [pc.challengeId, pc]));
+		return (staticData.challenges ?? [])
+			.filter((c) => c.entityType === EEntityType.Enemy && c.targetEntityId === e.id)
+			.map((c) => {
+				const pc = progressById.get(c.id);
+				const progress = pc?.progress ?? 0;
+				const completed = pc?.completed ?? false;
+				const progressText =
+					c.progressGoal === 1 ? (completed ? 'done' : 'sealed') : `${Math.round(progress)}/${c.progressGoal}`;
+				return {
+					id: c.id,
+					name: c.name,
+					typeLabel: challengeTypeName(c.challengeTypeId, staticData.challengeTypes),
+					accent: challengeTypeColor(c.challengeTypeId),
+					progressText,
+					completed
+				};
+			});
+	});
+
+	/** Dossier sub-tabs — Challenges only when the enemy has related challenges. */
+	readonly subTabs = $derived.by<SubTabVM[]>(() =>
+		this.challenges.length > 0 ? [...SUB_TAB_DEFS, { key: 'challenges', label: 'Challenges' }] : SUB_TAB_DEFS
+	);
+
+	/* ── handlers ──────────────────────────────────────────────────────────────── */
+
+	selectTab(tab: CodexTab): void {
+		this.tab = tab;
+	}
+
+	/** Select an enemy: reset to the Attributes sub-tab and reseed the level to its band. */
+	selectEnemy(id: number): void {
+		this.selectedEnemyId = id;
+		this.sub = 'attributes';
+		this.level = this.levelFor(this.resolveEnemy(id));
+	}
+
+	selectSub(sub: EnemySubTab): void {
+		this.sub = sub;
+	}
+
+	setLevel(level: number): void {
+		this.level = level;
+	}
+
+	toggleScaling(): void {
+		this.scaling = !this.scaling;
+	}
+
+	setFilter(filter: EnemyFilter): void {
+		this.filter = filter;
+	}
+
+	/* ── helpers (store reads, kept off the reactive graph for the constructor) ──── */
+
+	/** Resolve an enemy id against the catalogue, falling back to the head of the list. */
+	private resolveEnemy(id: number): IEnemy | undefined {
+		const enemies = (staticData.enemies ?? []).filter((e) => !e.retiredAt);
+		return enemies.find((e) => e.id === id) ?? enemies[0];
+	}
+
+	/** The level to scale an enemy to by default: the boss's fixed level, else its band midpoint. */
+	private levelFor(enemy: IEnemy | undefined): number {
+		if (!enemy) {
+			return 1;
+		}
+		const r = levelRange(enemy, staticData.zones ?? []);
+		return r.fixed ? r.min : Math.round((r.min + r.max) / 2);
+	}
+}

--- a/UI/src/routes/game/screens/codex/enemy-level.ts
+++ b/UI/src/routes/game/screens/codex/enemy-level.ts
@@ -1,0 +1,42 @@
+/* Pure level-band + spawn-share maths for the Codex enemy views. Kept free of
+   reactive state (and the store) so it can be unit-tested directly and shared by
+   the enemy table, the dossier, and the future Zones tab. */
+
+import type { IEnemy, IZone } from '$lib/api';
+
+export interface LevelRange {
+	min: number;
+	max: number;
+	/** A boss is a fixed-level encounter (min === max). */
+	fixed: boolean;
+}
+
+/** An enemy's level band: a boss is fixed at its zone's `bossLevel`; a normal enemy spans the
+ *  min/max levels of the zones it spawns in. Zones are resolved by id (the zero-based convention);
+ *  an enemy with no resolvable spawn zone degrades to level 1. */
+export function levelRange(enemy: IEnemy, zones: IZone[]): LevelRange {
+	if (enemy.isBoss) {
+		const zone = zones.find((z) => z?.bossEnemyId === enemy.id);
+		const level = zone?.bossLevel ?? 1;
+		return { min: level, max: level, fixed: true };
+	}
+	const spawnZones = enemy.spawns.map((s) => zones[s.zoneId]).filter(Boolean);
+	if (spawnZones.length === 0) {
+		return { min: 1, max: 1, fixed: false };
+	}
+	return {
+		min: Math.min(...spawnZones.map((z) => z.levelMin)),
+		max: Math.max(...spawnZones.map((z) => z.levelMax)),
+		fixed: false
+	};
+}
+
+/** Total spawn weight across every enemy that spawns in a zone — the denominator for a spawn share. */
+export function zoneTotalWeight(zoneId: number, enemies: IEnemy[]): number {
+	return enemies.reduce((sum, e) => sum + (e.spawns.find((s) => s.zoneId === zoneId)?.weight ?? 0), 0);
+}
+
+/** A spawn's share of its zone as a 0–100 percentage (0 when the zone has no weight). */
+export function spawnShare(weight: number, total: number): number {
+	return total > 0 ? Math.round((weight / total) * 100) : 0;
+}

--- a/UI/src/routes/game/screens/codex/enemy-stats.ts
+++ b/UI/src/routes/game/screens/codex/enemy-stats.ts
@@ -1,0 +1,75 @@
+/* Enemy attribute values at a given level, for the Codex enemy dossier. Generalises the
+   Skills screen's `enemyDefense` (skills-view.svelte.ts): each attribute distribution entry
+   contributes `baseAmount + amountPerLevel * level` additively, then the derived secondary
+   stats (Max Health, Defense) are resolved through the same `BattleAttributes` composition the
+   battle uses — so the displayed numbers match combat by construction.
+
+   An enemy's `attributeDistribution` carries only the six core (primary) attributes; Max Health /
+   Defense are never stored, they are derived here. The per-level slope of a derived stat is the
+   linear delta `f(level + 1) − f(level)` (the additive→derived composition is linear in level).
+   Memoised per enemy+level so dragging the dossier's level slider doesn't rebuild a full
+   `BattleAttributes` per read. */
+
+import { EAttribute, type IEnemy } from '$lib/api';
+import { BattleAttributes } from '$lib/battle/battle-attributes';
+
+export interface EnemyAttributeValue {
+	attributeId: EAttribute;
+	/** Base amount at level 0 (the distribution's `baseAmount`; 0 for a derived stat). */
+	base: number;
+	/** Increase per level (the distribution's `amountPerLevel`, or a derived stat's linear slope). */
+	perLevel: number;
+	/** Resolved (rounded) value at the requested level. */
+	value: number;
+}
+
+export interface EnemyAttributes {
+	/** The six core attributes straight from the distribution. */
+	primary: EnemyAttributeValue[];
+	/** Derived stats not stored on the enemy (Max Health, Defense), computed via the battle pass. */
+	secondary: EnemyAttributeValue[];
+}
+
+/** The derived secondary stats surfaced in the dossier, in display order. */
+const DERIVED_SECONDARY: EAttribute[] = [EAttribute.MaxHealth, EAttribute.Defense];
+
+/** Memoised result by enemy identity → level (mirrors `enemyDefenseCache`): a record replaced on a
+ *  reference-data reload is recomputed (and the stale entry GC'd) rather than served a wrong value. */
+const cache = new WeakMap<IEnemy, Map<number, EnemyAttributes>>();
+
+/** Build the enemy's `BattleAttributes` at a level (additive distribution + the derived pass). */
+function buildAt(enemy: IEnemy, level: number): BattleAttributes {
+	const modifiers = enemy.attributeDistribution.map((dist) => ({
+		attributeId: dist.attributeId,
+		amount: dist.baseAmount + dist.amountPerLevel * level
+	}));
+	return new BattleAttributes(modifiers, true);
+}
+
+/** The enemy's primary + derived-secondary attribute values at a level (memoised per enemy+level). */
+export function enemyAttributesAtLevel(enemy: IEnemy, level: number): EnemyAttributes {
+	let byLevel = cache.get(enemy);
+	if (byLevel === undefined) {
+		byLevel = new Map<number, EnemyAttributes>();
+		cache.set(enemy, byLevel);
+	}
+	const cached = byLevel.get(level);
+	if (cached !== undefined) {
+		return cached;
+	}
+	const atLevel = buildAt(enemy, level);
+	const atNext = buildAt(enemy, level + 1);
+	const primary: EnemyAttributeValue[] = enemy.attributeDistribution.map((dist) => ({
+		attributeId: dist.attributeId,
+		base: dist.baseAmount,
+		perLevel: dist.amountPerLevel,
+		value: Math.round(dist.baseAmount + dist.amountPerLevel * level)
+	}));
+	const secondary: EnemyAttributeValue[] = DERIVED_SECONDARY.map((id) => {
+		const value = atLevel.getValue(id);
+		return { attributeId: id, base: 0, perLevel: atNext.getValue(id) - value, value: Math.round(value) };
+	});
+	const result: EnemyAttributes = { primary, secondary };
+	byLevel.set(level, result);
+	return result;
+}

--- a/UI/src/routes/game/screens/screen-defs.ts
+++ b/UI/src/routes/game/screens/screen-defs.ts
@@ -8,6 +8,7 @@ import Skills from './skills/Skills.svelte';
 import Attributes from './attributes/Attributes.svelte';
 import AttributeBreakdown from './attribute-breakdown/AttributeBreakdown.svelte';
 import Statistics from './stats/Statistics.svelte';
+import Codex from './codex/Codex.svelte';
 import Options from './options/Options.svelte';
 
 /** A navigable game screen shown in the sidebar. */
@@ -49,6 +50,7 @@ export const GAME_SCREENS: ScreenDef[] = [
 		component: AttributeBreakdown
 	},
 	{ key: 'stats', label: 'Stats', group: 'character', built: true, component: Statistics },
+	{ key: 'codex', label: 'Codex', group: 'character', built: true, component: Codex },
 	{ key: 'options', label: 'Options', group: 'settings', built: true, component: Options },
 	{ key: 'help', label: 'Help', group: 'settings', built: false },
 	{ key: 'quit', label: 'Quit', group: 'settings', built: true },

--- a/UI/src/routes/game/screens/stats/ByStatisticView.svelte
+++ b/UI/src/routes/game/screens/stats/ByStatisticView.svelte
@@ -5,7 +5,11 @@
 	<div class="scroll">
 		<div class="grid" data-testid="stat-card-grid">
 			{#each view.shownStats as stat (stat.id)}
-				<StatCard summary={view.data.summaryFor(stat.id)} {stat} onPickEntity={(kind, id) => view.goEntity(kind, id)} />
+				<StatCard
+					summary={view.data.summaryFor(stat.id)}
+					{stat}
+					onPickEntity={(kind, id) => view.openEntity(kind, id)}
+				/>
 			{/each}
 		</div>
 	</div>

--- a/UI/src/routes/game/screens/stats/EntityPicker.svelte
+++ b/UI/src/routes/game/screens/stats/EntityPicker.svelte
@@ -31,7 +31,7 @@
 				class="entity"
 				class:on
 				data-testid="entity-{entity.id}"
-				onclick={() => view.setEntId(entity.id)}
+				onclick={() => view.openEntity(view.entKind, entity.id)}
 			>
 				<StatGlyph kind={view.entKind} size={15} color={on ? statKindColor(view.entKind) : undefined} />
 				<span class="name">{entity.name}</span>

--- a/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
+++ b/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
@@ -324,8 +324,9 @@ export class StatisticsView {
 	mode = $state<ViewMode>('stat');
 	/** Active category tab in the "by statistic" view (or `all`). */
 	statCat = $state<StatCategory | 'all'>('combat');
-	/** Active entity-kind tab in the "by entity" view. */
-	entKind = $state<StatEntityKind>('enemy');
+	/** Active entity-kind tab in the "by entity" view. Defaults to a kind with an in-place dossier
+	 *  (zone) — the enemy kind now opens the Codex instead (see {@link switchKind}). */
+	entKind = $state<StatEntityKind>('zone');
 	/** Selected entity id in the "by entity" view. */
 	entId = $state<number>(0);
 	/** Entity-picker search query. */
@@ -376,8 +377,15 @@ export class StatisticsView {
 		this.query = query;
 	}
 
-	/** Switch entity kind, resetting the selection + search to that kind. */
+	/** Switch entity kind, resetting the selection + search to that kind. The Enemy kind opens the
+	 *  Codex instead — enemy reference data and per-entity stats live there now, so an in-place enemy
+	 *  dossier would be a dead-end (every enemy click deep-links to the Codex). Zones/skills stay in
+	 *  place until the Codex gains those tabs (#999). */
 	switchKind(kind: StatEntityKind): void {
+		if (kind === 'enemy') {
+			navigation.requestScreen('codex', { tab: 'enemies' } satisfies CodexNavPayload);
+			return;
+		}
 		this.entKind = kind;
 		this.entId = this.data.entityList(kind)[0]?.id ?? 0;
 		this.query = '';

--- a/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
+++ b/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
@@ -17,8 +17,9 @@
    the `GetPlayerStatistics` socket command; entity ids resolve against the live staticData. */
 
 import { EEntityType, EStatisticType, type IPlayerStatistic, type IStatisticType } from '$lib/api';
-import { staticData } from '$stores';
+import { navigation, staticData } from '$stores';
 import { statCategoryLabel } from './statistics-display';
+import type { CodexNavPayload } from '../codex/codex-view.svelte';
 
 export type StatUnit = 'count' | 'damage' | 'time';
 export type StatAgg = 'sum' | 'max' | 'min';
@@ -388,6 +389,21 @@ export class StatisticsView {
 		this.entId = id;
 		this.query = '';
 		this.mode = 'entity';
+	}
+
+	/** Open an entity from a picker/stat row. Enemies deep-link into the Codex dossier (their
+	 *  per-entity statistics live there now); zones/skills still open the in-place dossier until the
+	 *  Codex gains those tabs. */
+	openEntity(kind: StatEntityKind, id: number): void {
+		if (kind === 'enemy') {
+			navigation.requestScreen('codex', {
+				tab: 'enemies',
+				enemyId: id,
+				sub: 'statistics'
+			} satisfies CodexNavPayload);
+			return;
+		}
+		this.goEntity(kind, id);
 	}
 
 	/** Jump from an entity's stat tile back to that stat's category. */

--- a/UI/src/stores/index.ts
+++ b/UI/src/stores/index.ts
@@ -1,4 +1,5 @@
 export * from './static-data.svelte.ts';
+export * from './navigation.svelte.ts';
 export * from './statistics.svelte.ts';
 export * from './challenges.svelte.ts';
 export * from './logs.svelte.ts';

--- a/UI/src/stores/navigation.svelte.ts
+++ b/UI/src/stores/navigation.svelte.ts
@@ -1,0 +1,36 @@
+/* Cross-screen navigation intent. The active in-game screen is local state in
+   `routes/game/+page.svelte`; this module-level store lets any screen request a switch to another
+   screen, optionally handing it a one-shot `payload` the target consumes on mount (e.g. the
+   Statistics screen deep-linking an enemy into the Codex dossier). The `+page.svelte` shell reacts
+   to `requestedScreen` and routes through its existing `handleNavigate`. */
+
+let requestedScreen = $state<string | null>(null);
+/** A one-shot handoff for the target screen — deliberately NOT reactive (read once on mount). */
+let pendingPayload: unknown = undefined;
+
+export const navigation = {
+	/** The screen a component has asked the shell to switch to, or `null` when there's no request. */
+	get requestedScreen() {
+		return requestedScreen;
+	},
+
+	/** Request a switch to a screen, optionally carrying a one-shot payload for the target screen. */
+	requestScreen(key: string, payload?: unknown) {
+		requestedScreen = key;
+		pendingPayload = payload;
+	},
+
+	/** Read (and clear) the payload handed to the target screen. A one-shot, non-reactive handoff,
+	 *  so a later manual navigation to the same screen opens at its defaults. */
+	consumePayload<T>(): T | undefined {
+		const payload = pendingPayload as T | undefined;
+		pendingPayload = undefined;
+		return payload;
+	},
+
+	/** Clear the pending screen request once the shell has switched (leaves any payload for the
+	 *  target screen to consume on mount). */
+	clear() {
+		requestedScreen = null;
+	}
+};

--- a/UI/src/tests/routes/game/screens/codex/Codex.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/Codex.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+import { EAttribute, EChallengeType, EEntityType, EStatisticType } from '$lib/api';
+import { SERVER_STAT_TYPES } from '../stats/stat-fixtures';
+
+// Codex fetches the player's statistics + challenges over the socket and resolves reference data
+// from staticData. Mock the socket fetch and replace staticData; keep the real statistics /
+// playerChallenges / navigation stores (the screen drives them).
+const { mockFetchSocket, staticData } = vi.hoisted(() => ({
+	mockFetchSocket: vi.fn(),
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	staticData: {} as any
+}));
+
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$lib/api')>();
+	return { ...actual, fetchSocketData: mockFetchSocket };
+});
+vi.mock('$stores', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$stores')>();
+	return { ...actual, staticData };
+});
+
+import Codex from '$routes/game/screens/codex/Codex.svelte';
+import { statistics, playerChallenges, navigation } from '$stores';
+
+const dist = () => [
+	{ attributeId: EAttribute.Strength, baseAmount: 10, amountPerLevel: 1 },
+	{ attributeId: EAttribute.Endurance, baseAmount: 8, amountPerLevel: 0.8 },
+	{ attributeId: EAttribute.Intellect, baseAmount: 3, amountPerLevel: 0.2 },
+	{ attributeId: EAttribute.Agility, baseAmount: 6, amountPerLevel: 0.5 },
+	{ attributeId: EAttribute.Dexterity, baseAmount: 5, amountPerLevel: 0.4 },
+	{ attributeId: EAttribute.Luck, baseAmount: 3, amountPerLevel: 0.2 }
+];
+
+const STATS = [
+	{ statisticTypeId: EStatisticType.EnemiesKilled, entityId: 0, value: 100 },
+	{ statisticTypeId: EStatisticType.EnemiesKilled, entityId: 1, value: 20 }
+];
+const PLAYER_CHALLENGES = [{ challengeId: 0, progress: 62, completed: false }];
+
+function seedStaticData(): void {
+	staticData.zones = [
+		{ id: 0, name: 'Emberreach', order: 1, levelMin: 1, levelMax: 10, bossEnemyId: 2, bossLevel: 10 },
+		{ id: 1, name: 'Ashfen Marsh', order: 2, levelMin: 11, levelMax: 22, bossLevel: 22 }
+	];
+	staticData.enemies = [
+		{
+			id: 0,
+			name: 'Dust Skitterer',
+			isBoss: false,
+			attributeDistribution: dist(),
+			skillPool: [0, 1],
+			spawns: [
+				{ zoneId: 0, weight: 60 },
+				{ zoneId: 1, weight: 20 }
+			]
+		},
+		{
+			id: 1,
+			name: 'Bog Lurker',
+			isBoss: false,
+			attributeDistribution: dist(),
+			skillPool: [1],
+			spawns: [{ zoneId: 1, weight: 40 }]
+		},
+		{ id: 2, name: 'Cinder Tyrant', isBoss: true, attributeDistribution: dist(), skillPool: [0, 1], spawns: [] }
+	];
+	staticData.skills = [
+		{ id: 0, name: 'Cleave', baseDamage: 14, cooldownMs: 1800, damageMultipliers: [], effects: [] },
+		{ id: 1, name: 'War Cry', baseDamage: 0, cooldownMs: 6000, damageMultipliers: [], effects: [] }
+	];
+	staticData.challenges = [
+		{
+			id: 0,
+			name: 'Cull the Skitterers',
+			challengeTypeId: EChallengeType.EnemiesKilled,
+			entityType: EEntityType.Enemy,
+			targetEntityId: 0,
+			progressGoal: 100
+		}
+	];
+	staticData.challengeTypes = [{ id: EChallengeType.EnemiesKilled, goalComparison: 1, name: 'Enemies Killed' }];
+	staticData.statisticTypes = SERVER_STAT_TYPES;
+	staticData.attributes = [
+		{ id: EAttribute.Strength, name: 'Strength', code: 'STR', attributeType: 1 },
+		{ id: EAttribute.MaxHealth, name: 'Max Health', code: '', attributeType: 2 },
+		{ id: EAttribute.Defense, name: 'Defense', code: '', attributeType: 2 }
+	];
+}
+
+beforeEach(() => {
+	seedStaticData();
+	statistics.reset();
+	playerChallenges.reset();
+	navigation.clear();
+	navigation.consumePayload();
+	mockFetchSocket.mockImplementation((cmd: string) => {
+		if (cmd === 'GetPlayerStatistics') {
+			return Promise.resolve(STATS);
+		}
+		if (cmd === 'GetPlayerChallenges') {
+			return Promise.resolve(PLAYER_CHALLENGES);
+		}
+		return Promise.resolve([]);
+	});
+});
+
+afterEach(() => cleanup());
+
+describe('Codex screen', () => {
+	it('renders the tab bar with live counts and the enemy table', async () => {
+		render(Codex);
+		expect(screen.getByTestId('codex-screen')).toBeTruthy();
+		// Three section tabs with real counts.
+		expect(screen.getByTestId('codex-tab-enemies').textContent).toContain('3');
+		expect(screen.getByTestId('codex-tab-zones').textContent).toContain('2');
+		expect(screen.getByTestId('codex-tab-skills').textContent).toContain('2');
+		// Rows for every enemy.
+		expect(screen.getByTestId('codex-enemy-0')).toBeTruthy();
+		expect(screen.getByTestId('codex-enemy-2').textContent).toContain('BOSS');
+		// The first enemy's dossier shows by default on the Attributes sub-tab (a normal enemy → slider).
+		expect(screen.getByTestId('codex-dossier').textContent).toContain('Dust Skitterer');
+		expect(await screen.findByTestId('codex-level-slider')).toBeTruthy();
+	});
+
+	it('filters the enemy table by Normal / Boss', async () => {
+		render(Codex);
+		await fireEvent.click(screen.getByTestId('codex-filter-boss'));
+		expect(screen.queryByTestId('codex-enemy-0')).toBeNull();
+		expect(screen.getByTestId('codex-enemy-2')).toBeTruthy();
+		await fireEvent.click(screen.getByTestId('codex-filter-normal'));
+		expect(screen.getByTestId('codex-enemy-0')).toBeTruthy();
+		expect(screen.queryByTestId('codex-enemy-2')).toBeNull();
+	});
+
+	it('reveals the scaling breakdown when "Show scaling" is toggled', async () => {
+		render(Codex);
+		expect(screen.queryByText(/\/lvl ×/)).toBeNull();
+		await fireEvent.click(screen.getByTestId('codex-scaling-toggle'));
+		expect(screen.getAllByText(/\/lvl ×/).length).toBeGreaterThan(0);
+	});
+
+	it('shows a fixed-level encounter for a boss', async () => {
+		render(Codex);
+		await fireEvent.click(screen.getByTestId('codex-enemy-2'));
+		expect(screen.getByText('FIXED ENCOUNTER')).toBeTruthy();
+		expect(screen.queryByTestId('codex-level-slider')).toBeNull();
+	});
+
+	it('navigates the dossier sub-tabs (statistics / skills / spawns / challenges)', async () => {
+		render(Codex);
+		// Statistics — the player's per-enemy record loads via the socket.
+		await fireEvent.click(screen.getByTestId('codex-subtab-statistics'));
+		expect(await screen.findByTestId('codex-enemy-stats')).toBeTruthy();
+		expect(screen.getByText('Enemies Killed')).toBeTruthy();
+		// Skills pool.
+		await fireEvent.click(screen.getByTestId('codex-subtab-skills'));
+		expect(screen.getByText('Cleave')).toBeTruthy();
+		// Spawns table.
+		await fireEvent.click(screen.getByTestId('codex-subtab-spawns'));
+		expect(screen.getByText('Spawns in 2 zones')).toBeTruthy();
+		expect(screen.getByText('Emberreach')).toBeTruthy();
+		// Challenges (present for this enemy).
+		await fireEvent.click(screen.getByTestId('codex-subtab-challenges'));
+		expect(screen.getByText('Cull the Skitterers')).toBeTruthy();
+		expect(screen.getByText('62/100')).toBeTruthy();
+	});
+
+	it('shows a placeholder for the not-yet-built Zones and Skills tabs', async () => {
+		render(Codex);
+		await fireEvent.click(screen.getByTestId('codex-tab-zones'));
+		expect(screen.getByTestId('codex-coming-soon').textContent).toContain('Zones');
+		await fireEvent.click(screen.getByTestId('codex-tab-skills'));
+		expect(screen.getByTestId('codex-coming-soon').textContent).toContain('Skills');
+	});
+
+	it('surfaces a load error in the statistics sub-tab', async () => {
+		mockFetchSocket.mockImplementation((cmd: string) =>
+			cmd === 'GetPlayerStatistics' ? Promise.reject(new Error('down')) : Promise.resolve([])
+		);
+		render(Codex);
+		await fireEvent.click(screen.getByTestId('codex-subtab-statistics'));
+		expect(await screen.findByText('Your statistics could not be loaded.')).toBeTruthy();
+	});
+});

--- a/UI/src/tests/routes/game/screens/codex/codex-display.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/codex-display.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import type { LevelRange } from '$routes/game/screens/codex/enemy-level';
+import {
+	enemyAccent,
+	enemyKindLabel,
+	formatBand,
+	formatCooldown,
+	tabAccent
+} from '$routes/game/screens/codex/codex-display';
+
+describe('formatBand', () => {
+	it('shows a fixed boss level as L{n}', () => {
+		expect(formatBand({ min: 10, max: 10, fixed: true } as LevelRange)).toBe('L10');
+	});
+
+	it('shows a ranged band as min–max', () => {
+		expect(formatBand({ min: 18, max: 28, fixed: false } as LevelRange)).toBe('18–28');
+	});
+});
+
+describe('formatCooldown', () => {
+	it('renders a utility (zero) cooldown as a dash', () => {
+		expect(formatCooldown(0)).toBe('—');
+	});
+
+	it('renders whole-second cooldowns without a decimal', () => {
+		expect(formatCooldown(2000)).toBe('2s');
+		expect(formatCooldown(6000)).toBe('6s');
+	});
+
+	it('renders sub-second precision to one decimal', () => {
+		expect(formatCooldown(1800)).toBe('1.8s');
+		expect(formatCooldown(900)).toBe('0.9s');
+	});
+});
+
+describe('accents + labels', () => {
+	it('tints a boss gold and a normal enemy salmon', () => {
+		expect(enemyAccent(true)).toBe('var(--boss-accent)');
+		expect(enemyAccent(false)).toBe('var(--enemy-accent)');
+	});
+
+	it('labels the enemy kind', () => {
+		expect(enemyKindLabel(true)).toBe('Boss');
+		expect(enemyKindLabel(false)).toBe('Enemy');
+	});
+
+	it('maps each tab to its themed section accent', () => {
+		expect(tabAccent('enemies')).toBe('var(--enemy-accent)');
+		expect(tabAccent('zones')).toBe('var(--accent)');
+		expect(tabAccent('skills')).toBe('var(--attr-intellect)');
+	});
+});

--- a/UI/src/tests/routes/game/screens/codex/codex-view.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/codex-view.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EAttribute, EChallengeType, EEntityType, EStatisticType, type IPlayerStatistic } from '$lib/api';
+import { SERVER_STAT_TYPES } from '../stats/stat-fixtures';
+
+// CodexView reads reference data + challenge progress from the stores, and reuses the Statistics
+// screen's query engine — all mocked here. (The Statistics view-model also imports `navigation`.)
+const { staticData, playerChallenges, navigation } = vi.hoisted(() => ({
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	staticData: {} as any,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	playerChallenges: { all: [] as any[] },
+	navigation: { requestScreen: vi.fn(), consumePayload: vi.fn(), clear: vi.fn() }
+}));
+vi.mock('$stores', () => ({ staticData, playerChallenges, navigation }));
+
+import { CodexView } from '$routes/game/screens/codex/codex-view.svelte';
+
+const dist = () => [
+	{ attributeId: EAttribute.Strength, baseAmount: 10, amountPerLevel: 1 },
+	{ attributeId: EAttribute.Endurance, baseAmount: 8, amountPerLevel: 0.8 },
+	{ attributeId: EAttribute.Intellect, baseAmount: 3, amountPerLevel: 0.2 },
+	{ attributeId: EAttribute.Agility, baseAmount: 6, amountPerLevel: 0.5 },
+	{ attributeId: EAttribute.Dexterity, baseAmount: 5, amountPerLevel: 0.4 },
+	{ attributeId: EAttribute.Luck, baseAmount: 3, amountPerLevel: 0.2 }
+];
+
+function seed(): void {
+	staticData.zones = [
+		{ id: 0, name: 'Emberreach', order: 1, levelMin: 1, levelMax: 10, bossEnemyId: 2, bossLevel: 10 },
+		{ id: 1, name: 'Ashfen Marsh', order: 2, levelMin: 11, levelMax: 22, bossLevel: 22 },
+		{ id: 2, name: 'Sunken Causeway', order: 3, levelMin: 18, levelMax: 28, bossLevel: 28 }
+	];
+	staticData.enemies = [
+		{
+			id: 0,
+			name: 'Dust Skitterer',
+			isBoss: false,
+			attributeDistribution: dist(),
+			skillPool: [0, 1],
+			spawns: [
+				{ zoneId: 0, weight: 60 },
+				{ zoneId: 1, weight: 20 }
+			]
+		},
+		{
+			id: 1,
+			name: 'Bog Lurker',
+			isBoss: false,
+			attributeDistribution: dist(),
+			skillPool: [1],
+			spawns: [{ zoneId: 1, weight: 40 }]
+		},
+		{ id: 2, name: 'Cinder Tyrant', isBoss: true, attributeDistribution: dist(), skillPool: [0, 1], spawns: [] }
+	];
+	staticData.skills = [
+		{ id: 0, name: 'Cleave', baseDamage: 14, cooldownMs: 1800, damageMultipliers: [], effects: [] },
+		{ id: 1, name: 'War Cry', baseDamage: 0, cooldownMs: 6000, damageMultipliers: [], effects: [] }
+	];
+	staticData.challenges = [
+		{
+			id: 0,
+			name: 'Cull the Skitterers',
+			challengeTypeId: EChallengeType.EnemiesKilled,
+			entityType: EEntityType.Enemy,
+			targetEntityId: 0,
+			progressGoal: 100
+		},
+		{
+			id: 1,
+			name: 'The Tyrant Falls',
+			challengeTypeId: EChallengeType.BossesDefeated,
+			entityType: EEntityType.Enemy,
+			targetEntityId: 2,
+			progressGoal: 1
+		}
+	];
+	staticData.challengeTypes = [
+		{ id: EChallengeType.EnemiesKilled, goalComparison: 1, name: 'Enemies Killed' },
+		{ id: EChallengeType.BossesDefeated, goalComparison: 1, name: 'Bosses Defeated' }
+	];
+	staticData.statisticTypes = SERVER_STAT_TYPES;
+	staticData.attributes = [];
+	playerChallenges.all = [{ challengeId: 0, progress: 62, completed: false }];
+}
+
+const STATS: IPlayerStatistic[] = [
+	{ statisticTypeId: EStatisticType.EnemiesKilled, entityId: 0, value: 100 },
+	{ statisticTypeId: EStatisticType.EnemiesKilled, entityId: 1, value: 20 }
+];
+
+beforeEach(() => {
+	seed();
+	navigation.requestScreen.mockClear();
+});
+
+describe('CodexView tabs', () => {
+	it('reports live counts per section', () => {
+		const tabs = new CodexView().tabs;
+		expect(tabs.map((t) => [t.key, t.count])).toEqual([
+			['enemies', 3],
+			['zones', 3],
+			['skills', 2]
+		]);
+	});
+});
+
+describe('CodexView enemy rows', () => {
+	it('projects zone + skill counts (boss shows a single zone)', () => {
+		const rows = new CodexView().enemyRows;
+		expect(rows.find((r) => r.id === 0)).toMatchObject({ zoneCount: 2, skillCount: 2, band: '1–22' });
+		expect(rows.find((r) => r.id === 2)).toMatchObject({ zoneCount: 1, skillCount: 2, band: 'L10', isBoss: true });
+	});
+
+	it('filters by normal / boss', () => {
+		const view = new CodexView();
+		view.setFilter('boss');
+		expect(view.enemyRows.map((r) => r.id)).toEqual([2]);
+		view.setFilter('normal');
+		expect(view.enemyRows.map((r) => r.id)).toEqual([0, 1]);
+	});
+});
+
+describe('CodexView selection', () => {
+	it('falls back to the head of the list when no enemy is selected', () => {
+		expect(new CodexView().selectedEnemy?.id).toBe(0);
+	});
+
+	it('seeds the level to the band midpoint for a normal enemy', () => {
+		// Dust Skitterer spans 1–22 → midpoint 12.
+		expect(new CodexView().level).toBe(12);
+	});
+
+	it('selectEnemy reseeds the level (fixed for a boss) and resets the sub-tab', () => {
+		const view = new CodexView();
+		view.selectSub('skills');
+		view.selectEnemy(2);
+		expect(view.selectedEnemy?.id).toBe(2);
+		expect(view.level).toBe(10); // boss fixed level
+		expect(view.sub).toBe('attributes');
+		expect(view.range?.fixed).toBe(true);
+	});
+});
+
+describe('CodexView dossier projections', () => {
+	it('includes the Challenges sub-tab only when the enemy has related challenges', () => {
+		const view = new CodexView();
+		view.selectEnemy(0); // has challenge 0
+		expect(view.subTabs.map((t) => t.key)).toContain('challenges');
+		view.selectEnemy(1); // no challenges
+		expect(view.subTabs.map((t) => t.key)).not.toContain('challenges');
+	});
+
+	it('builds enemy-scoped challenge rows with progress text', () => {
+		const view = new CodexView();
+		view.selectEnemy(0);
+		expect(view.challenges).toEqual([
+			expect.objectContaining({ id: 0, typeLabel: 'Enemies Killed', progressText: '62/100', completed: false })
+		]);
+		// A goal-of-1 boss challenge with no progress reads as "sealed".
+		view.selectEnemy(2);
+		expect(view.challenges[0].progressText).toBe('sealed');
+	});
+
+	it('sorts spawn shares descending and collapses a boss to a single Encounter', () => {
+		const view = new CodexView();
+		view.selectEnemy(0);
+		expect(view.spawnHeading).toBe('Spawns in 2 zones');
+		expect(view.spawns).toEqual([
+			expect.objectContaining({ zoneName: 'Emberreach', share: 100 }),
+			expect.objectContaining({ zoneName: 'Ashfen Marsh', share: 33 })
+		]);
+		view.selectEnemy(2);
+		expect(view.spawnHeading).toBe('Encounter');
+		expect(view.spawns).toEqual([
+			expect.objectContaining({ zoneName: 'Emberreach', share: 100, weightLabel: 'boss fight' })
+		]);
+	});
+
+	it('lists the enemy’s skill pool with base/cooldown meta', () => {
+		const view = new CodexView();
+		view.selectEnemy(0);
+		expect(view.skillRows).toEqual([
+			{ id: 0, name: 'Cleave', meta: 'base 14 · 1.8s cd' },
+			{ id: 1, name: 'War Cry', meta: 'utility · 6s cd' }
+		]);
+	});
+
+	it('reuses the statistics query for the player’s per-enemy record', () => {
+		const view = new CodexView();
+		view.stats = STATS;
+		view.selectEnemy(0);
+		const killed = view.statistics.find((s) => s.label === 'Enemies Killed');
+		expect(killed?.value).toBe('100');
+	});
+
+	it('scales primary attributes to the current level', () => {
+		const view = new CodexView();
+		view.selectEnemy(0); // level → 12
+		const str = view.attributes.primary.find((p) => p.attributeId === EAttribute.Strength);
+		expect(str?.value).toBe(Math.round(10 + 1 * 12)); // 22
+		expect(view.attributes.secondary.map((s) => s.attributeId)).toEqual([EAttribute.MaxHealth, EAttribute.Defense]);
+	});
+});
+
+describe('CodexView nav payload', () => {
+	it('seeds tab / enemy / sub-tab / level from a deep-link payload', () => {
+		const view = new CodexView({ tab: 'enemies', enemyId: 2, sub: 'statistics' });
+		expect(view.tab).toBe('enemies');
+		expect(view.selectedEnemyId).toBe(2);
+		expect(view.sub).toBe('statistics');
+		expect(view.level).toBe(10); // boss fixed level
+	});
+});

--- a/UI/src/tests/routes/game/screens/codex/enemy-level.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/enemy-level.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import type { IEnemy, IZone } from '$lib/api';
+import { levelRange, spawnShare, zoneTotalWeight } from '$routes/game/screens/codex/enemy-level';
+
+const zones = [
+	{ id: 0, name: 'Emberreach', order: 1, levelMin: 1, levelMax: 10, bossEnemyId: 2, bossLevel: 10 },
+	{ id: 1, name: 'Ashfen Marsh', order: 2, levelMin: 11, levelMax: 22, bossLevel: 22 },
+	{ id: 2, name: 'Sunken Causeway', order: 3, levelMin: 18, levelMax: 28, bossLevel: 28 }
+] as IZone[];
+
+const enemy = (over: Partial<IEnemy>): IEnemy =>
+	({ id: 0, name: 'E', isBoss: false, attributeDistribution: [], skillPool: [], spawns: [], ...over }) as IEnemy;
+
+describe('levelRange', () => {
+	it('fixes a boss at its zone’s bossLevel (min === max)', () => {
+		const boss = enemy({ id: 2, isBoss: true, spawns: [] });
+		expect(levelRange(boss, zones)).toEqual({ min: 10, max: 10, fixed: true });
+	});
+
+	it('spans the min/max levels across a normal enemy’s spawn zones', () => {
+		const e = enemy({
+			spawns: [
+				{ zoneId: 0, weight: 60 },
+				{ zoneId: 2, weight: 20 }
+			]
+		});
+		// zone 0 (1–10) and zone 2 (18–28) → 1–28
+		expect(levelRange(e, zones)).toEqual({ min: 1, max: 28, fixed: false });
+	});
+
+	it('uses the single zone’s band for a one-zone spawn', () => {
+		const e = enemy({ spawns: [{ zoneId: 1, weight: 40 }] });
+		expect(levelRange(e, zones)).toEqual({ min: 11, max: 22, fixed: false });
+	});
+
+	it('degrades to level 1 for an enemy with no resolvable spawn zone', () => {
+		expect(levelRange(enemy({ spawns: [] }), zones)).toEqual({ min: 1, max: 1, fixed: false });
+	});
+
+	it('degrades to level 1 for a boss with no owning zone', () => {
+		expect(levelRange(enemy({ id: 9, isBoss: true }), zones)).toEqual({ min: 1, max: 1, fixed: true });
+	});
+});
+
+describe('zoneTotalWeight', () => {
+	it('sums every enemy’s spawn weight in a zone', () => {
+		const enemies = [
+			enemy({
+				id: 0,
+				spawns: [
+					{ zoneId: 1, weight: 40 },
+					{ zoneId: 2, weight: 18 }
+				]
+			}),
+			enemy({ id: 1, spawns: [{ zoneId: 1, weight: 35 }] }),
+			enemy({ id: 2, spawns: [{ zoneId: 2, weight: 5 }] })
+		];
+		expect(zoneTotalWeight(1, enemies)).toBe(75);
+		expect(zoneTotalWeight(2, enemies)).toBe(23);
+		expect(zoneTotalWeight(0, enemies)).toBe(0);
+	});
+});
+
+describe('spawnShare', () => {
+	it('returns the rounded percentage of the zone total', () => {
+		expect(spawnShare(40, 75)).toBe(53);
+		expect(spawnShare(60, 80)).toBe(75);
+	});
+
+	it('guards a zero total', () => {
+		expect(spawnShare(10, 0)).toBe(0);
+	});
+});

--- a/UI/src/tests/routes/game/screens/codex/enemy-stats.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/enemy-stats.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EAttribute, type IEnemy } from '$lib/api';
+
+// enemy-stats composes BattleAttributes, which reads attribute names from the staticData store.
+vi.mock('$stores', () => ({ staticData: {} }));
+
+import { enemyAttributesAtLevel } from '$routes/game/screens/codex/enemy-stats';
+import { BattleAttributes } from '$lib/battle/battle-attributes';
+
+const distribution = [
+	{ attributeId: EAttribute.Strength, baseAmount: 12, amountPerLevel: 1.4 },
+	{ attributeId: EAttribute.Endurance, baseAmount: 10, amountPerLevel: 1.1 },
+	{ attributeId: EAttribute.Intellect, baseAmount: 4, amountPerLevel: 0.3 },
+	{ attributeId: EAttribute.Agility, baseAmount: 8, amountPerLevel: 0.9 },
+	{ attributeId: EAttribute.Dexterity, baseAmount: 6, amountPerLevel: 0.6 },
+	{ attributeId: EAttribute.Luck, baseAmount: 3, amountPerLevel: 0.2 }
+];
+
+const makeEnemy = (): IEnemy =>
+	({
+		id: 0,
+		name: 'Marauder',
+		isBoss: false,
+		attributeDistribution: distribution,
+		skillPool: [],
+		spawns: []
+	}) as IEnemy;
+
+describe('enemyAttributesAtLevel', () => {
+	it('scales each primary attribute by base + perLevel × level', () => {
+		const { primary } = enemyAttributesAtLevel(makeEnemy(), 20);
+		const str = primary.find((p) => p.attributeId === EAttribute.Strength)!;
+		expect(str).toMatchObject({ base: 12, perLevel: 1.4 });
+		expect(str.value).toBe(Math.round(12 + 1.4 * 20)); // 40
+		expect(primary).toHaveLength(6);
+	});
+
+	it('derives Max Health and Defense (absent from the distribution) via the battle composition', () => {
+		const enemy = makeEnemy();
+		const { secondary } = enemyAttributesAtLevel(enemy, 20);
+		expect(secondary.map((s) => s.attributeId)).toEqual([EAttribute.MaxHealth, EAttribute.Defense]);
+
+		// Matches the canonical BattleAttributes build the battle uses.
+		const expected = new BattleAttributes(
+			distribution.map((d) => ({ attributeId: d.attributeId, amount: d.baseAmount + d.amountPerLevel * 20 })),
+			true
+		);
+		expect(secondary[0].value).toBe(Math.round(expected.getValue(EAttribute.MaxHealth)));
+		expect(secondary[1].value).toBe(Math.round(expected.getValue(EAttribute.Defense)));
+		expect(secondary[0].value).toBeGreaterThan(0);
+		expect(secondary[1].value).toBeGreaterThan(0);
+	});
+
+	it('exposes a constant per-level slope for derived stats (linear in level)', () => {
+		const enemy = makeEnemy();
+		const a = enemyAttributesAtLevel(enemy, 5).secondary;
+		const b = enemyAttributesAtLevel(enemy, 30).secondary;
+		expect(a[0].perLevel).toBeCloseTo(b[0].perLevel, 6);
+		expect(a[1].perLevel).toBeCloseTo(b[1].perLevel, 6);
+		expect(a[0].perLevel).toBeGreaterThan(0);
+	});
+
+	it('memoises the result per enemy + level', () => {
+		const enemy = makeEnemy();
+		expect(enemyAttributesAtLevel(enemy, 12)).toBe(enemyAttributesAtLevel(enemy, 12));
+		expect(enemyAttributesAtLevel(enemy, 12)).not.toBe(enemyAttributesAtLevel(enemy, 13));
+	});
+});

--- a/UI/src/tests/routes/game/screens/stats/EntityPicker.test.ts
+++ b/UI/src/tests/routes/game/screens/stats/EntityPicker.test.ts
@@ -30,9 +30,17 @@ beforeEach(() => {
 
 afterEach(() => cleanup());
 
+// The picker renders whatever kind the view is on. Enemies no longer have an in-place default
+// (they open the Codex), so the enemy-kind cases set the kind directly rather than via switchKind.
+function enemyView(): StatisticsView {
+	const view = new StatisticsView();
+	view.entKind = 'enemy';
+	return view;
+}
+
 describe('EntityPicker', () => {
 	it('lists the entities of the active kind and tags a boss enemy', () => {
-		render(EntityPicker, { props: { view: new StatisticsView() } });
+		render(EntityPicker, { props: { view: enemyView() } });
 
 		expect(screen.getByText('Cave Bat')).toBeTruthy();
 		expect(screen.getByText('Goblin')).toBeTruthy();
@@ -41,7 +49,7 @@ describe('EntityPicker', () => {
 	});
 
 	it('filters the list by the search query', async () => {
-		render(EntityPicker, { props: { view: new StatisticsView() } });
+		render(EntityPicker, { props: { view: enemyView() } });
 
 		await fireEvent.input(screen.getByLabelText('Search enemies'), { target: { value: 'gob' } });
 
@@ -50,7 +58,7 @@ describe('EntityPicker', () => {
 	});
 
 	it('shows an empty state when nothing matches', async () => {
-		render(EntityPicker, { props: { view: new StatisticsView() } });
+		render(EntityPicker, { props: { view: enemyView() } });
 
 		await fireEvent.input(screen.getByLabelText('Search enemies'), { target: { value: 'zzzzz' } });
 
@@ -58,7 +66,7 @@ describe('EntityPicker', () => {
 	});
 
 	it('deep-links an enemy to the Codex dossier instead of selecting it in place', async () => {
-		const view = new StatisticsView();
+		const view = enemyView();
 		render(EntityPicker, { props: { view } });
 
 		await fireEvent.click(screen.getByTestId('entity-1'));

--- a/UI/src/tests/routes/game/screens/stats/EntityPicker.test.ts
+++ b/UI/src/tests/routes/game/screens/stats/EntityPicker.test.ts
@@ -2,13 +2,14 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
 import { SERVER_STAT_TYPES } from './stat-fixtures';
 
-// EntityPicker reads its entity lists through a StatisticsView, which resolves
-// them from the in-memory staticData store — mocked here.
-const { staticData } = vi.hoisted(() => ({
+// EntityPicker reads its entity lists through a StatisticsView, which resolves them from the
+// in-memory staticData store and (for the enemy deep-link) the navigation store — both mocked here.
+const { staticData, navigation } = vi.hoisted(() => ({
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	staticData: {} as any
+	staticData: {} as any,
+	navigation: { requestScreen: vi.fn() }
 }));
-vi.mock('$stores', () => ({ staticData }));
+vi.mock('$stores', () => ({ staticData, navigation }));
 
 import EntityPicker from '$routes/game/screens/stats/EntityPicker.svelte';
 import { StatisticsView } from '$routes/game/screens/stats/statistics-view.svelte';
@@ -19,8 +20,12 @@ beforeEach(() => {
 		{ id: 0, name: 'Cave Bat', isBoss: false },
 		{ id: 1, name: 'Goblin', isBoss: true }
 	];
-	staticData.zones = [{ id: 0, name: 'Verdant Hollow', order: 3 }];
+	staticData.zones = [
+		{ id: 0, name: 'Verdant Hollow', order: 3 },
+		{ id: 1, name: 'Frostspire', order: 5 }
+	];
 	staticData.skills = [{ id: 0, name: 'Cleave' }];
+	navigation.requestScreen.mockClear();
 });
 
 afterEach(() => cleanup());
@@ -52,12 +57,26 @@ describe('EntityPicker', () => {
 		expect(screen.getByText('No matches.')).toBeTruthy();
 	});
 
-	it('selects an entity on click, marking its button active', async () => {
+	it('deep-links an enemy to the Codex dossier instead of selecting it in place', async () => {
 		const view = new StatisticsView();
 		render(EntityPicker, { props: { view } });
 
 		await fireEvent.click(screen.getByTestId('entity-1'));
 
+		// Enemies now open in the Codex (their per-entity stats live there); the in-place selection
+		// is untouched.
+		expect(navigation.requestScreen).toHaveBeenCalledWith('codex', { tab: 'enemies', enemyId: 1, sub: 'statistics' });
+		expect(view.entId).toBe(0);
+	});
+
+	it('selects a non-enemy entity in place, marking its button active', async () => {
+		const view = new StatisticsView();
+		view.switchKind('zone');
+		render(EntityPicker, { props: { view } });
+
+		await fireEvent.click(screen.getByTestId('entity-1'));
+
+		expect(navigation.requestScreen).not.toHaveBeenCalled();
 		expect(view.entId).toBe(1);
 		expect(screen.getByTestId('entity-1').classList.contains('on')).toBe(true);
 	});

--- a/UI/src/tests/routes/game/screens/stats/Statistics.test.ts
+++ b/UI/src/tests/routes/game/screens/stats/Statistics.test.ts
@@ -23,6 +23,7 @@ vi.mock('$stores', async (importOriginal) => {
 });
 
 import Statistics from '$routes/game/screens/stats/Statistics.svelte';
+import { navigation } from '$stores';
 
 const STATS: IPlayerStatistic[] = [
 	{ statisticTypeId: EStatisticType.EnemiesKilled, entityId: 0, value: 300 },
@@ -43,6 +44,8 @@ beforeEach(() => {
 	staticData.skills = [{ id: 0, name: 'Cleave' }];
 	mockToastError.mockClear();
 	mockFetchSocket.mockResolvedValue(STATS);
+	navigation.clear();
+	navigation.consumePayload();
 });
 
 afterEach(() => cleanup());
@@ -74,14 +77,15 @@ describe('Statistics screen', () => {
 		expect(screen.getByText('Fastest Victory')).toBeTruthy();
 	});
 
-	it('pivots from a stat card entity row into that entity’s dossier (cross-link)', async () => {
+	it('deep-links an enemy stat row into the Codex (cross-link)', async () => {
 		render(Statistics);
-		// Cave Bat (entity 0) is the most-killed enemy, so its row is in the
-		// Enemies Killed card (stat id 1) once the values load. Clicking it pivots.
+		// Cave Bat (entity 0) is the most-killed enemy, so its row is in the Enemies Killed card
+		// (stat id 1) once the values load. Clicking an enemy now opens the Codex dossier, where the
+		// per-entity statistics live — it does not open the in-place stats dossier.
 		const row = await screen.findByTestId('stat-row-1-0');
 		await fireEvent.click(row);
-		expect(screen.getByTestId('entity-dossier')).toBeTruthy();
-		expect(screen.getByTestId('entity-picker')).toBeTruthy();
+		expect(navigation.requestedScreen).toBe('codex');
+		expect(screen.queryByTestId('entity-dossier')).toBeNull();
 	});
 
 	it('shows a friendly empty state for a player with no statistics', async () => {

--- a/UI/src/tests/routes/game/screens/stats/statistics-view.test.ts
+++ b/UI/src/tests/routes/game/screens/stats/statistics-view.test.ts
@@ -206,11 +206,12 @@ describe('StatisticsData.isEmpty', () => {
 });
 
 describe('StatisticsView navigation', () => {
-	it('initialises to the by-statistic view on the first enemy', () => {
+	it('initialises to the by-statistic view, defaulting the by-entity kind to zone', () => {
 		const view = seededView();
 		expect(view.mode).toBe('stat');
 		expect(view.statCat).toBe('combat');
-		expect(view.entKind).toBe('enemy');
+		// Enemies open in the Codex now, so the in-place by-entity view defaults to a kind it can show.
+		expect(view.entKind).toBe('zone');
 		expect(view.entId).toBe(0);
 	});
 
@@ -228,6 +229,14 @@ describe('StatisticsView navigation', () => {
 		expect(view.entKind).toBe('skill');
 		expect(view.entId).toBe(0);
 		expect(view.query).toBe('');
+	});
+
+	it('switchKind to enemy opens the Codex instead of an in-place dossier', () => {
+		const view = seededView();
+		view.switchKind('enemy');
+		expect(navigation.requestScreen).toHaveBeenCalledWith('codex', { tab: 'enemies' });
+		// The in-place kind is left as-is (no enemy dossier).
+		expect(view.entKind).toBe('zone');
 	});
 
 	it('goEntity pivots into an entity dossier', () => {
@@ -265,6 +274,7 @@ describe('StatisticsView navigation', () => {
 
 	it('filters entities by the search query', () => {
 		const view = seededView();
+		view.entKind = 'enemy';
 		view.setQuery('gob');
 		expect(view.filteredEntities.map((e) => e.id)).toEqual([1]);
 	});
@@ -281,6 +291,7 @@ describe('StatisticsView navigation', () => {
 
 	it('falls back to the unfiltered list head (not the search box) when entId is unresolved', () => {
 		const view = seededView();
+		view.entKind = 'enemy';
 		view.mode = 'entity';
 		// An entId that resolves to no concrete entity for the kind (e.g. initial
 		// state or a kind-switch landing on a missing id).

--- a/UI/src/tests/routes/game/screens/stats/statistics-view.test.ts
+++ b/UI/src/tests/routes/game/screens/stats/statistics-view.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EEntityType, EStatisticType, type IPlayerStatistic } from '$lib/api';
 
-// StatisticsView reads the statistic-type catalogue + entity lists from the
-// in-memory staticData store, so it is mocked here.
-const { staticData } = vi.hoisted(() => ({
+// StatisticsView reads the statistic-type catalogue + entity lists from the in-memory staticData
+// store, and deep-links enemies into the Codex via the navigation store — both mocked here.
+const { staticData, navigation } = vi.hoisted(() => ({
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	staticData: {} as any
+	staticData: {} as any,
+	navigation: { requestScreen: vi.fn() }
 }));
-vi.mock('$stores', () => ({ staticData }));
+vi.mock('$stores', () => ({ staticData, navigation }));
 
 import {
 	buildStatTypes,
@@ -61,6 +62,7 @@ function seededView(): StatisticsView {
 
 beforeEach(() => {
 	seedStaticData();
+	navigation.requestScreen.mockClear();
 });
 
 describe('buildStatTypes', () => {
@@ -242,6 +244,23 @@ describe('StatisticsView navigation', () => {
 		view.goStat('exploration');
 		expect(view.mode).toBe('stat');
 		expect(view.statCat).toBe('exploration');
+	});
+
+	it('openEntity deep-links an enemy into the Codex (per-entity stats live there)', () => {
+		const view = seededView();
+		view.openEntity('enemy', 1);
+		expect(navigation.requestScreen).toHaveBeenCalledWith('codex', { tab: 'enemies', enemyId: 1, sub: 'statistics' });
+		// The in-place dossier is left untouched for the enemy.
+		expect(view.mode).toBe('stat');
+	});
+
+	it('openEntity opens a zone/skill in place (no Codex tab for them yet)', () => {
+		const view = seededView();
+		view.openEntity('zone', 0);
+		expect(navigation.requestScreen).not.toHaveBeenCalled();
+		expect(view.mode).toBe('entity');
+		expect(view.entKind).toBe('zone');
+		expect(view.entId).toBe(0);
 	});
 
 	it('filters entities by the search query', () => {

--- a/docs/frontend-screens.md
+++ b/docs/frontend-screens.md
@@ -91,6 +91,15 @@ The Statistics screen (`src/routes/game/screens/stats`) presents the player's tr
 - **Real data, sourced two ways by lifetime.** Statistic *values* are per-player and change, so they're fetched fresh on mount; the type *metadata* and the entity lists are static reference data loaded once. Entity ids resolve against `staticData` by index, the zero-based convention the rest of the app uses.
 - (Empty-vs-error handling follows the shared rule above.)
 
+## Codex screen (the reference glossary)
+
+The Codex screen (`src/routes/game/screens/codex`) is a **read-only reference glossary** of the game's content behind a top-level tab bar (Enemies / Zones / Skills). Each tab is a master/detail: a filterable list beside a detail dossier. Only the **Enemies tab is built**; Zones/Skills show a placeholder (real count badges, "coming soon" body) and are tracked as follow-ups. It's a port of a Claude Design handoff onto live reference/runtime data — none of the prototype's mock catalogues survive.
+
+- **Reference facts come from the stores; nothing is fabricated.** The enemy dossier reads `staticData.enemies/zones/skills/challenges`, the per-enemy player record via the Statistics screen's `StatisticsData.statsForEntity`, and challenge progress from `playerChallenges`. Level bands, spawn shares and the dossier projections live in pure modules (`enemy-level`, `codex-display`) unit-tested without rendering.
+- **Enemy stat scaling reuses the real battle build.** The Attributes sub-tab scales an enemy to a chosen level (a slider for normal enemies; a fixed level for bosses); each primary attribute is `base + perLevel × level` straight from its `attributeDistribution`, and the derived **Max Health / Defense** are computed through the same `BattleAttributes` composition the battle uses (`enemy-stats`, generalising the Skills screen's `enemyDefense`) — so the numbers match combat by construction. The per-level slope of a derived stat is its linear two-point delta. "Show scaling" reveals the base/per-level breakdown.
+- **Per-entity statistics live here, not on the Statistics screen.** The dossier's Statistics sub-tab is the player's record against an enemy, and the Statistics screen now **deep-links an enemy into this dossier** (via the navigation store — see [frontend.md](./frontend.md) → _Cross-screen navigation_) instead of rendering its own in-place enemy dossier. Zones/skills keep the in-place dossier until the Codex gains those tabs.
+- **Cross-links degrade gracefully.** The dossier's Skills/Spawns rows show data but are non-interactive until the Zones/Skills tabs exist; the search box and sort control are display-only in this slice.
+
 ## Card Game screen (the Initiative Loom)
 
 The Card Game screen (`src/routes/game/screens/card-game`) is **"The Initiative Loom"** — a real-time card-boss duel imported from a Claude Design handoff, a deliberate *active* break from the idle grind: the present (a glowing **NOW** line) is a moving deadline, cards are multi-tick **spans** on a scrolling timeline, and each resolves the instant its right edge crosses NOW.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -104,6 +104,10 @@ A few cross-cutting conventions follow from that rule:
 - **Change-state has its own token trio.** A pending add/edit/remove in the admin editor uses dedicated `--change-added`/`-modified`/`-removed` tokens, deliberately separate from `--accent`/`--warning`/`--enemy-accent` even where they currently share a hue — reserve `--warning` for validation.
 - **Shared chrome is set once in `common.scss`** — the themed scrollbar (`--scrollbar-thumb`/`-hover`), an opaque `html, body` backstop behind the themeable `.page-base` surface (kills the first-frame white flash), and a `prefers-reduced-motion` collapse of transitions/animations. The reduced-motion rule doubles as the root-cause fix for motion-driven Playwright flakiness (the e2e config sets `reducedMotion: 'reduce'`) — prefer it over per-test waits.
 
+## Cross-screen navigation
+
+The active in-game screen is local state in `routes/game/+page.svelte` (a screen key driving the registry lookup). For a screen to **send the player to another screen** — optionally handing it a target to open — there is a small module-level intent store (`$stores/navigation`): a caller invokes `requestScreen(key, payload?)`, the game shell reacts and switches screens through its existing `handleNavigate`, and the destination screen reads its one-shot `payload` via `consumePayload()` on mount. The payload is deliberately **not reactive** (a read-once handoff), so a later manual navigation opens the screen at its defaults. This is the seam for deep-links like the Statistics screen opening an enemy in the Codex dossier, without threading callbacks through the shell.
+
 ## In-game screen design notes
 
 Per-screen design decisions live in **[frontend-screens.md](./frontend-screens.md)**. When you add a new in-game screen, document its notable decisions there — surface a decision in this file only if it establishes a cross-cutting pattern other screens are expected to follow.


### PR DESCRIPTION
## What & why

Implements the `Glossary.dc.html` Claude Design handoff as a new in-game **Codex** reference screen (Character nav group), ported onto **live reference/runtime data** rather than the prototype's mock catalogues.

Scoped as the **Enemies-first slice** (per the agreed plan): the Enemies tab is fully built; Zones and Skills appear in the tab bar with real count badges but render a themed "coming soon" placeholder (tracked as follow-ups below).

## Enemies tab (master/detail)

- Filterable enemy table (All / Normal / Boss) beside a dossier with **Attributes, Statistics, Skills, Spawns, Challenges** sub-tabs (Challenges only shows when the enemy has related challenges).
- **Attributes** scales an enemy to a chosen level — a slider for normal enemies, a fixed-level readout for bosses. Primary bars come straight from the real `attributeDistribution`; the derived **Max Health / Defense** are computed through the *same* `BattleAttributes` composition the battle uses (generalising the Skills screen's `enemyDefense`), so the numbers match combat by construction. "Show scaling" reveals the `base + per/lvl × level` breakdown.
- Projection maths live in pure, unit-tested modules (`enemy-level`, `enemy-stats`, `codex-display`); the reactive view-model only wires state to them.

## Per-entity statistics move into the Codex

The dossier's Statistics sub-tab is the player's per-enemy record, reusing the Stats screen's `StatisticsData.statsForEntity`. The **Statistics screen now deep-links an enemy into this dossier** (Statistics sub-tab) instead of rendering its own in-place enemy dossier. Zones/skills keep their current in-place behavior until the Codex gains those tabs.

## Cross-screen navigation

Adds a small general-purpose intent store (`$stores/navigation`): a caller requests a screen + one-shot payload, the game shell switches via its existing `handleNavigate`, and the target screen consumes the payload on mount. This is the seam for the Stats→Codex deep-link without threading callbacks through the shell.

## Theming & docs

- Every design hex maps to existing semantic CSS variables (`--enemy-accent`, `--boss-accent`, `--attr-*`, `--challenge-*`, …) — **no new tokens, no hardcoded colors**.
- Docs updated: a Codex section in `docs/frontend-screens.md` and a cross-screen-navigation note in `docs/frontend.md`.

## Reviewer notes

- The derived **Max Health / Defense** cards read whatever the real `BattleAttributes` formulas produce (single source of truth with combat) — intentionally **not** the design mock's numbers.
- Search box and "sort: level" are **display-only** in this slice (follow-up #5).

## Verification

- **Full unit suite passes** (2180 tests), incl. the new Codex tests (`enemy-level`, `enemy-stats`, `codex-display`, `codex-view`, and a `Codex` render test) and updated stats tests for the deep-link.
- `svelte-check`: **0 errors / 0 warnings**; **eslint clean**; the `src/routes/**` coverage gate passes (lines 93.6 / functions 92.8 / statements 94.5). CI is green.
- No live in-browser check: the Codex is gated behind auth + the game shell + backend reference data (Postgres/Redis/API + a seeded, logged-in player), which a frontend-only dev server can't exercise — the data layer is covered by mocked unit tests instead.

## Follow-ups (not in this PR)

1. Codex: **Zones tab**
2. Codex: **Skills tab** (reuse `skill-effect-display`)
3. Enable enemy-dossier Skills/Spawns **cross-links** once 1–2 land
4. Stats→Codex **zone/skill deep-links** + retire the in-place enemy dossier
5. Codex: **functional search + sort**
6. Promote `enemyAttributesAtLevel` to `$lib/common` and delegate `skills-view`'s `enemyDefense` to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
