### PR TITLE
Fix state_referenced_locally warning in statify (#1031)

### DIFF
--- a/UI/src/lib/common/statify.svelte.ts
+++ b/UI/src/lib/common/statify.svelte.ts
@@ -90,7 +90,9 @@ const defineProxiedArrayProp = <T extends object>(
 ) => {
 	statifyArrayValues(data);
 	let state = $state(data);
-	let stateProxy = $state.raw(proxyArray(state));
+	// Wrap the reactive `state` array (not raw `data`) so mutations stay reactive. A $derived rebuilds
+	// the proxy when `state` is reassigned and reads it reactively, avoiding a stale local capture.
+	const stateProxy = $derived(proxyArray(state));
 	Object.defineProperty(statified, property, {
 		get() {
 			return stateProxy;
@@ -98,7 +100,6 @@ const defineProxiedArrayProp = <T extends object>(
 		set(value) {
 			statifyArrayValues(value);
 			state = value;
-			stateProxy = proxyArray(state);
 		}
 	});
 };


### PR DESCRIPTION
## Summary

Resolves the pre-existing Svelte 5 `state_referenced_locally` warning emitted from `UI/src/lib/common/statify.svelte.ts` during build/test runs (#1031).

## Root cause & verdict (real bug vs. benign read)

In `defineProxiedArrayProp`, the array proxy was built by reading the `$state` array in the **same scope it was declared**:

```ts
let state = $state(data);
let stateProxy = $state.raw(proxyArray(state)); // captures only the initial value → warning
```

This is the issue's case **(b): a deliberate, correct local read**, not a reactivity bug — element mutations stayed reactive (the proxy delegates to the reactive `state` array) and the proxy was rebuilt in the setter on reassignment. But the local capture is exactly what the compiler flags.

## Why suppression wasn't the right tool here

The project's existing convention is `// svelte-ignore state_referenced_locally`, but that only works in `.svelte` component files. `.svelte.ts` rune modules are TypeScript-preprocessed (comments stripped) **before** the Svelte compiler runs, so the directive never reaches it — verified: the comment had no effect on the build warning. So the correct resolution is to fix it at the source.

## Fix

Follow the compiler's own hint ("reference it inside a derived instead") and make the wrapper a `$derived`:

```ts
let state = $state(data);
const stateProxy = $derived(proxyArray(state));
```

- Reads `state` reactively (no warning).
- Rebuilds the proxy when the array is **reassigned** (same trigger as before), memoized otherwise (stable identity on element mutations).
- The setter's now-redundant manual `stateProxy = proxyArray(state)` rebuild is removed (no dead code left behind).

Behavior is unchanged.

## How it addresses the issue

- ✅ Determined the warning is a benign deliberate local read, not a reactivity bug.
- ✅ Fixed at the source (suppression isn't viable in `.svelte.ts`).
- ✅ Warning no longer prints during `npm run check` / build, no behavior change.

## Test plan

- [x] `npm run build` — the `statify.svelte.ts:…:state_referenced_locally` warning is gone (was printed for both SSR and client environments before).
- [x] `npm run lint` (eslint + `svelte-check`) — clean, 0 errors / 0 warnings.
- [x] `statify.svelte.test.ts` — 6/6 pass (covers array push reactivity, element statification, array reassignment through the setter).
- [x] `npm run test:unit:ci` — full suite green (**2226 passed**), coverage gate passes.

Closes #1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017mjXB1o2hVFCoj7Uo7ewKN)_