### PR TITLE
Harden socket handler layer (#953)

### DIFF
--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -83,6 +83,25 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
+        public async Task Processor_ResyncNoticeAlsoFails_WarnsThatTheClientMayHaveMissedTheCue()
+        {
+            // The original push faults and is escalated; if the ServerCommandFailed re-sync notice itself does
+            // not get through (here it also faults), the client never receives the re-sync cue for a gating
+            // command and would diverge silently — so the lost cue is surfaced at warning (#953), not ignored.
+            var commands = new CapturingCommandFactory(throwOn: name =>
+                name is "ChallengeCompleted" or "ServerCommandFailed" ? new InvalidOperationException("boom") : null);
+            var (processor, _) = BuildProcessor(commands);
+
+            var queue = new FakeQueue(new SocketCommandInfo("ChallengeCompleted") { Id = "push-1" });
+
+            await processor(queue);
+
+            Assert.Contains(_logs.Entries, e => e.Level == LogLevel.Warning
+                && e.Message.Contains("may not have received the re-sync cue")
+                && e.Message.Contains("ChallengeCompleted"));
+        }
+
+        [Fact]
         public async Task Processor_DequeueFaultThenValidCommand_QueueKeepsDrainingAndProcessorDoesNotThrow()
         {
             var commands = new CapturingCommandFactory(throwOn: _ => null);

--- a/Game.Api.Tests/Unit/SocketReadLoopTests.cs
+++ b/Game.Api.Tests/Unit/SocketReadLoopTests.cs
@@ -1,0 +1,182 @@
+using Game.Abstractions.DataAccess;
+using Game.Api.Services;
+using Game.Api.Sockets;
+using Game.Api.Sockets.Commands;
+using Game.Application;
+using Game.Core.Players;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System.Net.WebSockets;
+using Xunit;
+
+namespace Game.Api.Tests.Unit
+{
+    /// <summary>
+    /// Verifies the read-loop's terminal-fault handling (#953): a thrown receive that does not transition the
+    /// WebSocket state must stop the loop and close the socket rather than tight-spinning on the same failure,
+    /// while a client-initiated close frame still completes the closing handshake. Scripted <see cref="WebSocket"/>
+    /// stand-ins keep these as plain unit tests.
+    /// </summary>
+    public sealed class SocketReadLoopTests : IDisposable
+    {
+        private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);
+
+        private readonly ServiceProvider _provider;
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly CapturingLoggerProvider _logs = new();
+
+        public SocketReadLoopTests()
+        {
+            _provider = new ServiceCollection()
+                .AddScoped<IUnitOfWork, NoOpUnitOfWork>()
+                .BuildServiceProvider();
+            _scopeFactory = _provider.GetRequiredService<IServiceScopeFactory>();
+            _loggerFactory = LoggerFactory.Create(b => b.AddProvider(_logs).SetMinimumLevel(LogLevel.Trace));
+        }
+
+        [Fact]
+        public async Task ReadLoop_ReceiveThrowsWhileSocketStaysOpen_StopsAndClosesInsteadOfSpinning()
+        {
+            // A receive failure that does NOT transition WebSocketState (the socket stays Open) would loop the
+            // read loop forever on the same throw — a tight CPU spin that floods the log. The fix treats a
+            // thrown receive as terminal: the loop reads exactly once, then closes the socket so teardown can
+            // complete.
+            var socket = new ScriptedReadWebSocket();
+            socket.QueueThrow(new WebSocketException("decode failure that leaves the socket open"));
+            var (context, handler) = CreateHandler(socket);
+
+            using var inactivityStop = new CancellationTokenSource();
+            handler.Listen(hostStopping: inactivityStop.Token);
+
+            await context.WaitSocketClosed().WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
+            inactivityStop.Cancel();
+            await handler.Completion.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
+
+            // The loop did not spin: it read once, then broke. And it closed the still-open socket gracefully.
+            Assert.Equal(1, socket.ReceiveAttempts);
+            Assert.True(socket.CloseAsyncCalled);
+            Assert.Equal(WebSocketCloseStatus.NormalClosure, socket.CloseStatusUsed);
+            Assert.Contains(_logs.Entries, e => e.Level == LogLevel.Error && e.Message.Contains("closing the socket"));
+        }
+
+        [Fact]
+        public async Task ReadLoop_ClientCloseFrame_CompletesTheClosingHandshake()
+        {
+            // A client-initiated close still drives the read loop out of the CloseReceived state and completes
+            // the handshake — the terminal-fault break must not regress the normal close path.
+            var socket = new ScriptedReadWebSocket();
+            socket.QueueClose();
+            var (context, handler) = CreateHandler(socket);
+
+            using var inactivityStop = new CancellationTokenSource();
+            handler.Listen(hostStopping: inactivityStop.Token);
+
+            await context.WaitSocketClosed().WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
+            inactivityStop.Cancel();
+            await handler.Completion.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
+
+            // The close frame was consumed (one read) and the loop exited via the CloseReceived state to
+            // complete teardown, without retrying. SocketContext.Close only emits a close frame from the Open
+            // state, so on CloseReceived it settles the close without re-sending one (no CloseAsync).
+            Assert.Equal(1, socket.ReceiveAttempts);
+            Assert.Equal(WebSocketState.CloseReceived, socket.State);
+            // A clean client close is not an error.
+            Assert.DoesNotContain(_logs.Entries, e => e.Level == LogLevel.Error);
+        }
+
+        private (SocketContext Context, SocketHandler Handler) CreateHandler(WebSocket socket)
+        {
+            var session = new SessionService(new NoOpSessionStore());
+            session.CreateSession(userId: 1, playerId: 1);
+            var context = new SocketContext(socket, playerId: 1, session, _loggerFactory.CreateLogger<SocketContext>());
+            var handler = new SocketHandler(context, new StubCommandFactory(), _scopeFactory,
+                _loggerFactory.CreateLogger<SocketHandler>(), () => Task.CompletedTask);
+            return (context, handler);
+        }
+
+        public void Dispose()
+        {
+            _loggerFactory.Dispose();
+            _provider.Dispose();
+        }
+
+        /// <summary>
+        /// A <see cref="WebSocket"/> stand-in that scripts a single receive step (a thrown receive or a client
+        /// close frame) and records the close frame, so the read loop's terminal-fault and clean-close paths can
+        /// be driven deterministically. A throw leaves <see cref="State"/> Open — exactly the case that would
+        /// spin the loop — and counts every receive so a test can assert the loop did not retry.
+        /// </summary>
+        private sealed class ScriptedReadWebSocket : WebSocket
+        {
+            private Exception? _throwOnReceive;
+            private bool _closeFrameQueued;
+            private WebSocketState _state = WebSocketState.Open;
+
+            public int ReceiveAttempts { get; private set; }
+            public bool CloseAsyncCalled { get; private set; }
+            public WebSocketCloseStatus? CloseStatusUsed { get; private set; }
+
+            public void QueueThrow(Exception toThrow) => _throwOnReceive = toThrow;
+            public void QueueClose() => _closeFrameQueued = true;
+
+            public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+            {
+                ReceiveAttempts++;
+                if (_throwOnReceive is not null)
+                {
+                    // State deliberately stays Open: the receive throws without transitioning the socket, the
+                    // exact case the read loop must treat as terminal rather than re-looping.
+                    return Task.FromException<WebSocketReceiveResult>(_throwOnReceive);
+                }
+
+                if (_closeFrameQueued)
+                {
+                    _closeFrameQueued = false;
+                    _state = WebSocketState.CloseReceived;
+                    return Task.FromResult(new WebSocketReceiveResult(0, WebSocketMessageType.Close, endOfMessage: true));
+                }
+
+                // No further scripted input: block so a (buggy) spinning loop would be observable as repeated
+                // receive attempts rather than a completed read.
+                return new TaskCompletionSource<WebSocketReceiveResult>().Task;
+            }
+
+            public override Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
+            {
+                CloseAsyncCalled = true;
+                CloseStatusUsed = closeStatus;
+                _state = WebSocketState.Closed;
+                return Task.CompletedTask;
+            }
+
+            public override WebSocketState State => _state;
+            public override WebSocketCloseStatus? CloseStatus => null;
+            public override string? CloseStatusDescription => null;
+            public override string? SubProtocol => null;
+            public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken) => Task.CompletedTask;
+            public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken) => Task.CompletedTask;
+            public override void Abort() { }
+            public override void Dispose() { }
+        }
+
+        private sealed class StubCommandFactory : SocketCommandFactory
+        {
+            public override AbstractSocketCommand CreateCommand(SocketCommandInfo commandInfo, IServiceScope scope)
+                => throw new NotSupportedException("These tests script receives only; no command is executed.");
+        }
+
+        private sealed class NoOpSessionStore : ISessionStore
+        {
+            public Task<PlayerState?> GetSession(int userId, CancellationToken cancellationToken = default) => Task.FromResult<PlayerState?>(null);
+            public void Update(PlayerState sessionData, int playerId) { }
+            public void Clear(int userId) { }
+        }
+
+        private sealed class NoOpUnitOfWork : IUnitOfWork
+        {
+            public Task CommitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+    }
+}

--- a/Game.Api/Middleware/SocketInterceptorMiddleware.cs
+++ b/Game.Api/Middleware/SocketInterceptorMiddleware.cs
@@ -1,3 +1,4 @@
+using Game.Api.Models.Common;
 using Game.Api.Services;
 using Game.Application.Services;
 
@@ -26,9 +27,13 @@ namespace Game.Api.Middleware
             }
             else if (!await TryLoadPlayer(sessionService, sessionInitializer, scopeFactory, context.RequestAborted))
             {
-                // An authenticated session whose player can't be loaded can't play, so fail before
-                // upgrading the socket rather than erroring on the first command.
-                context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                // An authenticated session whose player can't be loaded can't play, so fail before upgrading
+                // the socket rather than erroring on the first command. The socket isn't upgraded yet, so a
+                // body can still be written: return the project's { errorMessage } envelope (a 404 — the
+                // player resource is absent, not a server fault; a genuine load error throws and is shaped by
+                // ExceptionHandlingMiddleware) rather than a bare 500.
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                await context.Response.WriteAsJsonAsync(ApiResponse.Error("Player could not be loaded."), context.RequestAborted);
             }
             else
             {

--- a/Game.Api/Services/SocketManagerService.cs
+++ b/Game.Api/Services/SocketManagerService.cs
@@ -268,7 +268,14 @@ namespace Game.Api.Services
             {
                 // Dispatched directly (not re-queued over pub/sub) since the failing socket is right here;
                 // ExecuteServerCommand runs it under the same command lock and owns the send to the client.
-                await socket.ExecuteServerCommand(new ServerCommandFailedInfo(commandInfo.Name));
+                // Capture the outcome: if the notice itself doesn't get through (e.g. the socket just closed),
+                // the client never gets the re-sync cue for a gating command like ChallengeCompleted and would
+                // diverge silently — so surface it for an operator rather than ignoring the result.
+                var noticeOutcome = await socket.ExecuteServerCommand(new ServerCommandFailedInfo(commandInfo.Name));
+                if (noticeOutcome is not SocketCommandOutcome.Succeeded)
+                {
+                    _logger.LogWarning("The re-sync notice for a failed server command did not complete (outcome: {Outcome}); the client may not have received the re-sync cue for {Command} on socket: {Id}.", noticeOutcome, commandInfo.Name, socket.Id);
+                }
             }
 
             _logger.LogWarning("Dead-lettered a failing server-initiated command and notified the client: {CommandInfo} on socket: {Id}", commandInfo, socket.Id);

--- a/Game.Api/Sockets/SocketHandler.cs
+++ b/Game.Api/Sockets/SocketHandler.cs
@@ -46,7 +46,11 @@ namespace Game.Api.Sockets
         /// <summary>How often the inactivity watchdog re-checks the last-activity timestamp.</summary>
         private static readonly TimeSpan InactivityPollInterval = TimeSpan.FromSeconds(10);
 
-        private DateTime _lastResponse = DateTime.UtcNow;
+        // Written by the read loop and read by the inactivity loop on separate threads, so it is accessed via
+        // Interlocked to give the cross-thread happens-before edge a plain DateTime field would lack — a
+        // DateTime is a 16-byte struct that isn't even guaranteed to be read atomically (a torn read is
+        // possible). Stored as ticks because Interlocked operates on a long.
+        private long _lastResponseTicks = DateTime.UtcNow.Ticks;
 
         // The read and inactivity loops, tracked (rather than pure fire-and-forget) so a host shutdown can
         // await their completion within a bounded drain window — see SocketConnectionRegistry.
@@ -116,12 +120,7 @@ namespace Game.Api.Sockets
             if (outcome is SocketCommandOutcome.Faulted)
             {
                 _logger.LogError(fault, "An error occurred while executing a socket command: {CommandInfo}", commandInfo);
-                await _context.SendData(new ApiSocketResponse
-                {
-                    Id = commandInfo.Id,
-                    Name = commandInfo.Name,
-                    Error = "Internal Server Error"
-                });
+                await SendErrorAsync(commandInfo, "Internal Server Error");
             }
         }
 
@@ -183,12 +182,7 @@ namespace Game.Api.Sockets
                     // but its now-late response is dropped: RunCommand never sends — this method owns the single
                     // send — so the client never receives a second response for the same id.
                     _logger.LogWarning("Socket command timed out after {Timeout} and was abandoned: {CommandInfo} on socket: {Id}", _commandTimeout, commandInfo, Id);
-                    await _context.SendData(new ApiSocketResponse
-                    {
-                        Id = commandInfo.Id,
-                        Name = commandInfo.Name,
-                        Error = "Command timed out."
-                    });
+                    await SendErrorAsync(commandInfo, "Command timed out.");
                     ReleaseCommandLockWhenSettled(commandTask, cts, commandInfo);
                     lockHandedOff = true;
                     return (SocketCommandOutcome.TimedOut, null);
@@ -261,7 +255,7 @@ namespace Game.Api.Sockets
         {
             try
             {
-                while (DateTime.UtcNow - _lastResponse < InactivityTimeout && _context.State is Open)
+                while (DateTime.UtcNow.Ticks - Interlocked.Read(ref _lastResponseTicks) < InactivityTimeout.Ticks && _context.State is Open)
                 {
                     await Task.Delay(InactivityPollInterval, hostStopping);
                 }
@@ -289,7 +283,7 @@ namespace Game.Api.Sockets
                     if (!string.IsNullOrWhiteSpace(message))
                     {
                         _logger.LogDebug("Received socket data from playerId ({PlayerId}) on socket ({Id}): {Message}", PlayerId, Id, message);
-                        _lastResponse = DateTime.UtcNow;
+                        Interlocked.Exchange(ref _lastResponseTicks, DateTime.UtcNow.Ticks);
                         // Any inbound message (heartbeat ping or command) marks the connection live — keep its
                         // presence key from expiring on the same signal the inactivity check uses above.
                         await _onActivity();
@@ -304,15 +298,27 @@ namespace Game.Api.Sockets
                 }
                 catch (Exception ex)
                 {
-                    if (_context.State is Open) // Only log if the socket is still open, otherwise it's expected that exceptions may occur
+                    // A thrown receive is terminal: the socket can't be read from again, so stop reading
+                    // rather than looping. Most receive failures abort the socket (state leaves Open and the
+                    // do…while would exit anyway), but a failure that does NOT transition WebSocketState (e.g.
+                    // an OOM/decoding error while assembling the message) would otherwise leave the loop a
+                    // tight CPU spin that also floods the log — and the inactivity watchdog can't help because
+                    // _lastResponseTicks only advances on a successful read. Only log while still open, since a
+                    // receive throwing on an already-closing socket is expected.
+                    if (_context.State is Open)
                     {
-                        _logger.LogError(ex, "An error occurred while reading a socket message.");
+                        _logger.LogError(ex, "An error occurred while reading a socket message; closing the socket.");
                     }
+
+                    break;
                 }
             }
             while (_context.State is Open);
 
-            if (_context.State is CloseReceived)
+            // Complete the closing handshake for a client-initiated close, and close a socket the read loop is
+            // abandoning while still open (the terminal-fault break above) so teardown completes instead of
+            // leaving a half-open socket. Close is a no-op on an already-closed/aborted socket.
+            if (_context.State is Open or CloseReceived)
             {
                 await _context.Close(ESocketCloseReason.Finished);
             }
@@ -342,11 +348,7 @@ namespace Game.Api.Sockets
                         // it with a structured error instead of letting the null reach the command lookup — which
                         // would throw an unobserved exception and leave the client hanging on its request id.
                         _logger.LogWarning("Received socket command frame with no name: {Message} on socket: {Id}", message, Id);
-                        await _context.SendData(new ApiSocketResponse
-                        {
-                            Id = commandInfo.Id,
-                            Error = "Malformed command."
-                        });
+                        await SendErrorAsync(commandInfo, "Malformed command.");
                         return;
                     }
 
@@ -355,12 +357,7 @@ namespace Game.Api.Sockets
                         // Server-initiated commands (e.g. ChallengeCompleted, SocketReplaced) are only valid
                         // when dispatched via the backplane; a client sending one is rejected, not executed.
                         _logger.LogWarning("Client attempted to invoke server-initiated command: {CommandInfo} on socket: {Id}", commandInfo, Id);
-                        await _context.SendData(new ApiSocketResponse
-                        {
-                            Id = commandInfo.Id,
-                            Name = commandInfo.Name,
-                            Error = "Command cannot be invoked by the client."
-                        });
+                        await SendErrorAsync(commandInfo, "Command cannot be invoked by the client.");
                         return;
                     }
 
@@ -371,6 +368,21 @@ namespace Game.Api.Sockets
             {
                 _logger.LogWarning("Failed to deserialize socket command: {Message}", message);
             }
+        }
+
+        /// <summary>
+        /// Sends an error response frame for a command, echoing its id and name so the client can correlate the
+        /// failure with the request it is awaiting. The single place the error-frame shape is built, so every
+        /// failure path (fault, timeout, malformed/rejected frame) emits a consistent envelope.
+        /// </summary>
+        private Task SendErrorAsync(SocketCommandInfo commandInfo, string error)
+        {
+            return _context.SendData(new ApiSocketResponse
+            {
+                Id = commandInfo.Id,
+                Name = commandInfo.Name,
+                Error = error
+            });
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #953 — a cluster of small robustness/observability gaps in the WebSocket handler layer. None was a hot-path bug, but each was a latent reliability hole in an area the rest of the code treats with care.

### 1. `ReadLoop` no longer hot-spins on a persistent non-cancellation receive failure
`Game.Api/Sockets/SocketHandler.cs`

A thrown receive is now treated as **terminal**: after a non-drain exception the loop breaks and the post-loop close fires. Most receive failures abort the socket (state leaves `Open`, the `do…while` would exit anyway), but a failure that does **not** transition `WebSocketState` (e.g. an OOM/decoding error while assembling the message) previously left the loop a tight CPU spin that also flooded the log — and the watchdog couldn't help because the activity timestamp only advances on a *successful* read. The post-loop close now covers both `CloseReceived` (complete the client handshake) and a still-`Open` terminal break (close so teardown completes); `Close` is a no-op on an already-closed/aborted socket.

### 2. The inactivity-watchdog timestamp now has a memory-visibility guarantee
The `DateTime _lastResponse` field — written by the read loop, read by the inactivity loop on a separate thread with no synchronization — is replaced by a `long _lastResponseTicks` accessed via `Interlocked.Exchange`/`Interlocked.Read`. This gives the cross-thread happens-before edge and avoids the torn read possible on the 16-byte `DateTime` struct, matching the class's otherwise-meticulous concurrency discipline.

### 3. The socket-handshake failure path returns the `{ errorMessage }` envelope
`Game.Api/Middleware/SocketInterceptorMiddleware.cs`

When an authenticated session's player can't be loaded, the middleware previously set a bare `500` with no body. The socket isn't upgraded yet, so a body can still be written: it now returns the project's `ApiResponse.Error` envelope with a **404** (the player resource is absent — a genuine load *error* throws and is shaped by `ExceptionHandlingMiddleware` into a 500 as before).

### 4. A failed server-push re-sync notice is no longer silent
`Game.Api/Services/SocketManagerService.cs`

`EscalateFailedServerCommand` dispatches a `ServerCommandFailed` re-sync notice but ignored its outcome. The dispatch outcome is now captured and, when it's not `Succeeded`, warned on ("the client may not have received the re-sync cue for {Command}") — so a player whose gating `ChallengeCompleted` cue was lost (e.g. the socket closed mid-dispatch) leaves an operator signal instead of diverging silently.

### 5. DRY: the error-frame send is consolidated
The hand-rolled `new ApiSocketResponse { Id, Name, Error = … }` + `SendData` triple (which appeared across the fault, timeout, malformed-frame, and server-initiated-rejection paths) is extracted into a single `SendErrorAsync(SocketCommandInfo, string)` helper, so every failure path emits a consistent envelope.

## How it addresses the issue

Each of the five listed gaps is closed. Items 1, 2, and 5 are in `SocketHandler`; item 3 in the handshake middleware; item 4 in the pub/sub escalation path.

## Test plan

- **New** `Game.Api.Tests/Unit/SocketReadLoopTests.cs` — asserts the read loop reads exactly once and closes on a terminal receive fault (no spin), and that a client close frame still completes the handshake without an error.
- **New** test in `SocketCommandProcessorTests` — asserts a failed re-sync notice logs the "may not have received the re-sync cue" warning.
- The error-frame consolidation (#5) is covered by the existing fault/timeout/malformed-frame assertions, which continue to pass unchanged.
- `Game.Api.Tests` — **547 passed**; full solution builds with **0 warnings**.

## Notes for review

- **Item 3 scope:** the issue flagged the `500` path. The sibling `401` (unauthenticated) and `400` (non-WebSocket request) branches in the same middleware also return no body; I left those as-is to keep the change scoped, but they're a candidate for the same envelope treatment if desired (happy to fold in or file a follow-up).
- **No dedicated automated test for item 3:** the handshake "authenticated but player-not-loadable" branch is hard to reach deterministically in an integration test (it needs an authenticated session whose `SelectedPlayerId` resolves to a non-existent player), and per `docs/backend.md` the `Game.Api` middleware adapters are measure-only for coverage. The change is a small, self-contained response shaping. Flagging it here per the pick-up-issue guidance rather than leaving it unmentioned.

Closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012CfAe2rvKViDnmEMfkwQT1)_