### PR TITLE
Frontend small perf/cleanups (per-frame skill lookup, inventory .find→Map.get, item-tooltip test, KindTag fallback)

### DIFF
--- a/UI/src/routes/game/screens/attribute-breakdown/KindTag.svelte
+++ b/UI/src/routes/game/screens/attribute-breakdown/KindTag.svelte
@@ -17,7 +17,9 @@ interface Props {
 
 let { type }: Props = $props();
 
-const label = $derived(ATTRIBUTE_TYPE_GROUPS.find((g) => g.type === type)?.label ?? '');
+// Falls back to a visible "Unknown" rather than an empty pill so an unmapped EAttributeType (e.g. a
+// future enum addition the taxonomy hasn't caught up to) surfaces loudly instead of rendering blank.
+const label = $derived(ATTRIBUTE_TYPE_GROUPS.find((g) => g.type === type)?.label ?? 'Unknown');
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/game/screens/fight/ActiveEffectChips.svelte
+++ b/UI/src/routes/game/screens/fight/ActiveEffectChips.svelte
@@ -137,10 +137,32 @@ const tip = createAttributeTooltip(() => tooltip);
 let shownKey = $state<string>();
 const shownGroup = $derived(shownKey != null ? effectGroups.find((g) => g.key === shownKey) : undefined);
 
-// The skill an active effect came from: its `sourceId` is the authored skill-effect id, so find the
-// skill that owns it. Display-only (never touches battle math); undefined for a retired/unknown skill.
-const sourceSkillName = (sourceId: number): string | undefined =>
-	staticData.skills?.find((skill) => skill?.effects.some((e) => e.id === sourceId))?.name;
+// The skill an active effect came from: its `sourceId` is the authored skill-effect id, so look up
+// the skill that owns it. Display-only (never touches battle math); undefined for a retired/unknown
+// skill. Skill→effect ownership is static reference data, so the effectId→name index is memoised off
+// the `staticData.skills` reference and rebuilt only when that catalogue changes — rather than
+// rescanning every skill's effects per call (this resolves inside the per-frame `shownEffectContext`).
+let skillNameByEffectIdCache: { skills: unknown; map: Map<number, string> } | undefined;
+const skillNameByEffectId = (): Map<number, string> => {
+	const skills = staticData.skills;
+	if (!skillNameByEffectIdCache || skillNameByEffectIdCache.skills !== skills) {
+		// A plain memo cache, not reactive state — it never drives rendering, so SvelteMap is unwanted.
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const map = new Map<number, string>();
+		for (const skill of skills ?? []) {
+			if (!skill) {
+				continue;
+			}
+			for (const effect of skill.effects) {
+				map.set(effect.id, skill.name);
+			}
+		}
+		skillNameByEffectIdCache = { skills, map };
+	}
+	return skillNameByEffectIdCache.map;
+};
+
+const sourceSkillName = (sourceId: number): string | undefined => skillNameByEffectId().get(sourceId);
 
 // Live effect context for the panel: reads renderRemainingMs so the countdown pill depletes smoothly. A
 // single application names its source in the header; a stack names each application's source per row.

--- a/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
+++ b/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
@@ -75,6 +75,8 @@ export class InventoryView {
 
 	// Resolve selection/drag through the manager's itemId-keyed Map (its own O(1) access convention)
 	// rather than a linear scan of the list; `items` stays the source for list/count derivations.
+	// NOTE: unlockedItems is a plain (non-reactive) Map, so these re-resolve only on id changes, not on
+	// set changes — fine while items are add-only; if a removal path lands, clear the ids on removal.
 	readonly selected = $derived(
 		this.selectedId != null ? (inventoryManager.unlockedItems.get(this.selectedId) ?? null) : null
 	);

--- a/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
+++ b/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
@@ -73,12 +73,14 @@ export class InventoryView {
 		return map;
 	});
 
+	// Resolve selection/drag through the manager's itemId-keyed Map (its own O(1) access convention)
+	// rather than a linear scan of the list; `items` stays the source for list/count derivations.
 	readonly selected = $derived(
-		this.selectedId != null ? (this.items.find((i) => i.itemId === this.selectedId) ?? null) : null
+		this.selectedId != null ? (inventoryManager.unlockedItems.get(this.selectedId) ?? null) : null
 	);
 
 	readonly dragItem = $derived(
-		this.dragItemId != null ? (this.items.find((i) => i.itemId === this.dragItemId) ?? null) : null
+		this.dragItemId != null ? (inventoryManager.unlockedItems.get(this.dragItemId) ?? null) : null
 	);
 
 	readonly counts = $derived.by(() => {

--- a/UI/src/tests/routes/game/screens/attribute-breakdown/attribute-breakdown-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attribute-breakdown/attribute-breakdown-view.test.ts
@@ -17,6 +17,7 @@ vi.mock('$stores', () => ({ staticData }));
 
 import { attributeName } from '$lib/common';
 import {
+	ATTRIBUTE_TYPE_GROUPS,
 	AttributeBreakdownView,
 	buildGroups,
 	buildPlayerModifiers,
@@ -297,5 +298,17 @@ describe('formatting + labels', () => {
 		expect(
 			modifierLabel({ source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Endurance } as never)
 		).toBe('Endurance');
+	});
+});
+
+describe('ATTRIBUTE_TYPE_GROUPS taxonomy coverage', () => {
+	// KindTag resolves its label from these groups; an unmapped EAttributeType would render a blank
+	// pill, so every enum value must have a group. This fails loud if a future type is added without one.
+	it('maps every EAttributeType value to a display group', () => {
+		const mapped = new Set(ATTRIBUTE_TYPE_GROUPS.map((g) => g.type));
+		const values = Object.values(EAttributeType).filter((v): v is EAttributeType => typeof v === 'number');
+		for (const value of values) {
+			expect(mapped.has(value)).toBe(true);
+		}
 	});
 });

--- a/UI/src/tests/routes/game/screens/inventory/ItemTooltipControllerFixture.svelte
+++ b/UI/src/tests/routes/game/screens/inventory/ItemTooltipControllerFixture.svelte
@@ -1,0 +1,22 @@
+<!-- Drives createItemTooltip inside a real component lifecycle (it registers an onDestroy cleanup via
+     the tooltip store) so the controller can be exercised in isolation. The reactive `item` render
+     state is surfaced through `onHandle` so a test can assert show/move/hide effects. -->
+<div></div>
+
+<script lang="ts">
+import { createItemTooltip, type ItemTooltipHandle } from '$routes/game/screens/inventory/item-tooltip.svelte';
+
+interface Props {
+	onHandle: (handle: ItemTooltipHandle) => void;
+}
+
+const { onHandle }: Props = $props();
+
+// The controller never invokes the component getter for show/move/hide (it only drives the store's
+// position/visibility), so a minimal stand-in stands in for the rendered tooltip panel.
+const handle = createItemTooltip(() => ({ getBaseNode: () => document.createElement('div') }));
+
+// Hand the live handle to the test once; its getters stay reactive so later reads reflect mutations.
+// svelte-ignore state_referenced_locally
+onHandle(handle);
+</script>

--- a/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
@@ -16,6 +16,7 @@ const {
 	removeMod,
 	toastError,
 	unlockedMods,
+	unlockedItems,
 	sampleItems,
 	sampleSlots,
 	sampleStats,
@@ -28,6 +29,9 @@ const {
 	removeMod: vi.fn(),
 	toastError: vi.fn(),
 	unlockedMods: new Set<number>(),
+	// The manager's itemId-keyed Map that selection/drag now resolve through (kept in sync with
+	// sampleItems in beforeEach), mirroring InventoryManager.unlockedItems.
+	unlockedItems: new Map<number, Item>(),
 	sampleItems: [] as Item[],
 	sampleSlots: new Array(6).fill(undefined) as (Item | undefined)[],
 	sampleStats: [] as IBattlerAttribute[],
@@ -55,6 +59,7 @@ vi.mock('$lib/engine', () => ({
 		get equipmentStats() {
 			return sampleStats;
 		},
+		unlockedItems,
 		unlockedMods,
 		equipItem,
 		unequipItem,
@@ -96,6 +101,7 @@ beforeEach(() => {
 	setFavorite.mockClear();
 	toastError.mockClear();
 	unlockedMods.clear();
+	unlockedItems.clear();
 	staticData.itemMods = [];
 	sampleSlots.fill(undefined);
 	sampleStats.length = 0;
@@ -105,6 +111,10 @@ beforeEach(() => {
 		makeItem(2, 'Alpha Blade', EItemCategory.Weapon, ERarity.Legendary),
 		makeItem(3, 'Mid Ring', EItemCategory.Accessory, ERarity.Common)
 	);
+	// Mirror the manager's itemId-keyed Map so selection/drag resolution matches the list contents.
+	for (const item of sampleItems) {
+		unlockedItems.set(item.itemId, item);
+	}
 });
 
 describe('item-category display helpers', () => {

--- a/UI/src/tests/routes/game/screens/inventory/item-tooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/item-tooltip.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { flushSync } from 'svelte';
+import { tooltips, type TooltipData } from '$stores';
+import type { Item } from '$lib/battle';
+import type { ItemTooltipHandle } from '$routes/game/screens/inventory/item-tooltip.svelte';
+import Fixture from './ItemTooltipControllerFixture.svelte';
+
+afterEach(cleanup);
+
+const makeItem = (itemId: number, name: string): Item => ({ itemId, name }) as unknown as Item;
+
+// A pointer anchor resolves to its cursor coordinates; an element anchor would resolve off its box.
+const anchorAt = (x: number, y: number) => ({ clientX: x, clientY: y }) as MouseEvent;
+
+/** Renders the fixture and returns the live controller handle plus the tooltip store entry it owns. */
+const mountController = (): { handle: ItemTooltipHandle; data: TooltipData } => {
+	let handle: ItemTooltipHandle | undefined;
+	render(Fixture, { props: { onHandle: (h: ItemTooltipHandle) => (handle = h) } });
+	flushSync();
+	if (!handle) {
+		throw new Error('fixture did not surface the controller handle');
+	}
+	const data = [...tooltips.data].at(-1);
+	if (!data) {
+		throw new Error('controller did not register a tooltip');
+	}
+	return { handle, data };
+};
+
+describe('createItemTooltip', () => {
+	it('registers a tooltip on mount and unregisters it on destroy', () => {
+		const before = [...tooltips.data].length;
+		const view = render(Fixture, { props: { onHandle: () => {} } });
+		flushSync();
+		expect([...tooltips.data].length).toBe(before + 1);
+
+		view.unmount();
+		flushSync();
+		expect([...tooltips.data].length).toBe(before);
+	});
+
+	it('exposes a stable describedById for aria-describedby wiring', () => {
+		const { handle, data } = mountController();
+		expect(handle.controller.describedById).toBe(`tooltip-${data.id}`);
+	});
+
+	it('starts hidden with no item', () => {
+		const { handle, data } = mountController();
+		expect(handle.item).toBeUndefined();
+		expect(data.visible).toBe(false);
+	});
+
+	it('show sets the item, positions the panel, and reveals it', () => {
+		const { handle, data } = mountController();
+		const item = makeItem(7, 'Alpha Blade');
+
+		handle.controller.show(item, anchorAt(120, 45));
+		flushSync();
+
+		// `$state` deep-proxies the stored object, so compare by value rather than reference identity.
+		expect(handle.item?.itemId).toBe(7);
+		expect(handle.item?.name).toBe('Alpha Blade');
+		expect(data.position).toEqual({ x: 120, y: 45 });
+		expect(data.visible).toBe(true);
+	});
+
+	it('move repositions without clearing the shown item', () => {
+		const { handle, data } = mountController();
+		const item = makeItem(7, 'Alpha Blade');
+		handle.controller.show(item, anchorAt(120, 45));
+		flushSync();
+
+		handle.controller.move(anchorAt(200, 90));
+		flushSync();
+
+		// move only repositions the panel; the shown item is left intact.
+		expect(data.position).toEqual({ x: 200, y: 90 });
+		expect(handle.item?.itemId).toBe(7);
+		expect(data.visible).toBe(true);
+	});
+
+	it('hide clears the item and conceals the panel', () => {
+		const { handle, data } = mountController();
+		handle.controller.show(makeItem(7, 'Alpha Blade'), anchorAt(120, 45));
+		flushSync();
+
+		handle.controller.hide();
+		flushSync();
+
+		expect(handle.item).toBeUndefined();
+		expect(data.visible).toBe(false);
+	});
+});


### PR DESCRIPTION
Closes #957

Four small, isolated frontend cleanups.

## 1. Per-frame skill-by-effect-id lookup (`ActiveEffectChips.svelte`)
`sourceSkillName` did `staticData.skills?.find(s => s?.effects.some(e => e.id === sourceId))` — O(skills × effects) — inside the `shownEffectContext` `$derived`, which depends on a per-frame interpolated value, so the whole skill catalogue was rescanned every frame while an effect-chip tooltip was hovered. Replaced with an `effectId → skill name` `Map` memoised off the `staticData.skills` reference (skill→effect ownership is static reference data, so the index is rebuilt only when that catalogue changes); resolution is now `.get(sourceId)`.

## 2. Inventory selection/drag resolution (`inventory-view.svelte.ts`)
`selected` and `dragItem` did `this.items.find(i => i.itemId === id)`. `InventoryManager.unlockedItems` is a public `itemId`-keyed `Map` the manager resolves through everywhere, so both now use `inventoryManager.unlockedItems.get(id) ?? null`. `items` remains the source for the list/count/visible derivations.

## 3. `createItemTooltip` controller test (new)
`item-tooltip.svelte.ts` was the one view-model controller without a dedicated test. Added `item-tooltip.test.ts` (plus a small `ItemTooltipControllerFixture.svelte` so the controller's `onDestroy` cleanup runs in a real component lifecycle, mirroring the tooltip-store tests) asserting: `show` sets the item, positions the panel, and reveals it; `move` repositions without clearing the item; `hide` clears the item and conceals the panel; and register/unregister + `describedById` wiring.

## 4. `KindTag` fallback (`KindTag.svelte`)
An unmapped `EAttributeType` fell back to `''`, rendering an invisible empty pill. Changed the fallback to a visible `'Unknown'` so a future enum addition surfaces loudly, and added a test asserting every `EAttributeType` value maps to a display group (a durable guard against the taxonomy falling out of sync).

## Verification
- `vitest run` on all affected suites (inventory, attribute-breakdown, fight) — all green; the existing `ActiveEffectChips.test.ts` (which exercises `sourceSkillName`) still passes unchanged, confirming item 1's output is identical.
- `npm run check` (svelte-check): 0 errors / 0 warnings.
- `eslint .`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F7YCAqc161ytuGnXYCcrK

---
_Generated by [Claude Code](https://claude.ai/code/session_015F7YCAqc161ytuGnXYCcrK)_