### PR TITLE
Incorporate crit chance and damage into skill tooltip damage

### DIFF
--- a/UI/src/lib/battle/battle-formulas.ts
+++ b/UI/src/lib/battle/battle-formulas.ts
@@ -54,6 +54,16 @@ export function cooldownMultiplier(attributes: BattleAttributes): number {
 	return attributes.getValue(EAttribute.CooldownRecovery);
 }
 
+/** The long-run average damage multiplier from critical hits: a crit (probability `critChance`, a
+ *  [0,1] value) multiplies raw damage by `critDamage` (a base-≥1 multiplier), so over many fires the
+ *  expected raw damage is `raw × (1 + critChance × (critDamage − 1))`. A `critChance` of 0 (or a
+ *  `critDamage` of 1) leaves it at 1. This is a DISPLAY-ONLY helper for the skill tooltip's expected
+ *  damage; the live simulation rolls each crit individually (see `battleStep`), so it has no backend
+ *  mirror and is outside the battle-parity contract. */
+export function expectedCritMultiplier(critChance: number, critDamage: number): number {
+	return 1 + critChance * (critDamage - 1);
+}
+
 /** A skill effect's magnitude after caster-attribute scaling: the authored amount plus the caster's
  *  scaling-attribute value times the per-point coefficient (`scalingAmount`). A `scalingAmount` of 0
  *  leaves the authored amount unchanged. The `attributes` are the CASTER's, mirroring how a damage

--- a/UI/src/routes/game/screens/fight/SkillTooltip.svelte
+++ b/UI/src/routes/game/screens/fight/SkillTooltip.svelte
@@ -8,7 +8,13 @@
 	{/snippet}
 
 	<TooltipSection label="Damage breakdown">
-		<DamageBreakdown base={baseDamage} {multipliers} enemyDefense={opponent ? enemyDefense : undefined} {total} />
+		<DamageBreakdown
+			base={baseDamage}
+			{multipliers}
+			{crit}
+			enemyDefense={opponent ? enemyDefense : undefined}
+			{total}
+		/>
 	</TooltipSection>
 
 	<TooltipSection label="Tempo" last={effectLines.length === 0}>
@@ -24,8 +30,8 @@
 
 <script lang="ts">
 import { EAttribute } from '$lib/api';
-import { applyDefense, scaledEffectAmount, skillContributions, type Skill } from '$lib/battle';
-import { attributeIsHarmful, attributeName, describeEffect } from '$lib/common';
+import { applyDefense, expectedCritMultiplier, scaledEffectAmount, skillContributions, type Skill } from '$lib/battle';
+import { attributeIsHarmful, attributeName, describeEffect, formatAttributeValue } from '$lib/common';
 import { battleEngine } from '$lib/engine';
 import { staticData } from '$stores';
 import TooltipShell from '$components/tooltip/TooltipShell.svelte';
@@ -61,7 +67,24 @@ const multipliers = $derived(
 );
 const totalDamage = $derived(skill?.calculateDamage() ?? 0);
 const enemyDefense = $derived(opponent?.attributes.getValue(EAttribute.Defense) ?? 0);
-const total = $derived(applyDefense(totalDamage, enemyDefense));
+
+// Crit folds into the shown damage as its long-run average: the expected multiplier scales the raw
+// damage BEFORE Defense (mirroring the battle, where a crit punches through Defense), then Defense is
+// subtracted once. Display-only — the live battle rolls each crit individually.
+const critChance = $derived(skill?.owner.attributes.getValue(EAttribute.CriticalChance) ?? 0);
+const critDamage = $derived(skill?.owner.attributes.getValue(EAttribute.CriticalDamage) ?? 0);
+const critBonus = $derived(totalDamage * (expectedCritMultiplier(critChance, critDamage) - 1));
+// Surface the crit row only when a crit can occur — a 0 chance contributes nothing.
+const crit = $derived(
+	critChance > 0
+		? {
+				chance: formatAttributeValue(critChance, EAttribute.CriticalChance, staticData.attributes),
+				damage: critDamage,
+				bonus: critBonus
+			}
+		: undefined
+);
+const total = $derived(applyDefense(totalDamage + critBonus, enemyDefense));
 const cdMultiplier = $derived(skill?.owner.cdMultiplier ?? 1);
 const adjustedCd = $derived((skill?.cooldownMs ?? 0) / 1000 / cdMultiplier);
 const remainingCd = $derived(Math.max(adjustedCd - (skill?.renderChargeTime ?? 0) / 1000 / cdMultiplier, 0));

--- a/UI/src/routes/game/screens/fight/skill-tooltip/DamageBreakdown.svelte
+++ b/UI/src/routes/game/screens/fight/skill-tooltip/DamageBreakdown.svelte
@@ -13,6 +13,18 @@
 			<span class="tt-dmg-value positive">+{formatNum(mult.value)}</span>
 		</div>
 	{/each}
+	{#if crit}
+		<div class="tt-dmg-row">
+			<span class="tt-dmg-label">
+				<AttributeIcon id={EAttribute.CriticalChance} size={13} />
+				Critical
+				<span class="tt-mult-dim">{crit.chance} · ×{formatNum(crit.damage)}</span>
+			</span>
+			<span class="tt-dmg-value" class:positive={crit.bonus >= 0} class:negative={crit.bonus < 0}>
+				{crit.bonus >= 0 ? '+' : '−'}{formatNum(Math.abs(crit.bonus))}
+			</span>
+		</div>
+	{/if}
 	{#if enemyDefense !== undefined}
 		<div class="tt-dmg-row">
 			<span class="tt-dmg-label">Enemy defense</span>
@@ -27,7 +39,7 @@
 
 <script lang="ts">
 import { formatNum } from '$lib/common';
-import type { EAttribute } from '$lib/api';
+import { EAttribute } from '$lib/api';
 import AttributeIcon from '$components/AttributeIcon.svelte';
 
 interface DamageMultiplier {
@@ -41,15 +53,27 @@ interface DamageMultiplier {
 	value: number;
 }
 
+/** The expected contribution from critical hits, folded into the total before defense. */
+interface CritContribution {
+	/** Pre-formatted crit chance (e.g. `5%`). */
+	chance: string;
+	/** Crit damage as a direct multiplier (e.g. 1.5). */
+	damage: number;
+	/** The expected damage bonus over many fires (`raw × chance × (damage − 1)`). */
+	bonus: number;
+}
+
 interface Props {
 	base: number;
 	multipliers: DamageMultiplier[];
+	/** The expected crit contribution, or undefined when no crit can occur (0 chance). */
+	crit: CritContribution | undefined;
 	/** Enemy defense subtracted from the total, or undefined when there is no opponent. */
 	enemyDefense: number | undefined;
 	total: number;
 }
 
-const { base, multipliers, enemyDefense, total }: Props = $props();
+const { base, multipliers, crit, enemyDefense, total }: Props = $props();
 </script>
 
 <style lang="scss">

--- a/UI/src/tests/lib/battle/battle-formulas.test.ts
+++ b/UI/src/tests/lib/battle/battle-formulas.test.ts
@@ -6,6 +6,7 @@ import {
 	applyDefense,
 	calculateSkillDamage,
 	cooldownMultiplier,
+	expectedCritMultiplier,
 	skillContributions
 } from '$lib/battle/battle-formulas';
 
@@ -173,6 +174,25 @@ describe('battle-formulas', () => {
 
 		it('slows cooldowns for a CooldownRecovery below 1', () => {
 			expect(cooldownMultiplier(makeAttributes([[EAttribute.CooldownRecovery, 0.5]]))).toBeCloseTo(0.5, 10);
+		});
+	});
+
+	describe('expectedCritMultiplier', () => {
+		it('is 1 when crit chance is 0', () => {
+			expect(expectedCritMultiplier(0, 1.5)).toBe(1);
+		});
+
+		it('is 1 when crit damage is a 1x multiplier (a crit adds nothing)', () => {
+			expect(expectedCritMultiplier(0.5, 1)).toBe(1);
+		});
+
+		it('blends the crit and non-crit damage by chance', () => {
+			// 5% chance to deal 1.5x → expected 1 + 0.05 * 0.5 = 1.025
+			expect(expectedCritMultiplier(0.05, 1.5)).toBeCloseTo(1.025, 10);
+		});
+
+		it('equals the crit multiplier at a guaranteed crit', () => {
+			expect(expectedCritMultiplier(1, 2)).toBe(2);
 		});
 	});
 });

--- a/UI/src/tests/routes/game/screens/fight/SkillTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/SkillTooltip.test.ts
@@ -73,7 +73,41 @@ describe('SkillTooltip', () => {
 		expect(list.textContent).toContain('10');
 		expect(list.textContent).toContain('+40');
 		expect(list.textContent).toContain('-5');
+		// No crit row when the battler has no crit chance (the default fixture owner).
+		expect(list.textContent).not.toContain('Critical');
 		expect((container.querySelector('.tt-total-value') as HTMLElement).textContent).toContain('45');
+	});
+
+	it('folds the expected crit contribution into the breakdown and total', () => {
+		staticData.attributes = [
+			makeAttribute(EAttribute.Strength, 'Strength'),
+			makeAttribute(EAttribute.CriticalChance, 'Critical Chance', { isPercentage: true })
+		];
+		// Crit chance 50%, crit damage ×2 → expected multiplier 1 + 0.5·(2−1) = 1.5.
+		const critOwner = makeBattler({
+			attributes: [
+				{ attributeId: EAttribute.Strength, amount: 20 },
+				{ attributeId: EAttribute.CooldownRecovery, amount: 1 },
+				{ attributeId: EAttribute.CriticalChance, amount: 0.5 },
+				{ attributeId: EAttribute.CriticalDamage, amount: 2 }
+			]
+		});
+		const skill = makeSkill(critOwner, {
+			name: 'Cleave',
+			baseDamage: 10,
+			damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 2 }],
+			cooldownMs: 1000
+		});
+		const { container } = render(SkillTooltip, { props: { skill } });
+
+		const list = container.querySelector('.tt-dmg-list') as HTMLElement;
+		// raw = base 10 + STR(20)×2 = 50; crit adds 50 × 0.5·(2−1) = +25; enemy defense −5.
+		expect(list.textContent).toContain('Critical');
+		expect(list.textContent).toContain('50%'); // crit chance
+		expect(list.textContent).toContain('×2'); // crit damage multiplier
+		expect(list.textContent).toContain('+25'); // expected crit bonus
+		// total = 50 + 25 − 5 = 70
+		expect((container.querySelector('.tt-total-value') as HTMLElement).textContent).toContain('70');
 	});
 
 	it('omits the enemy-defense row and uses raw damage when there is no opponent', () => {


### PR DESCRIPTION
## Summary

The in-fight skill tooltip's damage breakdown previously ignored critical hits, so the displayed total/DPS understated a skill's real output for any crit-capable battler. This folds the **long-run average** crit contribution into the tooltip.

- Adds a display-only `expectedCritMultiplier(critChance, critDamage)` helper to `battle-formulas.ts` — `1 + critChance × (critDamage − 1)`. The live simulation still rolls each crit individually (`battleStep`), so this has no backend mirror and is outside the battle-parity contract.
- `SkillTooltip.svelte` scales the raw damage by the expected crit multiplier **before** Defense (mirroring the battle, where a crit punches through Defense), then subtracts Defense once. The total and the derived DPS now reflect crit.
- `DamageBreakdown.svelte` gains a **Critical** row (between the attribute multipliers and Enemy defense) showing the crit chance, the crit-damage multiplier (e.g. `5% · ×1.5`), and the expected bonus. The row is omitted when the battler has no crit chance.

## How it addresses the issue

Resolves the request to incorporate crit chance and damage into the skill tooltip's damage calculations — the shown total now matches the average damage the skill deals once crits are accounted for, and the breakdown surfaces exactly where that contribution comes from.

## Test plan

- [x] New unit tests for `expectedCritMultiplier` (zero chance, 1× crit damage, blended, guaranteed crit).
- [x] New `SkillTooltip` test asserting the crit row (chance / ×multiplier / bonus) and the crit-adjusted total; existing breakdown test now also asserts the row is absent with no crit chance.
- [x] `npm run lint` (eslint + svelte-check) clean.
- [x] `npm run test:unit:ci` — 224 files / 2362 tests pass.

## Follow-up

The skills-screen inspector (`skills-view.svelte.ts` → `SkillDamageBreakdown.svelte`) computes its "effective dmg / dps" via `applyDefense(rawDamage, defense)` and does **not** include crit, so it is now inconsistent with this tooltip. Filed as a follow-up rather than expanding this issue's "skill tooltip" scope.

Closes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtMLgXvvGLVWFFZ9ik9jMB)_