### PR TITLE
Re-seed RenderEngine clock on start to avoid spurious first-frame delta (#1079)

### DIFF
--- a/UI/src/lib/engine/render-engine.ts
+++ b/UI/src/lib/engine/render-engine.ts
@@ -15,6 +15,9 @@ export class RenderEngine {
 
 	public start() {
 		if (!this.running) {
+			// Re-seed the clock so the first frame's delta is ~one frame, not the entire wall-clock gap
+			// the engine was stopped (mirrors LogicalEngine.start, which resets its clock to avoid this).
+			this.time = performance.now();
 			this.running = true;
 			this.renderLoop();
 		}

--- a/UI/src/tests/lib/engine/render-engine.test.ts
+++ b/UI/src/tests/lib/engine/render-engine.test.ts
@@ -78,14 +78,28 @@ describe('RenderEngine', () => {
 
 		it('passes delta as the elapsed time since the previous frame', () => {
 			performanceNow = 1000;
-			engine.start(); // delta = 1000 − 0 (initial time)
+			engine.start(); // start re-seeds time to now, so the first frame's delta is 0
 
-			expect(renderUpdates[0][0]).toBe(1000);
+			expect(renderUpdates[0][0]).toBe(0);
 
 			performanceNow = 1016;
 			rafCallbacks.shift()?.(); // second frame: delta = 1016 − 1000 = 16
 
 			expect(renderUpdates[1][0]).toBe(16);
+		});
+
+		it('first-frame delta after a stop/start gap is one frame, not the gap', () => {
+			performanceNow = 1000;
+			engine.start();
+			engine.stop();
+
+			// A long gap elapses while stopped (e.g. minutes on the admin screen).
+			performanceNow = 60_000;
+			renderUpdates.length = 0;
+			engine.start();
+
+			// Without re-seeding, delta would be the whole 59_000ms gap; it must be one frame (~0) instead.
+			expect(renderUpdates[0][0]).toBe(0);
 		});
 
 		it('passes logicalDelta as the difference from logicEngine.time', () => {


### PR DESCRIPTION
## Summary

`RenderEngine.stop()` only flips `running = false`, leaving `this.time` holding the last frame's `performance.now()`. On the next `start()`, the first `update()` computes `delta = newTime - this.time`, so `delta` equals the **entire wall-clock gap** the engine was stopped (e.g. minutes on the admin screen). That raw `delta` drives `Battler.updateRenderCooldowns` and `BattleEngine.startLoading`'s countdown (`loadingTime -= delta`), so a render restart while a loading countdown is live could instantly drain it.

This is the latent correctness bug and inconsistency with `LogicalEngine` described in #1079 — `LogicalEngine.start()` already re-seeds its clock (`this.time = this.lastTime = performance.now()`) precisely to avoid this.

## How it addresses the issue

- `RenderEngine.start()` now seeds `this.time = performance.now()` before starting the loop, mirroring `LogicalEngine.start()`. The first frame's delta after a (re)start is therefore one frame (~0), not the gap.

## Test plan

- Updated `render-engine.test.ts`: the first-frame delta is now `0` (start re-seeds to now), with the second frame still `16`.
- Added a regression test pinning the issue's stated invariant — *"delta after a stop/start gap is one frame, not the gap"*: a 59s stopped gap yields a `0` first-frame delta on restart.
- `render-engine.test.ts`: 13 passed.
- `npm run lint` (eslint + svelte-check): 0 errors, 0 warnings.

Frontend-only; no battle-step logic touched, so backend parity is unaffected.

Closes #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkGCCEQ53zRa8cAZzwmDgQ)_