### PR TITLE
Extract shared SerializedQueue for optimistic-mutation queues (#1183)

### DIFF
--- a/UI/src/lib/common/index.ts
+++ b/UI/src/lib/common/index.ts
@@ -12,4 +12,5 @@ export * from './item-display';
 export * from './types';
 export * from './hooks';
 export * from './event-measuring';
+export * from './serialized-queue';
 export * from './statify.svelte';

--- a/UI/src/lib/common/serialized-queue.ts
+++ b/UI/src/lib/common/serialized-queue.ts
@@ -1,0 +1,27 @@
+/**
+ * Serializes async operations onto a single chain so each one runs only after the previous has fully
+ * settled — its persist and any rollback included. Overlapping optimistic mutations would otherwise
+ * interleave their rollback baselines: one operation's rollback could restore a snapshot taken before
+ * another's optimistic change, silently discarding it and leaving local state diverged from the server.
+ * Chaining queues the operations instead, which is better UX than dropping the later one — the same
+ * "collapse concurrency" spirit as auth.ts's single-flight refresh.
+ *
+ * Each caller keeps its own optimistic-apply + rollback policy inside the operation closure; the queue
+ * only owns the ordering and the always-fulfilled tail.
+ */
+export class SerializedQueue {
+	/** Tail of the queue; each enqueued operation chains off it. Kept always-fulfilled (see {@link run}). */
+	private tail: Promise<unknown> = Promise.resolve();
+
+	/**
+	 * Queues `operation` to run after every previously-enqueued operation has settled, returning a promise
+	 * for its result (rejecting if `operation` itself rejects). `operation` runs regardless of whether the
+	 * previous one fulfilled or rejected. The internal tail swallows that rejection so one operation's
+	 * failure can't break the chain or surface as an unhandled rejection on the shared promise.
+	 */
+	run<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.tail.then(operation, operation);
+		this.tail = result.catch(() => undefined);
+		return result;
+	}
+}

--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -2,6 +2,7 @@ import { IInventoryItem, IBattlerAttribute, ELogType, EItemCategory, EEquipmentS
 import { playerManager } from '$lib/engine';
 import { BattleAttributes, Item, newItem, newItemMod } from '$lib/battle';
 import { logMessage } from '$lib/engine/log';
+import { SerializedQueue } from '$lib/common';
 
 // Re-exported from the generated client so the established `$lib/engine` import sites keep resolving
 // it here while the single source of truth is the codegen'd enum.
@@ -66,8 +67,8 @@ export class InventoryManager {
 	 */
 	private grantedSkillIdsCache: number[] = [];
 
-	/** Tail of the optimistic-mutation queue; each mutation chains off it so rollback baselines never interleave. */
-	private lastOperation: Promise<unknown> = Promise.resolve();
+	/** Serializes the optimistic mutations so rollback baselines never interleave (see {@link serialize}). */
+	private queue = new SerializedQueue();
 
 	public initialize() {
 		this.unlockedItems.clear();
@@ -318,16 +319,11 @@ export class InventoryManager {
 	 * included. Overlapping callers (a double-click equip, dragging a second item while the first
 	 * persist is still in flight) would otherwise interleave baselines: one operation's rollback could
 	 * restore a snapshot taken before another's optimistic change, silently discarding it and leaving
-	 * local state diverged from the server. Chaining onto a single promise — the same "collapse
-	 * concurrency" spirit as auth.ts's single-flight refresh — queues the actions instead, which is
-	 * better UX than dropping the second one.
+	 * local state diverged from the server. The shared {@link SerializedQueue} queues the actions instead,
+	 * which is better UX than dropping the second one.
 	 */
 	private serialize<T>(operation: () => Promise<T>): Promise<T> {
-		const result = this.lastOperation.then(operation, operation);
-		// The queue tracks settlement only — swallowing a failure here keeps one operation's rejection
-		// from breaking the chain or surfacing as an unhandled rejection on the shared promise.
-		this.lastOperation = result.catch(() => undefined);
-		return result;
+		return this.queue.run(operation);
 	}
 
 	/** The equip mutation, reassigning a fresh slot array so a captured snapshot stays a valid baseline. */

--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -25,7 +25,7 @@ import {
 	skillContributions,
 	type SkillContribution
 } from '$lib/battle';
-import { enemyDefense } from '$lib/common';
+import { enemyDefense, SerializedQueue } from '$lib/common';
 import { playerManager, inventoryManager } from '$lib/engine';
 import { staticData, toastError } from '$stores';
 
@@ -130,9 +130,9 @@ export class SkillsView {
 	private pendingLoadout = $state<number[] | null>(null);
 	/** Last loadout the server confirmed — the rollback target when the latest commit fails. */
 	private committed: number[] = [];
-	/** Tail of the optimistic-commit queue; each commit chains off it so persists apply in edit order
-	 *  and rollback baselines never interleave (mirrors the inventory manager's serialized mutations). */
-	private lastCommit: Promise<unknown> = Promise.resolve();
+	/** Serializes the optimistic commits so persists apply in edit order and rollback baselines never
+	 *  interleave (mirrors the inventory manager's serialized mutations). */
+	private queue = new SerializedQueue();
 	/** Monotonic edit counter; a failed persist rolls back only when it was the latest edit issued. */
 	private commitSeq = 0;
 	search = $state('');
@@ -448,16 +448,16 @@ export class SkillsView {
 	/** Optimistically apply a new loadout, persist it atomically, and revert on failure. The player
 	 *  manager owns the loadout mutation (so battles/other screens see it without a reload).
 	 *
-	 *  Commits are serialized on {@link lastCommit} so their persists apply in edit order and never
-	 *  interleave rollback baselines: only the *latest* edit's failure rolls back — to the last
-	 *  server-confirmed loadout ({@link committed}), not a per-call snapshot — so an earlier failure
-	 *  can't silently discard a later successful edit. The optimistic write itself is synchronous, so
-	 *  rapid edits read fresh state and queue rather than racing. */
+	 *  Commits are serialized on {@link queue} so their persists apply in edit order and never interleave
+	 *  rollback baselines: only the *latest* edit's failure rolls back — to the last server-confirmed
+	 *  loadout ({@link committed}), not a per-call snapshot — so an earlier failure can't silently discard
+	 *  a later successful edit. The optimistic write itself is synchronous, so rapid edits read fresh state
+	 *  and queue rather than racing. */
 	private commit(next: number[]): void {
 		this.pendingLoadout = next;
 		playerManager.setSelectedSkills(next);
 		const seq = ++this.commitSeq;
-		const result = this.lastCommit.then(async () => {
+		this.queue.run(async () => {
 			const response = await apiSocket.sendSocketCommand('SetSelectedSkills', next);
 			const isLatest = seq === this.commitSeq;
 			if (response.error) {
@@ -473,8 +473,5 @@ export class SkillsView {
 				}
 			}
 		});
-		// Keep the queue tail always-fulfilled: a rejecting callback would otherwise make every later
-		// commit skip its persist and raise an unhandled rejection (mirrors the inventory manager's serialize).
-		this.lastCommit = result.catch(() => undefined);
 	}
 }

--- a/UI/src/tests/lib/common/serialized-queue.test.ts
+++ b/UI/src/tests/lib/common/serialized-queue.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { SerializedQueue } from '$lib/common';
+
+// SerializedQueue runs each enqueued operation only after the previous one has fully settled, returning
+// a promise for each operation's own result and keeping its internal tail always-fulfilled so one
+// failure can't break the chain.
+
+/** A manually-resolved promise plus its resolve/reject handles, for driving settlement order in tests. */
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+describe('SerializedQueue', () => {
+	it('returns each operation result to its own caller', async () => {
+		const queue = new SerializedQueue();
+		const a = queue.run(async () => 'a');
+		const b = queue.run(async () => 'b');
+		expect(await a).toBe('a');
+		expect(await b).toBe('b');
+	});
+
+	it('does not start an operation until the previous one has settled', async () => {
+		const queue = new SerializedQueue();
+		const order: string[] = [];
+		const first = deferred<void>();
+
+		const a = queue.run(async () => {
+			order.push('a-start');
+			await first.promise;
+			order.push('a-end');
+		});
+		const b = queue.run(async () => {
+			order.push('b-start');
+		});
+
+		// `b` must wait for `a` to settle, even though it was enqueued immediately.
+		await Promise.resolve();
+		expect(order).toEqual(['a-start']);
+
+		first.resolve();
+		await Promise.all([a, b]);
+		expect(order).toEqual(['a-start', 'a-end', 'b-start']);
+	});
+
+	it('rejects the failing operation to its caller but still runs later operations', async () => {
+		const queue = new SerializedQueue();
+		const failing = queue.run(async () => {
+			throw new Error('boom');
+		});
+		const next = queue.run(async () => 'after');
+
+		await expect(failing).rejects.toThrow('boom');
+		expect(await next).toBe('after');
+	});
+
+	it('runs operations in enqueue order', async () => {
+		const queue = new SerializedQueue();
+		const order: number[] = [];
+		const runs = [0, 1, 2, 3].map((n) =>
+			queue.run(async () => {
+				order.push(n);
+			})
+		);
+		await Promise.all(runs);
+		expect(order).toEqual([0, 1, 2, 3]);
+	});
+});


### PR DESCRIPTION
## Summary

Both `InventoryManager` and `SkillsView` had grown a hand-rolled copy of the same "serialized optimistic mutation" pattern — chaining each mutation off a shared `lastOperation`/`lastCommit` promise so rollback baselines never interleave, with a `.catch(() => undefined)` tail keeping the shared promise always-fulfilled. The chaining/guard mechanics were identical; only the per-operation body and rollback model differed.

This extracts the queue mechanics into a small **`SerializedQueue`** helper in `$lib/common` and routes both call sites through it. Each caller keeps its own optimistic-apply + rollback policy inside the operation closure — only the ordering and the always-fulfilled tail move into the helper.

## How it addresses the issue

- New `UI/src/lib/common/serialized-queue.ts` — `SerializedQueue` owns the `tail` promise, the `tail.then(op, op)` chaining, and the `.catch(() => undefined)` tail, exposing a single `run(operation)`.
- `InventoryManager.serialize` now delegates to a `SerializedQueue` instance (its public surface and per-mutation rollback closures are unchanged).
- `SkillsView.commit` now enqueues through the same helper; the `commitSeq`/`isLatest` baseline-advancement logic stays in the closure.
- No user-facing behavior change — pure DRY/maintainability cleanup, exactly the two consumers the issue named.

The `tail.then(op, op)` form (run the next operation regardless of whether the previous fulfilled or rejected) preserves the inventory manager's original `.then(operation, operation)` semantics; the skills view used a single-arg `.then`, but since the tail is always-fulfilled the two were already equivalent in practice.

## Test plan

- [x] New `serialized-queue.test.ts` covers: each op's result returns to its own caller; an op doesn't start until the previous settles; a rejecting op rejects to its caller but later ops still run; enqueue order is preserved.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] Existing `skills-view` and `inventory-manager`/player tests pass unchanged (178 tests across the affected suites).

## Note

The `#1191` part-2 baseline-advancement correctness nuance also lives in `SkillsView.commit` and is left untouched here, as that issue intends — this PR only relocates the queue mechanics.

Closes #1183

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVAcVb3j7bigQ94Ng2tRLH)_