### PR TITLE
Make IApiSocketResponse.data optional so the error-path guard is type-enforced

### DIFF
--- a/UI/src/lib/api/api-socket-request.ts
+++ b/UI/src/lib/api/api-socket-request.ts
@@ -38,9 +38,9 @@ export class ApiSocketRequest<T extends ApiSocketCommand | void = void> {
 	 *  drops before the server answered. Mirrors the shape of a server-reported error so callers handle it
 	 *  through the same `response.error` path they already use, rather than a separate reject channel. */
 	public settleWithError(error: string) {
-		// An error response carries no `data` (matching how the server signals errors), so the cast bridges
-		// the type's non-optional `data` field that callers already guard with optional chaining.
-		this.promiseResolver({ id: this.id, name: this.commandName, error } as IApiSocketResponse<T>);
+		// An error response carries no `data`, matching how the server signals errors so callers fall
+		// through the same `response.error` guard rather than reading a partial payload.
+		this.promiseResolver({ id: this.id, name: this.commandName, error });
 	}
 
 	public async getResponse() {

--- a/UI/src/lib/api/api-socket.ts
+++ b/UI/src/lib/api/api-socket.ts
@@ -48,7 +48,9 @@ export interface IApiSocketResponse<T extends ApiSocketCommand | void = void> {
 	id: string;
 	name: T;
 	error?: string;
-	data: T extends ApiSocketCommand ? ApiSocketResponseTypes[T] : never;
+	// Optional because every failure (server error, dropped connection, timeout) resolves with an
+	// `error` and no `data`; the type then forces callers to guard `error`/optional-chain `data`.
+	data?: T extends ApiSocketCommand ? ApiSocketResponseTypes[T] : never;
 }
 
 let socket: WebSocket;
@@ -417,8 +419,10 @@ export async function fetchSocketData<T extends ApiSocketCommandNoRequest>(
 	command: T
 ): Promise<ApiSocketResponseTypes[T]> {
 	const response = await apiSocket.sendSocketCommand(command);
-	if (response.error) {
-		throw new Error(response.error);
+	// A failure resolves with an `error` and no `data`; a successful reply always carries data, so a
+	// missing payload on a non-error response is itself a protocol error worth surfacing as a throw.
+	if (response.error || response.data === undefined) {
+		throw new Error(response.error ?? 'The server returned no data.');
 	}
 	return response.data;
 }

--- a/UI/src/tests/lib/api/api-socket.test.ts
+++ b/UI/src/tests/lib/api/api-socket.test.ts
@@ -532,6 +532,19 @@ describe('ApiSocket', () => {
 
 			await expect(promise).rejects.toThrow('Server boom');
 		});
+
+		it('throws when a non-error response carries no data', async () => {
+			const promise = fetchSocketData('GetZones');
+			await flushMicrotasks();
+			const ws = lastWs();
+			const sent = JSON.parse(ws.send.mock.calls[0][0]);
+
+			// A reply with neither an error nor a payload is a protocol violation; surface it as a throw
+			// rather than handing back undefined as if it were valid data.
+			receive(ws, JSON.stringify({ id: sent.id, name: 'GetZones' }));
+
+			await expect(promise).rejects.toThrow('The server returned no data.');
+		});
 	});
 
 	describe('socket error propagation', () => {


### PR DESCRIPTION
## Summary

The socket transport signals **every** failure (server error, dropped connection, per-request timeout) by **resolving** the promise with a response carrying an `error` field and **no `data`** — callers are expected to inspect `response.error` and optional-chain `response.data?.x`. But `IApiSocketResponse.data` was declared **non-optional**, so:

- `settleWithError` had to use an `as IApiSocketResponse<T>` assertion to fabricate a legitimately data-less error response, and
- any caller dereferencing `response.data` without first checking `error` (or optional-chaining) compiled fine, throwing only on the rarely-tested error path — a latent runtime-throw trap.

This makes `data` optional (`data?: …`), so the type system now enforces the very guard the docs describe.

## How it addresses the issue (#940)

- **The cast is gone.** `settleWithError` constructs the data-less error response directly, no `as` assertion.
- **The guard is now type-enforced.** Every caller that dereferences `response.data` must guard `error` / optional-chain. Audited all socket-response consumers:
  - `enemy-manager.ts`, `engine.ts`, `attributes-view.svelte.ts` already optional-chain or guard `!response.data` — no change needed, and they now type-check correctly.
  - `fetchSocketData` previously dereferenced `response.data` after only checking `error`; the two fields aren't coupled in the type, so it now also surfaces a data-less **non-error** reply (a protocol violation) as a throw rather than returning `undefined` as if it were valid data.
  - `+page.svelte` and `session.ts` `.data` derefs are on **HTTP** `ApiRequest` responses, not the socket type — unaffected.

No consumer code changes were required; this is purely the type tightening plus the `fetchSocketData` completeness guard. This is squarely the CLAUDE.md guideline (avoid the null-forgiving operator / unsafe casts; handle nullability properly).

## Test plan

- [x] `npm run lint` (eslint + `svelte-check`) — 0 errors / 0 warnings across 981 files
- [x] `npm run test:unit:ci` — **2183 passed** (214 files)
- [x] New test: `fetchSocketData` throws when a non-error response carries no data (covers the new completeness guard). Existing `api-socket-request` tests already pin `response.data === undefined` on the error path.

No battle logic touched, so no parity changes; nothing is codegen'd here.

Closes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyXCQnQtvz1aKxvCBw6h3y)_