### PR TITLE
Set ForwardLimit on ForwardedHeadersConfig for multi-hop proxy chains (#1236)

### DIFF
--- a/Game.Api.Tests/Integration/ForwardedHeadersTrustTests.cs
+++ b/Game.Api.Tests/Integration/ForwardedHeadersTrustTests.cs
@@ -23,15 +23,24 @@ namespace Game.Api.Tests.Integration
         protected const string Fingerprint = "fp-fwd-headers";
         protected const string SimulatedPeerIp = "203.0.113.9";
         protected const string SpoofedClientIp = "9.9.9.9";
+        // A second proxy hop (e.g. a CDN sitting in front of the ingress) for the multi-hop ForwardLimit cases.
+        protected const string IntermediateProxyIp = "203.0.113.50";
 
         protected ForwardedHeadersTrustTestsBase(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
             : base(containers, testOutputHelper) { }
 
-        protected abstract string? KnownProxy { get; }
+        /// <summary>The proxy IPs trusted by this scenario (empty trusts nothing).</summary>
+        protected abstract IReadOnlyList<string> KnownProxies { get; }
+
+        /// <summary>The trust-chain depth to configure; null leaves the deployment default (1) in place.</summary>
+        protected virtual int? ForwardLimit => null;
+
+        /// <summary>The X-Forwarded-For value the client sends; a single spoofed entry by default.</summary>
+        protected virtual string ForwardedForHeader => SpoofedClientIp;
 
         protected override GameServerFactory CreateFactory(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
         {
-            return new ForwardedHeadersFactory(containers, testOutputHelper, SimulatedPeerIp, KnownProxy);
+            return new ForwardedHeadersFactory(containers, testOutputHelper, SimulatedPeerIp, KnownProxies, ForwardLimit);
         }
 
         protected async Task<string> ReadRecordedIpAsync(int userId)
@@ -58,7 +67,7 @@ namespace Game.Api.Tests.Integration
         {
             var (client, _) = await LoginAndBuildClientAsync(username, password);
             client.DefaultRequestHeaders.TryAddWithoutValidation(ClientHints.DeviceFingerprintHeader, Fingerprint);
-            client.DefaultRequestHeaders.TryAddWithoutValidation("X-Forwarded-For", SpoofedClientIp);
+            client.DefaultRequestHeaders.TryAddWithoutValidation("X-Forwarded-For", ForwardedForHeader);
             return client;
         }
 
@@ -70,20 +79,27 @@ namespace Game.Api.Tests.Integration
             IntegrationTestContainers containers,
             ITestOutputHelper testOutputHelper,
             string simulatedPeerIp,
-            string? knownProxy) : GameServerFactory(containers, testOutputHelper)
+            IReadOnlyList<string> knownProxies,
+            int? forwardLimit) : GameServerFactory(containers, testOutputHelper)
         {
             protected override void ConfigureWebHost(IWebHostBuilder builder)
             {
                 base.ConfigureWebHost(builder);
 
-                if (knownProxy is not null)
+                if (knownProxies.Count > 0 || forwardLimit is not null)
                 {
                     builder.ConfigureAppConfiguration((_, config) =>
                     {
-                        config.AddInMemoryCollection(new Dictionary<string, string?>
+                        var settings = new Dictionary<string, string?>();
+                        for (var i = 0; i < knownProxies.Count; i++)
                         {
-                            ["ForwardedHeaders:KnownProxies:0"] = knownProxy,
-                        });
+                            settings[$"ForwardedHeaders:KnownProxies:{i}"] = knownProxies[i];
+                        }
+                        if (forwardLimit is not null)
+                        {
+                            settings["ForwardedHeaders:ForwardLimit"] = forwardLimit.Value.ToString();
+                        }
+                        config.AddInMemoryCollection(settings);
                     });
                 }
 
@@ -121,7 +137,7 @@ namespace Game.Api.Tests.Integration
             : base(containers, testOutputHelper) { }
 
         // No proxy is trusted, so a spoofed X-Forwarded-For must be ignored.
-        protected override string? KnownProxy => null;
+        protected override IReadOnlyList<string> KnownProxies => [];
 
         [Fact]
         public async Task SpoofedForwardedFor_FromUntrustedPeer_IsIgnored()
@@ -145,7 +161,7 @@ namespace Game.Api.Tests.Integration
             : base(containers, testOutputHelper) { }
 
         // The simulated socket peer is configured as a known proxy, so its X-Forwarded-For is honoured.
-        protected override string? KnownProxy => SimulatedPeerIp;
+        protected override IReadOnlyList<string> KnownProxies => [SimulatedPeerIp];
 
         [Fact]
         public async Task ForwardedFor_FromTrustedProxy_IsHonoured()
@@ -158,6 +174,59 @@ namespace Game.Api.Tests.Integration
 
             var recordedIp = await ReadRecordedIpAsync(userId);
             Assert.Equal(SpoofedClientIp, recordedIp);
+        }
+    }
+
+    [Collection("Integration")]
+    public class ForwardedHeadersMultiHopTests : ForwardedHeadersTrustTestsBase
+    {
+        public ForwardedHeadersMultiHopTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        // Both hops of a CDN → ingress chain are trusted and ForwardLimit matches the chain depth (2),
+        // so the walk reaches the original client entry rather than stopping at the intermediate proxy.
+        protected override IReadOnlyList<string> KnownProxies => [SimulatedPeerIp, IntermediateProxyIp];
+        protected override int? ForwardLimit => 2;
+        protected override string ForwardedForHeader => $"{SpoofedClientIp}, {IntermediateProxyIp}";
+
+        [Fact]
+        public async Task ForwardedFor_AcrossTrustedChain_ResolvesTheRealClient()
+        {
+            var userId = await SeedUserAsync("fwdmultihop", "fwdpass");
+            using var client = await LoginWithDeviceAsync("fwdmultihop", "fwdpass");
+
+            var response = await client.GetAsync("/api/Login/Status", CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var recordedIp = await ReadRecordedIpAsync(userId);
+            Assert.Equal(SpoofedClientIp, recordedIp);
+        }
+    }
+
+    [Collection("Integration")]
+    public class ForwardedHeadersDefaultLimitMultiHopTests : ForwardedHeadersTrustTestsBase
+    {
+        public ForwardedHeadersDefaultLimitMultiHopTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        // Both hops are trusted but the default ForwardLimit (1) is left in place, so the walk stops at the
+        // intermediate proxy — the real client is never reached. This pins the exact behaviour #1236 fixes:
+        // a multi-hop deployment must raise ForwardLimit to reach the true client IP.
+        protected override IReadOnlyList<string> KnownProxies => [SimulatedPeerIp, IntermediateProxyIp];
+        protected override string ForwardedForHeader => $"{SpoofedClientIp}, {IntermediateProxyIp}";
+
+        [Fact]
+        public async Task ForwardedFor_WithDefaultLimit_StopsAtTheIntermediateProxy()
+        {
+            var userId = await SeedUserAsync("fwddefaultlimit", "fwdpass");
+            using var client = await LoginWithDeviceAsync("fwddefaultlimit", "fwdpass");
+
+            var response = await client.GetAsync("/api/Login/Status", CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var recordedIp = await ReadRecordedIpAsync(userId);
+            Assert.Equal(IntermediateProxyIp, recordedIp);
+            Assert.NotEqual(SpoofedClientIp, recordedIp);
         }
     }
 }

--- a/Game.Api.Tests/Unit/ForwardedHeadersConfigTests.cs
+++ b/Game.Api.Tests/Unit/ForwardedHeadersConfigTests.cs
@@ -8,8 +8,9 @@ namespace Game.Api.Tests.Unit
 {
     /// <summary>
     /// Covers <see cref="ForwardedHeadersConfig.Apply"/>: the framework defaults (loopback) are cleared so
-    /// the trust set is entirely explicit, only X-Forwarded-For is honoured, and configured proxies/networks
-    /// are parsed onto the options while unparseable entries are skipped.
+    /// the trust set is entirely explicit, only X-Forwarded-For is honoured, the trust-chain depth
+    /// (ForwardLimit) is projected (defaulting to 1), and configured proxies/networks are parsed onto the
+    /// options while unparseable entries are skipped.
     /// </summary>
     public class ForwardedHeadersConfigTests
     {
@@ -57,6 +58,36 @@ namespace Game.Api.Tests.Unit
             Assert.Contains(options.KnownProxies, p => p.Equals(IPAddress.Parse("::1")));
             Assert.Single(options.KnownIPNetworks);
             Assert.Equal(System.Net.IPNetwork.Parse("172.16.0.0/12"), options.KnownIPNetworks[0]);
+        }
+
+        [Fact]
+        public void Apply_DefaultsForwardLimitToOne()
+        {
+            var options = new ForwardedHeadersOptions();
+
+            new ForwardedHeadersConfig().Apply(options);
+
+            Assert.Equal(1, options.ForwardLimit);
+        }
+
+        [Fact]
+        public void Apply_SetsConfiguredForwardLimit()
+        {
+            var options = new ForwardedHeadersOptions();
+
+            new ForwardedHeadersConfig { ForwardLimit = 2 }.Apply(options);
+
+            Assert.Equal(2, options.ForwardLimit);
+        }
+
+        [Fact]
+        public void Apply_WithNullForwardLimit_DisablesTheLimit()
+        {
+            var options = new ForwardedHeadersOptions();
+
+            new ForwardedHeadersConfig { ForwardLimit = null }.Apply(options);
+
+            Assert.Null(options.ForwardLimit);
         }
 
         [Fact]

--- a/Game.Api/Forwarding/ForwardedHeadersConfig.cs
+++ b/Game.Api/Forwarding/ForwardedHeadersConfig.cs
@@ -22,6 +22,16 @@ namespace Game.Api.Forwarding
         public List<string> KnownNetworks { get; set; } = [];
 
         /// <summary>
+        /// How many <c>X-Forwarded-For</c> entries to walk back from the socket peer inward — the depth of
+        /// the trusted proxy chain. Defaults to <c>1</c> (a single proxy), matching the framework default,
+        /// so single-proxy deployments are unchanged. A legitimate multi-hop chain (e.g. CDN → ingress) must
+        /// raise this to the chain length so the real client IP — not the last proxy's — reaches
+        /// <c>RemoteIpAddress</c> (and therefore the rate-limiter/login-backoff partition key). <c>null</c>
+        /// disables the limit (walk every entry), which is only safe when every hop is on the trust allowlist.
+        /// </summary>
+        public int? ForwardLimit { get; set; } = 1;
+
+        /// <summary>
         /// Whether any trusted proxy is configured. When false the forwarded-headers middleware must not
         /// run at all: with an empty allowlist it would skip its known-proxy check and trust the header
         /// unconditionally, which is exactly the spoofing we are guarding against.
@@ -33,10 +43,12 @@ namespace Game.Api.Forwarding
         /// <c>X-Forwarded-For</c> from the configured proxies/networks. ASP.NET Core defaults the known
         /// proxies/networks to loopback, so the framework lists are cleared first and repopulated solely
         /// from configuration — making the trust set entirely explicit and "trust nothing" the safe default.
+        /// The trust depth (<see cref="ForwardLimit"/>) is the other half of that explicit trust set.
         /// </summary>
         public void Apply(ForwardedHeadersOptions options)
         {
             options.ForwardedHeaders = ForwardedHeaders.XForwardedFor;
+            options.ForwardLimit = ForwardLimit;
             options.KnownProxies.Clear();
             options.KnownIPNetworks.Clear();
 

--- a/Game.Api/Startup.cs
+++ b/Game.Api/Startup.cs
@@ -84,7 +84,14 @@ namespace Game.Api
             // when at least one is configured, so by default a spoofed X-Forwarded-For from a direct client
             // is ignored and the recorded IP stays the socket peer address (#910).
             builder.Services.AddOptions<ForwardedHeadersConfig>()
-                .BindConfiguration(ForwardedHeadersConfig.SectionName);
+                .BindConfiguration(ForwardedHeadersConfig.SectionName)
+                // ForwardLimit is the trust-chain depth: null means "no limit" (walk every entry), otherwise
+                // it must be at least 1. Validated on start so a misconfigured zero/negative fails fast rather
+                // than silently dropping all forwarded entries even when trusted proxies are configured.
+                .Validate(
+                    options => options.ForwardLimit is null || options.ForwardLimit >= 1,
+                    "ForwardedHeaders:ForwardLimit must be null (no limit) or at least 1")
+                .ValidateOnStart();
             builder.Services.AddOptions<ForwardedHeadersOptions>()
                 .Configure<IOptions<ForwardedHeadersConfig>>((options, config) => config.Value.Apply(options));
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -72,6 +72,7 @@ The login-tracking IP (an audit surface) is read from `HttpContext.Connection.Re
 - Configure proxies under the **`ForwardedHeaders`** section: `KnownProxies` (a list of individual IPs, e.g. `"10.0.0.1"`, `"::1"`) and `KnownNetworks` (a list of CIDR ranges, e.g. `"10.0.0.0/8"`). Both default to **empty**.
 - **The default is "trust nothing":** with neither list set, the middleware is not added at all and a spoofed `X-Forwarded-For` is ignored — the recorded IP is the socket peer. (An empty allowlist would otherwise make ASP.NET Core's middleware *skip* its known-proxy check and trust the header unconditionally, so it is deliberately left off rather than configured-but-empty.)
 - A real deployment behind a load balancer / ingress must set the relevant proxy IPs or CIDRs so the player's true client IP is recorded.
+- **`ForwardLimit`** sets the trust-chain depth — how many `X-Forwarded-For` entries are walked back. It defaults to **1** (a single proxy), so single-proxy deployments need not set it. A legitimate multi-hop chain (e.g. CDN → ingress) must raise it to the chain length **and** trust every hop, or only the last entry is consumed and the recorded IP is the nearest proxy rather than the real client. `null` disables the limit (walk every entry) — only safe when every hop is on the allowlist. Validated on start (`null` or ≥ 1) so a misconfigured zero/negative fails fast.
 
 ## Battle-simulation performance tests
 


### PR DESCRIPTION
## Summary

`ForwardedHeadersConfig.Apply` made the trusted-proxy set entirely explicit (clearing the framework's loopback defaults and repopulating solely from config) but never set `ForwardLimit`, leaving the framework default of **1**. That's correct for a single proxy, but a legitimate multi-hop chain (e.g. CDN → ingress) would have only the **last** `X-Forwarded-For` entry consumed — so `RemoteIpAddress` never reaches the real client, silently degrading the partition key used by the per-IP rate limiter and the per-account login backoff / login tracking (`ClientIp.Resolve`). The class exists precisely to make the trust set explicit, and the trust-chain *depth* is the other half of that configuration.

## How it addresses the issue

- **`ForwardedHeadersConfig.ForwardLimit`** — a config-bound nullable `int` defaulting to **1** (so single-proxy deployments are unchanged), projected onto `ForwardedHeadersOptions` in `Apply`. `null` disables the limit (walk every entry), only safe when every hop is on the trust allowlist.
- **Startup validation** — `.Validate(...).ValidateOnStart()` requiring `null` or `≥ 1`, so a misconfigured zero/negative fails fast rather than silently dropping all forwarded entries even with trusted proxies configured. This matches the existing config pattern (CORS, login-backoff, player-creation cap).
- **Docs** — `infrastructure.md` documents the `ForwardLimit` setting under the trusted-reverse-proxies section.

## Test plan

- [x] `dotnet build` clean (0 warnings); `dotnet format --verify-no-changes` clean on both touched projects.
- [x] **Unit** (`ForwardedHeadersConfigTests`): `Apply` defaults `ForwardLimit` to 1, projects an explicit value, and passes through `null` (unlimited).
- [x] **Integration** (`ForwardedHeadersTrustTests`): generalized the harness to a trusted multi-hop chain. A new test proves a trusted CDN → ingress chain with `ForwardLimit=2` resolves the **real client** IP; a contrast test pins that the **default limit of 1** stops at the intermediate proxy (the exact behaviour this issue fixes). The existing single-proxy trusted/untrusted tests still pass.
- [x] Full `*ForwardedHeaders*` filter: **12 passed**, twice (stable).

## Notes

- The `ForwardLimit` value only takes effect when trusted proxies are configured (the middleware is gated on `HasTrustedProxies`), so the default-everywhere behaviour for deployments with no proxy is unchanged.

Closes #1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0155Ef3WjBEdNVcmWPq3JVcx)_