### PR TITLE
Align background reference-cache reload with the request-time path

### DIFF
--- a/Game.Application.Tests/DataAccess/CoalescingReferenceCacheReloaderTests.cs
+++ b/Game.Application.Tests/DataAccess/CoalescingReferenceCacheReloaderTests.cs
@@ -65,6 +65,47 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task RunAsync_Sweep_ReloadsAllHoldersConcurrently()
+        {
+            // Each holder blocks until every holder has entered its reload: a serial sweep would deadlock here
+            // (the second holder never enters until the first returns) and the gate would time out, so the
+            // gate opening proves the reloads ran concurrently rather than back-to-back.
+            var gate = new ConcurrentEntryGate(participants: 3);
+            var holders = new[] { new GatedCache(gate), new GatedCache(gate), new GatedCache(gate) };
+            var policy = new ReferenceCacheReloadPolicy(TimeSpan.Zero, maxAttempts: 1, baseDelay: TimeSpan.Zero);
+            await using var harness = new Harness(policy, holders);
+
+            harness.Reloader.NotifyChanged();
+
+            await WaitUntilAsync(() => holders.All(h => h.CompletedReloads == 1), "every holder to reload concurrently");
+        }
+
+        [Fact]
+        public async Task RunAsync_FailureMidSweep_RetriesOnlyTheFailedHolderAndSkipsSucceededOnes()
+        {
+            // The middle holder fails its first attempt; the others succeed. The retry must re-run only the
+            // failed holder, never the already-succeeded ones (re-reloading a succeeded build-then-swap is
+            // wasted work).
+            var first = new RecordingCache();
+            var failing = new RecordingCache { FailFirstAttempts = 1 };
+            var last = new RecordingCache();
+            var policy = new ReferenceCacheReloadPolicy(TimeSpan.Zero, maxAttempts: 3, baseDelay: TimeSpan.Zero);
+            await using var harness = new Harness(policy, first, failing, last);
+
+            harness.Reloader.NotifyChanged();
+
+            await WaitUntilAsync(() => failing.CompletedReloads == 1, "the failed holder to succeed on retry");
+            // The succeeded holders ran exactly once; only the failed holder was attempted again.
+            Assert.Equal(1, first.Attempts);
+            Assert.Equal(1, last.Attempts);
+            Assert.Equal(2, failing.Attempts);
+            Assert.Equal(1, first.CompletedReloads);
+            Assert.Equal(1, last.CompletedReloads);
+            Assert.Single(harness.Logs.Entries, e => e.Level == LogLevel.Warning);
+            Assert.DoesNotContain(harness.Logs.Entries, e => e.Level == LogLevel.Error);
+        }
+
+        [Fact]
         public async Task RunAsync_TransientFailure_RetriesAndCompletesTheSweep()
         {
             var cache = new RecordingCache { FailFirstAttempts = 1 };
@@ -203,6 +244,40 @@ namespace Game.Application.Tests.DataAccess
 
                 Interlocked.Increment(ref _completedReloads);
                 return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>
+        /// Releases all participants only once every one of them has entered its reload, so a sweep completes
+        /// iff the reloads ran concurrently — a serial sweep would deadlock waiting for a peer that never starts.
+        /// </summary>
+        private sealed class ConcurrentEntryGate(int participants)
+        {
+            private readonly TaskCompletionSource _allEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private int _entered;
+
+            public Task SignalEnteredAndWaitAsync()
+            {
+                if (Interlocked.Increment(ref _entered) == participants)
+                {
+                    _allEntered.TrySetResult();
+                }
+
+                return _allEntered.Task;
+            }
+        }
+
+        /// <summary>A reload that blocks at a shared gate until every gated holder has entered concurrently.</summary>
+        private sealed class GatedCache(ConcurrentEntryGate gate) : IReloadableReferenceCache
+        {
+            private int _completedReloads;
+
+            public int CompletedReloads => Volatile.Read(ref _completedReloads);
+
+            public async Task ReloadAsync(CancellationToken cancellationToken = default)
+            {
+                await gate.SignalEnteredAndWaitAsync();
+                Interlocked.Increment(ref _completedReloads);
             }
         }
 

--- a/Game.DataAccess/CoalescingReferenceCacheReloader.cs
+++ b/Game.DataAccess/CoalescingReferenceCacheReloader.cs
@@ -60,32 +60,86 @@ namespace Game.DataAccess
 
         private async Task ReloadAllAsync(CancellationToken cancellationToken)
         {
+            var pending = caches.ToList();
             for (var attempt = 1; attempt <= policy.MaxAttempts; attempt++)
             {
-                try
+                // Retry only the holders that haven't succeeded yet: each reload is a build-then-swap that
+                // leaves the prior snapshot in place on failure, so re-reloading a succeeded holder is wasted work.
+                var failure = await ReloadConcurrentlyAsync(pending, cancellationToken);
+                if (failure is null)
                 {
-                    foreach (var cache in caches)
-                    {
-                        await cache.ReloadAsync(cancellationToken);
-                    }
-
                     return;
                 }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+
+                pending = failure.StillPending;
+                if (attempt < policy.MaxAttempts)
                 {
-                    throw;
-                }
-                catch (Exception ex) when (attempt < policy.MaxAttempts)
-                {
-                    logger.LogWarning(ex, "Background reference-cache reload failed on attempt {Attempt} of {MaxAttempts}; retrying.", attempt, policy.MaxAttempts);
+                    logger.LogWarning(failure.Error, "Background reference-cache reload failed on attempt {Attempt} of {MaxAttempts}; retrying.", attempt, policy.MaxAttempts);
                     await Task.Delay(policy.DelayAfterAttempt(attempt), cancellationToken);
                 }
-                catch (Exception ex)
+                else
                 {
                     // Readers keep serving the previous snapshots; the next notification triggers a fresh sweep.
-                    logger.LogError(ex, "Background reference-cache reload failed after {MaxAttempts} attempts; keeping the current snapshots.", policy.MaxAttempts);
+                    logger.LogError(failure.Error, "Background reference-cache reload failed after {MaxAttempts} attempts; keeping the current snapshots.", policy.MaxAttempts);
                 }
             }
         }
+
+        /// <summary>
+        /// Reloads every still-pending holder concurrently — matching the request-time AdminCacheReloadFilter:
+        /// each rebuilds its snapshot on its own scoped context and swaps it atomically, and no holder depends
+        /// on another's reload order, so a serial pass only adds latency and could leave some sets fresh and
+        /// some stale if one query failed mid-list. Awaits every reload before inspecting results so one
+        /// failure doesn't abandon the others mid-flight, returns <c>null</c> on full success, and rethrows
+        /// promptly on cancellation so the loop unwinds.
+        /// </summary>
+        private static async Task<ReloadFailure?> ReloadConcurrentlyAsync(
+            List<IReloadableReferenceCache> pending,
+            CancellationToken cancellationToken)
+        {
+            // Start every reload, capturing a holder that throws synchronously as a faulted task so it lines up
+            // with the others by index and is retried like any async failure (rather than escaping the await).
+            var reloads = pending.Select(cache => StartReload(cache, cancellationToken)).ToList();
+            try
+            {
+                await Task.WhenAll(reloads);
+                return null;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception error)
+            {
+                // Keep the holders whose reload didn't succeed; the succeeded ones drop out so a retry skips
+                // them. Task.WhenAll surfaces only the first fault, which is enough to log the failure cause.
+                var stillPending = new List<IReloadableReferenceCache>();
+                for (var i = 0; i < pending.Count; i++)
+                {
+                    if (!reloads[i].IsCompletedSuccessfully)
+                    {
+                        stillPending.Add(pending[i]);
+                    }
+                }
+
+                return new ReloadFailure(stillPending, error);
+            }
+        }
+
+        /// <summary>Invokes a reload, turning a synchronous throw into a faulted task so the caller can await it uniformly.</summary>
+        private static Task StartReload(IReloadableReferenceCache cache, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return cache.ReloadAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException(ex);
+            }
+        }
+
+        /// <summary>A failed concurrent sweep: the holders still needing a reload and the fault to log.</summary>
+        private sealed record ReloadFailure(List<IReloadableReferenceCache> StillPending, Exception Error);
     }
 }


### PR DESCRIPTION
Closes #1008

## Summary

The two entry points that reload the in-memory reference caches after an admin write had diverged. The request-time `AdminCacheReloadFilter` reloads all holders concurrently via `Task.WhenAll`, while the cross-instance background `CoalescingReferenceCacheReloader` reloaded them serially in a `foreach` and, on a mid-sweep failure, re-reloaded the already-succeeded holders on the next retry. Both paths were correctness-safe (no holder depends on another's reload order); this is an efficiency/consistency cleanup, not a bug fix.

This change aligns the background reloader with the request-time path:

- **Concurrent reload.** `ReloadAllAsync` now reloads all pending holders concurrently via `Task.WhenAll` (extracted into `ReloadConcurrentlyAsync`), matching the filter — closing the latency gap (N sequential DB round-trips becomes one concurrent fan-out) and the comment rationale is kept consistent with `AdminCacheReloadFilter`'s.
- **Retry only the unsucceeded holders.** The retry loop now tracks the still-pending set across attempts, so a failure on one holder no longer re-runs the build-then-swap for holders that already succeeded (wasted work — each succeeded reload already published its fresh snapshot).
- **Preserved semantics.** Retry/coalescing behaviour and cancellation-token propagation are unchanged: a cancellation rethrows promptly so the loop unwinds, and `Task.WhenAll` is awaited fully before inspecting results so one failure doesn't abandon the others mid-flight. A holder that throws synchronously is captured as a faulted task (`StartReload`) so it is retried uniformly rather than escaping the await.

No documentation change: the change is a narrowly-scoped efficiency cleanup and the documented cache-reload architecture (build-then-swap, retry-with-backoff, readers never disturbed) is unchanged.

## How I tested

- `dotnet build Game.sln -warnaserror` — full solution builds with **0 warnings, 0 errors**.
- Added two unit tests to `CoalescingReferenceCacheReloaderTests` and verified each genuinely guards the new behaviour (each fails against the prior implementation):
  - `RunAsync_Sweep_ReloadsAllHoldersConcurrently` — holders block at a shared gate that only opens once all have entered, so it completes iff the reloads run concurrently (a serial sweep deadlocks/times out — confirmed).
  - `RunAsync_FailureMidSweep_RetriesOnlyTheFailedHolderAndSkipsSucceededOnes` — asserts the succeeded holders are attempted exactly once and only the failed holder is retried (fails under the old retry-the-whole-sweep behaviour — confirmed).
- `dotnet test Game.Application.Tests` — full suite green: **342 passed, 0 failed** (the 8 reloader tests included).

Integration tests were not run for this change — it touches only in-process logic with no Redis/Postgres dependency, and the reloader's pub/sub glue is covered by existing `ReferenceCacheSynchronizerTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F7YCAqc161ytuGnXYCcrK

---
_Generated by [Claude Code](https://claude.ai/code/session_015F7YCAqc161ytuGnXYCcrK)_