### PR TITLE
Split non-test verifications into separate CI jobs (#943)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -62,7 +62,10 @@ jobs:
             - 'UI/**'
             - '.github/workflows/**'
 
-  test-backend:
+  # Non-test backend verifications (codegen drift + formatter), split out of test-backend so that
+  # job is left with just build + tests/coverage (its longest path). Both checks need the build, so
+  # this job builds independently and runs in parallel with test-backend rather than chaining off it.
+  verify-backend:
     needs: [detect-changes]
     # always()/!cancelled() lets this evaluate even when detect-changes was skipped (push events).
     if: |
@@ -73,8 +76,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
 
     - name: Install .NET Core
       uses: actions/setup-dotnet@v5
@@ -106,6 +107,66 @@ jobs:
       # --no-restore reuses the restore/build from "Build solution" above; without it dotnet format
       # triggers its own implicit restore + MSBuild evaluation (mirrors the codegen/coverage steps).
       run: dotnet format --verify-no-changes --no-restore
+
+  # Non-test frontend verification (ESLint + svelte-check, both via `npm run lint`), split out of
+  # test-frontend so that job is left with just the unit-test + coverage run. Runs in parallel.
+  verify-frontend:
+    needs: [detect-changes]
+    # always()/!cancelled() lets this evaluate even when detect-changes was skipped (push events).
+    if: |
+      always() && !cancelled() &&
+      (github.event_name == 'push' || needs.detect-changes.outputs.frontend == 'true')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: UI
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+
+    - name: Set up Node
+      uses: actions/setup-node@v6
+      with:
+        node-version-file: UI/.nvmrc
+        cache: npm
+        cache-dependency-path: UI/package-lock.json
+
+    - name: Install node modules
+      run: npm ci
+
+    - name: Run lint (ESLint + svelte-check)
+      run: npm run lint
+
+  test-backend:
+    needs: [detect-changes]
+    # always()/!cancelled() lets this evaluate even when detect-changes was skipped (push events).
+    if: |
+      always() && !cancelled() &&
+      (github.event_name == 'push' || needs.detect-changes.outputs.backend == 'true')
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Cache NuGet packages
+      uses: actions/cache@v5
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          nuget-${{ runner.os }}-
+
+    - name: Build solution
+      run: dotnet build
 
     - name: Execute tests with coverage gate
       # build/coverage.ps1 restores the coverage tools, collects one merged Cobertura across the whole
@@ -160,9 +221,6 @@ jobs:
       # .nvmrc (see "Set up Node"); keep local dev on that same version (`nvm use`) or the lock can
       # drift — the optional WASM-runtime deps are recorded differently across npm versions.
       run: npm ci
-
-    - name: Run ESLint
-      run: npm run lint
 
     - name: Run unit tests
       run: npm run test:unit:ci
@@ -296,7 +354,7 @@ jobs:
     # skipped (path-filtered out); fails if any job failed or was cancelled, including
     # detect-changes itself (a change-detection failure should block the PR, not silently skip tests).
     if: always()
-    needs: [detect-changes, test-backend, test-frontend, test-e2e]
+    needs: [detect-changes, verify-backend, verify-frontend, test-backend, test-frontend, test-e2e]
     runs-on: ubuntu-latest
     steps:
     - name: Verify all jobs passed or were skipped

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -28,6 +28,13 @@ The codegen also emits a small amount of **static domain data** that the fronten
 
 Because all of this lands under `UI/src/lib/api/types`, the existing CI codegen-drift check already guards it: a retune of a coefficient (or an enum value) that isn't regenerated fails the `git diff`, so the cross-implementation parity no longer rests on a human keeping the two files in step.
 
+## CI job split: verifications run apart from tests
+
+The `run-tests.yml` workflow keeps the **non-test verifications in their own jobs**, separate from the heavy test jobs: `verify-backend` runs the TypeScript codegen-drift check and `dotnet format --verify-no-changes`, and `verify-frontend` runs `npm run lint` (ESLint + `svelte-check`). This leaves `test-backend` on just build + tests/coverage (its longest path) and `test-frontend` on `npm ci` + the unit-test/coverage run, with the verifications running in parallel rather than in series ahead of the tests.
+
+- **`verify-backend` builds the solution again** (the codegen and formatter both need the binaries) rather than chaining off `test-backend`. This is the same free-CI-minutes-for-shorter-critical-path trade-off the parallel `test-e2e` build makes, and serves #943's goal of shortening the longest job.
+- Both verify jobs reuse the per-area `detect-changes` gating, so a frontend-only PR still won't spin up .NET (and vice-versa), and `all-checks-passed` lists them in `needs` so they stay blocking for branch protection.
+
 ## Shared domain-object test builders
 
 Domain aggregates like `Player` have many `required` members, so tests previously hand-rolled the full object graph in every file that needed one — adding a member meant editing every copy. Shared **fluent builders** (e.g. `PlayerBuilder`) now own that construction with sensible defaults, so a test specifies only the fields it cares about and adding a required member is a one-line change in the builder.


### PR DESCRIPTION
## Summary

Splits the non-test verification steps out of the heavy test jobs into their own jobs, as requested in #943, so the test jobs run leaner and the verifications run in parallel.

- **New `verify-backend` job** — runs the TypeScript codegen-drift check and `dotnet format --verify-no-changes`, moved out of `test-backend`. Both checks need the build, so this job does its own `dotnet build` and runs concurrently with `test-backend` rather than chaining off it.
- **New `verify-frontend` job** — runs `npm run lint` (ESLint + `svelte-check`, since the repo's `lint` script is `eslint . && npm run check`), moved out of `test-frontend`.
- **`test-backend`** is left with just build + tests/coverage — its longest path — shortening its wall-clock by the codegen + format time.
- **`test-frontend`** is left with just `npm ci` + the unit-test/coverage run.
- **`all-checks-passed`** now lists the two new jobs in `needs`, so they stay blocking for branch protection.

Both new jobs reuse the existing `detect-changes` gating (backend vs. frontend) and the same toolchain/cache setup as their test counterparts, so a frontend-only PR still won't spin up .NET and vice-versa.

## How it addresses the issue

#943 asks to split a CI job for the non-test verifications (codegen, dotnet formatter, ESLint + svelte check) "mostly to speed up the test-backend job, which usually runs the longest." Moving codegen + format off the `test-backend` critical path is the main win; they now run in parallel in `verify-backend` instead of in series before the tests.

## Design note for reviewer

The issue says "a new CI job" (singular). I implemented it as **two parallel jobs** (`verify-backend` / `verify-frontend`) rather than one combined job, because:
- It serves the stated goal (wall-clock speed) better — a single combined job would serialize the backend build and the frontend lint, whereas two jobs run them concurrently.
- It mirrors the existing `test-backend` / `test-frontend` split and reuses the per-area `detect-changes` gating cleanly (no per-step conditionals), so each side stays independently skippable.

Happy to consolidate into a single job if you'd prefer that — it's a small change either way.

There is a deliberate trade-off: `verify-backend` builds the solution again (in parallel with `test-backend`'s build) since codegen + format require the binaries. This costs an extra parallel build of runner minutes in exchange for the shorter critical path, consistent with the issue's "speed up test-backend" intent and the repo's existing preference for simple parallelism over build-artifact sharing (see the `test-e2e` notes in `docs/infrastructure.md`).

## Test plan

- [x] Workflow YAML parses and the job graph is correct (`detect-changes` → `verify-backend`/`verify-frontend`/`test-backend`/`test-frontend`/`test-e2e` → `all-checks-passed`).
- [x] Every moved step uses the exact command from the previously-passing workflow; no command text changed.
- [ ] CI on this PR exercises all jobs end-to-end (the workflow change touches `.github/workflows/**`, which both change-detection filters include, so backend, frontend, and e2e all run).

Closes #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016CFH93e4bwuQ63XrNfL6jc)_