### PR TITLE
Notify users to allowlist the game as always-active on background time-loss (#1074)

### DIFF
--- a/UI/src/lib/engine/background-throttle-notice.ts
+++ b/UI/src/lib/engine/background-throttle-notice.ts
@@ -1,0 +1,99 @@
+import { onIdleTimeLost } from './logical-engine';
+import { toastWarning } from '$stores';
+import { safeLocalStorage } from '$lib/common/local-storage';
+import type { Action } from '$lib/common';
+
+// A backgrounded tab is throttled by the browser, so the logical engine discards the idle time it
+// can't process within its catch-up cap (see logical-engine `update`). Once a single hidden period
+// has silently cost the player more than this much idle progress, nudge them — once, ever — to
+// allowlist the game as always-active so the foreground rate keeps running while the tab is hidden.
+const LOST_TIME_NOTICE_THRESHOLD_MS = 60_000;
+const NOTICE_SHOWN_KEY = 'gs:bgThrottleNoticeShown';
+
+const BASE_MESSAGE = 'Idle progress pauses while this tab runs in the background.';
+
+/**
+ * The notice text, tailored to the current browser. Chromium browsers expose a per-site
+ * always-active list; Firefox and Safari have no per-site equivalent, so we say so plainly and
+ * fall back to keeping the tab in the foreground.
+ */
+export const backgroundThrottleGuidance = (): string => {
+	const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+	// Edge's UA also contains "Chrome", so it must be matched first.
+	if (/Edg\//.test(ua)) {
+		return `${BASE_MESSAGE} To keep progressing, open Edge Settings → System and performance and add this site to “Never put these sites to sleep.”`;
+	}
+	if (/Chrome\//.test(ua)) {
+		return `${BASE_MESSAGE} To keep progressing, open Chrome Settings → Performance and add this site to “Always keep these sites active.”`;
+	}
+	if (/Firefox\//.test(ua)) {
+		return `${BASE_MESSAGE} Firefox has no per-site always-active setting — keep the game in a focused window to keep progressing.`;
+	}
+	if (/Safari\//.test(ua)) {
+		return `${BASE_MESSAGE} Safari has no per-site always-active setting — keep the game tab in the foreground to keep progressing.`;
+	}
+	return `${BASE_MESSAGE} Check your browser’s performance settings for a “keep sites active” option, or keep the game tab in the foreground.`;
+};
+
+/**
+ * Watches for meaningful idle time lost to background-tab throttling and shows a one-time,
+ * dismissible notice nudging the user to allowlist the game as always-active. Tied to the engine
+ * lifecycle (started/stopped alongside the logical engine in `engine.ts`).
+ */
+export class BackgroundThrottleMonitor {
+	private unhookIdleTimeLost?: Action;
+	private lostWhileHiddenMs = 0;
+	private running = false;
+
+	public start() {
+		if (this.running || typeof document === 'undefined') {
+			return;
+		}
+		this.running = true;
+		this.lostWhileHiddenMs = 0;
+		this.unhookIdleTimeLost = onIdleTimeLost((lostMs) => this.recordLostTime(lostMs));
+		document.addEventListener('visibilitychange', this.handleVisibilityChange);
+	}
+
+	public stop() {
+		if (!this.running) {
+			return;
+		}
+		this.running = false;
+		this.lostWhileHiddenMs = 0;
+		this.unhookIdleTimeLost?.();
+		this.unhookIdleTimeLost = undefined;
+		document.removeEventListener('visibilitychange', this.handleVisibilityChange);
+	}
+
+	// Only count time discarded while the tab is hidden: the catch-up cap can also clip a foreground
+	// main-thread stall, but the backgrounding case is the one this notice addresses.
+	private recordLostTime(lostMs: number) {
+		if (document.hidden) {
+			this.lostWhileHiddenMs += lostMs;
+		}
+	}
+
+	private handleVisibilityChange = () => {
+		if (document.hidden) {
+			// Entering a new hidden period — measure it on its own.
+			this.lostWhileHiddenMs = 0;
+			return;
+		}
+		// Back in the foreground: if the hidden period cost a meaningful amount of idle progress, nudge.
+		if (this.lostWhileHiddenMs >= LOST_TIME_NOTICE_THRESHOLD_MS) {
+			this.maybeShowNotice();
+		}
+		this.lostWhileHiddenMs = 0;
+	};
+
+	private maybeShowNotice() {
+		const storage = safeLocalStorage();
+		if (storage?.getItem(NOTICE_SHOWN_KEY)) {
+			return;
+		}
+		// Persist before showing so the one-time guarantee holds even if the toast is dismissed instantly.
+		storage?.setItem(NOTICE_SHOWN_KEY, '1');
+		toastWarning(backgroundThrottleGuidance(), { duration: 0 });
+	}
+}

--- a/UI/src/lib/engine/background-throttle-notice.ts
+++ b/UI/src/lib/engine/background-throttle-notice.ts
@@ -8,7 +8,7 @@ import type { Action } from '$lib/common';
 // has silently cost the player more than this much idle progress, nudge them — once, ever — to
 // allowlist the game as always-active so the foreground rate keeps running while the tab is hidden.
 const LOST_TIME_NOTICE_THRESHOLD_MS = 60_000;
-const NOTICE_SHOWN_KEY = 'gs:bgThrottleNoticeShown';
+const NOTICE_SHOWN_KEY = 'gameserver.bgThrottleNoticeShown';
 
 const BASE_MESSAGE = 'Idle progress pauses while this tab runs in the background.';
 
@@ -43,6 +43,7 @@ export const backgroundThrottleGuidance = (): string => {
 export class BackgroundThrottleMonitor {
 	private unhookIdleTimeLost?: Action;
 	private lostWhileHiddenMs = 0;
+	private resumeCatchUpPending = false;
 	private running = false;
 
 	public start() {
@@ -51,6 +52,7 @@ export class BackgroundThrottleMonitor {
 		}
 		this.running = true;
 		this.lostWhileHiddenMs = 0;
+		this.resumeCatchUpPending = false;
 		this.unhookIdleTimeLost = onIdleTimeLost((lostMs) => this.recordLostTime(lostMs));
 		document.addEventListener('visibilitychange', this.handleVisibilityChange);
 	}
@@ -61,31 +63,49 @@ export class BackgroundThrottleMonitor {
 		}
 		this.running = false;
 		this.lostWhileHiddenMs = 0;
+		this.resumeCatchUpPending = false;
 		this.unhookIdleTimeLost?.();
 		this.unhookIdleTimeLost = undefined;
 		document.removeEventListener('visibilitychange', this.handleVisibilityChange);
 	}
 
-	// Only count time discarded while the tab is hidden: the catch-up cap can also clip a foreground
-	// main-thread stall, but the backgrounding case is the one this notice addresses.
 	private recordLostTime(lostMs: number) {
+		// A throttled tab keeps firing (slowed) timers while hidden, so it accumulates here directly.
 		if (document.hidden) {
 			this.lostWhileHiddenMs += lostMs;
+			return;
 		}
+		// A frozen/discarded tab (Memory Saver — the audience this notice targets) runs no timers
+		// while hidden; its single catch-up poll fires just after the resume `visibilitychange`, with
+		// `document.hidden` already false. Credit that first post-resume event to the hidden period
+		// that just ended rather than dropping it as a foreground stall.
+		if (this.resumeCatchUpPending) {
+			this.resumeCatchUpPending = false;
+			this.lostWhileHiddenMs += lostMs;
+			this.evaluate();
+		}
+		// Otherwise it's a genuine foreground stall the catch-up cap clipped — ignore it.
 	}
 
 	private handleVisibilityChange = () => {
 		if (document.hidden) {
 			// Entering a new hidden period — measure it on its own.
 			this.lostWhileHiddenMs = 0;
+			this.resumeCatchUpPending = false;
 			return;
 		}
-		// Back in the foreground: if the hidden period cost a meaningful amount of idle progress, nudge.
+		// Back in the foreground. A throttled tab has already accumulated its loss (evaluate it now);
+		// a frozen tab's loss arrives as the next catch-up poll, so arm the one-shot resume credit.
+		this.resumeCatchUpPending = true;
+		this.evaluate();
+	};
+
+	// Nudges once if the hidden period cost a meaningful amount of idle progress.
+	private evaluate() {
 		if (this.lostWhileHiddenMs >= LOST_TIME_NOTICE_THRESHOLD_MS) {
 			this.maybeShowNotice();
 		}
-		this.lostWhileHiddenMs = 0;
-	};
+	}
 
 	private maybeShowNotice() {
 		const storage = safeLocalStorage();

--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -5,6 +5,7 @@ import { BattleEngine } from './battle/battle-engine';
 import { statify, type Action, resolveUnlockReward, challengeCompletedMessage } from '$lib/common';
 import { RenderEngine } from './render-engine';
 import { LogicalEngine } from './logical-engine';
+import { BackgroundThrottleMonitor } from './background-throttle-notice';
 import { InventoryManager } from './player/inventory-manager';
 import { EnemyManager } from './battle/enemy-manager';
 import {
@@ -25,6 +26,9 @@ export const enemyManager = statify(new EnemyManager());
 export const logicEngine = statify(new LogicalEngine());
 export const renderEngine = statify(new RenderEngine());
 export const battleEngine = statify(new BattleEngine());
+
+// No reactive state to expose — it only fires a toast — so it isn't statified.
+const backgroundThrottleMonitor = new BackgroundThrottleMonitor();
 
 export const SESSION_REPLACED_TITLE = 'Session Replaced';
 export const SESSION_REPLACED_BODY =
@@ -133,6 +137,7 @@ export const handleSocketReplaced = async () => {
 
 const stopGame = () => {
 	logicEngine.stop();
+	backgroundThrottleMonitor.stop();
 	renderEngine.stop();
 	enemyManager.stop();
 	battleEngine.stop();
@@ -150,8 +155,10 @@ const stopGame = () => {
 
 const startLogicEngine = () => {
 	logicEngine.start();
+	backgroundThrottleMonitor.start();
 	onDestroy(() => {
 		logicEngine.stop();
+		backgroundThrottleMonitor.stop();
 	});
 };
 

--- a/UI/src/lib/engine/logical-engine.ts
+++ b/UI/src/lib/engine/logical-engine.ts
@@ -11,6 +11,12 @@ const logicalUpdateHook = createHook<[number]>();
 const notifyLogicalUpdate = logicalUpdateHook.notify;
 export const onLogicalUpdate = logicalUpdateHook.onNotified;
 
+// Fires with the ms of idle time the catch-up cap discarded on an over-budget poll (e.g. a
+// backgrounded, throttled tab). Consumed by the background-throttle notice, not the battle loop.
+const idleTimeLostHook = createHook<[number]>();
+const notifyIdleTimeLost = idleTimeLostHook.notify;
+export const onIdleTimeLost = idleTimeLostHook.onNotified;
+
 export class LogicalEngine {
 	public time = 0;
 	public tickRate = 0;
@@ -53,8 +59,10 @@ export class LogicalEngine {
 
 	private update(timeDelta: number) {
 		if (timeDelta > tickSizeX5) {
-			this.time += timeDelta - tickSizeX5;
+			const lostTime = timeDelta - tickSizeX5;
+			this.time += lostTime;
 			timeDelta = tickSizeX5;
+			notifyIdleTimeLost(lostTime);
 		}
 
 		this.timeBank += timeDelta;

--- a/UI/src/tests/lib/engine/background-throttle-notice.test.ts
+++ b/UI/src/tests/lib/engine/background-throttle-notice.test.ts
@@ -61,6 +61,9 @@ describe('BackgroundThrottleMonitor', () => {
 	afterEach(() => {
 		monitor.stop();
 		vi.unstubAllGlobals();
+		// vi.unstubAllGlobals doesn't undo a defineProperty, so drop our own-property override of
+		// document.hidden and let it fall back to the jsdom prototype getter.
+		delete (document as unknown as Record<string, unknown>).hidden;
 	});
 
 	const lose = (ms: number) => h.state.idleTimeLostCb?.(ms);
@@ -81,6 +84,25 @@ describe('BackgroundThrottleMonitor', () => {
 		goHidden();
 		lose(10_000);
 		goVisible();
+
+		expect(h.toastWarning).not.toHaveBeenCalled();
+	});
+
+	it('credits a frozen tab whose loss arrives only as the post-resume catch-up poll', () => {
+		monitor.start();
+		goHidden(); // frozen: no timers fire while hidden, so nothing accumulates
+		goVisible(); // resume flips document.hidden before the catch-up poll
+		lose(70_000); // the single catch-up poll, fired with document.hidden already false
+
+		expect(h.toastWarning).toHaveBeenCalledTimes(1);
+	});
+
+	it('credits only the first post-resume event, then treats later loss as a foreground stall', () => {
+		monitor.start();
+		goHidden();
+		goVisible();
+		lose(100); // the post-resume catch-up poll — consumes the one-shot credit (below threshold)
+		lose(70_000); // a genuine later foreground stall — ignored
 
 		expect(h.toastWarning).not.toHaveBeenCalled();
 	});

--- a/UI/src/tests/lib/engine/background-throttle-notice.test.ts
+++ b/UI/src/tests/lib/engine/background-throttle-notice.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Hoisted so the (hoisted) vi.mock factories below can reference them safely.
+const h = vi.hoisted(() => ({
+	toastWarning: vi.fn(),
+	unhook: vi.fn(),
+	state: {
+		lsStore: {} as Record<string, string>,
+		lsAvailable: true,
+		idleTimeLostCb: undefined as ((ms: number) => void) | undefined
+	}
+}));
+
+vi.mock('$stores', () => ({ toastWarning: h.toastWarning }));
+
+vi.mock('$lib/common/local-storage', () => ({
+	safeLocalStorage: () =>
+		h.state.lsAvailable
+			? {
+					getItem: (k: string) => h.state.lsStore[k] ?? null,
+					setItem: (k: string, v: string) => {
+						h.state.lsStore[k] = v;
+					}
+				}
+			: null
+}));
+
+// Capture the callback the monitor registers so the test can drive lost-time events directly.
+vi.mock('$lib/engine/logical-engine', () => ({
+	onIdleTimeLost: (cb: (ms: number) => void) => {
+		h.state.idleTimeLostCb = cb;
+		return h.unhook;
+	}
+}));
+
+import { BackgroundThrottleMonitor, backgroundThrottleGuidance } from '$lib/engine/background-throttle-notice';
+
+let hidden = false;
+const goHidden = () => {
+	hidden = true;
+	document.dispatchEvent(new Event('visibilitychange'));
+};
+const goVisible = () => {
+	hidden = false;
+	document.dispatchEvent(new Event('visibilitychange'));
+};
+
+describe('BackgroundThrottleMonitor', () => {
+	let monitor: BackgroundThrottleMonitor;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		h.state.lsStore = {};
+		h.state.lsAvailable = true;
+		h.state.idleTimeLostCb = undefined;
+		hidden = false;
+		Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+		monitor = new BackgroundThrottleMonitor();
+	});
+
+	afterEach(() => {
+		monitor.stop();
+		vi.unstubAllGlobals();
+	});
+
+	const lose = (ms: number) => h.state.idleTimeLostCb?.(ms);
+
+	it('shows a one-time dismissible notice after a hidden period loses past the threshold', () => {
+		monitor.start();
+		goHidden();
+		lose(30_000);
+		lose(40_000);
+		goVisible();
+
+		expect(h.toastWarning).toHaveBeenCalledTimes(1);
+		expect(h.toastWarning).toHaveBeenCalledWith(expect.any(String), { duration: 0 });
+	});
+
+	it('does not notify when the hidden period loses less than the threshold', () => {
+		monitor.start();
+		goHidden();
+		lose(10_000);
+		goVisible();
+
+		expect(h.toastWarning).not.toHaveBeenCalled();
+	});
+
+	it('ignores idle time lost while the tab is visible (a foreground stall is not backgrounding)', () => {
+		monitor.start();
+		lose(120_000); // visible — not background throttling
+		goHidden();
+		goVisible();
+
+		expect(h.toastWarning).not.toHaveBeenCalled();
+	});
+
+	it('measures each hidden period on its own (a prior near-miss does not carry over)', () => {
+		monitor.start();
+		goHidden();
+		lose(50_000);
+		goVisible(); // below threshold; accumulator resets
+		goHidden();
+		lose(50_000);
+		goVisible(); // again below threshold on its own
+
+		expect(h.toastWarning).not.toHaveBeenCalled();
+	});
+
+	it('notifies at most once, ever (persisted flag suppresses later periods)', () => {
+		monitor.start();
+		goHidden();
+		lose(70_000);
+		goVisible(); // fires
+		goHidden();
+		lose(70_000);
+		goVisible(); // suppressed
+
+		expect(h.toastWarning).toHaveBeenCalledTimes(1);
+	});
+
+	it('stops counting and unsubscribes after stop', () => {
+		monitor.start();
+		monitor.stop();
+		expect(h.unhook).toHaveBeenCalled();
+
+		goHidden();
+		lose(70_000);
+		goVisible();
+		expect(h.toastWarning).not.toHaveBeenCalled();
+	});
+
+	it('start is idempotent', () => {
+		monitor.start();
+		monitor.start();
+		goHidden();
+		lose(70_000);
+		goVisible();
+
+		expect(h.toastWarning).toHaveBeenCalledTimes(1);
+	});
+
+	it('stop before start is a no-op', () => {
+		expect(() => monitor.stop()).not.toThrow();
+		expect(h.unhook).not.toHaveBeenCalled();
+	});
+
+	it('degrades gracefully when local storage is unavailable (still notifies, no persistence)', () => {
+		h.state.lsAvailable = false;
+		monitor.start();
+		goHidden();
+		lose(70_000);
+		goVisible();
+
+		expect(h.toastWarning).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not start when document is unavailable (SSR)', () => {
+		vi.stubGlobal('document', undefined);
+		const ssrMonitor = new BackgroundThrottleMonitor();
+
+		expect(() => ssrMonitor.start()).not.toThrow();
+		// start bailed before subscribing, so the hook was never registered.
+		expect(h.state.idleTimeLostCb).toBeUndefined();
+	});
+});
+
+describe('backgroundThrottleGuidance', () => {
+	afterEach(() => vi.unstubAllGlobals());
+
+	it.each([
+		['Mozilla/5.0 Chrome/120 Safari/537.36 Edg/120.0', /Edge Settings/], // Edge before Chrome
+		['Mozilla/5.0 Chrome/120.0 Safari/537.36', /Chrome Settings/],
+		['Mozilla/5.0 Firefox/120.0', /Firefox has no/],
+		['Mozilla/5.0 Version/17.0 Safari/605.1.15', /Safari has no/]
+	])('tailors guidance to the UA %s', (ua, matcher) => {
+		vi.stubGlobal('navigator', { userAgent: ua });
+		expect(backgroundThrottleGuidance()).toMatch(matcher);
+	});
+
+	it('falls back to generic guidance for an unrecognized UA', () => {
+		vi.stubGlobal('navigator', { userAgent: 'SomeBot/1.0' });
+		expect(backgroundThrottleGuidance()).toMatch(/keep sites active/);
+	});
+
+	it('falls back to generic guidance when navigator is unavailable', () => {
+		vi.stubGlobal('navigator', undefined);
+		expect(backgroundThrottleGuidance()).toMatch(/keep sites active/);
+	});
+});

--- a/UI/src/tests/lib/engine/engine.test.ts
+++ b/UI/src/tests/lib/engine/engine.test.ts
@@ -78,7 +78,8 @@ vi.mock('$lib/engine/logical-engine', () => ({
 	LogicalEngine: class {
 		start = vi.fn();
 		stop = vi.fn();
-	}
+	},
+	onIdleTimeLost: vi.fn(() => vi.fn())
 }));
 vi.mock('$lib/engine/render-engine', () => ({
 	RenderEngine: class {

--- a/UI/src/tests/lib/engine/logical-engine.test.ts
+++ b/UI/src/tests/lib/engine/logical-engine.test.ts
@@ -11,7 +11,7 @@ vi.stubGlobal('window', {
 	requestAnimationFrame: vi.fn()
 });
 
-import { LogicalEngine, onLogicalUpdate, tickSize } from '$lib/engine/logical-engine';
+import { LogicalEngine, onLogicalUpdate, onIdleTimeLost, tickSize } from '$lib/engine/logical-engine';
 
 describe('LogicalEngine', () => {
 	let engine: LogicalEngine;
@@ -122,5 +122,33 @@ describe('LogicalEngine', () => {
 		expect(engine.time).toBe(1000);
 
 		nowSpy.mockRestore();
+	});
+
+	it('reports the discarded idle time via onIdleTimeLost when the catch-up cap clips a long stall', () => {
+		let now = 0;
+		const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now);
+		const lost: number[] = [];
+		const unhook = onIdleTimeLost((ms: number) => lost.push(ms), false);
+
+		engine.start(); // lastTime = 0
+		now = 1000; // a 1000ms stall before the next poll
+		vi.advanceTimersByTime(10); // one poll sees a 1000ms delta → discards 1000 − tickSizeX5
+
+		expect(lost).toEqual([1000 - tickSize * 5]);
+
+		unhook();
+		nowSpy.mockRestore();
+	});
+
+	it('does not report idle time lost when polls stay within the catch-up cap', () => {
+		const lost: number[] = [];
+		const unhook = onIdleTimeLost((ms: number) => lost.push(ms), false);
+
+		engine.start();
+		vi.advanceTimersByTime(tickSize * 3);
+
+		expect(lost).toEqual([]);
+
+		unhook();
 	});
 });


### PR DESCRIPTION
## Summary

Interim mitigation for the background-tab time-loss problem (follow-up surfaced by the #922 spike; the robust fix is researched in spike #1073).

The client-driven idle loop (`logical-engine.ts`) is throttled when the browser backgrounds the tab, so the engine's catch-up cap (`tickSizeX5`) **discards** the over-budget time. A backgrounded character silently loses idle progress, and offline rewards never recover it because the socket stays alive (the character isn't "away"). This PR detects a meaningful loss and nudges the user — once — to add the game to their browser's always-active list so the foreground rate keeps running while the tab is hidden.

## How it addresses the issue

- **`LogicalEngine` reports discarded idle time** via a new `onIdleTimeLost` hook, fired from the existing catch-up-cap branch (the one place over-budget time is dropped) — no behavioural change to the loop itself.
- **`BackgroundThrottleMonitor`** (`UI/src/lib/engine/background-throttle-notice.ts`) accumulates lost time **only while the tab is hidden** (so a foreground main-thread stall, which the cap can also clip, doesn't trigger it). On return to the foreground, if the hidden period cost more than the threshold (default **60s** of lost idle), it shows a **one-time, dismissible** warning toast and persists a `localStorage` flag so it never nags again.
- **Browser-specific guidance:** Chrome → Settings → Performance "Always keep these sites active"; Edge → System and performance "Never put these sites to sleep"; Firefox and Safari have no per-site equivalent, so the notice says so plainly and falls back to keeping the tab focused; unknown UAs get generic guidance.
- Wired into the engine lifecycle alongside the logical engine (`engine.ts`), torn down on stop/`SocketReplaced`.

## Notes / judgement calls

- **Toast over modal.** Used the existing sticky, dismissible `toastWarning` (a non-blocking nudge) rather than a blocking modal that would interrupt the moment the user returns to the tab.
- **Per-hidden-period detection.** The accumulator resets each time the tab hides, so the threshold is measured per hidden period (matching the issue's "after a hidden period"); the persisted flag makes it one-time across the whole account/browser.
- **Threshold** is a single named constant (`LOST_TIME_NOTICE_THRESHOLD_MS`) for easy tuning.

## Test plan

- **`background-throttle-notice.test.ts`** (new): notice fires past the threshold (one-time, dismissible, `duration: 0`); below-threshold no-op; foreground loss ignored; each hidden period measured independently; at-most-once via the persisted flag; stop unsubscribes; idempotent start; stop-before-start no-op; graceful degradation when `localStorage` is unavailable; SSR (no `document`) no-op. Plus `backgroundThrottleGuidance` per-browser (Edge-before-Chrome ordering, Firefox, Safari, unknown, no-navigator).
- **`logical-engine.test.ts`**: `onIdleTimeLost` reports the discarded ms on a long stall and stays silent within the cap.
- Updated `engine.test.ts`'s `logical-engine` mock for the new export.
- Full frontend suite green: **2298** unit tests; `npm run lint` clean (eslint + svelte-check); coverage floors pass. Frontend-only, no battle-step logic touched (backend parity unaffected).

Closes #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmn37Gvbb9dRmfND1rytwz)_