### PR TITLE
Align frontend loadout dedup with backend Distinct (#1231)

### DIFF
--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -704,6 +704,21 @@ namespace Game.Core.Tests.Battle
                     ExpectedPlayerDied: false,
                     ExpectedTotalMs: 2000),
 
+                // The SAME skill selected twice is de-duplicated WITHIN the selected loadout (first wins): the
+                // player fields S1 once (22−2 = 20/hit, cooldown 400). The 100-HP enemy dies on hit 5 at tick 50
+                // → 2000ms. (Without intra-selected dedupe the two copies — 40/tick — would kill on hit 3 at
+                // 1200ms.) Pins the single Distinct() over the full loadout that the frontend mirrors.
+                ["duplicateSelectedSkill"] = new ParityScenario(
+                    Player: () => MakeBattlerWithGrants(
+                        strength: 10,
+                        selectedSkillIds: [1, 1],
+                        grants: [],
+                        skillPool: [MakeSkill(1, baseDamage: 22, cooldownMs: 400)]),
+                    Enemy: () => MakeEnemy(strength: 10, endurance: 0, skills: []),
+                    ExpectedVictory: true,
+                    ExpectedPlayerDied: false,
+                    ExpectedTotalMs: 2000),
+
                 // A granted skill carrying an EFFECT works exactly as a selected one would: the item grants a
                 // skill whose self +10 Strength buff stacks each fire, ramping its own damage. Str×1.0 raw less
                 // 2 Def deals 8,18,28,38,48,58 (Str climbing 10→60); cumulative 8,26,54,92,140,198 drops the

--- a/Game.Core.Tests/Battle/BattleSnapshotTests.cs
+++ b/Game.Core.Tests/Battle/BattleSnapshotTests.cs
@@ -319,6 +319,26 @@ namespace Game.Core.Tests.Battle
         }
 
         [Fact]
+        public void ToBattler_DuplicateSelectedSkill_AppearsOnce()
+        {
+            var snapshot = new BattleSnapshot
+            {
+                Level = 1,
+                StatAllocations = [],
+                EquippedItems = [],
+                SkillIds = [3, 3],
+            };
+
+            var battler = snapshot.ToBattler(
+                ThrowItem,
+                ThrowMod,
+                SkillResolver(MakeSkill(3)));
+
+            // The same skill selected twice is de-duplicated within the selected loadout (first wins).
+            Assert.Equal([3], battler.Skills.Select(s => s.Skill.Id));
+        }
+
+        [Fact]
         public void ToBattler_TwoItemsGrantingSameSkill_AppearsOnce()
         {
             var snapshot = new BattleSnapshot

--- a/UI/src/lib/battle/battler.ts
+++ b/UI/src/lib/battle/battler.ts
@@ -345,19 +345,23 @@ export class Battler {
 
 	/** Assembles the battler's loadout: the player-selected skills first (in their chosen order, padded to
 	 *  the loadout cap so the fight screen keeps its fixed slots), then the item-granted skills (already
-	 *  gathered in EEquipmentSlot order) de-duplicated by id against the selected skills and each other —
-	 *  first occurrence wins. Mirrors the backend `BattleSnapshot.ToBattler` / `BattleLoadout.OrderSkillIds`
-	 *  assembly so the two simulators field the same skills (battle parity). */
+	 *  gathered in EEquipmentSlot order) — the whole sequence de-duplicated by id, first occurrence wins.
+	 *  Mirrors the backend `BattleSnapshot.ToBattler` / `BattleLoadout.OrderSkillIds` assembly (a single
+	 *  `Distinct()` over selected + granted) so the two simulators field the same skills (battle parity). */
 	private fillSkills(battlerData: BattlerData, grantedSkillIds: number[]) {
 		const skillData = staticData.skills ?? [];
-		const skills: (Skill | undefined)[] = battlerData.selectedSkills.map(
-			(skillId) => new Skill(skillData[skillId], this)
-		);
+		const seen = new Set<number>();
+		const skills: (Skill | undefined)[] = [];
+		for (const skillId of battlerData.selectedSkills) {
+			if (!seen.has(skillId)) {
+				seen.add(skillId);
+				skills.push(new Skill(skillData[skillId], this));
+			}
+		}
 		while (skills.length < MAX_SELECTED_SKILLS) {
 			skills.push(undefined);
 		}
 
-		const seen = new Set(battlerData.selectedSkills);
 		for (const skillId of grantedSkillIds) {
 			if (!seen.has(skillId)) {
 				seen.add(skillId);

--- a/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
+++ b/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
@@ -913,6 +913,20 @@ const scenarios: ParityScenario[] = [
 		expected: { victory: true, playerDied: false, totalMs: 2000 }
 	},
 
+	// The SAME skill selected twice is de-duplicated WITHIN the selected loadout (first wins): the player
+	// fields it once (22−2 = 20/hit, cooldown 400). The 100-HP enemy dies on hit 5 at tick 50 → 2000ms.
+	// (Without intra-selected dedupe the two copies — 40/tick — would kill on hit 3 at 1200ms.) Pins that the
+	// frontend mirrors the backend's single Distinct() over the full loadout, not just granted-vs-selected.
+	{
+		name: 'duplicateSelectedSkill',
+		player: () => {
+			const skill = granted.register(makeSkill(22, 400));
+			return granted.build([{ id: EAttribute.Strength, amount: 10 }], [skill, skill], []);
+		},
+		enemy: () => makeBattler([{ id: EAttribute.Strength, amount: 10 }], []),
+		expected: { victory: true, playerDied: false, totalMs: 2000 }
+	},
+
 	// A granted skill carrying an EFFECT works exactly as a selected one would: the item grants a skill whose
 	// self +10 Strength buff stacks each fire, ramping its own damage. Str×1.0 raw less 2 Def deals
 	// 8,18,28,38,48,58 (Str climbing 10→60); cumulative 8,26,54,92,140,198 drops the 150-HP enemy on fire 6 at


### PR DESCRIPTION
## Summary

The shared battle-loadout rule must field the same skills on both simulators (it's parity-critical — the backend replays the client's battle as anti-cheat), but the two implementations deduped **different input sets**:

- **Backend** `BattleLoadout.OrderSkillIds` runs a single `Distinct()` over the **whole** `selected.Concat(granted)` sequence — so a duplicate *within* the selected skills is also collapsed.
- **Frontend** `fillSkills` only built its `seen` set from the selected skills and deduped the **granted** skills against it; the selected skills were mapped directly with **no intra-selected dedup**.

So a `selectedSkills` containing the same id twice (e.g. `[5, 5, 3]`) would be fielded **once** by the backend and **twice** by the frontend — that skill fires an extra time per tick on the client, the simulators diverge, and the backend replay would reject a legitimate victory.

I verified the issue's claim by reading both implementations. It is currently **unreachable** — `SetSelectedSkills` anti-cheat rejects duplicate ids — but two sides having different dedup rules for the same input is a latent parity footgun: a future loadout/grant change that let a dup through would silently break battle parity, the worst class of bug here. The issue's note that the padding-to-cap difference is *not* a problem (undefined slots are skipped) is also correct — only the dedup asymmetry needed fixing.

## How it addresses the issue

Took the issue's cheapest suggested fix: rebuild `fillSkills` around a single `seen` set seeded **as it maps the selected skills** (skipping intra-selected dups), then pad to the loadout cap (preserving the fight screen's fixed slots), then append the granted skills deduped against the same set. This mirrors the backend's single `Distinct()` over the full loadout exactly. No backend code change was needed — it was already correct; the frontend was the diverging side.

## Test plan

- [x] **Parity matrix mirrored** — added a `duplicateSelectedSkill` scenario to **both** `battle-simulation-parity.test.ts` and `BattleSimulatorParityTests.cs`, same `2000ms` expected result (a skill selected twice fields once at 20/hit → dies hit 5; un-deduped 40/tick would kill at 1200ms, so the scenario fails against the pre-fix frontend and passes after).
- [x] Backend `BattleSnapshotTests.ToBattler_DuplicateSelectedSkill_AppearsOnce` unit test, alongside the existing granted-dedupe unit tests.
- [x] `dotnet build Game.sln` clean (0 warnings); `dotnet format --verify-no-changes` clean on changed files.
- [x] Backend `Game.Core.Tests` green (813); frontend `npm run lint` clean; full frontend unit suite **2497/2497** pass.

Closes #1231

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014f6yrW43z15owAMGaER1ES

---
_Generated by [Claude Code](https://claude.ai/code/session_014f6yrW43z15owAMGaER1ES)_