### PR TITLE
Fix re-entrant async worker loop corrupting IsRunning (#1136)

### DIFF
--- a/Game.Infrastructure.Tests/BackgroundWorkerTests.cs
+++ b/Game.Infrastructure.Tests/BackgroundWorkerTests.cs
@@ -339,6 +339,77 @@ namespace Game.Infrastructure.Tests
             }
         }
 
+        [Fact]
+        public void AsyncWorker_SignaledRepeatedlyDuringRun_NeverOverlapsAndSettlesNotRunning()
+        {
+            // Reproduces #1136: an async callback returns to the thread pool at its first incomplete await, which
+            // re-arms the wait mid-run. Pre-fix, a Start() during an in-flight async run launched a *second concurrent*
+            // loopAction and the finishing run's trailing IsRunning = false could clobber the new run's true. The fix
+            // gates the async loop to one run at a time and coalesces mid-run signals into a single trailing pass.
+            var active = 0;
+            var maxActive = 0;
+            var totalRuns = 0;
+            using var firstRunStarted = new ManualResetEventSlim(false);
+            var releaseFirstRun = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            async Task Action()
+            {
+                var now = Interlocked.Increment(ref active);
+                InterlockedMax(ref maxActive, now);
+                Interlocked.Increment(ref totalRuns);
+
+                // Hold only the first run suspended mid-await so the test can fire more signals while it is in flight;
+                // every later (coalesced) run runs straight through.
+                if (!firstRunStarted.IsSet)
+                {
+                    firstRunStarted.Set();
+                    await releaseFirstRun.Task.WaitAsync(WaitTimeout);
+                }
+
+                Interlocked.Decrement(ref active);
+            }
+
+            var worker = new BackgroundWorker(NullLogger<BackgroundWorker>.Instance, Action);
+
+            worker.Start();
+            Assert.True(firstRunStarted.Wait(WaitTimeout, TestContext.Current.CancellationToken), "The first async run did not start.");
+            Assert.True(worker.IsRunning);
+
+            // Signal repeatedly while the first run is suspended at its await. Pre-fix each re-armed wait fired a
+            // concurrent run (driving maxActive past 1); post-fix they collapse into one trailing pass.
+            for (var i = 0; i < 20; i++)
+            {
+                worker.Start();
+            }
+
+            releaseFirstRun.SetResult();
+            WaitUntil(() => !worker.IsRunning && Volatile.Read(ref active) == 0);
+
+            // Two loopAction calls never ran at once.
+            Assert.Equal(1, Volatile.Read(ref maxActive));
+            // The mid-run signals were not lost — the coalesced trailing run executed.
+            Assert.True(Volatile.Read(ref totalRuns) >= 2, "The coalesced trailing run did not execute.");
+            // The worker settles in a stable, non-running terminal state.
+            Assert.False(worker.IsRunning);
+
+            worker.Kill();
+        }
+
+        // Atomically raises target to value when value is greater, used to detect any overlapping run.
+        private static void InterlockedMax(ref int target, int value)
+        {
+            int current;
+            do
+            {
+                current = Volatile.Read(ref target);
+                if (value <= current)
+                {
+                    return;
+                }
+            }
+            while (Interlocked.CompareExchange(ref target, value, current) != current);
+        }
+
         // Calls Start() repeatedly until the worker is torn down, asserting any disposed exception is the clean
         // worker-named guard rather than a leaked AutoResetEvent disposal (the issue #905 race).
         private static void SpinStartUntilTornDown(BackgroundWorker worker)

--- a/Game.Infrastructure/BackgroundWorker.cs
+++ b/Game.Infrastructure/BackgroundWorker.cs
@@ -34,6 +34,16 @@ namespace Game.Infrastructure
         // promptly rather than relying on a non-synchronized field.
         private volatile bool _isRunning = false;
 
+        // Gate for the async worker loop. Unlike the sync callback (which returns only once loopAction completes,
+        // so the thread pool re-arms the wait after the run finishes), an async callback returns to the pool at its
+        // first incomplete await — re-arming the wait mid-run. A Start() during an in-flight async run would then fire
+        // a second concurrent loopAction and the finishing run's trailing IsRunning = false could clobber it. This
+        // gate admits a single async run at a time and coalesces any signal that arrives mid-run into one trailing
+        // run. It is held only for the brief state transitions, never across the awaited loopAction.
+        private readonly object _runLock = new();
+        private bool _runActive = false;
+        private bool _runPending = false;
+
         /// <summary>
         /// A custom name for the <see cref="BackgroundWorker"/> used for logging purposes.
         /// </summary>
@@ -177,16 +187,49 @@ namespace Game.Infrastructure
         {
             return async (state, timedOut) =>
             {
-                try
+                // The thread pool re-arms this wait when the callback returns — which for an async callback is at the
+                // first incomplete await, not at task completion. If a run is already active, record that another pass
+                // is needed and bow out so two loopAction calls never overlap; the active run will pick it up.
+                lock (_runLock)
                 {
-                    await loopAction();
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "An error occurred while executing the async worker loop for background worker '{Name}' ({UniqueId}).", Name, _uniqueId);
+                    if (_runActive)
+                    {
+                        _runPending = true;
+                        return;
+                    }
+                    _runActive = true;
+                    // Reaffirm under the lock so a concurrent finishing run's IsRunning = false can't leave this run
+                    // wedged 'false' (Start() also publishes it true, but that write races the gated reset below).
+                    IsRunning = true;
                 }
 
-                IsRunning = false;
+                bool runAgain;
+                do
+                {
+                    try
+                    {
+                        await loopAction();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "An error occurred while executing the async worker loop for background worker '{Name}' ({UniqueId}).", Name, _uniqueId);
+                    }
+
+                    // A signal that arrived during the run leaves _runPending set; consume it and loop again rather than
+                    // exiting, coalescing any number of mid-run signals into exactly one trailing pass.
+                    lock (_runLock)
+                    {
+                        runAgain = _runPending;
+                        _runPending = false;
+                        if (!runAgain)
+                        {
+                            _runActive = false;
+                            IsRunning = false;
+                        }
+                    }
+                }
+                while (runAgain);
+
                 _logger.LogTrace("Sleeping background worker '{Name}' ({UniqueId}).", Name, _uniqueId);
             };
         }


### PR DESCRIPTION
## Summary

Fixes **#1136**: `BackgroundWorker`'s **async** worker loop could run re-entrantly and corrupt `IsRunning`.

The callback is registered with `executeOnlyOnce: false`, so the thread pool re-arms the wait as soon as the callback **returns** — which for an `async` callback is at its **first incomplete `await`**, not at task completion. So a `Start()` arriving while a previous async run was still in flight fired a **second concurrent** `loopAction()`, and the first run's trailing `IsRunning = false` could clobber the second run's `IsRunning = true`. The pub/sub wake path calls `Start()` on every inbound message, so back-to-back wakes during a drain make this realistically reachable, not a remote edge case.

The careful "publish `IsRunning = true` before `Set()`" ordering only protects the **sync** loop, whose callback doesn't return until `loopAction()` completes — the async path is the case it didn't cover.

## Fix

Gate the async loop with a lock-guarded `_runActive` / `_runPending` pair (the issue's "interlocked in-progress flag that coalesces overlapping signals into a single trailing run" option):

- A callback that finds a run already active records `_runPending` and bows out, so **two `loopAction()` calls never overlap**.
- The active run consumes `_runPending` in a `do/while`, so **any number of mid-run signals coalesce into exactly one trailing pass** (no lost wakes, no unbounded re-runs).
- `IsRunning` is set `true` on claim and reset `false` only at the gated exit, both under the lock, so a finishing run can't clobber a fresh run's state.

The lock is held only for the brief state transitions, **never across the awaited `loopAction`**. The **sync path is untouched** (it isn't vulnerable — its callback returns only after `loopAction()` completes). I chose this over re-registering with `executeOnlyOnce: true` to avoid per-run wait re-registration on the hot pub/sub wake path and the extra coordination it would need with `Kill()`/`Dispose()`.

## How it addresses the issue

- No overlapping async runs; `IsRunning` reaches a stable terminal value.
- Two concurrent drain passes over the same write-behind / cache-reload queue can no longer happen.

## Test plan

- [x] New concurrency test `AsyncWorker_SignaledRepeatedlyDuringRun_NeverOverlapsAndSettlesNotRunning`: holds the first async run suspended mid-`await`, fires 20 `Start()`s while it's in flight, then asserts **max observed concurrency == 1**, that the coalesced trailing run still executed (signals not lost), and a stable terminal `IsRunning == false`.
- [x] **Verified the test reproduces the bug**: reverting the production fix makes the new test fail (concurrent runs drive max-concurrency past 1); with the fix it passes.
- [x] Ran the new test 5× to check for flakiness — green every time.
- [x] Full `Game.Infrastructure.Tests` suite green (58 passed), `dotnet build` clean (0 warnings / 0 errors).

Closes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016KuUMwx6QYptACoLmeBV7A)_