### PR TITLE
test: pin SocketInterceptorMiddleware 404 (player-not-loadable) envelope

### DIFF
--- a/Game.Api.Tests/Integration/SocketConnectionTests.cs
+++ b/Game.Api.Tests/Integration/SocketConnectionTests.cs
@@ -3,11 +3,14 @@ using Game.Api.Models.Common;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using StackExchange.Redis;
 using System.Net;
 using System.Net.Http.Json;
 using System.Net.WebSockets;
+using System.Text.Json;
 using Xunit;
 
 namespace Game.Api.Tests.Integration
@@ -48,6 +51,18 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
 
             return seeded;
+        }
+
+        /// <summary>
+        /// Seeds a user with no player, so an authenticated handshake for it resolves no player to load.
+        /// Returns the userId (for WebSocket auth).
+        /// </summary>
+        private async Task<int> SeedUserWithoutPlayerAsync(string username = "socketnoplayer", string password = "socketpass")
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context, username, password);
+            return user.Id;
         }
 
         /// <summary>Reads the live TTL on the player's socket-presence key directly from Redis.</summary>
@@ -105,6 +120,35 @@ namespace Game.Api.Tests.Integration
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             var body = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(body);
+            Assert.False(string.IsNullOrWhiteSpace(body.ErrorMessage));
+        }
+
+        [Fact]
+        public async Task Socket_AuthenticatedButPlayerNotLoadable_ReturnsErrorEnvelope()
+        {
+            // The player-load short-circuit sits after the WebSocket-upgrade check, so — unlike the 401/400
+            // cases — it can't be reached with a plain GET (that stops at the 400 branch). The request is
+            // driven through the pipeline presenting as a WebSocket upgrade (a stubbed feature), but the
+            // socket is never accepted: the authenticated user has no player, so the handshake loads none and
+            // short-circuits to 404 with the { errorMessage } envelope still written to the (un-upgraded) body.
+            var userId = await SeedUserWithoutPlayerAsync();
+            var token = TestAuthHelper.CreateAccessToken(userId);
+
+            var context = await Factory.Server.SendAsync(ctx =>
+            {
+                ctx.Request.Method = HttpMethods.Get;
+                ctx.Request.Path = "/socket";
+                ctx.Request.QueryString = new QueryString($"?access_token={token}");
+                ctx.Features.Set<IHttpWebSocketFeature>(new StubWebSocketFeature());
+            }, CancellationToken);
+
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            // The response body stream isn't seekable, so deserialize straight from its start.
+            var body = await JsonSerializer.DeserializeAsync<ApiResponse>(
+                context.Response.Body,
+                new JsonSerializerOptions(JsonSerializerDefaults.Web),
+                CancellationToken);
             Assert.NotNull(body);
             Assert.False(string.IsNullOrWhiteSpace(body.ErrorMessage));
         }
@@ -168,6 +212,19 @@ namespace Game.Api.Tests.Integration
             Assert.NotNull(refreshed);
             Assert.True(decayed < initial, $"Expected the TTL to decay below {initial} but it was {decayed}.");
             Assert.True(refreshed > decayed, $"Expected activity to refresh the TTL above {decayed} but it was {refreshed}.");
+        }
+
+        /// <summary>
+        /// Presents a request to the pipeline as a WebSocket upgrade so the interceptor reaches its
+        /// post-upgrade checks, without ever completing a handshake. <see cref="AcceptAsync"/> is never
+        /// invoked by tests that short-circuit before the upgrade, so it deliberately throws.
+        /// </summary>
+        private sealed class StubWebSocketFeature : IHttpWebSocketFeature
+        {
+            public bool IsWebSocketRequest => true;
+
+            public Task<WebSocket> AcceptAsync(WebSocketAcceptContext context) =>
+                throw new InvalidOperationException("The stub WebSocket feature never accepts a connection.");
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1032.

`SocketInterceptorMiddleware` returns the project's `{ errorMessage }` envelope on three short-circuits. The `401` (unauthenticated) and `400` (non-WebSocket-upgrade) branches got integration tests in #1019, but the `404` (player-not-loadable, added in #1011) branch was never pinned by a test. This adds the missing one.

## What changed

- Added `Socket_AuthenticatedButPlayerNotLoadable_ReturnsErrorEnvelope` to `SocketConnectionTests`, mirroring the two existing envelope tests: it asserts the `404` status and a non-blank `errorMessage` body (presence, not exact text).
- Added a small `SeedUserWithoutPlayerAsync` helper (a user with no player → no resolvable player to load) and a private `StubWebSocketFeature`.

## Why it differs from the 401/400 tests

The player-load check sits **after** the WebSocket-upgrade check, so a plain `GET` (as the 401/400 tests use) would stop at the `400` branch and never reach `404`. The request therefore has to present as a WebSocket upgrade to get there. Since the TestServer `WebSocketClient` throws on a non-`101` handshake and hides the response body, the test drives the request through the full pipeline via `TestServer.SendAsync` with a stub `IHttpWebSocketFeature` (the socket is never accepted), which lets the `404` status **and** the envelope body both be asserted.

## Acceptance

- ✅ A test asserts the `404` short-circuit returns the `{ errorMessage }` envelope body.
- ✅ No production change (test-only).

## Testing

- `dotnet test Game.Api.Tests` — all 551 tests pass (one new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxWfr7ubzcJD4SDJKEgf3V)_