### PR TITLE
Extract a shared insert-if-missing helper for the write-behind unlock handlers (DRY)

### DIFF
--- a/Game.Application.Tests/DataAccess/InsertIfMissingIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/InsertIfMissingIntegrationTests.cs
@@ -1,0 +1,135 @@
+using Game.DataAccess.PlayerUpdates.Handlers;
+using Game.Infrastructure.Database;
+using Game.Infrastructure.Entities;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Game.Application.Tests.DataAccess
+{
+    /// <summary>
+    /// Verifies the shared <see cref="PlayerUpdateHandlerExtensions.InsertIfMissingAsync"/> contract once, at
+    /// the helper level: the existence-check-then-insert is idempotent under the queue's at-least-once read,
+    /// converging to a single row whether re-applied sequentially or as a concurrent double-apply that provokes
+    /// the unique-violation race the catch absorbs. The collapsed unlock handlers all route through this helper,
+    /// so their per-handler idempotency tests (see <see cref="PlayerUpdateHandlerIdempotencyIntegrationTests"/>)
+    /// exercise the same path and pin the wiring. Exercised against <see cref="UnlockedItem"/> as a
+    /// representative entity carrying a (player, item) unique key.
+    /// </summary>
+    [Collection("Integration")]
+    public class InsertIfMissingIntegrationTests : ApplicationIntegrationTestBase
+    {
+        // Enough concurrent inserts that several pass the existence check before any insert commits, so the
+        // unique-violation catch path is exercised rather than only the fast existence-check no-op.
+        private const int Parallelism = 8;
+
+        public InsertIfMissingIntegrationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        [Fact]
+        public async Task RowMissing_InsertsTheRow()
+        {
+            var playerId = await SeedPlayerAsync();
+            var itemId = await SeedItemAsync();
+
+            await InsertUnlockedItemAsync(playerId, itemId);
+
+            Assert.Equal(1, await CountUnlockedItemsAsync(playerId, itemId));
+        }
+
+        [Fact]
+        public async Task RowAlreadyPresent_DoesNotInsertOrInvokeFactoryTwice()
+        {
+            var playerId = await SeedPlayerAsync();
+            var itemId = await SeedItemAsync();
+
+            await InsertUnlockedItemAsync(playerId, itemId);
+
+            // The second call must short-circuit on the existence check and never run the factory.
+            var factoryInvoked = false;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                await context.InsertIfMissingAsync(
+                    (UnlockedItem ui) => ui.PlayerId == playerId && ui.ItemId == itemId,
+                    () =>
+                    {
+                        factoryInvoked = true;
+                        return new UnlockedItem { PlayerId = playerId, ItemId = itemId };
+                    });
+            }
+
+            Assert.False(factoryInvoked);
+            Assert.Equal(1, await CountUnlockedItemsAsync(playerId, itemId));
+        }
+
+        [Fact]
+        public async Task AppliedConcurrently_InsertsOneRowWithoutThrowing()
+        {
+            var playerId = await SeedPlayerAsync();
+            var itemId = await SeedItemAsync();
+
+            // Each insert runs through its own scope/context, mirroring the synchronizer's per-event scope, so
+            // several pass the existence check before any save commits — the cross-instance double-apply race.
+            var scopes = Enumerable.Range(0, Parallelism).Select(_ => CreateScope()).ToList();
+            try
+            {
+                var tasks = scopes.Select(s => Task.Run(() =>
+                {
+                    var context = s.ServiceProvider.GetRequiredService<GameContext>();
+                    return context.InsertIfMissingAsync(
+                        (UnlockedItem ui) => ui.PlayerId == playerId && ui.ItemId == itemId,
+                        () => new UnlockedItem { PlayerId = playerId, ItemId = itemId });
+                }));
+
+                // No throw despite the concurrent inserts racing on the (player, item) unique key.
+                await Task.WhenAll(tasks);
+            }
+            finally
+            {
+                foreach (var scope in scopes)
+                {
+                    scope.Dispose();
+                }
+            }
+
+            Assert.Equal(1, await CountUnlockedItemsAsync(playerId, itemId));
+        }
+
+        private async Task InsertUnlockedItemAsync(int playerId, int itemId)
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            await context.InsertIfMissingAsync(
+                (UnlockedItem ui) => ui.PlayerId == playerId && ui.ItemId == itemId,
+                () => new UnlockedItem { PlayerId = playerId, ItemId = itemId });
+        }
+
+        private async Task<int> CountUnlockedItemsAsync(int playerId, int itemId)
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            return await context.UnlockedItems
+                .CountAsync(ui => ui.PlayerId == playerId && ui.ItemId == itemId, CancellationToken);
+        }
+
+        private async Task<int> SeedPlayerAsync()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+            return player.Id;
+        }
+
+        private async Task<int> SeedItemAsync()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            return (await TestDataSeeder.CreateItemAsync(context)).Id;
+        }
+    }
+}

--- a/Game.Application.Tests/DataAccess/ToFirstByKeyTests.cs
+++ b/Game.Application.Tests/DataAccess/ToFirstByKeyTests.cs
@@ -1,0 +1,63 @@
+using Game.DataAccess.PlayerUpdates.Handlers;
+using Xunit;
+
+namespace Game.Application.Tests.DataAccess
+{
+    /// <summary>
+    /// Unit tests for the shared <see cref="PlayerUpdateHandlerExtensions.ToFirstByKey"/> dedup helper used by
+    /// the batched upsert handlers. It is pure in-process logic, so it is covered here classically rather than
+    /// through an integration test.
+    /// </summary>
+    public class ToFirstByKeyTests
+    {
+        private sealed record Row(int Key, string Value);
+
+        [Fact]
+        public void IndexesEachSourceByItsKey()
+        {
+            var rows = new[] { new Row(1, "a"), new Row(2, "b") };
+
+            var byKey = rows.ToFirstByKey(r => r.Key);
+
+            Assert.Equal(2, byKey.Count);
+            Assert.Equal("a", byKey[1].Value);
+            Assert.Equal("b", byKey[2].Value);
+        }
+
+        [Fact]
+        public void DuplicateKey_KeepsTheFirstRowRatherThanThrowing()
+        {
+            // A stray duplicate (which the unique key makes impossible in the DB) must not throw the way
+            // ToDictionary would — the whole reason the handlers prefer group-by-first.
+            var rows = new[] { new Row(1, "first"), new Row(1, "second") };
+
+            var byKey = rows.ToFirstByKey(r => r.Key);
+
+            var row = Assert.Single(byKey);
+            Assert.Equal(1, row.Key);
+            Assert.Equal("first", row.Value.Value);
+        }
+
+        [Fact]
+        public void EmptySource_ReturnsEmptyDictionary()
+        {
+            var byKey = Array.Empty<Row>().ToFirstByKey(r => r.Key);
+
+            Assert.Empty(byKey);
+        }
+
+        [Fact]
+        public void SupportsCompositeKeys()
+        {
+            var rows = new[] { new Row(1, "a"), new Row(1, "b") };
+
+            // Keying on the composite (key, value) makes the two rows distinct, mirroring the
+            // (StatisticTypeId, EntityId) tuple key in ProgressUpdatedHandler.
+            var byKey = rows.ToFirstByKey(r => (r.Key, r.Value));
+
+            Assert.Equal(2, byKey.Count);
+            Assert.Equal("a", byKey[(1, "a")].Value);
+            Assert.Equal("b", byKey[(1, "b")].Value);
+        }
+    }
+}

--- a/Game.DataAccess/PlayerUpdates/Handlers/AttributeAllocationsChangedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/AttributeAllocationsChangedHandler.cs
@@ -30,11 +30,9 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
                 .Where(pa => pa.PlayerId == evt.PlayerId)
                 .ToListAsync();
 
-            // Group-by-first rather than ToDictionary: the (player, attribute) primary key makes a duplicate
-            // impossible, but taking the first per key keeps a stray duplicate row from throwing here.
-            var rowsByAttributeId = currentRows
-                .GroupBy(pa => pa.AttributeId)
-                .ToDictionary(g => g.Key, g => g.First());
+            // The (player, attribute) primary key makes a duplicate impossible; ToFirstByKey still defends
+            // against a stray duplicate row throwing here (see InsertIfMissingAsync's sibling helper).
+            var rowsByAttributeId = currentRows.ToFirstByKey(pa => pa.AttributeId);
 
             foreach (var alloc in evt.Allocations)
             {

--- a/Game.DataAccess/PlayerUpdates/Handlers/ItemUnlockedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/ItemUnlockedHandler.cs
@@ -1,41 +1,20 @@
 using Game.Core.Players.Events;
 using Game.Infrastructure.Database;
 using Game.Infrastructure.Entities;
-using Microsoft.EntityFrameworkCore;
 
 namespace Game.DataAccess.PlayerUpdates.Handlers
 {
     internal sealed class ItemUnlockedHandler(GameContext context) : IPlayerUpdateHandler<ItemUnlockedEvent>
     {
-        public async Task HandleAsync(ItemUnlockedEvent evt)
+        public Task HandleAsync(ItemUnlockedEvent evt)
         {
-            // The existence check skips the common re-apply without touching the row (no tracking needed on
-            // this hot-path read), but isn't atomic with the insert. A concurrent apply of the same
-            // at-least-once event can insert the row between the check and the save, so the unique-violation
-            // catch absorbs that race as a benign no-op — the (player, item) primary key already holds it.
-            var exists = await context.UnlockedItems
-                .AsNoTracking()
-                .AnyAsync(ui => ui.PlayerId == evt.PlayerId && ui.ItemId == evt.ItemId);
-
-            if (exists)
-            {
-                return;
-            }
-
-            context.UnlockedItems.Add(new UnlockedItem
-            {
-                PlayerId = evt.PlayerId,
-                ItemId = evt.ItemId,
-            });
-
-            try
-            {
-                await context.SaveChangesAsync();
-            }
-            catch (DbUpdateException ex) when (ex.IsUniqueViolation())
-            {
-                // A concurrent apply inserted the same (player, item) first; the row exists, so this is a no-op.
-            }
+            return context.InsertIfMissingAsync(
+                (UnlockedItem ui) => ui.PlayerId == evt.PlayerId && ui.ItemId == evt.ItemId,
+                () => new UnlockedItem
+                {
+                    PlayerId = evt.PlayerId,
+                    ItemId = evt.ItemId,
+                });
         }
     }
 }

--- a/Game.DataAccess/PlayerUpdates/Handlers/ModUnlockedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/ModUnlockedHandler.cs
@@ -1,41 +1,20 @@
 using Game.Core.Players.Events;
 using Game.Infrastructure.Database;
 using Game.Infrastructure.Entities;
-using Microsoft.EntityFrameworkCore;
 
 namespace Game.DataAccess.PlayerUpdates.Handlers
 {
     internal sealed class ModUnlockedHandler(GameContext context) : IPlayerUpdateHandler<ModUnlockedEvent>
     {
-        public async Task HandleAsync(ModUnlockedEvent evt)
+        public Task HandleAsync(ModUnlockedEvent evt)
         {
-            // The existence check skips the common re-apply without touching the row (no tracking needed on
-            // this hot-path read), but isn't atomic with the insert. A concurrent apply of the same
-            // at-least-once event can insert the row between the check and the save, so the unique-violation
-            // catch absorbs that race as a benign no-op — the (player, mod) primary key already holds it.
-            var exists = await context.UnlockedMods
-                .AsNoTracking()
-                .AnyAsync(um => um.PlayerId == evt.PlayerId && um.ItemModId == evt.ItemModId);
-
-            if (exists)
-            {
-                return;
-            }
-
-            context.UnlockedMods.Add(new UnlockedMod
-            {
-                PlayerId = evt.PlayerId,
-                ItemModId = evt.ItemModId,
-            });
-
-            try
-            {
-                await context.SaveChangesAsync();
-            }
-            catch (DbUpdateException ex) when (ex.IsUniqueViolation())
-            {
-                // A concurrent apply inserted the same (player, mod) first; the row exists, so this is a no-op.
-            }
+            return context.InsertIfMissingAsync(
+                (UnlockedMod um) => um.PlayerId == evt.PlayerId && um.ItemModId == evt.ItemModId,
+                () => new UnlockedMod
+                {
+                    PlayerId = evt.PlayerId,
+                    ItemModId = evt.ItemModId,
+                });
         }
     }
 }

--- a/Game.DataAccess/PlayerUpdates/Handlers/PlayerUpdateHandlerExtensions.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/PlayerUpdateHandlerExtensions.cs
@@ -1,0 +1,64 @@
+using System.Linq.Expressions;
+using Game.Infrastructure.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace Game.DataAccess.PlayerUpdates.Handlers
+{
+    /// <summary>
+    /// Shared building blocks for the write-behind player-update handlers, factored out so the idempotency
+    /// contract these handlers depend on lives — and is tested — in one place rather than copy-pasted.
+    /// </summary>
+    internal static class PlayerUpdateHandlerExtensions
+    {
+        /// <summary>
+        /// Inserts <paramref name="factory"/>'s row only if no row matching <paramref name="existsPredicate"/>
+        /// is present, idempotent under the queue's at-least-once read. The existence check skips the common
+        /// re-apply without touching the row (no tracking needed on this hot-path read) but isn't atomic with
+        /// the insert: a concurrent apply of the same event can insert the row between the check and the save,
+        /// so the unique-violation catch absorbs that race as a benign no-op — the table's unique key already
+        /// holds the row. Re-applying therefore always converges to a single row.
+        /// </summary>
+        public static async Task InsertIfMissingAsync<TEntity>(
+            this GameContext context,
+            Expression<Func<TEntity, bool>> existsPredicate,
+            Func<TEntity> factory)
+            where TEntity : class
+        {
+            var exists = await context.Set<TEntity>()
+                .AsNoTracking()
+                .AnyAsync(existsPredicate);
+
+            if (exists)
+            {
+                return;
+            }
+
+            context.Set<TEntity>().Add(factory());
+
+            try
+            {
+                await context.SaveChangesAsync();
+            }
+            catch (DbUpdateException ex) when (ex.IsUniqueViolation())
+            {
+                // A concurrent apply inserted the same row first; it already exists, so this is a no-op.
+            }
+        }
+
+        /// <summary>
+        /// Indexes <paramref name="source"/> by <paramref name="keySelector"/>, taking the first row per key.
+        /// Group-by-first rather than <c>ToDictionary</c>: the table's unique key makes a duplicate key
+        /// impossible, but taking the first keeps a stray duplicate row from throwing here and poisoning the
+        /// player's update stream.
+        /// </summary>
+        public static Dictionary<TKey, TSource> ToFirstByKey<TSource, TKey>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector)
+            where TKey : notnull
+        {
+            return source
+                .GroupBy(keySelector)
+                .ToDictionary(g => g.Key, g => g.First());
+        }
+    }
+}

--- a/Game.DataAccess/PlayerUpdates/Handlers/ProgressUpdatedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/ProgressUpdatedHandler.cs
@@ -44,12 +44,9 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
                         && typeIds.Contains(ps.StatisticTypeId)
                         && entityIds.Contains(ps.EntityId))
                     .ToListAsync();
-                // Group-by-first rather than ToDictionary: the unique index makes a duplicate (type, entity)
-                // impossible, but taking the first per key keeps a stray duplicate row from throwing here and
-                // permanently poisoning this player's progress stream.
-                var byKey = existing
-                    .GroupBy(ps => (ps.StatisticTypeId, ps.EntityId))
-                    .ToDictionary(g => g.Key, g => g.First());
+                // The unique index makes a duplicate (type, entity) impossible; ToFirstByKey still defends
+                // against a stray duplicate row throwing here and poisoning this player's progress stream.
+                var byKey = existing.ToFirstByKey(ps => (ps.StatisticTypeId, ps.EntityId));
 
                 foreach (var stat in evt.Statistics)
                 {
@@ -76,12 +73,9 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
                 var existing = await context.PlayerChallenges
                     .Where(pc => pc.PlayerId == evt.PlayerId && challengeIds.Contains(pc.ChallengeId))
                     .ToListAsync();
-                // Group-by-first for the same reason as the statistics lookup above: the (player, challenge)
-                // primary key makes a duplicate impossible, but defending the grouping keeps a stray duplicate
-                // from throwing and poisoning the stream.
-                var byId = existing
-                    .GroupBy(pc => pc.ChallengeId)
-                    .ToDictionary(g => g.Key, g => g.First());
+                // Same defensive grouping as the statistics lookup above: the (player, challenge) primary key
+                // makes a duplicate impossible, but ToFirstByKey keeps a stray duplicate from poisoning it.
+                var byId = existing.ToFirstByKey(pc => pc.ChallengeId);
 
                 foreach (var challenge in evt.Challenges)
                 {

--- a/Game.DataAccess/PlayerUpdates/Handlers/SkillUnlockedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/SkillUnlockedHandler.cs
@@ -1,45 +1,24 @@
 using Game.Core.Players.Events;
 using Game.Infrastructure.Database;
 using Game.Infrastructure.Entities;
-using Microsoft.EntityFrameworkCore;
 
 namespace Game.DataAccess.PlayerUpdates.Handlers
 {
     internal sealed class SkillUnlockedHandler(GameContext context) : IPlayerUpdateHandler<SkillUnlockedEvent>
     {
-        public async Task HandleAsync(SkillUnlockedEvent evt)
+        public Task HandleAsync(SkillUnlockedEvent evt)
         {
-            // The existence check skips the common re-apply without touching the row (no tracking needed on
-            // this hot-path read), but isn't atomic with the insert. A concurrent apply of the same
-            // at-least-once event can insert the row between the check and the save, so the unique-violation
-            // catch absorbs that race as a benign no-op — the (player, skill) primary key already holds it.
-            var exists = await context.PlayerSkills
-                .AsNoTracking()
-                .AnyAsync(ps => ps.PlayerId == evt.PlayerId && ps.SkillId == evt.SkillId);
-
-            if (exists)
-            {
-                return;
-            }
-
             // Earning a skill unlocks it without equipping it: Selected = false, Order = 0
             // (the player chooses their loadout separately).
-            context.PlayerSkills.Add(new PlayerSkill
-            {
-                PlayerId = evt.PlayerId,
-                SkillId = evt.SkillId,
-                Selected = false,
-                Order = 0,
-            });
-
-            try
-            {
-                await context.SaveChangesAsync();
-            }
-            catch (DbUpdateException ex) when (ex.IsUniqueViolation())
-            {
-                // A concurrent apply inserted the same (player, skill) first; the row exists, so this is a no-op.
-            }
+            return context.InsertIfMissingAsync(
+                (PlayerSkill ps) => ps.PlayerId == evt.PlayerId && ps.SkillId == evt.SkillId,
+                () => new PlayerSkill
+                {
+                    PlayerId = evt.PlayerId,
+                    SkillId = evt.SkillId,
+                    Selected = false,
+                    Order = 0,
+                });
         }
     }
 }


### PR DESCRIPTION
Closes #961

## Summary

The "make write-behind upsert handlers atomically idempotent" fixes left the same `AsNoTracking` existence check → return-if-exists → `Add` → `SaveChanges` → swallow-unique-violation algorithm copy-pasted across the unlock handlers, and the `GroupBy(...).First()` dedup duplicated across the batched upsert handlers. This is a targeted DRY pass that factors both out so the idempotency contract lives — and is tested — in one place.

Two narrowly-scoped helpers now live on a new shared `internal static` class, `PlayerUpdateHandlerExtensions`, in the `Handlers` folder (kept inside the data tier so it never surfaces above `Game.DataAccess`, consistent with the entity-isolation conventions in `docs/backend.md`):

- **`InsertIfMissingAsync(context, existsPredicate, factory)`** — an extension on `GameContext` that encapsulates the full insert-race idempotency contract. It resolves the `DbSet<TEntity>` via `context.Set<TEntity>()`, so the entity type is inferred from the predicate/factory and no `DbSet` needs to be threaded through.
- **`ToFirstByKey(keySelector)`** — the group-by-first dedup, returning a `Dictionary<TKey, TSource>`.

## Handlers collapsed

- **`ItemUnlockedHandler`, `ModUnlockedHandler`, `SkillUnlockedHandler`** now route through `InsertIfMissingAsync` (the skill handler keeps its `Selected = false, Order = 0` note in its factory).
- **`AttributeAllocationsChangedHandler`** and **`ProgressUpdatedHandler`** (its statistics, challenges, and tuple-keyed lookups) now use `ToFirstByKey`.

`ModAppliedHandler` and `LogPreferenceChangedHandler` are deliberately **left as-is**: their shapes differ from insert-if-missing (delete-then-insert; update-first-then-insert-then-re-update), and the only thing they share is the `catch ... when (ex.IsUniqueViolation())` clause — which is already factored into the `IsUniqueViolation()` extension. Folding them into `InsertIfMissingAsync` would distort the contract, so they were left out to keep the change narrowly scoped.

## How the idempotency contract is preserved

- The unique-violation detection is **unchanged** — every call site still keys off the existing `DbUpdateExceptionExtensions.IsUniqueViolation()` (`InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation }`), so the EF/Npgsql signature is identical across all handlers. The helper reuses that same extension verbatim.
- The collapsed handlers reproduce the original sequence exactly: `AsNoTracking().AnyAsync(...)` → early return → `Add` → `SaveChangesAsync()` → swallow the unique violation.

## Testing

- **`InsertIfMissingIntegrationTests`** (new) proves the contract once at the helper level against a real DB: row-missing inserts; already-present short-circuits without re-running the factory; and a concurrent double-apply (parallelism 8, each on its own DI scope/`GameContext`) converges to a single row without throwing — exercising the unique-violation catch.
- **`ToFirstByKeyTests`** (new, unit) covers indexing, duplicate-key-keeps-first (the reason for group-by-first over `ToDictionary`), empty source, and composite keys.
- The existing **`PlayerUpdateHandlerIdempotencyIntegrationTests`** (25 tests) still pass unchanged, confirming each refactored handler behaves identically.
- Full solution builds clean with `-warnaserror` (0 warnings).

Test results: helper integration tests 3/3 pass, `ToFirstByKey` unit tests 4/4 pass, existing handler idempotency suite 25/25 pass.

## Note / follow-up

The handler path does not currently thread a `CancellationToken` (the `IPlayerUpdateHandler.HandleAsync` signature and the `SaveChangesAsync()` calls take none), so the issue's suggested `ct` parameter was intentionally omitted to stay scoped to a DRY pass — adding one would mean changing the interface and dispatcher, a broader refactor. Worth a follow-up if cancellation should be plumbed through the synchronizer's drain handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F7YCAqc161ytuGnXYCcrK

---
_Generated by [Claude Code](https://claude.ai/code/session_015F7YCAqc161ytuGnXYCcrK)_