### PR TITLE
Add per-IP rate limiting to anonymous auth endpoints (#950)

### DIFF
--- a/Game.Api.Tests/Integration/AuthRateLimitingTests.cs
+++ b/Game.Api.Tests/Integration/AuthRateLimitingTests.cs
@@ -1,0 +1,98 @@
+using Game.Api.Models.Common;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    /// <summary>
+    /// Covers the per-client-IP auth rate limiter (#950): the anonymous auth endpoints are throttled with
+    /// the project's standard error envelope once the configured limit is exceeded, the limit is a shared
+    /// budget across those endpoints, and a request under the limit is unaffected. The factory pins the
+    /// limit to a small value so the throttle can be exercised deterministically (the in-memory TestServer
+    /// has no socket peer, so every request shares the "unknown" partition).
+    /// </summary>
+    [Collection("Integration")]
+    public class AuthRateLimitingTests : ApiIntegrationTestBase
+    {
+        private const int PermitLimit = 3;
+
+        public AuthRateLimitingTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        protected override GameServerFactory CreateFactory(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+        {
+            return new RateLimitedFactory(containers, testOutputHelper);
+        }
+
+        [Fact]
+        public async Task Login_BeyondPermitLimit_IsThrottledWithEnvelope()
+        {
+            var creds = new { Username = "nobody", Password = "wrong" };
+
+            // The first PermitLimit attempts run the endpoint (rejected as bad credentials, not throttled).
+            for (var i = 0; i < PermitLimit; i++)
+            {
+                var allowed = await Client.PostAsJsonAsync("/api/Login", creds, CancellationToken);
+                Assert.NotEqual(HttpStatusCode.TooManyRequests, allowed.StatusCode);
+            }
+
+            // The next attempt is throttled before the endpoint runs.
+            var throttled = await Client.PostAsJsonAsync("/api/Login", creds, CancellationToken);
+            Assert.Equal(HttpStatusCode.TooManyRequests, throttled.StatusCode);
+            Assert.True(throttled.Headers.Contains("Retry-After"));
+
+            var body = await throttled.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(body);
+            Assert.False(string.IsNullOrEmpty(body.ErrorMessage));
+        }
+
+        [Fact]
+        public async Task AuthEndpoints_ShareOnePerIpBudget()
+        {
+            var creds = new { Username = "nobody", Password = "wrong" };
+
+            // Exhaust the budget via Login.
+            for (var i = 0; i < PermitLimit; i++)
+            {
+                await Client.PostAsJsonAsync("/api/Login", creds, CancellationToken);
+            }
+
+            // A sibling auth endpoint draws from the same per-IP partition, so it is already throttled.
+            var createAccount = await Client.PostAsJsonAsync("/api/Login/CreateAccount", creds, CancellationToken);
+            Assert.Equal(HttpStatusCode.TooManyRequests, createAccount.StatusCode);
+        }
+
+        [Fact]
+        public async Task SingleRequest_UnderLimit_IsNotThrottled()
+        {
+            var response = await Client.PostAsJsonAsync(
+                "/api/Login", new { Username = "nobody", Password = "wrong" }, CancellationToken);
+
+            Assert.NotEqual(HttpStatusCode.TooManyRequests, response.StatusCode);
+        }
+
+        private sealed class RateLimitedFactory(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : GameServerFactory(containers, testOutputHelper)
+        {
+            protected override void ConfigureWebHost(IWebHostBuilder builder)
+            {
+                base.ConfigureWebHost(builder);
+
+                // Registered after the base config, so this small limit overrides the suite-wide high one.
+                builder.ConfigureAppConfiguration((_, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["RateLimiting:Auth:PermitLimit"] = PermitLimit.ToString(),
+                        ["RateLimiting:Auth:WindowSeconds"] = "60",
+                    });
+                });
+            }
+        }
+    }
+}

--- a/Game.Api.Tests/Unit/ClientIpResolutionTests.cs
+++ b/Game.Api.Tests/Unit/ClientIpResolutionTests.cs
@@ -1,4 +1,4 @@
-using Game.Api.Middleware;
+using Game.Api.Http;
 using Microsoft.AspNetCore.Http;
 using System.Net;
 using Xunit;
@@ -6,11 +6,12 @@ using Xunit;
 namespace Game.Api.Tests.Unit
 {
     /// <summary>
-    /// Covers <see cref="LoginTrackingMiddleware.ResolveIpAddress"/>: it reads the transport remote address
-    /// (corrected by the forwarded-headers middleware only for trusted proxies), never trusts a raw
-    /// <c>X-Forwarded-For</c> header itself, and falls back to "unknown" when there is no remote address.
+    /// Covers <see cref="ClientIp.Resolve"/>: it reads the transport remote address (corrected by the
+    /// forwarded-headers middleware only for trusted proxies), never trusts a raw <c>X-Forwarded-For</c>
+    /// header itself, and falls back to "unknown" when there is no remote address. This is the shared
+    /// resolution behind both login-IP tracking and the auth rate-limiter partition key.
     /// </summary>
-    public class LoginTrackingIpResolutionTests
+    public class ClientIpResolutionTests
     {
         private static HttpContext ContextWith(string? forwardedFor, IPAddress? remoteIp)
         {
@@ -28,7 +29,7 @@ namespace Game.Api.Tests.Unit
         {
             var context = ContextWith(forwardedFor: null, IPAddress.Parse("198.51.100.7"));
 
-            Assert.Equal("198.51.100.7", LoginTrackingMiddleware.ResolveIpAddress(context));
+            Assert.Equal("198.51.100.7", ClientIp.Resolve(context));
         }
 
         [Fact]
@@ -38,7 +39,7 @@ namespace Game.Api.Tests.Unit
             // forwarded-headers middleware (for a trusted proxy) may rewrite RemoteIpAddress.
             var context = ContextWith("203.0.113.5", IPAddress.Parse("198.51.100.7"));
 
-            Assert.Equal("198.51.100.7", LoginTrackingMiddleware.ResolveIpAddress(context));
+            Assert.Equal("198.51.100.7", ClientIp.Resolve(context));
         }
 
         [Fact]
@@ -46,7 +47,7 @@ namespace Game.Api.Tests.Unit
         {
             var context = ContextWith(forwardedFor: null, remoteIp: null);
 
-            Assert.Equal("unknown", LoginTrackingMiddleware.ResolveIpAddress(context));
+            Assert.Equal("unknown", ClientIp.Resolve(context));
         }
     }
 }

--- a/Game.Api.Tests/Unit/RateLimitingOptionsTests.cs
+++ b/Game.Api.Tests/Unit/RateLimitingOptionsTests.cs
@@ -1,0 +1,72 @@
+using Game.Api.RateLimiting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Game.Api.Tests.Unit
+{
+    public class RateLimitingOptionsTests
+    {
+        [Fact]
+        public void Defaults_AreSafePositiveLimits()
+        {
+            // Security hardening is on by default: an unconfigured deployment still gets a real limit.
+            var options = new RateLimitingOptions();
+
+            Assert.Equal(10, options.Auth.PermitLimit);
+            Assert.Equal(60, options.Auth.WindowSeconds);
+        }
+
+        [Fact]
+        public void Bind_OverridesOnlyTheConfiguredField()
+        {
+            var options = new RateLimitingOptions();
+            BuildConfiguration(("RateLimiting:Auth:PermitLimit", "5"))
+                .GetSection(RateLimitingOptions.SectionName)
+                .Bind(options);
+
+            Assert.Equal(5, options.Auth.PermitLimit);
+            // The window keeps its default since config did not supply one.
+            Assert.Equal(60, options.Auth.WindowSeconds);
+        }
+
+        [Fact]
+        public void Validation_SucceedsWithDefaults_WhenSectionAbsent()
+        {
+            using var provider = BuildValidatedProvider(new ConfigurationBuilder().Build());
+
+            var options = provider.GetRequiredService<IOptions<RateLimitingOptions>>().Value;
+            Assert.Equal(10, options.Auth.PermitLimit);
+        }
+
+        [Fact]
+        public void Validation_ThrowsWhenPermitLimitNotPositive()
+        {
+            var configuration = BuildConfiguration(("RateLimiting:Auth:PermitLimit", "0"));
+
+            using var provider = BuildValidatedProvider(configuration);
+
+            var ex = Assert.Throws<OptionsValidationException>(() =>
+                provider.GetRequiredService<IOptions<RateLimitingOptions>>().Value);
+            Assert.Contains("RateLimiting:Auth", ex.Message);
+        }
+
+        private static IConfiguration BuildConfiguration(params (string Key, string Value)[] settings)
+        {
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection(settings.ToDictionary(s => s.Key, s => (string?)s.Value))
+                .Build();
+        }
+
+        // Exercises the real options registration (AddAuthRateLimiter) so the test pins the actual
+        // bind + validate path rather than a re-declaration of it.
+        private static ServiceProvider BuildValidatedProvider(IConfiguration configuration)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(configuration);
+            services.AddAuthRateLimiter();
+            return services.BuildServiceProvider();
+        }
+    }
+}

--- a/Game.Api/Controllers/LoginController.cs
+++ b/Game.Api/Controllers/LoginController.cs
@@ -3,9 +3,11 @@ using Game.Api.Models.Auth;
 using Game.Api.Models.Common;
 using Game.Api.Models.Player;
 using Game.Api.Services;
+using Game.Api.RateLimiting;
 using Game.Application.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace Game.Api.Controllers
 {
@@ -27,6 +29,7 @@ namespace Game.Api.Controllers
         private readonly PlayerService _playerService = playerService;
 
         [AllowAnonymous]
+        [EnableRateLimiting(RateLimitingOptions.AuthPolicy)]
         [HttpPost("/api/[controller]")]
         public async Task<ApiResponse<LoginResult>> Login([FromBody] LoginCredentials creds)
         {
@@ -48,6 +51,7 @@ namespace Game.Api.Controllers
         }
 
         [AllowAnonymous]
+        [EnableRateLimiting(RateLimitingOptions.AuthPolicy)]
         [HttpPost]
         public async Task<ApiResponse<AuthTokens>> Refresh([FromBody] RefreshRequest request)
         {
@@ -58,6 +62,7 @@ namespace Game.Api.Controllers
         }
 
         [AllowAnonymous]
+        [EnableRateLimiting(RateLimitingOptions.AuthPolicy)]
         [HttpPost]
         public async Task<ApiResponse> CreateAccount([FromBody] LoginCredentials creds)
         {

--- a/Game.Api/Http/ClientIp.cs
+++ b/Game.Api/Http/ClientIp.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Game.Api.Http
+{
+    /// <summary>
+    /// Resolves the originating client IP for a request, used as the partition key for rate limiting and
+    /// the recorded address for login tracking. It reads the transport remote address, which the
+    /// forwarded-headers middleware corrects to the real client only when the request arrives through a
+    /// configured trusted proxy — so a spoofed <c>X-Forwarded-For</c> from a direct client is never
+    /// honoured (#910). Falls back to "unknown" when there is no remote address.
+    /// </summary>
+    internal static class ClientIp
+    {
+        internal static string Resolve(HttpContext context)
+        {
+            return context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        }
+    }
+}

--- a/Game.Api/Middleware/LoginTrackingMiddleware.cs
+++ b/Game.Api/Middleware/LoginTrackingMiddleware.cs
@@ -27,7 +27,7 @@ namespace Game.Api.Middleware
                     var hints = ClientHints.FromHeaders(context.Request.Headers);
                     await trackingService.RecordConnection(
                         sessionService.UserId,
-                        ResolveIpAddress(context),
+                        ClientIp.Resolve(context),
                         fingerprint,
                         hints.UserAgent,
                         hints.SecChUa,
@@ -42,16 +42,6 @@ namespace Game.Api.Middleware
             }
 
             await _next(context);
-        }
-
-        /// <summary>
-        /// Resolves the originating client IP from the transport remote address. The forwarded-headers
-        /// middleware corrects this to the real client only when the request arrives through a configured
-        /// trusted proxy, so a spoofed <c>X-Forwarded-For</c> from a direct client is never honoured (#910).
-        /// </summary>
-        internal static string ResolveIpAddress(HttpContext context)
-        {
-            return context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
         }
     }
 

--- a/Game.Api/RateLimiting/RateLimiterServiceCollectionExtensions.cs
+++ b/Game.Api/RateLimiting/RateLimiterServiceCollectionExtensions.cs
@@ -1,0 +1,72 @@
+using Game.Api.Http;
+using Game.Api.Models.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System.Globalization;
+using System.Threading.RateLimiting;
+
+namespace Game.Api.RateLimiting
+{
+    /// <summary>
+    /// Registers the auth-endpoint rate limiter: a per-client-IP fixed-window policy that throttles the
+    /// anonymous auth endpoints to blunt credential stuffing, refresh-token brute force, and the PBKDF2
+    /// resource-exhaustion vector (#950). The partition key is resolved the same trusted-proxy way as the
+    /// login-IP tracking, so a spoofed <c>X-Forwarded-For</c> can't shard an attacker across partitions.
+    /// </summary>
+    public static class RateLimiterServiceCollectionExtensions
+    {
+        public static IServiceCollection AddAuthRateLimiter(this IServiceCollection services)
+        {
+            services.AddOptions<RateLimitingOptions>()
+                .BindConfiguration(RateLimitingOptions.SectionName)
+                .Validate(
+                    options => options.Auth.PermitLimit > 0 && options.Auth.WindowSeconds > 0,
+                    "RateLimiting:Auth PermitLimit and WindowSeconds must be positive")
+                .ValidateOnStart();
+
+            services.AddRateLimiter(options =>
+            {
+                options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+                options.OnRejected = OnRejected;
+                options.AddPolicy(RateLimitingOptions.AuthPolicy, BuildAuthPartition);
+            });
+
+            return services;
+        }
+
+        // One fixed-window partition per client IP. A new partition's limits are read once (on first touch)
+        // from the validated options, so a deployment's configured limits apply without re-reading per call.
+        private static RateLimitPartition<string> BuildAuthPartition(HttpContext httpContext)
+        {
+            var limits = httpContext.RequestServices
+                .GetRequiredService<IOptions<RateLimitingOptions>>().Value.Auth;
+
+            return RateLimitPartition.GetFixedWindowLimiter(ClientIp.Resolve(httpContext), _ =>
+                new FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = limits.PermitLimit,
+                    Window = TimeSpan.FromSeconds(limits.WindowSeconds),
+                    QueueLimit = 0,
+                });
+        }
+
+        // Surface the throttle as the project's standard { errorMessage } envelope (mirroring every other
+        // failure response) plus a Retry-After hint, rather than the framework's empty 429 body.
+        private static async ValueTask OnRejected(OnRejectedContext context, CancellationToken token)
+        {
+            context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+
+            if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
+            {
+                context.HttpContext.Response.Headers.RetryAfter =
+                    ((int)retryAfter.TotalSeconds).ToString(CultureInfo.InvariantCulture);
+            }
+
+            await context.HttpContext.Response.WriteAsJsonAsync(
+                new ApiResponse { ErrorMessage = "Too many requests. Please slow down and try again shortly." },
+                token);
+        }
+    }
+}

--- a/Game.Api/RateLimiting/RateLimitingOptions.cs
+++ b/Game.Api/RateLimiting/RateLimitingOptions.cs
@@ -1,0 +1,34 @@
+namespace Game.Api.RateLimiting
+{
+    /// <summary>
+    /// Configuration for the auth-endpoint rate limiter, bound from the "RateLimiting" configuration
+    /// section. Unlike the CORS origins, these carry safe non-empty defaults so an unconfigured deployment
+    /// is still protected (security hardening should be on by default); a deployment only overrides them to
+    /// tune the limits. The values are validated as positive on start so an accidental zero fails fast
+    /// rather than silently disabling protection.
+    /// </summary>
+    public class RateLimitingOptions
+    {
+        /// <summary>The configuration section this options class binds from.</summary>
+        public const string SectionName = "RateLimiting";
+
+        /// <summary>The named policy applied to the anonymous auth endpoints.</summary>
+        public const string AuthPolicy = "auth";
+
+        /// <summary>
+        /// The per-client-IP window for the anonymous auth endpoints (login, refresh, account creation) —
+        /// the credential-stuffing, refresh-token brute-force, and PBKDF2 resource-exhaustion surface.
+        /// </summary>
+        public RateLimitWindow Auth { get; set; } = new() { PermitLimit = 10, WindowSeconds = 60 };
+    }
+
+    /// <summary>A fixed-window rate limit: at most <see cref="PermitLimit"/> requests per window.</summary>
+    public class RateLimitWindow
+    {
+        /// <summary>Maximum number of requests permitted per window per partition.</summary>
+        public int PermitLimit { get; set; }
+
+        /// <summary>The length of the fixed window, in seconds.</summary>
+        public int WindowSeconds { get; set; }
+    }
+}

--- a/Game.Api/Startup.cs
+++ b/Game.Api/Startup.cs
@@ -7,6 +7,7 @@ using Game.Api.Events;
 using Game.Api.Filters;
 using Game.Api.Forwarding;
 using Game.Api.Middleware;
+using Game.Api.RateLimiting;
 using Game.Api.Services;
 using Game.Api.Sockets.Commands;
 using Game.Application.Auth;
@@ -85,6 +86,11 @@ namespace Game.Api
                 .BindConfiguration(ForwardedHeadersConfig.SectionName);
             builder.Services.AddOptions<ForwardedHeadersOptions>()
                 .Configure<IOptions<ForwardedHeadersConfig>>((options, config) => config.Value.Apply(options));
+
+            // Throttle the anonymous auth endpoints per client IP to blunt credential stuffing, refresh-token
+            // brute force, and the PBKDF2 resource-exhaustion vector. Limits are config-bound with safe
+            // defaults so an unconfigured deployment is still protected (#950).
+            builder.Services.AddAuthRateLimiter();
 
             ConfigureAuth(builder);
 
@@ -188,6 +194,10 @@ namespace Game.Api
                     .AllowAnyMethod()
                     .AllowCredentials();
             });
+
+            // After CORS so a throttled browser request still carries the CORS headers needed to read the
+            // 429 envelope, and after forwarded-headers (above) so the partition keys off the real client IP.
+            app.UseRateLimiter();
 
             app.UseAuthentication();
             app.UseSessionLoader();

--- a/Game.Api/appsettings.json
+++ b/Game.Api/appsettings.json
@@ -5,5 +5,11 @@
       "Microsoft.AspNetCore": "Warning",
       "Microsoft.EntityFrameworkCore": "Information"
     }
+  },
+  "RateLimiting": {
+    "Auth": {
+      "PermitLimit": 10,
+      "WindowSeconds": 60
+    }
   }
 }

--- a/Game.TestInfrastructure/Base/GameServerFactory.cs
+++ b/Game.TestInfrastructure/Base/GameServerFactory.cs
@@ -42,6 +42,10 @@ namespace Game.TestInfrastructure.Base
                     ["Jwt:Issuer"] = Game.Api.Constants.SERVER_PRINCIPAL,
                     ["Jwt:Audience"] = Game.Api.Constants.SERVER_PRINCIPAL,
                     ["Cors:AllowedOrigins:0"] = "http://localhost:5174",
+                    // Effectively disable the auth rate limiter for the shared integration suite; the
+                    // dedicated rate-limit tests override this with a small limit to exercise throttling.
+                    ["RateLimiting:Auth:PermitLimit"] = "100000",
+                    ["RateLimiting:Auth:WindowSeconds"] = "60",
                     ["DataAccessOptions:DatabaseSystem"] = "1",
                     ["DataAccessOptions:EnableSensitiveLogging"] = "true",
                     ["DataAccessOptions:CacheSystem"] = "0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,11 @@ services:
       # 4173). Outside Development the API has no built-in default and validates this at startup, so
       # the dockerized e2e stack must supply it or the API aborts on boot.
       Cors__AllowedOrigins__0: "http://localhost:4173"
+      # Effectively disable the auth rate limiter for e2e: the whole Playwright suite logs in through
+      # the Vite proxy from one source IP (localhost), so every auth request shares a single partition
+      # and the production-default 10/min limit would 429 the parallel login-heavy tests. Mirrors the
+      # high limit the integration-test factory sets for the same reason.
+      RateLimiting__Auth__PermitLimit: "100000"
       # Secrets required at startup. These are throwaway values for CI / e2e only.
       HashPepper: docker-compose-e2e-pepper
       Jwt__SigningKey: docker-compose-e2e-signing-key-at-least-32-bytes-long

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -147,6 +147,10 @@ Account creation and the login/refresh/logout flows are orchestrated by `Account
 
 At most one active account may hold a given username, enforced by a **partial unique index** (`Username WHERE ArchivedAt IS NULL`) so two concurrent creations can't both slip past the up-front availability check and insert duplicate active rows. The filter excludes archived users, preserving username reuse after archival. Account creation therefore commits its own insert in the data tier (rather than deferring to the per-request unit of work) so the index's unique-violation surfaces as a clean "username taken" result instead of a 500 raised after the action returns.
 
+### Auth endpoint rate limiting
+
+The anonymous auth endpoints (login, refresh, account creation) are throttled by a **per-client-IP fixed-window** rate limiter (ASP.NET Core's built-in `AddRateLimiter`), blunting credential stuffing, refresh-token brute force, and the PBKDF2 resource-exhaustion vector. The three endpoints share one `"auth"` policy, so the limit is a **combined per-IP budget** an attacker can't multiply across endpoints. The partition key is the client IP resolved the same trusted-proxy way as login tracking (`ClientIp.Resolve`), so a spoofed `X-Forwarded-For` can't shard a caller across partitions. A throttled request returns the standard `{ errorMessage }` envelope (429) with a `Retry-After` header. Unlike the CORS origins, the limits carry **safe positive defaults** so an unconfigured deployment is still protected — config only tunes them — and are validated as positive on start so an accidental zero fails fast rather than silently disabling the guard.
+
 ## CORS allowed origins (deployment config)
 
 The browser CORS policy's allowed origins are **configuration-bound, not hardcoded** — they are deployment-specific. The list supports multiple origins and is validated at startup (must be non-empty), so a misconfigured environment fails fast rather than silently rejecting every browser request. The local dev origin ships in the Development config.


### PR DESCRIPTION
## Summary

The anonymous auth endpoints — `Login`, `Refresh`, `CreateAccount` (all `[AllowAnonymous]` on `LoginController`) — were completely unmetered (`#950`). That left three live abuse vectors open: credential stuffing against `Login`, refresh-token brute force against `Refresh`, and — because PBKDF2 runs at 600k iterations — a CPU resource-exhaustion DoS where every login/create guess costs the server real work.

This wires ASP.NET Core's built-in rate limiter (`AddRateLimiter` / `UseRateLimiter`) with a **per-client-IP fixed-window** policy applied to those three endpoints.

### How it works

- **One shared `"auth"` policy** across the three endpoints, so the limit is a **combined per-IP budget** an attacker can't multiply by spreading across endpoints. Applied via `[EnableRateLimiting(RateLimitingOptions.AuthPolicy)]`.
- **Partition key = the trusted-proxy-correct client IP.** I extracted the IP resolution that already lived in `LoginTrackingMiddleware` into a shared `ClientIp.Resolve` helper and use it for both, so a spoofed `X-Forwarded-For` from a direct client can't shard an attacker across partitions (consistent with #910 — only a configured trusted proxy's forwarded header is honoured).
- **429 returns the project's standard `{ errorMessage }` envelope** (via `OnRejected`) plus a `Retry-After` header, instead of the framework's empty 429 body — matching every other failure response shape the client already handles.
- **Config-bound with safe defaults.** `RateLimiting:Auth:{PermitLimit,WindowSeconds}` defaults to 10 requests / 60s. Unlike the CORS origins (which fail fast when unset), rate limiting carries **safe positive defaults** so an unconfigured deployment is *still protected* — config only tunes the numbers — and the limits are validated as positive on start so an accidental `0` fails fast rather than silently disabling the guard.

### Pipeline placement

`UseRateLimiter` runs **after** `UseCors` (so a throttled browser request still carries the CORS headers it needs to read the 429 body) and **after** the forwarded-headers middleware (so the partition keys off the corrected client IP).

## Scope note / decision

The issue also suggested *considering* an account-level lockout after N consecutive failed logins. I deliberately scoped that **out** of this PR and opened follow-up **#1010**: account-level lockout carries its own lockout-DoS tradeoff (an attacker can lock a victim out by spamming failed logins for their username) and needs a design decision, whereas per-IP limiting is the safe, unambiguous first line that directly closes the stated gap. Happy to fold it in here instead if preferred.

## Test plan

- [x] `dotnet build Game.Api` — clean (0 warnings)
- [x] **New** `Game.Api.Tests/Unit/RateLimitingOptionsTests.cs` — defaults, partial-bind, and the validate-on-start path (exercises the real `AddAuthRateLimiter` registration, not a re-declaration).
- [x] **New** `Game.Api.Tests/Integration/AuthRateLimitingTests.cs` — throttle-after-limit returns 429 + `Retry-After` + envelope; the shared per-IP budget spans `Login`→`CreateAccount`; a single request under the limit is untouched.
- [x] Retargeted the IP-resolution unit test to the new shared `ClientIp.Resolve` (renamed `LoginTrackingIpResolutionTests` → `ClientIpResolutionTests`); no behavior change, no dead code left behind.
- [x] `Game.Api.Tests` — **544 passed** (was 537; the shared test factory pins a high limit so existing suites aren't throttled, and the dedicated rate-limit tests override it with a small limit).

Docs updated: new "Auth endpoint rate limiting" subsection under Authentication in `docs/backend.md`.

Closes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)