### PR TITLE
SocketInterceptorMiddleware: return { errorMessage } envelope on the 401/400 short-circuits

### DIFF
--- a/Game.Api.Tests/Integration/SocketConnectionTests.cs
+++ b/Game.Api.Tests/Integration/SocketConnectionTests.cs
@@ -1,4 +1,5 @@
 using Game.Api;
+using Game.Api.Models.Common;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
@@ -77,6 +78,35 @@ namespace Game.Api.Tests.Integration
 
             await Assert.ThrowsAnyAsync<Exception>(
                 () => wsClient.ConnectAsync(new Uri("ws://localhost/socket"), CancellationToken));
+        }
+
+        [Fact]
+        public async Task Socket_Unauthenticated_ReturnsErrorEnvelope()
+        {
+            // A plain HTTP request to /socket with no token short-circuits to 401 before any upgrade, so the
+            // body carries the project's { errorMessage } envelope rather than being empty.
+            var response = await Client.GetAsync("/socket", CancellationToken);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            var body = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(body);
+            Assert.False(string.IsNullOrWhiteSpace(body.ErrorMessage));
+        }
+
+        [Fact]
+        public async Task Socket_AuthenticatedButNotWebSocketUpgrade_ReturnsErrorEnvelope()
+        {
+            // An authenticated but non-upgrade request to /socket short-circuits to 400 before any upgrade, so
+            // the body carries the { errorMessage } envelope rather than being empty.
+            var (userId, playerId) = await SeedAsync();
+            var authedClient = CreateAuthenticatedClient(userId, playerId);
+
+            var response = await authedClient.GetAsync("/socket", CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var body = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(body);
+            Assert.False(string.IsNullOrWhiteSpace(body.ErrorMessage));
         }
 
         [Fact]

--- a/Game.Api/Middleware/SocketInterceptorMiddleware.cs
+++ b/Game.Api/Middleware/SocketInterceptorMiddleware.cs
@@ -19,11 +19,16 @@ namespace Game.Api.Middleware
             }
             else if (!sessionService.Authenticated)
             {
+                // The socket isn't upgraded yet, so a body can still be written: return the project's
+                // { errorMessage } envelope rather than a bare status code.
                 context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                await context.Response.WriteAsJsonAsync(ApiResponse.Error("Authentication is required to open a socket connection."), context.RequestAborted);
             }
             else if (!context.WebSockets.IsWebSocketRequest)
             {
+                // As above, a body is still writable before the (here, absent) upgrade.
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await context.Response.WriteAsJsonAsync(ApiResponse.Error("The /socket endpoint requires a WebSocket upgrade request."), context.RequestAborted);
             }
             else if (!await TryLoadPlayer(sessionService, sessionInitializer, scopeFactory, context.RequestAborted))
             {


### PR DESCRIPTION
Closes #1012

## Summary

Follow-up to #953 / #1011, which fixed the handshake `500` path in `SocketInterceptorMiddleware` to return the project's `{ errorMessage }` envelope. The same middleware had two sibling short-circuits that still set a bare status code with no body:

- `401 Unauthorized` when the session is unauthenticated.
- `400 BadRequest` when the request to `/socket` isn't a WebSocket upgrade.

Both branches now write the `ApiResponse.Error(...)` envelope via `WriteAsJsonAsync`, using the exact same approach as the `404` branch from #1011. A body is writable at these points because the socket hasn't been upgraded yet. Clear, case-specific messages are provided for each (authentication required vs. WebSocket upgrade required). No status codes or control flow changed — this is response-shaping only.

## How I tested

- Built the full solution with `-warnaserror`: 0 warnings, 0 errors.
- Added two integration tests to `SocketConnectionTests` mirroring the existing handshake coverage, asserting each short-circuit now returns the `{ errorMessage }` body:
  - `Socket_Unauthenticated_ReturnsErrorEnvelope` — plain HTTP GET to `/socket` with no token returns 401 + envelope.
  - `Socket_AuthenticatedButNotWebSocketUpgrade_ReturnsErrorEnvelope` — authenticated non-upgrade GET returns 400 + envelope.
- Ran the targeted integration suite `--filter-class "*SocketConnectionTests"`: 7/7 passed (held the shared-infra lock briefly).
- Ran the full `Game.Api.Tests` unit suite: 136/136 passed.

## Notes / follow-ups

- #1011 fixed the `404` branch but did not add a dedicated integration test asserting its `{ errorMessage }` body; the two tests added here establish that pattern for the 401/400 branches. A matching test for the 404 (player-not-loadable) branch could be added later for symmetry, but it's outside this issue's scope.
- The middleware sets the status code directly, so the `ApiResponse` `ErrorCategory` (which only steers MVC results via `ErrorStatusFilter`) is intentionally irrelevant here — matching how the 404 branch passes only the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F7YCAqc161ytuGnXYCcrK

---
_Generated by [Claude Code](https://claude.ai/code/session_015F7YCAqc161ytuGnXYCcrK)_