### PR TITLE
Offline rewards: core offline simulation engine (Game.Core) (#1041)

### DIFF
--- a/Game.Application/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Game.Application/DependencyInjection/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Game.Application.Events;
 using Game.Application.Services;
 using Game.Core.Battle;
 using Game.Core.Battle.Events;
+using Game.Core.Battle.Offline;
 using Game.Core.Events;
 using Game.Core.Players;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,10 +17,11 @@ namespace Game.Application.DependencyInjection
         {
             RegisterDomainEventHandlers();
             return services
-                // BattleFactory and NewPlayerFactory are stateless domain services with no
-                // dependencies, so they are shared.
+                // BattleFactory, NewPlayerFactory and OfflineProgressSimulator are stateless domain
+                // services with no out-of-process dependencies, so they are shared.
                 .AddSingleton<BattleFactory>()
                 .AddSingleton<NewPlayerFactory>()
+                .AddSingleton<OfflineProgressSimulator>()
                 // Stateless (parameters come from injected options), so a single shared instance.
                 .AddSingleton<IPasswordHasher, Pbkdf2PasswordHasher>()
                 // Per-account login backoff: a stateless policy (shared) plus a scoped guard over the

--- a/Game.Core.Tests/Battle/Offline/OfflineProgressResultTests.cs
+++ b/Game.Core.Tests/Battle/Offline/OfflineProgressResultTests.cs
@@ -1,0 +1,113 @@
+using Game.Core.Attributes;
+using Game.Core.Battle;
+using Game.Core.Battle.Offline;
+using Game.Core.Enemies;
+using Xunit;
+using static Game.Core.EAttribute;
+
+namespace Game.Core.Tests.Battle.Offline
+{
+    /// <summary>
+    /// Focused coverage of the run-level aggregation the result folds out of its per-battle outcomes,
+    /// constructed directly so the win/loss/draw classification and reward totals are pinned without
+    /// depending on the battle simulation.
+    /// </summary>
+    public class OfflineProgressResultTests
+    {
+        [Fact]
+        public void EmptyBattles_AllAggregatesZero()
+        {
+            var result = new OfflineProgressResult(OfflineLoopMode.Idle, zoneId: 3, battles: []);
+
+            Assert.Equal(0, result.BattlesSimulated);
+            Assert.Equal(0, result.Wins);
+            Assert.Equal(0, result.Losses);
+            Assert.Equal(0, result.Draws);
+            Assert.Equal(0, result.TotalExp);
+            Assert.Equal(0, result.TotalBattleMs);
+            Assert.Empty(result.EnemyKillCounts);
+        }
+
+        [Fact]
+        public void ClassifiesWinLossAndDraw_ByVictoryAndPlayerDiedFlags()
+        {
+            var battles = new List<OfflineBattleOutcome>
+            {
+                Win(enemyId: 1, totalMs: 40, exp: 10),
+                Loss(enemyId: 1, totalMs: 200),
+                Draw(enemyId: 2, totalMs: 120_000),
+            };
+
+            var result = new OfflineProgressResult(OfflineLoopMode.Boss, zoneId: 5, battles);
+
+            Assert.Equal(3, result.BattlesSimulated);
+            Assert.Equal(1, result.Wins);
+            Assert.Equal(1, result.Losses);
+            Assert.Equal(1, result.Draws);
+            Assert.Equal(120_240, result.TotalBattleMs); // 40 + 200 + 120000
+        }
+
+        [Fact]
+        public void TotalExp_SumsOnlyVictoryRewards()
+        {
+            var battles = new List<OfflineBattleOutcome>
+            {
+                Win(enemyId: 1, totalMs: 40, exp: 7),
+                Win(enemyId: 1, totalMs: 40, exp: 11),
+                Loss(enemyId: 1, totalMs: 80), // a loss carries no exp even if one were supplied
+                Draw(enemyId: 1, totalMs: 120_000),
+            };
+
+            var result = new OfflineProgressResult(OfflineLoopMode.Idle, zoneId: 1, battles);
+
+            Assert.Equal(18, result.TotalExp);
+        }
+
+        [Fact]
+        public void EnemyKillCounts_CountsVictoriesPerEnemyOnly()
+        {
+            var battles = new List<OfflineBattleOutcome>
+            {
+                Win(enemyId: 1, totalMs: 40, exp: 1),
+                Win(enemyId: 1, totalMs: 40, exp: 1),
+                Win(enemyId: 2, totalMs: 40, exp: 1),
+                Loss(enemyId: 1, totalMs: 40), // a loss is not a kill
+                Draw(enemyId: 2, totalMs: 40), // a draw is not a kill
+            };
+
+            var result = new OfflineProgressResult(OfflineLoopMode.Idle, zoneId: 1, battles);
+
+            Assert.Equal(2, result.EnemyKillCounts.Count);
+            Assert.Equal(2, result.EnemyKillCounts[1]);
+            Assert.Equal(1, result.EnemyKillCounts[2]);
+        }
+
+        [Fact]
+        public void IsBossBattle_DerivedFromMode()
+        {
+            Assert.True(new OfflineProgressResult(OfflineLoopMode.Boss, 1, []).IsBossBattle);
+            Assert.False(new OfflineProgressResult(OfflineLoopMode.Idle, 1, []).IsBossBattle);
+        }
+
+        // ── Builders ─────────────────────────────────────────────────────────
+
+        private static OfflineBattleOutcome Win(int enemyId, int totalMs, int exp) =>
+            new(MakeEnemy(enemyId), new BattleResult(Victory: true, PlayerDied: false, totalMs, new BattleStats()), exp);
+
+        private static OfflineBattleOutcome Loss(int enemyId, int totalMs) =>
+            new(MakeEnemy(enemyId), new BattleResult(Victory: false, PlayerDied: true, totalMs, new BattleStats()), ExpReward: 0);
+
+        private static OfflineBattleOutcome Draw(int enemyId, int totalMs) =>
+            new(MakeEnemy(enemyId), new BattleResult(Victory: false, PlayerDied: false, totalMs, new BattleStats()), ExpReward: 0);
+
+        private static Enemy MakeEnemy(int id) => new()
+        {
+            Id = id,
+            Name = $"Enemy {id}",
+            IsBoss = false,
+            Level = 1,
+            AttributeDistributions = [new AttributeDistribution { AttributeId = Strength, BaseAmount = 1, AmountPerLevel = 0 }],
+            AvailableSkills = [],
+        };
+    }
+}

--- a/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
@@ -296,6 +296,23 @@ namespace Game.Core.Tests.Battle.Offline
             Assert.Equal(result.Wins, kill.Value);
         }
 
+        [Fact]
+        public void Simulate_CarriesEachBattlesStatsThrough_ForStatisticsConsolidation()
+        {
+            // The whole BattleResult — including its BattleStats — rides on each outcome so the orchestration
+            // layer (#1042) can feed every battle through the shared per-battle statistics-recording path. Pin
+            // that the stats are the real per-battle combat figures, not defaults.
+            var result = _simulator.Simulate(IdleParameters(ManyStepsBudget(), StrongPlayerWinScenario()));
+
+            Assert.NotEmpty(result.Battles);
+            Assert.All(result.Battles, battle =>
+            {
+                Assert.True(battle.Result.Stats.PlayerDamageDealt > 0);
+                Assert.True(battle.Result.Stats.PlayerSkillsUsed > 0);
+                Assert.NotEmpty(battle.Result.Stats.SkillStats);
+            });
+        }
+
         // ── Cancellation ─────────────────────────────────────────────────────
 
         [Fact]

--- a/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
@@ -1,0 +1,549 @@
+using Game.Core.Attributes;
+using Game.Core.Battle;
+using Game.Core.Battle.Offline;
+using Game.Core.Enemies;
+using Game.Core.Items;
+using Game.Core.Players;
+using Game.Core.Skills;
+using Game.Core.Zones;
+using Xunit;
+using static Game.Core.EAttribute;
+
+namespace Game.Core.Tests.Battle.Offline
+{
+    /// <summary>
+    /// Heavy unit coverage for the core offline simulation engine (#1041). Battles are made deterministic by
+    /// fixing the enemy, the zone level range, and the per-battle seed, so the budget accounting and reward
+    /// accumulation can be asserted exactly. A few scenarios deliberately vary the seed to exercise a mixed
+    /// run of wins/losses/draws.
+    /// </summary>
+    public class OfflineProgressSimulatorTests
+    {
+        private const int CooldownMs = 5000;
+        private const long TenHoursMs = 10L * 60 * 60 * 1000;
+
+        private readonly OfflineProgressSimulator _simulator = new(new BattleFactory());
+
+        // ── Empty / whole-skip ───────────────────────────────────────────────
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(-60_000)]
+        public void Simulate_NonPositiveBudget_ProducesEmptyWholeSkipResult(long awayMs)
+        {
+            // A non-positive away budget is the engine's "whole-skip": nothing is simulated and the result is
+            // empty, which the orchestration's no-progress short-circuit relies on.
+            var result = _simulator.Simulate(IdleParameters(awayMs, StrongPlayerWinScenario()));
+
+            Assert.Empty(result.Battles);
+            Assert.Equal(0, result.BattlesSimulated);
+            Assert.Equal(0, result.Wins);
+            Assert.Equal(0, result.Losses);
+            Assert.Equal(0, result.Draws);
+            Assert.Equal(0, result.TotalExp);
+            Assert.Empty(result.EnemyKillCounts);
+        }
+
+        [Fact]
+        public void Simulate_ZeroCap_ProducesEmptyResultEvenWithLongAwayTime()
+        {
+            // The cap clamps the budget; a zero cap leaves no budget regardless of how long the player was away.
+            var parameters = With(IdleParameters(TenHoursMs, StrongPlayerWinScenario()), capMs: 0);
+            var result = _simulator.Simulate(parameters);
+
+            Assert.Empty(result.Battles);
+        }
+
+        // ── Idle loop & budget accounting ────────────────────────────────────
+
+        [Fact]
+        public void Simulate_IdleLoop_RunsUntilBudgetExhausted_AccountingDurationPlusCooldown()
+        {
+            var scenario = StrongPlayerWinScenario();
+            // A single deterministic battle (fixed enemy + fixed seed) tells us the exact per-battle duration.
+            var battleMs = SingleBattleDurationMs(scenario);
+            var stepMs = battleMs + CooldownMs;
+            var awayMs = (stepMs * 4) + 1; // 4 full steps plus a sliver → a 5th battle starts
+
+            var result = _simulator.Simulate(IdleParameters(awayMs, scenario));
+
+            // Every battle is identical, so each consumes the same duration.
+            Assert.All(result.Battles, battle => Assert.Equal(battleMs, battle.Result.TotalMs));
+
+            // The loop keeps fighting while any budget remains, consuming duration + cooldown per battle, and
+            // stops once the budget is exhausted: the run is the fewest battles whose total cost covers the
+            // budget (the last battle overshoots by at most one step).
+            var count = result.BattlesSimulated;
+            Assert.True((count - 1L) * stepMs < awayMs, "The run stopped before the budget was exhausted.");
+            Assert.True(count * stepMs >= awayMs, "The run continued past an already-exhausted budget.");
+            Assert.Equal(5, count);
+        }
+
+        [Fact]
+        public void Simulate_AwayBudgetBelowOneStep_RunsExactlyOneBattle()
+        {
+            var scenario = StrongPlayerWinScenario();
+
+            // Any positive budget fights at least one battle; the battle (plus cooldown) then exhausts it.
+            var result = _simulator.Simulate(IdleParameters(awayMs: 1, scenario));
+
+            Assert.Single(result.Battles);
+        }
+
+        [Fact]
+        public void Simulate_IdleLoop_RollsEncounterLevelWithinZoneRange()
+        {
+            // Resolve the enemy at whatever level the idle loop rolls, recording the levels seen. The engine
+            // must drive the random idle encounter (BattleFactory.CreateBattleEnemy) within the zone's range.
+            var levels = new HashSet<int>();
+            var scenario = new Scenario
+            {
+                Zone = MakeZone(levelMin: 3, levelMax: 6),
+                // A strong player wins each battle quickly, so the run packs in many fast battles.
+                Snapshot = PlayerSnapshot(strength: 100, endurance: 100),
+                ResolveEnemy = level =>
+                {
+                    levels.Add(level);
+                    return WeakEnemy(level);
+                },
+            };
+
+            // Plenty of battles to exercise the whole range.
+            _simulator.Simulate(IdleParameters(TenHoursMs, scenario, capMs: TenHoursMs));
+
+            Assert.All(levels, level => Assert.InRange(level, 3, 6));
+            // The range has four levels; over thousands of battles every one should appear.
+            Assert.Equal(4, levels.Count);
+        }
+
+        // ── Cap vs budget boundary ───────────────────────────────────────────
+
+        [Fact]
+        public void Simulate_AwayExceedsCap_ClampsToCap()
+        {
+            var scenario = StrongPlayerWinScenario();
+            var battleMs = SingleBattleDurationMs(scenario);
+            var stepMs = battleMs + CooldownMs;
+            var capMs = stepMs * 3;
+
+            // Away far exceeds the cap, so the run is bounded by the cap, not the away time.
+            var clamped = _simulator.Simulate(With(IdleParameters(TenHoursMs, scenario), capMs: capMs));
+            // A run with away == cap is the reference: clamping must reproduce it exactly.
+            var atCap = _simulator.Simulate(With(IdleParameters(capMs, scenario), capMs: capMs));
+
+            Assert.Equal(3, clamped.BattlesSimulated);
+            Assert.Equal(atCap.BattlesSimulated, clamped.BattlesSimulated);
+        }
+
+        // ── Boss loop ────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Simulate_BossLoop_BuildsDeterministicBossEachBattle()
+        {
+            // Boss mode must fight the zone's dedicated boss at its fixed level with the full authored loadout,
+            // every battle — not a random idle encounter.
+            var resolvedLevels = new List<int>();
+            var scenario = new Scenario
+            {
+                Zone = MakeZone(levelMin: 1, levelMax: 1, bossEnemyId: 7, bossLevel: 12),
+                ResolveEnemy = level =>
+                {
+                    resolvedLevels.Add(level);
+                    return WeakEnemy(level, skillCount: 3);
+                },
+            };
+
+            var result = _simulator.Simulate(BossParameters(TenHoursMs, scenario, capMs: TenHoursMs));
+
+            Assert.NotEmpty(result.Battles);
+            Assert.All(resolvedLevels, level => Assert.Equal(12, level)); // always the fixed boss level
+            // The full authored loadout (no 4-skill cap) is brought into each boss battle.
+            Assert.All(result.Battles, battle => Assert.Equal(3, battle.Enemy.BattleSkills.Count));
+            Assert.Equal(OfflineLoopMode.Boss, result.Mode);
+            Assert.True(result.IsBossBattle);
+        }
+
+        [Fact]
+        public void Simulate_BossLoop_ContinuesThroughLosses()
+        {
+            // A player guaranteed to die must not stop the loop — offline boss farming keeps going through
+            // losses (decision 3), unlike the present-player loop that drops to idle.
+            var result = _simulator.Simulate(BossParameters(ManyStepsBudget(), AlwaysLoseBossScenario()));
+
+            Assert.True(result.BattlesSimulated > 1, "The boss loop stopped after a single loss.");
+            Assert.Equal(result.BattlesSimulated, result.Losses);
+            Assert.Equal(0, result.Wins);
+            Assert.Equal(0, result.Draws);
+        }
+
+        [Fact]
+        public void Simulate_BossLoop_VariedSeeds_ProducesMixedOutcomesMatchingDirectSimulation()
+        {
+            // A balanced boss fight whose outcome turns on the player's crit rolls: a fresh seed each battle
+            // varies the result. Drive a fixed seed sequence so the run is deterministic, and verify each
+            // battle matches an independent direct simulation of the same seed (proving fresh-seed-per-battle
+            // and that every outcome type is carried through).
+            var scenario = CoinFlipBossScenario();
+            // A generous seed pool (larger than any battle count this budget can produce) keyed by index, so
+            // every battle draws a distinct, known seed and the source never overruns.
+            var seeds = Enumerable.Range(0, 1024).Select(i => (uint)i).ToArray();
+            var seedIndex = 0;
+            var parameters = BossParameters(ManyStepsBudget(15), scenario) with
+            {
+                SeedSource = () => seeds[seedIndex++],
+            };
+
+            var result = _simulator.Simulate(parameters);
+
+            Assert.True(result.BattlesSimulated > 1);
+            Assert.Equal(result.BattlesSimulated, result.Wins + result.Losses + result.Draws);
+
+            // The run is a genuine mix, not a single repeated outcome.
+            var distinctOutcomeKinds = new[] { result.Wins, result.Losses, result.Draws }.Count(c => c > 0);
+            Assert.True(distinctOutcomeKinds >= 2,
+                $"Expected a mix of outcomes but got {result.Wins} wins / {result.Losses} losses / {result.Draws} draws.");
+
+            // Each simulated battle reproduces a direct BattleSimulator run of the same seed, in order —
+            // proving a fresh seed is consumed per battle and the loop carries every outcome type through.
+            for (var i = 0; i < result.BattlesSimulated; i++)
+            {
+                var expected = DirectBossSimulation(scenario, seeds[i]);
+                var actual = result.Battles[i].Result;
+                Assert.Equal(expected.Victory, actual.Victory);
+                Assert.Equal(expected.PlayerDied, actual.PlayerDied);
+                Assert.Equal(expected.TotalMs, actual.TotalMs);
+            }
+        }
+
+        // ── All-draw (zero rewards) ──────────────────────────────────────────
+
+        [Fact]
+        public void Simulate_AllDrawZone_ProducesBattlesButZeroRewards()
+        {
+            // Neither side can damage the other, so every battle runs to the cap as a draw — the most work for
+            // no reward. The result has battles but no wins, no exp, no kills (the no-progress short-circuit).
+            var result = _simulator.Simulate(IdleParameters(ManyStepsBudget(), StalemateScenario()));
+
+            Assert.True(result.BattlesSimulated > 1);
+            Assert.Equal(result.BattlesSimulated, result.Draws);
+            Assert.Equal(0, result.Wins);
+            Assert.Equal(0, result.Losses);
+            Assert.Equal(0, result.TotalExp);
+            Assert.Empty(result.EnemyKillCounts);
+            Assert.All(result.Battles, battle =>
+            {
+                Assert.False(battle.Result.Victory);
+                Assert.False(battle.Result.PlayerDied);
+                Assert.Equal(0, battle.ExpReward);
+            });
+        }
+
+        [Fact]
+        public void Simulate_AllDrawBoss_ProducesZeroRewards()
+        {
+            var scenario = StalemateScenario(bossEnemyId: 7, bossLevel: 3);
+
+            var result = _simulator.Simulate(BossParameters(ManyStepsBudget(), scenario));
+
+            Assert.True(result.BattlesSimulated > 1);
+            Assert.Equal(result.BattlesSimulated, result.Draws);
+            Assert.Equal(0, result.TotalExp);
+        }
+
+        // ── Reward accumulation ──────────────────────────────────────────────
+
+        [Fact]
+        public void Simulate_Wins_TotalExpEqualsSumOfPerVictoryRewards()
+        {
+            var scenario = StrongPlayerWinScenario();
+
+            var result = _simulator.Simulate(IdleParameters(ManyStepsBudget(), scenario));
+
+            Assert.True(result.Wins > 1);
+            Assert.Equal(result.BattlesSimulated, result.Wins); // the strong player wins every battle
+            var summed = result.Battles.Where(b => b.Result.Victory).Sum(b => (long)b.ExpReward);
+            Assert.Equal(summed, result.TotalExp);
+        }
+
+        [Fact]
+        public void Simulate_PerVictoryExp_MatchesDefeatRewardsFromSnapshot()
+        {
+            var scenario = StrongPlayerWinScenario();
+
+            var result = _simulator.Simulate(IdleParameters(ManyStepsBudget(), scenario));
+
+            // Each victory's exp is exactly what DefeatRewards computes from the same snapshot/enemy — the
+            // reward is consistent with the battle it was earned in.
+            var playerModifiers = scenario.Snapshot
+                .GetModifiers(scenario.ResolveItem, scenario.ResolveMod)
+                .ToList();
+            Assert.All(result.Battles, battle =>
+            {
+                var expected = new DefeatRewards(playerModifiers, battle.Enemy).ExpReward;
+                Assert.Equal(expected, battle.ExpReward);
+            });
+        }
+
+        [Fact]
+        public void Simulate_Wins_RecordsPerEnemyKillCounts()
+        {
+            var scenario = StrongPlayerWinScenario(); // a single enemy id (1) won every time
+            var result = _simulator.Simulate(IdleParameters(ManyStepsBudget(), scenario));
+
+            var kill = Assert.Single(result.EnemyKillCounts);
+            Assert.Equal(EnemyId, kill.Key);
+            Assert.Equal(result.Wins, kill.Value);
+        }
+
+        // ── Cancellation ─────────────────────────────────────────────────────
+
+        [Fact]
+        public void Simulate_CancellationRequested_Throws()
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.Throws<OperationCanceledException>(() =>
+                _simulator.Simulate(IdleParameters(TenHoursMs, StrongPlayerWinScenario()), cts.Token));
+        }
+
+        // ── Result metadata ──────────────────────────────────────────────────
+
+        [Fact]
+        public void Simulate_ResultCarriesModeAndZone()
+        {
+            var scenario = StrongPlayerWinScenario();
+            scenario.Zone = MakeZone(levelMin: 1, levelMax: 1, id: 42);
+
+            var result = _simulator.Simulate(IdleParameters(ManyStepsBudget(), scenario));
+
+            Assert.Equal(OfflineLoopMode.Idle, result.Mode);
+            Assert.False(result.IsBossBattle);
+            Assert.Equal(42, result.ZoneId);
+        }
+
+        // ── Scenario plumbing ────────────────────────────────────────────────
+
+        private const int EnemyId = 1;
+
+        /// <summary>A self-contained battle scenario: the zone, the player snapshot, and the resolvers.</summary>
+        private sealed class Scenario
+        {
+            public required Zone Zone { get; set; }
+            public BattleSnapshot Snapshot { get; init; } = EmptySnapshot();
+            public required Func<int, Enemy> ResolveEnemy { get; init; }
+            public Func<int, Item> ResolveItem { get; init; } = ThrowItem;
+            public Func<int, ItemMod> ResolveMod { get; init; } = ThrowMod;
+            public Func<int, Skill> ResolveSkill { get; init; } = id => PlayerAttackSkill();
+        }
+
+        private static OfflineSimulationParameters IdleParameters(long awayMs, Scenario scenario, long capMs = TenHoursMs) =>
+            new()
+            {
+                Snapshot = scenario.Snapshot,
+                Mode = OfflineLoopMode.Idle,
+                Zone = scenario.Zone,
+                AwayBudgetMs = awayMs,
+                CapMs = capMs,
+                CooldownMs = CooldownMs,
+                ResolveEnemy = scenario.ResolveEnemy,
+                ResolveItem = scenario.ResolveItem,
+                ResolveMod = scenario.ResolveMod,
+                ResolveSkill = scenario.ResolveSkill,
+                SeedSource = () => 0,
+            };
+
+        private static OfflineSimulationParameters BossParameters(long awayMs, Scenario scenario, long capMs = TenHoursMs) =>
+            IdleParameters(awayMs, scenario, capMs) with { Mode = OfflineLoopMode.Boss };
+
+        private static OfflineSimulationParameters With(OfflineSimulationParameters parameters, long capMs) =>
+            parameters with { CapMs = capMs };
+
+        // A budget comfortably larger than several battle steps, so a run produces many battles.
+        private static long ManyStepsBudget(int steps = 20) =>
+            steps * (GameConstants.DefaultMaxBattleMs + CooldownMs);
+
+        /// <summary>Runs a single deterministic battle (fixed enemy + fixed seed) to read its exact duration.</summary>
+        private static int SingleBattleDurationMs(Scenario scenario)
+        {
+            var enemy = new BattleFactory().CreateBattleEnemy(scenario.Zone, scenario.ResolveEnemy);
+            return DirectSimulation(scenario, enemy, seed: 0).TotalMs;
+        }
+
+        private static BattleResult DirectBossSimulation(Scenario scenario, uint seed)
+        {
+            var enemy = new BattleFactory().CreateBossEnemy(scenario.Zone, scenario.ResolveEnemy);
+            return DirectSimulation(scenario, enemy, seed);
+        }
+
+        private static BattleResult DirectSimulation(Scenario scenario, Enemy enemy, uint seed)
+        {
+            var playerBattler = scenario.Snapshot.ToBattler(scenario.ResolveItem, scenario.ResolveMod, scenario.ResolveSkill);
+            var enemyBattler = new Battler(
+                new AttributeCollection(enemy.GetAttributeModifiers()), enemy.BattleSkills, enemy.Level);
+            return new BattleSimulator(playerBattler, enemyBattler, seed).Simulate();
+        }
+
+        // ── Scenario presets ─────────────────────────────────────────────────
+
+        private static Scenario StrongPlayerWinScenario() => new()
+        {
+            Zone = MakeZone(levelMin: 1, levelMax: 1),
+            Snapshot = PlayerSnapshot(strength: 100, endurance: 100),
+            ResolveEnemy = level => WeakEnemy(level),
+        };
+
+        private static Scenario AlwaysLoseBossScenario() => new()
+        {
+            Zone = MakeZone(levelMin: 1, levelMax: 1, bossEnemyId: 7, bossLevel: 1),
+            Snapshot = PlayerSnapshot(strength: 1, endurance: 1),
+            ResolveEnemy = level => StrongEnemy(level),
+        };
+
+        private static Scenario StalemateScenario(int? bossEnemyId = null, int bossLevel = 1) => new()
+        {
+            // Both sides have huge Endurance (so MaxHealth/Defense clamp every hit to zero) and so neither can
+            // damage the other — every battle runs to the cap as a draw.
+            Zone = MakeZone(levelMin: 1, levelMax: 1, bossEnemyId: bossEnemyId, bossLevel: bossLevel),
+            Snapshot = PlayerSnapshot(strength: 1, endurance: 1000),
+            ResolveEnemy = level => MakeEnemy(level, strength: 1, endurance: 1000, skillCount: 1),
+        };
+
+        /// <summary>
+        /// A boss fight balanced so the player's crit rolls decide it. The boss's Defense (sourced from
+        /// Agility, so its health stays low) fully absorbs a normal player hit but not a crit, which punches
+        /// through (crit multiplies before Defense). The player's long skill cooldown limits it to a handful
+        /// of fires across the battle cap, so whether enough of them crit — varying with each battle's fresh
+        /// seed — flips the outcome between a win and a draw. The boss deals no damage through the player's
+        /// Defense, so the player never dies (the loop's continue-through-losses behaviour is pinned
+        /// separately by <see cref="AlwaysLoseBossScenario"/>).
+        /// </summary>
+        private static Scenario CoinFlipBossScenario() => new()
+        {
+            Zone = MakeZone(levelMin: 1, levelMax: 1, bossEnemyId: 7, bossLevel: 1),
+            // Dexterity/Luck drive a ~30% crit chance and a 1.75x crit multiplier.
+            Snapshot = PlayerSnapshot(strength: 50, endurance: 10, dexterity: 100, luck: 100),
+            // A long cooldown → only ~4 fires across the 120s cap, so crit count (and thus the outcome)
+            // swings battle to battle.
+            ResolveSkill = _ => SlowHeavySkill(),
+            // Defense from Agility (62), low MaxHealth (50): a normal 60 hit is absorbed, a 105 crit deals 43,
+            // so two crits win. Endurance/Strength left at 0 so health doesn't balloon.
+            ResolveEnemy = level => CoinFlipBoss(level),
+        };
+
+        // ── Builders ─────────────────────────────────────────────────────────
+
+        private static Zone MakeZone(int levelMin, int levelMax, int? bossEnemyId = null, int bossLevel = 1, int id = 1) => new()
+        {
+            Id = id,
+            LevelMin = levelMin,
+            LevelMax = levelMax,
+            BossEnemyId = bossEnemyId,
+            BossLevel = bossLevel,
+            UnlockChallengeId = null,
+        };
+
+        private static BattleSnapshot EmptySnapshot() => new()
+        {
+            Level = 1,
+            StatAllocations = [],
+            EquippedItems = [],
+            SkillIds = [0],
+        };
+
+        private static BattleSnapshot PlayerSnapshot(
+            double strength = 0, double endurance = 0, double dexterity = 0, double luck = 0) => new()
+        {
+            Level = 1,
+            StatAllocations =
+            [
+                new StatAllocation { Attribute = Strength, Amount = strength },
+                new StatAllocation { Attribute = Endurance, Amount = endurance },
+                new StatAllocation { Attribute = Dexterity, Amount = dexterity },
+                new StatAllocation { Attribute = Luck, Amount = luck },
+            ],
+            EquippedItems = [],
+            SkillIds = [0],
+        };
+
+        private static Enemy WeakEnemy(int level, int skillCount = 1) =>
+            MakeEnemy(level, strength: 5, endurance: 5, skillCount: skillCount);
+
+        private static Enemy StrongEnemy(int level, int skillCount = 1) =>
+            MakeEnemy(level, strength: 200, endurance: 200, skillCount: skillCount);
+
+        private static Enemy MakeEnemy(int level, double strength, double endurance, int skillCount)
+        {
+            var skills = Enumerable.Range(0, skillCount).Select(EnemyAttackSkill).ToList();
+            return new Enemy
+            {
+                Id = EnemyId,
+                Name = "Test Enemy",
+                IsBoss = false,
+                Level = level,
+                AttributeDistributions =
+                [
+                    new AttributeDistribution { AttributeId = Strength, BaseAmount = (decimal)strength, AmountPerLevel = 0 },
+                    new AttributeDistribution { AttributeId = Endurance, BaseAmount = (decimal)endurance, AmountPerLevel = 0 },
+                ],
+                AvailableSkills = skills,
+            };
+        }
+
+        private static Skill PlayerAttackSkill() => new()
+        {
+            Id = 0,
+            Name = "Attack",
+            Description = string.Empty,
+            CooldownMs = 1000,
+            BaseDamage = 10,
+            DamageMultipliers = [new DamageMultiplier { Attribute = Strength, Amount = 1.0 }],
+            Effects = [],
+        };
+
+        // A high-cooldown variant of the player's attack: it fires only a few times across the battle cap,
+        // so the count of crits among those fires (and thus the outcome) swings with each battle's seed.
+        private static Skill SlowHeavySkill() => new()
+        {
+            Id = 0,
+            Name = "Heavy Strike",
+            Description = string.Empty,
+            CooldownMs = 30_000,
+            BaseDamage = 10,
+            DamageMultipliers = [new DamageMultiplier { Attribute = Strength, Amount = 1.0 }],
+            Effects = [],
+        };
+
+        // The coin-flip boss: Defense (62) comes from Agility so its MaxHealth stays at the 50 base. A normal
+        // 60 player hit is fully absorbed; a 105 crit punches through for 43, so two crits are needed to win.
+        private static Enemy CoinFlipBoss(int level) => new()
+        {
+            Id = EnemyId,
+            Name = "Coin-Flip Boss",
+            IsBoss = true,
+            Level = level,
+            AttributeDistributions =
+            [
+                new AttributeDistribution { AttributeId = Agility, BaseAmount = 120, AmountPerLevel = 0 },
+            ],
+            AvailableSkills = [EnemyAttackSkill(0)],
+        };
+
+        private static Skill EnemyAttackSkill(int id) => new()
+        {
+            Id = id,
+            Name = $"Scratch {id}",
+            Description = string.Empty,
+            CooldownMs = 1500,
+            BaseDamage = 5,
+            DamageMultipliers = [],
+            Effects = [],
+        };
+
+        private static readonly Func<int, Item> ThrowItem =
+            id => throw new InvalidOperationException($"Unexpected item resolve for {id}");
+        private static readonly Func<int, ItemMod> ThrowMod =
+            id => throw new InvalidOperationException($"Unexpected mod resolve for {id}");
+    }
+}

--- a/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
@@ -453,19 +453,22 @@ namespace Game.Core.Tests.Battle.Offline
         };
 
         private static BattleSnapshot PlayerSnapshot(
-            double strength = 0, double endurance = 0, double dexterity = 0, double luck = 0) => new()
+            double strength = 0, double endurance = 0, double dexterity = 0, double luck = 0)
         {
-            Level = 1,
-            StatAllocations =
-            [
-                new StatAllocation { Attribute = Strength, Amount = strength },
-                new StatAllocation { Attribute = Endurance, Amount = endurance },
-                new StatAllocation { Attribute = Dexterity, Amount = dexterity },
-                new StatAllocation { Attribute = Luck, Amount = luck },
-            ],
-            EquippedItems = [],
-            SkillIds = [0],
-        };
+            return new()
+            {
+                Level = 1,
+                StatAllocations =
+                [
+                    new StatAllocation { Attribute = Strength, Amount = strength },
+                    new StatAllocation { Attribute = Endurance, Amount = endurance },
+                    new StatAllocation { Attribute = Dexterity, Amount = dexterity },
+                    new StatAllocation { Attribute = Luck, Amount = luck },
+                ],
+                EquippedItems = [],
+                SkillIds = [0],
+            };
+        }
 
         private static Enemy WeakEnemy(int level, int skillCount = 1) =>
             MakeEnemy(level, strength: 5, endurance: 5, skillCount: skillCount);

--- a/Game.Core/Battle/Offline/OfflineBattleOutcome.cs
+++ b/Game.Core/Battle/Offline/OfflineBattleOutcome.cs
@@ -1,0 +1,14 @@
+using Game.Core.Enemies;
+
+namespace Game.Core.Battle.Offline
+{
+    /// <summary>
+    /// The outcome of a single simulated offline battle, retained so the orchestration layer (the offline
+    /// reward-application sub-issue) can grant exp per victory and feed each battle's stats through the same
+    /// per-battle recording path the live battle-completion handler uses (rather than re-deriving the stat
+    /// logic — see spike #879, decision 7). The simulator computes <see cref="ExpReward"/> from the player's
+    /// (stationary) snapshot at simulation time so the value matches the battle it was earned in; it is
+    /// <c>0</c> for a non-victory.
+    /// </summary>
+    public record OfflineBattleOutcome(Enemy Enemy, BattleResult Result, int ExpReward);
+}

--- a/Game.Core/Battle/Offline/OfflineLoopMode.cs
+++ b/Game.Core/Battle/Offline/OfflineLoopMode.cs
@@ -1,0 +1,19 @@
+namespace Game.Core.Battle.Offline
+{
+    /// <summary>
+    /// Which battle the player's idle loop replays for the whole away period. Mirrors the persisted
+    /// <see cref="Players.Player.AutoChallengeBoss"/> flag: <see cref="Idle"/> fights random encounters in the
+    /// player's current zone, <see cref="Boss"/> auto-challenges that same zone's dedicated boss. Both modes
+    /// loop their battle type continuously — wins, losses, and draws all carry on to the next battle (the
+    /// online auto-fight-off-on-loss only fires while the player is present to observe it).
+    /// </summary>
+    public enum OfflineLoopMode
+    {
+        /// <summary>Idle-farming the current zone: a fresh random encounter (enemy/level/loadout) each battle.</summary>
+        Idle,
+
+        /// <summary>Auto-challenging the current zone's dedicated boss: the same boss each battle, with a fresh
+        /// seed so the crit/dodge/block RNG can vary the outcome.</summary>
+        Boss,
+    }
+}

--- a/Game.Core/Battle/Offline/OfflineProgressResult.cs
+++ b/Game.Core/Battle/Offline/OfflineProgressResult.cs
@@ -1,0 +1,81 @@
+namespace Game.Core.Battle.Offline
+{
+    /// <summary>
+    /// The accumulated result of replaying a player's missed idle/boss battles over an away period. Carries
+    /// the per-battle outcomes the orchestration layer needs to apply rewards and consolidate statistics,
+    /// plus the run-level aggregates the welcome-back summary surfaces. The simulator only computes and
+    /// returns this — it never mutates the player or persists anything (that is the orchestration sub-issue).
+    /// </summary>
+    public class OfflineProgressResult
+    {
+        /// <summary>The loop mode that was simulated, constant for the whole run.</summary>
+        public OfflineLoopMode Mode { get; }
+
+        /// <summary>The zone the loop ran in, constant for the whole run. The zone every recorded battle is
+        /// attributed to.</summary>
+        public int ZoneId { get; }
+
+        /// <summary>Whether the simulated loop was boss-farming, derived from <see cref="Mode"/> — the
+        /// boss-battle flag every recorded battle carries into the statistics path.</summary>
+        public bool IsBossBattle => Mode == OfflineLoopMode.Boss;
+
+        /// <summary>Every simulated battle, in order, with its result and earned exp.</summary>
+        public IReadOnlyList<OfflineBattleOutcome> Battles { get; }
+
+        /// <summary>The number of battles simulated.</summary>
+        public int BattlesSimulated => Battles.Count;
+
+        /// <summary>Battles the player won.</summary>
+        public int Wins { get; }
+
+        /// <summary>Battles the player lost (died).</summary>
+        public int Losses { get; }
+
+        /// <summary>Battles that ended in a draw (neither combatant died before the battle cap).</summary>
+        public int Draws { get; }
+
+        /// <summary>The total exp earned across all victories — equal to the sum of each victory's
+        /// <see cref="OfflineBattleOutcome.ExpReward"/>.</summary>
+        public long TotalExp { get; }
+
+        /// <summary>The total simulated battle time, in milliseconds, excluding the inter-battle cooldown
+        /// gaps.</summary>
+        public long TotalBattleMs { get; }
+
+        /// <summary>Per-enemy victory (kill) counts, keyed by enemy id. Only victories contribute, mirroring
+        /// the live <c>EnemiesKilled</c> statistic.</summary>
+        public IReadOnlyDictionary<int, int> EnemyKillCounts { get; }
+
+        public OfflineProgressResult(OfflineLoopMode mode, int zoneId, IReadOnlyList<OfflineBattleOutcome> battles)
+        {
+            Mode = mode;
+            ZoneId = zoneId;
+            Battles = battles;
+
+            // Fold the per-battle outcomes into the run-level aggregates in a single pass, keeping the
+            // outcome list the one source of truth (the summary is a materialized view of it).
+            var killCounts = new Dictionary<int, int>();
+            foreach (var battle in battles)
+            {
+                TotalBattleMs += battle.Result.TotalMs;
+
+                if (battle.Result.Victory)
+                {
+                    Wins++;
+                    TotalExp += battle.ExpReward;
+                    killCounts[battle.Enemy.Id] = killCounts.GetValueOrDefault(battle.Enemy.Id) + 1;
+                }
+                else if (battle.Result.PlayerDied)
+                {
+                    Losses++;
+                }
+                else
+                {
+                    Draws++;
+                }
+            }
+
+            EnemyKillCounts = killCounts;
+        }
+    }
+}

--- a/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
+++ b/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
@@ -1,0 +1,93 @@
+using Game.Core.Attributes;
+using Game.Core.Enemies;
+
+namespace Game.Core.Battle.Offline
+{
+    /// <summary>
+    /// Replays a player's missed idle/boss battles over an away period and returns the accumulated results.
+    /// A pure domain service: it reuses <see cref="BattleFactory"/>, <see cref="BattleSnapshot"/> and
+    /// <see cref="BattleSimulator"/> and resolves catalog data through caller-supplied funcs, so it touches
+    /// no persistence or application layer (applying the rewards is the orchestration sub-issue's job).
+    /// <para>
+    /// Full simulation is exact and cheap because offline battles are <em>stationary</em> (spike #879): a
+    /// player's combat power and reward distribution never change while away, and the post-battle cooldown
+    /// throttles the battle count, so the whole away period is replayed battle-by-battle rather than sampled.
+    /// </para>
+    /// </summary>
+    public class OfflineProgressSimulator(BattleFactory battleFactory)
+    {
+        private readonly BattleFactory _battleFactory = battleFactory;
+
+        /// <summary>
+        /// Loops the mode's battle type for the whole away budget — building a fresh enemy and a fresh battle
+        /// each iteration, consuming <c>battle duration + cooldown</c> from the budget per battle — until the
+        /// budget (clamped to the cap) is exhausted. Wins, losses, and draws all continue to the next battle.
+        /// Observes <paramref name="cancellationToken"/> so a long run unwinds promptly rather than risking the
+        /// command timeout.
+        /// </summary>
+        public OfflineProgressResult Simulate(OfflineSimulationParameters parameters, CancellationToken cancellationToken = default)
+        {
+            var outcomes = new List<OfflineBattleOutcome>();
+
+            // Clamp the away budget to the cap (away > cap clamps to cap). A non-positive budget produces an
+            // empty result without simulating anything — the whole away period is skipped.
+            var remainingMs = Math.Min(parameters.AwayBudgetMs, parameters.CapMs);
+
+            // The player's power is stationary offline, so the modifier set that measures each victory's exp
+            // reward never changes — materialize it once and reuse it for every battle's DefeatRewards.
+            var playerModifiers = parameters.Snapshot
+                .GetModifiers(parameters.ResolveItem, parameters.ResolveMod)
+                .ToList();
+
+            while (remainingMs > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var enemy = BuildEnemy(parameters);
+                var result = SimulateBattle(parameters, enemy);
+
+                // Exp is earned only on a victory, measured from the stationary snapshot like the live path.
+                var expReward = result.Victory ? new DefeatRewards(playerModifiers, enemy).ExpReward : 0;
+                outcomes.Add(new OfflineBattleOutcome(enemy, result, expReward));
+
+                // Each battle consumes its own duration plus the post-battle cooldown gap before the next.
+                // Battle duration is always at least one tick, so the budget strictly decreases and the loop
+                // terminates even with a zero cooldown.
+                remainingMs -= result.TotalMs + parameters.CooldownMs;
+            }
+
+            return new OfflineProgressResult(parameters.Mode, parameters.Zone.Id, outcomes);
+        }
+
+        /// <summary>
+        /// Builds the enemy for the next battle according to the loop mode: a random idle encounter in the
+        /// zone, or the zone's deterministic dedicated boss. Mirrors the live battle-start factory calls so
+        /// the enemy is built identically to an online battle.
+        /// </summary>
+        private Enemy BuildEnemy(OfflineSimulationParameters parameters)
+        {
+            return parameters.Mode switch
+            {
+                OfflineLoopMode.Idle => _battleFactory.CreateBattleEnemy(parameters.Zone, parameters.ResolveEnemy),
+                OfflineLoopMode.Boss => _battleFactory.CreateBossEnemy(parameters.Zone, parameters.ResolveEnemy),
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(parameters), parameters.Mode, $"Unhandled offline loop mode {parameters.Mode}."),
+            };
+        }
+
+        /// <summary>
+        /// Runs one battle with a fresh seed. Both battlers are rebuilt per battle because the simulation
+        /// mutates battler health/effects (a battler is single-use); rebuilding the player from the stationary
+        /// snapshot mirrors the live replay path.
+        /// </summary>
+        private static BattleResult SimulateBattle(OfflineSimulationParameters parameters, Enemy enemy)
+        {
+            var playerBattler = parameters.Snapshot.ToBattler(
+                parameters.ResolveItem, parameters.ResolveMod, parameters.ResolveSkill);
+            var enemyBattler = new Battler(
+                new AttributeCollection(enemy.GetAttributeModifiers()), enemy.BattleSkills, enemy.Level);
+
+            return new BattleSimulator(playerBattler, enemyBattler, parameters.SeedSource()).Simulate();
+        }
+    }
+}

--- a/Game.Core/Battle/Offline/OfflineSimulationParameters.cs
+++ b/Game.Core/Battle/Offline/OfflineSimulationParameters.cs
@@ -1,0 +1,70 @@
+using Game.Core.Enemies;
+using Game.Core.Items;
+using Game.Core.Skills;
+using Game.Core.Zones;
+
+namespace Game.Core.Battle.Offline
+{
+    /// <summary>
+    /// The inputs to one offline-progress simulation. Grouped into a single object because the simulator
+    /// needs the player snapshot, the loop it was running, the away/cap/cooldown timings, and the catalog
+    /// resolvers — too many to thread as positional arguments. The resolvers mirror how
+    /// <see cref="BattleFactory"/> and <see cref="BattleSnapshot"/> already take resolver funcs, keeping the
+    /// domain free of data-access references; the application layer supplies the concrete catalog lookups.
+    /// </summary>
+    public record OfflineSimulationParameters
+    {
+        /// <summary>
+        /// The player's battle-relevant state, captured once. A player's combat power is stationary while
+        /// offline (allocations and gear cannot change), so this single snapshot drives every simulated
+        /// battle and the exp-reward power measurement.
+        /// </summary>
+        public required BattleSnapshot Snapshot { get; init; }
+
+        /// <summary>The idle loop the player was running at disconnect — idle-farming or boss-farming.</summary>
+        public required OfflineLoopMode Mode { get; init; }
+
+        /// <summary>
+        /// The zone the loop operates in (the player's current zone). For <see cref="OfflineLoopMode.Idle"/>
+        /// its level range drives the random encounter; for <see cref="OfflineLoopMode.Boss"/> its fixed boss
+        /// level and <see cref="Zone.BossEnemyId"/> drive the deterministic boss build.
+        /// </summary>
+        public required Zone Zone { get; init; }
+
+        /// <summary>How long the player was away, in milliseconds. Clamped to <see cref="CapMs"/>. A
+        /// non-positive budget simulates nothing (a whole-skip).</summary>
+        public required long AwayBudgetMs { get; init; }
+
+        /// <summary>The maximum away time that is ever simulated, in milliseconds (the 10h cap). Bounds the
+        /// CPU cost of a long absence and an all-draw zone that would otherwise earn nothing for the most
+        /// work.</summary>
+        public required long CapMs { get; init; }
+
+        /// <summary>The post-battle cooldown gap, in milliseconds, consumed alongside each battle's duration.
+        /// This is the throttle that bounds how many battles fit in the away period.</summary>
+        public required int CooldownMs { get; init; }
+
+        /// <summary>
+        /// Resolves the enemy to fight for a rolled/fixed level. The semantics depend on <see cref="Mode"/> —
+        /// a random per-zone spawn for idle, the zone's boss for boss mode — and the caller supplies the
+        /// matching lookup, so the simulator stays mode-agnostic and data-access-free.
+        /// </summary>
+        public required Func<int, Enemy> ResolveEnemy { get; init; }
+
+        /// <summary>Resolves an equipped item by id when reconstructing the player from the snapshot.</summary>
+        public required Func<int, Item> ResolveItem { get; init; }
+
+        /// <summary>Resolves an applied item mod by id when reconstructing the player from the snapshot.</summary>
+        public required Func<int, ItemMod> ResolveMod { get; init; }
+
+        /// <summary>Resolves a selected skill by id when reconstructing the player from the snapshot.</summary>
+        public required Func<int, Skill> ResolveSkill { get; init; }
+
+        /// <summary>
+        /// Supplies a fresh battle RNG seed for each simulated battle, mirroring the live path's per-battle
+        /// seed. Injected so tests can drive deterministic outcomes; production passes the same cryptographic
+        /// seed source the live battle start uses.
+        /// </summary>
+        public required Func<uint> SeedSource { get; init; }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the core offline simulation engine from spike #879 (sub-issue #1041): a pure `Game.Core` domain service that replays a player's missed idle/boss battles over an away period and returns the accumulated results — **without** mutating the player or persisting anything (reward application is the orchestration sub-issue #1042).

The whole away period is replayed battle-by-battle (exact, not sampled) because offline battles are **stationary** — combat power and reward distribution never change while away, and the post-battle cooldown throttles the battle count, so a full 10h replay stays cheap (spike decision 1).

## What's included

- **`OfflineProgressSimulator`** — loops the loop mode's battle type for the whole away budget. Each iteration builds a fresh enemy and a fresh battle, runs `BattleSimulator.Simulate()`, and consumes `battle duration + cooldown` from the budget (clamped to the cap) until exhausted. Wins, losses, and draws all continue to the next battle (decision 3). Observes a `CancellationToken` so a long run unwinds promptly.
  - **Idle** → `BattleFactory.CreateBattleEnemy` (random enemy/level/loadout).
  - **Boss** → `BattleFactory.CreateBossEnemy` (deterministic boss, fresh seed each battle).
- **`OfflineSimulationParameters`** — bundles the inputs (snapshot, mode, zone, away budget, cap, cooldown, enemy/item/mod/skill resolvers, and an injectable seed source). Resolvers mirror how `BattleFactory`/`BattleSnapshot` already take resolver funcs, keeping the domain free of data-access references.
- **`OfflineBattleOutcome`** — one simulated battle's result (enemy, `BattleResult`, per-victory exp), the raw material #1042 needs to grant exp per victory and feed each battle through the shared statistics-recording path (decision 7).
- **`OfflineProgressResult`** — the per-battle outcomes plus the run-level aggregates the welcome-back summary surfaces (win/loss/draw counts, total exp, per-enemy kill counts).
- **`OfflineLoopMode`** — Idle / Boss.
- Registers the stateless simulator in DI alongside `BattleFactory`/`NewPlayerFactory`.

The exp reward is computed in-engine via `DefeatRewards` against the (stationary) snapshot, so each victory's payout matches the battle it was earned in. The seed source is injected so tests are fully deterministic.

## How it addresses the issue

Covers every bullet in #1041's scope: a pure domain service taking the snapshot, mode + zone, away budget, cap, cooldown, and resolver funcs; looping the mode's battle type with `duration + cooldown` budget accounting; accumulating win/loss/draw counts, total/per-victory exp, per-enemy kills, and the per-battle stats the statistics consolidation needs; returning a structured result without mutating or persisting; and an injectable RNG source.

## Test plan

`Game.Core.Tests/Battle/Offline/` (all green; full suite: 683 Core + 425 Application):

- [x] Idle loop runs until budget exhausted; `duration + cooldown` accounting is exact
- [x] Away > cap clamps to cap (and reproduces an at-cap run)
- [x] Zero cap / non-positive away → empty whole-skip result
- [x] Idle rolls encounter level within the zone range
- [x] Boss loop builds the deterministic boss (fixed level, full loadout) each battle
- [x] Boss loop continues through losses; and through draws (all-draw → zero rewards)
- [x] Seed-varied boss run produces a genuine mix of outcomes, each matching a direct `BattleSimulator` run of the same seed
- [x] `TotalExp` equals the sum of per-victory `DefeatRewards`; per-victory exp matches a snapshot computation; per-enemy kill counts recorded
- [x] Cancellation requested throws
- [x] Focused `OfflineProgressResult` aggregation tests (win/loss/draw classification, exp summing, kill counts)

## Notes / follow-ups

- Reward **application**, statistics/challenge consolidation, the `GetOfflineProgress` socket command, and the 5-minute away threshold + CPU-waste short-circuit live in the orchestration sub-issue **#1042**, which consumes this engine. Per the spike, the `game-design.md` / `backend.md` / `backend-battle.md` documentation lands with the full feature (#1042/#1043), so this engine-only PR adds no docs.
- `OfflineProgressSimulator.SimulateBattle` and the application-layer `BattleService.SimulateBattle` share a few lines of battler construction but live in different layers (Core vs Application) and differ in enemy-loadout handling, so they aren't extracted.

Closes #1041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hx4j69QmMrnYaw3kahdCPb)_