### PR TITLE
Allow level-0 proficiency modifiers in admin authoring (#1174)

### DIFF
--- a/Game.Application.Tests/DataAccess/AdminProficienciesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminProficienciesIntegrationTests.cs
@@ -205,7 +205,7 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Theory]
-        [InlineData(0)]  // level 0 is the untrained state, never a payout level
+        [InlineData(-1)] // below the just-opened state, never a payout level
         [InlineData(11)] // past the cap (MaxLevel 10), so it would never fire
         public async Task SetModifiers_LevelOutOfRange_ReturnsFailure(int level)
         {
@@ -230,6 +230,38 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SetModifiers_LevelZero_IsAllowedAndPersisted()
+        {
+            // Level 0 is the just-opened state: a modifier authored there is an "on-open" bonus that the domain
+            // honors cumulatively (Proficiency.ModifiersForLevel uses l.Level <= level). The authoring path must
+            // accept what the domain is built and tested to apply.
+            int proficiencyId;
+            using (var seedScope = CreateScope())
+            {
+                proficiencyId = (await SeedProficiencyAsync(seedScope)).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminProficiencies>();
+                Assert.True(admin.SetModifiers(new SetProficiencyModifiersData
+                {
+                    Id = proficiencyId,
+                    Modifiers = [Modifier(level: 0, EAttribute.Strength, 7m)],
+                }).Succeeded);
+                await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using var assertScope = CreateScope();
+            var assertContext = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+            var modifier = await assertContext.ProficiencyLevelModifiers
+                .SingleAsync(m => m.ProficiencyId == proficiencyId, CancellationToken);
+            Assert.Equal(0, modifier.Level);
+            Assert.Equal(7m, modifier.Amount);
+        }
+
+        [Fact]
         public async Task SetRewards_LevelOutOfRange_ReturnsFailureBeforeTheSkillCheck()
         {
             int proficiencyId;
@@ -247,6 +279,32 @@ namespace Game.Application.Tests.DataAccess
             {
                 Id = proficiencyId,
                 Rewards = [new Contracts.ProficiencyLevelReward { Level = 11, RewardSkillId = 99999 }],
+            });
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("out of range", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SetRewards_LevelZero_ReturnsFailure()
+        {
+            // Unlike modifiers, a level-0 reward is rejected: a reward fires only by crossing a milestone
+            // (RewardSkillsCrossed uses l.Level > fromLevel), which a level-0 reward never does — the on-open
+            // grant is the proficiency's SeedSkillId. The level check fires before the skill id is resolved.
+            int proficiencyId;
+            using (var seedScope = CreateScope())
+            {
+                proficiencyId = (await SeedProficiencyAsync(seedScope)).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminProficiencies>();
+
+            var result = admin.SetRewards(new SetProficiencyRewardsData
+            {
+                Id = proficiencyId,
+                Rewards = [new Contracts.ProficiencyLevelReward { Level = 0, RewardSkillId = 99999 }],
             });
 
             Assert.False(result.Succeeded);

--- a/Game.DataAccess/Repositories/Admin/AdminProficiencies.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminProficiencies.cs
@@ -80,8 +80,10 @@ namespace Game.DataAccess.Repositories.Admin
             }
 
             // A per-level bonus only pays out at a level the proficiency can actually reach (the curve is
-            // interpreted in #1116), so a level outside 1..MaxLevel would author a payout that never fires.
-            if (FindLevelOutOfRange(proficiency, data.Modifiers.Select(m => m.Level), "level modifier") is { } rejection)
+            // interpreted in #1116), so a level outside 0..MaxLevel would author a payout that never fires.
+            // Level 0 is allowed for modifiers: the cumulative bonus rule (Proficiency.ModifiersForLevel uses
+            // l.Level <= level) honors a payout authored at the just-opened state.
+            if (FindLevelOutOfRange(proficiency, data.Modifiers.Select(m => m.Level), "level modifier", minLevel: 0) is { } rejection)
             {
                 return rejection;
             }
@@ -110,9 +112,12 @@ namespace Game.DataAccess.Repositories.Admin
                 return AdminSaveResult.NotFound("Proficiency");
             }
 
-            // A milestone reward only pays out at a reachable level (see SetModifiers), so reject one authored
-            // outside 1..MaxLevel before the anti-tamper skill check.
-            if (FindLevelOutOfRange(proficiency, data.Rewards.Select(r => r.Level), "level reward") is { } levelRejection)
+            // A milestone reward only pays out at a reachable, crossable level, so reject one authored outside
+            // 1..MaxLevel before the anti-tamper skill check. Unlike modifiers, level 0 is not allowed: a reward
+            // is granted by crossing a milestone (Proficiency.RewardSkillsCrossed uses l.Level > fromLevel, and
+            // fromLevel is never below 0), so a level-0 reward could never fire — the on-open grant is the
+            // proficiency's SeedSkillId.
+            if (FindLevelOutOfRange(proficiency, data.Rewards.Select(r => r.Level), "level reward", minLevel: 1) is { } levelRejection)
             {
                 return levelRejection;
             }
@@ -235,17 +240,18 @@ namespace Game.DataAccess.Repositories.Admin
             return null;
         }
 
-        /// <summary>Returns a rejection if any authored level falls outside <c>1..MaxLevel</c>, else null. A
-        /// payout level must be reachable: level 0 is the untrained state and levels past the cap never
-        /// fire.</summary>
-        private static AdminSaveResult? FindLevelOutOfRange(Entities.Proficiency proficiency, IEnumerable<int> levels, string role)
+        /// <summary>Returns a rejection if any authored level falls outside <c><paramref name="minLevel"/>..MaxLevel</c>,
+        /// else null. A payout level must be reachable, and levels past the cap never fire. <paramref name="minLevel"/>
+        /// is 0 for modifiers (a payout authored at the just-opened state is honored cumulatively) and 1 for rewards
+        /// (a reward fires only by crossing a milestone, which a level-0 reward never does).</summary>
+        private static AdminSaveResult? FindLevelOutOfRange(Entities.Proficiency proficiency, IEnumerable<int> levels, string role, int minLevel)
         {
             foreach (var level in levels)
             {
-                if (level < 1 || level > proficiency.MaxLevel)
+                if (level < minLevel || level > proficiency.MaxLevel)
                 {
                     return AdminSaveResult.Failure(
-                        $"Proficiency {role} level {level} is out of range (must be between 1 and the cap of {proficiency.MaxLevel}).");
+                        $"Proficiency {role} level {level} is out of range (must be between {minLevel} and the cap of {proficiency.MaxLevel}).");
                 }
             }
 


### PR DESCRIPTION
## Summary

Resolves the internal contradiction reported in #1174: the only proficiency authoring path forbade a capability the domain layer is built and tested to honor.

`AdminProficiencies.FindLevelOutOfRange` rejected any modifier/reward level `< 1`, but `Proficiency.ModifiersForLevel` uses `l.Level <= level` and has a dedicated passing test (`ProficiencyModifiersTests.ModifiersForLevel_IncludesAPayoutAuthoredAtLevelZero`). So a level-0 "on-open" bonus the domain applies could never be authored.

I went with **Option 1 (allow it)** from the issue — it's consistent with the domain, its test, and the spike's seed-on-open semantics ("opening a tier is itself an event").

## The modifier/reward asymmetry (design note for review)

I deliberately did **not** lower the floor uniformly. The fix lowers the floor to **0 for modifiers only**; **rewards keep the floor at 1**:

- **Modifiers** are cumulative (`ModifiersForLevel` → `l.Level <= level`), so a level-0 payout is meaningful and is honored.
- **Rewards** are granted by *crossing* a milestone (`RewardSkillsCrossed` → `l.Level > fromLevel`, and `fromLevel` is never below 0). A level-0 reward could therefore **never** fire — the on-open skill grant is the proficiency's `SeedSkillId` (`ProficiencyRewardService.Open`).

Uniformly allowing level 0 would have swapped the issue's contradiction for a new one (authoring a reward the domain silently ignores). Keeping rewards at 1 closes the reported gap without opening a dead-capability one. Flagging this here in case you'd rather rewards also accept level 0 for authoring symmetry — happy to change it, but I believe the asymmetry is correct.

## Changes

- `FindLevelOutOfRange` now takes a `minLevel` parameter; `SetModifiers` passes `0`, `SetRewards` passes `1`. Error message and XML doc updated to reflect the per-role floor.

## Test plan

- Updated `SetModifiers_LevelOutOfRange_ReturnsFailure` theory: `0` → `-1` (still out of range), `11` unchanged.
- Added `SetModifiers_LevelZero_IsAllowedAndPersisted` — a level-0 modifier now saves and round-trips.
- Added `SetRewards_LevelZero_ReturnsFailure` — locks in the deliberate asymmetry (level-0 rewards stay rejected).
- `dotnet build` clean (0 warnings); full `Game.Application.Tests` suite green (530 passed).

Closes #1174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5T1Dmnx2Dc8ejVHynr1Bk

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5T1Dmnx2Dc8ejVHynr1Bk)_