### PR TITLE
Remove dead computed fields on OfflineProgressResult (#1235)

### DIFF
--- a/Game.Core.Tests/Battle/Offline/OfflineProgressResultTests.cs
+++ b/Game.Core.Tests/Battle/Offline/OfflineProgressResultTests.cs
@@ -24,8 +24,6 @@ namespace Game.Core.Tests.Battle.Offline
             Assert.Equal(0, result.Losses);
             Assert.Equal(0, result.Draws);
             Assert.Equal(0, result.TotalExp);
-            Assert.Equal(0, result.TotalBattleMs);
-            Assert.Empty(result.EnemyKillCounts);
         }
 
         [Fact]
@@ -44,7 +42,6 @@ namespace Game.Core.Tests.Battle.Offline
             Assert.Equal(1, result.Wins);
             Assert.Equal(1, result.Losses);
             Assert.Equal(1, result.Draws);
-            Assert.Equal(120_240, result.TotalBattleMs); // 40 + 200 + 120000
         }
 
         [Fact]
@@ -61,25 +58,6 @@ namespace Game.Core.Tests.Battle.Offline
             var result = new OfflineProgressResult(OfflineLoopMode.Idle, zoneId: 1, battles);
 
             Assert.Equal(18, result.TotalExp);
-        }
-
-        [Fact]
-        public void EnemyKillCounts_CountsVictoriesPerEnemyOnly()
-        {
-            var battles = new List<OfflineBattleOutcome>
-            {
-                Win(enemyId: 1, totalMs: 40, exp: 1),
-                Win(enemyId: 1, totalMs: 40, exp: 1),
-                Win(enemyId: 2, totalMs: 40, exp: 1),
-                Loss(enemyId: 1, totalMs: 40), // a loss is not a kill
-                Draw(enemyId: 2, totalMs: 40), // a draw is not a kill
-            };
-
-            var result = new OfflineProgressResult(OfflineLoopMode.Idle, zoneId: 1, battles);
-
-            Assert.Equal(2, result.EnemyKillCounts.Count);
-            Assert.Equal(2, result.EnemyKillCounts[1]);
-            Assert.Equal(1, result.EnemyKillCounts[2]);
         }
 
         [Fact]

--- a/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
@@ -43,7 +43,6 @@ namespace Game.Core.Tests.Battle.Offline
             Assert.Equal(0, result.Losses);
             Assert.Equal(0, result.Draws);
             Assert.Equal(0, result.TotalExp);
-            Assert.Empty(result.EnemyKillCounts);
         }
 
         [Fact]
@@ -231,7 +230,6 @@ namespace Game.Core.Tests.Battle.Offline
             Assert.Equal(0, result.Wins);
             Assert.Equal(0, result.Losses);
             Assert.Equal(0, result.TotalExp);
-            Assert.Empty(result.EnemyKillCounts);
             Assert.All(result.Battles, battle =>
             {
                 Assert.False(battle.Result.Victory);
@@ -337,17 +335,6 @@ namespace Game.Core.Tests.Battle.Offline
                 var expected = new DefeatRewards(playerModifiers, battle.Enemy).ExpReward;
                 Assert.Equal(expected, battle.ExpReward);
             });
-        }
-
-        [Fact]
-        public void Simulate_Wins_RecordsPerEnemyKillCounts()
-        {
-            var scenario = StrongPlayerWinScenario(); // a single enemy id (1) won every time
-            var result = _simulator.Simulate(IdleParameters(ManyStepsBudget(), scenario));
-
-            var kill = Assert.Single(result.EnemyKillCounts);
-            Assert.Equal(EnemyId, kill.Key);
-            Assert.Equal(result.Wins, kill.Value);
         }
 
         [Fact]

--- a/Game.Core/Battle/Offline/OfflineProgressResult.cs
+++ b/Game.Core/Battle/Offline/OfflineProgressResult.cs
@@ -38,14 +38,6 @@ namespace Game.Core.Battle.Offline
         /// <see cref="OfflineBattleOutcome.ExpReward"/>.</summary>
         public long TotalExp { get; }
 
-        /// <summary>The total simulated battle time, in milliseconds, excluding the inter-battle cooldown
-        /// gaps.</summary>
-        public long TotalBattleMs { get; }
-
-        /// <summary>Per-enemy victory (kill) counts, keyed by enemy id. Only victories contribute, mirroring
-        /// the live <c>EnemiesKilled</c> statistic.</summary>
-        public IReadOnlyDictionary<int, int> EnemyKillCounts { get; }
-
         public OfflineProgressResult(OfflineLoopMode mode, int zoneId, IReadOnlyList<OfflineBattleOutcome> battles)
         {
             Mode = mode;
@@ -54,16 +46,12 @@ namespace Game.Core.Battle.Offline
 
             // Fold the per-battle outcomes into the run-level aggregates in a single pass, keeping the
             // outcome list the one source of truth (the summary is a materialized view of it).
-            var killCounts = new Dictionary<int, int>();
             foreach (var battle in battles)
             {
-                TotalBattleMs += battle.Result.TotalMs;
-
                 if (battle.Result.Victory)
                 {
                     Wins++;
                     TotalExp += battle.ExpReward;
-                    killCounts[battle.Enemy.Id] = killCounts.GetValueOrDefault(battle.Enemy.Id) + 1;
                 }
                 else if (battle.Result.PlayerDied)
                 {
@@ -74,8 +62,6 @@ namespace Game.Core.Battle.Offline
                     Draws++;
                 }
             }
-
-            EnemyKillCounts = killCounts;
         }
     }
 }


### PR DESCRIPTION
Closes #1235

## Summary

`OfflineProgressResult.EnemyKillCounts` and `TotalBattleMs` were computed and populated for every offline simulation run but referenced **only by tests** — no production code reads them. This removes both as dead code.

## How it addresses the issue

I confirmed the issue's claim before acting:
- `BattleService.ApplyOfflineRewards` iterates `result.Battles` directly and records authoritative per-enemy kill stats through `PlayerProgress.RecordBattleCompleted` — it never reads `EnemyKillCounts` or `TotalBattleMs`.
- The client-facing welcome-back surface, `OfflineProgressSummary`, projects only `Wins`/`Losses`/`Draws`/`TotalExp` from the result. Neither removed field reaches the client.
- A repo-wide grep showed both members appearing only in their own definition and in test assertions.

Since there is no existing welcome-back surface consuming them, removal (the issue's primary suggested fix) is the right call over wiring them up. Changes:
- Removed `EnemyKillCounts` and `TotalBattleMs` properties and the per-pass kill-count accumulation from `OfflineProgressResult`; the constructor's single fold now computes only the surfaced aggregates.
- Removed the tests that pinned the two fields (`EnemyKillCounts_CountsVictoriesPerEnemyOnly`, `Simulate_Wins_RecordsPerEnemyKillCounts`) and the stray `TotalBattleMs`/`EnemyKillCounts` assertions in the empty/stalemate cases.

`battle.Result.TotalMs` is untouched — it's still consumed per-battle by `RecordBattleCompleted`; only the unused run-level aggregate was removed.

## Test plan

- [x] `dotnet build` — Game.Core + Game.Core.Tests clean (0 warnings).
- [x] `dotnet test` — Game.Core.Tests green (819 passed, 0 failed).
- [x] `dotnet format --verify-no-changes` clean on all three changed files.
- [x] Repo-wide grep confirms no remaining references to either field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012S7ryrsqitgNzZCbTZ5L1V

---
_Generated by [Claude Code](https://claude.ai/code/session_012S7ryrsqitgNzZCbTZ5L1V)_