### PR TITLE
Floor damage-over-time at zero to prevent uncapped heal (#1080)

### DIFF
--- a/Game.Core.Tests/Battle/BattleDamageOverTimeTests.cs
+++ b/Game.Core.Tests/Battle/BattleDamageOverTimeTests.cs
@@ -33,6 +33,20 @@ namespace Game.Core.Tests.Battle
         }
 
         [Fact]
+        public void ApplyDamageOverTime_NegativePerSecondAttribute_IsFlooredAtZero_NoHeal()
+        {
+            // A negative DamageTakenPerSecond must NOT heal: DoT floors at zero (like TakeDamage) so it can't
+            // bypass the MaxHealth cap or book negative damage. The battler starts below full to prove no heal.
+            var battler = MakeBattler(Stat(Strength, 10), Stat(DamageTakenPerSecond, -50)); // MaxHealth 100
+            battler.TakeDamage(52); // Defense 2 → 50 damage → CurrentHealth 50
+
+            var dealt = battler.ApplyDamageOverTime(40); // -50 * 40 / 1000 = -2, floored to 0
+
+            Assert.Equal(0, dealt);
+            Assert.Equal(50, battler.CurrentHealth);
+        }
+
+        [Fact]
         public void ApplyHealOverTime_ScalesPerSecondAttributeByTick()
         {
             var battler = MakeBattler(Stat(Strength, 10), Stat(HealthRegenPerSecond, 75)); // MaxHealth 100

--- a/Game.Core/Battle/Battler.cs
+++ b/Game.Core/Battle/Battler.cs
@@ -83,11 +83,15 @@ namespace Game.Core.Battle
         /// <summary>
         /// Applies one tick of damage-over-time from <see cref="DamageTakenPerSecond"/> (authored per second,
         /// scaled to <paramref name="ms"/>). Unlike <see cref="TakeDamage"/> it <b>bypasses Defense</b>, and
-        /// returns the damage dealt so the caller can attribute it to the battle statistics.
+        /// returns the damage dealt so the caller can attribute it to the battle statistics. Floored at zero
+        /// (like <see cref="TakeDamage"/>) so a negative <see cref="DamageTakenPerSecond"/> can't heal past the
+        /// <see cref="MaxHealth"/> cap or book negative statistics — a heal must go through the capped
+        /// <see cref="ApplyHealOverTime"/> channel instead.
         /// </summary>
         public double ApplyDamageOverTime(int ms)
         {
             var damage = _attributes[DamageTakenPerSecond] * ms / 1000.0;
+            damage = damage > 0 ? damage : 0;
             CurrentHealth -= damage;
             return damage;
         }

--- a/UI/src/lib/battle/battler.ts
+++ b/UI/src/lib/battle/battler.ts
@@ -150,9 +150,12 @@ export class Battler {
 	}
 
 	/** Applies one tick of damage-over-time from DamageTakenPerSecond (authored per second, scaled to
-	 *  `timeDelta`). Unlike {@link takeDamage} it BYPASSES Defense; returns the damage dealt. */
+	 *  `timeDelta`). Unlike {@link takeDamage} it BYPASSES Defense; returns the damage dealt. Floored at zero
+	 *  (like {@link takeDamage}) so a negative DamageTakenPerSecond can't heal past the MaxHealth cap — a heal
+	 *  must go through the capped {@link applyHealOverTime} channel instead. */
 	public applyDamageOverTime(timeDelta: number) {
-		const damage = (this.attributes.getValue(EAttribute.DamageTakenPerSecond) * timeDelta) / 1000;
+		const rawDamage = (this.attributes.getValue(EAttribute.DamageTakenPerSecond) * timeDelta) / 1000;
+		const damage = rawDamage > 0 ? rawDamage : 0;
 		this.currentHealth -= damage;
 		this.isDead = this.currentHealth <= 0;
 		return damage;

--- a/UI/src/tests/lib/battle/battler-dot.test.ts
+++ b/UI/src/tests/lib/battle/battler-dot.test.ts
@@ -40,6 +40,21 @@ describe('Battler damage/heal-over-time', () => {
 		expect(battler.currentHealth).toBe(startHealth - 2);
 	});
 
+	it('floors a negative DamageTakenPerSecond at zero (no heal past the cap)', () => {
+		// A negative DamageTakenPerSecond must NOT heal: DoT floors at zero (like takeDamage) so it can't
+		// bypass the MaxHealth cap. The battler starts below full to prove no heal.
+		const battler = makeBattler([
+			{ id: EAttribute.Strength, amount: 10 }, // MaxHealth 100
+			{ id: EAttribute.DamageTakenPerSecond, amount: -50 }
+		]);
+		battler.takeDamage(52); // Defense 2 → 50 damage → currentHealth 50
+
+		const dealt = battler.applyDamageOverTime(40); // -50 * 40 / 1000 = -2, floored to 0
+
+		expect(dealt).toBe(0);
+		expect(battler.currentHealth).toBe(50);
+	});
+
 	it('scales HealthRegenPerSecond by the tick', () => {
 		const battler = makeBattler([
 			{ id: EAttribute.Strength, amount: 10 }, // MaxHealth 100


### PR DESCRIPTION
## Summary

`Battler.ApplyDamageOverTime` applied the per-tick DoT unconditionally with **no floor**, unlike its two sibling methods that *do* guard:
- `TakeDamage` floors at zero.
- `ApplyHealOverTime` caps the heal at `MaxHealth`.

So a **negative** `DamageTakenPerSecond` — reachable purely through authored skill-effect content (effects can apply arbitrary additive/multiplicative magnitudes to any attribute via the admin Workbench) — would make `CurrentHealth -= damage` *add* health with **no `MaxHealth` cap** (an unbounded heal) and book negative values into `DamageDealt`/`DamageTaken` (and thus challenge progress). The frontend mirrored the same unclamped subtraction, so both simulators agreed — and both were wrong in the same way.

Not currently exploitable (no authored effect produces a negative DoT today), so this is hardening rather than an active defect.

## How it addresses the issue

Clamps DoT to `>= 0` before applying, mirroring `TakeDamage`, on **both** sides (a parity surface — must stay in lockstep):

- `Game.Core/Battle/Battler.cs` — `ApplyDamageOverTime`
- `UI/src/lib/battle/battler.ts` — `applyDamageOverTime`

A heal must instead go through the capped `ApplyHealOverTime` channel rather than silently bypassing the `MaxHealth` cap.

## Test plan

Added mirrored unit/parity tests for a negative-magnitude DoT (battler starts below full health to prove no heal occurs):

- `Game.Core.Tests/Battle/BattleDamageOverTimeTests.cs` — `ApplyDamageOverTime_NegativePerSecondAttribute_IsFlooredAtZero_NoHeal`
- `UI/src/tests/lib/battle/battler-dot.test.ts` — `floors a negative DamageTakenPerSecond at zero (no heal past the cap)`

Verified green locally:
- Backend: `BattleDamageOverTimeTests` — 9 passed.
- Frontend: `battler-dot.test.ts` — 6 passed; `npm run lint` clean (0 errors/warnings).

Closes #1080

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmroRyuR5sc4bqR7BRnZfa)_