### PR TITLE
Auth hardening: constant-work unknown-user login + rate-limit Logout (#1168)

### DIFF
--- a/Game.Abstractions/Auth/IPasswordHasher.cs
+++ b/Game.Abstractions/Auth/IPasswordHasher.cs
@@ -23,6 +23,14 @@ namespace Game.Abstractions.Auth
         /// caller to re-hash and persist it.
         /// </summary>
         PasswordVerificationResult Verify(string password, string storedHash);
+
+        /// <summary>
+        /// Performs password-derivation work equivalent to a real <see cref="Verify"/> against a fixed
+        /// internal dummy hash, discarding the result. Called on the unknown-username login branch so it
+        /// spends the same time as a known-username verify, preventing username enumeration by response
+        /// timing (the present-vs-absent-account branch a constant-time hash comparison alone cannot cover).
+        /// </summary>
+        void VerifyDummy(string password);
     }
 
     /// <summary>

--- a/Game.Api.Tests/Integration/AuthRateLimitingTests.cs
+++ b/Game.Api.Tests/Integration/AuthRateLimitingTests.cs
@@ -68,6 +68,23 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task Logout_DrawsFromThePerIpBudget()
+        {
+            // Exhaust the budget via Login.
+            for (var i = 0; i < PermitLimit; i++)
+            {
+                await Client.PostAsJsonAsync(
+                    "/api/Login", new { Username = "nobody", Password = "wrong" }, CancellationToken);
+            }
+
+            // Logout is anonymous like its siblings, so it must also be throttled once the shared budget is
+            // spent — closing the gap where it could be spammed unthrottled as a token-revocation surface.
+            var loggedOut = await Client.PostAsJsonAsync(
+                "/api/Login/Logout", new { RefreshToken = "any-token" }, CancellationToken);
+            Assert.Equal(HttpStatusCode.TooManyRequests, loggedOut.StatusCode);
+        }
+
+        [Fact]
         public async Task SingleRequest_UnderLimit_IsNotThrottled()
         {
             var response = await Client.PostAsJsonAsync(

--- a/Game.Api/Controllers/LoginController.cs
+++ b/Game.Api/Controllers/LoginController.cs
@@ -214,6 +214,7 @@ namespace Game.Api.Controllers
         }
 
         [AllowAnonymous]
+        [EnableRateLimiting(RateLimitingOptions.AuthPolicy)]
         [HttpPost]
         public async Task<ApiResponse> Logout([FromBody] RefreshRequest request)
         {

--- a/Game.Application.Tests/Auth/Pbkdf2PasswordHasherTests.cs
+++ b/Game.Application.Tests/Auth/Pbkdf2PasswordHasherTests.cs
@@ -88,6 +88,21 @@ namespace Game.Application.Tests.Auth
         }
 
         [Theory]
+        [InlineData(Password)]
+        [InlineData("")]
+        [InlineData("any other password")]
+        public void VerifyDummy_DoesNotThrow_ForAnyInput(string password)
+        {
+            var hasher = Create();
+
+            // The unknown-user timing mitigation must run derivation work for any supplied password without
+            // throwing — including the empty string and a password that never matches a real account.
+            var exception = Record.Exception(() => hasher.VerifyDummy(password));
+
+            Assert.Null(exception);
+        }
+
+        [Theory]
         [InlineData("")]
         [InlineData("not-a-real-hash")]
         [InlineData("$pbkdf2-sha256$")]

--- a/Game.Application.Tests/Services/AccountServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/AccountServiceIntegrationTests.cs
@@ -289,6 +289,42 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task Login_NonexistentUser_PerformsEquivalentPasswordWork()
+        {
+            using var scope = CreateScope();
+            var hasher = new RecordingPasswordHasher(TestPepper);
+            var accountService = CreateAccountService(scope.ServiceProvider, passwordHasher: hasher);
+
+            var result = await accountService.Login("ghost", "whatever");
+
+            Assert.False(result.Success);
+            Assert.Equal(LoginStatus.InvalidCredentials, result.Status);
+            // The unknown-user branch must spend the dummy derivation work (and never a real verify it has no
+            // hash for), so its response time matches a known-user verify and can't be used to enumerate names.
+            Assert.Equal(1, hasher.VerifyDummyCalls);
+            Assert.Equal(0, hasher.VerifyCalls);
+        }
+
+        [Fact]
+        public async Task Login_WrongPassword_PerformsRealVerifyNotDummy()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            await TestDataSeeder.CreateUserAsync(context, "knownuser", "correctpass");
+
+            var hasher = new RecordingPasswordHasher(TestPepper);
+            var accountService = CreateAccountService(scope.ServiceProvider, passwordHasher: hasher);
+
+            var result = await accountService.Login("knownuser", "incorrect");
+
+            Assert.False(result.Success);
+            Assert.Equal(LoginStatus.InvalidCredentials, result.Status);
+            // A known username takes the real verify path; the dummy path is for unknown users only.
+            Assert.Equal(1, hasher.VerifyCalls);
+            Assert.Equal(0, hasher.VerifyDummyCalls);
+        }
+
+        [Fact]
         public async Task Login_UserWithoutPlayer_SucceedsWithEmptySummaries()
         {
             using var scope = CreateScope();
@@ -763,12 +799,14 @@ namespace Game.Application.Tests.Services
             int iterations = 1000,
             LoginBackoffOptions? backoffOptions = null,
             TimeProvider? timeProvider = null,
-            int maxPlayersPerAccount = 6)
+            int maxPlayersPerAccount = 6,
+            IPasswordHasher? passwordHasher = null)
         {
             // A real PBKDF2 hasher (cheap iteration count) using the same pepper the seeder hashed with,
             // so seeded credentials verify exactly as they would in production. A higher iteration count
-            // can be supplied to exercise the transparent work-factor upgrade on login.
-            var hasher = new Pbkdf2PasswordHasher(Options.Create(new PasswordHashingOptions
+            // can be supplied to exercise the transparent work-factor upgrade on login, or a custom hasher
+            // injected to observe which derivation path a login took.
+            var hasher = passwordHasher ?? new Pbkdf2PasswordHasher(Options.Create(new PasswordHashingOptions
             {
                 Pepper = TestPepper,
                 Iterations = iterations,
@@ -801,6 +839,36 @@ namespace Game.Application.Tests.Services
         /// (<c>LoginControllerTests</c>); these tests exercise the account orchestration against the real
         /// Postgres/Redis collaborators, for which the access-token contents are irrelevant.
         /// </summary>
+        /// <summary>
+        /// A real PBKDF2 hasher that records which derivation path each login took, so a test can assert the
+        /// unknown-user branch spends the dummy work rather than short-circuiting (the timing-oracle fix).
+        /// </summary>
+        private sealed class RecordingPasswordHasher(string pepper) : IPasswordHasher
+        {
+            private readonly Pbkdf2PasswordHasher _inner = new(Options.Create(new PasswordHashingOptions
+            {
+                Pepper = pepper,
+                Iterations = 1000,
+            }));
+
+            public int VerifyCalls { get; private set; }
+            public int VerifyDummyCalls { get; private set; }
+
+            public string Hash(string password) => _inner.Hash(password);
+
+            public PasswordVerificationResult Verify(string password, string storedHash)
+            {
+                VerifyCalls++;
+                return _inner.Verify(password, storedHash);
+            }
+
+            public void VerifyDummy(string password)
+            {
+                VerifyDummyCalls++;
+                _inner.VerifyDummy(password);
+            }
+        }
+
         private sealed class StubAccessTokenService : IAccessTokenService
         {
             public string CreateAccessToken(int userId, IReadOnlyList<string> roles, int? playerId = null)

--- a/Game.Application/Auth/Pbkdf2PasswordHasher.cs
+++ b/Game.Application/Auth/Pbkdf2PasswordHasher.cs
@@ -25,16 +25,23 @@ namespace Game.Application.Auth
         private const string FormatPrefix = "$pbkdf2-sha256$";
         private const int KeyLengthBytes = 32;
         private const int SaltLengthBytes = 16;
+        // A fixed plaintext whose hash an unknown-user login verifies against; its content is irrelevant
+        // since the comparison is never expected to match — only the derivation cost matters.
+        private const string DummyPassword = "unknown-user-timing-mitigation";
         private static readonly HashAlgorithmName DerivationAlgorithm = HashAlgorithmName.SHA256;
 
         private readonly int _iterations;
         private readonly byte[] _pepper;
+        // A dummy hash at the current work factor, derived once on first use. Verifying a supplied password
+        // against it costs the same PBKDF2 work as a real account, masking the unknown-user branch.
+        private readonly Lazy<string> _dummyHash;
 
         public Pbkdf2PasswordHasher(IOptions<PasswordHashingOptions> options)
         {
             var value = options.Value;
             _iterations = value.Iterations;
             _pepper = Encoding.UTF8.GetBytes(value.Pepper);
+            _dummyHash = new Lazy<string>(() => Hash(DummyPassword));
         }
 
         public string Hash(string password)
@@ -67,6 +74,13 @@ namespace Game.Application.Auth
             return iterations == _iterations
                 ? PasswordVerificationResult.Success
                 : PasswordVerificationResult.SuccessRehashNeeded;
+        }
+
+        public void VerifyDummy(string password)
+        {
+            // Run a full verify (derivation + constant-time compare) against the dummy hash and discard the
+            // outcome — the call exists only to spend the same work a real verify would on a known username.
+            Verify(password, _dummyHash.Value);
         }
 
         private byte[] Derive(string password, byte[] salt, int iterations)

--- a/Game.Application/Services/AccountService.cs
+++ b/Game.Application/Services/AccountService.cs
@@ -84,6 +84,9 @@ namespace Game.Application.Services
             var account = await _users.GetUser(username);
             if (account is null)
             {
+                // Spend the same PBKDF2 work a real account's verify would, so an unknown username is not
+                // distinguishable by response time (defeating timing-based username enumeration).
+                _passwordHasher.VerifyDummy(password);
                 await _backoffGuard.RegisterFailure(username);
                 return AccountLoginResult.Failed(LoginStatus.InvalidCredentials);
             }

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -174,7 +174,7 @@ The **token is the sole authorization source of truth** (roles are read off the 
 
 ### Password hashing
 
-Passwords use **PBKDF2-HMAC-SHA256** behind an `IPasswordHasher` abstraction. A hash is stored in a self-contained, tunable format carrying the iteration count and a per-hash salt (default 600k iterations, the OWASP floor); an application-wide pepper is folded in via HMAC and validated at startup so a missing pepper fails fast. Verification is constant-time, and a valid credential stored with an outdated work factor is transparently re-hashed on next login.
+Passwords use **PBKDF2-HMAC-SHA256** behind an `IPasswordHasher` abstraction. A hash is stored in a self-contained, tunable format carrying the iteration count and a per-hash salt (default 600k iterations, the OWASP floor); an application-wide pepper is folded in via HMAC and validated at startup so a missing pepper fails fast. Verification is constant-time, and a valid credential stored with an outdated work factor is transparently re-hashed on next login. An **unknown username** still runs equivalent derivation work via `IPasswordHasher.VerifyDummy` (against a fixed dummy hash), so the login response time does not reveal whether an account exists — a constant-time hash compare alone cannot cover the present-vs-absent-account branch.
 
 ### Account/login orchestration
 


### PR DESCRIPTION
## Summary

Closes #1168 — two small auth-surface hardening gaps in the `LoginController`/`AccountService` login flow. Neither was a live exploit; both are cheap to close.

## 1. Login username-enumeration timing oracle

`AccountService.Login` returned immediately for an **unknown** username (`GetUser` → null) **without any password work**, while a **known** username ran the deliberately-slow PBKDF2 verify. The response-time gap is large and measurable, letting an attacker enumerate valid usernames by timing — one request per probe, under the per-IP limiter and per-account backoff (which throttle guessing, not timing). The existing `FixedTimeEquals` only makes the hash *comparison* constant-time; it doesn't cover the present-vs-absent-account branch.

**Fix:** the unknown-user branch now spends equivalent derivation work via a new `IPasswordHasher.VerifyDummy(password)` — a full derive + constant-time compare against a fixed, lazily-precomputed dummy hash at the current work factor, result discarded — before returning the same `InvalidCredentials`. Both branches now do one PBKDF2 derivation.

- `IPasswordHasher` gains `VerifyDummy`; `Pbkdf2PasswordHasher` precomputes the dummy hash once (`Lazy<string>`) so its work factor tracks config.
- The dummy hash is derived from a fixed constant; only its derivation cost matters (the compare is never expected to match).

## 2. `Logout` was anonymous but unthrottled

`LoginController.Logout` is `[AllowAnonymous]` but, unlike its siblings `Login`/`Refresh`/`CreateAccount`, carried no `[EnableRateLimiting(AuthPolicy)]` — an unthrottled refresh-token revocation/probing surface. The limiter is opt-in per endpoint, so the asymmetry left it open.

**Fix:** added `[EnableRateLimiting(RateLimitingOptions.AuthPolicy)]` to `Logout`, matching the other anonymous auth endpoints.

## Tests

- **`Pbkdf2PasswordHasherTests`** — `VerifyDummy` runs for any input (incl. the empty string and a non-matching password) without throwing.
- **`AccountServiceIntegrationTests`** (via a recording-hasher decorator over the real PBKDF2 hasher) — an unknown-user login spends the **dummy** derivation path and never a real verify; a known-user wrong-password login takes the **real** verify path and never the dummy. This is the deterministic regression guard for the timing fix (no flaky wall-clock assertions).
- **`AuthRateLimitingTests`** — `Logout` draws from the shared per-IP budget and is throttled once it's spent.

## Test plan

- `dotnet build` — clean (0 warnings, 0 errors).
- `Game.Application.Tests` — 533 passed.
- `Game.Api.Tests` — 610 passed.

## Docs

Updated the password-hashing section of `docs/backend.md` to note the unknown-user constant-work mitigation (a constant-time hash compare alone cannot cover the present-vs-absent-account branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKBvRnakFydDJkwqZAgrVk)_