### PR TITLE
Game.Core progress/player correctness & hygiene cleanups (#912)

### DIFF
--- a/Game.Application/Services/AccountService.cs
+++ b/Game.Application/Services/AccountService.cs
@@ -81,12 +81,13 @@ namespace Game.Application.Services
                 return AccountLoginResult.Failed(LoginStatus.Banned);
             }
 
-            if (account.PlayerIds.Count == 0)
+            var selectedPlayerId = SelectPlayerId(account.PlayerIds);
+            if (selectedPlayerId is null)
             {
                 return AccountLoginResult.Failed(LoginStatus.NoPlayer);
             }
 
-            var player = await _playerRepo.GetPlayer(account.PlayerIds[0]);
+            var player = await _playerRepo.GetPlayer(selectedPlayerId.Value);
             if (player is null)
             {
                 return AccountLoginResult.Failed(LoginStatus.PlayerDataNotFound);
@@ -122,6 +123,17 @@ namespace Game.Application.Services
         public async Task<int?> ResolveSelectedPlayerId(int userId)
         {
             var playerIds = await _users.GetPlayerIds(userId);
+            return SelectPlayerId(playerIds);
+        }
+
+        /// <summary>
+        /// Selects which player an account's session binds to. The game is single-player per account today,
+        /// so this is always the first (and only) player; centralizing it here keeps the login and
+        /// session-rehydration paths from diverging and gives a future player-selection mechanism a single
+        /// seam to grow from. Returns <see langword="null"/> when the account has no player.
+        /// </summary>
+        private static int? SelectPlayerId(IReadOnlyList<int> playerIds)
+        {
             return playerIds.Count > 0 ? playerIds[0] : null;
         }
 

--- a/Game.Core.Tests/Players/InventoryTests.cs
+++ b/Game.Core.Tests/Players/InventoryTests.cs
@@ -33,6 +33,16 @@ namespace Game.Core.Tests.Players
             Assert.Single(inventory.UnlockedItems);
         }
 
+        [Fact]
+        public void UnlockItem_ReportsWhetherItWasNewlyUnlocked()
+        {
+            var inventory = new Inventory();
+            var item = MakeItem(42);
+
+            Assert.True(inventory.UnlockItem(item));
+            Assert.False(inventory.UnlockItem(item));
+        }
+
         // ── UnlockMod ───────────────────────────────────────────────────────
 
         [Fact]
@@ -54,6 +64,15 @@ namespace Game.Core.Tests.Players
             inventory.UnlockMod(7);
 
             Assert.Single(inventory.UnlockedMods);
+        }
+
+        [Fact]
+        public void UnlockMod_ReportsWhetherItWasNewlyUnlocked()
+        {
+            var inventory = new Inventory();
+
+            Assert.True(inventory.UnlockMod(7));
+            Assert.False(inventory.UnlockMod(7));
         }
 
         // ── TryEquipItem ────────────────────────────────────────────────────
@@ -604,6 +623,30 @@ namespace Game.Core.Tests.Players
             Assert.Equal(10, Assert.Single(slot.AppliedMods).ItemModId);
             // The rebuilt index is live, so a lookup-driven operation against the restored item resolves it.
             Assert.True(restored.TryEquipItem(3, EEquipmentSlot.AccessorySlot));
+        }
+
+        // ── Slot ItemId is derived from Item (single source of truth) ────────
+
+        [Fact]
+        public void EquipmentSlot_ItemId_IsDerivedFromItem()
+        {
+            // ItemId can never desync from Item: it is computed from it rather than stored independently.
+            var slot = new EquipmentSlot(EEquipmentSlot.WeaponSlot);
+            Assert.Null(slot.ItemId);
+
+            slot.Set(MakeItem(7, EItemCategory.Weapon));
+            Assert.Equal(7, slot.ItemId);
+
+            slot.Clear();
+            Assert.Null(slot.ItemId);
+        }
+
+        [Fact]
+        public void UnlockedItemSlot_ItemId_IsDerivedFromItem()
+        {
+            var slot = new UnlockedItemSlot { Item = MakeItem(9), AppliedMods = [] };
+
+            Assert.Equal(9, slot.ItemId);
         }
 
         // ── Helpers ──────────────────────────────────────────────────────────

--- a/Game.Core.Tests/Players/NewPlayerFactoryTests.cs
+++ b/Game.Core.Tests/Players/NewPlayerFactoryTests.cs
@@ -1,5 +1,6 @@
 using Game.Core.Players;
 using Xunit;
+using CoreAttribute = Game.Core.Attributes.Attribute;
 
 namespace Game.Core.Tests.Players
 {
@@ -43,14 +44,14 @@ namespace Game.Core.Tests.Players
         }
 
         [Fact]
-        public void Create_GrantsEachCoreAttributeAtStartingAmount()
+        public void Create_GrantsAnAllocationRowForEveryCoreAttribute()
         {
             var newPlayer = _factory.Create("hero");
 
-            Assert.Equal(NewPlayerFactory.AttributeCount, newPlayer.Attributes.Count);
-            Assert.Equal(
-                Enumerable.Range(0, NewPlayerFactory.AttributeCount).Select(id => (EAttribute)id),
-                newPlayer.Attributes.Select(attribute => attribute.Attribute));
+            // The seed set is exactly the core (directly-allocatable) attributes — derived from the
+            // attribute taxonomy, not a hardcoded count — so a new core attribute is granted automatically.
+            var expectedCoreAttributes = Enum.GetValues<EAttribute>().Where(CoreAttribute.IsCore).ToList();
+            Assert.Equal(expectedCoreAttributes, newPlayer.Attributes.Select(attribute => attribute.Attribute));
             Assert.All(newPlayer.Attributes, attribute =>
                 Assert.Equal(NewPlayerFactory.StartingAttributeAmount, attribute.Amount));
         }

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -263,6 +263,46 @@ namespace Game.Core.Tests.Players
             Assert.Single(player.Skills);
         }
 
+        // ── Idempotent unlocks raise no event on the no-op path ──────────────
+
+        [Fact]
+        public void UnlockItem_AlreadyUnlocked_DoesNotRaiseSecondEvent()
+        {
+            var player = MakePlayer();
+            var item = MakeItem(id: 10);
+            player.UnlockItem(item);
+            player.ClearEvents();
+
+            player.UnlockItem(item);
+
+            // Re-granting an already-owned item is a no-op: no redundant write-behind work or client notice.
+            Assert.Empty(player.DomainEvents.OfType<ItemUnlockedEvent>());
+        }
+
+        [Fact]
+        public void UnlockMod_AlreadyUnlocked_DoesNotRaiseSecondEvent()
+        {
+            var player = MakePlayer();
+            player.UnlockMod(5);
+            player.ClearEvents();
+
+            player.UnlockMod(5);
+
+            Assert.Empty(player.DomainEvents.OfType<ModUnlockedEvent>());
+        }
+
+        [Fact]
+        public void UnlockSkill_AlreadyUnlocked_DoesNotRaiseSecondEvent()
+        {
+            var player = MakePlayer();
+            player.UnlockSkill(MakeSkill(id: 7));
+            player.ClearEvents();
+
+            player.UnlockSkill(MakeSkill(id: 7));
+
+            Assert.Empty(player.DomainEvents.OfType<SkillUnlockedEvent>());
+        }
+
         // ── CompleteChallenge ────────────────────────────────────────────────
 
         [Fact]

--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -235,6 +235,25 @@ namespace Game.Core.Tests.Progress
         }
 
         [Fact]
+        public void RecordBattleCompleted_BossVictoryInAlreadyClearedZone_DoesNotRecountGlobalZonesCleared()
+        {
+            // First-clear is gated on the per-zone row's presence (the documented invariant), not a magic 0.
+            // An aggregate loaded with the zone already cleared must not re-bump the global counter on a
+            // re-farm — exercising the load-then-mutate path the in-session re-farm test doesn't.
+            var progress = MakeProgress(statistics:
+            [
+                Stat(EStatisticType.ZonesCleared, null, 1m),
+                Stat(EStatisticType.ZonesCleared, 2, 1m),
+            ]);
+
+            progress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000,
+                new BattleStats(), isBossBattle: true, zoneId: 2);
+
+            Assert.Equal(1m, progress.GetStatisticValue(EStatisticType.ZonesCleared, null));
+            Assert.Equal(1m, progress.GetStatisticValue(EStatisticType.ZonesCleared, 2));
+        }
+
+        [Fact]
         public void RecordBattleCompleted_PlayerDied_IncrementsPlayerDeaths()
         {
             var progress = MakeProgress();
@@ -612,6 +631,22 @@ namespace Game.Core.Tests.Progress
 
             Assert.Single(completed);
             Assert.True(Assert.Single(progress.ChallengeProgress).Completed);
+        }
+
+        [Fact]
+        public void EvaluateChallenges_NewlyRelevantChallengeWithNoProgress_PersistsNoInfoFreeRow()
+        {
+            // A challenge that becomes relevant but gains no progress this battle must not commit an
+            // information-free (zero-progress, incomplete) row: it stays out of both the write-behind
+            // persist set and the cached snapshot exposed via ChallengeProgress.
+            var challenge = MakeChallenge(id: 0, EChallengeType.EnemiesKilled, goal: 5);
+            var progress = MakeProgress(); // no EnemiesKilled statistic recorded yet
+
+            var completed = progress.EvaluateChallenges([challenge]);
+
+            Assert.Empty(completed);
+            Assert.Empty(progress.DirtyChallenges);
+            Assert.Empty(progress.ChallengeProgress);
         }
 
         [Fact]

--- a/Game.Core/Players/Inventories/EquipmentSlot.cs
+++ b/Game.Core/Players/Inventories/EquipmentSlot.cs
@@ -23,14 +23,17 @@ namespace Game.Core.Players.Inventories
         public EItemCategory ItemCategory => GetItemCategory(Value);
 
         /// <summary>
-        /// The item ID of the equipped item, or null when the slot is empty.
-        /// </summary>
-        public int? ItemId { get; set; }
-
-        /// <summary>
-        /// The item that is currently equipped in this slot.
+        /// The item that is currently equipped in this slot, or null when the slot is empty. The single
+        /// source of truth for what the slot holds; <see cref="ItemId"/> is derived from it so the two can
+        /// never desync.
         /// </summary>
         public Item? Item { get; set; }
+
+        /// <summary>
+        /// The item ID of the equipped item, or null when the slot is empty. Derived from
+        /// <see cref="Item"/> rather than stored independently.
+        /// </summary>
+        public int? ItemId => Item?.Id;
 
         /// <summary>
         /// Creates a new equipment slot based on the given enum value.
@@ -46,7 +49,6 @@ namespace Game.Core.Players.Inventories
         /// </summary>
         public void Set(Item item)
         {
-            ItemId = item.Id;
             Item = item;
         }
 
@@ -55,7 +57,6 @@ namespace Game.Core.Players.Inventories
         /// </summary>
         public void Clear()
         {
-            ItemId = null;
             Item = null;
         }
 

--- a/Game.Core/Players/Inventories/Inventory.cs
+++ b/Game.Core/Players/Inventories/Inventory.cs
@@ -190,24 +190,32 @@ namespace Game.Core.Players.Inventories
             return true;
         }
 
-        public void UnlockItem(Item item)
+        /// <summary>
+        /// Unlocks <paramref name="item"/> for the player, returning whether it was newly unlocked
+        /// (<c>false</c> when the player already owned it) so the caller can skip the no-op event and persist.
+        /// </summary>
+        public bool UnlockItem(Item item)
         {
             if (_unlockedItems.ContainsKey(item.Id))
             {
-                return;
+                return false;
             }
 
             _unlockedItems[item.Id] = new UnlockedItemSlot
             {
-                ItemId = item.Id,
                 Item = item,
                 AppliedMods = [],
             };
+            return true;
         }
 
-        public void UnlockMod(int itemModId)
+        /// <summary>
+        /// Unlocks the modifier with the given <paramref name="itemModId"/>, returning whether it was newly
+        /// unlocked (<c>false</c> when the player already owned it).
+        /// </summary>
+        public bool UnlockMod(int itemModId)
         {
-            UnlockedMods.Add(itemModId);
+            return UnlockedMods.Add(itemModId);
         }
 
         private static List<EquipmentSlot> NewEquippedList()

--- a/Game.Core/Players/Inventories/UnlockedItemSlot.cs
+++ b/Game.Core/Players/Inventories/UnlockedItemSlot.cs
@@ -7,8 +7,12 @@ namespace Game.Core.Players.Inventories
     /// </summary>
     public class UnlockedItemSlot
     {
-        public required int ItemId { get; set; }
+        /// <summary>The unlocked item. The single source of truth; <see cref="ItemId"/> derives from it.</summary>
         public required Item Item { get; set; }
+
+        /// <summary>The id of the unlocked <see cref="Item"/>, derived rather than stored independently.</summary>
+        public int ItemId => Item.Id;
+
         public required List<AppliedModSlot> AppliedMods { get; set; }
 
         /// <summary>Whether the player has favorited this item.</summary>

--- a/Game.Core/Players/NewPlayerFactory.cs
+++ b/Game.Core/Players/NewPlayerFactory.cs
@@ -1,3 +1,5 @@
+using Game.Core.Attributes;
+
 namespace Game.Core.Players
 {
     /// <summary>
@@ -10,9 +12,6 @@ namespace Game.Core.Players
     {
         /// <summary>Number of starter skills granted to a new player (skill ids 0..N-1), all selected.</summary>
         public const int StarterSkillCount = 3;
-
-        /// <summary>Number of core attributes a new player starts with (attribute ids 0..N-1).</summary>
-        public const int AttributeCount = 6;
 
         /// <summary>The starting amount for each of a new player's core attributes.</summary>
         public const double StartingAttributeAmount = 5d;
@@ -37,8 +36,13 @@ namespace Game.Core.Players
                 Skills = Enumerable.Range(0, StarterSkillCount)
                     .Select((id, index) => new NewPlayerSkill { SkillId = id, Selected = true, Order = index })
                     .ToList(),
-                Attributes = Enumerable.Range(0, AttributeCount)
-                    .Select(id => new StatAllocation { Attribute = (EAttribute)id, Amount = StartingAttributeAmount })
+                // Seed an allocation row for exactly the core (directly-allocatable) attributes, derived from
+                // the attribute set itself rather than a hardcoded count — so adding a seventh core attribute
+                // automatically grants new players its allocation row (without one, PlayerStatPoints rejects
+                // every allocation into it, permanently blocking the stat).
+                Attributes = Enum.GetValues<EAttribute>()
+                    .Where(Attribute.IsCore)
+                    .Select(attribute => new StatAllocation { Attribute = attribute, Amount = StartingAttributeAmount })
                     .ToList(),
                 LogPreferences = CreateDefaultLogPreferences(),
             };

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -70,37 +70,43 @@ namespace Game.Core.Players
         }
 
         /// <summary>
-        /// Unlocks an item for the player and raises an <see cref="ItemUnlockedEvent"/>.
+        /// Unlocks an item for the player and raises an <see cref="ItemUnlockedEvent"/> only when the item
+        /// was newly unlocked — re-granting an already-owned item is a no-op (no redundant write-behind or
+        /// client "unlocked!" notification).
         /// </summary>
         public void UnlockItem(Item item)
         {
-            Inventory.UnlockItem(item);
-            RaiseEvent(new ItemUnlockedEvent(Id, item.Id));
+            if (Inventory.UnlockItem(item))
+            {
+                RaiseEvent(new ItemUnlockedEvent(Id, item.Id));
+            }
         }
 
         /// <summary>
-        /// Unlocks a modifier for the player and raises a <see cref="ModUnlockedEvent"/>.
+        /// Unlocks a modifier for the player and raises a <see cref="ModUnlockedEvent"/> only when the
+        /// modifier was newly unlocked — re-granting an already-owned modifier is a no-op.
         /// </summary>
         public void UnlockMod(int itemModId)
         {
-            Inventory.UnlockMod(itemModId);
-            RaiseEvent(new ModUnlockedEvent(Id, itemModId));
+            if (Inventory.UnlockMod(itemModId))
+            {
+                RaiseEvent(new ModUnlockedEvent(Id, itemModId));
+            }
         }
 
         /// <summary>
-        /// Unlocks a skill for the player and raises a <see cref="SkillUnlockedEvent"/>. The skill is
-        /// added to <see cref="Skills"/> unselected — earning a skill does not equip it (the player
-        /// chooses their loadout via the selection flow). Mirrors <see cref="UnlockItem"/>: the in-memory
-        /// set is de-duplicated and the event is raised for the idempotent write-behind insert to apply.
+        /// Unlocks a skill for the player and raises a <see cref="SkillUnlockedEvent"/> only when the skill
+        /// was newly unlocked. The skill is added to <see cref="Skills"/> unselected — earning a skill does
+        /// not equip it (the player chooses their loadout via the selection flow). Mirrors
+        /// <see cref="UnlockItem"/>: re-granting an already-owned skill is a no-op.
         /// </summary>
         public void UnlockSkill(Skill skill)
         {
             if (!Skills.Any(s => s.Id == skill.Id))
             {
                 Skills.Add(skill);
+                RaiseEvent(new SkillUnlockedEvent(Id, skill.Id));
             }
-
-            RaiseEvent(new SkillUnlockedEvent(Id, skill.Id));
         }
 
         /// <summary>

--- a/Game.Core/Progress/PlayerProgress.cs
+++ b/Game.Core/Progress/PlayerProgress.cs
@@ -73,9 +73,10 @@ namespace Game.Core.Progress
                     Record(EStatisticType.BossesDefeated, enemy.Id, 1);
 
                     // ZonesCleared counts distinct zones ever cleared, not boss-victory events. The per-zone
-                    // entry is a binary "cleared" flag, and the global counter only bumps on a zone's first
-                    // clear (its 0 -> 1 transition), so re-farming a boss never re-counts the zone.
-                    if (GetStatisticValue(EStatisticType.ZonesCleared, zoneId) == 0)
+                    // entry is a binary "cleared" flag whose absence (not a magic 0) is the "never cleared"
+                    // state, so the global counter only bumps on a zone's first clear and re-farming a boss
+                    // never re-counts the zone — keying off row presence per the documented invariant.
+                    if (!TryGetStatisticValue(EStatisticType.ZonesCleared, zoneId, out _))
                     {
                         Record(EStatisticType.ZonesCleared, null, 1);
                         Record(EStatisticType.ZonesCleared, zoneId, 1);
@@ -128,20 +129,26 @@ namespace Game.Core.Progress
                     continue;
                 }
 
+                // Evaluate a newly-relevant challenge against a working row without committing it yet: a
+                // challenge that becomes relevant but gains no progress this battle must not persist an
+                // information-free (zero-progress, incomplete) row, which would bloat the write-behind and
+                // the cache snapshot and partially undo the RelevantTo reverse-index scoping.
                 var isNew = playerChallenge is null;
-                if (playerChallenge is null)
-                {
-                    playerChallenge = new PlayerChallenge(challenge, progress: 0, completed: false);
-                    _challenges[challenge.Id] = playerChallenge;
-                }
+                playerChallenge ??= new PlayerChallenge(challenge, progress: 0, completed: false);
 
                 var beforeProgress = playerChallenge.Progress;
                 var beforeCompleted = playerChallenge.Completed;
 
                 challenge.UpdateChallengeProgress(playerChallenge, this);
 
-                if (isNew || playerChallenge.Progress != beforeProgress || playerChallenge.Completed != beforeCompleted)
+                if (playerChallenge.Progress != beforeProgress || playerChallenge.Completed != beforeCompleted)
                 {
+                    // Commit a freshly-created row only once it actually carries information.
+                    if (isNew)
+                    {
+                        _challenges[challenge.Id] = playerChallenge;
+                    }
+
                     _dirtyChallenges.Add(challenge.Id);
                 }
 

--- a/Game.DataAccess/Mapping/PlayerMapper.cs
+++ b/Game.DataAccess/Mapping/PlayerMapper.cs
@@ -99,7 +99,6 @@ namespace Game.DataAccess.Mapping
 
                 unlockedItems.Add(new UnlockedItemSlot
                 {
-                    ItemId = ui.ItemId,
                     Item = coreItem,
                     AppliedMods = appliedMods,
                     Favorite = ui.Favorite,


### PR DESCRIPTION
## Summary

Addresses the grab-bag of latent correctness/hygiene issues in `Game.Core`'s player + progress aggregates from #912. None was an active user-facing bug; each was a fragility or guideline mismatch.

1. **`ZonesCleared` first-clear keys off row presence, not a magic 0.** `PlayerProgress` now branches on `!TryGetStatisticValue(...)` (the documented invariant) instead of `GetStatisticValue(...) == 0`, removing the latent double-count trap.
2. **`EvaluateChallenges` no longer persists info-free challenge rows.** A newly-relevant challenge is committed to the aggregate (and marked dirty) only once it actually gains progress or completes — so a zero-progress, incomplete row no longer hits the write-behind queue *or* the cache snapshot, restoring the `RelevantTo` reverse-index scoping.
3. **`NewPlayerFactory` derives the allocation seed from the core attribute set.** Replaces the hardcoded `AttributeCount = 6` with `Enum.GetValues<EAttribute>().Where(Attribute.IsCore)`, so adding a seventh core attribute automatically grants new players its allocation row (without one, `PlayerStatPoints` permanently rejects allocations into it).
4. **Idempotent unlocks raise no event on the no-op path.** `Inventory.UnlockItem`/`UnlockMod` now return whether a change occurred, and `Player` raises `ItemUnlocked`/`ModUnlocked`/`SkillUnlocked` only when something actually unlocked — no redundant write-behind work or client "unlocked!" notice on a re-grant.
5. **`EquipmentSlot`/`UnlockedItemSlot` make `Item` the single source of truth.** `ItemId` is now derived (`Item?.Id` / `Item.Id`) rather than an independently-settable property, so the two can never desync on the battle-parity surface.
6. **`AccountService` factors the duplicated player selection.** `Login` and `ResolveSelectedPlayerId` now share one `SelectPlayerId` helper instead of each hardcoding `PlayerIds[0]`.

## Notes / decisions

- **Item 3 sources from the core set, not the display `Primary` taxonomy.** The issue suggested deriving from `EAttributeType.Primary`, but `Enums.cs` and `backend.md` deliberately keep the display taxonomy *distinct* from the core/allocatable power-calc invariant. The set that actually governs which attributes get an allocation row (and which `PlayerStatPoints.TryUpdateAttributes` accepts) is `Attribute.IsCore`, so I seeded from that — the more correct source.
- **Item 6 (low urgency) was treated as the DRY/document option, not a new multi-player selection feature.** The single-player-per-account invariant is documented on the new `SelectPlayerId` helper, which is the single seam a real selection mechanism would grow from. A real multi-player selection path remains future work and is out of scope here.

## Test plan

- [x] `dotnet build` clean (0 warnings)
- [x] `Game.Core.Tests` — 649 passed
- [x] `Game.Application.Tests` — 334 passed
- [x] `Game.Api.Tests` — 537 passed

New coverage: no-op unlock events (item 4), derived `ItemId` on both slot types (item 5), presence-gated first clear on a loaded aggregate (item 1), and the no-info-free-row challenge path (item 2). Items 3 & 6 are pinned by the updated `NewPlayerFactoryTests` and the existing `AccountServiceIntegrationTests`. No battle math changed, so no frontend parity changes; nothing is `[ClientMirrored]`, so no codegen drift.

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyETdxoik4drm1QMNzP83M)_