### PR TITLE
Validate authored intrinsic-enum FK references on admin reference saves (#1148)

### DIFF
--- a/Game.Application.Tests/DataAccess/AdminItemModsIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminItemModsIntegrationTests.cs
@@ -42,6 +42,36 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public void SaveItemMods_UndefinedRarity_ReturnsFailureWithoutPersisting()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminItemMods>();
+
+            var result = admin.SaveItemMods(
+            [
+                new Change<Contracts.ItemMod> { ChangeType = EChangeType.Add, Item = NewItemMod(name: "Bad Rarity", rarity: (ERarity)0) },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("0 is not a valid item mod rarity.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void SaveItemMods_UndefinedType_ReturnsFailureWithoutPersisting()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminItemMods>();
+
+            var result = admin.SaveItemMods(
+            [
+                new Change<Contracts.ItemMod> { ChangeType = EChangeType.Add, Item = NewItemMod(name: "Bad Type", type: (EItemModType)0) },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("0 is not a valid item mod type.", result.ErrorMessage);
+        }
+
+        [Fact]
         public async Task SaveItemMods_AddAndEdit_PersistAndUpdateInPlace()
         {
             int modId;

--- a/Game.Application.Tests/DataAccess/AdminItemsIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminItemsIntegrationTests.cs
@@ -89,6 +89,36 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public void SaveItems_UndefinedRarity_ReturnsFailureWithoutPersisting()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminItems>();
+
+            var item = NewItem(name: "Bad Rarity Item");
+            item.RarityId = (ERarity)0;
+
+            var result = admin.SaveItems([new Change<Contracts.Item> { ChangeType = EChangeType.Add, Item = item }]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("0 is not a valid item rarity.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void SaveItems_UndefinedCategory_ReturnsFailureWithoutPersisting()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminItems>();
+
+            var item = NewItem(name: "Bad Category Item");
+            item.ItemCategoryId = (EItemCategory)0;
+
+            var result = admin.SaveItems([new Change<Contracts.Item> { ChangeType = EChangeType.Add, Item = item }]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("0 is not a valid item category.", result.ErrorMessage);
+        }
+
+        [Fact]
         public void SaveModSlots_AddForUnknownItem_ReturnsNotFound()
         {
             using var scope = CreateScope();

--- a/Game.Application.Tests/DataAccess/AdminSkillsIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminSkillsIntegrationTests.cs
@@ -259,6 +259,27 @@ namespace Game.Application.Tests.DataAccess
             }
         }
 
+        [Fact]
+        public void SaveSkills_UndefinedRarity_ReturnsFailureWithoutPersisting()
+        {
+            // A missing/0 RarityId has no Rarities row; the up-front guard rejects it as a clean BadRequest
+            // instead of letting it surface as an opaque FK 500 at commit.
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminSkills>();
+
+            var result = admin.SaveSkills(
+            [
+                new Change<Contracts.Skill>
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = NewSkill("Bad Rarity Skill", (ERarity)0),
+                },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("0 is not a valid skill rarity.", result.ErrorMessage);
+        }
+
         private static Contracts.Skill NewSkill(string name, ERarity rarity, int id = 0)
         {
             return new Contracts.Skill

--- a/Game.Application.Tests/DataAccess/ReferenceFieldValidationTests.cs
+++ b/Game.Application.Tests/DataAccess/ReferenceFieldValidationTests.cs
@@ -1,0 +1,92 @@
+using Game.Abstractions;
+using Game.Abstractions.Contracts.Admin;
+using Game.Core;
+using Game.DataAccess.Repositories.Admin;
+using Xunit;
+
+namespace Game.Application.Tests.DataAccess
+{
+    public class ReferenceFieldValidationTests
+    {
+        private sealed class TestModel : IModel
+        {
+            public required ERarity Rarity { get; init; }
+        }
+
+        private static Change<TestModel> Change(EChangeType changeType, ERarity rarity) => new()
+        {
+            ChangeType = changeType,
+            Item = new TestModel { Rarity = rarity },
+        };
+
+        [Fact]
+        public void FindUndefinedEnum_AllValid_ReturnsNull()
+        {
+            var changes = new[]
+            {
+                Change(EChangeType.Add, ERarity.Common),
+                Change(EChangeType.Edit, ERarity.Mythic),
+            };
+
+            Assert.Null(ReferenceFieldValidation.FindUndefinedEnum(changes, m => m.Rarity, "rarity"));
+        }
+
+        [Fact]
+        public void FindUndefinedEnum_UndefinedAdd_ReturnsFailureNamingTheValue()
+        {
+            // 0 is not a member of ERarity (Common = 1), so it has no backing reference row — the guard rejects
+            // it up front instead of letting it 500 on the FK at commit.
+            var result = ReferenceFieldValidation.FindUndefinedEnum(
+                [Change(EChangeType.Add, (ERarity)0)], m => m.Rarity, "skill rarity");
+
+            Assert.NotNull(result);
+            Assert.False(result.Succeeded);
+            Assert.Equal("0 is not a valid skill rarity.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void FindUndefinedEnum_UndefinedEdit_IsRejected()
+        {
+            // Edits are validated too — a re-tier to an unmapped value is the same FK hazard as an insert.
+            var result = ReferenceFieldValidation.FindUndefinedEnum(
+                [Change(EChangeType.Edit, (ERarity)99)], m => m.Rarity, "rarity");
+
+            Assert.NotNull(result);
+            Assert.Equal("99 is not a valid rarity.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void FindUndefinedEnum_UndefinedDelete_IsSkipped()
+        {
+            // A delete targets an existing row by id and carries no authored field worth validating, so an
+            // unmapped value on a delete must not trip the guard.
+            var result = ReferenceFieldValidation.FindUndefinedEnum(
+                [Change(EChangeType.Delete, (ERarity)0)], m => m.Rarity, "rarity");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void FindUndefinedEnum_ReturnsFirstViolationInOrder()
+        {
+            var changes = new[]
+            {
+                Change(EChangeType.Add, ERarity.Rare),
+                Change(EChangeType.Add, (ERarity)7),
+                Change(EChangeType.Edit, (ERarity)8),
+            };
+
+            var result = ReferenceFieldValidation.FindUndefinedEnum(changes, m => m.Rarity, "rarity");
+
+            Assert.NotNull(result);
+            Assert.Equal("7 is not a valid rarity.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void FindUndefinedEnum_EmptyChangeSet_ReturnsNull()
+        {
+            Assert.Null(ReferenceFieldValidation.FindUndefinedEnum(
+                Array.Empty<Change<TestModel>>(), m => m.Rarity, "rarity"));
+        }
+    }
+}

--- a/Game.DataAccess/Repositories/Admin/AdminItemMods.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminItemMods.cs
@@ -18,6 +18,18 @@ namespace Game.DataAccess.Repositories.Admin
 
         public AdminSaveResult SaveItemMods(IReadOnlyList<Change<Contracts.ItemMod>> changes)
         {
+            // Authoring guards: the rarity/type FKs point at enum-seeded reference tables, so an unmapped value
+            // (a missing/0 payload) would 500 on the FK at commit — reject it up front as a clean failure.
+            if (ReferenceFieldValidation.FindUndefinedEnum(changes, m => m.RarityId, "item mod rarity") is { } rarityRejection)
+            {
+                return rarityRejection;
+            }
+
+            if (ReferenceFieldValidation.FindUndefinedEnum(changes, m => m.ItemModTypeId, "item mod type") is { } typeRejection)
+            {
+                return typeRejection;
+            }
+
             return ChangeSetProcessor.Apply(changes,
                 add: item => _entityStore.Insert(new Entities.ItemMod
                 {

--- a/Game.DataAccess/Repositories/Admin/AdminItems.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminItems.cs
@@ -23,9 +23,21 @@ namespace Game.DataAccess.Repositories.Admin
 
         public AdminSaveResult SaveItems(IReadOnlyList<Change<Contracts.Item>> changes)
         {
-            // Authoring guard (anti-tamper): a skill an item grants must declare itself Item-acquirable. The
-            // flag is the declared intent; this reference is the reality, so the save bridges them — rejected
-            // up front before anything is staged (a tampered admin client can't bypass the filtered picker).
+            // Authoring guards (rejected up front before anything is staged). The rarity/category FKs point at
+            // enum-seeded reference tables, so an unmapped value would 500 on the FK at commit — reject it cleanly.
+            if (ReferenceFieldValidation.FindUndefinedEnum(changes, i => i.RarityId, "item rarity") is { } rarityRejection)
+            {
+                return rarityRejection;
+            }
+
+            if (ReferenceFieldValidation.FindUndefinedEnum(changes, i => i.ItemCategoryId, "item category") is { } categoryRejection)
+            {
+                return categoryRejection;
+            }
+
+            // Anti-tamper: a skill an item grants must declare itself Item-acquirable. The flag is the declared
+            // intent; this reference is the reality, so the save bridges them (a tampered admin client can't
+            // bypass the filtered picker).
             if (FindGrantedSkillFlagViolation(changes) is { } rejection)
             {
                 return rejection;

--- a/Game.DataAccess/Repositories/Admin/AdminSkills.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminSkills.cs
@@ -18,6 +18,13 @@ namespace Game.DataAccess.Repositories.Admin
 
         public AdminSaveResult SaveSkills(IReadOnlyList<Change<Contracts.Skill>> changes)
         {
+            // Authoring guard: a skill's rarity is a FK into the enum-seeded Rarities table, so an unmapped
+            // tier (a missing/0 payload) would 500 on the FK at commit — reject it up front as a clean failure.
+            if (ReferenceFieldValidation.FindUndefinedEnum(changes, s => s.RarityId, "skill rarity") is { } rejection)
+            {
+                return rejection;
+            }
+
             return ChangeSetProcessor.Apply(changes,
                 add: item => _entityStore.Insert(new Entities.Skill
                 {

--- a/Game.DataAccess/Repositories/Admin/ReferenceFieldValidation.cs
+++ b/Game.DataAccess/Repositories/Admin/ReferenceFieldValidation.cs
@@ -1,0 +1,52 @@
+using Game.Abstractions;
+using Game.Abstractions.Contracts.Admin;
+using Game.Abstractions.DataAccess.Admin;
+
+namespace Game.DataAccess.Repositories.Admin
+{
+    /// <summary>
+    /// Shared up-front guards for authored intrinsic-enum reference fields (e.g. rarity, category, mod type).
+    /// Each such field is persisted as a foreign key into an enum-seeded reference table, so a value outside
+    /// its <see cref="Enum"/> (a missing/<c>0</c> payload, or any unmapped tier) has no backing row and would
+    /// otherwise surface as an opaque <c>FK</c> 500 at commit instead of a clean validation rejection. Running
+    /// the check here — before anything is staged — keeps the rejection a graceful <see cref="AdminSaveResult"/>
+    /// (mapped to a 400) and leaves the batch unmodified.
+    /// </summary>
+    /// <remarks>
+    /// This deliberately covers only single-value enum FKs. A <c>[Flags]</c> field (e.g. a skill's acquisition
+    /// bitmask) is a free combination of its members, so <see cref="Enum.IsDefined{TEnum}(TEnum)"/> would wrongly
+    /// reject valid composite values — those need no such guard.
+    /// </remarks>
+    internal static class ReferenceFieldValidation
+    {
+        /// <summary>
+        /// Returns a rejection for the first added/edited change whose <paramref name="field"/> value is not a
+        /// defined <typeparamref name="TEnum"/> member, or <c>null</c> when every change carries a valid value.
+        /// Deletes are skipped — a delete targets an existing row by id and carries no authored field worth validating.
+        /// </summary>
+        public static AdminSaveResult? FindUndefinedEnum<T, TEnum>(
+            IReadOnlyList<Change<T>> changes,
+            Func<T, TEnum> field,
+            string fieldName)
+            where T : IModel
+            where TEnum : struct, Enum
+        {
+            foreach (var change in changes)
+            {
+                if (change.ChangeType == EChangeType.Delete)
+                {
+                    continue;
+                }
+
+                var value = field(change.Item);
+                if (!Enum.IsDefined(value))
+                {
+                    return AdminSaveResult.Failure(
+                        $"{Convert.ToInt32(value)} is not a valid {fieldName}.");
+                }
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1148 — a follow-up from the #1128 / PR #1147 skill-rarity review.

`AdminSkills.SaveSkills` persisted `RarityId` straight through to the entity, so a missing/`0` `RarityId` (or any value with no matching `Rarities` row) was caught only by the `FK_Skills_Rarities_RarityId` foreign key and surfaced as an opaque **500** instead of a clean validation rejection. `ERarity` has no `0` member (`Common = 1`), so `(ERarity)0` is not a valid tier — the exact gap behind the failing test fixed in PR #1147.

## What changed

- **New shared guard `ReferenceFieldValidation.FindUndefinedEnum`** (`Game.DataAccess/Repositories/Admin/`): rejects any add/edit change whose authored single-value enum FK isn't a defined member, returning `AdminSaveResult.Failure` up front before anything is staged. The controllers already map `Failure` → `BadRequest`, so a bad payload now gets a clean 400 + message instead of a 500. Deletes are skipped (they target an existing row by id).
- **Wired into all three reference-data save paths** for every intrinsic single-value enum FK they persist:
  - `AdminSkills.SaveSkills` → `RarityId`
  - `AdminItems.SaveItems` → `RarityId`, `ItemCategoryId`
  - `AdminItemMods.SaveItemMods` → `RarityId`, `ItemModTypeId`

## On the "generic helper" question (and scope beyond skills)

The issue asked to consider whether a generic *"validate authored FK references"* helper is warranted. It is: `RarityId` is straight-through on **skills, items, and item mods**, and `ItemCategoryId` / `ItemModTypeId` are the identical FK-backed-enum gap (all three enums start at `1`, so a `0`/missing payload 500s the FK). Rather than fix skills alone and leave three near-identical latent 500s, I extracted one small generic guard and applied it to every such FK on the paths I was already touching. **Flagging this as the deliberate scope decision** — the issue named skills, and I extended to the parallel cases; happy to trim back to skill-rarity only if you'd prefer.

`[Flags]` fields (skill `Acquisition`) are deliberately **not** covered — a free combination of members is valid, and `Enum.IsDefined` would wrongly reject composite values. This matches the issue's note that acquisition needs no such guard.

## Test plan

- `dotnet build` — clean (0 warnings, 0 errors).
- New pure unit tests `ReferenceFieldValidationTests` (6) — valid passes, undefined add/edit rejected, delete skipped, first-violation order, empty set.
- New integration wiring tests confirming each DI-resolved save path rejects before the FK hit: skill rarity, item rarity, item category, item-mod rarity, item-mod type.
- Full `Game.Application.Tests` suite green (539 passed).

## Notes / possible follow-up

This covers the intrinsic single-value enum FKs on the reference *save* paths. Other authored FK references (e.g. relationship setters that already validate membership their own way) are unaffected. If a broader "validate every authored FK" sweep is wanted it can be a separate tech-debt task — this PR scopes to the reported rarity gap and its immediate siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMGbKifLjtXdoVqhkaeh8v)_