### PR TITLE
Extract shared SkillCardStats sub-block from EquippedBand / InnateBand (#1113)

### DIFF
--- a/UI/src/routes/game/screens/skills/EquippedBand.svelte
+++ b/UI/src/routes/game/screens/skills/EquippedBand.svelte
@@ -69,16 +69,7 @@
 					</div>
 				{/if}
 				<span class="en">{metrics.skill.name}</span>
-				<div class="es">
-					<div class="stat"><span class="v accent">{fmt(view.effective(id))}</span><span class="k">dmg</span></div>
-					<div class="stat"><span class="v">{metrics.cooldown.toFixed(1)}s</span><span class="k">cd</span></div>
-					<div class="stat"><span class="v accent">{fmt(view.effectiveDps(id))}</span><span class="k">dps</span></div>
-				</div>
-				<div class="chips">
-					{#each metrics.skill.damageMultipliers as mult (mult.attributeId)}
-						<AttributeChip attributeId={mult.attributeId} />
-					{/each}
-				</div>
+				<SkillCardStats {view} {metrics} />
 			</div>
 		{:else}
 			<button type="button" class="eqcard empty" class:dimmed={swapping} onclick={() => focusAvailable()}>
@@ -90,9 +81,8 @@
 </div>
 
 <script lang="ts">
-import { formatNum } from '$lib/common';
-import AttributeChip from '$components/AttributeChip.svelte';
 import OverlayButton from '$components/OverlayButton.svelte';
+import SkillCardStats from './SkillCardStats.svelte';
 import type { SkillsView } from './skills-view.svelte';
 
 type Props = {
@@ -108,8 +98,6 @@ const swapName = $derived(view.pendingSwap != null ? (view.metric(view.pendingSw
 
 /** Fixed-length slot list (capacity), nulls for empty slots. */
 const slots = $derived(Array.from({ length: view.cap }, (_, i) => view.equipped[i] ?? null));
-
-const fmt = (n: number) => formatNum(Math.round(n));
 
 /** Selecting an empty slot surfaces the first available skill to equip. */
 const focusAvailable = () => {
@@ -337,44 +325,6 @@ const onDragEnd = () => {
 		font-size: 13.5px;
 		font-weight: 500;
 		line-height: 1.1;
-	}
-
-	.es {
-		display: flex;
-		gap: 13px;
-		margin-top: auto;
-	}
-
-	.chips {
-		display: flex;
-		gap: 5px;
-		// Above the overlay so each chip keeps its own hover (the shared attribute tooltip).
-		position: relative;
-		z-index: 2;
-	}
-}
-
-.stat {
-	display: flex;
-	flex-direction: column;
-	gap: 2px;
-
-	.v {
-		font-size: 15px;
-		font-weight: 500;
-		line-height: 1;
-
-		&.accent {
-			color: var(--accent);
-		}
-	}
-
-	.k {
-		font-family: var(--mono);
-		font-size: 8px;
-		letter-spacing: 1.2px;
-		text-transform: uppercase;
-		color: var(--text-muted);
 	}
 }
 </style>

--- a/UI/src/routes/game/screens/skills/InnateBand.svelte
+++ b/UI/src/routes/game/screens/skills/InnateBand.svelte
@@ -16,20 +16,7 @@
 				{#if innate.duplicate}
 					<span class="dupe-note">already in your loadout</span>
 				{:else if metrics}
-					<div class="es">
-						<div class="stat">
-							<span class="v accent">{fmt(view.effective(innate.skill.id))}</span><span class="k">dmg</span>
-						</div>
-						<div class="stat"><span class="v">{metrics.cooldown.toFixed(1)}s</span><span class="k">cd</span></div>
-						<div class="stat">
-							<span class="v accent">{fmt(view.effectiveDps(innate.skill.id))}</span><span class="k">dps</span>
-						</div>
-					</div>
-					<div class="chips">
-						{#each metrics.skill.damageMultipliers as mult (mult.attributeId)}
-							<AttributeChip attributeId={mult.attributeId} />
-						{/each}
-					</div>
+					<SkillCardStats {view} {metrics} />
 				{/if}
 			</div>
 		{/each}
@@ -37,8 +24,7 @@
 {/if}
 
 <script lang="ts">
-import { formatNum } from '$lib/common';
-import AttributeChip from '$components/AttributeChip.svelte';
+import SkillCardStats from './SkillCardStats.svelte';
 import type { SkillsView } from './skills-view.svelte';
 
 type Props = {
@@ -46,8 +32,6 @@ type Props = {
 };
 
 const { view }: Props = $props();
-
-const fmt = (n: number) => formatNum(Math.round(n));
 </script>
 
 <style lang="scss">
@@ -114,41 +98,5 @@ const fmt = (n: number) => formatNum(Math.round(n));
 	letter-spacing: 0.8px;
 	text-transform: uppercase;
 	color: var(--text-tertiary);
-}
-
-.es {
-	display: flex;
-	gap: 12px;
-	margin-top: auto;
-}
-
-.stat {
-	display: flex;
-	flex-direction: column;
-	gap: 2px;
-
-	.v {
-		font-size: 14px;
-		font-weight: 500;
-		line-height: 1;
-
-		&.accent {
-			color: var(--accent);
-		}
-	}
-
-	.k {
-		font-family: var(--mono);
-		font-size: 8px;
-		letter-spacing: 1.2px;
-		text-transform: uppercase;
-		color: var(--text-muted);
-	}
-}
-
-.chips {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 4px;
 }
 </style>

--- a/UI/src/routes/game/screens/skills/SkillCardStats.svelte
+++ b/UI/src/routes/game/screens/skills/SkillCardStats.svelte
@@ -1,0 +1,71 @@
+<!-- Shared skill-card stats sub-block: the dmg / cd / dps rows + the damage-multiplier chips.
+     Consumed by both the editable EquippedBand and the read-only InnateBand so the two stay in
+     sync (effective dmg/dps are defense-aware reads off the live view). -->
+<div class="es">
+	<div class="stat"><span class="v accent">{fmt(view.effective(skill.id))}</span><span class="k">dmg</span></div>
+	<div class="stat"><span class="v">{metrics.cooldown.toFixed(1)}s</span><span class="k">cd</span></div>
+	<div class="stat"><span class="v accent">{fmt(view.effectiveDps(skill.id))}</span><span class="k">dps</span></div>
+</div>
+<div class="chips">
+	{#each skill.damageMultipliers as mult (mult.attributeId)}
+		<AttributeChip attributeId={mult.attributeId} />
+	{/each}
+</div>
+
+<script lang="ts">
+import { formatNum } from '$lib/common';
+import AttributeChip from '$components/AttributeChip.svelte';
+import type { SkillsView, SkillMetrics } from './skills-view.svelte';
+
+type Props = {
+	view: SkillsView;
+	metrics: SkillMetrics;
+};
+
+const { view, metrics }: Props = $props();
+
+const skill = $derived(metrics.skill);
+const fmt = (n: number) => formatNum(Math.round(n));
+</script>
+
+<style lang="scss">
+.es {
+	display: flex;
+	gap: 13px;
+	margin-top: auto;
+}
+
+.stat {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+
+	.v {
+		font-size: 15px;
+		font-weight: 500;
+		line-height: 1;
+
+		&.accent {
+			color: var(--accent);
+		}
+	}
+
+	.k {
+		font-family: var(--mono);
+		font-size: 8px;
+		letter-spacing: 1.2px;
+		text-transform: uppercase;
+		color: var(--text-muted);
+	}
+}
+
+.chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 5px;
+	// Sits above a host card's full-bleed overlay (EquippedBand) so each chip keeps its own hover
+	// tooltip; the z-index is inert in bands without an overlay (InnateBand).
+	position: relative;
+	z-index: 2;
+}
+</style>

--- a/UI/src/tests/routes/game/screens/skills/AttributeChipStub.svelte
+++ b/UI/src/tests/routes/game/screens/skills/AttributeChipStub.svelte
@@ -1,0 +1,7 @@
+<!-- Test stub for AttributeChip: a countable marker so SkillCardStats chip rendering can be asserted
+     without pulling in the real icon/tooltip machinery. -->
+<span data-testid="attr-chip" data-attr={attributeId}></span>
+
+<script lang="ts">
+const { attributeId }: { attributeId: number } = $props();
+</script>

--- a/UI/src/tests/routes/game/screens/skills/SkillCardStats.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/SkillCardStats.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EAttribute, ESkillAcquisition } from '$lib/api';
+import type { IChallenge, IEnemy, ISkill, IZone } from '$lib/api';
+
+// Engine/stores/api are mocked so constructing a real SkillsView doesn't drag in the game engine.
+// AttributeChip is stubbed to a marker so chip rendering can be asserted without the icon/tooltip machinery.
+const { mockPlayerManager, mockInventoryManager, sendSocketCommand, toastError, staticData } = vi.hoisted(() => {
+	const playerManager = {
+		unlockedSkills: [] as { skillId: number; selected: boolean; order?: number }[],
+		currentZone: 0,
+		attributes: [] as { attributeId: number; amount: number }[],
+		get selectedSkills(): number[] {
+			return playerManager.unlockedSkills
+				.filter((s) => s.selected)
+				.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+				.map((s) => s.skillId);
+		},
+		setSelectedSkills() {}
+	};
+	return {
+		mockPlayerManager: playerManager,
+		mockInventoryManager: {
+			equipmentStats: [] as { attributeId: number; amount: number }[],
+			equippedSlots: [] as ({ grantedSkillId?: number; name: string } | undefined)[]
+		},
+		sendSocketCommand: vi.fn(),
+		toastError: vi.fn(),
+		staticData: {
+			skills: [] as ISkill[],
+			challenges: [] as IChallenge[],
+			zones: undefined as IZone[] | undefined,
+			enemies: undefined as IEnemy[] | undefined,
+			attributes: undefined as unknown
+		}
+	};
+});
+
+vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager, inventoryManager: mockInventoryManager }));
+vi.mock('$stores', () => ({ staticData, toastError }));
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return { ...actual, apiSocket: { sendSocketCommand } };
+});
+vi.mock('$lib/api/types/game-constants', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return { ...actual, MAX_SELECTED_SKILLS: 3 };
+});
+vi.mock('$components/AttributeChip.svelte', () => ({ default: ChipStub }));
+
+import ChipStub from './AttributeChipStub.svelte';
+import { SkillsView } from '$routes/game/screens/skills/skills-view.svelte';
+import SkillCardStats from '$routes/game/screens/skills/SkillCardStats.svelte';
+
+const skill = (over: Partial<ISkill> & { id: number }): ISkill => ({
+	name: `Skill ${over.id}`,
+	baseDamage: 10,
+	damageMultipliers: [],
+	effects: [],
+	description: '',
+	cooldownMs: 2000,
+	iconPath: '',
+	acquisition: ESkillAcquisition.Player,
+	...over
+});
+
+let view: SkillsView;
+
+const setSkills = (skills: ISkill[]) => {
+	staticData.skills = skills;
+	mockPlayerManager.unlockedSkills = skills.map((s, i) => ({ skillId: s.id, selected: false, order: i }));
+	view = new SkillsView();
+};
+
+/** Narrows the optional metric to a non-undefined value (failing the test loudly otherwise). */
+const metricOf = (id: number) => {
+	const metrics = view.metric(id);
+	if (!metrics) {
+		throw new Error(`expected metrics for skill ${id}`);
+	}
+	return metrics;
+};
+
+beforeEach(() => {
+	sendSocketCommand.mockReset().mockResolvedValue({});
+	mockPlayerManager.attributes = [];
+	mockInventoryManager.equipmentStats = [];
+	mockInventoryManager.equippedSlots = [];
+});
+
+afterEach(cleanup);
+
+describe('SkillCardStats', () => {
+	it('renders the dmg / cd / dps stat rows from the live view', () => {
+		setSkills([skill({ id: 0, baseDamage: 10, cooldownMs: 2000 })]);
+		const metrics = metricOf(0);
+
+		const { container } = render(SkillCardStats, { props: { view, metrics } });
+		const keys = Array.from(container.querySelectorAll('.stat .k')).map((k) => k.textContent);
+		expect(keys).toEqual(['dmg', 'cd', 'dps']);
+
+		const values = Array.from(container.querySelectorAll('.stat .v')).map((v) => v.textContent);
+		// dmg = 10 (no defense), cd = 2.0s, dps = 10 / 2 = 5.
+		expect(values[0]).toBe('10');
+		expect(values[1]).toBe('2.0s');
+		expect(values[2]).toBe('5');
+	});
+
+	it('renders one chip per damage multiplier', () => {
+		setSkills([
+			skill({
+				id: 0,
+				damageMultipliers: [
+					{ attributeId: EAttribute.Endurance, multiplier: 2 },
+					{ attributeId: EAttribute.Intellect, multiplier: 3 }
+				]
+			})
+		]);
+		const metrics = metricOf(0);
+
+		const { container } = render(SkillCardStats, { props: { view, metrics } });
+		expect(container.querySelectorAll('[data-testid="attr-chip"]')).toHaveLength(2);
+	});
+
+	it('renders no chips when the skill has no damage multipliers', () => {
+		setSkills([skill({ id: 0, damageMultipliers: [] })]);
+		const metrics = metricOf(0);
+
+		const { container } = render(SkillCardStats, { props: { view, metrics } });
+		expect(container.querySelectorAll('[data-testid="attr-chip"]')).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary

Implements **#1113** (follow-up from #1112). The Skills screen's editable `EquippedBand` and read-only `InnateBand` both rendered a near-identical **stats sub-block** — the dmg / cd / dps `.es`/`.stat` rows plus the `AttributeChip` damage-multiplier chips — with duplicated markup and SCSS. A future tweak to how a skill card surfaces dmg/cd/dps had to be made in two places, and the two bands could silently diverge (they already had ~1px drift).

This extracts that shared block into a small subcomponent, per the *"keep components small, break out shared pieces into subcomponents"* guideline in `docs/frontend.md`.

## Changes

- **New `SkillCardStats.svelte`** (under `routes/game/screens/skills/`): renders the dmg/cd/dps rows + the damage-multiplier chips for one skill. Props are `view: SkillsView` and `metrics: SkillMetrics`; effective dmg/dps are defense-aware reads off the live view (`view.effective` / `view.effectiveDps`), cd/multipliers come from the passed metrics — no new derivation logic.
- **`EquippedBand.svelte` / `InnateBand.svelte`** now consume `<SkillCardStats {view} {metrics} />`. Each band keeps its own container/interaction styling and skill-name (`.en`) styling local. Removed the now-dead `formatNum`/`AttributeChip` imports, the local `fmt` helper, and the duplicated `.es`/`.stat`/`.chips` SCSS from both.

No user-facing behavior change of note. The two copies had trivial drift, now unified onto one canonical style in the subcomponent — exactly the silent divergence the issue calls out. Full accounting of what was unified:

- **Stat value font size:** innate `14px` → equipped `15px` (canonical).
- **`.es` gap:** innate `12px` → equipped `13px`; **`.chips` gap:** innate `4px` → equipped `5px`.
- **`.chips` `flex-wrap: wrap`:** previously only on `InnateBand`; now applies to `EquippedBand`'s chips too. Benign (equipped cards rarely hold enough chips to wrap, and wrapping is graceful) — flagged here for completeness.
- **`.chips` `position: relative; z-index: 2`:** needed so chips sit above `EquippedBand`'s full-bleed overlay to keep their hover tooltips; inert in `InnateBand` (no overlay), so safe to share.

## Test plan

- [x] New `SkillCardStats.test.ts`: asserts the dmg/cd/dps stat rows render with correct values, and one chip renders per damage multiplier (incl. the zero-multiplier case). `AttributeChip` is stubbed (`AttributeChipStub.svelte`) so the test stays focused on this component's responsibility.
- [x] Existing `EquippedBand` / `InnateBand` tests unchanged and green (they exercise the bands which now render the subcomponent).
- [x] Skills screen suite: **92 passed**.
- [x] `npm run lint` (eslint + `svelte-check`): clean, 0 errors / 0 warnings.

Closes #1113
