### PR TITLE
Guard zero-cooldown skill display against NaN/Infinity (#1232)

### DIFF
--- a/UI/src/lib/common/functions.ts
+++ b/UI/src/lib/common/functions.ts
@@ -3,6 +3,12 @@ export function formatNum(num: number): string {
 	return '' + parseFloat(num.toFixed(2));
 }
 
+/** Damage per second for a damage value over a cooldown in seconds. A non-positive cooldown yields 0
+ *  (rather than Infinity/NaN), so a zero-cooldown skill reads as 0 DPS consistently across surfaces. */
+export function damagePerSecond(damage: number, cooldown: number): number {
+	return cooldown > 0 ? damage / cooldown : 0;
+}
+
 export async function delay(delay: number) {
 	return new Promise<void>((res) => {
 		setTimeout(res, delay);

--- a/UI/src/routes/game/screens/fight/SkillTooltip.svelte
+++ b/UI/src/routes/game/screens/fight/SkillTooltip.svelte
@@ -18,7 +18,7 @@
 	</TooltipSection>
 
 	<TooltipSection label="Tempo" last={effectLines.length === 0}>
-		<TempoMetrics cooldown={adjustedCd} dps={total / adjustedCd} />
+		<TempoMetrics cooldown={adjustedCd} dps={damagePerSecond(total, adjustedCd)} />
 	</TooltipSection>
 
 	{#if effectLines.length > 0}
@@ -31,7 +31,14 @@
 <script lang="ts">
 import { EAttribute } from '$lib/api';
 import { applyDefense, expectedCritMultiplier, scaledEffectAmount, skillContributions, type Skill } from '$lib/battle';
-import { attributeIsHarmful, attributeName, describeEffect, formatAttributeValue, rarityColor } from '$lib/common';
+import {
+	attributeIsHarmful,
+	attributeName,
+	damagePerSecond,
+	describeEffect,
+	formatAttributeValue,
+	rarityColor
+} from '$lib/common';
 import { battleEngine } from '$lib/engine';
 import { staticData } from '$stores';
 import TooltipShell from '$components/tooltip/TooltipShell.svelte';
@@ -41,6 +48,7 @@ import CooldownPill from './skill-tooltip/CooldownPill.svelte';
 import DamageBreakdown from './skill-tooltip/DamageBreakdown.svelte';
 import EffectLines from './skill-tooltip/EffectLines.svelte';
 import TempoMetrics from './skill-tooltip/TempoMetrics.svelte';
+import { cooldownReadout } from './skill-cooldown';
 
 export const getBaseNode = () => container;
 
@@ -89,11 +97,12 @@ const crit = $derived(
 );
 const total = $derived(applyDefense(totalDamage + critBonus, enemyDefense));
 const cdMultiplier = $derived(skill?.owner.cdMultiplier ?? 1);
-const adjustedCd = $derived((skill?.cooldownMs ?? 0) / 1000 / cdMultiplier);
-const remainingCd = $derived(Math.max(adjustedCd - (skill?.renderChargeTime ?? 0) / 1000 / cdMultiplier, 0));
-const isReady = $derived(remainingCd <= 0.01);
-const cooldownProgress = $derived(isReady ? 100 : Math.max(0, ((adjustedCd - remainingCd) / adjustedCd) * 100));
-const remainingCdFormatted = $derived(remainingCd.toFixed(2));
+// Pure readout guards a zero/non-positive cooldown (an always-ready skill) against NaN/Infinity.
+const cooldown = $derived(cooldownReadout(skill?.cooldownMs ?? 0, skill?.renderChargeTime ?? 0, cdMultiplier));
+const adjustedCd = $derived(cooldown.adjustedCd);
+const isReady = $derived(cooldown.isReady);
+const cooldownProgress = $derived(cooldown.progress);
+const remainingCdFormatted = $derived(cooldown.remainingCd.toFixed(2));
 
 // Show each effect's magnitude resolved against the caster's (owner's) attributes, so a scaling effect
 // reads like the damage total does — the number the skill would actually apply right now.

--- a/UI/src/routes/game/screens/fight/Skills.svelte
+++ b/UI/src/routes/game/screens/fight/Skills.svelte
@@ -4,7 +4,7 @@
 			{#if skill}
 				<!-- Charge sweep/ready computed once per skill per frame (this row re-renders
 				     every animation frame for the player, enemy, and boss cards). -->
-				{@const charge = chargeState(skill)}
+				{@const charge = chargeProjection(skill.renderChargeTime, skill.cooldownMs)}
 				<!-- A focusable button so the per-skill combat tooltip is reachable by keyboard
 				     and screen reader, not just on hover. Its accessible name is the icon's alt. -->
 				<button
@@ -38,7 +38,7 @@
 </div>
 
 <script lang="ts">
-import type { Battler, Skill } from '$lib/battle';
+import type { Battler } from '$lib/battle';
 import { tintColor } from '$lib/common';
 import {
 	anchorPosition,
@@ -51,6 +51,7 @@ import SkillEffectBadge from '$components/SkillEffectBadge.svelte';
 import CooldownOverlay from '$components/CooldownOverlay.svelte';
 import { describedByTooltip } from '$components/tooltip/describedby-tooltip';
 import SkillTooltip from './SkillTooltip.svelte';
+import { chargeProjection } from './skill-cooldown';
 
 type Props = {
 	battler: Battler;
@@ -101,14 +102,6 @@ const handleLeave = (index: number) => {
 		tooltipSkillIndex = -1;
 		hideTooltip();
 	}
-};
-
-/** Per-frame charge projection for a slot, computed once per skill from the raw charge
- *  fraction — no string round-trip. `sweep` feeds the cooldown conic-gradient (in degrees)
- *  and `ready` thresholds the (clamped-to-1) fraction at 99.9%. */
-const chargeState = (skill: Skill) => {
-	const fraction = skill.renderChargeTime / skill.cooldownMs;
-	return { sweep: fraction * 360, ready: fraction >= 0.999 };
 };
 </script>
 

--- a/UI/src/routes/game/screens/fight/skill-cooldown.ts
+++ b/UI/src/routes/game/screens/fight/skill-cooldown.ts
@@ -1,0 +1,29 @@
+/* Pure cooldown/charge display math for the fight screen's skill surfaces (the slot overlay and the
+   skill tooltip's cooldown pill). A zero (or non-positive) cooldown skill fires every tick — in the
+   battle, `chargeTime >= cooldownMs` is always true — so it reads as permanently ready here. The
+   guards below keep that case from producing NaN/Infinity in the UI. */
+
+/** Radial charge projection for a skill slot's cooldown overlay: `sweep` is the revealed arc in
+ *  degrees (0–360, fed to the conic-gradient wedge) and `ready` thresholds the charge fraction at
+ *  99.9%. A non-positive cooldown is fully charged (always ready, full sweep). */
+export function chargeProjection(renderChargeTime: number, cooldownMs: number): { sweep: number; ready: boolean } {
+	const fraction = cooldownMs > 0 ? renderChargeTime / cooldownMs : 1;
+	return { sweep: fraction * 360, ready: fraction >= 0.999 };
+}
+
+/** Cooldown readout for the skill tooltip's cooldown pill: the player-adjusted cooldown and remaining
+ *  time (seconds), readiness, and the 0–100 fill. A non-positive adjusted cooldown reads as ready at
+ *  full fill. Mirrors the loadout screen's `cdMultiplier > 0` guard so a non-positive recovery
+ *  multiplier falls back to the raw cooldown rather than dividing by zero. */
+export function cooldownReadout(
+	cooldownMs: number,
+	renderChargeTime: number,
+	cdMultiplier: number
+): { adjustedCd: number; remainingCd: number; isReady: boolean; progress: number } {
+	const adjustedCd = cdMultiplier > 0 ? cooldownMs / 1000 / cdMultiplier : cooldownMs / 1000;
+	const charged = cdMultiplier > 0 ? renderChargeTime / 1000 / cdMultiplier : renderChargeTime / 1000;
+	const remainingCd = Math.max(adjustedCd - charged, 0);
+	const isReady = adjustedCd <= 0 || remainingCd <= 0.01;
+	const progress = isReady ? 100 : Math.max(0, ((adjustedCd - remainingCd) / adjustedCd) * 100);
+	return { adjustedCd, remainingCd, isReady, progress };
+}

--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -25,7 +25,7 @@ import {
 	skillContributions,
 	type SkillContribution
 } from '$lib/battle';
-import { enemyDefense, SerializedQueue } from '$lib/common';
+import { damagePerSecond, enemyDefense, SerializedQueue } from '$lib/common';
 import { playerManager, inventoryManager } from '$lib/engine';
 import { staticData, toastError } from '$stores';
 
@@ -84,9 +84,6 @@ export interface ComparePreset {
 }
 
 /* ── pure helpers (no reactive state — unit-tested directly) ───────────────── */
-
-/** Damage per second for a damage value over a cooldown (0 for a non-positive cooldown). */
-export const damagePerSecond = (damage: number, cooldown: number): number => (cooldown > 0 ? damage / cooldown : 0);
 
 /** Comparator over `SkillMetrics` for the given sort + Compare-vs defense.
  *  DPS/Damage rank by *effective* value (defense-aware), descending. The crit multiplier scales raw

--- a/UI/src/tests/routes/game/screens/fight/skill-cooldown.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/skill-cooldown.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { chargeProjection, cooldownReadout } from '$routes/game/screens/fight/skill-cooldown';
+
+describe('chargeProjection', () => {
+	it('maps the charge fraction to a 0–360 sweep', () => {
+		expect(chargeProjection(0, 1000)).toEqual({ sweep: 0, ready: false });
+		expect(chargeProjection(500, 1000)).toEqual({ sweep: 180, ready: false });
+	});
+
+	it('is ready at (and past) full charge', () => {
+		expect(chargeProjection(1000, 1000)).toEqual({ sweep: 360, ready: true });
+		expect(chargeProjection(999, 1000).ready).toBe(true); // 99.9% threshold
+		expect(chargeProjection(998, 1000).ready).toBe(false);
+	});
+
+	it('treats a zero cooldown as always ready instead of NaN', () => {
+		// A zero-cooldown skill fires every tick; renderChargeTime / cooldownMs would be 0/0 = NaN.
+		expect(chargeProjection(0, 0)).toEqual({ sweep: 360, ready: true });
+	});
+});
+
+describe('cooldownReadout', () => {
+	it('adjusts the cooldown by the recovery multiplier', () => {
+		const r = cooldownReadout(2000, 0, 1);
+		expect(r.adjustedCd).toBe(2);
+		expect(r.remainingCd).toBe(2);
+		expect(r.isReady).toBe(false);
+		expect(r.progress).toBe(0);
+
+		// A 2x recovery multiplier halves both the cooldown and the elapsed charge.
+		const fast = cooldownReadout(2000, 1000, 2);
+		expect(fast.adjustedCd).toBe(1);
+		expect(fast.remainingCd).toBeCloseTo(0.5);
+		expect(fast.progress).toBeCloseTo(50);
+	});
+
+	it('reports ready at full charge', () => {
+		const r = cooldownReadout(2000, 2000, 1);
+		expect(r.isReady).toBe(true);
+		expect(r.progress).toBe(100);
+	});
+
+	it('treats a zero cooldown as ready at full fill instead of NaN', () => {
+		const r = cooldownReadout(0, 0, 1);
+		expect(r.adjustedCd).toBe(0);
+		expect(r.isReady).toBe(true);
+		expect(r.progress).toBe(100);
+	});
+
+	it('falls back to the raw cooldown when the recovery multiplier is non-positive', () => {
+		const r = cooldownReadout(2000, 0, 0);
+		expect(r.adjustedCd).toBe(2);
+		expect(Number.isFinite(r.remainingCd)).toBe(true);
+		expect(r.progress).toBe(0);
+	});
+});

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -67,11 +67,11 @@ vi.mock('$lib/api/types/game-constants', async (importOriginal) => {
 
 import {
 	SkillsView,
-	damagePerSecond,
 	sortMetrics,
 	zoneSpawnLevel,
 	type SkillMetrics
 } from '$routes/game/screens/skills/skills-view.svelte';
+import { damagePerSecond } from '$lib/common';
 import { expectedCritMultiplier } from '$lib/battle';
 
 /* A skill with sensible defaults so each test only states what matters. */


### PR DESCRIPTION
## Summary

A skill authored with `cooldownMs === 0` fires every tick — the battle's `chargeTime >= cooldownMs` is always true (`battler.ts:129`), so it's "always ready". But two fight-screen display surfaces divided by the cooldown without guarding it:

- **`SkillTooltip` DPS** — `dps={total / adjustedCd}` yielded **`Infinity`** for a zero adjusted cooldown.
- **`Skills.svelte` slot charge** — `fraction = renderChargeTime / cooldownMs` yielded **`0 / 0 = NaN`**, rendering a broken `CooldownOverlay` (`sweep: NaN deg`) and a permanently-not-ready slot (`NaN >= 0.999` is false).

The loadout screen (`skills-view.svelte.ts`) already handled this gracefully via its `damagePerSecond` / `cdMultiplier > 0` guards; the fight screen was the diverging side.

## Verifying the issue's claims

I confirmed the two defects above, but the issue's third claim — that `SkillTooltip`'s **`cooldownProgress`** produces `NaN` — is **not** reachable in the current code. A zero `cooldownMs` makes `remainingCd === 0`, so `isReady` is true and the `isReady ? 100 : …` branch short-circuits **before** the `(… / adjustedCd)` divide ever runs. The genuine defects were the DPS metric and the slot charge fraction. The fix still routes `cooldownProgress` through the guarded helper, so the value stays correct regardless.

## How it addresses the issue

- New pure, unit-tested module `fight/skill-cooldown.ts`:
  - `chargeProjection(renderChargeTime, cooldownMs)` — slot overlay sweep/ready; a non-positive cooldown is fully charged (always ready).
  - `cooldownReadout(cooldownMs, renderChargeTime, cdMultiplier)` — tooltip cooldown/remaining/ready/progress; a non-positive adjusted cooldown reads ready at full fill, and it mirrors the loadout screen's `cdMultiplier > 0` fallback so a non-positive recovery multiplier can't reintroduce a divide-by-zero.
- Promoted `damagePerSecond` from `skills-view.svelte.ts` to `$lib/common` (it's a pure display helper) and reused it for the tooltip's DPS, so both surfaces share the single zero-cooldown guard instead of duplicating it (DRY) — and it removes a cross-screen import smell.
- `Skills.svelte` and `SkillTooltip.svelte` now consume the shared helpers; the now-unused inline `chargeState` and `Skill` import were removed.

## Scope note

I did **not** add backend/admin authoring validation to reject a `0` cooldown. The battle engine handles a zero cooldown deterministically (fires every tick), so it's an extreme-but-legitimate authored value, not a defect to forbid — forbidding it is a balance/authoring decision worth its own discussion, not part of a display-hardening fix. Happy to add it as a follow-up if a minimum cooldown is desired.

## Test plan

- [x] New `skill-cooldown.test.ts` — covers normal, full-charge, and the **zero-cooldown** edge for both helpers, plus the non-positive `cdMultiplier` fallback.
- [x] `damagePerSecond` zero-cooldown assertion preserved (moved import to `$lib/common`).
- [x] `npm run lint` (ESLint + svelte-check) clean — 0 errors, 0 warnings.
- [x] Full unit suite **2503/2503** pass; coverage thresholds satisfied.

Closes #1232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8FsxioKtasQmq8sdmkCH9

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8FsxioKtasQmq8sdmkCH9)_