### PR TITLE
Make next-battle prefetch best-effort so a win can't be double-credited (#1169)

### DIFF
--- a/Game.Api/Sockets/Commands/BattleLost.cs
+++ b/Game.Api/Sockets/Commands/BattleLost.cs
@@ -38,7 +38,11 @@ namespace Game.Api.Sockets.Commands
 
                 // A boss loss returns to the idle farm, so prefetch and bundle the next idle battle — letting
                 // the client begin it the instant the post-loss cooldown elapses, hiding the NewEnemy round-trip.
-                var next = await _battleService.PrepareNextIdleBattle(player, state, cancellationToken);
+                // The prefetch is best-effort: the loss is already durably recorded and its battle-cleared
+                // PlayerState is saved below regardless, so a prefetch failure must not strand that resolved
+                // state (which a reconnect would re-abandon, re-recording the completion). The client
+                // round-trips NewEnemy when none is bundled.
+                var next = await _battleService.TryPrepareNextIdleBattle(player, state, cancellationToken);
 
                 context.Session.SavePlayerState();
 
@@ -46,8 +50,8 @@ namespace Game.Api.Sockets.Commands
                 return Success(new BattleLostResponse
                 {
                     Cooldown = (state.EnemyCooldown - now).TotalMilliseconds,
-                    NextEnemy = EnemyInstance.FromSource(next),
-                    NextZoneId = player.CurrentZoneId,
+                    NextEnemy = next is not null ? EnemyInstance.FromSource(next) : null,
+                    NextZoneId = next is not null ? player.CurrentZoneId : null,
                 });
             }
             else

--- a/Game.Api/Sockets/Commands/DefeatEnemy.cs
+++ b/Game.Api/Sockets/Commands/DefeatEnemy.cs
@@ -43,14 +43,20 @@ namespace Game.Api.Sockets.Commands
                     player.Id, rewards.ExpReward);
 
                 // Prefetch and bundle the next idle battle so the client can begin it the instant the
-                // post-battle cooldown elapses, hiding the NewEnemy round-trip under the cooldown.
+                // post-battle cooldown elapses, hiding the NewEnemy round-trip under the cooldown. The prefetch
+                // is best-effort: the victory is already durably credited and its battle-cleared PlayerState is
+                // saved below regardless, so a prefetch failure must not strand that resolved state (which a
+                // reconnect would re-abandon and re-credit). The client round-trips NewEnemy when none is bundled.
                 EnemyInstance? nextEnemy = null;
                 int? nextZoneId = null;
                 if (!wasBossBattle)
                 {
-                    var next = await _battleService.PrepareNextIdleBattle(player, state, cancellationToken);
-                    nextEnemy = EnemyInstance.FromSource(next);
-                    nextZoneId = player.CurrentZoneId;
+                    var next = await _battleService.TryPrepareNextIdleBattle(player, state, cancellationToken);
+                    if (next is not null)
+                    {
+                        nextEnemy = EnemyInstance.FromSource(next);
+                        nextZoneId = player.CurrentZoneId;
+                    }
                 }
 
                 context.Session.SavePlayerState();

--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -420,6 +420,52 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task TryPrepareNextIdleBattle_PrefetchFails_SwallowsAndLeavesResolvedStateCleared()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, skill.Id);
+            var zone = await TestDataSeeder.CreateZoneAsync(context);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, skill.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+
+            // Win and resolve a battle: EndBattleVictory durably credits the win and clears the in-flight battle.
+            await battleService.StartBattle(player, state, zoneId: zone.Id);
+            state.BattleStartTime = DateTime.UtcNow.AddMinutes(-10);
+            var victory = await battleService.EndBattleVictory(player, state);
+            Assert.NotNull(victory);
+            Assert.False(state.HasActiveBattle);
+
+            // Force an unexpected prefetch failure: an out-of-range CurrentZoneId makes the prefetch's zone
+            // resolution throw (GetDomainZone) after the win is already credited — exactly the window that would
+            // otherwise strand the resolved state and let a reconnect re-abandon (and re-credit) the battle.
+            player.ChangeZone(999);
+            var next = await battleService.TryPrepareNextIdleBattle(player, state);
+
+            // The best-effort prefetch swallows the failure (no bundled next battle) and leaves the resolved
+            // (battle-cleared) state intact, so the command's SavePlayerState persists the credited outcome
+            // rather than stranding a stale active battle.
+            Assert.Null(next);
+            Assert.False(state.HasActiveBattle);
+            Assert.Null(state.ActiveEnemyId);
+        }
+
+        [Fact]
         public async Task EndBattleVictory_Success_PersistsPlayerToCache()
         {
             using var scope = CreateScope();

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -136,6 +136,31 @@ namespace Game.Application.Services
         }
 
         /// <summary>
+        /// Best-effort <see cref="PrepareNextIdleBattle"/> for the battle-end commands: on any prefetch failure
+        /// it logs and returns <c>null</c> instead of throwing. The victory/loss is already durably credited and
+        /// has cleared the in-flight battle on the <see cref="PlayerState"/>, but that resolved state is only
+        /// persisted to the session cache <em>after</em> this prefetch. Letting the prefetch throw would strand
+        /// the resolved state (the cleared battle is lost), so on reconnect the stale session still shows the
+        /// already-credited battle as active and the next <c>StartBattle</c> re-abandons — and thus re-credits —
+        /// it. Swallowing here keeps the caller on its path to save the resolved state; the client round-trips
+        /// <c>NewEnemy</c> when no next battle is bundled.
+        /// </summary>
+        public async Task<BattleStartResult?> TryPrepareNextIdleBattle(Player player, PlayerState state, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await PrepareNextIdleBattle(player, state, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Next-idle-battle prefetch failed for player {PlayerId}; returning without a bundled next enemy.",
+                    player.Id);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Starts a deterministic battle against the zone's dedicated boss (the "Challenge Boss" action),
         /// separate from the random idle spawn. The boss is fought at the zone's fixed level with its full
         /// authored skill loadout. Returns <c>null</c> when the zone has no dedicated boss authored. Unlike


### PR DESCRIPTION
## Summary

Closes #1169.

`DefeatEnemy` and `BattleLost` durably credit the resolved battle (exp + statistics/challenges, via the player write-behind aggregate) and clear the in-flight battle on the **in-memory** `PlayerState`, but only persist that cleared `PlayerState` to the session cache **after** prefetching the next idle battle. If the prefetch threw — e.g. an unexpected zone-resolution failure after `EnsureViableZone` — the win/loss was durably persisted while the cleared-battle/cooldown `PlayerState` was never written to the session. On reconnect the stale session still showed the resolved battle as active, so the first `StartBattle` would `AbandonBattle` it again and **re-credit an already-paid-out battle** — durable double-credit, exactly the class the battle anti-cheat otherwise prevents.

## How it's fixed

- Added `BattleService.TryPrepareNextIdleBattle` — a best-effort wrapper around `PrepareNextIdleBattle` that catches any prefetch failure, logs it, and returns `null` instead of throwing.
- `DefeatEnemy` and `BattleLost` now call it, so `context.Session.SavePlayerState()` **always** runs after the resolved (battle-cleared + cooldown) state. A prefetch failure can no longer strand that state; the response simply carries no bundled `NextEnemy`/`NextZoneId` and the client round-trips `NewEnemy` (already the contract — both fields are nullable and documented as "null when no next battle was prepared").

## Sibling-path audit (as the issue asked)

- **`BattleLost`** — same ordering bug (a re-abandon re-records the loss completion / re-counts challenges). Fixed the same way.
- **Boss-victory branch** (`DefeatEnemy`, `wasBossBattle`) — skips the prefetch entirely, so it was never exposed to this window. Left unchanged.
- **`ChallengeBoss`** — only *starts* a battle (no prior win to credit), so no double-credit window. Unchanged.

Why best-effort over "save before the prefetch": `SavePlayerState` is a fire-and-forget Redis write, and the happy-path save after the prefetch must persist the *prefetched* battle for its later anti-cheat replay. Saving both before and after would double the session write on the idle hot path; the best-effort catch keeps a single write on the happy path and only degrades (an extra `NewEnemy` round-trip) on the rare failure.

## Test plan

- Added `BattleServiceIntegrationTests.TryPrepareNextIdleBattle_PrefetchFails_SwallowsAndLeavesResolvedStateCleared`: wins/resolves a battle, forces an out-of-range `CurrentZoneId` so the prefetch's zone resolution throws, and asserts the wrapper swallows it (`null`) and leaves the resolved state cleared — so the command's `SavePlayerState` persists the credited outcome rather than a stale active battle.
- `BattleServiceIntegrationTests` (38) green, including the existing prefetch/abandon coverage.
- `DefeatEnemySocketTests`, `BattleLostSocketTests`, `NewEnemySocketTests` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Krz1ghABJZVNiCVjCZthdd)_