### PR TITLE
Frontend minor hardening: tooltip listener lifetime, frozen static modifiers, shared outcome classifier

### DIFF
--- a/UI/src/lib/battle/attribute-modifier.ts
+++ b/UI/src/lib/battle/attribute-modifier.ts
@@ -49,5 +49,12 @@ export type AttributeModifier = DerivedAttributeModifier | BaseAttributeModifier
  *  of, generated from `Game.Core.Attributes.Modifiers.StaticAttributeModifiers.All`
  *  and kept in the same order the backend applies them. The explicit type both
  *  documents the contract and verifies, at compile time, that the generated table
- *  conforms to the {@link AttributeModifier} union. */
-export const STATIC_ATTRIBUTE_MODIFIERS: readonly AttributeModifier[] = GENERATED_STATIC_ATTRIBUTE_MODIFIERS;
+ *  conforms to the {@link AttributeModifier} union.
+ *
+ *  Each `BattleAttributes` spreads these into its own modifier list, so every battler
+ *  shares the same modifier object references. The objects (and the table) are frozen
+ *  to enforce that shared-template invariant at runtime — a complement to the union's
+ *  `readonly` fields — so a stray mutation on one battler can't corrupt every other. */
+export const STATIC_ATTRIBUTE_MODIFIERS: readonly AttributeModifier[] = Object.freeze(
+	GENERATED_STATIC_ATTRIBUTE_MODIFIERS.map((modifier) => Object.freeze(modifier))
+);

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -212,7 +212,7 @@ export class BattleEngine {
 			)) {
 				const outcome = damageLogOutcome(byPlayer, crit, dodged, blocked);
 				logMessage(ELogType.Damage, this.damageLogMessage(skill.name, damage, outcome), outcome);
-				notifyCombatFloat(combatFloatEvent(byPlayer, crit, dodged, blocked, damage));
+				notifyCombatFloat(combatFloatEvent(outcome, damage));
 			}
 			this.logEffectApplications();
 			this.accumulateEffectDamage(timeDelta);
@@ -337,24 +337,21 @@ function damageLogOutcome(byPlayer: boolean, crit: boolean, dodged: boolean, blo
 	return 'enemy-hit';
 }
 
-/** Maps one activation's flags to the float that spawns for it, mirroring {@link damageLogOutcome}'s
- *  decision. A player hit floats over the enemy (crit when it crit); an incoming enemy hit floats over
- *  the player as a dodge (no number), a block, or a plain hit. */
-function combatFloatEvent(
-	byPlayer: boolean,
-	crit: boolean,
-	dodged: boolean,
-	blocked: boolean,
-	damage: number
-): CombatFloatEvent {
-	if (byPlayer) {
-		return { target: 'enemy', kind: crit ? 'crit' : 'hit', amount: damage };
+/** Maps one activation's resolved {@link LogOutcome} to the float that spawns for it, so the float and
+ *  the combat-log line are both driven by the single {@link damageLogOutcome} classifier rather than a
+ *  parallel copy of the flag branching. A player hit/crit floats over the enemy; an incoming enemy hit
+ *  floats over the player as a dodge (no number), a block, or a plain hit. */
+function combatFloatEvent(outcome: LogOutcome, damage: number): CombatFloatEvent {
+	switch (outcome) {
+		case 'player-crit':
+			return { target: 'enemy', kind: 'crit', amount: damage };
+		case 'player-hit':
+			return { target: 'enemy', kind: 'hit', amount: damage };
+		case 'player-dodge':
+			return { target: 'player', kind: 'dodge' };
+		case 'player-block':
+			return { target: 'player', kind: 'block', amount: damage };
+		case 'enemy-hit':
+			return { target: 'player', kind: 'hit', amount: damage };
 	}
-	if (dodged) {
-		return { target: 'player', kind: 'dodge' };
-	}
-	if (blocked) {
-		return { target: 'player', kind: 'block', amount: damage };
-	}
-	return { target: 'player', kind: 'hit', amount: damage };
 }

--- a/UI/src/stores/tooltip.svelte.ts
+++ b/UI/src/stores/tooltip.svelte.ts
@@ -43,11 +43,25 @@ export const anchorPosition = (anchor: TooltipAnchor): Position => {
 // already tracking the cursor, so re-anchoring the tooltip off the element's box on that focus would
 // make it jump away from the pointer (#880). `:focus-visible` isn't reliably readable inside a focus
 // handler, so we mirror its heuristic from the raw input events: keydown ⇒ keyboard, pointer ⇒ mouse.
-let focusViaKeyboard = true;
-if (typeof document !== 'undefined') {
-	// Capture phase so the modality is recorded before the focus the interaction triggers fires.
-	document.addEventListener('keydown', () => (focusViaKeyboard = true), true);
-	document.addEventListener('pointerdown', () => (focusViaKeyboard = false), true);
+interface FocusModality {
+	viaKeyboard: boolean;
+}
+
+// The capture-phase modality listeners are document/app-lifetime by design, so they are never torn
+// down. They and their shared state hang off a global singleton (keyed by a stable `Symbol.for`) so a
+// module re-evaluation — HMR, or repeated test imports — reuses the existing registration instead of
+// stacking a second, unremovable pair of listeners (a leak the codebase otherwise avoids).
+const focusModalityKey = Symbol.for('gameserver.tooltip.focusModality');
+const globalScope = globalThis as unknown as Record<symbol, FocusModality | undefined>;
+const existingModality = globalScope[focusModalityKey];
+const focusModality: FocusModality = existingModality ?? { viaKeyboard: true };
+if (!existingModality) {
+	globalScope[focusModalityKey] = focusModality;
+	if (typeof document !== 'undefined') {
+		// Capture phase so the modality is recorded before the focus the interaction triggers fires.
+		document.addEventListener('keydown', () => (focusModality.viaKeyboard = true), true);
+		document.addEventListener('pointerdown', () => (focusModality.viaKeyboard = false), true);
+	}
 }
 
 /**
@@ -56,7 +70,7 @@ if (typeof document !== 'undefined') {
  * would make the tooltip jump. Keyboard focus has no cursor, so it still pins the tooltip to the box.
  */
 export const focusAnchor = (event: FocusEvent): HTMLElement | undefined =>
-	focusViaKeyboard && event.currentTarget instanceof HTMLElement ? event.currentTarget : undefined;
+	focusModality.viaKeyboard && event.currentTarget instanceof HTMLElement ? event.currentTarget : undefined;
 
 // Keyed by the tooltip's stable id rather than held in a reactive array. An
 // array relied on `findIndex(... === data)` + `splice` to unregister, which is

--- a/UI/src/tests/lib/battle/attribute-modifier.test.ts
+++ b/UI/src/tests/lib/battle/attribute-modifier.test.ts
@@ -173,4 +173,11 @@ describe('STATIC_ATTRIBUTE_MODIFIERS', () => {
 	it('declares every static modifier as additive (the engine base/derived layer)', () => {
 		expect(STATIC_ATTRIBUTE_MODIFIERS.every((m) => m.type === EModifierType.Additive)).toBe(true);
 	});
+
+	it('freezes the table and its entries so the battler-shared template cannot be mutated', () => {
+		// Every BattleAttributes spreads these shared object references into its own modifier list, so a
+		// mutation here would corrupt every battler at once — the freeze makes that impossible at runtime.
+		expect(Object.isFrozen(STATIC_ATTRIBUTE_MODIFIERS)).toBe(true);
+		expect(STATIC_ATTRIBUTE_MODIFIERS.every((m) => Object.isFrozen(m))).toBe(true);
+	});
 });


### PR DESCRIPTION
## Summary

Addresses the three low-severity frontend code-health items bundled in #1082.

### 1. Module-level tooltip listeners registered but never removed
`stores/tooltip.svelte.ts` registered two capture-phase `document` listeners at module evaluation with no teardown — benign in production (true app-lifetime singleton) but leaking a pair per re-evaluation under HMR/repeated test imports. The modality state and its listeners now hang off a global singleton keyed by a stable `Symbol.for`, so a re-evaluation reuses the existing registration instead of stacking a second, unremovable pair. The listeners are still app-lifetime by design (now documented as such); the shared-state object lets them keep updating the live modality even across a re-eval, so `focusAnchor` behaviour is unchanged.

### 2. `STATIC_ATTRIBUTE_MODIFIERS` shared across every `BattleAttributes`
Each `BattleAttributes` spreads these shared modifier object references into its own list, and `removeModifier` matches by reference — safe today, but a future mutation of a static modifier on one battler would corrupt the shared template for all. The table and its entries are now `Object.freeze`d, enforcing the immutability invariant at runtime as a complement to the union's existing `readonly` fields. Per-instance cloning was rejected — it would defeat the shared-template optimization for no benefit over a freeze.

### 3. Duplicated outcome-branching in the battle engine
`battle-engine.ts` encoded the same `byPlayer/crit/dodged/blocked → outcome` decision twice (`damageLogOutcome` for the log, `combatFloatEvent` for the float). `combatFloatEvent` now derives its event from the resolved `LogOutcome`, so the single `damageLogOutcome` classifier is the sole source of that decision and the two surfaces can't drift. Pure FE refactor (these surfaces are frontend-only — the headless simulator emits neither), no battle-parity impact.

## Test plan
- [x] Added a freeze-invariant assertion to `attribute-modifier.test.ts`.
- [x] Existing `battle-engine` crit/dodge/block log + combat-float tests cover the refactor (behaviour preserved).
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — 224 files / 2357 tests pass.

## Note for review
Item 2's mutation vector was already blocked at compile time by the union's `readonly` fields; the freeze adds the runtime guarantee the issue asked for (it does not change the existing type-level contract). Flagging in case you'd prefer to rely on the type-level guard alone.

Closes #1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMhmQJUTucAoNZi7q1uKYj)_