### PR TITLE
Backend small cleanups: dead field, enum-count coupling, dup lookup, dead local (#1192)

### DIFF
--- a/Game.Api/Sockets/Commands/ChallengeBoss.cs
+++ b/Game.Api/Sockets/Commands/ChallengeBoss.cs
@@ -27,6 +27,11 @@ namespace Game.Api.Sockets.Commands
         {
             var state = context.Session.PlayerState;
             var player = context.Session.Player;
+            // Deliberate asymmetry with the auto-loop sibling SetAutoChallengeBoss (which always uses the
+            // current zone): the interactive challenge lets the client name a zone so a player can re-farm a
+            // previously-cleared boss without walking back. This can't reach locked content — StartBossBattle
+            // still gates on the zone being unlocked and not retired — so a client can only name a zone it has
+            // already unlocked.
             var zoneId = Parameters.ZoneId ?? player.CurrentZoneId;
 
             var result = await _battleService.StartBossBattle(player, state, zoneId, Parameters.ClientBattleMs, cancellationToken);

--- a/Game.Api/Sockets/SocketHandler.cs
+++ b/Game.Api/Sockets/SocketHandler.cs
@@ -134,7 +134,6 @@ namespace Game.Api.Sockets
         /// </summary>
         internal async Task<SocketCommandOutcome> ExecuteServerCommand(SocketCommandInfo commandInfo)
         {
-            var now = Stopwatch.GetTimestamp();
             _logger.LogTrace("Executing server-initiated command: {CommandInfo} on socket: {Id}", commandInfo, Id);
             var (outcome, fault) = await RunCommandUnderLock(commandInfo);
             if (outcome is SocketCommandOutcome.Faulted)

--- a/Game.Application.Tests/Events/BattleStatisticsEventHandlerTests.cs
+++ b/Game.Application.Tests/Events/BattleStatisticsEventHandlerTests.cs
@@ -197,7 +197,7 @@ namespace Game.Application.Tests.Events
             // The skill fired once in the won battle, so its proficiency is represented and (being the only one)
             // takes the whole pie; below the first threshold it accrues without leveling.
             var stats = new BattleStats();
-            stats.SkillStats[skill.Id] = new SkillStats { SkillId = skill.Id, Uses = 1 };
+            stats.SkillStats[skill.Id] = new SkillStats { Uses = 1 };
             await handler.HandleAsync(VictoryEvent(loadedPlayer, loadedEnemy, stats, difficultyMultiplier: 1.0), CancellationToken);
 
             var progressRepo = scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>();
@@ -248,7 +248,7 @@ namespace Game.Application.Tests.Events
             Assert.NotNull(loadedEnemy);
 
             var stats = new BattleStats();
-            stats.SkillStats[skill.Id] = new SkillStats { SkillId = skill.Id, Uses = 1 };
+            stats.SkillStats[skill.Id] = new SkillStats { Uses = 1 };
             await MakeHandler(scope).HandleAsync(
                 VictoryEvent(loadedPlayer, loadedEnemy, stats, difficultyMultiplier: 1.0), CancellationToken);
 
@@ -323,7 +323,7 @@ namespace Game.Application.Tests.Events
             Assert.NotNull(loadedEnemy);
 
             var stats = new BattleStats();
-            stats.SkillStats[skill.Id] = new SkillStats { SkillId = skill.Id, Uses = 1 };
+            stats.SkillStats[skill.Id] = new SkillStats { Uses = 1 };
             const double multiplier = 1.5;
 
             var liveLoaded = await playerRepo.GetPlayer(livePlayer.Id);

--- a/Game.Application.Tests/Services/ProficiencyRewardServiceTests.cs
+++ b/Game.Application.Tests/Services/ProficiencyRewardServiceTests.cs
@@ -260,7 +260,7 @@ namespace Game.Application.Tests.Services
         private static BattleStats FireSkill(int skillId)
         {
             var stats = new BattleStats();
-            stats.SkillStats[skillId] = new SkillStats { SkillId = skillId, Uses = 1 };
+            stats.SkillStats[skillId] = new SkillStats { Uses = 1 };
             return stats;
         }
     }

--- a/Game.Core.Tests/Battle/BattleContextTests.cs
+++ b/Game.Core.Tests/Battle/BattleContextTests.cs
@@ -20,7 +20,6 @@ namespace Game.Core.Tests.Battle
 
             Assert.Equal(1, context.Stats.PlayerSkillsUsed);
             var skill = Assert.Contains(5, (IReadOnlyDictionary<int, SkillStats>)context.Stats.SkillStats);
-            Assert.Equal(5, skill.SkillId);
             Assert.Equal(1, skill.Uses);
             Assert.Equal(30.0, skill.TotalDamage);
             Assert.Equal(30.0, skill.HighestSingleAttack);

--- a/Game.Core.Tests/Players/InventoryTests.cs
+++ b/Game.Core.Tests/Players/InventoryTests.cs
@@ -7,6 +7,18 @@ namespace Game.Core.Tests.Players
 {
     public class InventoryTests
     {
+        // ── Equipment slots ─────────────────────────────────────────────────
+
+        [Fact]
+        public void NewInventory_HasExactlyOneSlotPerEquipmentSlotValue()
+        {
+            var inventory = new Inventory();
+
+            var slotValues = inventory.EquipmentSlots.Select(s => s.Value).ToList();
+            Assert.Equal(Enum.GetValues<EEquipmentSlot>().Length, slotValues.Count);
+            Assert.Equal(Enum.GetValues<EEquipmentSlot>().ToHashSet(), slotValues.ToHashSet());
+        }
+
         // ── UnlockItem ──────────────────────────────────────────────────────
 
         [Fact]

--- a/Game.Core.Tests/Players/InventoryTests.cs
+++ b/Game.Core.Tests/Players/InventoryTests.cs
@@ -161,20 +161,20 @@ namespace Game.Core.Tests.Players
 
             var result = inventory.TryUnequipItem(EEquipmentSlot.AccessorySlot);
 
-            Assert.True(result);
+            Assert.Equal(1, result);
             var slot = inventory.EquipmentSlots.First(s => s.Value == EEquipmentSlot.AccessorySlot);
             Assert.Null(slot.ItemId);
             Assert.Null(slot.Item);
         }
 
         [Fact]
-        public void TryUnequipItem_EmptySlot_ReturnsFalse()
+        public void TryUnequipItem_EmptySlot_ReturnsNull()
         {
             var inventory = new Inventory();
 
             var result = inventory.TryUnequipItem(EEquipmentSlot.AccessorySlot);
 
-            Assert.False(result);
+            Assert.Null(result);
         }
 
         // ── TryApplyMod ─────────────────────────────────────────────────────

--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -286,8 +286,8 @@ namespace Game.Core.Tests.Progress
                 PlayerSkillsUsed = 3,
                 SkillStats =
                 {
-                    [10] = new SkillStats { SkillId = 10, Uses = 2, TotalDamage = 60.0, HighestSingleAttack = 35.0 },
-                    [20] = new SkillStats { SkillId = 20, Uses = 1, TotalDamage = 15.0, HighestSingleAttack = 15.0 },
+                    [10] = new SkillStats { Uses = 2, TotalDamage = 60.0, HighestSingleAttack = 35.0 },
+                    [20] = new SkillStats { Uses = 1, TotalDamage = 15.0, HighestSingleAttack = 15.0 },
                 },
             };
 

--- a/Game.Core/Battle/BattleContext.cs
+++ b/Game.Core/Battle/BattleContext.cs
@@ -153,7 +153,7 @@ namespace Game.Core.Battle
                 Stats.PlayerSkillsUsed++;
                 if (!Stats.SkillStats.TryGetValue(skillId, out var value))
                 {
-                    value = new SkillStats { SkillId = skillId };
+                    value = new SkillStats();
                     Stats.SkillStats[skillId] = value;
                 }
 

--- a/Game.Core/Battle/BattleStats.cs
+++ b/Game.Core/Battle/BattleStats.cs
@@ -12,7 +12,6 @@ namespace Game.Core.Battle
 
     public class SkillStats
     {
-        public int SkillId { get; set; }
         public int Uses { get; set; }
         public double TotalDamage { get; set; }
         public double HighestSingleAttack { get; set; }

--- a/Game.Core/Players/Inventories/Inventory.cs
+++ b/Game.Core/Players/Inventories/Inventory.cs
@@ -8,8 +8,6 @@ namespace Game.Core.Players.Inventories
     /// </summary>
     public class Inventory
     {
-        private static readonly int EquipSlots = (int)Enum.GetValues<EEquipmentSlot>().Max();
-
         /// <summary>
         /// All unlocked items indexed by <see cref="UnlockedItemSlot.ItemId"/>. The index is the backing
         /// store for the public <see cref="UnlockedItems"/> view, so every per-item lookup
@@ -107,16 +105,20 @@ namespace Game.Core.Players.Inventories
             return true;
         }
 
-        public bool TryUnequipItem(EEquipmentSlot slot)
+        /// <summary>
+        /// Clears the equipment slot for <paramref name="slot"/>, returning the id of the item that was
+        /// unequipped, or null when the slot was already empty (a no-op).
+        /// </summary>
+        public int? TryUnequipItem(EEquipmentSlot slot)
         {
             var equipSlot = EquipmentSlots.FirstOrDefault(s => s.Value == slot);
-            if (equipSlot is null || !equipSlot.ItemId.HasValue)
+            if (equipSlot?.ItemId is not int itemId)
             {
-                return false;
+                return null;
             }
 
             equipSlot.Clear();
-            return true;
+            return itemId;
         }
 
         public bool TryApplyMod(int itemId, int itemModId, int itemModSlotId, ItemMod mod)
@@ -220,8 +222,10 @@ namespace Game.Core.Players.Inventories
 
         private static List<EquipmentSlot> NewEquippedList()
         {
-            return Enumerable.Range(0, EquipSlots + 1)
-                .Select(index => new EquipmentSlot((EEquipmentSlot)index)
+            // Derive one slot per equipment-slot enum value directly, so the slot set tracks the enum
+            // without depending on it being contiguous or 0-based.
+            return Enum.GetValues<EEquipmentSlot>()
+                .Select(slot => new EquipmentSlot(slot)
                 {
                     Item = null,
                 }).ToList();

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -304,14 +304,7 @@ namespace Game.Core.Players
 
         public bool TryUnequipItem(EEquipmentSlot slot)
         {
-            var equipSlot = Inventory.EquipmentSlots.FirstOrDefault(s => s.Value == slot);
-            if (equipSlot?.ItemId is null)
-            {
-                return false;
-            }
-
-            var itemId = equipSlot.ItemId.Value;
-            if (!Inventory.TryUnequipItem(slot))
+            if (Inventory.TryUnequipItem(slot) is not int itemId)
             {
                 return false;
             }


### PR DESCRIPTION
## Summary

Addresses the basket of small, low-risk backend cleanups in #1192.

### Clear cleanups (done)

- **Dead `SkillStats.SkillId`** — removed the denormalized field on `Game.Core/Battle/BattleStats.cs`. It duplicated the `Dictionary<int, SkillStats>` key and was never read by production code (only tests). `BattleContext.RecordSkillUse` now constructs `new SkillStats()`; the tests that set/read the field were updated.
- **`Inventory.EquipSlots` enum-count coupling** — `NewEquippedList` now derives one slot per `EEquipmentSlot` value directly from `Enum.GetValues<EEquipmentSlot>()`, dropping the brittle `(int)…Max()` + `Range(0, EquipSlots + 1)` pattern that was correct only while the enum stays contiguous and 0-based. The `EquipSlots` static field is gone.
- **Duplicated slot lookup in `Player.TryUnequipItem`** — `Inventory.TryUnequipItem` now returns the unequipped item id (`int?`) instead of `bool`, so the player no longer re-scans `EquipmentSlots` to capture the id for the `ItemUnequippedEvent`.
- **Dead local in `SocketHandler.ExecuteServerCommand`** — removed the unused `var now = Stopwatch.GetTimestamp();` (the real timing lives in `RunCommandUnderLock`'s `finally`).

### Confirm-intended item — `ChallengeBoss` client zone

This one is a product decision, not a defect. `ChallengeBoss` accepts a client-supplied `ZoneId` (`Parameters.ZoneId ?? player.CurrentZoneId`) while the auto-loop sibling `SetAutoChallengeBoss` always uses the current zone. Since `StartBossBattle` still gates on the zone being **unlocked and not retired**, the parameter can't reach locked content — a client can only name a zone it has already unlocked (e.g. to re-farm a previously-cleared boss without walking back). That reads as a deliberate, player-favouring choice consistent with the project's other documented asymmetries, so I took the **non-behavior-changing** option: kept it and documented the asymmetry with a code comment.

👉 If you'd rather **drop the parameter** and force `player.CurrentZoneId` instead, that's a one-line change — happy to flip it. Flagging for your call.

## Test plan

- [x] `dotnet build` — clean, 0 warnings
- [x] `Game.Core.Tests` — 810 passed
- [x] `Game.Application.Tests` — 555 passed (Postgres/Redis integration)
- [x] `Game.Api.Tests` — 611 passed (integration)

No frontend changes (backend-only); the frontend battle code has no per-skill `SkillStats`/`skillId` equivalent, so removing the dead field has no parity impact.

Closes #1192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194RnT6n3kY8PKpswJv9fpd

---
_Generated by [Claude Code](https://claude.ai/code/session_0194RnT6n3kY8PKpswJv9fpd)_