### PR TITLE
Game.Api polish: unknown-command rejection, stale comments, Retry-After rounding (#1144)

### DIFF
--- a/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
@@ -51,6 +51,24 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
+        public async Task HandleMessage_UnknownCommandName_RejectsWithUnknownCommandErrorInsteadOfFaulting()
+        {
+            // A frame naming a command with no registered generator (a stale/garbage name) is a bad request,
+            // not an internal fault: it must be rejected with a structured "Unknown command." error rather than
+            // reaching the command lookup, whose throw would be logged at error and surfaced as an
+            // "Internal Server Error".
+            var (socket, handler) = CreateHandler(_ => null);
+
+            await handler.HandleMessage("{\"id\":\"c1\",\"name\":\"Unknown\",\"parameters\":null}");
+
+            Assert.Contains(socket.SentMessages, m => m.Contains("Unknown command.") && m.Contains("c1"));
+            Assert.Contains(_logs.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("unknown socket command"));
+            // It never reached the fault path: no error-level log, no "Internal Server Error" frame.
+            Assert.DoesNotContain(_logs.Entries, e => e.Level == LogLevel.Error);
+            Assert.DoesNotContain(socket.SentMessages, m => m.Contains("Internal Server Error"));
+        }
+
+        [Fact]
         public async Task ExecuteCommand_CommandFaults_SurfacesInternalServerErrorToTheClient()
         {
             var (socket, handler) = CreateHandler(name => name == "Boom" ? new InvalidOperationException("boom") : null);
@@ -138,6 +156,10 @@ namespace Game.Api.Tests.Unit
             {
                 return new StubCommand(commandInfo.Name, throwOn(commandInfo.Name)) { Id = commandInfo.Id };
             }
+
+            // Every name is treated as registered except the explicit "Unknown" sentinel, so the
+            // HandleMessage unknown-command guard can be exercised without populating the static registry.
+            public override bool IsKnownCommand(string commandName) => commandName != "Unknown";
         }
 
         private sealed class StubCommand(string name, Exception? toThrow) : AbstractSocketCommand

--- a/Game.Api.Tests/Unit/SocketCommandFactoryTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandFactoryTests.cs
@@ -48,5 +48,26 @@ namespace Game.Api.Tests.Unit
 
             Assert.False(factory.IsServerInitiatedOnly(commandName));
         }
+
+        [Theory]
+        [InlineData("GetZones")]
+        [InlineData("DefeatEnemy")]
+        [InlineData("SocketReplaced")]
+        public void IsKnownCommand_ReturnsTrue_ForRegisteredCommands(string commandName)
+        {
+            var factory = new SocketCommandFactory();
+
+            Assert.True(factory.IsKnownCommand(commandName));
+        }
+
+        [Theory]
+        [InlineData("NonExistentCommand")]
+        [InlineData("")]
+        public void IsKnownCommand_ReturnsFalse_ForUnregisteredCommands(string commandName)
+        {
+            var factory = new SocketCommandFactory();
+
+            Assert.False(factory.IsKnownCommand(commandName));
+        }
     }
 }

--- a/Game.Api/RateLimiting/RateLimiterServiceCollectionExtensions.cs
+++ b/Game.Api/RateLimiting/RateLimiterServiceCollectionExtensions.cs
@@ -60,8 +60,10 @@ namespace Game.Api.RateLimiting
 
             if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
             {
+                // Round up (matching the per-account login backoff's Retry-After): truncating a sub-second
+                // remaining window to 0 would tell the client it may retry immediately when it can't.
                 context.HttpContext.Response.Headers.RetryAfter =
-                    ((int)retryAfter.TotalSeconds).ToString(CultureInfo.InvariantCulture);
+                    ((int)Math.Ceiling(retryAfter.TotalSeconds)).ToString(CultureInfo.InvariantCulture);
             }
 
             await context.HttpContext.Response.WriteAsJsonAsync(

--- a/Game.Api/Services/SocketCommandFactory.cs
+++ b/Game.Api/Services/SocketCommandFactory.cs
@@ -20,6 +20,18 @@ namespace Game.Api.Services
         }
 
         /// <summary>
+        /// Whether a generator is registered for the named command. Lets the inbound client path reject an
+        /// unknown command name (e.g. a stale name across deploys) with a structured rejection rather than
+        /// letting it reach <see cref="CreateCommand"/>, whose throw would be misclassified as an internal
+        /// fault — logged at error and surfaced to the client as an "Internal Server Error". Virtual so a test
+        /// double can control known-ness without populating the static registry.
+        /// </summary>
+        public virtual bool IsKnownCommand(string commandName)
+        {
+            return _socketCommandGenerators.ContainsKey(commandName);
+        }
+
+        /// <summary>
         /// Creates the requested socket command inside a fresh DI scope.
         /// The caller is responsible for disposing the returned <see cref="IServiceScope"/>
         /// after the command has executed (and after any post-execution work such as UoW commit).

--- a/Game.Api/Sockets/Commands/AbstractReferenceDataCommand.cs
+++ b/Game.Api/Sockets/Commands/AbstractReferenceDataCommand.cs
@@ -4,9 +4,8 @@ namespace Game.Api.Sockets.Commands
 {
     /// <summary>
     /// Base for socket commands that fetch a read-only reference-data collection
-    /// (the static/intrinsic data the loading screen needs). Mirrors the
-    /// corresponding reference-data HTTP endpoints so the data can be loaded over
-    /// the authenticated WebSocket connection instead of a separate HTTP request.
+    /// (the static/intrinsic data the loading screen needs), served over the
+    /// authenticated WebSocket connection.
     /// </summary>
     /// <typeparam name="TModel">The API model type returned in the collection.</typeparam>
     public abstract class AbstractReferenceDataCommand<TModel> : AbstractSocketCommandWithResponseData<IEnumerable<TModel>>, IReferenceDataCommand

--- a/Game.Api/Sockets/Commands/GetAttributes.cs
+++ b/Game.Api/Sockets/Commands/GetAttributes.cs
@@ -3,8 +3,7 @@ using Attribute = Game.Api.Models.Attributes.Attribute;
 namespace Game.Api.Sockets.Commands
 {
     /// <summary>
-    /// Returns the intrinsic attribute reference-data collection. WebSocket
-    /// equivalent of the <c>GET /api/Attributes</c> endpoint.
+    /// Serves the intrinsic attribute reference-data set over the socket.
     /// </summary>
     public class GetAttributes : AbstractReferenceDataCommand<Attribute>
     {

--- a/Game.Api/Sockets/Commands/GetChallengeTypes.cs
+++ b/Game.Api/Sockets/Commands/GetChallengeTypes.cs
@@ -3,8 +3,7 @@ using Game.Api.Models.Progress;
 namespace Game.Api.Sockets.Commands
 {
     /// <summary>
-    /// Returns the intrinsic challenge-type reference-data collection. WebSocket
-    /// equivalent of the <c>GET /api/Challenges/ChallengeTypes</c> endpoint.
+    /// Serves the intrinsic challenge-type reference-data set over the socket.
     /// </summary>
     public class GetChallengeTypes : AbstractReferenceDataCommand<ChallengeType>
     {

--- a/Game.Api/Sockets/Commands/GetChallenges.cs
+++ b/Game.Api/Sockets/Commands/GetChallenges.cs
@@ -6,8 +6,7 @@ using CoreChallenge = Game.Core.Progress.Challenge;
 namespace Game.Api.Sockets.Commands
 {
     /// <summary>
-    /// Returns the full challenge reference-data collection. WebSocket equivalent
-    /// of the <c>GET /api/Challenges</c> endpoint.
+    /// Serves the full challenge reference-data set over the socket.
     /// </summary>
     public class GetChallenges : AbstractReferenceDataCommand<Challenge>
     {

--- a/Game.Api/Sockets/Commands/GetEnemies.cs
+++ b/Game.Api/Sockets/Commands/GetEnemies.cs
@@ -4,8 +4,7 @@ using Game.Abstractions.DataAccess;
 namespace Game.Api.Sockets.Commands
 {
     /// <summary>
-    /// Returns the full enemy reference-data collection. WebSocket equivalent of
-    /// the <c>GET /api/Enemies</c> endpoint.
+    /// Serves the full enemy reference-data set over the socket.
     /// </summary>
     public class GetEnemies : AbstractReferenceDataCommand<Enemy>
     {

--- a/Game.Api/Sockets/Commands/GetItemMods.cs
+++ b/Game.Api/Sockets/Commands/GetItemMods.cs
@@ -4,8 +4,7 @@ using Game.Abstractions.DataAccess;
 namespace Game.Api.Sockets.Commands
 {
     /// <summary>
-    /// Returns the full item-modifier reference-data collection. WebSocket
-    /// equivalent of the <c>GET /api/ItemMods</c> endpoint.
+    /// Serves the full item-modifier reference-data set over the socket.
     /// </summary>
     public class GetItemMods : AbstractReferenceDataCommand<ItemMod>
     {

--- a/Game.Api/Sockets/Commands/GetItems.cs
+++ b/Game.Api/Sockets/Commands/GetItems.cs
@@ -4,8 +4,7 @@ using Game.Abstractions.DataAccess;
 namespace Game.Api.Sockets.Commands
 {
     /// <summary>
-    /// Returns the full item reference-data collection. WebSocket equivalent of
-    /// the <c>GET /api/Items</c> endpoint.
+    /// Serves the full item reference-data set over the socket.
     /// </summary>
     public class GetItems : AbstractReferenceDataCommand<Item>
     {

--- a/Game.Api/Sockets/Commands/GetPlayerChallenges.cs
+++ b/Game.Api/Sockets/Commands/GetPlayerChallenges.cs
@@ -7,10 +7,9 @@ namespace Game.Api.Sockets.Commands
     /// <summary>
     /// Returns the connected player's challenge progress (player progress). Unlike the reference-data
     /// commands this is player-scoped: it resolves the player from the socket session and delegates to
-    /// <see cref="IPlayerProgressRepository.GetChallenges"/> — the same read the <c>GET /api/Challenges/Player</c>
-    /// endpoint runs (cache-first, so it serves warm cached progress). Named to stay unambiguous against
-    /// the reference-data <see cref="GetChallenges"/> command, which returns the challenge definitions
-    /// rather than the player's progress.
+    /// <see cref="IPlayerProgressRepository.GetChallenges"/> (cache-first, so it serves warm cached
+    /// progress). Named to stay unambiguous against the reference-data <see cref="GetChallenges"/>
+    /// command, which returns the challenge definitions rather than the player's progress.
     /// </summary>
     public class GetPlayerChallenges : AbstractSocketCommandWithResponseData<IEnumerable<PlayerChallenge>>
     {

--- a/Game.Api/Sockets/Commands/GetPlayerStatistics.cs
+++ b/Game.Api/Sockets/Commands/GetPlayerStatistics.cs
@@ -7,10 +7,9 @@ namespace Game.Api.Sockets.Commands
     /// <summary>
     /// Returns the connected player's tracked statistics (player progress). Unlike the reference-data
     /// commands this is player-scoped: it resolves the player from the socket session and delegates to
-    /// <see cref="IPlayerProgressRepository.GetStatistics"/> — the same read the <c>GET /api/Statistics</c>
-    /// endpoint runs (cache-first, so it serves warm cached progress). Named to stay unambiguous against
-    /// the reference-data <see cref="GetStatisticTypes"/> command, which returns statistic metadata rather
-    /// than the player's values.
+    /// <see cref="IPlayerProgressRepository.GetStatistics"/> (cache-first, so it serves warm cached
+    /// progress). Named to stay unambiguous against the reference-data <see cref="GetStatisticTypes"/>
+    /// command, which returns statistic metadata rather than the player's values.
     /// </summary>
     public class GetPlayerStatistics : AbstractSocketCommandWithResponseData<IEnumerable<PlayerStatistic>>
     {

--- a/Game.Api/Sockets/Commands/GetSkills.cs
+++ b/Game.Api/Sockets/Commands/GetSkills.cs
@@ -4,8 +4,7 @@ using Game.Abstractions.DataAccess;
 namespace Game.Api.Sockets.Commands
 {
     /// <summary>
-    /// Returns the full skill reference-data collection. WebSocket equivalent of
-    /// the <c>GET /api/Skills</c> endpoint.
+    /// Serves the full skill reference-data set over the socket.
     /// </summary>
     public class GetSkills : AbstractReferenceDataCommand<Skill>
     {

--- a/Game.Api/Sockets/Commands/GetStatisticTypes.cs
+++ b/Game.Api/Sockets/Commands/GetStatisticTypes.cs
@@ -3,8 +3,7 @@ using Game.Api.Models.Progress;
 namespace Game.Api.Sockets.Commands
 {
     /// <summary>
-    /// Returns the intrinsic statistic-type reference-data collection. WebSocket
-    /// equivalent of the <c>GET /api/Statistics/StatisticTypes</c> endpoint.
+    /// Serves the intrinsic statistic-type reference-data set over the socket.
     /// </summary>
     public class GetStatisticTypes : AbstractReferenceDataCommand<StatisticType>
     {

--- a/Game.Api/Sockets/Commands/GetZones.cs
+++ b/Game.Api/Sockets/Commands/GetZones.cs
@@ -4,8 +4,7 @@ using Game.Abstractions.DataAccess;
 namespace Game.Api.Sockets.Commands
 {
     /// <summary>
-    /// Returns the full zone reference-data collection. WebSocket equivalent of
-    /// the <c>GET /api/Zones</c> endpoint.
+    /// Serves the full zone reference-data set over the socket.
     /// </summary>
     public class GetZones : AbstractReferenceDataCommand<Zone>
     {

--- a/Game.Api/Sockets/Commands/SocketReplaced.cs
+++ b/Game.Api/Sockets/Commands/SocketReplaced.cs
@@ -8,9 +8,17 @@ namespace Game.Api.Sockets.Commands
 
         public override async Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
+            // This command deliberately owns its own send-then-close rather than deferring the send to the
+            // command runner: the success frame is what the client's SocketReplaced handler reacts to, and it
+            // must reach the client BEFORE the close frame — but the runner sends only after this returns, which
+            // is too late. Close() then moves the socket out of Open, so the runner's subsequent unconditional
+            // SendData of the returned response is a no-op (SendData returns false on a non-Open socket); the
+            // returned value is never transmitted. It is returned as Success() (not an empty frame) purely
+            // defensively: were the ordering ever changed so the socket were still Open, the runner would emit a
+            // valid success frame rather than a spurious empty one.
             await context.SendData(Success());
             await context.Close(ESocketCloseReason.SocketReplaced);
-            return new();
+            return Success();
         }
     }
 

--- a/Game.Api/Sockets/SocketHandler.cs
+++ b/Game.Api/Sockets/SocketHandler.cs
@@ -366,6 +366,17 @@ namespace Game.Api.Sockets
                         return;
                     }
 
+                    if (!_commandFactory.IsKnownCommand(commandInfo.Name))
+                    {
+                        // An unknown command name (a stale/garbage name, realistic across deploys) is a
+                        // bad request, not an internal fault: reject it with a structured error like the
+                        // sibling rejections above instead of letting it reach the command lookup, whose
+                        // throw would be logged at error and surfaced to the client as "Internal Server Error".
+                        _logger.LogWarning("Received unknown socket command: {CommandInfo} on socket: {Id}", commandInfo, Id);
+                        await SendErrorAsync(commandInfo, "Unknown command.");
+                        return;
+                    }
+
                     await ExecuteCommand(commandInfo);
                 }
             }


### PR DESCRIPTION
Closes #1144.

Addresses the four low-severity Game.Api polish items from the code-health review.

## 1. Unknown client command name → bad request, not internal fault

`SocketHandler.HandleMessage` validated that a command name was non-empty and not server-initiated, but not that it was *known*. An unknown name (a stale/garbage name, realistic across deploys) flowed into `SocketCommandFactory.CreateCommand`, which threw `InvalidOperationException` — classified as `Faulted`, **logged at `LogError` with the exception**, and returned to the client as `"Internal Server Error"`.

Adds `SocketCommandFactory.IsKnownCommand` (an O(1) lookup against the existing generator dictionary) and a guard in `HandleMessage` that rejects with a structured `"Unknown command."`, consistent with the `"Malformed command."` / `"Command cannot be invoked by the client."` rejections beside it.

## 2. Stale doc comments referencing removed HTTP endpoints

The `Get*` reference-data commands (and the two player-progress reads) said things like *"WebSocket equivalent of the `GET /api/Enemies` endpoint"*. Those controllers no longer exist — only `Login`, `Tags`, and the `Admin*` set remain, so the HTTP→socket migration is complete. Reworded to *"Serves the … reference-data set over the socket"* and dropped the `GET /api/X` references from the player-progress and base-class comments too.

## 3. Consistent `Retry-After` rounding

The IP rate limiter emitted `(int)retryAfter.TotalSeconds` (truncates — a 0.4 s remaining window emits `Retry-After: 0`, telling a client it may retry immediately when it can't), while the per-account login backoff used `Math.Ceiling`. Switched the IP limiter to `Math.Ceiling` so both 429 paths round up.

> A shared 429-envelope/`Retry-After` helper (noted as a "consider" in the issue) was left out: the two call sites differ enough in shape (rejection middleware vs. controller) that extracting one for a single formatting line wasn't clearly a win. Easy follow-up if a third 429 path appears.

## 4. `SocketReplaced` self-send-then-close (latent footgun)

`SocketReplaced.ExecuteAsync` self-sends `Success()` then closes, returning `new()` — which `RunCommandUnderLock` then unconditionally sends, a no-op only because `Close()` already moved the socket out of `Open`. The self-send-then-close is actually **required**: the client's `SocketReplaced` handler reacts to the success frame, which must arrive *before* the close frame, and the runner sends only after the command returns (too late). Documented that, and changed the return to `Success()` (not an empty frame) so that even a future reorder leaving the socket `Open` would emit a valid success frame rather than a spurious empty one.

## Test plan

- [x] `dotnet build` — clean, 0 warnings.
- [x] `dotnet test` full backend suite — green (Core 802, Infrastructure 58, Application 528, Api 609).
- [x] New unit coverage: `HandleMessage` unknown-command rejection (structured error, no fault-path error log / "Internal Server Error"), and `IsKnownCommand` true/false for registered/unregistered names.

No frontend changes — the reworded comments are XML doc summaries that don't affect the TypeScript codegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRr3jdTfzajDgMYeUPspsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRr3jdTfzajDgMYeUPspsr)_