### PR TITLE
Fix torn read in Zones reference repo across build-then-swap (#1139)

### DIFF
--- a/Game.DataAccess/Repositories/Zones.cs
+++ b/Game.DataAccess/Repositories/Zones.cs
@@ -20,33 +20,44 @@ namespace Game.DataAccess.Repositories
 
         public Contracts.Zone GetZone(int zoneId)
         {
-            return ValidateZoneId(zoneId)
-                ? ZoneMapper.ToContract(Entities[zoneId])
+            // Capture the volatile snapshot once so the bounds check and the index read the same list;
+            // a build-then-swap publishing a shorter snapshot between the two reads would otherwise tear.
+            var entities = holder.Current;
+            return IsValidZoneId(entities, zoneId)
+                ? ZoneMapper.ToContract(entities[zoneId])
                 : throw new ArgumentOutOfRangeException(nameof(zoneId));
         }
 
         public Core.Zones.Zone GetDomainZone(int zoneId)
         {
-            return ValidateZoneId(zoneId)
-                ? ZoneMapper.ToCore(Entities[zoneId])
+            var entities = holder.Current;
+            return IsValidZoneId(entities, zoneId)
+                ? ZoneMapper.ToCore(entities[zoneId])
                 : throw new ArgumentOutOfRangeException(nameof(zoneId));
         }
 
         public Zone? LookupZone(int zoneId)
         {
-            return ValidateZoneId(zoneId) ? Entities[zoneId] : null;
+            var entities = holder.Current;
+            return IsValidZoneId(entities, zoneId) ? entities[zoneId] : null;
         }
 
         public bool IsZoneRetired(int zoneId)
         {
-            return ValidateZoneId(zoneId)
-                ? Entities[zoneId].RetiredAt is not null
+            var entities = holder.Current;
+            return IsValidZoneId(entities, zoneId)
+                ? entities[zoneId].RetiredAt is not null
                 : throw new ArgumentOutOfRangeException(nameof(zoneId));
         }
 
         public bool ValidateZoneId(int zoneId)
         {
-            return zoneId >= 0 && zoneId < Entities.Count;
+            return IsValidZoneId(holder.Current, zoneId);
+        }
+
+        private static bool IsValidZoneId(IReadOnlyList<Zone> entities, int zoneId)
+        {
+            return zoneId >= 0 && zoneId < entities.Count;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the torn read in `Game.DataAccess/Repositories/Zones.cs` flagged in #1139. Each lookup (`GetZone` / `GetDomainZone` / `LookupZone` / `IsZoneRetired`) called `ValidateZoneId(zoneId)` — which read `Entities.Count` (read #1 of the volatile snapshot) — and then indexed `Entities[zoneId]` (read #2). A build-then-swap publishing a *shorter* snapshot between the two reads could pass validation against the old list and throw `IndexOutOfRangeException` against the new one on a hot zone lookup during an admin-triggered reload.

## How it addresses the issue

- Each lookup now captures `holder.Current` **once** into a local and runs both the bounds check and the index against that same list — the exact snapshot-capture pattern `Enemies` already uses (`var snapshot = Snapshot;`).
- Extracted a private `IsValidZoneId(IReadOnlyList<Zone> entities, int zoneId)` helper so the bounds check operates on the captured local. The public `ValidateZoneId(int zoneId)` (on `IZones`, called by `Enemies`/`BattleService`) is preserved and delegates to the helper — it was already a single volatile read, so it never teared on its own.

No behavior change for valid or invalid ids; this is correctness hardening for the concurrent reload window.

## Test plan

- [x] `dotnet build Game.DataAccess` — clean, 0 warnings.
- [x] `ZonesIntegrationTests` (14 tests) green — covers `GetZone`/`GetDomainZone`/`LookupZone`/`IsZoneRetired` valid + invalid-id paths.

## Note on test coverage

I did not add a dedicated torn-read regression test. Reproducing the race deterministically requires injecting a snapshot swap *between* the two reads, but `ZonesCacheHolder` is `internal sealed` with a private, non-injectable `_current`, and `Zones` depends on the concrete holder — so a deterministic test would mean adding production seams that exist only for the test. This matches how the identical `Enemies` capture pattern is covered (integration tests pin behavior; the capture itself is verified by reasoning). Happy to add a fakeable seam + unit test if preferred.

Closes #1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmdJuwGS3R2JXmg39S4Xcw)_