### PR TITLE
Backend minor cleanups: allocation nits, dead defensive code, conventions (#1143)

### DIFF
--- a/Game.Application.Tests/DataAccess/ReferenceDataSharedInstanceTests.cs
+++ b/Game.Application.Tests/DataAccess/ReferenceDataSharedInstanceTests.cs
@@ -181,6 +181,31 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task GetDomainZone_ReturnsSharedInstanceAndCorrectData()
+        {
+            int zoneId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                zoneId = (await TestDataSeeder.CreateZoneAsync(context, "Shared Zone", levelMin: 4, levelMax: 7)).Id;
+            }
+
+            await ReloadReferenceCachesAsync();
+
+            using var scope = CreateScope();
+            var zones = scope.ServiceProvider.GetRequiredService<IZones>();
+
+            var first = zones.GetDomainZone(zoneId);
+            var second = zones.GetDomainZone(zoneId);
+
+            // The optimization: repeated reads hand back the snapshot's pre-materialized instance, not a fresh map.
+            Assert.Same(first, second);
+            Assert.Equal(zoneId, first.Id);
+            Assert.Equal(4, first.LevelMin);
+            Assert.Equal(7, first.LevelMax);
+        }
+
+        [Fact]
         public async Task ChallengesAll_ReturnsSnapshotDirectlyWithoutCopying()
         {
             int challengeId;

--- a/Game.Core/AggregateRoot.cs
+++ b/Game.Core/AggregateRoot.cs
@@ -1,4 +1,5 @@
 using Game.Core.Events;
+using System.Collections.ObjectModel;
 
 namespace Game.Core
 {
@@ -11,10 +12,19 @@ namespace Game.Core
     {
         private readonly List<IDomainEvent> _domainEvents = [];
 
+        // A ReadOnlyCollection is a live view over the backing list, so the wrapper is built once and reused
+        // rather than re-allocated on every get — the dispatcher reads Count then ToArray per drain iteration.
+        private readonly ReadOnlyCollection<IDomainEvent> _domainEventsView;
+
+        protected AggregateRoot()
+        {
+            _domainEventsView = _domainEvents.AsReadOnly();
+        }
+
         /// <summary>
         /// Domain events raised during the current operation.
         /// </summary>
-        public IReadOnlyList<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+        public IReadOnlyList<IDomainEvent> DomainEvents => _domainEventsView;
 
         /// <summary>
         /// Records a domain event to be dispatched by the application layer.

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -173,6 +173,9 @@ namespace Game.Core.Players
         /// </summary>
         public void UnlockSkill(Skill skill)
         {
+            // A linear "already unlocked?" scan, unlike the deliberately O(1) UnlockItem/UnlockMod paths.
+            // Skills grow far slower than items (and aren't read on the battle-start hot path the way the
+            // unlocked-item set is), so the scan over the small skill count is acceptable here.
             if (!Skills.Any(s => s.Id == skill.Id))
             {
                 Skills.Add(skill);

--- a/Game.DataAccess/Constants.cs
+++ b/Game.DataAccess/Constants.cs
@@ -1,6 +1,6 @@
 ﻿namespace Game.DataAccess
 {
-    internal class Constants
+    internal static class Constants
     {
         internal const string CACHE_SESSION_PREFIX = "Session";
         internal const string CACHE_PLAYER_PREFIX = "Player";

--- a/Game.DataAccess/Mapping/EnemyMapper.cs
+++ b/Game.DataAccess/Mapping/EnemyMapper.cs
@@ -2,6 +2,7 @@ using Game.Core;
 using Game.Core.Attributes;
 using Game.Core.Enemies;
 using Contracts = Game.Abstractions.Contracts;
+using CoreSkill = Game.Core.Skills.Skill;
 using EntityEnemy = Game.Infrastructure.Entities.Enemy;
 using EntitySkill = Game.Infrastructure.Entities.Skill;
 
@@ -57,16 +58,30 @@ namespace Game.DataAccess.Mapping
                         BaseAmount = ad.BaseAmount,
                         AmountPerLevel = ad.AmountPerLevel,
                     }).ToList(),
-                // The cached skill list is the zero-based, contiguous-id reference set (docs/backend.md
-                // → Reference Data), so a skill resolves by direct index instead of a per-call dictionary.
-                // A persisted EnemySkill.SkillId is FK-guaranteed in range against the contiguity-asserted
-                // skill set, so the index always resolves; an out-of-range id would be content-data
-                // corruption and throws loudly here rather than silently dropping the skill (the loud-fail
-                // policy the player-load path enforces, vs. the prior skip-if-missing filter).
                 AvailableSkills = entity.EnemySkills
-                    .Select(es => SkillMapper.ToCore(allSkills[es.SkillId]))
+                    .Select(es => ResolveSkill(entity, es.SkillId, allSkills))
                     .ToList(),
             };
+        }
+
+        /// <summary>
+        /// Resolves an enemy's available skill by direct index into the cached, zero-based, contiguous-id
+        /// skill set (docs/backend.md → Reference Data). A persisted <c>EnemySkill.SkillId</c> is
+        /// FK-guaranteed in range against the (contiguity-asserted) skill set, so this always resolves; an
+        /// out-of-range id can only be content-data corruption and fails loudly with a diagnosable message
+        /// naming the enemy and offending id — mirroring the player-load loud-fail policy rather than the
+        /// prior filter that silently dropped the skill from the loadout.
+        /// </summary>
+        private static CoreSkill ResolveSkill(EntityEnemy enemy, int skillId, IReadOnlyList<EntitySkill> allSkills)
+        {
+            if (skillId < 0 || skillId >= allSkills.Count)
+            {
+                throw new InvalidOperationException(
+                    $"Enemy {enemy.Id} ('{enemy.Name}') references a skill with Id {skillId} that does not " +
+                    "resolve against the skill catalog (a content-data mistake — a referenced id is out of range).");
+            }
+
+            return SkillMapper.ToCore(allSkills[skillId]);
         }
     }
 }

--- a/Game.DataAccess/Mapping/EnemyMapper.cs
+++ b/Game.DataAccess/Mapping/EnemyMapper.cs
@@ -59,10 +59,11 @@ namespace Game.DataAccess.Mapping
                     }).ToList(),
                 // The cached skill list is the zero-based, contiguous-id reference set (docs/backend.md
                 // → Reference Data), so a skill resolves by direct index instead of a per-call dictionary.
-                // The bounds check skips a malformed out-of-range ref, matching the prior skip-if-missing
-                // behaviour (a persisted EnemySkill.SkillId is FK-guaranteed in range, so it is defensive).
+                // A persisted EnemySkill.SkillId is FK-guaranteed in range against the contiguity-asserted
+                // skill set, so the index always resolves; an out-of-range id would be content-data
+                // corruption and throws loudly here rather than silently dropping the skill (the loud-fail
+                // policy the player-load path enforces, vs. the prior skip-if-missing filter).
                 AvailableSkills = entity.EnemySkills
-                    .Where(es => es.SkillId >= 0 && es.SkillId < allSkills.Count)
                     .Select(es => SkillMapper.ToCore(allSkills[es.SkillId]))
                     .ToList(),
             };

--- a/Game.DataAccess/Repositories/Caching/ZonesCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/ZonesCacheHolder.cs
@@ -1,15 +1,27 @@
+using Game.DataAccess.Mapping;
 using Game.Infrastructure.Database;
 using Game.Infrastructure.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using CoreZone = Game.Core.Zones.Zone;
 
 namespace Game.DataAccess.Repositories.Caching
 {
-    /// <summary>Singleton snapshot holder for the cached zone entity list.</summary>
+    /// <summary>
+    /// An immutable snapshot of the zone reference set: the ordered zone entity list and the lean
+    /// gameplay <see cref="CoreZone"/>s the per-battle setup reads hand back (aligned by zero-based id with
+    /// the entity list). Both are built and published together so a reader can never observe a new entity
+    /// list against stale (or null) domain models.
+    /// </summary>
+    internal sealed record ZoneSnapshot(
+        IReadOnlyList<Zone> Entities,
+        IReadOnlyList<CoreZone> CoreZones);
+
+    /// <summary>Singleton snapshot holder for the cached zone list and its pre-materialized domain models.</summary>
     internal sealed class ZonesCacheHolder(IServiceScopeFactory scopeFactory)
-        : ReferenceCacheHolder<IReadOnlyList<Zone>>(scopeFactory)
+        : ReferenceCacheHolder<ZoneSnapshot>(scopeFactory)
     {
-        protected override async Task<IReadOnlyList<Zone>> BuildSnapshotAsync(GameContext context, CancellationToken cancellationToken)
+        protected override async Task<ZoneSnapshot> BuildSnapshotAsync(GameContext context, CancellationToken cancellationToken)
         {
             var zones = await context.Zones
                 .AsNoTracking()
@@ -19,7 +31,11 @@ namespace Game.DataAccess.Repositories.Caching
 
             zones.AssertZeroBasedContiguity("Zones");
 
-            return zones;
+            // Pre-map the lean domain models once here (aligned by id with the entity list) so the gameplay
+            // reads hand back a shared instance rather than re-mapping a fresh CoreZone per battle setup.
+            var coreZones = zones.Select(ZoneMapper.ToCore).ToList();
+
+            return new ZoneSnapshot(zones, coreZones);
         }
     }
 }

--- a/Game.DataAccess/Repositories/Roles.cs
+++ b/Game.DataAccess/Repositories/Roles.cs
@@ -8,16 +8,19 @@ namespace Game.DataAccess.Repositories
     {
         // Roles are intrinsic reference data: the ERole enum is the source of truth and the database
         // is only seeded from it (see GameContext). There is therefore nothing to query — the full
-        // set can be constructed in memory directly from the enum.
+        // set is built once from the enum (avoiding the per-call reflection-backed ToString()).
+        private static readonly Role[] _roles = Enum.GetValues<ERole>()
+            .Select(role => new Role
+            {
+                Id = (int)role,
+                Name = role.ToString(),
+            })
+            .ToArray();
+
+        // Returns a fresh list per call so a caller cannot mutate the shared precomputed set.
         public List<Role> GetRoles()
         {
-            return Enum.GetValues<ERole>()
-                .Select(role => new Role
-                {
-                    Id = (int)role,
-                    Name = role.ToString(),
-                })
-                .ToList();
+            return [.. _roles];
         }
     }
 }

--- a/Game.DataAccess/Repositories/Zones.cs
+++ b/Game.DataAccess/Repositories/Zones.cs
@@ -8,21 +8,21 @@ namespace Game.DataAccess.Repositories
 {
     internal class Zones(ZonesCacheHolder holder) : IZones, IZoneEntityCache
     {
-        private IReadOnlyList<Zone> Entities => holder.Current;
+        // A single volatile read of the current snapshot; capturing it once per call keeps the bounds check
+        // and the index reading the same list, so a build-then-swap mid-call can never tear.
+        private ZoneSnapshot Snapshot => holder.Current;
 
         // The snapshot instance changes on every build-then-swap, so it doubles as the content-version key.
-        public object VersionKey => holder.Current;
+        public object VersionKey => Snapshot;
 
         public List<Contracts.Zone> All()
         {
-            return [.. Entities.Select(ZoneMapper.ToContract)];
+            return [.. Snapshot.Entities.Select(ZoneMapper.ToContract)];
         }
 
         public Contracts.Zone GetZone(int zoneId)
         {
-            // Capture the volatile snapshot once so the bounds check and the index read the same list;
-            // a build-then-swap publishing a shorter snapshot between the two reads would otherwise tear.
-            var entities = holder.Current;
+            var entities = Snapshot.Entities;
             return IsValidZoneId(entities, zoneId)
                 ? ZoneMapper.ToContract(entities[zoneId])
                 : throw new ArgumentOutOfRangeException(nameof(zoneId));
@@ -30,21 +30,24 @@ namespace Game.DataAccess.Repositories
 
         public Core.Zones.Zone GetDomainZone(int zoneId)
         {
-            var entities = holder.Current;
-            return IsValidZoneId(entities, zoneId)
-                ? ZoneMapper.ToCore(entities[zoneId])
+            // Hands back the snapshot's shared, pre-materialized domain model rather than mapping a fresh
+            // CoreZone per call — this is the per-battle setup hot path and the model is immutable, so the
+            // shared instance is safe (docs/backend.md → Reference Data).
+            var snapshot = Snapshot;
+            return IsValidZoneId(snapshot.Entities, zoneId)
+                ? snapshot.CoreZones[zoneId]
                 : throw new ArgumentOutOfRangeException(nameof(zoneId));
         }
 
         public Zone? LookupZone(int zoneId)
         {
-            var entities = holder.Current;
+            var entities = Snapshot.Entities;
             return IsValidZoneId(entities, zoneId) ? entities[zoneId] : null;
         }
 
         public bool IsZoneRetired(int zoneId)
         {
-            var entities = holder.Current;
+            var entities = Snapshot.Entities;
             return IsValidZoneId(entities, zoneId)
                 ? entities[zoneId].RetiredAt is not null
                 : throw new ArgumentOutOfRangeException(nameof(zoneId));
@@ -52,7 +55,7 @@ namespace Game.DataAccess.Repositories
 
         public bool ValidateZoneId(int zoneId)
         {
-            return IsValidZoneId(holder.Current, zoneId);
+            return IsValidZoneId(Snapshot.Entities, zoneId);
         }
 
         private static bool IsValidZoneId(IReadOnlyList<Zone> entities, int zoneId)


### PR DESCRIPTION
## Summary

Addresses the basket of small, low-risk backend cleanups tracked in #1143. Each is individually minor; bundled into one sweep.

### Allocation / perf nits
- **`AggregateRoot.DomainEvents`** — was `_domainEvents.AsReadOnly()`, allocating a fresh `ReadOnlyCollection` on every get (the dispatcher reads `Count` then `ToArray` per drain iteration). Now the wrapper is built once in the constructor; `ReadOnlyCollection` is a *live view* over the backing list, so it still reflects every `RaiseEvent`/`ClearEvents`.
- **`Roles.GetRoles()`** — was re-enumerating `Enum.GetValues()` and rebuilding `Role`s (with reflection-backed `ToString()`) on every call for intrinsic enum data. Now precomputed once as a `static readonly Role[]`; `GetRoles()` returns a fresh list copy so the shared set stays immutable to callers.
- **`Zones.GetDomainZone`** — was mapping a fresh `CoreZone` per call on the per-battle setup path, against the documented gameplay-read convention (every other read hands back shared pre-materialized instances). Introduces a `ZoneSnapshot` record (mirroring `EnemySnapshot`) bundling the entity list + pre-materialized `CoreZone`s so they swap atomically, and `GetDomainZone` now returns the shared instance. The `CoreZone` domain model is immutable (`init`-only, no mutable collections), so sharing is safe.

### Convention / dead code
- **`EnemyMapper.ToTemplate`** — removed the `.Where(es => es.SkillId >= 0 && es.SkillId < allSkills.Count)` filter that would *silently drop* a skill from an enemy loadout. Contiguity is asserted before templates build and `SkillId` is an FK into that set, so the filter could never validly exclude anything; a genuinely out-of-range id is now a loud index throw, matching the player-load loud-fail policy.
- **`Player.UnlockSkill`** — kept the linear unlocked-skill scan but documented why it's acceptable (skills grow far slower than items and aren't on the battle-start hot path the unlocked-item set is). Restructuring `Skills` into an id-keyed collection would ripple into mapping/serialization, out of scope for a minor cleanup.
- **`Game.DataAccess/Constants.cs`** — pure const-bag is now `internal static class`.

### Out of this PR
The Zones item in #1143 noted "coordinate with the Zones torn-read fix" — that fix already landed (each read captures `holder.Current` once), and this change keeps it: every method captures the snapshot once before the bounds-check + index.

## Test plan
- `dotnet build` — clean, 0 warnings.
- `Game.Core.Tests` — 761 passed.
- `Game.Application.Tests` (integration) — 508 passed, including a new `GetDomainZone_ReturnsSharedInstanceAndCorrectData` shared-instance test added alongside the existing reference-read cases.
- `Game.Api.Tests` — 603 passed (covers `GetRoles` via `AdminUsersControllerTests`).

Closes #1143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oWmT6gggtbLSrEu8tQjJr

---
_Generated by [Claude Code](https://claude.ai/code/session_018oWmT6gggtbLSrEu8tQjJr)_