### PR TITLE
Route CharacterSwitcher through the shared Popover overlay primitive

### DIFF
--- a/UI/src/routes/game/+page.svelte
+++ b/UI/src/routes/game/+page.svelte
@@ -17,9 +17,7 @@
 
 		<NavSidebar bind:pinned={sidebarPinned} {screens} active={currentScreen} onNavigate={handleNavigate} />
 
-		{#if showSwitcher}
-			<CharacterSwitcher onClose={() => (showSwitcher = false)} />
-		{/if}
+		<CharacterSwitcher open={showSwitcher} onClose={() => (showSwitcher = false)} />
 	</div>
 {:else}
 	<BootSplash />

--- a/UI/src/routes/game/CharacterSwitcher.svelte
+++ b/UI/src/routes/game/CharacterSwitcher.svelte
@@ -7,16 +7,10 @@
 
 	The game keeps running while the overlay is open, so cancelling is instant and lossless; only committing
 	to a switch tears anything down. -->
-<div
-	class="switcher-backdrop"
-	role="dialog"
-	aria-modal="true"
-	aria-label="Switch character"
-	data-testid="character-switcher"
-	tabindex="-1"
-	onkeydown={(e) => e.key === 'Escape' && onClose()}
->
-	<div class="switcher-panel">
+<!-- The overlay chrome (backdrop, Escape dismissal, focus trap, focus capture+restore, scroll lock) is
+	owned by the shared `Popover` primitive per docs/frontend.md; this component supplies only the content. -->
+<Popover {open} {onClose} label="Switch character" closeLabel="Cancel">
+	<div class="switcher-panel" data-testid="character-switcher">
 		{#if phase === 'loading'}
 			<div class="status-state" data-testid="switcher-loading">Loading characters…</div>
 			<button type="button" class="cancel" onclick={onClose}>Cancel</button>
@@ -42,22 +36,24 @@
 			</PlayerSelectPanel>
 		{/if}
 	</div>
-</div>
+</Popover>
 
 <script lang="ts">
-import { onMount } from 'svelte';
 import { ApiRequest, apiSocket, getRefreshToken, setTokens } from '$lib/api';
 import { playerManager, stopEngines } from '$lib/engine';
+import Popover from '$components/Popover.svelte';
 import { confirmSessionTakeover } from '../login/session-takeover';
 import PlayerSelectPanel from '../select/PlayerSelectPanel.svelte';
 import { PlayerSelectView, type PlayerSelectDeps } from '../select/player-select-view.svelte';
 
 interface Props {
+	/** Whether the switcher overlay is shown. The character list (re)loads each time it opens. */
+	open: boolean;
 	/** Closes the overlay, leaving the running game untouched. */
 	onClose: () => void;
 }
 
-let { onClose }: Props = $props();
+let { open, onClose }: Props = $props();
 
 type Phase = 'loading' | 'error' | 'ready';
 let phase = $state<Phase>('loading');
@@ -108,7 +104,11 @@ const reloadToBoot = () => {
 };
 const enterWorld = reloadToBoot;
 
-onMount(async () => {
+const loadCharacters = async () => {
+	phase = 'loading';
+	loadError = null;
+	view = null;
+
 	const response = await new ApiRequest('Login/Players').get();
 	if (response.status !== 200 || !response.data) {
 		loadError = response.error ?? 'Could not load your characters.';
@@ -123,22 +123,17 @@ onMount(async () => {
 		others
 	);
 	phase = 'ready';
+};
+
+// Load (fresh) whenever the overlay opens; while closed the Popover renders nothing and no fetch runs.
+$effect(() => {
+	if (open) {
+		void loadCharacters();
+	}
 });
 </script>
 
 <style lang="scss">
-.switcher-backdrop {
-	position: fixed;
-	inset: 0;
-	z-index: 50;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	padding: 40px;
-	background: color-mix(in srgb, var(--black) 62%, transparent);
-	backdrop-filter: blur(3px);
-}
-
 .switcher-panel {
 	width: 400px;
 	max-width: 100%;

--- a/UI/src/tests/routes/game/character-switcher.test.ts
+++ b/UI/src/tests/routes/game/character-switcher.test.ts
@@ -64,7 +64,7 @@ afterEach(() => {
 
 describe('CharacterSwitcher', () => {
 	it('lists the account characters, excluding the one currently being played', async () => {
-		render(CharacterSwitcher, { onClose: vi.fn() });
+		render(CharacterSwitcher, { open: true, onClose: vi.fn() });
 
 		await waitFor(() => expect(screen.getAllByTestId('player-card')).toHaveLength(1));
 		expect(screen.getByText('Rogue')).toBeTruthy();
@@ -77,7 +77,7 @@ describe('CharacterSwitcher', () => {
 			status: 200,
 			data: { tokens: { accessToken: 'a2', refreshToken: 'r2' }, player: { id: 2, name: 'Rogue' } }
 		});
-		render(CharacterSwitcher, { onClose: vi.fn() });
+		render(CharacterSwitcher, { open: true, onClose: vi.fn() });
 
 		await waitFor(() => expect(screen.getAllByTestId('player-card')).toHaveLength(1));
 		await fireEvent.click(screen.getAllByTestId('player-card')[0]);
@@ -95,7 +95,7 @@ describe('CharacterSwitcher', () => {
 
 	it('recovers with a reload when the switch fails after teardown', async () => {
 		postMock.mockResolvedValue({ status: 400, error: 'nope' });
-		render(CharacterSwitcher, { onClose: vi.fn() });
+		render(CharacterSwitcher, { open: true, onClose: vi.fn() });
 
 		await waitFor(() => expect(screen.getAllByTestId('player-card')).toHaveLength(1));
 		await fireEvent.click(screen.getAllByTestId('player-card')[0]);
@@ -108,7 +108,7 @@ describe('CharacterSwitcher', () => {
 
 	it('closes without touching the game when cancelled', async () => {
 		const onClose = vi.fn();
-		render(CharacterSwitcher, { onClose });
+		render(CharacterSwitcher, { open: true, onClose });
 
 		await waitFor(() => expect(screen.getByTestId('switcher-cancel')).toBeTruthy());
 		await fireEvent.click(screen.getByTestId('switcher-cancel'));
@@ -118,9 +118,26 @@ describe('CharacterSwitcher', () => {
 		expect(disconnectMock).not.toHaveBeenCalled();
 	});
 
+	it('closes on Escape via the shared overlay primitive', async () => {
+		const onClose = vi.fn();
+		render(CharacterSwitcher, { open: true, onClose });
+
+		await waitFor(() => expect(screen.getByTestId('switcher-cancel')).toBeTruthy());
+		await fireEvent.keyDown(window, { key: 'Escape' });
+
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('does not load characters while closed', async () => {
+		render(CharacterSwitcher, { open: false, onClose: vi.fn() });
+
+		expect(getMock).not.toHaveBeenCalled();
+		expect(screen.queryByTestId('character-switcher')).toBeNull();
+	});
+
 	it('surfaces an error state when the character list fails to load', async () => {
 		getMock.mockResolvedValue({ status: 500, error: 'boom' });
-		render(CharacterSwitcher, { onClose: vi.fn() });
+		render(CharacterSwitcher, { open: true, onClose: vi.fn() });
 
 		await waitFor(() => expect(screen.getByTestId('switcher-error')).toBeTruthy());
 		expect(screen.getByText('boom')).toBeTruthy();
@@ -131,7 +148,7 @@ describe('CharacterSwitcher', () => {
 			status: 200,
 			data: { id: 9, name: 'Mage', level: 1, currentZoneId: 0, lastActivity: '2026-06-21T00:00:00Z' }
 		});
-		render(CharacterSwitcher, { onClose: vi.fn() });
+		render(CharacterSwitcher, { open: true, onClose: vi.fn() });
 
 		await waitFor(() => expect(screen.getAllByTestId('player-card')).toHaveLength(1));
 		await fireEvent.click(screen.getByTestId('show-create'));


### PR DESCRIPTION
## Summary

The in-game character switcher (`UI/src/routes/game/CharacterSwitcher.svelte`) hand-rolled a modal backdrop that declared `role="dialog"`/`aria-modal="true"` but had no real focus management:

- Nothing focused the dialog on mount, so the Escape handler only fired if focus already happened to be inside the panel.
- There was no focus trap and no focus restore on close.

`docs/frontend.md` / `docs/frontend-overlays.md` say to prefer the shared overlay primitives over a hand-rolled backdrop. This PR routes the switcher through the existing `Popover` primitive, which owns the entire interaction model the content should stay free of: backdrop/Escape dismissal, a focus trap, focus capture+restore, and a body scroll lock.

## How it addresses the issue

- Replaced the bespoke `.switcher-backdrop` (and its inline `onkeydown` Escape handler, `role`/`aria-modal`/`tabindex`) with `<Popover open={open} onClose={onClose} label="Switch character" closeLabel="Cancel">`. The component now supplies only its content.
- Made the switcher `open`-driven (a new `open` prop) instead of mount-gated by the parent's `{#if showSwitcher}`, mirroring `SortFilterModal`. This keeps `Popover` mounted across the close transition so its focus-restore effect can return focus to the trigger — a `{#if}` unmount would skip it.
- The character list now (re)loads via an `open`-gated `$effect` each time the overlay opens; while closed, `Popover` renders nothing and no fetch runs.
- Removed the now-dead backdrop styles.

`Popover`'s focus trap / focus restore / Escape behavior is already thoroughly covered by `Popover.test.ts`, so the switcher only needs to verify it delegates correctly.

### Note on import style

`Popover` is imported via its direct path (`$components/Popover.svelte`) rather than the `$components` barrel that `SortFilterModal` uses. The barrel re-exports `ChallengeTooltip`, `log-panel`, and `nav-menu`, which drag heavy transitive `$lib` dependencies into the switcher's isolated unit test (which fully mocks `$lib/api`). The direct import keeps the unit boundary clean.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — 2427 passed
- [x] Updated `character-switcher.test.ts` to pass `open: true`, plus two new tests: Escape dismissal delegated to the overlay, and no character load while closed.

Closes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011f4jjzN9cEhYEWzmrisRCj)_