### PR TITLE
Keep selection/status out of derived list projections (#1238)

### DIFF
--- a/UI/src/routes/admin/workbench/Workbench.svelte
+++ b/UI/src/routes/admin/workbench/Workbench.svelte
@@ -39,7 +39,6 @@ import { Loading } from '$components';
 import './workbench.scss';
 import type { EntityConfig, Identified } from './entities/types';
 import { EntityStore } from './entity-store.svelte';
-import { entityWarnings } from './validation';
 import WorkbenchIcon from './WorkbenchIcon.svelte';
 import WorkbenchList from './components/WorkbenchList.svelte';
 import WorkbenchDetail from './components/WorkbenchDetail.svelte';
@@ -70,9 +69,12 @@ const selected = $derived(store ? (store.items.find((it) => it.id === selId) ?? 
 const selectedBaseline = $derived(store && selected ? store.baselineOf(selected.id) : undefined);
 const liveItems = $derived.by(() => {
 	const s = store;
-	return s ? s.items.filter((it) => s.status(it) !== 'deleted') : [];
+	return s ? s.items.filter((it) => s.stateOf(it).status !== 'deleted') : [];
 });
-const flagged = $derived(liveItems.filter((it) => entityWarnings(entity, it).length > 0).length);
+const flagged = $derived.by(() => {
+	const s = store;
+	return s ? liveItems.filter((it) => s.stateOf(it).warnings.length > 0).length : 0;
+});
 
 // If the selected record was removed (e.g. deleted then saved), fall back to the first.
 $effect(() => {

--- a/UI/src/routes/admin/workbench/components/WorkbenchList.svelte
+++ b/UI/src/routes/admin/workbench/components/WorkbenchList.svelte
@@ -21,8 +21,9 @@
 
 	<div class="list-scroll">
 		{#each filtered as record (record.id)}
-			{@const status = store.status(record)}
-			{@const warns = entityWarnings(entity, record)}
+			{@const state = store.stateOf(record)}
+			{@const status = state.status}
+			{@const warns = state.warnings}
 			{@const badge = entity.listBadge?.(record)}
 			{@const edge =
 				status === 'added'
@@ -81,7 +82,6 @@
 <script lang="ts">
 import type { EntityConfig, Identified } from '../entities/types';
 import type { EntityStore } from '../entity-store.svelte';
-import { entityWarnings } from '../validation';
 import WorkbenchIcon from '../WorkbenchIcon.svelte';
 import WarnTriangle from './WarnTriangle.svelte';
 
@@ -97,7 +97,7 @@ const { entity, store, selectedId, onSelect, onNew }: Props = $props();
 
 let q = $state('');
 const filtered = $derived(store.items.filter((it) => (it.name ?? '').toLowerCase().includes(q.toLowerCase())));
-const liveCount = $derived(store.items.filter((it) => store.status(it) !== 'deleted').length);
+const liveCount = $derived(store.items.filter((it) => store.stateOf(it).status !== 'deleted').length);
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/admin/workbench/entity-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/entity-store.svelte.ts
@@ -1,9 +1,16 @@
 import { SvelteSet } from 'svelte/reactivity';
 import { toastError } from '$stores';
 import { canonicalEqual, PersistFailedError } from './save-helpers';
+import { entityWarnings } from './validation';
 import type { EntityConfig, Identified, SaveDiff } from './entities/types';
 
 export type RecordStatus = 'clean' | 'added' | 'modified' | 'deleted';
+
+/** A record's change status plus its validation warnings — memoised together off the store. */
+export interface RecordState {
+	status: RecordStatus;
+	warnings: string[];
+}
 
 const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
 export const recordsEqual = canonicalEqual;
@@ -54,12 +61,36 @@ export class EntityStore<T extends Identified> {
 		return recordsEqual(record, baseline) ? 'clean' : 'modified';
 	}
 
+	/**
+	 * Per-record status + validation warnings, keyed by id. Memoised here so the consumers (the list
+	 * rows, the page summary, the save-bar counts) read O(1) lookups instead of each re-running the
+	 * structural diff per record. Recomputes only when the records, baseline, or pending deletes
+	 * change — a search keystroke or a selection change (which touch neither) reuses the cached map.
+	 */
+	recordStates = $derived.by<Record<number, RecordState>>(() => {
+		const map: Record<number, RecordState> = {};
+		for (const record of this.items) {
+			map[record.id] = { status: this.status(record), warnings: entityWarnings(this.config, record) };
+		}
+		return map;
+	});
+
+	/** The memoised status + warnings for a record (recomputed on the fly for an unknown id). */
+	stateOf(record: T): RecordState {
+		return (
+			this.recordStates[record.id] ?? {
+				status: this.status(record),
+				warnings: entityWarnings(this.config, record)
+			}
+		);
+	}
+
 	counts = $derived.by(() => {
 		let added = 0;
 		let modified = 0;
 		let deleted = 0;
-		for (const record of this.items) {
-			switch (this.status(record)) {
+		for (const { status } of Object.values(this.recordStates)) {
+			switch (status) {
 				case 'added':
 					added++;
 					break;

--- a/UI/src/routes/game/screens/codex/EnemyTable.svelte
+++ b/UI/src/routes/game/screens/codex/EnemyTable.svelte
@@ -14,7 +14,7 @@
 			<button
 				type="button"
 				class="row"
-				class:selected={row.selected}
+				class:selected={row.id === view.selectedEnemyId}
 				class:boss={row.isBoss}
 				data-testid="codex-enemy-{row.id}"
 				onclick={() => view.selectEnemy(row.id)}

--- a/UI/src/routes/game/screens/codex/SkillTable.svelte
+++ b/UI/src/routes/game/screens/codex/SkillTable.svelte
@@ -13,7 +13,7 @@
 			<button
 				type="button"
 				class="row"
-				class:selected={row.selected}
+				class:selected={row.id === view.selectedSkillId}
 				data-testid="codex-skill-{row.id}"
 				onclick={() => view.selectSkill(row.id)}
 			>

--- a/UI/src/routes/game/screens/codex/ZoneRail.svelte
+++ b/UI/src/routes/game/screens/codex/ZoneRail.svelte
@@ -9,7 +9,7 @@
 			<button
 				type="button"
 				class="row"
-				class:selected={row.selected}
+				class:selected={row.id === view.selectedZoneId}
 				style:--status-color={zoneStatusColor(row.status)}
 				data-testid="codex-zone-{row.id}"
 				onclick={() => view.selectZone(row.id)}

--- a/UI/src/routes/game/screens/codex/codex-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/codex-view.svelte.ts
@@ -99,7 +99,6 @@ export interface EnemyRowVM {
 	skillCount: number;
 	/** Pre-lowercased search haystack: name + kind + zone names (spawn zones, or a boss's encounter zone). */
 	searchText: string;
-	selected: boolean;
 }
 
 export interface SubTabVM {
@@ -144,7 +143,6 @@ export interface ZoneRowVM {
 	/** Enemies (excluding the boss) that spawn in this zone. */
 	spawnCount: number;
 	hasBoss: boolean;
-	selected: boolean;
 }
 
 export interface ZoneBossVM {
@@ -178,7 +176,6 @@ export interface SkillRowVM {
 	usedByCount: number;
 	/** Themeable rarity hue for the row's tier mark. */
 	rarityColor: string;
-	selected: boolean;
 }
 
 /** The selected skill's rarity tier (hue + label) for the dossier header. */
@@ -354,8 +351,7 @@ export class CodexView {
 					level: range.min,
 					zoneCount: e.isBoss ? 1 : e.spawns.length,
 					skillCount: e.skillPool.length,
-					searchText: [e.name, enemyKindLabel(e.isBoss), ...zoneNames].join(' ').toLowerCase(),
-					selected: e.id === this.selectedEnemyId
+					searchText: [e.name, enemyKindLabel(e.isBoss), ...zoneNames].join(' ').toLowerCase()
 				};
 			})
 			.filter((row) => matchesEnemySearch(row, this.search))
@@ -501,8 +497,7 @@ export class CodexView {
 			band: formatBand({ min: z.levelMin, max: z.levelMax, fixed: false }),
 			status: resolveZoneStatus(statistics.isZoneCleared(z.id), this.isZoneLocked(z)),
 			spawnCount: enemies.filter((e) => e.spawns.some((s) => s.zoneId === z.id)).length,
-			hasBoss: z.bossEnemyId != null,
-			selected: z.id === this.selectedZoneId
+			hasBoss: z.bossEnemyId != null
 		}));
 	});
 
@@ -593,8 +588,7 @@ export class CodexView {
 			baseDamageLabel: formatBaseDamage(sk.baseDamage),
 			cooldownLabel: formatCooldown(sk.cooldownMs),
 			usedByCount: enemies.filter((e) => e.skillPool.includes(sk.id)).length,
-			rarityColor: rarityColor(sk.rarityId),
-			selected: sk.id === this.selectedSkillId
+			rarityColor: rarityColor(sk.rarityId)
 		}));
 	});
 

--- a/UI/src/tests/routes/admin/workbench/entity-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entity-store.test.ts
@@ -313,4 +313,53 @@ describe('EntityStore', () => {
 			expect(store.status(record)).toBe('modified');
 		});
 	});
+
+	describe('recordStates memo', () => {
+		// A config with a required-name field so warnings are exercised alongside status.
+		const requiredNameConfig = (): EntityConfig<Row> => ({
+			...makeConfig(),
+			sections: [
+				{
+					kind: 'fields',
+					key: 'identity',
+					label: 'Identity',
+					glyph: 'box',
+					fields: [{ key: 'name', label: 'Name', type: 'text', required: true }]
+				}
+			]
+		});
+
+		it('exposes per-record status + validation warnings keyed by id', () => {
+			const store = new EntityStore(requiredNameConfig(), seed);
+			store.patch(1, (draft) => (draft.value = 99));
+
+			expect(store.recordStates[0].status).toBe('clean');
+			expect(store.recordStates[1].status).toBe('modified');
+			expect(store.recordStates[0].warnings).toEqual([]);
+		});
+
+		it('surfaces a validation warning for a record that violates a required field', () => {
+			const store = new EntityStore(requiredNameConfig(), seed);
+			const id = store.addItem(); // a fresh record has a blank (required) name
+
+			const state = store.stateOf(store.items.find((r) => r.id === id)!);
+			expect(state.status).toBe('added');
+			expect(state.warnings).toEqual(['Name required']);
+		});
+
+		it('stateOf recomputes for an id absent from the memo (defensive fallback)', () => {
+			const store = new EntityStore(requiredNameConfig(), seed);
+			// A record not in the store still resolves to a sensible state rather than throwing.
+			expect(store.stateOf({ id: 99, name: 'Ghost', value: 0 }).status).toBe('added');
+		});
+
+		it('counts derive from the memoised states', () => {
+			const store = new EntityStore(makeConfig(), seed);
+			store.addItem();
+			store.patch(0, (draft) => (draft.value = 7));
+			store.removeItem(1);
+
+			expect(store.counts).toMatchObject({ added: 1, modified: 1, deleted: 1, total: 3 });
+		});
+	});
 });

--- a/UI/src/tests/routes/game/screens/codex/Codex.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/Codex.test.ts
@@ -309,6 +309,16 @@ describe('Codex screen', () => {
 		expect(dossier.textContent).toContain('Strength');
 	});
 
+	it('marks the selected row and moves the highlight on click (selection applied in the component)', async () => {
+		render(Codex);
+		// The head enemy is selected by default; clicking another row moves the `selected` class.
+		expect(screen.getByTestId('codex-enemy-0').classList.contains('selected')).toBe(true);
+		expect(screen.getByTestId('codex-enemy-1').classList.contains('selected')).toBe(false);
+		await fireEvent.click(screen.getByTestId('codex-enemy-1'));
+		expect(screen.getByTestId('codex-enemy-0').classList.contains('selected')).toBe(false);
+		expect(screen.getByTestId('codex-enemy-1').classList.contains('selected')).toBe(true);
+	});
+
 	it('surfaces a load error in the statistics sub-tab', async () => {
 		mockFetchSocket.mockImplementation((cmd: string) =>
 			cmd === 'GetPlayerStatistics' ? Promise.reject(new Error('down')) : Promise.resolve([])

--- a/UI/src/tests/routes/game/screens/codex/codex-view.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/codex-view.test.ts
@@ -548,10 +548,11 @@ describe('CodexView skill table', () => {
 		expect(rows.find((r) => r.id === 2)).toMatchObject({ name: 'Focus', cooldownLabel: '—', usedByCount: 0 });
 	});
 
-	it('marks the selected skill', () => {
+	it('tracks the selected skill (the row highlight reads selectedSkillId, kept out of the projection)', () => {
 		const view = new CodexView();
 		view.selectSkill(1);
-		expect(view.skillRows.find((r) => r.selected)?.id).toBe(1);
+		expect(view.selectedSkillId).toBe(1);
+		expect(view.selectedSkill?.id).toBe(1);
 	});
 
 	it('tints each row by its rarity tier and exposes the selected skill rarity for the dossier', () => {


### PR DESCRIPTION
## Summary

Stops two list-projection pipelines from re-running on input that doesn't change the underlying data, per #1238.

### Codex — selection out of the row projections
`enemyRows` / `zoneRows` / `skillRows` folded the current selection into each row (`selected: e.id === this.selectedEnemyId`). Reading the selection id inside the `$derived` made the whole `map → filter → sort` pipeline a dependency of the selection, so every click rebuilt **and re-sorted** the full list.

- Dropped the `selected` flag from `EnemyRowVM` / `ZoneRowVM` / `SkillRowVM` and their projections.
- Selection now applies in the components: `class:selected={row.id === view.selectedEnemyId}` (and the zone/skill equivalents). The highlight reads the same raw `selectedXId` as before, so behaviour is unchanged — only the sorted list no longer invalidates on selection.

### Workbench — memoised per-record status + warnings
`store.status(record)` runs a `JSON.stringify`-based structural diff (`canonicalEqual`) per record, and `entityWarnings(...)` was recomputed in three consumers (page summary, save-bar counts, list rows). On every search keystroke the `{#each}` re-ran the diff for each rendered row.

- Added `recordStates` (a `$derived` `{ status, warnings }` map keyed by id) and a `stateOf(record)` accessor on `EntityStore`. The memo recomputes only when records / baseline / pending-deletes change, so a search keystroke or selection reuses the cached map.
- `counts`, `Workbench.svelte` (`liveItems` / `flagged`), and `WorkbenchList.svelte` (rows + `liveCount`) all read the memo instead of re-diffing. `status` stays public for the single-record consumers (`WorkbenchDetail`, `ChallengeRewardSection`).

Both changes are also a readability win and scale with content size (O(n·log n) per click → cached), as the issue notes.

## How it addresses the issue
Implements both suggested fixes verbatim: keep `selected` out of the codex projections and apply it in the component; memoise a per-record `{ status, warnings }` map off the store rather than recomputing it in three consumers.

## Test plan
- `npm run lint` (eslint + svelte-check) — clean.
- `npm run test:unit:ci` — 2659 passing.
- Codex: updated the view-model selection test to assert `selectedSkillId` (the contract the component now reads), and added a `Codex.test.ts` test pinning that the `selected` class is applied to the head row by default and moves to the clicked row.
- Workbench: added `entity-store` tests for `recordStates` / `stateOf` (status + required-field warnings, the absent-id fallback, and counts deriving from the memo).

Closes #1238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAkhL31JyW64Pc77ARURSN)_