### PR TITLE
Add backend test coverage for write-behind handlers and admin item-mod/challenge repos (#958)

### DIFF
--- a/Game.Application.Tests/DataAccess/AdminChallengesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminChallengesIntegrationTests.cs
@@ -1,0 +1,153 @@
+using Game.Abstractions.Contracts.Admin;
+using Game.Abstractions.DataAccess;
+using Game.Abstractions.DataAccess.Admin;
+using Game.Core;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Contracts = Game.Abstractions.Contracts;
+
+namespace Game.Application.Tests.DataAccess
+{
+    /// <summary>
+    /// Exercises <see cref="IAdminChallenges"/> <c>SaveChallenges</c>: the zero-based-id Edit-existence
+    /// rejection (an out-of-range id is a not-found rejection, not an EF 0-row update), the delete-not-supported
+    /// guard, the duplicate-key rejection, and a successful Add/Edit round-trip. Seeding, the admin write, and
+    /// the assertion each use a separate DI scope so the write runs against an empty change tracker.
+    /// </summary>
+    [Collection("Integration")]
+    public class AdminChallengesIntegrationTests : ApplicationIntegrationTestBase
+    {
+        public AdminChallengesIntegrationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        [Fact]
+        public void SaveChallenges_EditOutOfRangeId_ReturnsNotFound()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge> { ChangeType = EChangeType.Edit, Item = NewChallenge(id: 99999) },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Challenge not found.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void SaveChallenges_EditNegativeId_ReturnsNotFound()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge> { ChangeType = EChangeType.Edit, Item = NewChallenge(id: -1) },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Challenge not found.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SaveChallenges_AddAndEdit_PersistAndUpdateInPlace()
+        {
+            int challengeId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                challengeId = (await TestDataSeeder.CreateChallengeAsync(context, name: "Original")).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            var changes = new List<Change<Contracts.Challenge>>
+            {
+                new() { ChangeType = EChangeType.Add, Item = NewChallenge(name: "Brand New", progressGoal: 25m) },
+                new() { ChangeType = EChangeType.Edit, Item = NewChallenge(id: challengeId, name: "Renamed", progressGoal: 50m) },
+            };
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+                Assert.True(admin.SaveChallenges(changes).Succeeded);
+                await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var edited = await context.Challenges.AsNoTracking().SingleAsync(c => c.Id == challengeId, CancellationToken);
+                Assert.Equal("Renamed", edited.Name);
+                Assert.Equal(50m, edited.ProgressGoal);
+                Assert.Contains(await context.Challenges.AsNoTracking().ToListAsync(CancellationToken), c => c.Name == "Brand New");
+            }
+        }
+
+        [Fact]
+        public async Task SaveChallenges_DeleteOfChallenge_ReturnsFailureNotSupported()
+        {
+            int challengeId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                challengeId = (await TestDataSeeder.CreateChallengeAsync(context)).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // Challenges are zero-based-id reference data: a hard delete would open an Id gap, so they are
+            // retired, never deleted. A Delete change is a graceful business failure rather than a throw.
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge> { ChangeType = EChangeType.Delete, Item = NewChallenge(id: challengeId) },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("retired, not deleted", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SaveChallenges_DuplicateEditKey_ReturnsFailureWithoutThrowing()
+        {
+            int challengeId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                challengeId = (await TestDataSeeder.CreateChallengeAsync(context)).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // Two Edits of the same id would double-track the row and surface as an opaque EF 500 mid-batch;
+            // the processor must reject the malformed batch up front as a graceful failure.
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge> { ChangeType = EChangeType.Edit, Item = NewChallenge(id: challengeId, name: "A") },
+                new Change<Contracts.Challenge> { ChangeType = EChangeType.Edit, Item = NewChallenge(id: challengeId, name: "B") },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("The submitted challenge change set contains duplicate entries.", result.ErrorMessage);
+        }
+
+        private static Contracts.Challenge NewChallenge(
+            int id = 0, string name = "Test Challenge", decimal progressGoal = 10m) => new()
+            {
+                Id = id,
+                Name = name,
+                Description = "",
+                ChallengeTypeId = EChallengeType.EnemiesKilled,
+                ProgressGoal = progressGoal,
+            };
+    }
+}

--- a/Game.Application.Tests/DataAccess/AdminItemModsIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminItemModsIntegrationTests.cs
@@ -1,0 +1,286 @@
+using Game.Abstractions.Contracts.Admin;
+using Game.Abstractions.DataAccess;
+using Game.Abstractions.DataAccess.Admin;
+using Game.Core;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Contracts = Game.Abstractions.Contracts;
+using Entities = Game.Infrastructure.Entities;
+
+namespace Game.Application.Tests.DataAccess
+{
+    /// <summary>
+    /// Exercises <see cref="IAdminItemMods"/> write paths: the identity-level Edit-existence rejection and
+    /// delete-not-supported guard on <c>SaveItemMods</c>, the membership-guarded attribute upsert and its
+    /// duplicate-key rejection, and the tag-association replace. Seeding, the admin write, and the assertion
+    /// each use a separate DI scope so the write runs against an empty change tracker, as a real admin call does.
+    /// </summary>
+    [Collection("Integration")]
+    public class AdminItemModsIntegrationTests : ApplicationIntegrationTestBase
+    {
+        public AdminItemModsIntegrationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        [Fact]
+        public void SaveItemMods_EditUnknownItemMod_ReturnsNotFound()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminItemMods>();
+
+            var result = admin.SaveItemMods(
+            [
+                new Change<Contracts.ItemMod> { ChangeType = EChangeType.Edit, Item = NewItemMod(id: 99999) },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Item mod not found.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SaveItemMods_AddAndEdit_PersistAndUpdateInPlace()
+        {
+            int modId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                modId = (await TestDataSeeder.CreateItemModAsync(context, name: "Original")).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            var changes = new List<Change<Contracts.ItemMod>>
+            {
+                new() { ChangeType = EChangeType.Add, Item = NewItemMod(name: "Brand New") },
+                new() { ChangeType = EChangeType.Edit, Item = NewItemMod(id: modId, name: "Renamed", rarity: ERarity.Rare) },
+            };
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminItemMods>();
+                Assert.True(admin.SaveItemMods(changes).Succeeded);
+                await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var edited = await context.ItemMods.AsNoTracking().SingleAsync(m => m.Id == modId, CancellationToken);
+                Assert.Equal("Renamed", edited.Name);
+                Assert.Equal((int)ERarity.Rare, edited.RarityId);
+                Assert.Contains(await context.ItemMods.AsNoTracking().ToListAsync(CancellationToken), m => m.Name == "Brand New");
+            }
+        }
+
+        [Fact]
+        public async Task SaveItemMods_DeleteOfItemMod_ReturnsFailureNotSupported()
+        {
+            int modId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                modId = (await TestDataSeeder.CreateItemModAsync(context)).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // Item mods are zero-based-id reference data: a hard delete would open an Id gap, so it is
+            // retired (a RetiredAt edit), never deleted. A Delete change is a graceful business failure.
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminItemMods>();
+
+            var result = admin.SaveItemMods(
+            [
+                new Change<Contracts.ItemMod> { ChangeType = EChangeType.Delete, Item = NewItemMod(id: modId) },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("retired, not deleted", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SaveItemMods_DuplicateEditKey_ReturnsFailureWithoutThrowing()
+        {
+            int modId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                modId = (await TestDataSeeder.CreateItemModAsync(context)).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // Two Edits of the same id would double-track the row and surface as an opaque EF 500 mid-batch;
+            // the processor must reject the malformed batch up front as a graceful failure.
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminItemMods>();
+
+            var result = admin.SaveItemMods(
+            [
+                new Change<Contracts.ItemMod> { ChangeType = EChangeType.Edit, Item = NewItemMod(id: modId, name: "A") },
+                new Change<Contracts.ItemMod> { ChangeType = EChangeType.Edit, Item = NewItemMod(id: modId, name: "B") },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("The submitted item mod change set contains duplicate entries.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void SetAttributes_UnknownItemMod_ReturnsNotFound()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminItemMods>();
+
+            var result = admin.SetAttributes(new AddEditAttributesData { Id = 99999, Changes = [] });
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Item mod not found.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SetAttributes_AddsEditsAndDeletesAgainstMembership()
+        {
+            int modId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                // CreateItemModAsync seeds a single Strength attribute (amount 5).
+                modId = (await TestDataSeeder.CreateItemModAsync(context)).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // Add Intellect, edit the existing Strength, and delete a non-member (Endurance) — the delete must
+            // reconcile away as a guarded no-op rather than an EF 0-row delete.
+            var data = new AddEditAttributesData
+            {
+                Id = modId,
+                Changes =
+                [
+                    new Change<Contracts.BattlerAttribute> { ChangeType = EChangeType.Add, Item = NewAttribute(EAttribute.Intellect, 7m) },
+                    new Change<Contracts.BattlerAttribute> { ChangeType = EChangeType.Edit, Item = NewAttribute(EAttribute.Strength, 99m) },
+                    new Change<Contracts.BattlerAttribute> { ChangeType = EChangeType.Delete, Item = NewAttribute(EAttribute.Endurance, 0m) },
+                ],
+            };
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminItemMods>();
+                Assert.True(admin.SetAttributes(data).Succeeded);
+                await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var attributes = await context.ItemModAttributes.AsNoTracking()
+                    .Where(a => a.ItemModId == modId)
+                    .ToListAsync(CancellationToken);
+
+                Assert.Equal(2, attributes.Count);
+                Assert.Equal(99m, attributes.Single(a => a.AttributeId == (int)EAttribute.Strength).Amount);
+                Assert.Equal(7m, attributes.Single(a => a.AttributeId == (int)EAttribute.Intellect).Amount);
+                Assert.DoesNotContain(attributes, a => a.AttributeId == (int)EAttribute.Endurance);
+            }
+        }
+
+        [Fact]
+        public async Task SetAttributes_DuplicateKeyInBatch_ReturnsFailureWithoutThrowing()
+        {
+            int modId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                modId = (await TestDataSeeder.CreateItemModAsync(context)).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // Two Adds of the same attribute would double-track the composite key; reject the batch up front.
+            var data = new AddEditAttributesData
+            {
+                Id = modId,
+                Changes =
+                [
+                    new Change<Contracts.BattlerAttribute> { ChangeType = EChangeType.Add, Item = NewAttribute(EAttribute.Agility, 1m) },
+                    new Change<Contracts.BattlerAttribute> { ChangeType = EChangeType.Add, Item = NewAttribute(EAttribute.Agility, 2m) },
+                ],
+            };
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminItemMods>();
+
+            var result = admin.SetAttributes(data);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("The submitted item mod attribute change set contains duplicate entries.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SetTags_UnknownItemMod_ReturnsNotFound()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminItemMods>();
+
+            var result = await admin.SetTags(new SetTagsData { Id = 99999, TagIds = [] }, CancellationToken);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Item mod not found.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SetTags_ReplacesAssociations()
+        {
+            int modId, keptTagId, addedTagId, removedTagId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                modId = (await TestDataSeeder.CreateItemModAsync(context)).Id;
+                keptTagId = (await TestDataSeeder.CreateTagAsync(context, name: "Kept")).Id;
+                addedTagId = (await TestDataSeeder.CreateTagAsync(context, name: "Added")).Id;
+                removedTagId = (await TestDataSeeder.CreateTagAsync(context, name: "Removed")).Id;
+                context.ItemModTags.AddRange(
+                    new Entities.ItemModTag { ItemModId = modId, TagId = keptTagId },
+                    new Entities.ItemModTag { ItemModId = modId, TagId = removedTagId });
+                await context.SaveChangesAsync(CancellationToken);
+            }
+            await ReloadReferenceCachesAsync();
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminItemMods>();
+                var result = await admin.SetTags(new SetTagsData { Id = modId, TagIds = [keptTagId, addedTagId] }, CancellationToken);
+                Assert.True(result.Succeeded);
+                await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var tagIds = (await context.ItemModTags.AsNoTracking()
+                    .Where(t => t.ItemModId == modId)
+                    .Select(t => t.TagId)
+                    .ToListAsync(CancellationToken))
+                    .OrderBy(id => id)
+                    .ToList();
+
+                Assert.Equal([keptTagId, addedTagId], tagIds);
+                Assert.DoesNotContain(removedTagId, tagIds);
+            }
+        }
+
+        private static Contracts.ItemMod NewItemMod(
+            int id = 0, string name = "Test Mod", EItemModType type = EItemModType.Prefix, ERarity rarity = ERarity.Common) => new()
+            {
+                Id = id,
+                Name = name,
+                Description = "",
+                ItemModTypeId = type,
+                RarityId = rarity,
+                Attributes = [],
+                Tags = [],
+            };
+
+        private static Contracts.BattlerAttribute NewAttribute(EAttribute attribute, decimal amount) =>
+            new() { AttributeId = attribute, Amount = amount };
+    }
+}

--- a/Game.Application.Tests/DataAccess/PlayerUpdateHandlerIdempotencyIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerUpdateHandlerIdempotencyIntegrationTests.cs
@@ -493,6 +493,60 @@ namespace Game.Application.Tests.DataAccess
             Assert.True(row.Favorite);
         }
 
+        [Fact]
+        public async Task PlayerCoreUpdated_AppliedTwice_ConvergesToLatestValuesWithoutDuplicating()
+        {
+            var playerId = await SeedPlayerAsync();
+            var zoneId = await SeedZoneAsync();
+
+            // Update-only against the always-present Players row: re-applying with higher absolute values
+            // updates the row in place rather than duplicating, so the core fields converge to the latest.
+            await ApplyAsync(new PlayerCoreUpdatedEvent(playerId, Level: 7, Exp: 120, CurrentZoneId: zoneId, StatPointsGained: 130, StatPointsUsed: 110));
+            await ApplyAsync(new PlayerCoreUpdatedEvent(playerId, Level: 9, Exp: 250, CurrentZoneId: zoneId, StatPointsGained: 160, StatPointsUsed: 140));
+
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var row = Assert.Single(await context.Players.AsNoTracking()
+                .Where(p => p.Id == playerId)
+                .ToListAsync(CancellationToken));
+            Assert.Equal(9, row.Level);
+            Assert.Equal(250, row.Exp);
+            Assert.Equal(zoneId, row.CurrentZoneId);
+            Assert.Equal(160, row.StatPointsGained);
+            Assert.Equal(140, row.StatPointsUsed);
+        }
+
+        [Fact]
+        public async Task ModRemoved_AppliedTwice_DeletesTheSlotsModAndIsIdempotent()
+        {
+            var (playerId, itemId, slotId, modId) = await SeedAppliedModFixtureAsync();
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                await TestDataSeeder.ApplyModToItemAsync(context, playerId, itemId, slotId, modId);
+            }
+
+            // The first apply deletes the slot's mod; the second is a benign no-op against the now-missing
+            // row rather than throwing, so a re-delivered event converges to the same empty slot.
+            var evt = new ModRemovedEvent(playerId, itemId, slotId);
+            await ApplyAsync(evt);
+            await ApplyAsync(evt);
+
+            Assert.Equal(0, await CountAsync(c => c.AppliedMods.CountAsync(am => am.PlayerId == playerId && am.ItemId == itemId && am.ItemModSlotId == slotId, CancellationToken)));
+        }
+
+        [Fact]
+        public async Task ModRemoved_RowMissing_IsNoOp()
+        {
+            // No AppliedMod row exists for the slot (e.g. the remove reordered ahead of the apply, or a
+            // re-delivery after the row is already gone): the delete must match zero rows without throwing.
+            var (playerId, itemId, slotId, _) = await SeedAppliedModFixtureAsync();
+
+            await ApplyAsync(new ModRemovedEvent(playerId, itemId, slotId));
+
+            Assert.Equal(0, await CountAsync(c => c.AppliedMods.CountAsync(am => am.PlayerId == playerId && am.ItemId == itemId && am.ItemModSlotId == slotId, CancellationToken)));
+        }
+
         private static AttributeAllocationsChangedEvent MakeAttributeEvent(int playerId, double intellect, double strength) => new(
             playerId,
             [
@@ -616,6 +670,13 @@ namespace Game.Application.Tests.DataAccess
             using var scope = CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
             return (await TestDataSeeder.CreateItemModAsync(context)).Id;
+        }
+
+        private async Task<int> SeedZoneAsync()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            return (await TestDataSeeder.CreateZoneAsync(context)).Id;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fills the concrete backend test-coverage gaps from #958. Much of the original issue was already addressed by work that landed after it was filed, so this PR closes the genuinely-remaining gaps and splits the one infrastructure item into a follow-up.

### What this PR adds

**Part 1 — write-behind handlers (the two that were still untested).** The other four named handlers (`ItemEquipped`/`ItemUnequipped`/`ItemFavoriteChanged`/`SelectedSkillsChanged`) were covered by #936's fix; the two that weren't are now pinned in `PlayerUpdateHandlerIdempotencyIntegrationTests`:
- `PlayerCoreUpdatedHandler` — update-only against the always-present `Players` row converges to the latest snapshot on re-apply.
- `ModRemovedHandler` — idempotent delete (applied twice converges to the empty slot) and a missing-row no-op.

**Part 2 — admin repos (the two that were still untested).** `AdminItems`/`AdminSkills` already had integration tests (#964); this PR adds the matching coverage for the other two:
- `AdminItemModsIntegrationTests` — identity-level edit-existence rejection, delete-not-supported guard, duplicate-key rejection, the membership-guarded attribute add/edit/delete + upsert, attribute duplicate-key rejection, and the tag-association replace.
- `AdminChallengesIntegrationTests` — the zero-based-id edit-existence rejection (out-of-range and negative id), delete-not-supported guard, duplicate-key rejection, and a successful Add/Edit round-trip.

### Already covered (no change needed)

- **Part 1** — the four reorder-sensitive handlers are covered by the existing reorder/idempotency/concurrent tests in `PlayerUpdateHandlerIdempotencyIntegrationTests`.
- **Part 3** — `CoalescingReferenceCacheReloaderTests` pins coalescing N→1, retry-then-succeed, and retry-exhausted-keeps-snapshot; `ReferenceCacheHolderTests` pins the keep-prior-snapshot-on-failed-build behaviour; and the `Id == index` build invariant is pinned by `ReferenceDataBoundsCheckTests`.

### Split out

- **Part 4** (carve `Game.Api`'s socket/services/filters namespaces into a *gated* coverage sub-area) is tracked in **#1034**. It's a build-infrastructure change — the gate reads coverage at assembly granularity, so per-namespace gating needs ReportGenerator namespace filters, an extended floors schema, and gate-script changes — distinct from the test-writing in this PR and needing a design decision on which namespaces/floors.

## Test plan

- [x] `dotnet build Game.Application.Tests` — clean (0 warnings).
- [x] New tests pass: `AdminItemModsIntegrationTests`, `AdminChallengesIntegrationTests`, `PlayerUpdateHandlerIdempotencyIntegrationTests`.
- [x] Full `Game.Application.Tests` suite green (387 passed).

Closes #958.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zMXdotj76fG7Dza9frAXE

---
_Generated by [Claude Code](https://claude.ai/code/session_015zMXdotj76fG7Dza9frAXE)_