### PR TITLE
Gate persisted boss mode on actual boss-loop engagement (#1067)

### DIFF
--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -72,6 +72,10 @@ export class EnemyManager {
 	/** Resolver that short-circuits an in-flight retry backoff so a stop / superseding transition need
 	 *  not wait out the full delay before the loop re-checks whether it should still be running. */
 	private cancelBackoff?: () => void;
+	/** The last `AutoChallengeBoss` value synced to the backend, so {@link syncAutoChallengeBoss} drops
+	 *  redundant re-syncs (e.g. a returnToIdle when the persisted mode is already idle). `undefined` until
+	 *  the first sync, so the first authoritative state is always sent. */
+	private lastSyncedAutoChallengeBoss?: boolean;
 
 	public start() {
 		if (!this.started) {
@@ -248,6 +252,10 @@ export class EnemyManager {
 			if (result.data?.enemyInstance) {
 				this.currentEnemy = result.data.enemyInstance;
 				notifyNewEnemyLoaded(this.currentEnemy);
+				// Now genuinely in the boss loop, so persist boss mode iff auto-fight is armed — a pre-armed
+				// toggle (set while still idle-farming) only becomes real boss-farming here. A one-off challenge
+				// (auto-fight off) stays idle-persisted: a single victory hands straight back to the idle loop.
+				this.syncAutoChallengeBoss(this.autoFight);
 			} else {
 				if (result.error) {
 					logMessage(ELogType.Debug, 'There was an error challenging the boss: ' + result.error);
@@ -288,11 +296,11 @@ export class EnemyManager {
 	/** Toggle auto-fight: when on, a boss victory immediately re-challenges the boss. */
 	public setAutoFight(on: boolean) {
 		this.autoFight = on;
-		// Persist the player's auto-fight intent (#1040's "mirror the live autoFight state" semantic). Note
-		// auto-fight can be pre-armed from BossTrigger while the loop is still idle, so this persists boss
-		// mode on intent rather than active engagement; whether to gate on mode==='boss' is tracked in #1067
-		// (must be settled before the offline-sim consumer in #1041/#1042 reads the field).
-		this.syncAutoChallengeBoss(on);
+		// Persist boss mode only when the loop is *actually* boss-farming: auto-fight on AND already engaged in
+		// the boss loop. Auto-fight can be pre-armed from BossTrigger while the loop is still idle-farming —
+		// that is intent, not engagement, and must not persist boss (the offline sim would otherwise resume a
+		// never-challenged player as a boss-farmer). challengeBoss() re-syncs once a pre-armed player engages.
+		this.syncAutoChallengeBoss(on && this.mode === 'boss');
 	}
 
 	private returnToIdle(sync = true) {
@@ -314,8 +322,17 @@ export class EnemyManager {
 	 * player's `CurrentZoneId`. Fire-and-forget — anti-cheat validation is the server's, and a transient
 	 * failure only leaves the persisted mode briefly stale, corrected by the next sync or the backend's
 	 * boss-loss/draw backstop.
+	 *
+	 * Deduped against the last value actually sent so redundant transitions — e.g. every returnToIdle path
+	 * firing when the persisted mode is already idle — don't emit a no-op socket command. The live `autoFight`
+	 * starts false each session even when the persisted mode is boss; reconciling that stale-initial state on
+	 * login is the welcome-back gate's job (#1043).
 	 */
 	private syncAutoChallengeBoss(enabled: boolean) {
+		if (enabled === this.lastSyncedAutoChallengeBoss) {
+			return;
+		}
+		this.lastSyncedAutoChallengeBoss = enabled;
 		void apiSocket.sendSocketCommand('SetAutoChallengeBoss', enabled);
 	}
 

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -650,25 +650,62 @@ describe('EnemyManager boss mode', () => {
 		expect(manager.autoFight).toBe(false);
 	});
 
-	it('syncs boss mode to the backend when auto-fight is toggled on', () => {
+	it('does not persist boss mode when auto-fight is pre-armed while idle-farming', () => {
+		// Option A (#1067): toggling auto-fight on from the boss trigger while still idle-farming is intent,
+		// not engagement — it must NOT persist boss, or the offline sim would resume a never-challenged player
+		// as a boss-farmer. The live flag flips, but the persisted mode stays idle.
+		manager.setAutoFight(true);
+		expect(manager.autoFight).toBe(true);
+		expect(send).not.toHaveBeenCalledWith('SetAutoChallengeBoss', true);
+	});
+
+	it('persists boss mode when auto-fight is toggled on while engaged in the boss loop', async () => {
 		// Mirroring the live auto-fight state to the durable player so the offline sim resumes the boss loop.
 		// The boss is always the current zone's boss, so only the enabled flag is sent (no zone).
+		await manager.challengeBoss();
+		send.mockClear();
+
 		manager.setAutoFight(true);
+
 		expect(send).toHaveBeenCalledWith('SetAutoChallengeBoss', true);
 	});
 
-	it('syncs idle mode to the backend when auto-fight is toggled off', () => {
+	it('persists boss mode when a pre-armed auto-fight player then challenges', async () => {
+		// The pre-arm becomes real boss-farming the moment the player actually challenges: challengeBoss
+		// re-syncs and persists boss even though the toggle itself (while idle) did not.
+		manager.setAutoFight(true);
+		expect(send).not.toHaveBeenCalledWith('SetAutoChallengeBoss', true);
+
+		await manager.challengeBoss();
+
+		expect(send).toHaveBeenCalledWith('SetAutoChallengeBoss', true);
+	});
+
+	it('persists idle mode to the backend when auto-fight is toggled off', () => {
 		manager.setAutoFight(false);
 		expect(send).toHaveBeenCalledWith('SetAutoChallengeBoss', false);
 	});
 
 	it('syncs idle mode when retreating from the boss (returnToIdle)', async () => {
+		// Boss-farming (persisted boss), then retreat back to idle ⇒ the persisted mode flips to idle.
 		await manager.challengeBoss();
+		manager.setAutoFight(true);
 		send.mockClear();
 
 		await manager.retreatFromBoss();
 
 		expect(send).toHaveBeenCalledWith('SetAutoChallengeBoss', false);
+	});
+
+	it('does not re-sync idle mode when the persisted mode is already idle (dedup)', async () => {
+		// Every returnToIdle path fires a sync, but with no boss ever persisted the redundant idle syncs are
+		// deduped: a retreat from a one-off (auto-fight-off) challenge must not re-emit an idle command.
+		await manager.challengeBoss();
+		send.mockClear();
+
+		await manager.retreatFromBoss();
+
+		expect(send).not.toHaveBeenCalledWith('SetAutoChallengeBoss', expect.anything());
 	});
 
 	it('syncs idle mode on a boss loss (returnToIdle)', async () => {

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -670,6 +670,19 @@ describe('EnemyManager boss mode', () => {
 		expect(send).toHaveBeenCalledWith('SetAutoChallengeBoss', true);
 	});
 
+	it('persists idle mode when auto-fight is toggled off while engaged in the boss loop', async () => {
+		// The one-off-mid-farm handoff: turning auto-fight off during an active boss fight means the next
+		// victory hands back to idle, so the persisted mode must flip to idle even though mode is still 'boss'.
+		// Directly exercises the mode gate (a fresh-idle toggle-off would read false regardless of the gate).
+		await manager.challengeBoss();
+		manager.setAutoFight(true);
+		send.mockClear();
+
+		manager.setAutoFight(false);
+
+		expect(send).toHaveBeenCalledWith('SetAutoChallengeBoss', false);
+	});
+
 	it('persists boss mode when a pre-armed auto-fight player then challenges', async () => {
 		// The pre-arm becomes real boss-farming the moment the player actually challenges: challengeBoss
 		// re-syncs and persists boss even though the toggle itself (while idle) did not.


### PR DESCRIPTION
## Summary

Follow-up from #1040 (PR #1066). Resolves the two points raised in #1067 about the frontend auto-challenge-boss mode sync. Both were harmless today (no consumer reads `Player.AutoChallengeBoss` yet) but needed settling before the offline-rewards sim (#1042) loops the persisted mode for the whole away budget.

### 1. Pre-armed-while-idle semantic (the should-fix) — **Option A**

`AutoFightToggle` is rendered on the **not-engaged** `BossTrigger`, so a player can pre-arm auto-fight *before* pressing Challenge. The previous `setAutoFight` persisted boss mode on that intent alone, so a player who pre-armed and then walked away **without ever challenging** would be resumed by the offline sim as a boss-farmer instead of an idle-farmer.

Per #1040's stated goal — persist *what the loop is actually doing* — I took **option A**: gate the boss-persist on actual engagement rather than intent.

- `setAutoFight(on)` now syncs `on && mode === 'boss'`, so pre-arming while idle-farming persists **idle**, not boss.
- `challengeBoss()` re-syncs on a successful engage, so a pre-armed player who *does* challenge still persists boss (and a one-off, auto-fight-off challenge stays idle-persisted — a single victory hands straight back to the idle loop).

**On the related zone-retarget question** (changing the idle zone while `AutoChallengeBoss` is true silently retargeting the new zone's boss): the issue notes this *"only matters in combination with the pre-arm case above."* Option A eliminates that combination — boss is never persisted while idle-farming — so no separate zone-reset is required. (A deliberate mid-fight zone navigation during an active auto-fight boss farm retargets the boss the player is *actively* fighting, which matches intent and is pre-existing; the backend's `CurrentZoneId` isn't updated mid-engagement anyway.)

### 2. Dedup redundant syncs (the nit)

Every `returnToIdle()` path (retreat, boss loss/draw, single-victory handoff, failed-challenge fallback) fired `SetAutoChallengeBoss(false)` unconditionally — even when the persisted mode was already idle. `syncAutoChallengeBoss` now tracks the last value actually sent and drops a no-op, cutting the redundant socket traffic. The tracker starts `undefined` so the first authoritative state always sends.

### 3. Tie-in (#1043)

Point 3 (a returning boss-farmer's live `autoFight` resets to idle while the persisted mode stays boss until the next sync) is **left to the welcome-back gate (#1043)**, which the spike already says "includes the frontend half of #1040's mode-sync." The dedup's stale-initial subtlety is documented in code pointing at #1043 rather than reconciled here, to avoid overlapping that work.

## How it addresses the issue

`UI/src/lib/engine/battle/enemy-manager.ts`:
- `setAutoFight` → `syncAutoChallengeBoss(on && this.mode === 'boss')`.
- `challengeBoss` success branch → `syncAutoChallengeBoss(this.autoFight)` (mode is `'boss'` there).
- `syncAutoChallengeBoss` → deduped against `lastSyncedAutoChallengeBoss`.

No backend change: the `SetAutoChallengeBoss` command already just stores the bool, and the anti-cheat validation (current zone has a boss) is satisfied whenever boss is now persisted.

## Test plan

`UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts` — reworked/added to cover option A + dedup:
- pre-arm while idle does **not** persist boss;
- toggling auto-fight on while engaged persists boss;
- pre-arm **then** challenge persists boss;
- retreat/loss/draw from a boss-farm persist idle;
- a redundant return-to-idle (one-off challenge) does **not** re-emit an idle command.

- `npm run lint` clean (eslint + svelte-check, 0 errors).
- Full frontend unit suite green: **2282 passed** (215 files).

Frontend-only; no battle-step logic touched, so backend parity is unaffected.

Closes #1067

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3HypTpYeAr5cWJ46wyU2V)_