### PR TITLE
Show actual event time in combat log (#1104)

### DIFF
--- a/UI/src/components/log-panel/LogRow.svelte
+++ b/UI/src/components/log-panel/LogRow.svelte
@@ -10,7 +10,7 @@
 	style:box-shadow={isLatest ? `inset 2px 0 0 ${kind.color}` : undefined}
 	style:--row-height="{rowHeight}px"
 >
-	<span class="row-time" class:latest={isLatest}>{formatLogTime(log.id)}</span>
+	<span class="row-time" class:latest={isLatest}>{formatLogTime(log.timestamp)}</span>
 
 	<div
 		class="row-chip"
@@ -63,7 +63,7 @@ const rowOpacity = $derived(isLatest ? 1 : Math.max(0.4, 0.9 - index * 0.1));
 	font-family: var(--mono);
 	font-size: 10.5px;
 	letter-spacing: 0.4px;
-	min-width: 38px;
+	min-width: 54px;
 	color: var(--text-muted);
 
 	&.latest {

--- a/UI/src/components/log-panel/log-kind.ts
+++ b/UI/src/components/log-panel/log-kind.ts
@@ -83,10 +83,12 @@ export function logKind(log: LogMessage): LogKind {
 	}
 }
 
-/** Treats the monotonically-increasing log id as an elapsed-time clock. */
-export function formatLogTime(id: number): string {
-	const totalSeconds = Math.floor(id / 60);
-	const minutes = Math.floor(totalSeconds / 60);
-	const seconds = totalSeconds % 60;
-	return `${String(minutes % 100).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+/** Formats an entry's wall-clock timestamp (epoch ms) as local 24-hour HH:MM:SS, so the panel
+ *  shows the actual time each event occurred. */
+export function formatLogTime(timestamp: number): string {
+	const date = new Date(timestamp);
+	const hours = String(date.getHours()).padStart(2, '0');
+	const minutes = String(date.getMinutes()).padStart(2, '0');
+	const seconds = String(date.getSeconds()).padStart(2, '0');
+	return `${hours}:${minutes}:${seconds}`;
 }

--- a/UI/src/lib/engine/log.ts
+++ b/UI/src/lib/engine/log.ts
@@ -14,6 +14,8 @@ export interface LogMessage {
 	id: number;
 	logType: ELogType;
 	message: string;
+	/** Epoch-ms wall-clock time the event was logged, so the panel shows when it actually happened. */
+	timestamp: number;
 	/** Optional outcome for `Damage` entries; absent for every other channel. */
 	outcome?: LogOutcome;
 }

--- a/UI/src/routes/game/screens/options/LivePreview.svelte
+++ b/UI/src/routes/game/screens/options/LivePreview.svelte
@@ -77,7 +77,7 @@ function makeEvent(): LogMessage {
 	// to the first sample so a future WEIGHTS/SAMPLES mismatch degrades instead of crashing.
 	const sample = SAMPLES.find((s) => s.logType === logType) ?? SAMPLES[0];
 	const message = sample.messages[Math.floor(Math.random() * sample.messages.length)];
-	return { id: nextId++, logType: sample.logType, message };
+	return { id: nextId++, logType: sample.logType, message, timestamp: Date.now() };
 }
 
 // Stored oldest → newest; rendered newest-first to mirror the real LogPanel.

--- a/UI/src/stores/logs.svelte.ts
+++ b/UI/src/stores/logs.svelte.ts
@@ -15,7 +15,7 @@ export const addLog = (logType: ELogType, message: string, outcome?: LogOutcome)
 	if (logsData.length >= maxLogEntries) {
 		logsData.pop();
 	}
-	logsData.unshift({ id: ++lastId, logType, message, outcome });
+	logsData.unshift({ id: ++lastId, logType, message, timestamp: Date.now(), outcome });
 };
 
 /** Clear the combat log and its id counter (e.g. on logout / session replacement) so the

--- a/UI/src/tests/components/log-panel/LogPanel.test.ts
+++ b/UI/src/tests/components/log-panel/LogPanel.test.ts
@@ -30,8 +30,8 @@ describe('LogPanel', () => {
 
 	it('renders log messages and the event count', () => {
 		// Stored newest-first (unshift), so id 2 is the newest entry.
-		logData.unshift({ id: 1, logType: ELogType.Damage, message: 'You used Cleave and dealt 10 damage!' });
-		logData.unshift({ id: 2, logType: ELogType.ItemFound, message: 'Unlocked: Iron Helm!' });
+		logData.unshift({ id: 1, logType: ELogType.Damage, message: 'You used Cleave and dealt 10 damage!', timestamp: 0 });
+		logData.unshift({ id: 2, logType: ELogType.ItemFound, message: 'Unlocked: Iron Helm!', timestamp: 0 });
 
 		render(LogPanel);
 		const panel = screen.getByTestId('log-panel');
@@ -41,7 +41,12 @@ describe('LogPanel', () => {
 	});
 
 	it('renders a skill-effect message with its dedicated glyph', () => {
-		logData.unshift({ id: 3, logType: ELogType.SkillEffect, message: 'You are empowered: +15 Strength for 5s' });
+		logData.unshift({
+			id: 3,
+			logType: ELogType.SkillEffect,
+			message: 'You are empowered: +15 Strength for 5s',
+			timestamp: 0
+		});
 
 		render(LogPanel);
 		expect(screen.getByTestId('log-panel').textContent).toContain('You are empowered: +15 Strength for 5s');

--- a/UI/src/tests/components/log-panel/log-kind.test.ts
+++ b/UI/src/tests/components/log-panel/log-kind.test.ts
@@ -3,10 +3,10 @@ import { ELogType } from '$lib/api';
 import type { LogOutcome } from '$lib/engine/log';
 import { logKind, formatLogTime, logColors } from '../../../components/log-panel/log-kind';
 
-type LogMessage = { id: number; logType: ELogType; message: string; outcome?: LogOutcome };
+type LogMessage = { id: number; logType: ELogType; message: string; timestamp: number; outcome?: LogOutcome };
 
 function makeLog(logType: ELogType, message: string, outcome?: LogOutcome): LogMessage {
-	return { id: 1, logType, message, outcome };
+	return { id: 1, logType, message, timestamp: 0, outcome };
 }
 
 describe('logKind', () => {
@@ -139,40 +139,23 @@ describe('logKind', () => {
 });
 
 describe('formatLogTime', () => {
-	it('formats id 0 as 00:00', () => {
-		expect(formatLogTime(0)).toBe('00:00');
+	// Construct each instant from local-time components and read it back with the same local
+	// getters, so the assertions are independent of the runner's timezone.
+	const at = (h: number, m: number, s: number) => new Date(2026, 5, 21, h, m, s).getTime();
+
+	it('formats an afternoon timestamp as local 24-hour HH:MM:SS', () => {
+		expect(formatLogTime(at(14, 32, 7))).toBe('14:32:07');
 	});
 
-	it('ids below 60 still show 00:00 (sub-second resolution rounds down)', () => {
-		expect(formatLogTime(30)).toBe('00:00');
-		expect(formatLogTime(59)).toBe('00:00');
+	it('pads single-digit hours, minutes, and seconds with a leading zero', () => {
+		expect(formatLogTime(at(3, 5, 9))).toBe('03:05:09');
 	});
 
-	it('formats exactly one second', () => {
-		expect(formatLogTime(60)).toBe('00:01');
+	it('formats midnight as 00:00:00', () => {
+		expect(formatLogTime(at(0, 0, 0))).toBe('00:00:00');
 	});
 
-	it('formats one minute boundary', () => {
-		expect(formatLogTime(3600)).toBe('01:00');
-	});
-
-	it('formats a value with both minutes and seconds', () => {
-		// 90 seconds = 1 min 30 sec → id = 90 * 60 = 5400
-		expect(formatLogTime(5400)).toBe('01:30');
-	});
-
-	it('pads single-digit minutes and seconds with a leading zero', () => {
-		// 5 min 9 sec → id = 309 * 60 = 18540
-		expect(formatLogTime(18540)).toBe('05:09');
-	});
-
-	it('wraps minutes at 100 (minutes % 100)', () => {
-		// 100 minutes → id = 6000 * 60 = 360000
-		expect(formatLogTime(360000)).toBe('00:00');
-	});
-
-	it('handles large ids correctly', () => {
-		// 99 min 59 sec → id = (99*60 + 59) * 60 = 359940
-		expect(formatLogTime(359940)).toBe('99:59');
+	it('formats the last second of the day', () => {
+		expect(formatLogTime(at(23, 59, 59))).toBe('23:59:59');
 	});
 });

--- a/UI/src/tests/stores/logs.test.ts
+++ b/UI/src/tests/stores/logs.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ELogType } from '$lib/api';
 import { logs, addLog, resetLogs } from '$stores/logs.svelte';
 
 describe('logs store', () => {
 	beforeEach(() => {
 		resetLogs();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	it('prepends new entries newest-first', () => {
@@ -20,6 +24,15 @@ describe('logs store', () => {
 
 		// Newest-first, so index 0 (the latest) holds the higher id.
 		expect(logs()[0].id).toBeGreaterThan(logs()[1].id);
+	});
+
+	it('stamps each entry with the wall-clock time it was logged', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-06-21T14:32:07.000Z'));
+
+		addLog(ELogType.Exp, 'Timed');
+
+		expect(logs()[0].timestamp).toBe(Date.now());
 	});
 
 	it('caps the list at 40 entries, dropping the oldest', () => {


### PR DESCRIPTION
## Summary

Fixes #1104 — the combat-log panel's per-row time had no relation to when the event actually occurred.

Each `LogRow` rendered `formatLogTime(log.id)`, and `formatLogTime` treated the entry's **monotonic id** as a clock (`id / 60` "seconds"). Since the id increments once per logged event — not once per second — the displayed time was a fabricated counter, not the real event time.

## How it addresses the issue

- Added a `timestamp` (epoch ms) field to `LogMessage`, set to `Date.now()` in `addLog` — the single funnel every real log entry passes through.
- Rewrote `formatLogTime` to format an actual timestamp as local 24-hour **HH:MM:SS**, and `LogRow` now renders `log.timestamp`.
- Widened the time column (38px → 54px) to fit the longer value.
- Updated the Options screen's live-preview sample feed (which builds `LogMessage`s directly) to stamp its synthetic entries the same way.

### Note on the chosen format

I went with **wall-clock time-of-day (HH:MM:SS)** as the most literal reading of "the actual time that logged events take place". Combat events arrive several per second, so second-level granularity is needed (HH:MM would collapse many entries onto one value). If you'd prefer an *elapsed*-since-session clock instead (closer to the old MM:SS shape, but backed by real timestamps), that's a small follow-up — happy to switch.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — 2354 passed
- Rewrote the `formatLogTime` unit suite for timestamp formatting (timezone-independent: each instant is built from and read back via local-time components).
- Added a `logs` store test asserting each entry is stamped with the wall-clock time it was logged (fake timers).
- Updated `LogPanel` / `log-kind` tests to satisfy the new required field.

This is a frontend-only change; no backend or battle-parity surfaces are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMqupUun3WnZ7pFuqy9DF3

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMqupUun3WnZ7pFuqy9DF3)_