### PR TITLE
Surface proficiency XP / level-up / milestone feedback (#1121)

### DIFF
--- a/Game.Application.Tests/Services/AccountServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/AccountServiceIntegrationTests.cs
@@ -78,7 +78,7 @@ namespace Game.Application.Tests.Services
             var logPreferencesByType = await verifyContext.Set<LogPreference>()
                 .Where(preference => preference.PlayerId == createdPlayer.Id)
                 .ToDictionaryAsync(preference => preference.LogTypeId, preference => preference.Enabled, CancellationToken);
-            Assert.Equal(7, logPreferencesByType.Count);
+            Assert.Equal(8, logPreferencesByType.Count);
             Assert.False(logPreferencesByType[(int)ELogType.Damage]);
             Assert.False(logPreferencesByType[(int)ELogType.Debug]);
             Assert.True(logPreferencesByType[(int)ELogType.Exp]);
@@ -86,6 +86,7 @@ namespace Game.Application.Tests.Services
             Assert.True(logPreferencesByType[(int)ELogType.ItemFound]);
             Assert.True(logPreferencesByType[(int)ELogType.EnemyDefeated]);
             Assert.True(logPreferencesByType[(int)ELogType.SkillEffect]);
+            Assert.True(logPreferencesByType[(int)ELogType.Proficiency]);
         }
 
         [Fact]

--- a/Game.Core.Tests/Players/NewPlayerFactoryTests.cs
+++ b/Game.Core.Tests/Players/NewPlayerFactoryTests.cs
@@ -92,7 +92,7 @@ namespace Game.Core.Tests.Players
                 preference => preference.LogType,
                 preference => preference.Enabled);
 
-            Assert.Equal(7, enabledByType.Count);
+            Assert.Equal(8, enabledByType.Count);
             Assert.False(enabledByType[ELogType.Damage]);
             Assert.False(enabledByType[ELogType.Debug]);
             Assert.True(enabledByType[ELogType.Exp]);
@@ -100,6 +100,7 @@ namespace Game.Core.Tests.Players
             Assert.True(enabledByType[ELogType.ItemFound]);
             Assert.True(enabledByType[ELogType.EnemyDefeated]);
             Assert.True(enabledByType[ELogType.SkillEffect]);
+            Assert.True(enabledByType[ELogType.Proficiency]);
         }
     }
 }

--- a/Game.Core/Enums.cs
+++ b/Game.Core/Enums.cs
@@ -239,7 +239,13 @@ namespace Game.Core
         /// Logs for skill-effect activity in battle: timed buff/debuff application and
         /// per-second damage-over-time / heal-over-time summaries.
         /// </summary>
-        SkillEffect = 7
+        SkillEffect = 7,
+
+        /// <summary>
+        /// Logs for proficiency progression earned from won battles: XP gained, level-ups,
+        /// milestones reached, and newly-opened proficiencies.
+        /// </summary>
+        Proficiency = 8
     }
 
     /// <summary>

--- a/Game.Core/Players/NewPlayerFactory.cs
+++ b/Game.Core/Players/NewPlayerFactory.cs
@@ -76,6 +76,7 @@ namespace Game.Core.Players
                 new() { LogType = ELogType.ItemFound, Enabled = true },
                 new() { LogType = ELogType.EnemyDefeated, Enabled = true },
                 new() { LogType = ELogType.SkillEffect, Enabled = true },
+                new() { LogType = ELogType.Proficiency, Enabled = true },
             ];
         }
     }

--- a/Game.Infrastructure/Migrations/20260623221434_AddProficiencyLogType.Designer.cs
+++ b/Game.Infrastructure/Migrations/20260623221434_AddProficiencyLogType.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Game.Infrastructure.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20260623221434_AddProficiencyLogType")]
+    partial class AddProficiencyLogType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Game.Infrastructure/Migrations/20260623221434_AddProficiencyLogType.cs
+++ b/Game.Infrastructure/Migrations/20260623221434_AddProficiencyLogType.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Game.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProficiencyLogType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "LogTypes",
+                columns: new[] { "Id", "DefaultValue", "Name" },
+                values: new object[] { 8, false, "Proficiency" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "LogTypes",
+                keyColumn: "Id",
+                keyValue: 8);
+        }
+    }
+}

--- a/UI/src/components/log-panel/log-kind.ts
+++ b/UI/src/components/log-panel/log-kind.ts
@@ -71,6 +71,8 @@ export function logKind(log: LogMessage): LogKind {
 			return { color: REWARD, glyph: 'crit', label: 'Exp' };
 		case ELogType.LevelUp:
 			return { color: REWARD, glyph: 'crit', label: 'Level' };
+		case ELogType.Proficiency:
+			return { color: REWARD, glyph: 'crit', label: 'Prof' };
 		case ELogType.EnemyDefeated:
 			return fromPlayer
 				? { color: ENEMY, glyph: 'kill', label: 'Defeat' }

--- a/UI/src/lib/api/types/enums.ts
+++ b/UI/src/lib/api/types/enums.ts
@@ -106,6 +106,7 @@ export enum ELogType {
 	ItemFound = 5,
 	EnemyDefeated = 6,
 	SkillEffect = 7,
+	Proficiency = 8,
 }
 
 export enum EModifierType {

--- a/UI/src/lib/common/index.ts
+++ b/UI/src/lib/common/index.ts
@@ -3,6 +3,7 @@ export * from './rarity';
 export * from './challenge-type';
 export * from './tag-color';
 export * from './challenge-unlocks';
+export * from './proficiency-feedback';
 export * from './zone-progression';
 export * from './enemy-attributes';
 export * from './attribute-display';

--- a/UI/src/lib/common/proficiency-feedback.ts
+++ b/UI/src/lib/common/proficiency-feedback.ts
@@ -1,0 +1,31 @@
+/* Player-facing phrasing for the `ProficiencyXpGained` push (spike #982 area H). A won battle accrues
+   proficiency XP, which can cross a level, hit an authored milestone (optionally granting a skill), or
+   open a brand-new proficiency. These pure formatters are the single home for that phrasing so the
+   success-toasts and the combat-log lines stay consistent — mirroring `challengeCompletedMessage`. The
+   caller resolves the proficiency/skill names from reference data and decides which channel each line
+   goes to; these just shape the text. */
+
+/** Combat-log line announcing the proficiency XP a battle earned. `xp` is the caller-rounded whole
+ *  number of XP gained (the caller suppresses the line when it rounds to zero). */
+export function proficiencyXpMessage(proficiencyName: string, xp: number): string {
+	return `${proficiencyName}: +${xp} proficiency XP`;
+}
+
+/** Announces a proficiency reaching a new level (no milestone). Used for both the toast and the log. */
+export function proficiencyLevelMessage(proficiencyName: string, level: number): string {
+	return `${proficiencyName} reached level ${level}`;
+}
+
+/** Announces an authored milestone the gain crossed, naming the skill it granted when present (a
+ *  milestone with no skill is a bonus-only milestone). Used for both the toast and the log. */
+export function proficiencyMilestoneMessage(proficiencyName: string, level: number, skillName?: string): string {
+	const base = `${proficiencyName} milestone reached: level ${level}`;
+	return skillName ? `${base} — unlocked ${skillName}` : base;
+}
+
+/** Announces a newly-opened proficiency, naming the seed skill granted with it when present (a node
+ *  opened via a world skill carries no seed skill). Used for both the toast and the log. */
+export function proficiencyOpenedMessage(proficiencyName: string, seedSkillName?: string): string {
+	const base = `New proficiency unlocked: ${proficiencyName}`;
+	return seedSkillName ? `${base} — granted ${seedSkillName}` : base;
+}

--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -1,11 +1,22 @@
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
 import { BattleEngine } from './battle/battle-engine';
-import { statify, type Action, resolveUnlockReward, challengeCompletedMessage } from '$lib/common';
+import {
+	statify,
+	type Action,
+	resolveUnlockReward,
+	challengeCompletedMessage,
+	proficiencyXpMessage,
+	proficiencyLevelMessage,
+	proficiencyMilestoneMessage,
+	proficiencyOpenedMessage
+} from '$lib/common';
 import { RenderEngine } from './render-engine';
 import { LogicalEngine } from './logical-engine';
 import { BackgroundThrottleMonitor } from './background-throttle-notice';
 import { InventoryManager } from './player/inventory-manager';
+import { playerManager } from './player/player-manager';
+import { logMessage } from './log';
 import { EnemyManager } from './battle/enemy-manager';
 import {
 	staticData,
@@ -17,7 +28,13 @@ import {
 	toastSuccess,
 	navigation
 } from '$stores';
-import { apiSocket, type IApiSocketResponse } from '$lib/api';
+import {
+	apiSocket,
+	ELogType,
+	type IApiSocketResponse,
+	type IProficiencyXpResultModel,
+	type IProficiencyOpenedModel
+} from '$lib/api';
 
 export const inventoryManager = statify(new InventoryManager());
 export const enemyManager = statify(new EnemyManager());
@@ -35,6 +52,7 @@ export const SESSION_REPLACED_BODY =
 
 let socketReplacedUnhook: Action | undefined;
 let challengeCompletedUnhook: Action | undefined;
+let proficiencyXpGainedUnhook: Action | undefined;
 let serverCommandFailedUnhook: Action | undefined;
 
 export const startGame = () => {
@@ -55,22 +73,26 @@ export const startGame = () => {
 		startBattleEngine();
 		socketReplacedUnhook = apiSocket.listenCommand('SocketReplaced', handleSocketReplaced, true);
 		challengeCompletedUnhook = apiSocket.listenCommand('ChallengeCompleted', handleChallengeCompleted, true);
+		proficiencyXpGainedUnhook = apiSocket.listenCommand('ProficiencyXpGained', handleProficiencyXpGained, true);
 		serverCommandFailedUnhook = apiSocket.listenCommand('ServerCommandFailed', handleServerCommandFailed, true);
 	}
 };
 
 /**
  * Reacts to a ServerCommandFailed notice: the server dead-lettered a server-pushed command that threw and
- * is telling us to re-sync rather than silently diverge from the authoritative state. The only push that
- * leaves divergent client state is ChallengeCompleted (its completion gates zone navigation), so a failed
- * one force-reloads the authoritative challenge progress; any reward it carried still surfaces on the next
- * natural load of the inventory/skills stores.
+ * is telling us to re-sync rather than silently diverge from the authoritative state. Two pushes leave
+ * divergent client state: ChallengeCompleted (its completion gates zone navigation) and ProficiencyXpGained
+ * (its levels feed the live battler's attribute bonuses), so a failed one force-reloads the matching
+ * authoritative progress; any reward/skill it carried still surfaces on the next natural load of the
+ * inventory/skills stores.
  */
 export const handleServerCommandFailed = (response: IApiSocketResponse<'ServerCommandFailed'>) => {
 	const failedCommand = response.data?.commandName;
 	console.warn(`A server-pushed command failed on the server and was dead-lettered: ${failedCommand ?? 'unknown'}.`);
 	if (failedCommand === 'ChallengeCompleted') {
 		void playerChallenges.load(true);
+	} else if (failedCommand === 'ProficiencyXpGained') {
+		void playerProficiencies.load(true);
 	}
 };
 
@@ -123,6 +145,86 @@ const notifyChallengeCompleted = (challengeId: number) => {
 	});
 };
 
+/**
+ * Applies a proficiency-XP push from a won battle (spike #982 area H): surfaces the per-proficiency XP,
+ * level-ups, milestones, and newly-opened proficiencies, makes any milestone/seed skill usable
+ * immediately (mirroring the challenge-reward unlock), then updates the proficiency store so the tree and
+ * the live battler's bonuses reflect the gain without a refetch. Prior levels are read off the store
+ * before it is updated, since the push carries only the new level — the level-up is detected by comparison.
+ */
+export const handleProficiencyXpGained = (response: IApiSocketResponse<'ProficiencyXpGained'>) => {
+	const data = response.data;
+	if (!data) {
+		return;
+	}
+
+	for (const result of data.proficiencies) {
+		notifyProficiencyResult(result, playerProficiencies.levelOf(result.proficiencyId));
+		for (const skillId of result.grantedSkillIds) {
+			playerManager.addUnlockedSkill(skillId);
+		}
+	}
+	for (const opened of data.opened) {
+		notifyProficiencyOpened(opened);
+		if (opened.seedSkillId != null) {
+			playerManager.addUnlockedSkill(opened.seedSkillId);
+		}
+	}
+
+	playerProficiencies.applyXpGained(data);
+};
+
+/**
+ * Surfaces one proficiency's outcome. Routine XP goes to the combat log only (it lands every won battle,
+ * like the player's own XP); a level-up adds a log line, and crossing a milestone both logs and toasts —
+ * naming the granted skill, resolved from the proficiency's authored level rewards. A plain level-up also
+ * toasts, but only when no milestone was crossed at the same time, so the richer milestone toast isn't
+ * duplicated. Unknown reference ids are skipped (the store is still updated by the caller).
+ */
+const notifyProficiencyResult = (result: IProficiencyXpResultModel, previousLevel: number) => {
+	const proficiency = staticData.proficiencies?.[result.proficiencyId];
+	if (!proficiency) {
+		return;
+	}
+	const name = proficiency.name;
+
+	const xp = Math.round(result.xpGained);
+	if (xp > 0) {
+		logMessage(ELogType.Proficiency, proficiencyXpMessage(name, xp));
+	}
+
+	const leveledUp = result.newLevel > previousLevel;
+	if (leveledUp) {
+		logMessage(ELogType.Proficiency, proficiencyLevelMessage(name, result.newLevel));
+	}
+
+	for (const milestoneLevel of result.milestonesCrossed) {
+		const skillId = proficiency.levelRewards.find((reward) => reward.level === milestoneLevel)?.rewardSkillId;
+		const skillName = skillId != null ? staticData.skills?.[skillId]?.name : undefined;
+		const message = proficiencyMilestoneMessage(name, milestoneLevel, skillName);
+		logMessage(ELogType.Proficiency, message);
+		toastSuccess(message);
+	}
+
+	if (leveledUp && result.milestonesCrossed.length === 0) {
+		toastSuccess(proficiencyLevelMessage(name, result.newLevel));
+	}
+};
+
+/** Surfaces a newly-opened proficiency (a maxed tier's next tier, or a newly-satisfied gateway), naming
+ *  the seed skill granted with it when present. Both a combat-log line and a toast, since an unlock is a
+ *  notable, infrequent event. Unknown reference ids are skipped. */
+const notifyProficiencyOpened = (opened: IProficiencyOpenedModel) => {
+	const proficiency = staticData.proficiencies?.[opened.proficiencyId];
+	if (!proficiency) {
+		return;
+	}
+	const seedSkillName = opened.seedSkillId != null ? staticData.skills?.[opened.seedSkillId]?.name : undefined;
+	const message = proficiencyOpenedMessage(proficiency.name, seedSkillName);
+	logMessage(ELogType.Proficiency, message);
+	toastSuccess(message);
+};
+
 // Use goto() not location.href — a reload re-runs the boot gate and bounces an authenticated client back into the game.
 export const handleSocketReplaced = async () => {
 	stopGame();
@@ -157,6 +259,7 @@ const stopGame = () => {
 	resetLogs();
 	socketReplacedUnhook?.();
 	challengeCompletedUnhook?.();
+	proficiencyXpGainedUnhook?.();
 	serverCommandFailedUnhook?.();
 	// SocketReplaced routes back to login client-side (no reload), so the socket singleton survives. Tear
 	// it down explicitly, otherwise the keepalive ping would silently reconnect and fight the session that

--- a/UI/src/routes/game/screens/options/LivePreview.svelte
+++ b/UI/src/routes/game/screens/options/LivePreview.svelte
@@ -49,6 +49,10 @@ const SAMPLES: { logType: ELogType; messages: string[] }[] = [
 	{ logType: ELogType.ItemFound, messages: ['Found a Sapphire Shard.'] },
 	{ logType: ELogType.Exp, messages: ['Earned 47 exp.'] },
 	{ logType: ELogType.LevelUp, messages: ['Congratulations, you leveled up!'] },
+	{
+		logType: ELogType.Proficiency,
+		messages: ['Fire Magic: +12 proficiency XP', 'Fire Magic milestone reached: level 5 — unlocked Fireball']
+	},
 	{ logType: ELogType.Debug, messages: ['battle.tick resolved in 4ms.'] }
 ];
 
@@ -62,6 +66,7 @@ const WEIGHTS: ELogType[] = [
 	ELogType.Exp,
 	ELogType.EnemyDefeated,
 	ELogType.LevelUp,
+	ELogType.Proficiency,
 	ELogType.Debug
 ];
 

--- a/UI/src/routes/game/screens/options/options-view.svelte.ts
+++ b/UI/src/routes/game/screens/options/options-view.svelte.ts
@@ -79,6 +79,14 @@ export const LOG_TYPES: LogTypeDef[] = [
 		color: logColors.reward
 	},
 	{
+		id: ELogType.Proficiency,
+		group: 'progression',
+		name: 'Proficiency',
+		desc: 'Proficiency XP, level-ups, milestones, and unlocks from won battles.',
+		glyph: 'crit',
+		color: logColors.reward
+	},
+	{
 		id: ELogType.ItemFound,
 		group: 'items',
 		name: 'Items Found',

--- a/UI/src/stores/proficiencies.svelte.ts
+++ b/UI/src/stores/proficiencies.svelte.ts
@@ -4,7 +4,7 @@
    composes its per-level/milestone attribute bonuses (spike #982 area E) from these levels against the
    proficiency reference data, mirroring the backend battle snapshot. */
 
-import { fetchSocketData, type IPlayerProficiency } from '$lib/api';
+import { fetchSocketData, type IPlayerProficiency, type IProficiencyXpGainedModel } from '$lib/api';
 import { proficiencyModifiers } from '$lib/battle/proficiency-modifiers';
 import type { AttributeModifier } from '$lib/battle/attribute-modifier';
 import { staticData } from './static-data.svelte';
@@ -62,6 +62,39 @@ export const playerProficiencies = {
 	/** The player's proficiency attribute bonuses for the live battler (see {@link battleModifiers}). */
 	get battleModifiers() {
 		return battleModifiers;
+	},
+
+	/** The player's current level in a proficiency, or 0 if they have not opened it yet. Read before
+	 *  {@link applyXpGained} to detect a level-up (the push carries the new level, not the prior one). */
+	levelOf(proficiencyId: number) {
+		return proficiencies.find((p) => p.proficiencyId === proficiencyId)?.level ?? 0;
+	},
+
+	/** Apply a `ProficiencyXpGained` push so progress-derived UI — the tree and the live battler's
+	 *  attribute bonuses — reflects it immediately without a refetch. Each result's new level/xp is set
+	 *  (inserting the proficiency if it was previously unopened), and any newly-opened proficiency the
+	 *  battle did not also train is added at level 0 so it appears straight away. A later `load(force)`
+	 *  reconciles against the authoritative server progress. The array is reassigned (not mutated) so the
+	 *  `battleModifiers` derived recomputes and the battle engine's by-reference change detection fires. */
+	applyXpGained(model: IProficiencyXpGainedModel) {
+		// Update each already-tracked proficiency in place to its new level/xp.
+		let next = proficiencies.map((existing): IPlayerProficiency => {
+			const result = model.proficiencies.find((r) => r.proficiencyId === existing.proficiencyId);
+			return result ? { proficiencyId: result.proficiencyId, level: result.newLevel, xp: result.newXp } : existing;
+		});
+		// Append any result for a proficiency the player had not yet opened.
+		for (const result of model.proficiencies) {
+			if (!next.some((p) => p.proficiencyId === result.proficiencyId)) {
+				next = [...next, { proficiencyId: result.proficiencyId, level: result.newLevel, xp: result.newXp }];
+			}
+		}
+		// Append any newly-opened proficiency the battle did not also train, at level 0.
+		for (const opened of model.opened) {
+			if (!next.some((p) => p.proficiencyId === opened.proficiencyId)) {
+				next = [...next, { proficiencyId: opened.proficiencyId, level: 0, xp: 0 }];
+			}
+		}
+		proficiencies = next;
 	},
 
 	/** Fetch the player's proficiency progress. Idempotent — only hits the network the first time

--- a/UI/src/tests/components/log-panel/log-kind.test.ts
+++ b/UI/src/tests/components/log-panel/log-kind.test.ts
@@ -109,6 +109,13 @@ describe('logKind', () => {
 		expect(result.label).toBe('Level');
 	});
 
+	it('returns the reward treatment for ELogType.Proficiency', () => {
+		const result = logKind(makeLog(ELogType.Proficiency, 'Fire Magic reached level 5'));
+		expect(result.color).toBe(logColors.reward);
+		expect(result.glyph).toBe('crit');
+		expect(result.label).toBe('Prof');
+	});
+
 	it('returns the effect treatment for ELogType.SkillEffect', () => {
 		const result = logKind(makeLog(ELogType.SkillEffect, 'You are empowered: +15 Strength for 5s'));
 		expect(result.color).toBe(logColors.effect);

--- a/UI/src/tests/lib/common/proficiency-feedback.test.ts
+++ b/UI/src/tests/lib/common/proficiency-feedback.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import {
+	proficiencyXpMessage,
+	proficiencyLevelMessage,
+	proficiencyMilestoneMessage,
+	proficiencyOpenedMessage
+} from '$lib/common';
+
+describe('proficiency-feedback messages', () => {
+	it('formats an XP-gained line', () => {
+		expect(proficiencyXpMessage('Fire Magic', 12)).toBe('Fire Magic: +12 proficiency XP');
+	});
+
+	it('formats a level-up line', () => {
+		expect(proficiencyLevelMessage('Fire Magic', 5)).toBe('Fire Magic reached level 5');
+	});
+
+	it('names the granted skill in a milestone message', () => {
+		expect(proficiencyMilestoneMessage('Fire Magic', 5, 'Fireball')).toBe(
+			'Fire Magic milestone reached: level 5 — unlocked Fireball'
+		);
+	});
+
+	it('omits the skill clause for a bonus-only milestone', () => {
+		expect(proficiencyMilestoneMessage('Fire Magic', 10)).toBe('Fire Magic milestone reached: level 10');
+	});
+
+	it('names the seed skill when a proficiency opens with one', () => {
+		expect(proficiencyOpenedMessage('Inferno Magic', 'Ember')).toBe(
+			'New proficiency unlocked: Inferno Magic — granted Ember'
+		);
+	});
+
+	it('omits the seed clause when a proficiency opens without one', () => {
+		expect(proficiencyOpenedMessage('Inferno Magic')).toBe('New proficiency unlocked: Inferno Magic');
+	});
+});

--- a/UI/src/tests/lib/engine/engine.test.ts
+++ b/UI/src/tests/lib/engine/engine.test.ts
@@ -26,11 +26,15 @@ const {
 		challenges?: ({ id: number; name: string; rewardItemId?: number } | undefined)[];
 		items?: ({ id: number; name: string; rarityId: number; itemCategoryId: number } | undefined)[];
 		itemMods?: unknown[];
-		skills?: unknown[];
+		skills?: ({ id: number; name: string } | undefined)[];
+		proficiencies?: (
+			| { id: number; name: string; levelRewards: { level: number; rewardSkillId: number }[] }
+			| undefined
+		)[];
 	},
 	statisticsStub: { load: vi.fn(), reset: vi.fn() },
 	playerChallengesStub: { load: vi.fn(), reset: vi.fn(), markCompleted: vi.fn() },
-	playerProficienciesStub: { load: vi.fn(), reset: vi.fn() },
+	playerProficienciesStub: { load: vi.fn(), reset: vi.fn(), levelOf: vi.fn(() => 0), applyXpGained: vi.fn() },
 	resetLogs: vi.fn(),
 	toastSuccess: vi.fn(),
 	navigation: { requestScreen: vi.fn() }
@@ -49,31 +53,44 @@ vi.mock('$stores', async () => {
 	};
 });
 
-const { listenCommand, disconnect, unlistenSocketReplaced, unlistenChallengeCompleted, unlistenServerCommandFailed } =
-	vi.hoisted(() => {
-		const unlistenSocketReplaced = vi.fn();
-		const unlistenChallengeCompleted = vi.fn();
-		const unlistenServerCommandFailed = vi.fn();
-		const listenCommand = vi.fn().mockImplementation((command: string) => {
-			if (command === 'SocketReplaced') {
-				return unlistenSocketReplaced;
-			}
-			if (command === 'ChallengeCompleted') {
-				return unlistenChallengeCompleted;
-			}
-			if (command === 'ServerCommandFailed') {
-				return unlistenServerCommandFailed;
-			}
-		});
-		const disconnect = vi.fn();
-		return {
-			listenCommand,
-			disconnect,
-			unlistenSocketReplaced,
-			unlistenChallengeCompleted,
-			unlistenServerCommandFailed
-		};
+const {
+	listenCommand,
+	disconnect,
+	unlistenSocketReplaced,
+	unlistenChallengeCompleted,
+	unlistenProficiencyXpGained,
+	unlistenServerCommandFailed
+} = vi.hoisted(() => {
+	const unlistenSocketReplaced = vi.fn();
+	const unlistenChallengeCompleted = vi.fn();
+	const unlistenProficiencyXpGained = vi.fn();
+	const unlistenServerCommandFailed = vi.fn();
+	const listenCommand = vi.fn().mockImplementation((command: string) => {
+		if (command === 'SocketReplaced') {
+			return unlistenSocketReplaced;
+		}
+		if (command === 'ChallengeCompleted') {
+			return unlistenChallengeCompleted;
+		}
+		if (command === 'ProficiencyXpGained') {
+			return unlistenProficiencyXpGained;
+		}
+		if (command === 'ServerCommandFailed') {
+			return unlistenServerCommandFailed;
+		}
 	});
+	const disconnect = vi.fn();
+	return {
+		listenCommand,
+		disconnect,
+		unlistenSocketReplaced,
+		unlistenChallengeCompleted,
+		unlistenProficiencyXpGained,
+		unlistenServerCommandFailed
+	};
+});
+const { logMessage } = vi.hoisted(() => ({ logMessage: vi.fn() }));
+const { addUnlockedSkill } = vi.hoisted(() => ({ addUnlockedSkill: vi.fn() }));
 // Partial mock: keep $lib/api's real exports (other modules in the graph, e.g. $lib/common, rely on
 // them) but swap apiSocket for a stub whose listenCommand/disconnect we can assert against.
 vi.mock('$lib/api', async (importOriginal) => ({
@@ -114,11 +131,14 @@ vi.mock('$lib/engine/player/inventory-manager', () => ({
 		addUnlockedMod = vi.fn();
 	}
 }));
+vi.mock('$lib/engine/player/player-manager', () => ({ playerManager: { addUnlockedSkill } }));
+vi.mock('$lib/engine/log', () => ({ logMessage }));
 
 import {
 	startGame,
 	handleSocketReplaced,
 	handleChallengeCompleted,
+	handleProficiencyXpGained,
 	handleServerCommandFailed,
 	SESSION_REPLACED_TITLE,
 	SESSION_REPLACED_BODY,
@@ -129,7 +149,14 @@ import {
 	inventoryManager
 } from '$lib/engine/engine';
 import { activeModal, clearModals, confirmActiveModal } from '$stores/modal.svelte';
-import { EItemCategory, ERarity, type IApiSocketResponse } from '$lib/api';
+import {
+	EItemCategory,
+	ELogType,
+	ERarity,
+	type IApiSocketResponse,
+	type IProficiencyXpResultModel,
+	type IProficiencyOpenedModel
+} from '$lib/api';
 
 /** Builds a ChallengeCompleted push response with the given reward ids (defaults: no rewards). */
 const challengeCompletedResponse = (
@@ -145,6 +172,7 @@ beforeEach(() => {
 	staticDataStub.items = undefined;
 	staticDataStub.itemMods = undefined;
 	staticDataStub.skills = undefined;
+	staticDataStub.proficiencies = undefined;
 });
 
 afterEach(() => {
@@ -202,6 +230,7 @@ describe('startGame', () => {
 		expect(battleEngine.start).toHaveBeenCalledTimes(1);
 		expect(listenCommand).toHaveBeenCalledWith('SocketReplaced', handleSocketReplaced, true);
 		expect(listenCommand).toHaveBeenCalledWith('ChallengeCompleted', handleChallengeCompleted, true);
+		expect(listenCommand).toHaveBeenCalledWith('ProficiencyXpGained', handleProficiencyXpGained, true);
 		expect(listenCommand).toHaveBeenCalledWith('ServerCommandFailed', handleServerCommandFailed, true);
 	});
 
@@ -224,12 +253,13 @@ describe('startGame', () => {
 		expect(activeModal.current?.body).toBe(SESSION_REPLACED_BODY);
 	});
 
-	it('stopGame unregisters SocketReplaced, ChallengeCompleted and ServerCommandFailed listeners', () => {
+	it('stopGame unregisters SocketReplaced, ChallengeCompleted, ProficiencyXpGained and ServerCommandFailed listeners', () => {
 		startGame();
 		void handleSocketReplaced();
 
 		expect(unlistenSocketReplaced).toHaveBeenCalledTimes(1);
 		expect(unlistenChallengeCompleted).toHaveBeenCalledTimes(1);
+		expect(unlistenProficiencyXpGained).toHaveBeenCalledTimes(1);
 		expect(unlistenServerCommandFailed).toHaveBeenCalledTimes(1);
 	});
 
@@ -322,6 +352,119 @@ describe('handleChallengeCompleted', () => {
 	});
 });
 
+/** Builds a ProficiencyXpGained push response with the given results / opened nodes. */
+const proficiencyXpResult = (
+	over: Partial<IProficiencyXpResultModel> & { proficiencyId: number }
+): IProficiencyXpResultModel => ({
+	xpGained: 10,
+	newLevel: 1,
+	newXp: 0,
+	milestonesCrossed: [],
+	grantedSkillIds: [],
+	...over
+});
+const proficiencyXpGainedResponse = (
+	proficiencies: IProficiencyXpResultModel[],
+	opened: IProficiencyOpenedModel[] = []
+): IApiSocketResponse<'ProficiencyXpGained'> =>
+	({
+		id: '',
+		name: 'ProficiencyXpGained',
+		data: { proficiencies, opened }
+	}) as IApiSocketResponse<'ProficiencyXpGained'>;
+
+describe('handleProficiencyXpGained', () => {
+	beforeEach(() => {
+		staticDataStub.proficiencies = [];
+		staticDataStub.proficiencies[0] = { id: 0, name: 'Fire Magic', levelRewards: [{ level: 5, rewardSkillId: 12 }] };
+		staticDataStub.skills = [];
+		staticDataStub.skills[12] = { id: 12, name: 'Fireball' };
+	});
+
+	it('applies the push to the proficiency store', () => {
+		const response = proficiencyXpGainedResponse([proficiencyXpResult({ proficiencyId: 0, newLevel: 2 })]);
+		handleProficiencyXpGained(response);
+
+		expect(playerProficienciesStub.applyXpGained).toHaveBeenCalledWith(response.data);
+	});
+
+	it('logs the XP gained on the Proficiency channel, rounding the decimal', () => {
+		handleProficiencyXpGained(proficiencyXpGainedResponse([proficiencyXpResult({ proficiencyId: 0, xpGained: 11.6 })]));
+
+		expect(logMessage).toHaveBeenCalledWith(ELogType.Proficiency, 'Fire Magic: +12 proficiency XP');
+	});
+
+	it('does not log an XP line when the rounded gain is zero', () => {
+		handleProficiencyXpGained(proficiencyXpGainedResponse([proficiencyXpResult({ proficiencyId: 0, xpGained: 0 })]));
+
+		expect(logMessage).not.toHaveBeenCalledWith(ELogType.Proficiency, expect.stringContaining('proficiency XP'));
+	});
+
+	it('toasts and logs a plain level-up when no milestone was crossed', () => {
+		playerProficienciesStub.levelOf.mockReturnValueOnce(1);
+		handleProficiencyXpGained(proficiencyXpGainedResponse([proficiencyXpResult({ proficiencyId: 0, newLevel: 2 })]));
+
+		expect(logMessage).toHaveBeenCalledWith(ELogType.Proficiency, 'Fire Magic reached level 2');
+		expect(toastSuccess).toHaveBeenCalledWith('Fire Magic reached level 2');
+	});
+
+	it('does not announce a level-up when the level is unchanged', () => {
+		playerProficienciesStub.levelOf.mockReturnValueOnce(2);
+		handleProficiencyXpGained(proficiencyXpGainedResponse([proficiencyXpResult({ proficiencyId: 0, newLevel: 2 })]));
+
+		expect(toastSuccess).not.toHaveBeenCalledWith(expect.stringContaining('reached level'));
+	});
+
+	it('toasts and logs a milestone naming the granted skill, and suppresses the redundant plain level-up toast', () => {
+		playerProficienciesStub.levelOf.mockReturnValueOnce(4);
+		handleProficiencyXpGained(
+			proficiencyXpGainedResponse([
+				proficiencyXpResult({ proficiencyId: 0, newLevel: 5, milestonesCrossed: [5], grantedSkillIds: [12] })
+			])
+		);
+
+		const milestone = 'Fire Magic milestone reached: level 5 — unlocked Fireball';
+		expect(toastSuccess).toHaveBeenCalledWith(milestone);
+		expect(logMessage).toHaveBeenCalledWith(ELogType.Proficiency, milestone);
+		expect(toastSuccess).not.toHaveBeenCalledWith('Fire Magic reached level 5');
+	});
+
+	it('unlocks milestone-granted skills so they are usable immediately', () => {
+		handleProficiencyXpGained(
+			proficiencyXpGainedResponse([proficiencyXpResult({ proficiencyId: 0, grantedSkillIds: [12] })])
+		);
+
+		expect(addUnlockedSkill).toHaveBeenCalledWith(12);
+	});
+
+	it('toasts a newly-opened proficiency and unlocks its seed skill', () => {
+		staticDataStub.proficiencies = [];
+		staticDataStub.proficiencies[3] = { id: 3, name: 'Inferno Magic', levelRewards: [] };
+		staticDataStub.skills = [];
+		staticDataStub.skills[7] = { id: 7, name: 'Ember' };
+
+		handleProficiencyXpGained(proficiencyXpGainedResponse([], [{ proficiencyId: 3, seedSkillId: 7 }]));
+
+		expect(toastSuccess).toHaveBeenCalledWith('New proficiency unlocked: Inferno Magic — granted Ember');
+		expect(addUnlockedSkill).toHaveBeenCalledWith(7);
+	});
+
+	it('does nothing when the push carries no data', () => {
+		handleProficiencyXpGained({ id: '', name: 'ProficiencyXpGained' } as IApiSocketResponse<'ProficiencyXpGained'>);
+
+		expect(playerProficienciesStub.applyXpGained).not.toHaveBeenCalled();
+		expect(toastSuccess).not.toHaveBeenCalled();
+	});
+
+	it('skips feedback for an unknown proficiency reference id but still applies the store update', () => {
+		const response = proficiencyXpGainedResponse([proficiencyXpResult({ proficiencyId: 99, newLevel: 2 })]);
+		handleProficiencyXpGained(response);
+
+		expect(toastSuccess).not.toHaveBeenCalled();
+		expect(playerProficienciesStub.applyXpGained).toHaveBeenCalledWith(response.data);
+	});
+});
+
 /** Builds a ServerCommandFailed notice naming the server-pushed command that failed. */
 const serverCommandFailedResponse = (commandName: string): IApiSocketResponse<'ServerCommandFailed'> =>
 	({ id: '', name: 'ServerCommandFailed', data: { commandName } }) as IApiSocketResponse<'ServerCommandFailed'>;
@@ -331,6 +474,12 @@ describe('handleServerCommandFailed', () => {
 		handleServerCommandFailed(serverCommandFailedResponse('ChallengeCompleted'));
 
 		expect(playerChallengesStub.load).toHaveBeenCalledWith(true);
+	});
+
+	it('force-reloads proficiency progress when a ProficiencyXpGained push was dead-lettered', () => {
+		handleServerCommandFailed(serverCommandFailedResponse('ProficiencyXpGained'));
+
+		expect(playerProficienciesStub.load).toHaveBeenCalledWith(true);
 	});
 
 	it('does not reload challenges for an unrelated failed command', () => {

--- a/UI/src/tests/stores/proficiencies.svelte.test.ts
+++ b/UI/src/tests/stores/proficiencies.svelte.test.ts
@@ -8,7 +8,13 @@ vi.mock('$lib/api', async (importOriginal) => {
 	return { ...actual, fetchSocketData: mockFetchSocket };
 });
 
-import { EAttribute, EModifierType, type IPlayerProficiency, type IProficiency } from '$lib/api';
+import {
+	EAttribute,
+	EModifierType,
+	type IPlayerProficiency,
+	type IProficiency,
+	type IProficiencyXpResultModel
+} from '$lib/api';
 import { EAttributeModifierSource } from '$lib/battle/attribute-modifier';
 import { playerProficiencies } from '$stores/proficiencies.svelte';
 import { staticData } from '$stores/static-data.svelte';
@@ -104,6 +110,81 @@ describe('proficiencies store', () => {
 		mockFetchSocket.mockResolvedValue([playerProficiency(2, 1)]);
 		await playerProficiencies.load();
 		expect(playerProficiencies.all).toEqual([playerProficiency(2, 1)]);
+	});
+
+	describe('levelOf', () => {
+		it('returns the stored level for a known proficiency and 0 for an unopened one', async () => {
+			mockFetchSocket.mockResolvedValue([playerProficiency(0, 3)]);
+			await playerProficiencies.load();
+
+			expect(playerProficiencies.levelOf(0)).toBe(3);
+			expect(playerProficiencies.levelOf(7)).toBe(0);
+		});
+	});
+
+	describe('applyXpGained', () => {
+		const xpResult = (proficiencyId: number, newLevel: number, newXp: number): IProficiencyXpResultModel => ({
+			proficiencyId,
+			xpGained: 10,
+			newLevel,
+			newXp,
+			milestonesCrossed: [],
+			grantedSkillIds: []
+		});
+
+		it('updates an existing proficiency in place to its new level and xp', async () => {
+			mockFetchSocket.mockResolvedValue([playerProficiency(0, 3, 20)]);
+			await playerProficiencies.load();
+
+			playerProficiencies.applyXpGained({ proficiencies: [xpResult(0, 4, 5)], opened: [] });
+
+			expect(playerProficiencies.all).toEqual([playerProficiency(0, 4, 5)]);
+		});
+
+		it('inserts a proficiency that was not yet in the store', async () => {
+			mockFetchSocket.mockResolvedValue([]);
+			await playerProficiencies.load();
+
+			playerProficiencies.applyXpGained({ proficiencies: [xpResult(2, 1, 8)], opened: [] });
+
+			expect(playerProficiencies.all).toEqual([playerProficiency(2, 1, 8)]);
+		});
+
+		it('adds a newly-opened proficiency at level 0 when the battle did not also train it', async () => {
+			mockFetchSocket.mockResolvedValue([]);
+			await playerProficiencies.load();
+
+			playerProficiencies.applyXpGained({
+				proficiencies: [],
+				opened: [{ proficiencyId: 5, seedSkillId: 12 }]
+			});
+
+			expect(playerProficiencies.all).toEqual([playerProficiency(5, 0, 0)]);
+		});
+
+		it('does not duplicate an opened proficiency the same push already trained', async () => {
+			mockFetchSocket.mockResolvedValue([]);
+			await playerProficiencies.load();
+
+			playerProficiencies.applyXpGained({
+				proficiencies: [xpResult(5, 1, 3)],
+				opened: [{ proficiencyId: 5 }]
+			});
+
+			expect(playerProficiencies.all).toEqual([playerProficiency(5, 1, 3)]);
+		});
+
+		it('reassigns the array so battleModifiers re-derives after a level change', async () => {
+			staticData.proficiencies = [proficiency(0, [additive(1, EAttribute.Strength, 4)])];
+			mockFetchSocket.mockResolvedValue([playerProficiency(0, 1)]);
+			await playerProficiencies.load();
+
+			const before = playerProficiencies.battleModifiers;
+			playerProficiencies.applyXpGained({ proficiencies: [xpResult(0, 2, 0)], opened: [] });
+
+			expect(playerProficiencies.battleModifiers).not.toBe(before);
+			expect(playerProficiencies.levelOf(0)).toBe(2);
+		});
 	});
 
 	describe('battleModifiers', () => {


### PR DESCRIPTION
Closes #1121 (spike #982 area H).

## Summary

Wires the client to the server-pushed `ProficiencyXpGained` command so a won battle's proficiency progress surfaces immediately instead of only after a refresh — mirroring the existing `ChallengeCompleted` feedback path.

On each push (`handleProficiencyXpGained` in `engine.ts`):

- **Store update.** `playerProficiencies.applyXpGained` sets each result's new level/xp (inserting a previously-unopened proficiency) and adds any newly-opened proficiency at level 0. The array is reassigned (not mutated) so the `battleModifiers` `$derived` recomputes and the battle engine's by-reference change detection re-derives the battler with the new bonus.
- **Immediate skill availability.** Milestone-granted (`grantedSkillIds`) and seed (`opened[].seedSkillId`) skills are unlocked client-side via `PlayerManager.addUnlockedSkill`, mirroring how challenge rewards are made usable without a refresh.
- **Feedback.** Level-ups, milestones (naming the granted skill, resolved from the proficiency's authored level rewards), and newly-opened proficiencies toast; routine per-battle XP goes to the combat log only (like the player's own XP). A plain level-up toast is suppressed when a milestone was crossed at the same time, so the richer milestone toast isn't duplicated.
- **Re-sync on dead-letter.** `handleServerCommandFailed` now force-reloads proficiency progress when a `ProficiencyXpGained` push is dead-lettered, alongside the existing `ChallengeCompleted` re-sync.

## Design decision: a dedicated `Proficiency` combat-log channel

Every combat-log line is filtered by an `ELogType` channel (toggleable in the Options "progression" group, alongside Experience and Level Up). Rather than reuse `Exp`/`LevelUp` — which would conflate proficiency progression with the player's own and mislabel the existing toggles — this adds a dedicated `ELogType.Proficiency`. Because `ELogType` is the backend's codegen'd source of truth and seeds a `LogTypes` reference table, this required a small backend change:

- `ELogType.Proficiency = 8` in `Game.Core/Enums.cs`
- New-player default preference (enabled), matching the other progression channels
- EF migration seeding the `LogTypes` row (mirrors the prior `AddSkillEffectLogType` migration exactly)
- Regenerated TypeScript codegen (`enums.ts`)
- Surfaced in `log-kind.ts`, the Options screen, and the live preview

## Notes / follow-ups

- The toast carries no "View" action because the Proficiencies tree screen (#1120, area G) isn't merged yet — a deep-link can be added once it lands.
- Documentation (`docs/frontend-screens.md`) for the proficiency UI is deferred to the tree-screen issue (#1120) per the spike, since the feedback here is cross-screen rather than a screen of its own.

## Test plan

- [x] `dotnet build` + full backend test suite (Core/Infrastructure/Application/Api) — all pass, including updated default-log-preference assertions.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — 2471 frontend tests pass, including new coverage for the engine handler (apply/unlock/toast/log, level-up vs milestone, unknown-id, no-data, dead-letter re-sync), the store `applyXpGained`/`levelOf`, the message helpers, and the new log-kind channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tahDJrwtrdd4MgmJMRnzL

---
_Generated by [Claude Code](https://claude.ai/code/session_013tahDJrwtrdd4MgmJMRnzL)_