### PR TITLE
Remove HTTP/JSON leak from Game.Core domain Extensions

### DIFF
--- a/Game.Api.Tests/CodeGen/CodeGenExtensionsTests.cs
+++ b/Game.Api.Tests/CodeGen/CodeGenExtensionsTests.cs
@@ -223,5 +223,31 @@ namespace Game.Api.Tests.CodeGen
         {
             Assert.False(typeof(Dictionary<string, int>).NeedsInterface());
         }
+
+        [Theory]
+        [InlineData("HelloWorld", "helloWorld")]
+        [InlineData("A", "a")]
+        [InlineData("alreadyLower", "alreadyLower")]
+        public void Decapitalize_LowercasesFirstCharacter(string input, string expected)
+        {
+            Assert.Equal(expected, input.Decapitalize());
+        }
+
+        [Fact]
+        public void Decapitalize_EmptyString_ReturnsEmpty()
+        {
+            Assert.Equal("", "".Decapitalize());
+        }
+
+        [Theory]
+        [InlineData("HelloWorld", "hello-world")]
+        [InlineData("oneTwoThree", "one-two-three")]
+        [InlineData("NoBreaks", "no-breaks")]
+        [InlineData("nobreak", "nobreak")]
+        [InlineData("", "")]
+        public void SnakeCase_InsertsHyphenBetweenLowerThenUpperAndLowercases(string input, string expected)
+        {
+            Assert.Equal(expected, input.SnakeCase());
+        }
     }
 }

--- a/Game.Api/CodeGen/Extensions.cs
+++ b/Game.Api/CodeGen/Extensions.cs
@@ -1,9 +1,28 @@
 ﻿using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace Game.Api.CodeGen
 {
-    internal static class CodeGenExtensions
+    internal static partial class CodeGenExtensions
     {
+        /// <summary>
+        /// Returns a copy of this string, but the first letter is lowercase. An empty string is returned unchanged.
+        /// Used to emit camelCase TypeScript identifiers from PascalCase member names.
+        /// </summary>
+        internal static string Decapitalize(this string str)
+        {
+            return str.Length == 0 ? str : string.Concat(str[0].ToString().ToLower(), str.AsSpan(1));
+        }
+
+        /// <summary>
+        /// Returns a copy of this string, but each sequence of a lowercase character followed by an uppercase character has a "-"
+        /// inserted between the characters then the entire string is converted to lowercase. Used to emit kebab-cased file names.
+        /// </summary>
+        internal static string SnakeCase(this string str)
+        {
+            return WordBreakRegex().Replace(str, "$1-$2").ToLower();
+        }
+
         internal static NullabilityInfo GetNullabilityInfo(this ParameterInfo parameter)
         {
             var nullabilityContext = new NullabilityInfoContext();
@@ -100,5 +119,8 @@ namespace Game.Api.CodeGen
         {
             return type.IsValueType && MirroredStructs.Contains(type);
         }
+
+        [GeneratedRegex("([a-z])([A-Z])")]
+        private static partial Regex WordBreakRegex();
     }
 }

--- a/Game.Core.Tests/ExtensionsTests.cs
+++ b/Game.Core.Tests/ExtensionsTests.cs
@@ -8,47 +8,6 @@ namespace Game.Core.Tests
         private record Sample(int Id, string Name);
 
         [Fact]
-        public void ToBase64_NonNull_EncodesToStringRepresentation()
-        {
-            // "abc" UTF-8 -> base64
-            Assert.Equal("YWJj", "abc".ToBase64());
-        }
-
-        [Fact]
-        public void ToBase64_NullReceiver_EncodesEmptyString()
-        {
-            string? value = null;
-
-            // The null-coalescing path falls back to "" which encodes to an empty base64 string.
-            Assert.Equal("", value.ToBase64());
-        }
-
-        [Fact]
-        public void Deserialize_HttpResponseWithContent_RoundTripsObject()
-        {
-            var original = new Sample(7, "thing");
-            using var msg = new HttpResponseMessage
-            {
-                Content = new StringContent(original.Serialize()),
-            };
-
-            var result = msg.Deserialize<Sample>();
-
-            Assert.Equal(original, result);
-        }
-
-        [Fact]
-        public void Deserialize_HttpResponseWithEmptyStream_ReturnsDefault()
-        {
-            using var msg = new HttpResponseMessage
-            {
-                Content = new StringContent(""),
-            };
-
-            Assert.Null(msg.Deserialize<Sample>());
-        }
-
-        [Fact]
         public void Deserialize_NonNullString_RoundTripsObject()
         {
             var original = new Sample(3, "json");
@@ -105,21 +64,6 @@ namespace Game.Core.Tests
         }
 
         [Theory]
-        [InlineData("HelloWorld", "helloWorld")]
-        [InlineData("A", "a")]
-        [InlineData("alreadyLower", "alreadyLower")]
-        public void Decapitalize_LowercasesFirstCharacter(string input, string expected)
-        {
-            Assert.Equal(expected, input.Decapitalize());
-        }
-
-        [Fact]
-        public void Decapitalize_EmptyString_ReturnsEmpty()
-        {
-            Assert.Equal("", "".Decapitalize());
-        }
-
-        [Theory]
         [InlineData("helloWorld", "HelloWorld")]
         [InlineData("a", "A")]
         [InlineData("AlreadyUpper", "AlreadyUpper")]
@@ -143,17 +87,6 @@ namespace Game.Core.Tests
         public void SpaceWords_InsertsSpaceBetweenLowerThenUpper(string input, string expected)
         {
             Assert.Equal(expected, input.SpaceWords());
-        }
-
-        [Theory]
-        [InlineData("HelloWorld", "hello-world")]
-        [InlineData("oneTwoThree", "one-two-three")]
-        [InlineData("NoBreaks", "no-breaks")]
-        [InlineData("nobreak", "nobreak")]
-        [InlineData("", "")]
-        public void SnakeCase_InsertsHyphenBetweenLowerThenUpperAndLowercases(string input, string expected)
-        {
-            Assert.Equal(expected, input.SnakeCase());
         }
     }
 }

--- a/Game.Core/Extensions.cs
+++ b/Game.Core/Extensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.RegularExpressions;
 
 namespace Game.Core
@@ -10,26 +9,6 @@ namespace Game.Core
     public static partial class Extensions
     {
         private static readonly JsonSerializerOptions _options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-
-        /// <summary>
-        /// Converts this object to a string using its <see cref="object.ToString"/> method then converts that to a base64 string representation.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="obj"></param>
-        /// <returns>A base64 <see cref="string"/> representation of this object.</returns>
-        public static string ToBase64<T>(this T obj)
-        {
-            return Convert.ToBase64String(Encoding.UTF8.GetBytes(obj?.ToString() ?? ""));
-        }
-
-        /// <summary>
-        /// Reads the <see cref="HttpRequestMessage.Content"/> as a JSON stream and deserializes it to an object of type <typeparamref name="T"/>.
-        /// </summary>
-        public static T? Deserialize<T>(this HttpResponseMessage msg)
-        {
-            var stream = msg.Content.ReadAsStream();
-            return stream.Length > 0 ? JsonSerializer.Deserialize<T>(stream, _options) : default;
-        }
 
         /// <summary>
         /// Deserializes this string from JSON to an object of type <typeparamref name="T"/>.
@@ -108,16 +87,6 @@ namespace Game.Core
         }
 
         /// <summary>
-        /// Returns a copy of this string, but the first letter is lowercase. An empty string is returned unchanged.
-        /// </summary>
-        /// <param name="str"></param>
-        /// <returns>A string with the first letter lowercase.</returns>
-        public static string Decapitalize(this string str)
-        {
-            return str.Length == 0 ? str : string.Concat(str[0].ToString().ToLower(), str.AsSpan(1));
-        }
-
-        /// <summary>
         /// Returns a copy of this string, but the first letter is uppercase. An empty string is returned unchanged.
         /// </summary>
         /// <param name="str"></param>
@@ -135,17 +104,6 @@ namespace Game.Core
         public static string SpaceWords(this string str)
         {
             return WordBreakRegex().Replace(str, "$1 $2");
-        }
-
-        /// <summary>
-        /// Returns a copy of this string, but each sequence of a lowercase character followed by an uppercase character has a "-" inserted between the characters
-        /// then the entire string is converted to lowercase.
-        /// </summary>
-        /// <param name="str"></param>
-        /// <returns>A string in lowercase with "-"s between each lowercase character followed by an uppercase character in the original string.</returns>
-        public static string SnakeCase(this string str)
-        {
-            return WordBreakRegex().Replace(str, "$1-$2").ToLower();
         }
 
         [GeneratedRegex("([a-z])([A-Z])")]


### PR DESCRIPTION
## Summary

`Game.Core/Extensions.cs` (the domain layer) carried helpers that pulled HTTP/codegen concerns into the heart of the game logic. Per the onion architecture (`docs/backend.md` → File Structure), `Game.Core` should not know about `HttpResponseMessage`. This addresses #1142.

## Changes

- **Removed `ToBase64<T>` and `Deserialize<T>(HttpResponseMessage)` outright** rather than relocating them. Investigation showed **both are dead** — their only references are their own unit tests (no production consumer anywhere in the solution). Removing the `HttpResponseMessage` overload also drops the `System.Net.Http` coupling from the domain project, which was the core of the issue.
- **Relocated `Decapitalize` and `SnakeCase` to `Game.Api/CodeGen/CodeGenExtensions`**, their sole consumers (`CodeGenTypeFormatter` / `CodeGenTypeDescriptor`). They emit TypeScript naming conventions, so they belong with the codegen, not in the domain.
- **`Capitalize` / `SpaceWords` stay in `Game.Core`** — they're used by domain models (`EquipmentSlot`, `Attribute`, `Rarity`, `*Type`) and reference-data seeding (`GameContext`), and carry no transport concern.
- Tests moved alongside the methods (`ExtensionsTests` → `CodeGenExtensionsTests` for the two relocated helpers).

### Note on the issue's framing

The issue suggested *relocating* `ToBase64`/`Deserialize(HttpResponseMessage)` "alongside their actual consumers" and *removing* `SnakeCase`/`Decapitalize` "if genuinely unused". The actual state was the inverse: the first two have **no** consumers (so relocating would just move dead code → removed), while `SnakeCase`/`Decapitalize` **are** consumed by `Game.Api/CodeGen` (so they move, not delete). The string-based `Serialize`/`Deserialize(string)` JSON helpers were left in place — they're heavily used across the data/infra tiers and carry no HTTP concern, so they're out of scope.

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings
- [x] `Game.Core.Tests` `ExtensionsTests` — 15 passed
- [x] `Game.Api.Tests` CodeGen namespace (incl. relocated `Decapitalize`/`SnakeCase` tests) — 214 passed

Closes #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNUcijEYHFz3KJBemCpT7Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNUcijEYHFz3KJBemCpT7Z)_