### PR TITLE
Harden Redis infrastructure edges (#1193)

### DIFF
--- a/Game.Infrastructure.Tests/RedisCommandBudgetTests.cs
+++ b/Game.Infrastructure.Tests/RedisCommandBudgetTests.cs
@@ -29,6 +29,27 @@ namespace Game.Infrastructure.Tests
         }
 
         [Fact]
+        public async Task Read_AwaitCancelledThenCommandFaults_DoesNotSurfaceTheAbandonedFault()
+        {
+            var command = new TaskCompletionSource<int>();
+            using var cts = new CancellationTokenSource();
+
+            var read = RedisCommandBudget.Read(command.Task, cts.Token);
+
+            // The await unwinds promptly on cancellation even though the command is still in flight.
+            await cts.CancelAsync();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => read);
+
+            // The abandoned command later faults. The Read path attaches a silent fault-observing continuation, so
+            // the exception is observed rather than left to surface via TaskScheduler.UnobservedTaskException — and
+            // nothing escapes back to the already-unwound caller.
+            command.SetException(new InvalidOperationException("redis blew up"));
+
+            Assert.True(command.Task.IsFaulted);
+            Assert.True(read.IsCanceled);
+        }
+
+        [Fact]
         public async Task Write_AwaitCancelledThenCommandFaults_LogsTheAbandonedFault()
         {
             var command = new TaskCompletionSource<int>();

--- a/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
@@ -181,8 +181,12 @@ namespace Game.Infrastructure.PubSub.Redis
         {
             if (_handles.TryRemove(id, out var handle))
             {
-                handle.worker?.Dispose();
+                // Unsubscribe the handler before disposing the worker, not after. The handler is worker.Start(),
+                // so disposing first leaves a window where a message still routed to the (now-removed-but-still-
+                // subscribed) handler calls Start() on a disposed worker — an ObjectDisposedException thrown on the
+                // StackExchange.Redis subscriber thread. Removing the subscription first closes that window.
                 await Subscriber.UnsubscribeAsync(RedisChannel.Literal(channel), handle.handler);
+                handle.worker?.Dispose();
             }
         }
     }

--- a/Game.Infrastructure/Redis/RedisCommandBudget.cs
+++ b/Game.Infrastructure/Redis/RedisCommandBudget.cs
@@ -8,10 +8,12 @@ namespace Game.Infrastructure.Redis
     /// <em>await</em> unwind promptly when the budget is cancelled (releasing the caller without waiting out the
     /// dependency's own command timeout); the underlying command still runs to completion in the background.
     /// <para>
-    /// The two differ in how a post-cancellation fault on that abandoned command is treated: a <see cref="Read"/>
-    /// loses only an unobserved read, so none is attached, whereas a <see cref="Write{T}"/> could have silently
-    /// failed with no other signal, so a fault-logging continuation is attached. <see cref="CancellationToken.None"/>
-    /// makes <c>WaitAsync</c> a zero-overhead no-op, so uncancelled callers pay nothing.
+    /// Both observe a post-cancellation fault on that abandoned command (so it never surfaces via
+    /// <see cref="TaskScheduler.UnobservedTaskException"/> on finalization), but they differ in how loudly: a
+    /// <see cref="Read"/> discards only a value, so its fault is observed <em>silently</em>, whereas a
+    /// <see cref="Write{T}"/> could have silently failed with no other signal, so its fault is <em>logged</em>.
+    /// <see cref="CancellationToken.None"/> makes <c>WaitAsync</c> a zero-overhead no-op, so uncancelled callers
+    /// pay nothing.
     /// </para>
     /// </summary>
     internal static class RedisCommandBudget
@@ -22,7 +24,19 @@ namespace Game.Infrastructure.Redis
             // inner task unchanged when that task is already complete (it checks IsCompleted before the token), so
             // a command that finished first would silently swallow the cancellation.
             cancellationToken.ThrowIfCancellationRequested();
-            return await command.WaitAsync(cancellationToken);
+            try
+            {
+                return await command.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Losing the read *value* is fine, but the abandoned command may still *fault* (the connection drop
+                // or timeout that triggered the cancellation). With no continuation that fault would surface via
+                // TaskScheduler.UnobservedTaskException on finalization, so observe it — silently, since unlike a
+                // Write a discarded read carries no signal worth logging.
+                ObserveFaultSilently(command);
+                throw;
+            }
         }
 
         public static async Task<T> Write<T>(Task<T> command, CancellationToken cancellationToken, ILogger logger, string faultMessage)
@@ -51,12 +65,26 @@ namespace Game.Infrastructure.Redis
             }
         }
 
-        // The abandoned command settles in the background after the cancelled await; OnlyOnFaulted +
-        // ExecuteSynchronously keeps this allocation-light and silent on success, logging only an actual fault.
+        // The abandoned command settles in the background after the cancelled await; this logs the fault as an
+        // error so a write that may not have applied isn't lost silently.
         private static void ObserveFault(Task command, ILogger logger, string faultMessage)
         {
+            OnFault(command, faulted => logger.LogError(faulted.Exception, "{FaultMessage}", faultMessage));
+        }
+
+        // Observe an abandoned read's fault without logging: a discarded read has no signal worth an error, but
+        // the fault must still be observed so it doesn't surface via TaskScheduler.UnobservedTaskException.
+        private static void ObserveFaultSilently(Task command)
+        {
+            OnFault(command, static faulted => _ = faulted.Exception);
+        }
+
+        // OnlyOnFaulted + ExecuteSynchronously keeps the continuation allocation-light and never schedules on
+        // success, running only when the abandoned command actually faults.
+        private static void OnFault(Task command, Action<Task> onFaulted)
+        {
             _ = command.ContinueWith(
-                faulted => logger.LogError(faulted.Exception, "{FaultMessage}", faultMessage),
+                onFaulted,
                 CancellationToken.None,
                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
                 TaskScheduler.Default);

--- a/Game.Infrastructure/Redis/RedisMultiplexerFactory.cs
+++ b/Game.Infrastructure/Redis/RedisMultiplexerFactory.cs
@@ -99,17 +99,11 @@ namespace Game.Infrastructure.Redis
             }
         }
 
-        internal static void ResetForTesting()
+        // Delegates to the production drain-clear-dispose so the test reset can't drift from it (it previously
+        // duplicated the logic with synchronous Dispose() where the production seam uses DisposeAsync()).
+        internal static Task ResetForTesting()
         {
-            lock (_lock)
-            {
-                foreach (var multiplexer in _multiplexers.Values)
-                {
-                    multiplexer.Dispose();
-                }
-
-                _multiplexers.Clear();
-            }
+            return DisposeAllAsync();
         }
 
         /// <summary>

--- a/Game.TestInfrastructure/Fixtures/IntegrationTestContainers.cs
+++ b/Game.TestInfrastructure/Fixtures/IntegrationTestContainers.cs
@@ -45,7 +45,7 @@ namespace Game.TestInfrastructure.Fixtures
                 _suiteLock = await CrossProcessLock.AcquireAsync(SuiteLockPath);
             }
 
-            RedisMultiplexerFactory.ResetForTesting();
+            await RedisMultiplexerFactory.ResetForTesting();
             await Task.WhenAll(_postgres.StartAsync(), _redis.StartAsync());
         }
 


### PR DESCRIPTION
## Summary

Addresses the three Redis-layer robustness follow-ups from #1193 (found during the `Game.Infrastructure` code-health review). All three are individually minor edges in an otherwise well-hardened layer.

### 1. `RedisCommandBudget.Read` — observe the abandoned read's fault
On budget cancellation, `Read` let `WaitAsync` throw and the caller unwound, but — unlike `Write` — attached **no continuation** to the still-running underlying command. If that abandoned read later *faulted* (the connection drop / timeout that triggered the cancellation), the fault was never observed and would surface via `TaskScheduler.UnobservedTaskException` on finalization. Losing the read *value* is fine; leaving the *fault* unobserved was the gap.

Fixed by observing the fault on the Read path too — **silently** (a discarded read carries no signal worth logging, unlike a write that may not have applied). Refactored the continuation attachment into a shared `OnFault` helper so the logged (`Write`) and silent (`Read`) variants don't duplicate it.

### 2. `RedisPubSubService.UnSubscribe(channel, id)` — unsubscribe before disposing the worker
`UnSubscribe` disposed the worker and *then* unsubscribed the handler in two non-atomic awaits. A message delivered in that window invoked the handler → `worker.Start()` on a disposed `BackgroundWorker`, throwing `ObjectDisposedException` on the StackExchange.Redis subscriber thread. Reordered to unsubscribe-before-dispose so once `UnsubscribeAsync` completes no further message can reach the handler, closing the window.

### 3. `RedisMultiplexerFactory.ResetForTesting` — delegate to the async dispose path
`ResetForTesting` duplicated `DisposeAllAsync`'s drain-clear-dispose but used synchronous `Dispose()` where the production seam uses `DisposeAsync()` — two implementations of the same teardown inviting drift. It now delegates to `DisposeAllAsync()`. The sole caller (`IntegrationTestContainers.InitializeAsync`, already async) now awaits it, avoiding sync-over-async.

## How it addresses the issue
Each of the three numbered items in #1193 is fixed as the issue recommended (silent fault observation on Read, unsubscribe-before-dispose, delegate the test reset to the async path).

## Test plan
- [x] `dotnet build` of the affected projects — clean, 0 warnings.
- [x] `Game.Infrastructure.Tests` full suite (60 tests) green, including a new `Read_AwaitCancelledThenCommandFaults_DoesNotSurfaceTheAbandonedFault` covering the new Read fault-observation branch.
- [x] `RedisPubSubServiceIntegrationTests` (6 tests) green — exercises the DI-resolved `UnSubscribe` and runs through the new async `ResetForTesting` at container init.

## Notes
- Item 2's reorder addresses the dispose-then-unsubscribe window the issue describes; an extremely narrow residual in-flight-dispatch race is left to `BackgroundWorker`'s own internal locking rather than swallowing its by-design `ObjectDisposedException` in the handler.

Closes #1193


---
_Generated by [Claude Code](https://claude.ai/code/session_015aUGq7iHkipj2xCRETXYFK)_