### PR TITLE
Wire enemy-dossier Skills/Spawns cross-links

### DIFF
--- a/UI/src/routes/game/screens/codex/EnemySkillsPanel.svelte
+++ b/UI/src/routes/game/screens/codex/EnemySkillsPanel.svelte
@@ -1,16 +1,20 @@
-<!-- Skills sub-tab: the enemy's skill pool. Rows are display-only for now — wiring them to deep-link
-     into the Codex Skills tab is tracked as a follow-up. -->
+<!-- Skills sub-tab: the enemy's skill pool. Each row cross-links into that skill's dossier. -->
 <div class="skills">
 	<div class="label">Skill pool · {view.enemySkillRows.length}</div>
 	<div class="list">
 		{#each view.enemySkillRows as skill (skill.id)}
-			<div class="skill">
+			<button
+				type="button"
+				class="skill"
+				data-testid="codex-enemy-skill-{skill.id}"
+				onclick={() => view.openSkill(skill.id)}
+			>
 				<span class="mark"></span>
 				<div class="text">
 					<div class="name">{skill.name}</div>
 					<div class="meta">{skill.meta}</div>
 				</div>
-			</div>
+			</button>
 		{/each}
 	</div>
 </div>
@@ -45,10 +49,18 @@ let { view }: Props = $props();
 	display: flex;
 	align-items: center;
 	gap: 11px;
+	width: 100%;
+	text-align: left;
 	background: var(--panel);
 	border: 1px solid var(--border-subtle);
 	border-radius: 5px;
 	padding: 9px 11px;
+	cursor: pointer;
+	font-family: var(--sans);
+
+	&:hover {
+		background: color-mix(in srgb, var(--attr-intellect) 8%, var(--panel));
+	}
 }
 
 .mark {

--- a/UI/src/routes/game/screens/codex/EnemySpawnsPanel.svelte
+++ b/UI/src/routes/game/screens/codex/EnemySpawnsPanel.svelte
@@ -1,11 +1,15 @@
 <!-- Spawns sub-tab: the zones this enemy spawns in (with its share of each zone's spawn table), or a
-     single "Encounter" row for a boss. Rows are display-only for now — they'll deep-link into the
-     Codex Zones tab once it's built (follow-up). -->
+     single "Encounter" row for a boss. Each row cross-links into that zone's dossier. -->
 <div class="spawns">
 	<div class="label">{view.spawnHeading}</div>
 	<div class="list">
 		{#each view.spawns as spawn (spawn.zoneId)}
-			<div class="spawn">
+			<button
+				type="button"
+				class="spawn"
+				data-testid="codex-enemy-spawn-{spawn.zoneId}"
+				onclick={() => view.openZone(spawn.zoneId)}
+			>
 				<div class="top">
 					<span class="zone">{spawn.zoneName}</span>
 					<span class="share">{spawn.share}%</span>
@@ -14,7 +18,7 @@
 					<span class="bar-wrap"><Bar value={spawn.share} presentational /></span>
 					<span class="weight">{spawn.weightLabel}</span>
 				</div>
-			</div>
+			</button>
 		{/each}
 	</div>
 </div>
@@ -44,6 +48,23 @@ let { view }: Props = $props();
 	display: flex;
 	flex-direction: column;
 	gap: 11px;
+}
+
+.spawn {
+	display: block;
+	width: 100%;
+	text-align: left;
+	background: transparent;
+	border: none;
+	border-radius: 4px;
+	padding: 4px;
+	margin: -4px;
+	cursor: pointer;
+	font-family: var(--sans);
+
+	&:hover {
+		background: color-mix(in srgb, var(--white) 4%, transparent);
+	}
 }
 
 .top {

--- a/UI/src/routes/game/screens/codex/codex-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/codex-view.svelte.ts
@@ -2,7 +2,8 @@
 
    The Enemies tab is a master/detail: a filterable enemy table beside a dossier with Attributes
    (live level-scaled stats + a "show scaling" breakdown), Statistics (the player's per-enemy record),
-   Skills, Spawns and Challenges sub-tabs. The Zones tab is a progression rail (a status dot per zone:
+   Skills, Spawns and Challenges sub-tabs — the Skills/Spawns rows cross-link into the Skills/Zones
+   tabs. The Zones tab is a progression rail (a status dot per zone:
    cleared / unlocked / locked) beside a zone dossier — level band, spawn pool, boss card, spawn table
    and unlock condition — whose boss card and spawn rows cross-link into the enemy dossier. The Skills
    tab is a master/detail skill catalogue: a skill table (base damage / cooldown / used-by count)
@@ -664,6 +665,18 @@ export class CodexView {
 	openEnemy(id: number): void {
 		this.tab = 'enemies';
 		this.selectEnemy(id);
+	}
+
+	/** Cross-link: jump to a zone's dossier from the enemy dossier's Spawns rows. */
+	openZone(id: number): void {
+		this.tab = 'zones';
+		this.selectZone(id);
+	}
+
+	/** Cross-link: jump to a skill's dossier from the enemy dossier's Skills rows. */
+	openSkill(id: number): void {
+		this.tab = 'skills';
+		this.selectSkill(id);
 	}
 
 	/* ── helpers (store reads, kept off the reactive graph for the constructor) ──── */

--- a/UI/src/tests/routes/game/screens/codex/Codex.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/Codex.test.ts
@@ -194,6 +194,24 @@ describe('Codex screen', () => {
 		expect(screen.getByText('62/100')).toBeTruthy();
 	});
 
+	it('cross-links an enemy spawn row into the zone dossier', async () => {
+		render(Codex);
+		// Dust Skitterer's Spawns sub-tab → Emberreach (zone 0).
+		await fireEvent.click(screen.getByTestId('codex-subtab-spawns'));
+		await fireEvent.click(screen.getByTestId('codex-enemy-spawn-0'));
+		// Lands on the Zones tab with Emberreach's dossier open.
+		expect(screen.getByTestId('codex-zone-dossier').textContent).toContain('Emberreach');
+	});
+
+	it('cross-links an enemy skill row into the skill dossier', async () => {
+		render(Codex);
+		// Dust Skitterer's Skills sub-tab → Cleave (skill 0).
+		await fireEvent.click(screen.getByTestId('codex-subtab-skills'));
+		await fireEvent.click(screen.getByTestId('codex-enemy-skill-0'));
+		// Lands on the Skills tab with Cleave's dossier open.
+		expect(screen.getByTestId('codex-skill-dossier').textContent).toContain('Cleave');
+	});
+
 	it('renders the Zones tab as a progression rail + dossier with a boss card and spawn table', async () => {
 		render(Codex);
 		await fireEvent.click(screen.getByTestId('codex-tab-zones'));

--- a/UI/src/tests/routes/game/screens/codex/codex-view.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/codex-view.test.ts
@@ -490,6 +490,28 @@ describe('CodexView zone → enemy cross-link', () => {
 	});
 });
 
+describe('CodexView enemy → zone cross-link', () => {
+	it('openZone switches to the Zones tab and selects the zone', () => {
+		const view = new CodexView();
+		view.selectEnemy(0); // a normal enemy with spawn zones
+		view.openZone(1);
+		expect(view.tab).toBe('zones');
+		expect(view.selectedZoneId).toBe(1);
+		expect(view.selectedZone?.id).toBe(1);
+	});
+});
+
+describe('CodexView enemy → skill cross-link', () => {
+	it('openSkill switches to the Skills tab and selects the skill', () => {
+		const view = new CodexView();
+		view.selectEnemy(0); // skill pool [0, 1]
+		view.openSkill(1);
+		expect(view.tab).toBe('skills');
+		expect(view.selectedSkillId).toBe(1);
+		expect(view.selectedSkill?.id).toBe(1);
+	});
+});
+
 describe('CodexView skill table', () => {
 	it('lists every skill in catalogue order with base/cooldown/used-by projections', () => {
 		const rows = new CodexView().skillRows;


### PR DESCRIPTION
## Summary

In the Codex enemy dossier, the **Skills** and **Spawns** rows were rendered non-interactively — there were no Zones/Skills tabs to link to when the Enemies tab first shipped (#995). Now that the Zones tab (#996) and Skills tab (#997) have landed, this wires those rows into real navigation:

- **Spawns row** → switches to the **Zones** tab and selects that zone.
- **Skill row** → switches to the **Skills** tab and selects that skill.

This is the mirror image of the cross-links the Zones/Skills tabs already have back into the enemy dossier.

## How it addresses the issue

- `CodexView` gains a single `openZone(id)` / `openSkill(id)` handler each — they set `tab` + the relevant selection, mirroring the existing `openEnemy(id)`.
- `EnemySpawnsPanel.svelte` and `EnemySkillsPanel.svelte` convert their list rows from `<div>`s to accessible `<button type="button">`s wired to those handlers, with a hover affordance and `data-testid`s matching the existing cross-link convention (`codex-enemy-spawn-{zoneId}`, `codex-enemy-skill-{skillId}`).
- The spawn cross-link works for both normal enemies (each spawn zone) and bosses (the single "Encounter" row links to its encounter zone).
- Stale "display-only / follow-up" comments removed; the `codex-view` module doc note updated to reflect the now-live cross-links.

## Test plan

- **Unit (`codex-view.test.ts`):** new tests assert `openZone`/`openSkill` switch the active tab and set the selection.
- **Render (`Codex.test.ts`):** new tests click an enemy spawn row → lands on the Zones tab with that zone's dossier, and an enemy skill row → lands on the Skills tab with that skill's dossier.
- ✅ `npm run lint` (eslint + `svelte-check`): 0 errors / 0 warnings.
- ✅ `npm run test:unit:ci`: **2246 passed**, coverage gate (incl. `src/routes/**`) passes.

Closes #998

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014pkX33UjxLe8LBhgH53jd8)_