### PR TITLE
Isolate login tracking on its own DI scope (#1230)

### DIFF
--- a/Game.Abstractions/DataAccess/IUserLogins.cs
+++ b/Game.Abstractions/DataAccess/IUserLogins.cs
@@ -4,7 +4,8 @@ namespace Game.Abstractions.DataAccess
     /// Persists lightweight user-connection tracking: a per-(user, IP, device) <c>UserLogin</c> whose
     /// last-connection timestamp is continually refreshed, the <c>Device</c> (deduplicated by fingerprint)
     /// the login references, and the <c>BrowserInfo</c> (deduplicated by user-agent) the device reports.
-    /// Mutations are queued on the change tracker; the caller commits the unit of work.
+    /// Each operation <b>owns its own commit</b> (like account creation) because it runs outside the
+    /// per-action commit filter and must retry its build-and-save on a concurrent-insert unique violation.
     /// </summary>
     public interface IUserLogins
     {

--- a/Game.Api.Tests/Integration/LoginTrackingIsolationTests.cs
+++ b/Game.Api.Tests/Integration/LoginTrackingIsolationTests.cs
@@ -1,0 +1,131 @@
+using Game.Abstractions.DataAccess;
+using Game.Api.Http;
+using Game.Infrastructure.Database;
+using Game.Infrastructure.Entities;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System.Net;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    /// <summary>
+    /// Pins the isolation guarantee of <c>LoginTrackingMiddleware</c> (#1230): because connection tracking
+    /// self-commits and its failures are swallowed, it must run on its own <c>GameContext</c> — otherwise a
+    /// non-unique save failure leaves queued inserts on the request's shared context that the per-action
+    /// commit filter then re-flushes (a 500 on an unrelated request) or silently persists. The fault double
+    /// reproduces that failure mode; the test asserts the unrelated request is unaffected and nothing leaks.
+    /// </summary>
+    [Collection("Integration")]
+    public class LoginTrackingIsolationTests : ApiIntegrationTestBase
+    {
+        private const string UserAgent = "TestAgent/1.0 (LoginTrackingIsolationTests)";
+        private const string Fingerprint = "fp-isolation";
+
+        public LoginTrackingIsolationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        protected override GameServerFactory CreateFactory(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+        {
+            return new FaultInjectingFactory(containers, testOutputHelper);
+        }
+
+        [Fact]
+        public async Task TrackingSaveFailure_DoesNotBreakTheRequest_OrPersistAnything()
+        {
+            // Arrange — a real, logged-in user whose first authenticated request triggers tracking, which the
+            // injected double makes fail with a non-unique (FK-violation) save error.
+            var userId = await SeedUserAsync("isouser", "isopass");
+            using var authClient = await LoginWithDeviceAsync("isouser", "isopass");
+
+            // Act — an unrelated, read-only request. Its commit must not inherit the failed tracking inserts.
+            var response = await authClient.GetAsync("/api/Login/Status", CancellationToken);
+
+            // Assert — the tracking failure was swallowed and isolated to its own scope, so the request still
+            // succeeds rather than 500-ing on a re-flushed bad insert.
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // And nothing the failed tracking queued rode along onto the request's unit of work.
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            Assert.Empty(await context.UserLogins.Where(l => l.UserId == userId).ToListAsync(CancellationToken));
+        }
+
+        private async Task<int> SeedUserAsync(string username, string password)
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context, username, password);
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
+            await ReloadReferenceCachesAsync();
+            return user.Id;
+        }
+
+        private async Task<HttpClient> LoginWithDeviceAsync(string username, string password)
+        {
+            var (client, _) = await LoginAndBuildClientAsync(username, password);
+            client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", UserAgent);
+            client.DefaultRequestHeaders.TryAddWithoutValidation(ClientHints.DeviceFingerprintHeader, Fingerprint);
+            return client;
+        }
+
+        private sealed class FaultInjectingFactory(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : GameServerFactory(containers, testOutputHelper)
+        {
+            protected override void ConfigureWebHost(IWebHostBuilder builder)
+            {
+                base.ConfigureWebHost(builder);
+                builder.ConfigureServices(services =>
+                    services.Replace(ServiceDescriptor.Scoped<IUserLogins, FaultInjectingUserLogins>()));
+            }
+        }
+
+        /// <summary>
+        /// Reproduces the issue's failure mode: queue the tracking inserts on the context, then hit a
+        /// non-unique save error — a <c>UserLogin</c> pointing at a nonexistent device, which violates the
+        /// device foreign key. The real repo only recovers from unique violations, so this propagates.
+        /// </summary>
+        private sealed class FaultInjectingUserLogins(GameContext context) : IUserLogins
+        {
+            public async Task RecordConnection(
+                int userId,
+                string ipAddress,
+                string deviceFingerprintHash,
+                string userAgent,
+                string? secChUa,
+                string? secChUaMobile,
+                string? secChUaPlatform,
+                CancellationToken cancellationToken = default)
+            {
+                context.UserLogins.Add(new UserLogin
+                {
+                    UserId = userId,
+                    IpAddress = ipAddress,
+                    DeviceId = int.MaxValue,
+                    LastConnection = DateTime.UtcNow,
+                });
+                await context.SaveChangesAsync(cancellationToken);
+            }
+
+            public Task SaveDeviceInfo(
+                string deviceFingerprintHash,
+                string userAgent,
+                string? secChUa,
+                string? secChUaMobile,
+                string? secChUaPlatform,
+                double? deviceMemory,
+                int? hardwareConcurrency,
+                CancellationToken cancellationToken = default)
+            {
+                throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/Game.Api/Middleware/LoginTrackingMiddleware.cs
+++ b/Game.Api/Middleware/LoginTrackingMiddleware.cs
@@ -9,15 +9,22 @@ namespace Game.Api.Middleware
     /// the user's last-connection timestamp. Runs after <see cref="SessionLoaderMiddleware"/> so the
     /// request's user identity is available. Recording is keyed on the device fingerprint the frontend
     /// sends as a header, so a request without one (e.g. a WebSocket handshake, which cannot set custom
-    /// headers) is skipped. Tracking is best-effort: any failure is logged and swallowed so it never
-    /// affects the response.
+    /// headers) is skipped.
+    /// <para>
+    /// Tracking is best-effort and <b>structurally isolated</b>: it runs on its own DI scope (its own
+    /// <c>GameContext</c>) and self-commits there, so a tracking save failure — which the swallow below
+    /// hides — can neither ride along on nor break the request's own unit of work (the per-action
+    /// <see cref="Filters.CommitFilter"/> commits a different context). Any failure is logged and
+    /// swallowed so it never affects the response, and the scope is disposed regardless of how the save
+    /// ended, discarding anything it queued.
+    /// </para>
     /// </summary>
     public class LoginTrackingMiddleware(RequestDelegate next, ILogger<LoginTrackingMiddleware> logger)
     {
         private readonly RequestDelegate _next = next;
         private readonly ILogger<LoginTrackingMiddleware> _logger = logger;
 
-        public async Task InvokeAsync(HttpContext context, SessionService sessionService, LoginTrackingService trackingService)
+        public async Task InvokeAsync(HttpContext context, SessionService sessionService, IServiceScopeFactory scopeFactory)
         {
             var fingerprint = ClientHints.DeviceFingerprint(context.Request.Headers);
             if (sessionService.Authenticated && fingerprint is not null)
@@ -25,6 +32,12 @@ namespace Game.Api.Middleware
                 try
                 {
                     var hints = ClientHints.FromHeaders(context.Request.Headers);
+                    // Resolve tracking from a dedicated scope so its GameContext is independent of the
+                    // request's. RecordConnection self-commits; sharing the request context would let a
+                    // non-unique save failure leave queued inserts that the later per-request commit
+                    // re-flushes (or breaks on). The scope is disposed here whatever the outcome.
+                    await using var scope = scopeFactory.CreateAsyncScope();
+                    var trackingService = scope.ServiceProvider.GetRequiredService<LoginTrackingService>();
                     await trackingService.RecordConnection(
                         sessionService.UserId,
                         ClientIp.Resolve(context),


### PR DESCRIPTION
## Summary

`LoginTrackingMiddleware` recorded connection tracking on the **request-scoped `GameContext`** and swallowed any failure to keep tracking best-effort ("never affects the response"). But sharing the request's context defeated that isolation:

- `RecordConnection` → `UserLogins.SaveWithConflictRetry` **self-commits**, and its retry loop only clears the change tracker on a **unique violation**.
- For any *other* save failure (a non-unique `DbUpdateException`, a transient connection fault), the `Added` tracking entities stay queued on the shared context.
- The middleware swallows the exception, then `_next` runs the real action and the per-action `CommitFilter` calls `CommitAsync` on the **same** context — so the leftover tracking inserts either silently persist as a side effect of an unrelated request, or fail again and turn a best-effort tracking failure into a **500 on an unrelated action**.

I verified the issue's claim end to end (middleware → `LoginTrackingService` → `UserLogins` → `CommitFilter`); it's accurate.

## How it addresses the issue

Takes the issue's **more robust** option: run the tracking work on its **own DI scope / `GameContext`** (these operations already self-commit, like account creation), so a tracking save failure is **structurally independent** of the request's unit of work. The scope is disposed regardless of outcome, discarding anything it queued — no leftover state can ride a later commit.

The middleware reads the request's user identity from the still request-scoped `SessionService`; only the tracking repository graph (`LoginTrackingService` → `IUserLogins` → `GameContext`) is resolved from the fresh scope.

### Notes
- **Doc fix:** the `IUserLogins` summary claimed "Mutations are queued on the change tracker; the caller commits the unit of work" — inaccurate, since both operations self-commit. Corrected to match reality (and the existing impl comment in `UserLogins`).
- **`DeviceInfo` controller path reviewed, left as-is:** `SaveDeviceInfo` also self-commits on the request context, but it runs inside a controller action that does **not** swallow — a non-unique failure throws out of the action, `CommitFilter` skips the commit, and the request 500s on its *own* work (correct). There's no ride-along onto an unrelated request, so it needs no change.
- **Scope:** backend-only. No battle-parity surface, no codegen, no frontend.

## Test plan

- [x] `dotnet build` clean (0 warnings); `dotnet format --verify-no-changes` clean on the changed file.
- [x] New `LoginTrackingIsolationTests` — a fault-injecting `IUserLogins` double reproduces the issue's failure mode (queue a tracking insert, then a **non-unique FK-violation** save failure) and asserts the unrelated `Status` request still returns 200 and **nothing leaks** to the DB. **Confirmed it's a genuine regression guard:** it fails (500) against the pre-fix shared-context middleware and passes against the fix.
- [x] Existing `LoginTrackingTests` (6) and `ForwardedHeadersTrustTests` (7) green; application-layer `UserLogins`/`LoginTracking` tests (4) green.

Closes #1230

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4LiHEgYctZ1hEXPJXCSM3)_