### PR TITLE
Serialize skills-loadout commits and derive equipped from the player manager

### DIFF
--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -457,7 +457,7 @@ export class SkillsView {
 		this.pendingLoadout = next;
 		playerManager.setSelectedSkills(next);
 		const seq = ++this.commitSeq;
-		this.lastCommit = this.lastCommit.then(async () => {
+		const result = this.lastCommit.then(async () => {
 			const response = await apiSocket.sendSocketCommand('SetSelectedSkills', next);
 			const isLatest = seq === this.commitSeq;
 			if (response.error) {
@@ -473,5 +473,8 @@ export class SkillsView {
 				}
 			}
 		});
+		// Keep the queue tail always-fulfilled: a rejecting callback would otherwise make every later
+		// commit skip its persist and raise an unhandled rejection (mirrors the inventory manager's serialize).
+		this.lastCommit = result.catch(() => undefined);
 	}
 }

--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -125,9 +125,16 @@ export function zoneSpawnLevel(zone: IZone): number {
 export class SkillsView {
 	/** The inspected skill (rail/band selection). */
 	selectedId = $state<number>(-1);
-	/** Working equipped loadout, ordered by priority. Optimistically updated, then
-	 *  persisted via {@link commit}; reverted if the persist fails. */
-	equipped = $state<number[]>([]);
+	/** Pending optimistic loadout while a commit is in flight (or after the latest commit failed without
+	 *  a newer edit); null when the screen mirrors the player manager. {@link equipped} reads through it. */
+	private pendingLoadout = $state<number[] | null>(null);
+	/** Last loadout the server confirmed — the rollback target when the latest commit fails. */
+	private committed: number[] = [];
+	/** Tail of the optimistic-commit queue; each commit chains off it so persists apply in edit order
+	 *  and rollback baselines never interleave (mirrors the inventory manager's serialized mutations). */
+	private lastCommit: Promise<unknown> = Promise.resolve();
+	/** Monotonic edit counter; a failed persist rolls back only when it was the latest edit issued. */
+	private commitSeq = 0;
 	search = $state('');
 	sort = $state<SkillSort>('dps');
 	filterAttributes = $state<EAttribute[]>([]);
@@ -145,13 +152,19 @@ export class SkillsView {
 		this.syncFromPlayer();
 	}
 
-	/** (Re)seed the working loadout + selection from the player manager. */
+	/** (Re)seed the committed baseline + inspector selection from the player manager. */
 	syncFromPlayer(): void {
-		this.equipped = [...playerManager.selectedSkills];
+		this.committed = [...playerManager.selectedSkills];
+		this.pendingLoadout = null;
 		if (this.selectedId < 0) {
 			this.selectedId = this.equipped[0] ?? staticData.skills?.[0]?.id ?? -1;
 		}
 	}
+
+	/** Working equipped loadout, ordered by priority: the pending optimistic edit while a commit is in
+	 *  flight, otherwise the player manager's committed loadout — so an external loadout change (e.g. a
+	 *  challenge skill unlock or server reconciliation) is reflected once no edit is pending. */
+	readonly equipped = $derived(this.pendingLoadout ?? [...playerManager.selectedSkills]);
 
 	/** The loadout cap (number of equip slots) — the single generated game constant. */
 	readonly cap = MAX_SELECTED_SKILLS;
@@ -368,9 +381,9 @@ export class SkillsView {
 			return;
 		}
 		if (this.isEquipped(id)) {
-			void this.commit(this.equipped.filter((x) => x !== id));
+			this.commit(this.equipped.filter((x) => x !== id));
 		} else if (this.equipped.length < this.cap) {
-			void this.commit([...this.equipped, id]);
+			this.commit([...this.equipped, id]);
 		} else {
 			this.pendingSwap = id;
 		}
@@ -385,7 +398,7 @@ export class SkillsView {
 		const next = this.equipped.map((x, i) => (i === slotIndex ? incoming : x));
 		this.selectedId = incoming;
 		this.pendingSwap = null;
-		void this.commit(next);
+		this.commit(next);
 	}
 
 	cancelSwap(): void {
@@ -400,7 +413,7 @@ export class SkillsView {
 		const next = [...this.equipped];
 		const [moved] = next.splice(from, 1);
 		next.splice(to, 0, moved);
-		void this.commit(next);
+		this.commit(next);
 	}
 
 	setDefense(defense: number): void {
@@ -433,16 +446,32 @@ export class SkillsView {
 	/* ── persistence ─────────────────────────────────────────────────────────── */
 
 	/** Optimistically apply a new loadout, persist it atomically, and revert on failure. The player
-	 *  manager owns the loadout mutation (so battles/other screens see it without a reload). */
-	private async commit(next: number[]): Promise<void> {
-		const previous = this.equipped;
-		this.equipped = next;
+	 *  manager owns the loadout mutation (so battles/other screens see it without a reload).
+	 *
+	 *  Commits are serialized on {@link lastCommit} so their persists apply in edit order and never
+	 *  interleave rollback baselines: only the *latest* edit's failure rolls back — to the last
+	 *  server-confirmed loadout ({@link committed}), not a per-call snapshot — so an earlier failure
+	 *  can't silently discard a later successful edit. The optimistic write itself is synchronous, so
+	 *  rapid edits read fresh state and queue rather than racing. */
+	private commit(next: number[]): void {
+		this.pendingLoadout = next;
 		playerManager.setSelectedSkills(next);
-		const response = await apiSocket.sendSocketCommand('SetSelectedSkills', next);
-		if (response.error) {
-			this.equipped = previous;
-			playerManager.setSelectedSkills(previous);
-			toastError('Your loadout could not be saved. Please try again.');
-		}
+		const seq = ++this.commitSeq;
+		this.lastCommit = this.lastCommit.then(async () => {
+			const response = await apiSocket.sendSocketCommand('SetSelectedSkills', next);
+			const isLatest = seq === this.commitSeq;
+			if (response.error) {
+				if (isLatest) {
+					playerManager.setSelectedSkills(this.committed);
+					this.pendingLoadout = null;
+					toastError('Your loadout could not be saved. Please try again.');
+				}
+			} else {
+				this.committed = next;
+				if (isLatest) {
+					this.pendingLoadout = null;
+				}
+			}
+		});
 	}
 }

--- a/UI/src/tests/routes/game/screens/skills/EquippedBand.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/EquippedBand.test.ts
@@ -259,8 +259,8 @@ describe('EquippedBand — reorder via move buttons (keyboard/touch)', () => {
 
 describe('EquippedBand — empty slot', () => {
 	beforeEach(() => {
-		// Free a slot so the band renders one empty card.
-		view.equipped = [0, 1];
+		// Free a slot (unequip Charlie) so the band renders one empty card.
+		view.toggle(2);
 	});
 
 	it('renders the empty slot as a real focusable button, not a presentational tile', () => {

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -371,17 +371,18 @@ describe('SkillsView — rail filtering & sorting', () => {
 });
 
 describe('SkillsView — loadout edits persist the ordered loadout', () => {
-	it('unequips a skill and sends the reduced loadout', () => {
+	it('unequips a skill and sends the reduced loadout', async () => {
 		view.toggle(0);
-		expect(view.equipped).toEqual([1, 2]);
-		expect(sendSocketCommand).toHaveBeenCalledWith('SetSelectedSkills', [1, 2]);
+		expect(view.equipped).toEqual([1, 2]); // optimistic, synchronous
+		// The persist is serialized, so the dispatch lands on a microtask.
+		await vi.waitFor(() => expect(sendSocketCommand).toHaveBeenCalledWith('SetSelectedSkills', [1, 2]));
 	});
 
-	it('equips into a free slot and sends the extended loadout', () => {
+	it('equips into a free slot and sends the extended loadout', async () => {
 		view.toggle(0); // free a slot first (cap is 3)
 		view.toggle(3);
 		expect(view.equipped).toEqual([1, 2, 3]);
-		expect(lastPayload()).toEqual([1, 2, 3]);
+		await vi.waitFor(() => expect(lastPayload()).toEqual([1, 2, 3]));
 	});
 
 	it('starts a swap (no command) when equipping into a full loadout', () => {
@@ -391,19 +392,19 @@ describe('SkillsView — loadout edits persist the ordered loadout', () => {
 		expect(sendSocketCommand).not.toHaveBeenCalled();
 	});
 
-	it('resolves a swap by replacing the chosen slot', () => {
+	it('resolves a swap by replacing the chosen slot', async () => {
 		view.toggle(3); // full → pending swap
 		view.swapInto(1);
 		expect(view.equipped).toEqual([0, 3, 2]);
 		expect(view.selectedId).toBe(3);
 		expect(view.pendingSwap).toBeNull();
-		expect(lastPayload()).toEqual([0, 3, 2]);
+		await vi.waitFor(() => expect(lastPayload()).toEqual([0, 3, 2]));
 	});
 
-	it('reorders the loadout', () => {
+	it('reorders the loadout', async () => {
 		view.reorder(0, 2);
 		expect(view.equipped).toEqual([1, 2, 0]);
-		expect(lastPayload()).toEqual([1, 2, 0]);
+		await vi.waitFor(() => expect(lastPayload()).toEqual([1, 2, 0]));
 	});
 
 	it('ignores toggling a skill the player has not unlocked', () => {
@@ -431,6 +432,41 @@ describe('SkillsView — persistence failure', () => {
 		// …then reverted once the failed command resolves.
 		expect(view.equipped).toEqual([0, 1, 2]);
 		expect(mockPlayerManager.selectedSkills).toEqual([0, 1, 2]);
+	});
+
+	it('keeps a later successful edit when an earlier overlapping commit fails', async () => {
+		// Two rapid edits: the first persist fails, the second succeeds. Because commits are serialized
+		// and only the latest edit's failure rolls back, the stale first failure must NOT clobber the
+		// second edit (the bug this guards against).
+		sendSocketCommand.mockReset();
+		sendSocketCommand.mockResolvedValueOnce({ error: 'nope' }).mockResolvedValue({});
+		view.toggle(0); // → [1, 2]
+		view.toggle(3); // → [1, 2, 3] (the later, winning edit)
+		await vi.waitFor(() => expect(sendSocketCommand).toHaveBeenCalledTimes(2));
+		await vi.waitFor(() => expect(view.equipped).toEqual([1, 2, 3]));
+		expect(mockPlayerManager.selectedSkills).toEqual([1, 2, 3]);
+		expect(toastError).not.toHaveBeenCalled();
+	});
+
+	it('reverts only to the last confirmed loadout when the latest edit fails', async () => {
+		view.toggle(0); // [0, 1, 2] → [1, 2], succeeds and is confirmed
+		await vi.waitFor(() => expect(mockPlayerManager.selectedSkills).toEqual([1, 2]));
+		sendSocketCommand.mockResolvedValueOnce({ error: 'nope' });
+		view.reorder(0, 1); // [1, 2] → [2, 1], fails
+		expect(view.equipped).toEqual([2, 1]); // optimistic
+		await vi.waitFor(() => expect(toastError).toHaveBeenCalled());
+		// Rolls back to the previously-confirmed [1, 2], not the original [0, 1, 2].
+		expect(view.equipped).toEqual([1, 2]);
+		expect(mockPlayerManager.selectedSkills).toEqual([1, 2]);
+	});
+
+	it('reconciles with the player manager once no edit is pending', async () => {
+		// An external loadout change (e.g. a challenge skill unlock) lands while a commit is in flight;
+		// once the queue drains the screen reflects the manager rather than the stale optimistic copy.
+		// (In production the statified manager also propagates such changes live while idle.)
+		view.toggle(0); // → [1, 2], in flight
+		mockPlayerManager.setSelectedSkills([3]); // external write
+		await vi.waitFor(() => expect(view.equipped).toEqual([3]));
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes the two correctness gaps in the Skills loadout screen reported in #1171.

### 1. Overlapping optimistic commits could silently revert a later edit (bug)

`SkillsView.commit` was fire-and-forget: it captured a per-call `previous = this.equipped` snapshot, optimistically applied the new loadout, then awaited `SetSelectedSkills`. If a second edit landed before the first persist resolved, the first commit's `previous` was already stale — so if that first persist **failed**, its rollback restored a baseline captured *before* the second (successful) edit, discarding it on both the view and the player manager.

Commits are now **serialized** on a `lastCommit` promise chain (the same pattern the inventory manager's `serialize()` already uses), so persists apply in edit order and rollback baselines never interleave. A failed persist rolls back **only when it was the latest edit issued** (tracked via a monotonic `commitSeq`), and it reverts to the last *server-confirmed* loadout (`committed`) rather than a stale per-call snapshot. An earlier failure superseded by a later successful edit no longer reverts or toasts.

### 2. `equipped` never re-synced from the player manager after construction (latent)

`equipped` was seeded once in the constructor and never reconciled, so an external loadout change (a future auto-equip-on-unlock, server reconciliation, the `ChallengeCompleted` skill-unlock push) left the screen showing a stale loadout. It's now a `$derived` that returns the pending optimistic edit while a commit is in flight, otherwise the player manager's committed loadout — so external changes are reflected once no edit is pending. Because the production `playerManager` is statified, this propagates reactively while idle.

## Notes

- The optimistic write to `equipped`/`playerManager` stays **synchronous**, so rapid edits read fresh state and queue rather than racing. Only the socket dispatch now lands on a microtask (consistent with the inventory manager's serialized mutations) — a couple of existing tests were updated to `await` the dispatch accordingly.
- Frontend-only; this is loadout persistence, not battle-tick logic, so no backend parity mirror is required.

## Test plan

- [x] New unit tests: an earlier overlapping commit failing keeps the later successful edit (no spurious revert/toast); the latest edit failing reverts to the last *confirmed* loadout (not the original); the screen reconciles with the manager once no edit is pending.
- [x] Existing skills-screen tests updated for the serialized (microtask) dispatch.
- [x] `npm run check` (svelte-check) — 0 errors.
- [x] `eslint .` — clean.
- [x] Full unit suite — 2438 passing.

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016rnXMdaNprh7BPJiGwh8Vt)_