### PR TITLE
Assert id==index contiguity when building reference snapshots (#955)

### DIFF
--- a/Game.Application.Tests/DataAccess/ReferenceSnapshotExtensionsTests.cs
+++ b/Game.Application.Tests/DataAccess/ReferenceSnapshotExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Game.DataAccess.Repositories;
+using Game.Infrastructure.Entities;
 using Xunit;
 
 namespace Game.Application.Tests.DataAccess
@@ -66,6 +67,64 @@ namespace Game.Application.Tests.DataAccess
             IReadOnlyList<string> empty = [];
 
             Assert.Throws<ArgumentOutOfRangeException>(() => empty.GetById(0, "thing"));
+        }
+
+        [Fact]
+        public void AssertZeroBasedContiguity_ContiguousIds_DoesNotThrow()
+        {
+            IReadOnlyList<Record> contiguous = [new(0), new(1), new(2)];
+
+            contiguous.AssertZeroBasedContiguity(r => r.Id, "things");
+        }
+
+        [Fact]
+        public void AssertZeroBasedContiguity_EmptySnapshot_DoesNotThrow()
+        {
+            IReadOnlyList<Record> empty = [];
+
+            empty.AssertZeroBasedContiguity(r => r.Id, "things");
+        }
+
+        [Fact]
+        public void AssertZeroBasedContiguity_DoesNotStartAtZero_Throws()
+        {
+            // Sorted by id but seeded from 1 — a gap at index 0 that OrderBy can't catch.
+            IReadOnlyList<Record> offByOne = [new(1), new(2), new(3)];
+
+            var ex = Assert.Throws<InvalidOperationException>(() => offByOne.AssertZeroBasedContiguity(r => r.Id, "widgets"));
+            Assert.Contains("widgets", ex.Message);
+            Assert.Contains("index 0", ex.Message);
+            Assert.Contains("Id 1", ex.Message);
+        }
+
+        [Fact]
+        public void AssertZeroBasedContiguity_GapInMiddle_ThrowsAtFirstMismatch()
+        {
+            // Sorted, contiguous through index 1, then missing id 2 — the record at index 2 has Id 3.
+            IReadOnlyList<Record> gap = [new(0), new(1), new(3), new(4)];
+
+            var ex = Assert.Throws<InvalidOperationException>(() => gap.AssertZeroBasedContiguity(r => r.Id, "widgets"));
+            Assert.Contains("index 2", ex.Message);
+            Assert.Contains("Id 3", ex.Message);
+        }
+
+        [Fact]
+        public void AssertZeroBasedContiguity_EntityOverload_ReadsIdOffTheContract()
+        {
+            // The entity overload reads Id off IZeroBasedIdentityEntity; a covariant entity list is accepted.
+            IReadOnlyList<FakeEntity> contiguous = [new() { Id = 0 }, new() { Id = 1 }];
+            contiguous.AssertZeroBasedContiguity("fakes");
+
+            IReadOnlyList<FakeEntity> gap = [new() { Id = 0 }, new() { Id = 2 }];
+            var ex = Assert.Throws<InvalidOperationException>(() => gap.AssertZeroBasedContiguity("fakes"));
+            Assert.Contains("index 1", ex.Message);
+        }
+
+        private sealed record Record(int Id);
+
+        private sealed class FakeEntity : IZeroBasedIdentityEntity
+        {
+            public int Id { get; set; }
         }
     }
 }

--- a/Game.DataAccess/Repositories/Caching/ChallengesCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/ChallengesCacheHolder.cs
@@ -46,6 +46,8 @@ namespace Game.DataAccess.Repositories.Caching
                 })
                 .ToListAsync(cancellationToken);
 
+            challenges.AssertZeroBasedContiguity(challenge => challenge.Id, "Challenges");
+
             return new ChallengeSnapshot(challenges, new ChallengeIndex(challenges));
         }
     }

--- a/Game.DataAccess/Repositories/Caching/EnemiesCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/EnemiesCacheHolder.cs
@@ -52,6 +52,12 @@ namespace Game.DataAccess.Repositories.Caching
                 .OrderBy(s => s.Id)
                 .ToListAsync(cancellationToken);
 
+            // Both lists are indexed by zero-based id: the templates align with the enemy list by index, and
+            // EnemyMapper.ToTemplate resolves an enemy's skills via allSkills[SkillId] — so a gap in either
+            // would silently mis-resolve. Assert before building so a bad reload fails the build-then-swap.
+            enemies.AssertZeroBasedContiguity("Enemies");
+            skills.AssertZeroBasedContiguity("Skills");
+
             var templates = enemies.Select(enemy => EnemyMapper.ToTemplate(enemy, skills)).ToList();
 
             return new EnemySnapshot(enemies, templates, BuildZoneEnemyTables(enemies));

--- a/Game.DataAccess/Repositories/Caching/ItemModsCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/ItemModsCacheHolder.cs
@@ -32,6 +32,8 @@ namespace Game.DataAccess.Repositories.Caching
                 .OrderBy(im => im.Id)
                 .ToListAsync(cancellationToken);
 
+            entities.AssertZeroBasedContiguity("ItemMods");
+
             return new ItemModSnapshot(entities, entities.Select(ItemMapper.ModToCore).ToList());
         }
     }

--- a/Game.DataAccess/Repositories/Caching/ItemsCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/ItemsCacheHolder.cs
@@ -34,6 +34,8 @@ namespace Game.DataAccess.Repositories.Caching
                 .OrderBy(i => i.Id)
                 .ToListAsync(cancellationToken);
 
+            entities.AssertZeroBasedContiguity("Items");
+
             return new ItemSnapshot(entities, entities.Select(ItemMapper.ToCore).ToList());
         }
     }

--- a/Game.DataAccess/Repositories/Caching/SkillsCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/SkillsCacheHolder.cs
@@ -33,6 +33,8 @@ namespace Game.DataAccess.Repositories.Caching
                 .OrderBy(s => s.Id)
                 .ToListAsync(cancellationToken);
 
+            entities.AssertZeroBasedContiguity("Skills");
+
             return new SkillSnapshot(entities, entities.Select(SkillMapper.ToCore).ToList());
         }
     }

--- a/Game.DataAccess/Repositories/Caching/ZonesCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/ZonesCacheHolder.cs
@@ -11,11 +11,15 @@ namespace Game.DataAccess.Repositories.Caching
     {
         protected override async Task<IReadOnlyList<Zone>> BuildSnapshotAsync(GameContext context, CancellationToken cancellationToken)
         {
-            return await context.Zones
+            var zones = await context.Zones
                 .AsNoTracking()
                 .Include(z => z.ZoneEnemies)
                 .OrderBy(z => z.Id)
                 .ToListAsync(cancellationToken);
+
+            zones.AssertZeroBasedContiguity("Zones");
+
+            return zones;
         }
     }
 }

--- a/Game.DataAccess/Repositories/ReferenceSnapshotExtensions.cs
+++ b/Game.DataAccess/Repositories/ReferenceSnapshotExtensions.cs
@@ -39,7 +39,7 @@ namespace Game.DataAccess.Repositories
 
         /// <summary>
         /// Asserts the zero-based-id contiguity invariant the snapshots rely on: the record at index
-        /// <c>i</c> must have <c>Id == i</c>, for every <c>i</c>. <see cref="OrderBy{T}"/>-by-id guarantees
+        /// <c>i</c> must have <c>Id == i</c>, for every <c>i</c>. <c>OrderBy</c>-by-id guarantees
         /// sort order but not that the ids run 0..n-1 with no gaps; a seed/migration gap (the one way a gap
         /// could appear, since hard-delete is blocked) would make every index lookup above the gap silently
         /// resolve the wrong record. Throwing here fails the build-then-swap so the prior good snapshot stays

--- a/Game.DataAccess/Repositories/ReferenceSnapshotExtensions.cs
+++ b/Game.DataAccess/Repositories/ReferenceSnapshotExtensions.cs
@@ -1,3 +1,5 @@
+using Game.Infrastructure.Entities;
+
 namespace Game.DataAccess.Repositories
 {
     /// <summary>
@@ -33,6 +35,40 @@ namespace Game.DataAccess.Repositories
             }
 
             return snapshot[id];
+        }
+
+        /// <summary>
+        /// Asserts the zero-based-id contiguity invariant the snapshots rely on: the record at index
+        /// <c>i</c> must have <c>Id == i</c>, for every <c>i</c>. <see cref="OrderBy{T}"/>-by-id guarantees
+        /// sort order but not that the ids run 0..n-1 with no gaps; a seed/migration gap (the one way a gap
+        /// could appear, since hard-delete is blocked) would make every index lookup above the gap silently
+        /// resolve the wrong record. Throwing here fails the build-then-swap so the prior good snapshot stays
+        /// in place (and a startup load surfaces the corruption as a boot failure) rather than serving
+        /// silently mis-resolved data.
+        /// </summary>
+        public static void AssertZeroBasedContiguity<T>(this IReadOnlyList<T> snapshot, Func<T, int> idSelector, string setName)
+        {
+            for (var i = 0; i < snapshot.Count; i++)
+            {
+                var id = idSelector(snapshot[i]);
+                if (id != i)
+                {
+                    throw new InvalidOperationException(
+                        $"Reference set '{setName}' violates the zero-based-id contiguity invariant: the record at " +
+                        $"index {i} has Id {id} (expected {i}). Ids must be seeded from 0 and contiguous; a gap " +
+                        "indicates a seed/migration mistake (top-level reference records are retired, never deleted).");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Entity overload of <see cref="AssertZeroBasedContiguity{T}(IReadOnlyList{T}, Func{T, int}, string)"/>
+        /// for the cached entity lists, reading <c>Id</c> off the shared
+        /// <see cref="IZeroBasedIdentityEntity"/> contract so no per-set id selector is needed.
+        /// </summary>
+        public static void AssertZeroBasedContiguity(this IReadOnlyList<IZeroBasedIdentityEntity> snapshot, string setName)
+        {
+            snapshot.AssertZeroBasedContiguity(entity => entity.Id, setName);
         }
     }
 }

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -47,7 +47,7 @@ Reference data is either **intrinsic** or **static**:
 
 The caches are immutable snapshots **loaded eagerly at startup** (a database problem surfaces as a boot failure, not a first-request failure) and refreshed by build-then-swap (see [Reference-data cache reload](#reference-data-cache-reload-build-then-swap)). There is no lazy-fill path.
 
-> **Contiguity is guaranteed by retirement, not convention.** Because lookups index by id, a hard delete of a non-terminal record would open a permanent gap that silently mis-resolves every lookup above it. Top-level reference records are therefore **retired, not deleted** (see below).
+> **Contiguity is guaranteed by retirement, not convention.** Because lookups index by id, a hard delete of a non-terminal record would open a permanent gap that silently mis-resolves every lookup above it. Top-level reference records are therefore **retired, not deleted** (see below). As a backstop against the one remaining way a gap could appear (a seed/migration mistake), each snapshot **asserts `Id == index` as it is built** and throws otherwise, so a corrupt set fails the build-then-swap (keeping the prior good snapshot, or surfacing as a boot failure on the startup load) rather than serving silently mis-resolved data.
 
 ### Retiring reference data (content lifecycle)
 


### PR DESCRIPTION
## Summary

The reference-data scheme rests on the invariant that a static reference record's `Id` doubles as its index into the cached list (ids seeded from 0). Contiguity is guaranteed *structurally* by retire-not-delete — and the admin repos reject top-level hard deletes — but **nothing asserted the invariant when a snapshot was built**. Every holder only `OrderBy(x => x.Id)`, which guarantees sort order, **not** contiguity from 0. A seed/migration gap (the one remaining way a gap could appear) would make `list[5]` silently resolve the wrong record on every lookup above the gap — silent corruption rather than a loud failure.

## How it addresses the issue

- Adds a centralized `AssertZeroBasedContiguity` helper to `ReferenceSnapshotExtensions` (next to the existing `Lookup`/`GetById` index helpers):
  - an **entity overload** over the shared `IZeroBasedIdentityEntity` contract (used by the five entity-backed holders via covariance — no per-set id selector needed), and
  - a generic **id-selector overload** for the challenge holder, which caches the projected domain `Challenge` rather than the EF entity.
- Calls it in **all six** holders right after the list is materialized. A violation throws `InvalidOperationException`, so:
  - on an **admin reload** the build-then-swap leaves the prior good snapshot in place (matching the existing fail-safe behavior pinned by `ReferenceCacheHolderTests`), and
  - on the **eager startup load** the corruption surfaces as a boot failure (the documented "a database problem surfaces as a boot failure" contract).
- The **enemies holder** also asserts the separate `skills` list it maps templates against — `EnemyMapper.ToTemplate` resolves an enemy's skills via `allSkills[SkillId]`, which the issue flags as inheriting the same fragility.
- Documents the backstop concisely in `docs/backend.md` → Reference Data.

## Not in this PR (follow-up)

The issue's "Related (orphaned player references)" section asks to decide a policy for `PlayerMapper`'s catalog resolution (skip the orphaned ownership row with a warning vs. guarantee referential integrity) **once the contiguity assertion is in place**. That's a genuine design fork, so I've opened a follow-up issue for it rather than bundling a decision here.

## Test plan

- New unit tests in `ReferenceSnapshotExtensionsTests` cover the contiguous case, empty list, off-by-one (seeded from 1), a mid-list gap (asserting the message names the failing index and id), and the entity overload reading `Id` off the contract.
- `Game.Application.Tests` — **340 passed** (includes the reference-cache holder/synchronizer integration tests that load the real seeded data through the new assertion, confirming no false-positive).

Closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8EYgsfLENSSBtpn2TQaHc)_