### PR TITLE
Make challenge type→statistic resolution total and fail-loud (#1137)

### DIFF
--- a/Game.Core.Tests/Progress/ChallengeTests.cs
+++ b/Game.Core.Tests/Progress/ChallengeTests.cs
@@ -66,6 +66,31 @@ namespace Game.Core.Tests.Progress
             Assert.False(playerChallenge.Completed);
         }
 
+        [Fact]
+        public void UpdateChallengeProgress_EveryChallengeType_AdvancesProgress_NeverSilentlyNoOps()
+        {
+            // Each challenge type must actually move progress when its tracked value is satisfied — a
+            // statistic-backed type from its statistic, LevelReached from the player's level. A type that
+            // is neither would fall through the fail-loud guard and throw, so this fails on a half-wired
+            // new type rather than letting it silently never progress.
+            var player = new PlayerBuilder().WithLevel(50).Build();
+
+            foreach (var type in Enum.GetValues<EChallengeType>())
+            {
+                var challenge = MakeChallenge(type, goal: 1);
+                var playerChallenge = new PlayerChallenge(challenge, progress: 0m, completed: false);
+                var statisticType = challenge.Type.StatisticType;
+                var statistics = statisticType is not null
+                    ? new[] { new PlayerStatistic { Type = statisticType.Id, EntityId = null, Value = 1m } }
+                    : [];
+                var progress = MakeProgress(player, statistics);
+
+                challenge.UpdateChallengeProgress(playerChallenge, progress);
+
+                Assert.True(playerChallenge.Completed, $"Challenge type {type} did not progress.");
+            }
+        }
+
         private static Challenge MakeChallenge(EChallengeType type, decimal goal, int? targetEntityId = null) => new()
         {
             Id = 0,

--- a/Game.Core.Tests/Progress/ChallengeTypeTests.cs
+++ b/Game.Core.Tests/Progress/ChallengeTypeTests.cs
@@ -135,5 +135,28 @@ namespace Game.Core.Tests.Progress
                 Assert.Equal(type, challengeType.Id);
             }
         }
+
+        [Fact]
+        public void EveryChallengeTypeEitherMapsToAStatisticOrIsExplicitlyHandled()
+        {
+            // The type→statistic resolution is total and fail-loud: every challenge type must either
+            // carry a backing statistic or be a deliberately statistic-less accumulator (LevelReached).
+            // A newly-added type with no GetStatisticType arm throws in the constructor rather than
+            // silently resolving to "no statistic" and never progressing.
+            var statisticLess = new HashSet<EChallengeType> { EChallengeType.LevelReached };
+
+            foreach (var type in Enum.GetValues<EChallengeType>())
+            {
+                var challengeType = new ChallengeType(type);
+                if (statisticLess.Contains(type))
+                {
+                    Assert.Null(challengeType.StatisticType);
+                }
+                else
+                {
+                    Assert.NotNull(challengeType.StatisticType);
+                }
+            }
+        }
     }
 }

--- a/Game.Core/Progress/Challenge.cs
+++ b/Game.Core/Progress/Challenge.cs
@@ -33,6 +33,14 @@ namespace Game.Core.Progress
                 // The player's level is always present, so the progress value is always real data.
                 playerChallenge.UpdateProgress(playerProgress.Player.Level, hasData: true);
             }
+            else
+            {
+                // A challenge type with no backing statistic must be explicitly handled above (like
+                // LevelReached). Falling through here means a new type was wired up only half-way and
+                // would otherwise silently never progress — fail loud instead.
+                throw new ArgumentOutOfRangeException(nameof(Type), Type.Id,
+                    $"Challenge type {Type.Id} has no backing statistic and no progress handling.");
+            }
         }
     }
 }

--- a/Game.Core/Progress/ChallengeType.cs
+++ b/Game.Core/Progress/ChallengeType.cs
@@ -44,7 +44,12 @@
                 EChallengeType.DamageDealt => EStatisticType.DamageDealt,
                 EChallengeType.BattlesWon => EStatisticType.BattlesWon,
                 EChallengeType.SkillsUsed => EStatisticType.SkillsUsed,
-                _ => null
+                // LevelReached accumulates the player's level directly and has no backing statistic;
+                // UpdateChallengeProgress special-cases it. Listed explicitly so the default arm can
+                // fail loud on a newly-added type that was wired up only half-way.
+                EChallengeType.LevelReached => null,
+                _ => throw new ArgumentOutOfRangeException(nameof(id), id,
+                    $"No statistic mapping defined for challenge type {id}.")
             };
         }
     }


### PR DESCRIPTION
## Summary

Fixes **#1137**. A new `EChallengeType` added without both (a) a `GetStatisticType` arm and (b) a branch in `UpdateChallengeProgress` would have its challenges **silently never progress** — no exception, no completion, its reward permanently unreachable. That contradicted the project's fail-loud convention for enum dispatch. This closes both halves of that gap.

## Changes

- **`ChallengeType.GetStatisticType`** — added an explicit `EChallengeType.LevelReached => null` arm and replaced the catch-all `_ => null` with a `throw new ArgumentOutOfRangeException`. The type→statistic resolution is now total: a newly-added type with no mapping arm throws in the `ChallengeType` constructor, which runs eagerly at cache build (so it surfaces as a boot failure, not a silent runtime no-op).
- **`Challenge.UpdateChallengeProgress`** — added a final `else` that throws for any statistic-less type that isn't explicitly handled (currently only `LevelReached`). This closes the second half: a new type given a `null` statistic mapping but no progress branch would otherwise still silently no-op.

## How it addresses the issue

Both required wiring points are now fail-loud, so a challenge type can no longer be wired up half-way without a loud, diagnosable failure naming the offending type — rather than shipping a challenge whose reward is permanently unreachable.

## Tests

- `ChallengeTypeTests.EveryChallengeTypeEitherMapsToAStatisticOrIsExplicitlyHandled` — asserts every `EChallengeType` either carries a backing statistic or is the deliberate statistic-less accumulator (`LevelReached`), with no silent fall-through.
- `ChallengeTests.UpdateChallengeProgress_EveryChallengeType_AdvancesProgress_NeverSilentlyNoOps` — drives `UpdateChallengeProgress` for every type with satisfying data and asserts each completes, so a half-wired new type trips the fail-loud guard instead of silently never progressing.

## Test plan

- [x] `dotnet build Game.Core` — clean (0 warnings / 0 errors).
- [x] Full `Game.Core.Tests` suite green (**729 passed, 0 failed**).

Closes #1137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017t3HkdPiaQ1tSogauqfJrU)_