### PR TITLE
Game.Core hygiene: live attribute docs, lazy DerivedNodes, relocate test Battler ctor (#956)

### DIFF
--- a/Game.Core.TestInfrastructure/Builders/BattlerFactory.cs
+++ b/Game.Core.TestInfrastructure/Builders/BattlerFactory.cs
@@ -1,0 +1,18 @@
+using Game.Core.Battle;
+using Game.Core.Players;
+
+namespace Game.Core.TestInfrastructure.Builders
+{
+    /// <summary>
+    /// Test-only convenience for building a <see cref="Battler"/> straight from a live <see cref="Player"/>
+    /// aggregate. Production never does this: it reconstructs a player's battler from a frozen
+    /// <see cref="BattleSnapshot"/> (the anti-cheat replay surface). This shortcut keeps battle tests terse
+    /// by composing the same attributes/skills/level off the live aggregate, and the two construction paths
+    /// are pinned to agree by BattleSnapshotTests.AssertBattlerParity.
+    /// </summary>
+    public static class BattlerFactory
+    {
+        public static Battler FromPlayer(Player player) =>
+            new(player.GetAttributes(), player.SelectedSkills, player.Level);
+    }
+}

--- a/Game.Core.Tests/Battle/BattleContextTests.cs
+++ b/Game.Core.Tests/Battle/BattleContextTests.cs
@@ -198,7 +198,7 @@ namespace Game.Core.Tests.Battle
                 .Select(a => new StatAllocation { Attribute = a.Attribute, Amount = a.Amount })
                 .ToList();
             var player = new PlayerBuilder().WithStatAllocations(statAllocations).Build();
-            return new Battler(player);
+            return BattlerFactory.FromPlayer(player);
         }
     }
 }

--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -664,7 +664,7 @@ namespace Game.Core.Tests.Battle
                 strength: 10, endurance: 15,
                 skills: [MakeSkill(2, baseDamage: 5, cooldownMs: 2000)]);
 
-            var sim = new BattleSimulator(new Battler(player), enemy, ParitySeed);
+            var sim = new BattleSimulator(BattlerFactory.FromPlayer(player), enemy, ParitySeed);
             var result = sim.Simulate();
 
             Assert.True(result.Victory);
@@ -755,7 +755,7 @@ namespace Game.Core.Tests.Battle
             List<Skill>? skills = null,
             (EAttribute Attribute, double Amount)[]? extra = null)
         {
-            return new Battler(MakePlayer(strength, endurance, agility, dexterity, skills, extra));
+            return BattlerFactory.FromPlayer(MakePlayer(strength, endurance, agility, dexterity, skills, extra));
         }
 
         private static Player MakePlayer(
@@ -834,7 +834,7 @@ namespace Game.Core.Tests.Battle
                 player.TryApplyMod(item.Id, mods[index].Id, index, mods[index]);
             }
 
-            return new Battler(player);
+            return BattlerFactory.FromPlayer(player);
         }
 
         private static ItemMod MakeMod(int id, EItemModType type, List<AttributeModifier> attributes) => new()

--- a/Game.Core.Tests/Battle/BattleSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorTests.cs
@@ -17,7 +17,7 @@ namespace Game.Core.Tests.Battle
             var player = MakePlayer(strength: 100, endurance: 100);
             var enemy = MakeEnemy(statTotal: 10);
 
-            var sim = new BattleSimulator(new Battler(player), enemy, seed: 0);
+            var sim = new BattleSimulator(BattlerFactory.FromPlayer(player), enemy, seed: 0);
             var result = sim.Simulate();
 
             Assert.True(result.Victory);
@@ -29,7 +29,7 @@ namespace Game.Core.Tests.Battle
             var player = MakePlayer(strength: 1, endurance: 1);
             var enemy = MakeEnemy(statTotal: 200);
 
-            var sim = new BattleSimulator(new Battler(player), enemy, seed: 0);
+            var sim = new BattleSimulator(BattlerFactory.FromPlayer(player), enemy, seed: 0);
             var result = sim.Simulate();
 
             Assert.False(result.Victory);
@@ -41,7 +41,7 @@ namespace Game.Core.Tests.Battle
             var player = MakePlayer(strength: 100, endurance: 100);
             var enemy = MakeEnemy(statTotal: 10);
 
-            var sim = new BattleSimulator(new Battler(player), enemy, seed: 0);
+            var sim = new BattleSimulator(BattlerFactory.FromPlayer(player), enemy, seed: 0);
             var result = sim.Simulate();
 
             Assert.True(result.TotalMs > 0);
@@ -53,7 +53,7 @@ namespace Game.Core.Tests.Battle
             var player = MakePlayer(strength: 10, endurance: 10, skills: []);
             var enemy = MakeEnemy(statTotal: 10, skills: []);
 
-            var sim = new BattleSimulator(new Battler(player), enemy, seed: 0);
+            var sim = new BattleSimulator(BattlerFactory.FromPlayer(player), enemy, seed: 0);
             var result = sim.Simulate();
 
             Assert.False(result.Victory);
@@ -67,7 +67,7 @@ namespace Game.Core.Tests.Battle
             var player = MakePlayer(strength: 50, endurance: 50);
             var enemy = MakeEnemy(statTotal: 20);
 
-            var sim = new BattleSimulator(new Battler(player), enemy, seed: 0);
+            var sim = new BattleSimulator(BattlerFactory.FromPlayer(player), enemy, seed: 0);
             var result = sim.Simulate();
 
             Assert.Equal(0, result.TotalMs % 40);
@@ -79,7 +79,7 @@ namespace Game.Core.Tests.Battle
             var player = MakePlayer(strength: 100, endurance: 100);
             var enemy = MakeEnemy(statTotal: 10);
 
-            var sim = new BattleSimulator(new Battler(player), enemy, seed: 0);
+            var sim = new BattleSimulator(BattlerFactory.FromPlayer(player), enemy, seed: 0);
             var result = sim.Simulate();
 
             Assert.True(result.Victory);
@@ -94,7 +94,7 @@ namespace Game.Core.Tests.Battle
             var player = MakePlayer(strength: 50, endurance: 50);
             var enemy = MakeEnemy(statTotal: 50);
 
-            var sim = new BattleSimulator(new Battler(player), enemy, seed: 0);
+            var sim = new BattleSimulator(BattlerFactory.FromPlayer(player), enemy, seed: 0);
             var result = sim.Simulate(maxMs: 200);
 
             Assert.True(result.TotalMs <= 200);

--- a/Game.Core.Tests/Battle/BattleSkillTests.cs
+++ b/Game.Core.Tests/Battle/BattleSkillTests.cs
@@ -123,7 +123,7 @@ namespace Game.Core.Tests.Battle
                 new() { Attribute = EAttribute.Dexterity, Amount = 0 },
                 new() { Attribute = EAttribute.Luck,      Amount = 0 },
             };
-            var attacker = new Battler(new PlayerBuilder()
+            var attacker = BattlerFactory.FromPlayer(new PlayerBuilder()
                 .WithStatAllocations(statAllocations)
                 .WithStatPointsGained(52)
                 .WithStatPointsUsed(52)
@@ -268,7 +268,7 @@ namespace Game.Core.Tests.Battle
                 .WithStatPointsGained(50)
                 .WithStatPointsUsed(50)
                 .Build();
-            return new Battler(player);
+            return BattlerFactory.FromPlayer(player);
         }
 
         private static Battler MakeBattlerWith(params (EAttribute Attribute, double Amount)[] attributes)
@@ -277,7 +277,7 @@ namespace Game.Core.Tests.Battle
                 .Select(a => new StatAllocation { Attribute = a.Attribute, Amount = a.Amount })
                 .ToList();
             var player = new PlayerBuilder().WithStatAllocations(statAllocations).Build();
-            return new Battler(player);
+            return BattlerFactory.FromPlayer(player);
         }
     }
 }

--- a/Game.Core.Tests/Battle/BattleSnapshotTests.cs
+++ b/Game.Core.Tests/Battle/BattleSnapshotTests.cs
@@ -234,7 +234,7 @@ namespace Game.Core.Tests.Battle
         private static void AssertBattlerParity(Player player,
             Func<int, Item> resolveItem, Func<int, ItemMod> resolveMod, Func<int, Skill> resolveSkill)
         {
-            var liveBattler = new Battler(player);
+            var liveBattler = BattlerFactory.FromPlayer(player);
             var snapshotBattler = BattleSnapshot.FromPlayer(player)
                 .ToBattler(resolveItem, resolveMod, resolveSkill);
 

--- a/Game.Core/Attributes/AttributeCollection.cs
+++ b/Game.Core/Attributes/AttributeCollection.cs
@@ -118,12 +118,12 @@ namespace Game.Core.Attributes
             if (modifier.Source is EAttributeModifierSource.Derived)
             {
                 var sourceNode = GetOrCreateNode((int)modifier.DerivedSource);
-                if (node.DerivedNodes.Contains(sourceNode))
+                if (node.DerivedNodes?.Contains(sourceNode) == true)
                 {
                     throw new AttributeCircularDerivedModifierException(modifier);
                 }
 
-                sourceNode.DerivedNodes.Add(node);
+                sourceNode.GetOrCreateDerivedNodes().Add(node);
             }
         }
 
@@ -149,8 +149,9 @@ namespace Game.Core.Attributes
                 }
             }
 
-            // The source node exists because removing a Derived modifier implies it was hooked here.
-            GetOrCreateNode((int)derivedSource).DerivedNodes.Remove(node);
+            // The source node's set exists because removing a Derived modifier implies it was hooked here;
+            // the null-conditional keeps the unhook a safe no-op even if it somehow was not.
+            GetOrCreateNode((int)derivedSource).DerivedNodes?.Remove(node);
         }
 
         private void AddStaticModifiers()

--- a/Game.Core/Attributes/AttributeCollectionNode.cs
+++ b/Game.Core/Attributes/AttributeCollectionNode.cs
@@ -18,7 +18,12 @@ namespace Game.Core.Attributes
         // means "no stored modifiers". The read and remove paths treat null as the empty set.
         public SortedLinkedList<AttributeModifier>? Modifiers { get; private set; }
         public double? CachedValue { get; private set; }
-        public HashSet<AttributeCollectionNode> DerivedNodes { get; } = [];
+
+        // Allocated lazily on the first derived link (see GetOrCreateDerivedNodes), mirroring Modifiers. A
+        // node that nothing derives from — e.g. the player-only crit/dodge/block attributes an enemy battler
+        // reads as zero on every DamageTarget call — never allocates the set. The cascade and unhook paths
+        // treat null as the empty set.
+        public HashSet<AttributeCollectionNode>? DerivedNodes { get; private set; }
 
         // Returns the modifier list, allocating it on first use. Only the add path calls this; the
         // read and remove paths leave the list null when no modifier was ever stored.
@@ -27,9 +32,21 @@ namespace Game.Core.Attributes
             return Modifiers ??= new(TypeComparer);
         }
 
+        // Returns the derived-node set, allocating it on first use. Only the derived-link add path calls
+        // this; the cascade and unhook paths leave the set null when no link was ever created.
+        public HashSet<AttributeCollectionNode> GetOrCreateDerivedNodes()
+        {
+            return DerivedNodes ??= [];
+        }
+
         public void SetCachedValue(double? value)
         {
             CachedValue = value;
+            if (DerivedNodes is null)
+            {
+                return;
+            }
+
             foreach (var derivedNode in DerivedNodes)
             {
                 if (derivedNode.CachedValue is not null)

--- a/Game.Core/Battle/Battler.cs
+++ b/Game.Core/Battle/Battler.cs
@@ -1,7 +1,5 @@
 using Game.Core.Attributes;
 using Game.Core.Attributes.Modifiers;
-using Game.Core.Players;
-using Game.Core.Players.Inventories;
 using Game.Core.Skills;
 using static Game.Core.EAttribute;
 
@@ -35,11 +33,6 @@ namespace Game.Core.Battle
         public int Level { get; private set; }
 
         public bool IsDead => CurrentHealth <= 0;
-
-        public Battler(Player player)
-            : this(player.GetAttributes(), player.SelectedSkills, player.Level)
-        {
-        }
 
         public Battler(AttributeCollection attributes, IEnumerable<Skill> skills, int level)
         {

--- a/Game.Core/Enums.cs
+++ b/Game.Core/Enums.cs
@@ -59,39 +59,44 @@ namespace Game.Core
         DropBonus = 9,
 
         /// <summary>
-        /// CURRENTLY UNUSED. A derived game attribute. Represents a % change to deal increased damage with an attack.
+        /// A derived game attribute. A decimal probability (0.05 = 5%) that an attack lands a critical hit,
+        /// compared directly against the battle RNG draw. Sourced from Dexterity/Luck (player-only).
         /// </summary>
         CriticalChance = 10,
 
         /// <summary>
-        /// CURRENTLY UNUSED. A derived game attribute. Represents an additive % increase in the amount of damage dealt when a critical hit occurs.
+        /// A derived game attribute. A base-≥1 multiplier (base 1.5) read directly: on a critical hit the raw
+        /// damage is multiplied by it before Defense is subtracted, so it can punch through Defense.
         /// </summary>
         CriticalDamage = 11,
 
         /// <summary>
-        /// CURRENTLY UNUSED. A derived game attribute. Represents a % change to ignore all damage from an incoming attack.
+        /// A derived game attribute. A decimal probability (0.05 = 5%) to fully ignore an incoming attack,
+        /// compared directly against the battle RNG draw. Sourced from Agility (player-only).
         /// </summary>
         DodgeChance = 12,
 
         /// <summary>
-        /// CURRENTLY UNUSED. A derived game attribute. Represents a % change to ignore part of the damage from an incoming attack.
+        /// A derived game attribute. A decimal probability (0.05 = 5%) to block part of an incoming attack,
+        /// compared directly against the battle RNG draw. Sourced from Endurance (player-only).
         /// </summary>
         BlockChance = 13,
 
         /// <summary>
-        /// CURRENTLY UNUSED. A derived game attribute. Represents a flat reduction for damage received when a block occurs.
+        /// A derived game attribute. A flat reduction (base 2) applied alongside Defense when an incoming
+        /// attack is blocked.
         /// </summary>
         BlockReduction = 14,
 
         /// <summary>
-        /// CURRENTLY UNUSED. A per-second attribute representing the amount of damage taken each second from
-        /// damage-over-time effects. Consumed by the DoT/HoT simulator phase (#334).
+        /// A per-second attribute representing the amount of damage taken each second from damage-over-time
+        /// effects. Consumed by the end-of-tick DoT/HoT simulator phase (bypasses Defense).
         /// </summary>
         DamageTakenPerSecond = 15,
 
         /// <summary>
-        /// CURRENTLY UNUSED. A per-second attribute representing the amount of health restored each second from
-        /// heal-over-time effects. Consumed by the DoT/HoT simulator phase (#334).
+        /// A per-second attribute representing the amount of health restored each second from heal-over-time
+        /// effects. Consumed by the end-of-tick DoT/HoT simulator phase (capped at MaxHealth).
         /// </summary>
         HealthRegenPerSecond = 16
     }


### PR DESCRIPTION
## Summary

Addresses the three independent `Game.Core` hygiene items in #956.

### 1. Stale "CURRENTLY UNUSED" XML docs on now-live attributes — fixed
`Game.Core/Enums.cs`

`CriticalChance`, `CriticalDamage`, `DodgeChance`, `BlockChance`, `BlockReduction`, `DamageTakenPerSecond`, and `HealthRegenPerSecond` were all documented as **"CURRENTLY UNUSED"** despite being fully wired (crit/dodge/block in `BattleContext.DamageTarget`, DoT/HoT in `Battler` + `BattleContext.ResolveDamageOverTime`) and documented as live mechanics in `game-design.md`. The docs now describe the current behavior, mirroring game-design.md:
- `% change` → `% chance` for the three chance attributes, with a note that each is a decimal probability compared directly against the battle RNG and which core attribute sources it (player-only).
- `CriticalDamage` corrected from "additive % increase" to a base-≥1 multiplier (base 1.5) read directly before Defense.
- Dropped the now-irrelevant issue reference on the DoT/HoT attributes. (`DropBonus` is genuinely obsolete and was left as-is.)

### 2. `AttributeCollectionNode.DerivedNodes` eagerly allocated — made lazy
`Game.Core/Attributes/AttributeCollectionNode.cs` (+ 3 call sites in `AttributeCollection.cs`)

`Modifiers` is allocated lazily, but `DerivedNodes` was eagerly `= []` on every node, so the first read of *any* attribute allocated a node **and** an empty `HashSet` — including the player-only crit/dodge/block attributes an enemy battler reads as zero on every `DamageTarget` call. `DerivedNodes` is now null until the first derived link (new `GetOrCreateDerivedNodes`, mirroring `GetOrCreateModifiers`); the cascade (`SetCachedValue`) and unhook paths treat null as the empty set. Pure allocation optimization, no behavior change — the derived-cascade / circular-detection / unhook / derived-only-source paths are already covered by `AttributeCollectionTests`.

### 3. Test-only `Battler(Player)` ctor bypassing the production snapshot path
`Game.Core/Battle/Battler.cs`, new `Game.Core.TestInfrastructure/Builders/BattlerFactory.cs`, 5 test files

The `Battler(Player)` constructor was referenced **only by tests** (production always builds battlers via `BattleSnapshot.ToBattler`). I took the issue's **option 2** (keep a direct-from-player construction guarded by an explicit cross-path parity test) — and that test already exists as `BattleSnapshotTests.AssertBattlerParity`, which asserts the direct path and the production snapshot path produce identical attributes/level/health/skills. To also clear the literal smell (a test-only ctor living in production `Game.Core`), I removed the ctor and relocated the convenience to the test-infrastructure project as `BattlerFactory.FromPlayer`, updating the 15 call sites. The removed ctor's two now-dead `using`s were trimmed.

**Deliberately not done (option 1):** fully routing the simulator/parity tests through `BattleSnapshot.FromPlayer(...).ToBattler(...)` would force per-test catalog resolvers and is a larger change that overlaps with the shared `PlayerBuilder` work in #817. The existing `AssertBattlerParity` already pins the snapshot↔direct equivalence, so I left that as a follow-up rather than expanding a `scope: small` issue. Happy to do it under #817 if preferred.

## Test plan

- `dotnet build Game.sln` — **0 warnings, 0 errors** (all 12 projects, confirming nothing else referenced the removed ctor).
- `dotnet test Game.Core.Tests` — **649 passed** (includes the battle simulator/parity/snapshot/context/skill tests now routed through `BattlerFactory`, and the `AttributeCollection` derived-cascade suite covering the lazy-`DerivedNodes` change).

No battle-math behavior changed, so no frontend parity mirror is needed.

Closes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015CKY7gSgUHEHfMwoo6pu2N)_