### PR TITLE
Restore codegen unmapped-struct safety net for Guid/TimeSpan (#1081)

### DIFF
--- a/Game.Api.Tests/CodeGen/CodeGenExtensionsTests.cs
+++ b/Game.Api.Tests/CodeGen/CodeGenExtensionsTests.cs
@@ -131,6 +131,32 @@ namespace Game.Api.Tests.CodeGen
         }
 
         [Fact]
+        public void NeedsInterface_Guid_ReturnsFalse()
+        {
+            // Guid is a non-primitive struct with no TypeScript mapping; it must not generate an interface.
+            Assert.False(typeof(Guid).NeedsInterface());
+        }
+
+        [Fact]
+        public void NeedsInterface_TimeSpan_ReturnsFalse()
+        {
+            Assert.False(typeof(TimeSpan).NeedsInterface());
+        }
+
+        [Fact]
+        public void NeedsInterface_DateTimeOffset_ReturnsFalse()
+        {
+            Assert.False(typeof(DateTimeOffset).NeedsInterface());
+        }
+
+        [Fact]
+        public void NeedsInterface_ListOfGuid_ReturnsFalse()
+        {
+            // The element type is the unmapped struct, so the enumerable must not generate an interface.
+            Assert.False(typeof(List<Guid>).NeedsInterface());
+        }
+
+        [Fact]
         public void NeedsInterface_ListOfClass_ReturnsTrue()
         {
             // For enumerables, checks the generic argument

--- a/Game.Api.Tests/CodeGen/CodeGenTypeFormatterTests.cs
+++ b/Game.Api.Tests/CodeGen/CodeGenTypeFormatterTests.cs
@@ -304,6 +304,32 @@ namespace Game.Api.Tests.CodeGen
             var ex = Assert.Throws<InvalidOperationException>(() => CodeGenTypeFormatter.GetTypeText(descriptor));
             Assert.Contains("Char", ex.Message);
         }
+
+        [Fact]
+        public void GetTypeText_UnmappedGuid_Throws()
+        {
+            // Guid is a non-primitive struct with no TypeScript mapping. Before #1081 NeedsInterface let it
+            // through and the formatter emitted a nonsense IGuid; it must now throw at generation time.
+            var descriptor = GetPropertyDescriptor<ModelWithUnmappedStruct>("GuidValue");
+            var ex = Assert.Throws<InvalidOperationException>(() => CodeGenTypeFormatter.GetTypeText(descriptor));
+            Assert.Contains("Guid", ex.Message);
+        }
+
+        [Fact]
+        public void GetTypeText_UnmappedTimeSpan_Throws()
+        {
+            var descriptor = GetPropertyDescriptor<ModelWithUnmappedStruct>("TimeSpanValue");
+            var ex = Assert.Throws<InvalidOperationException>(() => CodeGenTypeFormatter.GetTypeText(descriptor));
+            Assert.Contains("TimeSpan", ex.Message);
+        }
+
+        [Fact]
+        public void GetTypeText_UnmappedDateTimeOffset_Throws()
+        {
+            var descriptor = GetPropertyDescriptor<ModelWithUnmappedStruct>("DateTimeOffsetValue");
+            var ex = Assert.Throws<InvalidOperationException>(() => CodeGenTypeFormatter.GetTypeText(descriptor));
+            Assert.Contains("DateTimeOffset", ex.Message);
+        }
     }
 
     public class GenericHolder

--- a/Game.Api.Tests/CodeGen/TestFixtures.cs
+++ b/Game.Api.Tests/CodeGen/TestFixtures.cs
@@ -92,6 +92,17 @@ namespace Game.Api.Tests.CodeGen
         public char CharValue { get; set; }
     }
 
+    // A model whose property types are non-primitive BCL structs (Guid, TimeSpan, DateTimeOffset) with
+    // no TypeScript mapping. NeedsInterface must reject them so GetTypeText throws rather than emitting a
+    // nonsense IGuid/ITimeSpan/IDateTimeOffset interface — the safety net #1081 restored via the
+    // mirrored-struct allow-list.
+    public class ModelWithUnmappedStruct : IModel
+    {
+        public Guid GuidValue { get; set; }
+        public TimeSpan TimeSpanValue { get; set; }
+        public DateTimeOffset DateTimeOffsetValue { get; set; }
+    }
+
     public class NestedModel : IModel
     {
         public SimpleModel Child { get; set; } = new();

--- a/Game.Api/CodeGen/ApiCodeGenerator.cs
+++ b/Game.Api/CodeGen/ApiCodeGenerator.cs
@@ -21,7 +21,7 @@ namespace Game.Api.CodeGen
         public void GenerateCode(Assembly assembly, CodeGenOptions options)
         {
             var start = Stopwatch.GetTimestamp();
-            _logger.LogDebug($"Beginning code generation.");
+            _logger.LogDebug("Beginning code generation.");
 
             var controllerTypes = assembly.GetTypes().Where(type => type.IsAssignableTo(typeof(ControllerBase)));
             var endpointMetadata = controllerTypes.SelectMany(c => new ControllerMetadataExtractor(c).Endpoints).ToList();

--- a/Game.Api/CodeGen/Data/ControllerMetadataExtractor.cs
+++ b/Game.Api/CodeGen/Data/ControllerMetadataExtractor.cs
@@ -50,7 +50,7 @@ namespace Game.Api.CodeGen.Data
 
             const string apiPrefix = "api/";
             route = route.TrimStart('/');
-            if (route.StartsWith(apiPrefix))
+            if (route.StartsWith(apiPrefix, StringComparison.Ordinal))
             {
                 route = route[apiPrefix.Length..];
             }
@@ -58,6 +58,8 @@ namespace Game.Api.CodeGen.Data
             return new EndpointMetadata(endpoint)
             {
                 Endpoint = route,
+                // Every action in this codebase carries an explicit HTTP-method attribute; an
+                // unannotated action falls back to GET (the client emits a GET request).
                 IsGet = methodAtt?.HttpMethods?.Contains("GET") ?? true
             };
         }

--- a/Game.Api/CodeGen/Extensions.cs
+++ b/Game.Api/CodeGen/Extensions.cs
@@ -88,9 +88,17 @@ namespace Game.Api.CodeGen
             return type.IsClass && !type.IsGenericParameter && type != typeof(string);
         }
 
+        // Structs intended to be mirrored to TypeScript as interfaces. This is an explicit allow-list,
+        // not a deny-list: an unlisted struct (Guid, TimeSpan, DateTimeOffset, DateOnly, …) has no
+        // TypeScript mapping, so it must fall through to GetTypeText's throw and surface at generation
+        // time rather than silently emit a reference to an interface that is never generated. A
+        // deny-list would let any not-yet-excluded BCL struct slip through that safety net. DateTime and
+        // decimal are mapped to primitives directly in GetTypeText, so they never reach here.
+        private static readonly HashSet<Type> MirroredStructs = [];
+
         private static bool IsStructThatNeedsInterface(Type type)
         {
-            return type.IsValueType && !type.IsPrimitive && type != typeof(DateTime) && type != typeof(decimal);
+            return type.IsValueType && MirroredStructs.Contains(type);
         }
     }
 }

--- a/Game.Api/CodeGen/Writers/ApiInterfaceWriter.cs
+++ b/Game.Api/CodeGen/Writers/ApiInterfaceWriter.cs
@@ -39,12 +39,16 @@ namespace Game.Api.CodeGen.Writers
                 .Where(d => d.NeedsInterface)
                 .DistinctBy(CodeGenTypeFormatter.GetImportText);
 
+            // Materialized once: the grouping is enumerated by the foreach below and again by
+            // GetExportsText, and re-running the lazy chain would repeat the reflection-heavy
+            // SelectMany(GetAllUsedDescriptors) + DistinctBy walk on each pass.
             var interfaceDataGroups = allDescriptors.Select(d => new InterfaceDescriptorData
             {
                 Descriptor = d,
                 FilePath = d.IsEnum ? enumPath : $"{interfacesFolder}/{d.LastNamespacePart}.ts"
             })
-            .GroupBy(data => data.FilePath);
+            .GroupBy(data => data.FilePath)
+            .ToList();
 
             foreach (var group in interfaceDataGroups)
             {


### PR DESCRIPTION
## Summary

`CodeGenTypeFormatter.GetTypeText` has a deliberate `throw` for any type with no TypeScript mapping, so a broken client surfaces at generation time. But `NeedsInterface()` did **not** reject `Guid`/`TimeSpan`/`DateTimeOffset`: `IsStructThatNeedsInterface` was a deny-list (`IsValueType && !IsPrimitive && != DateTime && != decimal`), so those non-primitive BCL structs took the `NeedsInterface` branch and `ApiInterfaceWriter` would emit a nonsense `IGuid`/`ITimeSpan` interface instead of reaching the `throw`. Latent today (no DTO uses them), but the safety net was provably broken for exactly the types it names.

### Primary fix — allow-list instead of deny-list

`IsStructThatNeedsInterface` is now an explicit **allow-list** of structs intended to mirror (currently empty — every DTO in the codebase is a class, and no struct is mirrored today). This is strictly more robust than excluding the three named structs: it makes the safety net catch **every** unmapped struct (Guid, TimeSpan, DateTimeOffset, and future ones like `DateOnly`/`Half`/`Int128`), aligning with the project's loud fail-fast policy. `DateTime`/`decimal` are mapped to primitives directly in `GetTypeText`, so they never reach here. Confirmed no codegen drift — regenerating the TS client produces no changes.

### Bundled minor cleanups

1. **Culture-sensitive route check** — `route.StartsWith(apiPrefix)` now uses `StringComparison.Ordinal`.
2. **Interpolated log template** — `LogDebug($"Beginning code generation.")` → plain template (CA2254).
3. **Multi-enumeration of deferred LINQ** — `interfaceDataGroups` is now materialized with `.ToList()`, so the reflection-heavy `SelectMany(GetAllUsedDescriptors)` + `DistinctBy` walk runs once instead of again inside `GetExportsText`.
4. **`IsGet` default** — left as-is (every action in the codebase carries an explicit HTTP-method attribute), with a comment documenting that an unannotated action falls back to GET. This was a "confirm intended" item, not a defect.

## Test plan

- **New tests:** `NeedsInterface` returns `false` for `Guid`/`TimeSpan`/`DateTimeOffset`/`List<Guid>`; `GetTypeText` throws (with the type name in the message) for `Guid`/`TimeSpan`/`DateTimeOffset` properties — mirroring the existing `byte`/`char` throw tests. New `ModelWithUnmappedStruct` fixture.
- Full **Game.Api.Tests** suite green: **562** passed (0 failed).
- `dotnet build` clean (0 warnings); `dotnet format --verify-no-changes` clean on `Game.Api` and `Game.Api.Tests`.
- TS client regenerated — **no drift**.

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Lpb9tnUbsaxraR3hWEw9U)_