### PR TITLE
Backend minor cleanups: ApplyExp threshold, EnsureViableZone, reconciler DRY (#1083)

### DIFF
--- a/Game.Application.Tests/DataAccess/AdminEnemiesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminEnemiesIntegrationTests.cs
@@ -268,7 +268,7 @@ namespace Game.Application.Tests.DataAccess
             var result = admin.SetAttributeDistributions(data);
 
             Assert.False(result.Succeeded);
-            Assert.Equal("The submitted attribute distribution set contains duplicate entries.", result.ErrorMessage);
+            Assert.Equal("The submitted attribute distribution change set contains duplicate entries.", result.ErrorMessage);
         }
 
         [Fact]

--- a/Game.Application.Tests/DataAccess/AdminZonesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminZonesIntegrationTests.cs
@@ -111,7 +111,7 @@ namespace Game.Application.Tests.DataAccess
             var result = admin.SetEnemies(data);
 
             Assert.False(result.Succeeded);
-            Assert.Equal("The submitted enemy set contains duplicate entries.", result.ErrorMessage);
+            Assert.Equal("The submitted enemy change set contains duplicate entries.", result.ErrorMessage);
         }
 
         [Fact]

--- a/Game.Application.Tests/DataAccess/ChildCollectionReconcilerTests.cs
+++ b/Game.Application.Tests/DataAccess/ChildCollectionReconcilerTests.cs
@@ -67,7 +67,7 @@ namespace Game.Application.Tests.DataAccess
             var result = Reconcile(existing, desired, recorder);
 
             Assert.False(result.Succeeded);
-            Assert.Equal("The submitted child set contains duplicate entries.", result.ErrorMessage);
+            Assert.Equal("The submitted child change set contains duplicate entries.", result.ErrorMessage);
             Assert.Empty(recorder.Deleted);
             Assert.Empty(recorder.Updated);
             Assert.Empty(recorder.Inserted);

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -610,10 +610,13 @@ namespace Game.Application.Services
             }
 
             var completedChallengeIds = await _progressRepo.GetCompletedChallengeIds(player.Id, cancellationToken);
+            // Filter to viable candidates before ordering, then resolve each domain zone once (lazily, so the
+            // resolve stops at the first unlocked match) rather than re-resolving it inside the predicate.
             var destination = _zones.All()
+                .Where(zone => IsZoneViable(zone.Id))
                 .OrderBy(zone => zone.Order)
-                .FirstOrDefault(zone =>
-                    IsZoneViable(zone.Id) && _zones.GetDomainZone(zone.Id).IsUnlocked(completedChallengeIds));
+                .Select(zone => _zones.GetDomainZone(zone.Id))
+                .FirstOrDefault(zone => zone.IsUnlocked(completedChallengeIds));
             var newZoneId = destination?.Id ?? NewPlayerFactory.StartingZoneId;
 
             if (newZoneId != player.CurrentZoneId)

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -170,6 +170,16 @@ namespace Game.Core.Tests.Players
             Assert.Empty(player.DomainEvents.OfType<PlayerLeveledUpEvent>());
         }
 
+        [Fact]
+        public void GrantExp_CorruptZeroLevel_FailsFastInsteadOfSpinning()
+        {
+            // Level is required and ≥ 1 on every real construction path, so a Level of 0 is a corrupt
+            // aggregate. The grant must throw loudly rather than tolerate a zero level-up threshold.
+            var player = MakePlayer(level: 0, exp: 0);
+
+            Assert.Throws<InvalidOperationException>(() => player.GrantExp(100));
+        }
+
         // ── UnlockItem ──────────────────────────────────────────────────────
 
         [Fact]

--- a/Game.Core.Tests/Progress/ChallengeTypeTests.cs
+++ b/Game.Core.Tests/Progress/ChallengeTypeTests.cs
@@ -89,6 +89,35 @@ namespace Game.Core.Tests.Progress
         }
 
         [Fact]
+        public void EveryChallengeTypeMapsToItsIntendedGoalComparison()
+        {
+            // The two tests above pin the derivation rule (AtMost iff Min-aggregated), but that rule is
+            // self-referential: it can't catch a future Min-backed statistic whose challenge should still
+            // accumulate "at least". This pins the concrete intended direction per type, so adding a new
+            // challenge type (or flipping a backing statistic to Min) forces a deliberate decision here
+            // rather than silently inheriting an AtMost goal.
+            var expected = new Dictionary<EChallengeType, EChallengeGoalComparison>
+            {
+                [EChallengeType.EnemiesKilled] = EChallengeGoalComparison.AtLeast,
+                [EChallengeType.BossesDefeated] = EChallengeGoalComparison.AtLeast,
+                [EChallengeType.ZonesCleared] = EChallengeGoalComparison.AtLeast,
+                [EChallengeType.LevelReached] = EChallengeGoalComparison.AtLeast,
+                [EChallengeType.TimeTrial] = EChallengeGoalComparison.AtMost,
+                [EChallengeType.DamageDealt] = EChallengeGoalComparison.AtLeast,
+                [EChallengeType.BattlesWon] = EChallengeGoalComparison.AtLeast,
+                [EChallengeType.SkillsUsed] = EChallengeGoalComparison.AtLeast,
+            };
+
+            // A newly-added challenge type must declare its intended direction above before this passes.
+            Assert.Equal(Enum.GetValues<EChallengeType>().ToHashSet(), expected.Keys.ToHashSet());
+
+            foreach (var (type, comparison) in expected)
+            {
+                Assert.Equal(comparison, new ChallengeType(type).GoalComparison);
+            }
+        }
+
+        [Fact]
         public void Name_IsHumanReadableWithSpaces()
         {
             var challengeType = new ChallengeType(EChallengeType.EnemiesKilled);

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -117,15 +117,25 @@ namespace Game.Core.Players
         /// </summary>
         private void ApplyExp(int amount)
         {
-            Exp += Math.Clamp(amount, 0, ServerGameConstants.MaxExpPerGrant);
-            // Guard the threshold against a non-positive level so a pre-initialized Level of 0 can't make
-            // the threshold 0 and spin the loop.
-            while (Exp >= Math.Max(1, Level) * GameConstants.ExpPerLevel)
+            // Level is required and ≥ 1 on every construction path, so a Level of 0 here is a corrupt
+            // aggregate, not a state to silently tolerate. Fail loudly (matching the fail-fast policy in
+            // e.g. BattleSnapshot.FromPlayer) rather than papering over it with a Math.Max guard that would
+            // spin the level-up loop on a zero threshold.
+            if (Level < 1)
             {
-                Exp -= Math.Max(1, Level) * GameConstants.ExpPerLevel;
+                throw new InvalidOperationException(
+                    $"Player {Id} has a corrupt Level of {Level}; expected at least 1.");
+            }
+
+            Exp += Math.Clamp(amount, 0, ServerGameConstants.MaxExpPerGrant);
+            var levelThreshold = Level * GameConstants.ExpPerLevel;
+            while (Exp >= levelThreshold)
+            {
+                Exp -= levelThreshold;
                 Level++;
                 StatPoints.StatPointsGained += GameConstants.StatPointsPerLevel;
                 RaiseEvent(new PlayerLeveledUpEvent(this, Level, StatPoints.StatPointsGained));
+                levelThreshold = Level * GameConstants.ExpPerLevel;
             }
         }
 

--- a/Game.DataAccess/Repositories/Admin/ChildCollectionReconciler.cs
+++ b/Game.DataAccess/Repositories/Admin/ChildCollectionReconciler.cs
@@ -48,7 +48,9 @@ namespace Game.DataAccess.Repositories.Admin
             {
                 if (!desiredKeys.Add(desiredKey(item)))
                 {
-                    return AdminSaveResult.Failure($"The submitted {resourceName} set contains duplicate entries.");
+                    // Route through the shared helper so the duplicate-rejection wording can't drift from the
+                    // change-set processors'. resourceName is always supplied here, so the type arg is unused.
+                    return ChangeSetProcessor.DuplicateFailure<TDesired>(resourceName);
                 }
             }
 


### PR DESCRIPTION
## Summary

Addresses the four low-severity backend code-health notes bundled in #1083. No behaviour change beyond a stricter fail-fast and a unified rejection message.

### 1. `Player.ApplyExp` — recomputed threshold + a guard masking a corrupt invariant
`Game.Core/Players/Player.cs`. The level-up threshold `Math.Max(1, Level) * ExpPerLevel` was computed twice per loop iteration; it's now hoisted to one `levelThreshold` local (recomputed once per level gained). The `Math.Max(1, Level)` guard only papered over a corrupt `Level == 0` aggregate, so it's replaced with an explicit `Level < 1` fail-fast at the top, consistent with the loud-fail policy in `BattleSnapshot.FromPlayer`.

### 2. `EnsureViableZone` resolved the domain zone per candidate inside the predicate
`Game.Application/Services/BattleService.cs`. The relocation scan now filters to viable candidates **before** ordering, then resolves each domain zone once via a lazy `Select` (so `FirstOrDefault` stops resolving at the first unlocked match) instead of re-resolving inside the predicate. Cold path (relocation only); purely a readability/redundancy cleanup.

### 3. Pin the `Min` → `AtMost` invariant
`Game.Core/Progress/ChallengeType.cs`. The existing tests pin the *derivation rule* (`AtMost` iff `Min`-aggregated), but that rule is self-referential and can't catch a future `Min`-backed statistic whose challenge should still accumulate "at least". Added `EveryChallengeTypeMapsToItsIntendedGoalComparison`, an exhaustive per-type expected-direction map guarded so a newly-added `EChallengeType` forces a deliberate declaration before it passes.

### 4. Reconciler duplicate-message bypassed the shared helper (DRY)
`Game.DataAccess/Repositories/Admin/ChildCollectionReconciler.cs`. The hand-built duplicate message now routes through `ChangeSetProcessor.DuplicateFailure`, so the wording is centralized and can't drift. This unifies the copy from `"... {resource} set contains duplicate entries."` to `"... {resource} change set contains duplicate entries."`; the three reconciler-path test assertions were updated to match.

## Test plan
- `dotnet build` — clean, 0 warnings.
- `Game.Core.Tests` — 713 passed (incl. new `GrantExp_CorruptZeroLevel_FailsFastInsteadOfSpinning` and `EveryChallengeTypeMapsToItsIntendedGoalComparison`).
- `Game.Application.Tests` — 455 passed (incl. the integration tests whose duplicate-message assertions were updated).

## Notes
- Backend-only; no frontend or battle-parity surface touched.

Closes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Se2SsXiddsQjTLaWaJ8znB)_