### PR TITLE
Add GetPaths reference socket command + client plumbing (#1214)

### DIFF
--- a/Game.Api.Tests/Integration/ReferenceDataSocketTests.cs
+++ b/Game.Api.Tests/Integration/ReferenceDataSocketTests.cs
@@ -11,6 +11,7 @@ using System.Net.Http.Json;
 using System.Net.WebSockets;
 using Xunit;
 using Attribute = Game.Api.Models.Attributes.Attribute;
+using Path = Game.Abstractions.Contracts.Path;
 
 namespace Game.Api.Tests.Integration
 {
@@ -250,6 +251,33 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task GetPaths_ReturnsSeededPaths()
+        {
+            int userId;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                var path = await TestDataSeeder.CreatePathAsync(context, "RefPyromancy");
+                await TestDataSeeder.CreateProficiencyAsync(context, "RefFlameTier", pathId: path.Id);
+
+                var user = await TestDataSeeder.CreateUserAsync(context, "pathsocketuser", "pathsocketpass");
+                await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+                userId = user.Id;
+            }
+
+            await ReloadReferenceCachesAsync();
+            await LoginAsync("pathsocketuser", "pathsocketpass");
+
+            await using var socketClient = await ConnectAsync(userId);
+
+            var response = await socketClient.SendCommandAsync<List<Path>>("GetPaths");
+
+            Assert.Null(response.Error);
+            Assert.NotNull(response.Data);
+            Assert.Contains(response.Data, p => p.Name == "RefPyromancy");
+        }
+
+        [Fact]
         public async Task GetStatisticTypes_ReturnsIntrinsicStatisticTypes()
         {
             var userId = await SeedReferenceDataAndLoginAsync();
@@ -280,7 +308,7 @@ namespace Game.Api.Tests.Integration
             // One entry per Get* reference-data command the loading screen pulls.
             Assert.Equal(
                 ["GetAttributes", "GetChallengeTypes", "GetChallenges", "GetEnemies", "GetItemMods",
-                 "GetItems", "GetProficiencies", "GetSkills", "GetStatisticTypes", "GetZones"],
+                 "GetItems", "GetPaths", "GetProficiencies", "GetSkills", "GetStatisticTypes", "GetZones"],
                 response.Data.Select(v => v.Command).OrderBy(c => c, StringComparer.Ordinal));
             Assert.All(response.Data, v => Assert.False(string.IsNullOrEmpty(v.Version)));
         }

--- a/Game.Api/Sockets/Commands/GetPaths.cs
+++ b/Game.Api/Sockets/Commands/GetPaths.cs
@@ -1,0 +1,29 @@
+using Game.Abstractions.DataAccess;
+using Path = Game.Abstractions.Contracts.Path;
+
+namespace Game.Api.Sockets.Commands
+{
+    /// <summary>
+    /// Returns the full path reference-data collection — the ordered proficiency tracks (each with its
+    /// skill contributions) the client renders the proficiency tree's rails and "Trained by" chips from.
+    /// Version-keyed off the same proficiency snapshot as <see cref="GetProficiencies"/>.
+    /// </summary>
+    public class GetPaths : AbstractReferenceDataCommand<Path>
+    {
+        private readonly IProficiencies _proficiencies;
+
+        public override string Name { get; set; } = nameof(GetPaths);
+
+        public GetPaths(IProficiencies proficiencies)
+        {
+            _proficiencies = proficiencies;
+        }
+
+        protected override IEnumerable<Path> GetReferenceData()
+        {
+            return _proficiencies.AllPaths();
+        }
+
+        protected override object VersionKey => _proficiencies.VersionKey;
+    }
+}

--- a/UI/src/lib/api/types/api-socket-type-map.ts
+++ b/UI/src/lib/api/types/api-socket-type-map.ts
@@ -21,6 +21,7 @@ import type {
 	INewEnemyModel,
 	INewEnemyRequest,
 	IOfflineProgressModel,
+	IPath,
 	IPlayerChallenge,
 	IPlayerProficiency,
 	IPlayerStatistic,
@@ -49,6 +50,7 @@ export type ApiSocketResponseTypes = {
 	'GetItemMods': IItemMod[];
 	'GetItems': IItem[];
 	'GetOfflineProgress': IOfflineProgressModel;
+	'GetPaths': IPath[];
 	'GetPlayerChallenges': IPlayerChallenge[];
 	'GetPlayerProficiencies': IPlayerProficiency[];
 	'GetPlayerStatistics': IPlayerStatistic[];

--- a/UI/src/lib/engine/reference-data.ts
+++ b/UI/src/lib/engine/reference-data.ts
@@ -121,6 +121,13 @@ export const REFERENCE_DATA: RefDataSource[] = [
 		'GetProficiencies',
 		() => staticData.proficiencies,
 		(d) => (staticData.proficiencies = d)
+	),
+	refSource(
+		'paths',
+		'Paths',
+		'GetPaths',
+		() => staticData.paths,
+		(d) => (staticData.paths = d)
 	)
 ];
 

--- a/UI/src/stores/static-data.svelte.ts
+++ b/UI/src/stores/static-data.svelte.ts
@@ -5,6 +5,7 @@ import {
 	IEnemy,
 	IItem,
 	IItemMod,
+	IPath,
 	IProficiency,
 	ISkill,
 	IStatisticType,
@@ -21,6 +22,7 @@ let challenges = $state<IChallenge[]>();
 let challengeTypes = $state<IChallengeType[]>();
 let statisticTypes = $state<IStatisticType[]>();
 let proficiencies = $state<IProficiency[]>();
+let paths = $state<IPath[]>();
 
 /* The backing `$state` slots are genuinely `undefined` until the loading screen (or the silent
    session-resume path) populates them, so the getters honestly expose `T[] | undefined` rather than
@@ -88,6 +90,12 @@ export const staticData = {
 	set proficiencies(value: IProficiency[] | undefined) {
 		proficiencies = value;
 	},
+	get paths(): IPath[] | undefined {
+		return paths;
+	},
+	set paths(value: IPath[] | undefined) {
+		paths = value;
+	},
 	get loaded(): boolean {
 		return [
 			zones,
@@ -99,7 +107,8 @@ export const staticData = {
 			challenges,
 			challengeTypes,
 			statisticTypes,
-			proficiencies
+			proficiencies,
+			paths
 		].every((set) => set != null);
 	}
 };

--- a/UI/src/tests/lib/engine/reference-data.test.ts
+++ b/UI/src/tests/lib/engine/reference-data.test.ts
@@ -40,7 +40,8 @@ const SETS = [
 	'challenges',
 	'challengeTypes',
 	'statisticTypes',
-	'proficiencies'
+	'proficiencies',
+	'paths'
 ];
 
 const COMMANDS = [
@@ -53,7 +54,8 @@ const COMMANDS = [
 	'GetChallenges',
 	'GetChallengeTypes',
 	'GetStatisticTypes',
-	'GetProficiencies'
+	'GetProficiencies',
+	'GetPaths'
 ];
 
 /** Builds the GetReferenceDataVersions payload, defaulting every set to "v1". */

--- a/UI/src/tests/routes/loading/loading-view.test.ts
+++ b/UI/src/tests/routes/loading/loading-view.test.ts
@@ -45,7 +45,8 @@ const SETS = [
 	'challenges',
 	'challengeTypes',
 	'statisticTypes',
-	'proficiencies'
+	'proficiencies',
+	'paths'
 ];
 
 const COMMANDS = [
@@ -58,7 +59,8 @@ const COMMANDS = [
 	'GetChallenges',
 	'GetChallengeTypes',
 	'GetStatisticTypes',
-	'GetProficiencies'
+	'GetProficiencies',
+	'GetPaths'
 ];
 
 /** Builds the GetReferenceDataVersions payload, defaulting every set to "v1". */

--- a/UI/src/tests/stores/static-data.test.ts
+++ b/UI/src/tests/stores/static-data.test.ts
@@ -13,7 +13,8 @@ const SLOTS = [
 	'challenges',
 	'challengeTypes',
 	'statisticTypes',
-	'proficiencies'
+	'proficiencies',
+	'paths'
 ] as const;
 
 const clearAll = () => {


### PR DESCRIPTION
## Summary

`IPath` is codegen'd to the client (`contracts.ts`) but no command ever served it — there was no `GetPaths` anywhere, no `staticData.paths` slot, and no reference-data registration (a gap left by area F / #1119). The proficiency tree screen (#1120) needs the path **name** (rail/spine header) and **contributions** ("Trained by" chips + training-state detection), neither derivable from the proficiency tiers alone.

This is pure plumbing — `GetProficiencies` mirrored end to end. All the backend pieces already existed (`IProficiencies.AllPaths()`, the shared `VersionKey`, the `Path` contract, and the `IPath` codegen output reachable via the admin endpoints); only the socket command and the client wiring were missing.

## How it addresses the issue

**Backend**
- New `GetPaths` reference socket command returning `IEnumerable<Path>` (→ `IPath[]`), version-keyed off the **same proficiency snapshot** as `GetProficiencies`. It's auto-discovered by both the `SocketCommandFactory` scan and the `IReferenceDataCommand` versioning registration, so no manual wiring.
- `Path` is aliased to `Game.Abstractions.Contracts.Path` in the command (and the test) to avoid the implicit-usings collision with `System.IO.Path`.

**Frontend**
- Registered `paths` (`GetPaths`) in `UI/src/lib/engine/reference-data.ts` — it rides the existing version-keyed local cache and the all-or-nothing resume path for free.
- Added the `staticData.paths` slot and folded it into the `loaded` gate in `static-data.svelte.ts`.

**Codegen**
- Regenerated `api-socket-type-map.ts` (`'GetPaths': IPath[];` + the `IPath` import) so the CI codegen-drift check stays green.

## Test plan

- [x] Backend: `GetPaths_ReturnsSeededPaths` integration test + `GetPaths` added to the `GetReferenceDataVersions` command-list assertion. `ReferenceDataSocketTests` — 14/14 pass.
- [x] Frontend: `paths`/`GetPaths` added to the store-slot test (`static-data.test.ts`) and the reference-data + loading-view registration tests. Full unit run: 2496/2496 pass, coverage thresholds satisfied.
- [x] `npm run lint` (ESLint + svelte-check) clean.
- [x] `dotnet build Game.sln` clean; `dotnet format --verify-no-changes` clean on changed files.

## Acceptance criteria

- [x] `staticData.paths` populated from `GetPaths`, version-keyed and locally cached.
- [x] `staticData.loaded` accounts for paths.
- [x] Unit test for the store slot + registration.

Closes #1214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXT3iduTBT2HQJaGvW75az

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXT3iduTBT2HQJaGvW75az)_