### PR TITLE
Clear Loading.svelte reveal-delay timer on unmount (#1140)

### DIFF
--- a/UI/src/components/Loading.svelte
+++ b/UI/src/components/Loading.svelte
@@ -33,9 +33,11 @@ let waitingOnDelay = $state(true);
 
 onMount(() => {
 	waitingOnDelay = !!delay;
-	if (delay) {
-		setTimeout(() => (waitingOnDelay = false), delay);
+	if (!delay) {
+		return;
 	}
+	const timer = setTimeout(() => (waitingOnDelay = false), delay);
+	return () => clearTimeout(timer);
 });
 
 const offset = Math.floor(Math.random() * 360);

--- a/UI/src/tests/components/Loading.test.ts
+++ b/UI/src/tests/components/Loading.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
 import Loading from '$components/Loading.svelte';
 
@@ -40,5 +40,21 @@ describe('Loading', () => {
 		// until the timeout fires even though loading=true.
 		const { container } = render(Loading, { props: { loading: true, delay: 500 } });
 		expect(container.querySelector('.loading-spinner-container')).toBeNull();
+	});
+
+	it('clears the reveal-delay timer on unmount so it never fires after destroy', () => {
+		const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+		const { unmount } = render(Loading, { props: { loading: true, delay: 500 } });
+		unmount();
+		expect(clearSpy).toHaveBeenCalled();
+		clearSpy.mockRestore();
+	});
+
+	it('does not arm a timer when no delay is set', () => {
+		const setSpy = vi.spyOn(globalThis, 'setTimeout');
+		const { unmount } = render(Loading, { props: { loading: true } });
+		expect(setSpy).not.toHaveBeenCalled();
+		unmount();
+		setSpy.mockRestore();
 	});
 });


### PR DESCRIPTION
## Summary

`Loading.svelte` armed a reveal-delay `setTimeout` in `onMount` but never cleared it. When a `Loading` with a `delay` unmounts before the delay elapses — exactly the case the delay exists for, a spinner that resolves before its reveal delay — the timer still fired and wrote `$state` (`waitingOnDelay`) on a destroyed component. Every other timer in the codebase (CombatFloaters, ToastContainer, LivePreview) is tracked and cleared; this was the lone exception.

## How it addresses the issue

`onMount` now returns a cleanup function that clears the timer, so the pending write can never run after the component is destroyed:

```js
onMount(() => {
    waitingOnDelay = !!delay;
    if (!delay) {
        return;
    }
    const timer = setTimeout(() => (waitingOnDelay = false), delay);
    return () => clearTimeout(timer);
});
```

## Test plan

- [x] Added a test asserting the reveal-delay timer is cleared on unmount.
- [x] Added a test asserting no timer is armed when no `delay` is set.
- [x] `npx vitest --run Loading` — all green.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.

Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATWg3pvxYe5A4T4uQnBMYD)_