### PR TITLE
Harden ItemEquippedHandler retry against re-violating the slot unique index (#1233)

### DIFF
--- a/Game.Application.Tests/DataAccess/PlayerUpdateHandlerIdempotencyIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerUpdateHandlerIdempotencyIntegrationTests.cs
@@ -441,6 +441,45 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task ItemEquipped_DifferentItemsRacingIntoSameSlot_ConvergesToASingleOccupant()
+        {
+            // Two *different* items race into the same slot from independent scopes — the cross-instance case the
+            // (player, slot) unique index guards, and the one ItemEquippedHandler's retry can re-violate (an equip
+            // evicts a different item, so vacate-then-place is two writes with a race window, unlike
+            // ModAppliedHandler's single-row settle). The bounded in-handler retry converges transient
+            // re-occupation; whatever still loses the race past that bound surfaces to the queue, which redelivers.
+            // Regardless of interleaving the slot must never end doubly occupied, and the at-least-once redelivery
+            // (applied in order below) deterministically settles the later item in with the earlier unequipped.
+            var playerId = await SeedPlayerAsync();
+            var firstItemId = await SeedItemAsync();
+            var secondItemId = await SeedItemAsync();
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                await TestDataSeeder.LinkItemToPlayerAsync(context, playerId, firstItemId);
+                await TestDataSeeder.LinkItemToPlayerAsync(context, playerId, secondItemId);
+            }
+
+            var slot = (int)EEquipmentSlot.HelmSlot;
+            await ApplyRacingThenRedeliverAsync(
+                new ItemEquippedEvent(playerId, firstItemId, slot),
+                new ItemEquippedEvent(playerId, secondItemId, slot));
+
+            using var verifyScope = CreateScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
+            // The unique index guarantees at most one occupant; the redelivery applied both, so exactly one item
+            // holds the slot — the later one wins — and the other is unequipped. Never two occupants, never a lost row.
+            var occupant = Assert.Single(await verifyContext.UnlockedItems.AsNoTracking()
+                .Where(ui => ui.PlayerId == playerId && ui.EquipmentSlotId == slot)
+                .ToListAsync(CancellationToken));
+            Assert.Equal(secondItemId, occupant.ItemId);
+            var displaced = Assert.Single(await verifyContext.UnlockedItems.AsNoTracking()
+                .Where(ui => ui.PlayerId == playerId && ui.ItemId == firstItemId)
+                .ToListAsync(CancellationToken));
+            Assert.Null(displaced.EquipmentSlotId);
+        }
+
+        [Fact]
         public async Task ItemUnequipped_AppliedTwice_ClearsSlotAndConverges()
         {
             var playerId = await SeedPlayerAsync();
@@ -778,6 +817,42 @@ namespace Game.Application.Tests.DataAccess
                 {
                     scope.Dispose();
                 }
+            }
+        }
+
+        // Races the given events through independent scopes (the cross-instance slot contention), then redelivers
+        // them in order. A handler that exhausts its in-handler retries under contention is the queue's cue to
+        // redeliver, so a throw in the concurrent phase is the designed backstop rather than a failure — it is
+        // swallowed, and the sequential redelivery (no contention, so the later event wins) settles the final state.
+        private async Task ApplyRacingThenRedeliverAsync<TEvent>(params TEvent[] events)
+        {
+            var scopes = events.Select(_ => CreateScope()).ToList();
+            try
+            {
+                await Task.WhenAll(events.Zip(scopes, (evt, scope) => Task.Run(async () =>
+                {
+                    var handler = scope.ServiceProvider.GetRequiredService<IPlayerUpdateHandler<TEvent>>();
+                    try
+                    {
+                        await handler.HandleAsync(evt);
+                    }
+                    catch (DbUpdateException)
+                    {
+                        // Lost the race past the in-handler bound; the redelivery below converges it, as the queue would.
+                    }
+                })));
+            }
+            finally
+            {
+                foreach (var scope in scopes)
+                {
+                    scope.Dispose();
+                }
+            }
+
+            foreach (var evt in events)
+            {
+                await ApplyAsync(evt);
             }
         }
 

--- a/Game.DataAccess/PlayerUpdates/Handlers/ItemEquippedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/ItemEquippedHandler.cs
@@ -7,21 +7,31 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
 {
     internal sealed class ItemEquippedHandler(GameContext context) : IPlayerUpdateHandler<ItemEquippedEvent>
     {
+        // Bounded re-attempts on a (player, slot) unique violation, mirroring UserLogins.SaveWithConflictRetry.
+        // Unlike ModAppliedHandler — whose conflict is the row it already owns (its key includes the slot),
+        // settled by a single ExecuteUpdate that can't re-violate — an equip must *evict a different item* from
+        // the destination slot, so the vacate and the place are two writes with an unavoidable window. A
+        // concurrent apply of the same at-least-once event, an ItemUnlockedEvent reordered behind this one, or a
+        // cross-instance writer can re-occupy the slot between the vacate and the save and re-trip the index, so
+        // the retry here genuinely can re-violate (ModAppliedHandler's cannot). Each pass re-vacates whoever won
+        // that race and re-places this item, so transient contention converges in-handler instead of burning the
+        // queue's coarser per-event attempt budget; a still-failing final attempt propagates to that queue
+        // retry/dead-letter backstop (at-least-once + idempotent handlers, so nothing is lost) rather than looping.
+        private const int MaxSaveAttempts = 3;
+
         public async Task HandleAsync(ItemEquippedEvent evt)
         {
-            // The clear-then-upsert isn't atomic, so a concurrent apply of the same at-least-once event — or an
-            // ItemUnlockedEvent reordered behind this one — can take the destination slot between our clear and
-            // save. On the resulting unique violation, re-run once: the re-run's server-side clear vacates the
-            // row that won the race, so the second pass converges. A second failure propagates to the queue's
-            // retry policy rather than looping. (Mirrors ModAppliedHandler.)
-            try
+            for (var attempt = 1; ; attempt++)
             {
-                await ApplyAsync(evt);
-            }
-            catch (DbUpdateException ex) when (ex.IsUniqueViolation())
-            {
-                context.ChangeTracker.Clear();
-                await ApplyAsync(evt);
+                try
+                {
+                    await ApplyAsync(evt);
+                    return;
+                }
+                catch (DbUpdateException ex) when (attempt < MaxSaveAttempts && ex.IsUniqueViolation())
+                {
+                    context.ChangeTracker.Clear();
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

`ItemEquippedHandler` retried a `(PlayerId, EquipmentSlotId)` unique violation by clearing the change tracker and re-running the **insert-capable** `ApplyAsync` exactly once. Because `ApplyAsync` does a server-side vacate (`ExecuteUpdate`) **then** a `FirstOrDefault` + `Add`/update + `SaveChanges`, the retry could re-trip the same unique index if a writer re-occupied the destination slot between the retry's vacate and its save — ultimately dead-lettering a legitimate equip under sustained contention.

## Verifying the issue's claims

I confirmed the issue's core claim by reading both handlers: the retry **can** re-violate, and the `// (Mirrors ModAppliedHandler.)` comment overstated the guarantee.

But the issue's **first suggested fix rests on a false premise.** It proposes "a non-re-violating `ExecuteUpdate` that reassigns the item's slot (mirroring `ModAppliedHandler`)". `ModAppliedHandler`'s retry can't re-violate only because its key (`PlayerId, ItemId, ItemModSlotId`) **includes the slot** — the conflicting row *is* the row it owns, so a single-row `ExecuteUpdate` settling a non-key column (`ItemModId`) converges. An **equip is structurally different**: it must **evict a *different* item** from the destination slot, so vacate-then-place is inherently *two* writes with an unavoidable race window. No single `ExecuteUpdate` can mirror `ModAppliedHandler` here; truly closing the window would require serializing per-player slot writes (e.g. a Postgres advisory lock), which has no precedent in the codebase and is out of scope for a low-likelihood cross-instance edge that the per-player serialization + queue backstop already make rare.

## How it addresses the issue

Took the robust, in-scope path that mirrors a **real** codebase precedent — `UserLogins.SaveWithConflictRetry`:

- **Bounded retry loop** (`MaxSaveAttempts = 3`) replacing the one-shot retry. Each pass re-vacates whoever won the race and re-places this item, so transient cross-instance re-occupation converges **in-handler** instead of immediately burning the queue's coarser per-event attempt budget — directly reducing the "dead-letter a legitimate equip" risk the issue raises. A still-failing final attempt propagates to the queue retry/dead-letter backstop (at-least-once + idempotent handlers, so nothing is lost) rather than looping.
- **Corrected the misleading comment** — dropped the false `ModAppliedHandler` retry-parity claim and documented the real (weaker) semantics: the retry here genuinely *can* re-violate, why it converges anyway, and the queue backstop. (The `ApplyAsync`-internal "mirrors `ModAppliedHandler`'s clear-then-write" note stays — the *forward* vacate-then-write path genuinely does mirror it; only the *retry* claim was wrong.)

## Test plan

- [x] New integration test `ItemEquipped_DifferentItemsRacingIntoSameSlot_ConvergesToASingleOccupant` — races two **different** items into one slot from independent scopes (the cross-item eviction contention this handler's retry could re-violate, previously untested — the existing concurrent test races the *same* item / insert idempotency). Asserts the slot never ends doubly occupied and converges to a single occupant. A throw past the in-handler bound is swallowed (the queue's redelivery cue) and the at-least-once redelivery settles the final state deterministically.
- [x] `dotnet build Game.DataAccess` clean (0 warnings); `dotnet format --verify-no-changes` clean on changed files.
- [x] `PlayerUpdateHandlerIdempotencyIntegrationTests` — **34/34** pass.

## Scope note

I deliberately did **not** add a per-player advisory lock to fully close the race window. Given the existing per-player serialization (per-socket command lock, single-active-connection, sequential queue drain) the residual re-violation is a rare cross-instance edge, and the bounded loop + queue dead-letter backstop handle it without adding a hot-path lock and a new concurrency primitive to the codebase. Happy to file a follow-up if a hard cross-instance serialization guarantee is wanted.

Closes #1233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZieJV1D1MmpAGQ7uMY3Ax)_