### PR TITLE
Incorporate crit chance and damage into the skills-screen damage display

### DIFF
--- a/UI/src/routes/game/screens/skills/SkillDamageBreakdown.svelte
+++ b/UI/src/routes/game/screens/skills/SkillDamageBreakdown.svelte
@@ -15,6 +15,16 @@
 	{:else}
 		<div class="d-desc">No attribute scaling.</div>
 	{/if}
+	{#if view.critChance > 0}
+		<div class="brk-line crit">
+			<span class="brk-k">
+				<AttributeIcon id={EAttribute.CriticalChance} size={12} />
+				Critical
+				<span class="crit-meta">{critChanceLabel} · ×{formatNum(view.critDamage)}</span>
+			</span>
+			<span class="brk-v">+{fmt(view.critBonus(metrics.skill.id))}</span>
+		</div>
+	{/if}
 	<div class="brk-line def">
 		<span class="brk-k">Enemy defense</span><span class="brk-v">−{fmt(view.appliedDefense(metrics.skill.id))}</span>
 	</div>
@@ -24,10 +34,12 @@
 </div>
 
 <script lang="ts">
-import { attributeColor, attributeName, formatNum } from '$lib/common';
+import { EAttribute } from '$lib/api';
+import { attributeColor, attributeName, formatAttributeValue, formatNum } from '$lib/common';
 import { staticData } from '$stores';
 import Bar from '$components/Bar.svelte';
 import AttributeChip from '$components/AttributeChip.svelte';
+import AttributeIcon from '$components/AttributeIcon.svelte';
 import type { SkillMetrics, SkillsView } from './skills-view.svelte';
 
 type Props = {
@@ -40,6 +52,11 @@ const { view, metrics }: Props = $props();
 const fmt = (n: number) => formatNum(Math.round(n));
 
 const maxContribution = $derived(Math.max(metrics.skill.baseDamage, ...metrics.contributions.map((c) => c.value), 1));
+
+// Crit chance in its display form (e.g. `5%`), honoring the attribute's `isPercentage`/`decimals`.
+const critChanceLabel = $derived(
+	formatAttributeValue(view.critChance, EAttribute.CriticalChance, staticData.attributes)
+);
 </script>
 
 <style lang="scss">
@@ -100,6 +117,22 @@ const maxContribution = $derived(Math.max(metrics.skill.baseDamage, ...metrics.c
 	.brk-v {
 		font-family: var(--mono);
 		font-size: 11.5px;
+	}
+
+	&.crit {
+		.brk-k {
+			display: inline-flex;
+			align-items: center;
+			gap: 5px;
+		}
+
+		.brk-v {
+			color: var(--success);
+		}
+	}
+
+	.crit-meta {
+		color: color-mix(in srgb, var(--text-primary) 45%, transparent);
 	}
 
 	&.def {

--- a/UI/src/routes/game/screens/skills/SkillInspector.svelte
+++ b/UI/src/routes/game/screens/skills/SkillInspector.svelte
@@ -133,15 +133,20 @@ const rawNote = $derived.by(() => {
 	if (!metrics) {
 		return '';
 	}
-	const raw = fmt(view.rawDamage(metrics.skill.id));
+	const id = metrics.skill.id;
+	const raw = fmt(view.rawDamage(id));
+	// Surface the expected crit contribution inline so the note reconciles with the breakdown's
+	// Critical row and the crit-inclusive effective hit; omitted when no crit can occur.
+	const critBonus = view.critBonus(id);
+	const critPart = critBonus > 0 ? ` · +${fmt(critBonus)} crit` : '';
 	if (view.defense <= 0) {
-		return `${raw} raw damage · target has no defense`;
+		return `${raw} raw damage${critPart} · target has no defense`;
 	}
-	const applied = fmt(view.appliedDefense(metrics.skill.id));
-	if (view.effective(metrics.skill.id) === 0) {
-		return `${raw} raw − ${applied} def · fully blocked`;
+	const applied = fmt(view.appliedDefense(id));
+	if (view.effective(id) === 0) {
+		return `${raw} raw${critPart} − ${applied} def · fully blocked`;
 	}
-	return `${raw} raw − ${applied} def`;
+	return `${raw} raw${critPart} − ${applied} def`;
 });
 </script>
 

--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -21,6 +21,7 @@ import {
 	applyDefense,
 	calculateSkillDamage,
 	cooldownMultiplier,
+	expectedCritMultiplier,
 	skillContributions,
 	type SkillContribution
 } from '$lib/battle';
@@ -81,20 +82,27 @@ export interface ComparePreset {
 export const damagePerSecond = (damage: number, cooldown: number): number => (cooldown > 0 ? damage / cooldown : 0);
 
 /** Comparator over `SkillMetrics` for the given sort + Compare-vs defense.
- *  DPS/Damage rank by *effective* value (defense-aware), descending. */
-export function sortMetrics(sort: SkillSort, defense: number): (a: SkillMetrics, b: SkillMetrics) => number {
+ *  DPS/Damage rank by *effective* value (defense-aware), descending. The crit multiplier scales raw
+ *  damage before defense (mirroring {@link SkillsView.effective}), so the ranking matches the
+ *  crit-inclusive numbers the rows display; it defaults to 1 (no crit) for unit-test convenience. */
+export function sortMetrics(
+	sort: SkillSort,
+	defense: number,
+	critMultiplier = 1
+): (a: SkillMetrics, b: SkillMetrics) => number {
 	switch (sort) {
 		case 'name':
 			return (a, b) => a.skill.name.localeCompare(b.skill.name);
 		case 'cd':
 			return (a, b) => a.cooldown - b.cooldown;
 		case 'dmg':
-			return (a, b) => applyDefense(b.rawDamage, defense) - applyDefense(a.rawDamage, defense);
+			return (a, b) =>
+				applyDefense(b.rawDamage * critMultiplier, defense) - applyDefense(a.rawDamage * critMultiplier, defense);
 		case 'dps':
 		default:
 			return (a, b) =>
-				damagePerSecond(applyDefense(b.rawDamage, defense), b.cooldown) -
-				damagePerSecond(applyDefense(a.rawDamage, defense), a.cooldown);
+				damagePerSecond(applyDefense(b.rawDamage * critMultiplier, defense), b.cooldown) -
+				damagePerSecond(applyDefense(a.rawDamage * critMultiplier, defense), a.cooldown);
 	}
 }
 
@@ -157,6 +165,15 @@ export class SkillsView {
 		new BattleAttributes([...playerManager.attributes, ...inventoryManager.equipmentStats], true)
 	);
 
+	/** The player's expected critical-hit damage multiplier (≥1), folded into every effective-damage
+	 *  read so the page mirrors the in-fight skill tooltip and the battle (a crit scales raw damage
+	 *  before Defense). Player-wide — the crit attributes are the player's own — so it applies uniformly
+	 *  across the loadout; reuses the shared display-only `expectedCritMultiplier` rather than duplicating
+	 *  the formula. The live battle still rolls each crit individually. */
+	readonly critChance = $derived(this.battleAttributes.getValue(EAttribute.CriticalChance));
+	readonly critDamage = $derived(this.battleAttributes.getValue(EAttribute.CriticalDamage));
+	readonly critMultiplier = $derived(expectedCritMultiplier(this.critChance, this.critDamage));
+
 	/** Defense-independent metrics per catalogue skill, keyed by id. Recomputed
 	 *  wholesale when attributes/equipment change — read via {@link metric}. */
 	readonly metricsById = $derived.by(() => {
@@ -192,8 +209,11 @@ export class SkillsView {
 		return this.metricsById[id];
 	}
 
-	/** Slider ceiling: enough defense to fully block the biggest hit. */
-	readonly maxDamage = $derived(Math.max(1, ...this.catalogue.map((s) => this.metricsById[s.id]?.rawDamage ?? 0)));
+	/** Slider ceiling: enough defense to fully block the biggest hit — the biggest crit-scaled raw
+	 *  damage, since a crit punches through Defense (mirrors {@link effective}). */
+	readonly maxDamage = $derived(
+		Math.max(1, ...this.catalogue.map((s) => (this.metricsById[s.id]?.rawDamage ?? 0) * this.critMultiplier))
+	);
 
 	/** Enemy quick-picks for the Compare-vs bar, sourced from the player's current zone: every
 	 *  non-retired enemy that spawns there (defense at the range midpoint) plus the zone's dedicated
@@ -256,7 +276,7 @@ export class SkillsView {
 				}
 				return true;
 			});
-		return list.sort(sortMetrics(this.sort, this.defense));
+		return list.sort(sortMetrics(this.sort, this.defense, this.critMultiplier));
 	});
 
 	/** Equipped rail rows, ordered by loadout slot (not by the active sort). Built from
@@ -297,17 +317,26 @@ export class SkillsView {
 		return this.metricsById[id]?.cooldown ?? 0;
 	}
 
+	/** Effective single-hit damage: raw damage scaled by the expected crit multiplier (a crit
+	 *  punches through Defense, so it scales before subtraction), then less the Compare-vs defense. */
 	effective(id: number): number {
-		return applyDefense(this.rawDamage(id), this.defense);
+		return applyDefense(this.rawDamage(id) * this.critMultiplier, this.defense);
 	}
 
 	effectiveDps(id: number): number {
 		return damagePerSecond(this.effective(id), this.cooldown(id));
 	}
 
-	/** Defense actually applied to a skill (clamped to its raw damage, for display). */
+	/** Expected crit damage folded into a skill's hit before Defense (`raw × (critMultiplier − 1)`),
+	 *  0 when no crit can occur — drives the breakdown's Critical row and the raw-note's crit clause. */
+	critBonus(id: number): number {
+		return this.rawDamage(id) * (this.critMultiplier - 1);
+	}
+
+	/** Defense actually applied to a skill (clamped to its crit-scaled hit, for display), so the
+	 *  breakdown's raw + crit − defense reconciles with {@link effective}. */
 	appliedDefense(id: number): number {
-		return Math.min(this.defense, this.rawDamage(id));
+		return Math.min(this.defense, this.rawDamage(id) * this.critMultiplier);
 	}
 
 	/* ── selection + loadout edits ───────────────────────────────────────────── */

--- a/UI/src/tests/routes/game/screens/skills/SkillDamageBreakdown.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/SkillDamageBreakdown.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EAttribute, ESkillAcquisition, type IAttribute, type ISkill } from '$lib/api';
+
+// The breakdown resolves the crit-chance label and attribute names through the reference-data store,
+// so it is mocked. CriticalChance is flagged `isPercentage` so the chance renders as e.g. `50%`.
+const { staticData } = vi.hoisted(() => ({
+	staticData: {
+		attributes: [
+			{ id: EAttribute.CriticalChance, name: 'Critical Chance', code: 'CRIT', isPercentage: true, decimals: 0 }
+		] as unknown as IAttribute[]
+	}
+}));
+
+vi.mock('$stores', () => ({ staticData }));
+
+import SkillDamageBreakdown from '$routes/game/screens/skills/SkillDamageBreakdown.svelte';
+import type { SkillMetrics, SkillsView } from '$routes/game/screens/skills/skills-view.svelte';
+
+const stubSkill = (over: Partial<ISkill> = {}): ISkill => ({
+	id: 0,
+	name: 'Cleave',
+	baseDamage: 50,
+	damageMultipliers: [],
+	effects: [],
+	description: '',
+	cooldownMs: 1000,
+	iconPath: '',
+	acquisition: ESkillAcquisition.Player,
+	...over
+});
+
+const stubMetrics = (over: Partial<SkillMetrics> = {}): SkillMetrics => ({
+	skill: stubSkill(),
+	unlocked: true,
+	rawDamage: 50,
+	cooldown: 1,
+	contributions: [],
+	...over
+});
+
+// Only the members the component reads are stubbed; the per-skill reads ignore the id (one skill here).
+function stubView(over: Partial<Record<string, unknown>> = {}): SkillsView {
+	return {
+		critChance: 0.5,
+		critDamage: 2,
+		critBonus: () => 25,
+		appliedDefense: () => 5,
+		effective: () => 70,
+		...over
+	} as unknown as SkillsView;
+}
+
+afterEach(cleanup);
+
+describe('SkillDamageBreakdown — critical row', () => {
+	it('renders a Critical row with chance, ×multiplier and the expected bonus', () => {
+		const { container } = render(SkillDamageBreakdown, { props: { view: stubView(), metrics: stubMetrics() } });
+		const crit = container.querySelector('.brk-line.crit') as HTMLElement;
+		expect(crit).not.toBeNull();
+		expect(crit.textContent).toContain('Critical');
+		expect(crit.textContent).toContain('50%'); // crit chance (isPercentage)
+		expect(crit.textContent).toContain('×2'); // crit damage multiplier
+		expect(crit.textContent).toContain('+25'); // expected crit bonus
+	});
+
+	it('omits the Critical row when the player has no crit chance', () => {
+		const { container } = render(SkillDamageBreakdown, {
+			props: { view: stubView({ critChance: 0, critBonus: () => 0 }), metrics: stubMetrics() }
+		});
+		expect(container.querySelector('.brk-line.crit')).toBeNull();
+		// The defense and effective-hit lines still render.
+		expect(container.querySelector('.brk-line.def .brk-v')?.textContent).toContain('5');
+		expect(container.querySelector('.brk-line.total .brk-v')?.textContent).toContain('70');
+	});
+
+	it('orders the crit row between the scaling rows and the enemy-defense line', () => {
+		const { container } = render(SkillDamageBreakdown, { props: { view: stubView(), metrics: stubMetrics() } });
+		const rows = Array.from(container.querySelectorAll('.brk-line')).map((el) => el.className);
+		expect(rows).toEqual(['brk-line crit', 'brk-line def', 'brk-line total']);
+	});
+});

--- a/UI/src/tests/routes/game/screens/skills/SkillDamageBreakdown.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/SkillDamageBreakdown.test.ts
@@ -3,19 +3,19 @@ import { render, cleanup } from '@testing-library/svelte';
 import { EAttribute, ESkillAcquisition, type IAttribute, type ISkill } from '$lib/api';
 
 // The breakdown resolves the crit-chance label and attribute names through the reference-data store,
-// so it is mocked. CriticalChance is flagged `isPercentage` so the chance renders as e.g. `50%`.
-const { staticData } = vi.hoisted(() => ({
-	staticData: {
-		attributes: [
-			{ id: EAttribute.CriticalChance, name: 'Critical Chance', code: 'CRIT', isPercentage: true, decimals: 0 }
-		] as unknown as IAttribute[]
-	}
-}));
+// so it is mocked. The object backs the hoisted `vi.mock` factory, but its `attributes` are populated
+// after the imports run — the `EAttribute` enum isn't initialized while `vi.hoisted` executes.
+const { staticData } = vi.hoisted(() => ({ staticData: { attributes: [] as unknown[] } }));
 
 vi.mock('$stores', () => ({ staticData }));
 
 import SkillDamageBreakdown from '$routes/game/screens/skills/SkillDamageBreakdown.svelte';
 import type { SkillMetrics, SkillsView } from '$routes/game/screens/skills/skills-view.svelte';
+
+// CriticalChance is flagged `isPercentage` so the chance renders as e.g. `50%`.
+staticData.attributes = [
+	{ id: EAttribute.CriticalChance, name: 'Critical Chance', code: 'CRIT', isPercentage: true, decimals: 0 }
+] as unknown as IAttribute[];
 
 const stubSkill = (over: Partial<ISkill> = {}): ISkill => ({
 	id: 0,
@@ -76,7 +76,12 @@ describe('SkillDamageBreakdown — critical row', () => {
 
 	it('orders the crit row between the scaling rows and the enemy-defense line', () => {
 		const { container } = render(SkillDamageBreakdown, { props: { view: stubView(), metrics: stubMetrics() } });
-		const rows = Array.from(container.querySelectorAll('.brk-line')).map((el) => el.className);
+		// Drop Svelte's scoped style class (e.g. `svelte-xxxx`) so only the semantic classes are compared.
+		const rows = Array.from(container.querySelectorAll('.brk-line')).map((el) =>
+			Array.from(el.classList)
+				.filter((c) => !c.startsWith('svelte-'))
+				.join(' ')
+		);
 		expect(rows).toEqual(['brk-line crit', 'brk-line def', 'brk-line total']);
 	});
 });

--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -147,6 +147,7 @@ beforeEach(() => {
 	staticData.challenges = CHALLENGES;
 	staticData.zones = ZONES;
 	staticData.enemies = ENEMIES;
+	staticData.attributes = undefined;
 	mockPlayerManager.currentZone = 0;
 	mockPlayerManager.unlockedSkills = [
 		{ skillId: 0, selected: true, order: 0 },
@@ -414,6 +415,29 @@ describe('Skills screen', () => {
 		expect(cta.disabled).toBe(true);
 		expect(cta.textContent).toContain('Locked');
 		expect(container.querySelector('.d-hint')?.textContent).toContain('Unlock by completing');
+	});
+
+	it('folds the expected crit contribution into the inspector breakdown and raw note', async () => {
+		// CriticalChance is flagged `isPercentage` so the breakdown's chance renders as `50%`.
+		staticData.attributes = [
+			{ id: EAttribute.CriticalChance, name: 'Critical Chance', code: 'CRIT', isPercentage: true, decimals: 0 }
+		] as unknown as typeof staticData.attributes;
+		// Chance 0.5, damage 0.5 + 1.5 base = 2.0 → expected multiplier 1.5; Alpha's raw 10 → +5 crit.
+		mockPlayerManager.attributes = [
+			{ attributeId: EAttribute.CriticalChance, amount: 0.5 },
+			{ attributeId: EAttribute.CriticalDamage, amount: 0.5 }
+		];
+		const { container } = render(Skills);
+		// Alpha (equipped slot 1) is selected into the inspector by default.
+		expect(container.querySelector('.d-name')?.textContent).toBe('Alpha');
+
+		const crit = container.querySelector('.brk-line.crit') as HTMLElement;
+		expect(crit).not.toBeNull();
+		expect(crit.textContent).toContain('50%');
+		expect(crit.textContent).toContain('×2');
+		expect(crit.textContent).toContain('+5');
+		// The raw note surfaces the same crit contribution inline.
+		expect(container.querySelector('.rawnote')?.textContent).toContain('+5 crit');
 	});
 
 	it('shows the no-scaling note in the damage breakdown for a skill without multipliers', async () => {

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -61,6 +61,7 @@ import {
 	zoneSpawnLevel,
 	type SkillMetrics
 } from '$routes/game/screens/skills/skills-view.svelte';
+import { expectedCritMultiplier } from '$lib/battle';
 
 /* A skill with sensible defaults so each test only states what matters. */
 const skill = (over: Partial<ISkill> & { id: number }): ISkill => ({
@@ -222,6 +223,19 @@ describe('pure helpers', () => {
 
 	it('takes the midpoint of a zone range as the representative spawn level', () => {
 		expect(zoneSpawnLevel(ZONES[0])).toBe(5); // (2 + 8) / 2
+	});
+
+	it('folds the crit multiplier into the effective dps/damage ranking', () => {
+		// Two skills whose effective-DPS order flips once a global crit multiplier scales raw damage
+		// before defense (a crit punches through Defense, mirroring the battle and the displayed numbers).
+		const a = metric({ skill: skill({ id: 0 }), rawDamage: 30, cooldown: 3 });
+		const b = metric({ skill: skill({ id: 1 }), rawDamage: 22, cooldown: 2 });
+		// defense 10, no crit: A=(30−10)/3≈6.67 > B=(22−10)/2=6 → A first.
+		expect([b, a].sort(sortMetrics('dps', 10)).map((m) => m.skill.id)).toEqual([0, 1]);
+		// crit ×2: A=(60−10)/3≈16.67 < B=(44−10)/2=17 → B overtakes.
+		expect([a, b].sort(sortMetrics('dps', 10, 2)).map((m) => m.skill.id)).toEqual([1, 0]);
+		// dmg sort, defense 25: no crit both 5/0 → stable; ×2 lifts A=(60−25)=35 > B=(44−25)=19.
+		expect([a, b].sort(sortMetrics('dmg', 25, 2)).map((m) => m.skill.id)).toEqual([0, 1]);
 	});
 });
 
@@ -450,5 +464,60 @@ describe('SkillsView — compare-vs enemy presets', () => {
 		view.selectPreset(spawn);
 		expect(view.defense).toBe(spawn.defense);
 		expect(view.railList.map((m) => m.skill.id).slice(0, 2)).toEqual([3, 1]);
+	});
+});
+
+describe('SkillsView — critical hits fold into effective damage', () => {
+	beforeEach(() => {
+		// Give the player crit chance + damage; the derived attribute pass also adds the base crit
+		// damage (1.5) and any Dex/Luck contribution, so expectations are built off the view's resolved
+		// values rather than hard-coding the derived model. Here: chance 0.5, damage 0.5 + 1.5 = 2.0.
+		mockPlayerManager.attributes = [
+			{ attributeId: EAttribute.CriticalChance, amount: 0.5 },
+			{ attributeId: EAttribute.CriticalDamage, amount: 0.5 }
+		];
+		view = new SkillsView();
+	});
+
+	it('exposes a player-wide crit multiplier matching the shared display helper', () => {
+		expect(view.critChance).toBeCloseTo(0.5, 10);
+		expect(view.critDamage).toBeCloseTo(2, 10);
+		expect(view.critMultiplier).toBe(expectedCritMultiplier(view.critChance, view.critDamage));
+		expect(view.critMultiplier).toBeCloseTo(1.5, 10); // 1 + 0.5·(2−1)
+	});
+
+	it('leaves the multiplier at 1 when the player has no crit chance', () => {
+		mockPlayerManager.attributes = [];
+		const noCrit = new SkillsView();
+		expect(noCrit.critChance).toBe(0);
+		expect(noCrit.critMultiplier).toBe(1);
+		expect(noCrit.critBonus(0)).toBe(0);
+	});
+
+	it('scales raw damage by the crit multiplier before defense in effective/dps/burst', () => {
+		const k = view.critMultiplier;
+		view.setDefense(10);
+		// Alpha (id 0): baseDamage 12, no Strength allocated → rawDamage 12.
+		expect(view.rawDamage(0)).toBe(12);
+		expect(view.effective(0)).toBeCloseTo(Math.max(12 * k - 10, 0), 10); // (12·1.5−10)=8
+		expect(view.effectiveDps(0)).toBeCloseTo(view.effective(0) / view.cooldown(0), 10);
+		// Combined burst sums each loadout skill's crit-scaled effective hit.
+		const expectedBurst = [0, 1, 2].reduce((sum, id) => sum + Math.max(view.rawDamage(id) * k - 10, 0), 0);
+		expect(view.combinedEffectiveBurst).toBeCloseTo(expectedBurst, 10);
+	});
+
+	it('reports the expected crit bonus and clamps applied defense to the crit-scaled hit', () => {
+		const k = view.critMultiplier;
+		expect(view.critBonus(1)).toBeCloseTo(view.rawDamage(1) * (k - 1), 10); // Bravo: 40·0.5 = 20
+		// A defense above the crit-scaled hit fully blocks it; applied defense clamps to that hit so the
+		// breakdown's raw + crit − defense reconciles to 0.
+		view.setDefense(1000);
+		expect(view.appliedDefense(1)).toBeCloseTo(view.rawDamage(1) * k, 10);
+		expect(view.effective(1)).toBe(0);
+	});
+
+	it('raises the slider ceiling to the biggest crit-scaled hit', () => {
+		// Skill 4 (Echo) has the largest raw damage (100); the ceiling scales by the crit multiplier.
+		expect(view.maxDamage).toBeCloseTo(100 * view.critMultiplier, 10);
 	});
 });


### PR DESCRIPTION
## Summary

The skills-screen inspector ignored critical hits, so its **effective dmg / effective dps** big-numbers, the `rawNote` line, and `SkillDamageBreakdown` understated damage for any crit-capable build — and read lower than the in-fight `SkillTooltip` for the same skill (#1091 / #1106 had already folded crit into the tooltip). This aligns the two surfaces.

## How it addresses the issue

All numbers flow from a single player-wide multiplier, reusing the shared display-only helper rather than duplicating the formula:

- **`skills-view.svelte.ts`**
  - Adds `critChance` / `critDamage` / `critMultiplier` derived from the same `BattleAttributes` composition the page already uses (`expectedCritMultiplier` from `$lib/battle`). The crit attributes are the player's own, so no opponent context is needed.
  - `effective(id)` now scales raw damage by `critMultiplier` **before** `applyDefense` (a crit punches through Defense, mirroring `SkillTooltip` and the battle). `effectiveDps`, `combinedEffectiveDps`, and `combinedEffectiveBurst` flow through automatically.
  - Adds `critBonus(id)` (= `raw × (critMultiplier − 1)`) for the breakdown row and raw-note.
  - `appliedDefense(id)` is clamped to the **crit-scaled** hit, so the breakdown's `raw + crit − defense` reconciles with `effective`.
  - `sortMetrics` and `maxDamage` are made crit-aware so the rail ordering and the Compare-vs slider ceiling stay consistent with the crit-inclusive numbers shown (the ranking can otherwise genuinely flip near a defense threshold). `sortMetrics`'s new param defaults to `1`.
- **`SkillDamageBreakdown.svelte`** — adds a **Critical** row (chance · ×multiplier · expected bonus), consistent with the tooltip's breakdown, omitted when crit chance is 0.
- **`SkillInspector.svelte`** — `rawNote` gains an inline `· +N crit` clause when crit applies (no wording change when it doesn't).

## Test plan

- `UI/src/tests/.../skills-view.test.ts` — extends the pure-helper `sortMetrics` coverage with a crit-multiplier ranking flip, and adds a `critical hits` suite (multiplier matches `expectedCritMultiplier`; multiplier is 1 with no crit chance; crit scales `effective`/`effectiveDps`/`combinedEffectiveBurst` before defense; `critBonus` + `appliedDefense` clamp; slider ceiling scales).
- `UI/src/tests/.../SkillDamageBreakdown.test.ts` (new) — renders the Critical row (chance/×mult/+bonus), its omission at 0 crit chance, and its ordering.
- `UI/src/tests/.../Skills.test.ts` — full-screen test asserting the inspector breakdown's Critical row and the crit clause in the raw-note.

CI runs `npm run lint` and `npm run test:unit:ci`.

Closes #1107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbQrng4EPLTHjgsCGWGkoP)_