### PR TITLE
Derive Battler.isDead as a getter for backend parity (#1145)

### DIFF
--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -294,6 +294,28 @@ namespace Game.Core.Tests.Battle
                     ExpectedPlayerDied: false,
                     ExpectedTotalMs: 2000),
 
+                // MaxHealth debuff is LETHAL via the clamp (#1145): an Opponent MaxHealth additive −200 debuff
+                // drives the enemy's maximum below zero, so the clamp pulls its current health to ≤ 0 and the
+                // live IsDead getter reports death — a kill with NO direct damage, exercising the clamp path a
+                // cached isDead flag (re-synced only at the damage mutations) would miss. This is the frontend
+                // parity gap #1145 fixed by deriving isDead; the backend already derives IsDead so it passes here.
+                //   Player: skill baseDamage 0, no multiplier, cooldown 400 → fires tick 10. Effect: Opponent
+                //     −200 MaxHealth (additive), permanent.
+                //   Enemy:  Str=10 → MaxHealth=100, Def=2, no skills.
+                //   Tick 10: 0 direct damage, then −200 MaxHealth → MaxHealth −100, clamp 100→−100 → dead at 400ms.
+                ["maxHealthDebuffIsLethal"] = new ParityScenario(
+                    Player: () => MakeBattler(
+                        strength: 0, endurance: 0,
+                        skills:
+                        [
+                            MakeSkill(1, baseDamage: 0, cooldownMs: 400,
+                                effects: [MakeEffect(105, ESkillEffectTarget.Opponent, EAttribute.MaxHealth, EModifierType.Additive, -200, Permanent)]),
+                        ]),
+                    Enemy: () => MakeEnemy(strength: 10, endurance: 0, skills: []),
+                    ExpectedVictory: true,
+                    ExpectedPlayerDied: false,
+                    ExpectedTotalMs: 400),
+
                 // Same-tick CDR ordering: slot 0's self CooldownRecovery buff (applied after it fires) speeds
                 // up slot 1's charge accrual ON THE SAME TICK, because each slot reads the cooldown multiplier
                 // live in loadout order — so an earlier slot's effect influences a later slot firing that tick.

--- a/UI/src/lib/battle/battler.ts
+++ b/UI/src/lib/battle/battler.ts
@@ -79,7 +79,14 @@ export class Battler {
 	public currentHealth = 0;
 	public attributes: BattleAttributes = new BattleAttributes();
 	public skills: (Skill | undefined)[] = [];
-	public isDead = true;
+
+	/** Live-derived death state, mirroring the backend's `IsDead => CurrentHealth <= 0` getter so the two
+	 *  simulators agree by construction. Deriving it (rather than caching a flag re-synced at every
+	 *  currentHealth mutation) removes the whole "forgot to re-sync" class of parity drift — notably the
+	 *  MaxHealth-debuff clamp path, which lowers health without going through a damage mutation. */
+	public get isDead(): boolean {
+		return this.currentHealth <= 0;
+	}
 
 	/** The active timed effects on this battler, folded to one {@link ActiveEffectView} per (attribute,
 	 *  modifier type), as a reactive (`statify`) projection the active-effect chips render. Display-only
@@ -150,7 +157,6 @@ export class Battler {
 	public takeDamage(rawDamage: number, blockReduction = 0) {
 		const damage = applyDefense(rawDamage, this.attributes.getValue(EAttribute.Defense), blockReduction);
 		this.currentHealth -= damage;
-		this.isDead = this.currentHealth <= 0;
 		return damage;
 	}
 
@@ -165,7 +171,6 @@ export class Battler {
 	public applyDamageOverTime(timeDelta: number) {
 		const damage = (this.attributes.getValue(EAttribute.DamageTakenPerSecond) * timeDelta) / 1000;
 		this.currentHealth -= damage;
-		this.isDead = this.currentHealth <= 0;
 		return damage;
 	}
 
@@ -176,9 +181,6 @@ export class Battler {
 		const healed = Math.min(heal, this.attributes.getValue(EAttribute.MaxHealth) - this.currentHealth);
 		if (healed > 0) {
 			this.currentHealth += healed;
-			// Keep the cached flag in sync with currentHealth, mirroring takeDamage/applyDamageOverTime and
-			// the backend's always-live IsDead, so isDead is correct regardless of mutation ordering.
-			this.isDead = this.currentHealth <= 0;
 			return healed;
 		}
 
@@ -340,7 +342,6 @@ export class Battler {
 		}
 
 		this.currentHealth = this.attributes.getValue(EAttribute.MaxHealth);
-		this.isDead = false;
 	}
 
 	/** Assembles the battler's loadout: the player-selected skills first (in their chosen order, padded to

--- a/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
+++ b/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
@@ -389,6 +389,41 @@ const scenarios: ParityScenario[] = [
 		expected: { victory: true, playerDied: false, totalMs: 2000 }
 	},
 
+	// MaxHealth debuff is LETHAL via the clamp (#1145): an Opponent MaxHealth additive −200 debuff drives the
+	// enemy's maximum below zero, so the clamp pulls its current health to ≤ 0 and the live isDead getter
+	// reports death — a kill with NO direct damage, exercising the clamp path a cached isDead flag (re-synced
+	// only at the damage mutations) would miss. Mirrors the backend `maxHealthDebuffIsLethal` scenario.
+	//   Player: skill baseDamage 0, no multiplier, cooldown 400 (fires tick 10). Effect: Opponent −200 MaxHealth
+	//     (additive), permanent.
+	//   Enemy:  Str=10 → MaxHealth=100, Def=2, no skills.
+	//   Tick 10: 0 direct damage, then −200 MaxHealth → MaxHealth −100, clamp 100→−100 → dead at 400ms.
+	{
+		name: 'maxHealthDebuffIsLethal',
+		player: () =>
+			makeBattler(
+				[],
+				[
+					makeSkill(
+						0,
+						400,
+						[],
+						[
+							makeEffect(
+								105,
+								ESkillEffectTarget.Opponent,
+								EAttribute.MaxHealth,
+								EModifierType.Additive,
+								-200,
+								PERMANENT
+							)
+						]
+					)
+				]
+			),
+		enemy: () => makeBattler([{ id: EAttribute.Strength, amount: 10 }], []),
+		expected: { victory: true, playerDied: false, totalMs: 400 }
+	},
+
 	// Same-tick CDR ordering: slot 0's self CooldownRecovery buff speeds up slot 1's accrual on the same
 	// tick, because each slot reads the cooldown multiplier live in loadout order; slot 0 fires every tick
 	// and its buff STACKS, so cdMult climbs 1→2→3→… Mirrors the backend `cdrBuffSpeedsLaterSlotSameTick`.

--- a/UI/src/tests/lib/battle/battler.test.ts
+++ b/UI/src/tests/lib/battle/battler.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ERarity, EAttribute, ESkillAcquisition } from '$lib/api';
+import { ERarity, EAttribute, ESkillAcquisition, ESkillEffectTarget } from '$lib/api';
 import type { ISkill } from '$lib/api';
 import { EModifierType, EAttributeModifierSource } from '$lib/battle/attribute-modifier';
+import { makeEffect } from './battle-sim-test-utils';
 
 const mockSkills: ISkill[] = [];
 
@@ -302,6 +303,25 @@ describe('Battler', () => {
 			battler.takeDamage(99999);
 			expect(battler.isDead).toBe(true);
 			expect(battler.currentHealth).toBeLessThan(0);
+		});
+	});
+
+	describe('applyEffect MaxHealth clamp', () => {
+		// A MaxHealth debuff lowers health through the clamp, NOT a damage mutation (#1145). Deriving isDead
+		// keeps it correct on this path by construction; a cached flag re-synced only at the damage mutations
+		// would have missed it.
+		it('reports isDead when a MaxHealth debuff clamps health to <= 0', () => {
+			const battler = new Battler(
+				makeBattlerData({ selectedSkills: [], attributes: [{ attributeId: EAttribute.Strength, amount: 10 }] })
+			); // MaxHealth 100, currentHealth 100
+			expect(battler.isDead).toBe(false);
+
+			battler.applyEffect(
+				makeEffect(0, ESkillEffectTarget.Opponent, EAttribute.MaxHealth, EModifierType.Additive, -200, 1000)
+			);
+
+			expect(battler.currentHealth).toBeLessThanOrEqual(0);
+			expect(battler.isDead).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Closes #1145.

The frontend `Battler` (`UI/src/lib/battle/battler.ts`) cached `isDead` as a **field**, re-synced at each `currentHealth` damage mutation, while the backend computes `IsDead => CurrentHealth <= 0` **live**. The cache was correct only by discipline.

The issue's review comment identified a concrete, previously-untested manifestation: `clampHealthToMaxHealth` (reached from `applyEffect`/`advanceEffects`) lowers health *without* a damage mutation. A lethal `MaxHealth` debuff (multiplicative ≤ 0, or a large additive negative) therefore drove health to ≤ 0 while leaving the cached flag stale — a genuine FE/BE outcome/timing divergence on the anti-cheat replay surface.

## Changes

- **Convert `isDead` to a getter** (`get isDead() { return this.currentHealth <= 0; }`), removing the four manual re-syncs (`takeDamage`, `applyDamageOverTime`, `applyHealOverTime`, `reset`). The frontend now matches the backend's always-live `IsDead` **by construction**, eliminating the whole "forgot to re-sync" class of parity drift. The backend already derives `IsDead`, so no backend production change was needed.
- **Add a mirrored `maxHealthDebuffIsLethal` parity scenario** to both suites (`UI/src/tests/lib/battle/battle-simulation-parity.test.ts` and `Game.Core.Tests/Battle/BattleSimulatorParityTests.cs`): a skill with no direct damage applies an Opponent `−200 MaxHealth` (additive) debuff that kills the enemy purely via the clamp at 400 ms. This is the regression coverage the issue requested — it **fails under the old cached flag** (runs to timeout) and **passes** with the getter.
- **Add a focused `Battler` unit test** for the lethal-clamp path via `applyEffect` (the `applyEffect` clamp had no direct Battler-level coverage before).

## Test plan

- `dotnet build Game.Core.Tests` — clean (0 warnings).
- `BattleSimulatorParityTests` — 38 passed (incl. the new scenario); full `Game.Core.Tests` — 803 passed.
- FE `npm run lint` (eslint + svelte-check) — 0 errors / 0 warnings.
- FE `vitest --run` (full suite) — 2473 passed, incl. the new parity row and Battler unit test.

## Notes

- A MaxHealth debuff that drives the maximum below current health is the only health-lowering path that bypasses a damage mutation; this is exactly why the cached flag could diverge there. The getter makes the invariant structural rather than discipline-maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162MtQtmeSdYuYng1LaXDYW

---
_Generated by [Claude Code](https://claude.ai/code/session_0162MtQtmeSdYuYng1LaXDYW)_