### PR TITLE
Add Player.LastActivity away-time tracking foundation (#1039)

### DIFF
--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -44,7 +44,8 @@ namespace Game.Application.Tests.DataAccess
                 Exp: 1234,
                 CurrentZoneId: 0,
                 StatPointsGained: 100,
-                StatPointsUsed: 100);
+                StatPointsUsed: 100,
+                LastActivity: DateTime.UtcNow);
 
             var logger = new CapturingLogger<DataProviderSynchronizer>();
             var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
@@ -86,8 +87,8 @@ namespace Game.Application.Tests.DataAccess
             var logger = new CapturingLogger<DataProviderSynchronizer>();
             var synchronizer = new DataProviderSynchronizer(brokenServices, pubsub, logger, TestRetryPolicy);
 
-            var firstEvent = new PlayerCoreUpdatedEvent(1, 2, 3, 0, 100, 100);
-            var secondEvent = new PlayerCoreUpdatedEvent(2, 3, 4, 0, 100, 100);
+            var firstEvent = new PlayerCoreUpdatedEvent(1, 2, 3, 0, 100, 100, DateTime.UtcNow);
+            var secondEvent = new PlayerCoreUpdatedEvent(2, 3, 4, 0, 100, 100, DateTime.UtcNow);
             var queue = new InMemoryPubSubQueue(Serialize(firstEvent), Serialize(secondEvent));
 
             await synchronizer.ProcessQueue(queue);
@@ -120,7 +121,8 @@ namespace Game.Application.Tests.DataAccess
                 Exp: 4321,
                 CurrentZoneId: 0,
                 StatPointsGained: 100,
-                StatPointsUsed: 100);
+                StatPointsUsed: 100,
+                LastActivity: DateTime.UtcNow);
 
             var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
             var logger = new CapturingLogger<DataProviderSynchronizer>();
@@ -719,7 +721,8 @@ namespace Game.Application.Tests.DataAccess
                 Exp: 4242,
                 CurrentZoneId: 0,
                 StatPointsGained: 100,
-                StatPointsUsed: 100);
+                StatPointsUsed: 100,
+                LastActivity: DateTime.UtcNow);
 
             var realPubSub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
             var queue = realPubSub.GetQueue(Constants.PUBSUB_PLAYER_QUEUE);
@@ -838,7 +841,8 @@ namespace Game.Application.Tests.DataAccess
                 Exp: 5678,
                 CurrentZoneId: 0,
                 StatPointsGained: 100,
-                StatPointsUsed: 100);
+                StatPointsUsed: 100,
+                LastActivity: DateTime.UtcNow);
 
             var realPubSub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
 
@@ -885,7 +889,8 @@ namespace Game.Application.Tests.DataAccess
                 Exp: 9876,
                 CurrentZoneId: 0,
                 StatPointsGained: 100,
-                StatPointsUsed: 100);
+                StatPointsUsed: 100,
+                LastActivity: DateTime.UtcNow);
 
             var realPubSub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
             var queue = realPubSub.GetQueue(Constants.PUBSUB_PLAYER_QUEUE);

--- a/Game.Application.Tests/DataAccess/PlayerUpdateHandlerIdempotencyIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerUpdateHandlerIdempotencyIntegrationTests.cs
@@ -498,11 +498,13 @@ namespace Game.Application.Tests.DataAccess
         {
             var playerId = await SeedPlayerAsync();
             var zoneId = await SeedZoneAsync();
+            var firstActivity = new DateTime(2026, 6, 20, 8, 0, 0, DateTimeKind.Utc);
+            var latestActivity = new DateTime(2026, 6, 20, 9, 0, 0, DateTimeKind.Utc);
 
             // Update-only against the always-present Players row: re-applying with higher absolute values
             // updates the row in place rather than duplicating, so the core fields converge to the latest.
-            await ApplyAsync(new PlayerCoreUpdatedEvent(playerId, Level: 7, Exp: 120, CurrentZoneId: zoneId, StatPointsGained: 130, StatPointsUsed: 110));
-            await ApplyAsync(new PlayerCoreUpdatedEvent(playerId, Level: 9, Exp: 250, CurrentZoneId: zoneId, StatPointsGained: 160, StatPointsUsed: 140));
+            await ApplyAsync(new PlayerCoreUpdatedEvent(playerId, Level: 7, Exp: 120, CurrentZoneId: zoneId, StatPointsGained: 130, StatPointsUsed: 110, LastActivity: firstActivity));
+            await ApplyAsync(new PlayerCoreUpdatedEvent(playerId, Level: 9, Exp: 250, CurrentZoneId: zoneId, StatPointsGained: 160, StatPointsUsed: 140, LastActivity: latestActivity));
 
             using var scope = CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
@@ -514,6 +516,7 @@ namespace Game.Application.Tests.DataAccess
             Assert.Equal(zoneId, row.CurrentZoneId);
             Assert.Equal(160, row.StatPointsGained);
             Assert.Equal(140, row.StatPointsUsed);
+            Assert.Equal(latestActivity, row.LastActivity);
         }
 
         [Fact]

--- a/Game.Application.Tests/Mapping/PlayerMapperTests.cs
+++ b/Game.Application.Tests/Mapping/PlayerMapperTests.cs
@@ -114,6 +114,7 @@ namespace Game.Application.Tests.Mapping
             Assert.Equal(1, player.Id);
             Assert.Equal("Hero", player.Name);
             Assert.Equal(3, player.Level);
+            Assert.Equal(MappedLastActivity, player.LastActivity);
             Assert.Contains(100, player.Inventory.UnlockedMods);
             Assert.Contains(101, player.Inventory.UnlockedMods);
             var strength = player.StatPoints.StatAllocations.Single(a => a.Attribute == EAttribute.Strength);
@@ -174,6 +175,8 @@ namespace Game.Application.Tests.Mapping
             Assert.NotNull(ex.InnerException);
         }
 
+        private static readonly DateTime MappedLastActivity = new(2026, 6, 20, 10, 0, 0, DateTimeKind.Utc);
+
         private static EntityPlayer BuildPlayer(
             List<EntityPlayerSkill>? skills = null,
             List<EntityUnlockedItem>? unlockedItems = null,
@@ -189,6 +192,7 @@ namespace Game.Application.Tests.Mapping
                 CurrentZoneId = 0,
                 StatPointsGained = 0,
                 StatPointsUsed = 0,
+                LastActivity = MappedLastActivity,
                 PlayerSkills = skills ?? [],
                 UnlockedItems = unlockedItems ?? [],
                 AppliedMods = appliedMods ?? [],

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -165,7 +165,7 @@ namespace Game.Application.Services
                 return null;
             }
 
-            var rewards = RecordVictory(player, enemy, result, state);
+            var rewards = RecordVictory(player, enemy, result, state, now);
 
             state.SetCooldown(claimedTimestamp + PostBattleCooldown);
             state.ClearBattle();
@@ -194,9 +194,10 @@ namespace Game.Application.Services
                 return false;
             }
 
-            player.RecordBattleCompleted(enemy, result, state.IsBossBattle, state.BattleZoneId ?? player.CurrentZoneId);
+            var now = DateTime.UtcNow;
+            player.RecordBattleCompleted(enemy, result, state.IsBossBattle, state.BattleZoneId ?? player.CurrentZoneId, now);
 
-            state.SetCooldown(DateTime.UtcNow + PostBattleCooldown);
+            state.SetCooldown(now + PostBattleCooldown);
             state.ClearBattle();
 
             await _playerRepo.SavePlayer(player, cancellationToken);
@@ -206,7 +207,8 @@ namespace Game.Application.Services
 
         private async Task AbandonBattle(Player player, PlayerState state, CancellationToken cancellationToken = default)
         {
-            var elapsedMs = (int)(DateTime.UtcNow - state.BattleStartTime).TotalMilliseconds;
+            var now = DateTime.UtcNow;
+            var elapsedMs = (int)(now - state.BattleStartTime).TotalMilliseconds;
 
             // Clamp the anti-cheat replay window to the battle's maximum duration. A battle never runs past
             // DefaultMaxBattleMs on the client — it ends as a draw at the cap — so the replay must not either:
@@ -227,11 +229,11 @@ namespace Game.Application.Services
                 // The enemy died within the elapsed wall-clock time, so this abandon resolved as a real
                 // victory. Pay it out exactly like EndBattleVictory (exp + win/clear/challenge credit)
                 // rather than booking the win while silently withholding the earned exp (#206).
-                RecordVictory(player, enemy, result, state);
+                RecordVictory(player, enemy, result, state, now);
             }
             else
             {
-                player.RecordBattleCompleted(enemy, result, state.IsBossBattle, state.BattleZoneId ?? player.CurrentZoneId);
+                player.RecordBattleCompleted(enemy, result, state.IsBossBattle, state.BattleZoneId ?? player.CurrentZoneId, now);
             }
 
             state.ClearBattle();
@@ -251,7 +253,7 @@ namespace Game.Application.Services
         // (AbandonBattle's elapsedMs) — a win only resolves if the enemy died within time the server itself
         // observed, so the server-measured cap is the (stronger) control there and a client timestamp adds
         // nothing. Both paths therefore require a server-validated timeline; neither can be claimed early.
-        private DefeatRewards RecordVictory(Player player, CoreEnemy enemy, BattleResult result, PlayerState state)
+        private DefeatRewards RecordVictory(Player player, CoreEnemy enemy, BattleResult result, PlayerState state, DateTime timestamp)
         {
             // Measure the player's power for the reward from the same frozen snapshot the battle was simulated
             // against, not the live aggregate. Valid mid-battle socket commands (stat reallocation, gear swaps)
@@ -267,7 +269,7 @@ namespace Game.Application.Services
             var rewards = new DefeatRewards(snapshot.GetModifiers(_items.GetItem, _itemMods.GetItemMod), enemy);
 
             player.GrantExp(rewards.ExpReward);
-            player.RecordBattleCompleted(enemy, result, state.IsBossBattle, state.BattleZoneId ?? player.CurrentZoneId);
+            player.RecordBattleCompleted(enemy, result, state.IsBossBattle, state.BattleZoneId ?? player.CurrentZoneId, timestamp);
 
             return rewards;
         }

--- a/Game.Core.TestInfrastructure/Builders/PlayerBuilder.cs
+++ b/Game.Core.TestInfrastructure/Builders/PlayerBuilder.cs
@@ -17,6 +17,7 @@ namespace Game.Core.TestInfrastructure.Builders
         private int _level = 1;
         private int _exp = 0;
         private int _currentZoneId = 0;
+        private DateTime _lastActivity = DateTime.UtcNow;
         private List<StatAllocation> _statAllocations = [];
         private int _statPointsGained = 0;
         private int _statPointsUsed = 0;
@@ -46,6 +47,12 @@ namespace Game.Core.TestInfrastructure.Builders
         public PlayerBuilder WithExp(int exp)
         {
             _exp = exp;
+            return this;
+        }
+
+        public PlayerBuilder WithLastActivity(DateTime lastActivity)
+        {
+            _lastActivity = lastActivity;
             return this;
         }
 
@@ -92,6 +99,7 @@ namespace Game.Core.TestInfrastructure.Builders
             Level = _level,
             Exp = _exp,
             CurrentZoneId = _currentZoneId,
+            LastActivity = _lastActivity,
             StatPoints = new PlayerStatPoints
             {
                 StatAllocations = _statAllocations,

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -679,7 +679,7 @@ namespace Game.Core.Tests.Players
             var stats = new BattleStats { PlayerDamageDealt = 42.0 };
             var result = new BattleResult(Victory: true, PlayerDied: false, TotalMs: 3200, Stats: stats);
 
-            player.RecordBattleCompleted(enemy, result, isBossBattle: true, zoneId: 7);
+            player.RecordBattleCompleted(enemy, result, isBossBattle: true, zoneId: 7, timestamp: DateTime.UtcNow);
 
             var evt = player.DomainEvents.OfType<BattleCompletedEvent>().SingleOrDefault();
             Assert.NotNull(evt);
@@ -691,6 +691,37 @@ namespace Game.Core.Tests.Players
             Assert.Equal(stats, evt.Stats);
             Assert.True(evt.IsBossBattle);
             Assert.Equal(7, evt.ZoneId);
+        }
+
+        [Fact]
+        public void RecordBattleCompleted_StampsLastActivityAndRaisesCoreUpdated()
+        {
+            var player = MakePlayer();
+            var enemy = MakeEnemy(id: 5);
+            var result = new BattleResult(Victory: false, PlayerDied: true, TotalMs: 1000, Stats: new BattleStats());
+            var timestamp = new DateTime(2026, 6, 20, 12, 0, 0, DateTimeKind.Utc);
+
+            player.RecordBattleCompleted(enemy, result, isBossBattle: false, zoneId: 3, timestamp: timestamp);
+
+            Assert.Equal(timestamp, player.LastActivity);
+            var coreUpdated = player.DomainEvents.OfType<PlayerCoreUpdatedEvent>().SingleOrDefault();
+            Assert.NotNull(coreUpdated);
+            Assert.Equal(timestamp, coreUpdated.LastActivity);
+        }
+
+        // ── StampActivity ────────────────────────────────────────────────────
+
+        [Fact]
+        public void StampActivity_SetsLastActivityAndRaisesCoreUpdatedCarryingIt()
+        {
+            var player = MakePlayer();
+            var timestamp = new DateTime(2026, 6, 20, 15, 30, 0, DateTimeKind.Utc);
+
+            player.StampActivity(timestamp);
+
+            Assert.Equal(timestamp, player.LastActivity);
+            var evt = Assert.IsType<PlayerCoreUpdatedEvent>(Assert.Single(player.DomainEvents));
+            Assert.Equal(timestamp, evt.LastActivity);
         }
 
         // ── ClearEvents ──────────────────────────────────────────────────────

--- a/Game.Core/Players/Events/PlayerCoreUpdatedEvent.cs
+++ b/Game.Core/Players/Events/PlayerCoreUpdatedEvent.cs
@@ -3,7 +3,7 @@ using Game.Core.Events;
 namespace Game.Core.Players.Events
 {
     /// <summary>
-    /// Raised when a player's core fields change (level, exp, zone, stat points).
+    /// Raised when a player's core fields change (level, exp, zone, stat points, last-activity anchor).
     /// </summary>
     public record PlayerCoreUpdatedEvent(
         int PlayerId,
@@ -11,5 +11,6 @@ namespace Game.Core.Players.Events
         int Exp,
         int CurrentZoneId,
         int StatPointsGained,
-        int StatPointsUsed) : IDomainEvent;
+        int StatPointsUsed,
+        DateTime LastActivity) : IDomainEvent;
 }

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -20,6 +20,14 @@ namespace Game.Core.Players
         public required int Level { get; set; }
         public required int Exp { get; set; }
         public required int CurrentZoneId { get; set; }
+
+        /// <summary>
+        /// When the player was last active, the anchor the offline-rewards flow reads to compute away time
+        /// (<c>now − LastActivity</c>) server-side. Stamped on battle completion (the "last enemy defeated"
+        /// anchor) via <see cref="StampActivity"/> so it is current at any disconnect.
+        /// </summary>
+        public required DateTime LastActivity { get; set; }
+
         public required PlayerStatPoints StatPoints { get; set; }
         public required Inventory Inventory { get; set; }
         public required List<Skill> SelectedSkills { get; set; }
@@ -264,10 +272,24 @@ namespace Game.Core.Players
             RaiseEvent(new LogPreferenceChangedEvent(Id, logType, enabled));
         }
 
-        public void RecordBattleCompleted(Enemy enemy, BattleResult result, bool isBossBattle, int zoneId)
+        public void RecordBattleCompleted(Enemy enemy, BattleResult result, bool isBossBattle, int zoneId, DateTime timestamp)
         {
             RaiseEvent(new BattleCompletedEvent(
                 this, enemy, result.Victory, result.PlayerDied, result.TotalMs, result.Stats, isBossBattle, zoneId));
+            StampActivity(timestamp);
+        }
+
+        /// <summary>
+        /// Records that the player was active at <paramref name="timestamp"/>, advancing the away-time anchor
+        /// the offline-rewards flow reads. Stamped on every battle completion (so a loss — which raises no other
+        /// core update — still persists the anchor) and reset to "now" when offline progress is claimed at login,
+        /// so the next away period starts fresh and a re-claim is a no-op. Raises a
+        /// <see cref="PlayerCoreUpdatedEvent"/> so the change rides the existing write-behind save.
+        /// </summary>
+        public void StampActivity(DateTime timestamp)
+        {
+            LastActivity = timestamp;
+            RaiseCoreUpdated();
         }
 
         public IEnumerable<AttributeModifier> GetAllModifiers()
@@ -285,7 +307,7 @@ namespace Game.Core.Players
         {
             RaiseEvent(new PlayerCoreUpdatedEvent(
                 Id, Level, Exp, CurrentZoneId,
-                StatPoints.StatPointsGained, StatPoints.StatPointsUsed));
+                StatPoints.StatPointsGained, StatPoints.StatPointsUsed, LastActivity));
         }
     }
 }

--- a/Game.DataAccess/Mapping/PlayerMapper.cs
+++ b/Game.DataAccess/Mapping/PlayerMapper.cs
@@ -27,6 +27,9 @@ namespace Game.DataAccess.Mapping
                 CurrentZoneId = newPlayer.CurrentZoneId,
                 StatPointsGained = newPlayer.StatPointsGained,
                 StatPointsUsed = newPlayer.StatPointsUsed,
+                // Anchor away-time tracking at creation so a brand-new player's first login computes a fresh
+                // (near-zero) away period rather than an enormous one from the default DateTime.
+                LastActivity = DateTime.UtcNow,
             };
 
             player.PlayerSkills = newPlayer.Skills
@@ -155,6 +158,7 @@ namespace Game.DataAccess.Mapping
                 Level = entity.Level,
                 Exp = entity.Exp,
                 CurrentZoneId = entity.CurrentZoneId,
+                LastActivity = entity.LastActivity,
                 StatPoints = new PlayerStatPoints
                 {
                     StatAllocations = statAllocations,

--- a/Game.DataAccess/PlayerUpdates/Handlers/PlayerCoreUpdatedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/PlayerCoreUpdatedHandler.cs
@@ -15,7 +15,8 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
                     .SetProperty(p => p.Exp, evt.Exp)
                     .SetProperty(p => p.CurrentZoneId, evt.CurrentZoneId)
                     .SetProperty(p => p.StatPointsGained, evt.StatPointsGained)
-                    .SetProperty(p => p.StatPointsUsed, evt.StatPointsUsed));
+                    .SetProperty(p => p.StatPointsUsed, evt.StatPointsUsed)
+                    .SetProperty(p => p.LastActivity, evt.LastActivity));
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1039 (foundation sub-issue of #879, offline rewards). Maintains `Player.LastActivity` as a real "last active" timestamp so the offline-rewards flow can compute how long a player was away (`now − LastActivity`) **server-side**. Today the column exists on the `Player` DB entity but is set only at player creation and read only for the admin summary — nothing updates it during play, and it isn't on the core aggregate at all.

No user-facing effect on its own; this is the anchor every other offline-rewards piece (#1040–#1042) reads.

## How it addresses the issue

- **Core aggregate.** Adds `LastActivity` to `Game.Core/Players/Player.cs` (previously only on the EF entity + DB).
- **Stamped on battle completion.** New `StampActivity(DateTime timestamp)` sets the field and raises `PlayerCoreUpdatedEvent`. `RecordBattleCompleted` now takes a server timestamp and calls it, so **every** completion path — win, loss, and abandon (incl. won-abandon) — advances the anchor. A loss otherwise raises no core update, so this is what carries its anchor onto the Players row. `StampActivity` is also the reusable "set to now" entry point the offline-claim orchestration (#1042) will call at login (resetting it makes a re-claim a no-op).
- **Persisted via the existing write-behind path.** `LastActivity` rides `PlayerCoreUpdatedEvent` → `PlayerCoreUpdatedHandler` (absolute write), so it persists on the save battle-end already performs — no new event type on the hot path beyond the loss case that previously wrote nothing core.
- **Mapped on load.** `PlayerMapper.ToCore` reads `entity.LastActivity` onto the in-memory aggregate (Redis cache is source of truth; this is the DB-fallback path). The aggregate also serializes into the Redis cache automatically.
- **Anchored at creation.** `PlayerMapper.ToEntity` now stamps `LastActivity = UtcNow` for a brand-new player so its first login computes a fresh (near-zero) away period rather than an enormous one from the default `DateTime` — a small correctness fix, since the creation mapper wasn't setting it.

## Notes / design

- Away time is computed **server-side only**, never client-supplied — the timestamp comes from `BattleService`'s server clock (matching its existing `DateTime.UtcNow` usage), passed into the domain so the aggregate stays pure/testable.
- On a **victory**, `GrantExp` already raises a core update; the stamp raises a second carrying the new `LastActivity`. The write-behind handlers are idempotent absolute writes and the final value converges correctly — the extra update is on the async/batched queue, off the request path. Accepted for the robustness of a single completion method that no path can forget; the loss path inherently needed a new core update regardless.
- No frontend changes: `LastActivity` is server-only, not part of any battle-parity surface, and the domain event isn't code-generated.

## Test plan

Full backend suite green (`dotnet build` + `dotnet test`: 2073 passed, 0 failed).

- **Unit** (`PlayerTests`): `StampActivity` sets the field and raises a `PlayerCoreUpdatedEvent` carrying it; `RecordBattleCompleted` stamps `LastActivity` and raises the core update (loss path).
- **Mapping** (`PlayerMapperTests`): `ToCore` maps `LastActivity` from the entity.
- **Integration** (`PlayerUpdateHandlerIdempotencyIntegrationTests`): `PlayerCoreUpdatedEvent` round-trips `LastActivity` through the write-behind handler to the DB and converges to the latest value on re-apply.
- Updated the existing `PlayerCoreUpdatedEvent` constructions in `DataProviderSynchronizerTests` and the `PlayerBuilder` for the new field.

## Docs

No docs change in this PR: the foundation has no user-facing effect, and the offline-rewards architecture (including this anchor) is captured in `docs/spikes/879-offline-rewards.md`, to be promoted to `docs/backend.md` when the feature itself lands (per the spike's documentation note).

Closes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjQifDXv9TQzibE6LZrEAn)_