### PR TITLE
Reuse Bar and a shared focus-trap instead of re-implementing them (#1239)

### DIFF
--- a/UI/src/components/ModalHost.svelte
+++ b/UI/src/components/ModalHost.svelte
@@ -4,12 +4,15 @@
 	a focus trap, focus capture+restore, and a body scroll lock. Mounted once in the root layout
 	alongside the toast container.
 -->
-<svelte:window onkeydown={onKeydown} />
-
 {#if active}
 	<div class="modal-layer">
 		<button class="backdrop" type="button" tabindex="-1" aria-label="Dismiss dialog" onclick={dismiss}></button>
-		<div class="shell" tabindex="-1" bind:this={shell}>
+		<div
+			class="shell"
+			tabindex="-1"
+			bind:this={shell}
+			use:focusTrap={{ onEscape: dismiss, scrollLockClass: 'modal-open' }}
+		>
 			<!-- Key on the modal id so a queued modal remounts and replays the entrance animation
 			     rather than just swapping its props in place. -->
 			{#key active.id}
@@ -29,81 +32,26 @@
 
 <script lang="ts">
 import Modal from './Modal.svelte';
+import { focusTrap } from './focus-trap';
 import { activeModal, confirmActiveModal, cancelActiveModal, dismissActiveModal } from '$stores';
 
 const active = $derived(activeModal.current);
 
 let shell = $state<HTMLElement | null>(null);
-// The element focus is returned to once the last modal closes. A plain field (not reactive): only
-// read inside effects/handlers, never rendered.
-let restoreFocus: HTMLElement | null = null;
 
 // Backdrop click and Escape are non-button dismissals — a cancel for confirm/destructive, an
 // acknowledgement for the single-button acknowledge kind.
 const dismiss = () => dismissActiveModal();
 
-const onKeydown = (event: KeyboardEvent) => {
-	if (!active) {
-		return;
-	}
-	if (event.key === 'Escape') {
-		event.preventDefault();
-		dismiss();
-	} else if (event.key === 'Tab') {
-		trapTab(event);
-	}
-};
-
-// Keep Tab focus inside the dialog while it is open.
-const trapTab = (event: KeyboardEvent) => {
-	if (!shell) {
-		return;
-	}
-	const focusables = [...shell.querySelectorAll<HTMLElement>('button:not([disabled])')];
-	if (focusables.length === 0) {
-		return;
-	}
-	const first = focusables[0];
-	const last = focusables[focusables.length - 1];
-	const focused = document.activeElement;
-	if (!shell.contains(focused)) {
-		event.preventDefault();
-		first.focus();
-	} else if (event.shiftKey && focused === first) {
-		event.preventDefault();
-		last.focus();
-	} else if (!event.shiftKey && focused === last) {
-		event.preventDefault();
-		first.focus();
-	}
-};
-
-// On open, capture the outgoing focus and move it into the dialog — the cancel/safe action for a
-// destructive dialog so an accidental Enter can't confirm it, otherwise the primary action.
+// On open (and per queued modal — the shell persists while the inner card remounts), move focus into
+// the dialog — the cancel/safe action for a destructive dialog so an accidental Enter can't confirm
+// it, otherwise the primary action. Trap/Escape/scroll-lock/restore are owned by focusTrap.
 $effect(() => {
 	if (active && shell) {
-		restoreFocus ??= document.activeElement as HTMLElement | null;
 		const selector = active.kind === 'destructive' ? '[data-modal-cancel]' : '[data-modal-primary]';
 		const target = shell.querySelector<HTMLElement>(selector);
 		(target ?? shell).focus();
 	}
-});
-
-// On close, return focus to wherever it was before the dialog opened.
-$effect(() => {
-	if (!active && restoreFocus) {
-		restoreFocus.focus();
-		restoreFocus = null;
-	}
-});
-
-// Lock background scroll while a dialog is open.
-$effect(() => {
-	if (!active) {
-		return;
-	}
-	document.body.classList.add('modal-open');
-	return () => document.body.classList.remove('modal-open');
 });
 </script>
 

--- a/UI/src/components/Popover.svelte
+++ b/UI/src/components/Popover.svelte
@@ -8,12 +8,18 @@
 	The layer is absolutely positioned, so it overlays its nearest positioned ancestor rather than
 	the whole viewport; mount it inside a `position: relative` container.
 -->
-<svelte:window onkeydown={onKeydown} />
-
 {#if open}
 	<div class="popover-layer">
 		<button class="popover-backdrop" type="button" tabindex="-1" aria-label={closeLabel} onclick={onClose}></button>
-		<div class="popover-shell" role="dialog" aria-modal="true" aria-label={label} tabindex="-1" bind:this={shell}>
+		<div
+			class="popover-shell"
+			role="dialog"
+			aria-modal="true"
+			aria-label={label}
+			tabindex="-1"
+			bind:this={shell}
+			use:focusTrap={{ onEscape: onClose, scrollLockClass: 'popover-open' }}
+		>
 			{@render children()}
 		</div>
 	</div>
@@ -21,6 +27,7 @@
 
 <script lang="ts">
 import type { Snippet } from 'svelte';
+import { focusTrap, FOCUSABLE_SELECTOR } from './focus-trap';
 
 interface Props {
 	/** Whether the popover is shown. */
@@ -38,71 +45,14 @@ interface Props {
 const { open, onClose, label, closeLabel = 'Close', children }: Props = $props();
 
 let shell = $state<HTMLElement | null>(null);
-// The element focus is returned to once the popover closes. A plain field (not reactive): only read
-// inside effects/handlers, never rendered.
-let restoreFocus: HTMLElement | null = null;
 
-const onKeydown = (event: KeyboardEvent) => {
-	if (!open) {
-		return;
-	}
-	if (event.key === 'Escape') {
-		event.preventDefault();
-		onClose();
-	} else if (event.key === 'Tab') {
-		trapTab(event);
-	}
-};
-
-// Keep Tab focus inside the popover while it is open.
-const trapTab = (event: KeyboardEvent) => {
-	if (!shell) {
-		return;
-	}
-	const focusables = [...shell.querySelectorAll<HTMLElement>('button:not([disabled])')];
-	if (focusables.length === 0) {
-		return;
-	}
-	const first = focusables[0];
-	const last = focusables[focusables.length - 1];
-	const focused = document.activeElement;
-	if (!shell.contains(focused)) {
-		event.preventDefault();
-		first.focus();
-	} else if (event.shiftKey && focused === first) {
-		event.preventDefault();
-		last.focus();
-	} else if (!event.shiftKey && focused === last) {
-		event.preventDefault();
-		first.focus();
-	}
-};
-
-// On open, capture the outgoing focus and move it onto the first focusable inside the popover (or
-// the shell itself if it has none) so the trap has somewhere to anchor.
+// On open, move focus onto the first focusable inside the popover (or the shell itself if it has
+// none) so the trap has somewhere to anchor. Trap/Escape/scroll-lock/restore are owned by focusTrap.
 $effect(() => {
 	if (open && shell) {
-		restoreFocus ??= document.activeElement as HTMLElement | null;
-		const target = shell.querySelector<HTMLElement>('button:not([disabled])');
+		const target = shell.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
 		(target ?? shell).focus();
 	}
-});
-
-// On close, return focus to wherever it was before the popover opened.
-$effect(() => {
-	if (!open && restoreFocus) {
-		restoreFocus.focus();
-		restoreFocus = null;
-	}
-});
-
-// Lock background scroll while open.
-$effect(() => {
-	if (!open) {
-		return;
-	}
-	document.body.classList.add('popover-open');
-	return () => document.body.classList.remove('popover-open');
 });
 </script>
 

--- a/UI/src/components/focus-trap.ts
+++ b/UI/src/components/focus-trap.ts
@@ -1,0 +1,86 @@
+/**
+ * Focus-trap action shared by the blocking (`ModalHost`) and non-blocking (`Popover`) overlays — the
+ * interaction model their content stays free of: it keeps Tab focus inside the trapped element, routes
+ * Escape to a dismissal callback, locks background scroll, and restores focus to the element that was
+ * focused before the trap mounted. Attach it to the overlay's shell while it is open (the action's
+ * lifetime is the overlay's open lifetime, since the shell is rendered behind an `{#if}`).
+ *
+ * Initial focus is deliberately NOT owned here: the two consumers place it differently (the modal aims
+ * at its kind-appropriate action and must re-aim per queued modal; the popover takes the first
+ * focusable), so each keeps its own one-shot focus step and reuses `FOCUSABLE_SELECTOR` for it.
+ */
+
+/**
+ * Tab-reachable elements. Intentionally broader than a bare `button` so a modal/popover containing a
+ * link, input, or `[tabindex]` element still traps and anchors onto it.
+ */
+export const FOCUSABLE_SELECTOR =
+	'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export interface FocusTrapOptions {
+	/** Called when Escape is pressed while the trap is active (the overlay's dismiss path). */
+	onEscape?: () => void;
+	/** When set, the class toggled on `<body>` to lock background scroll while the trap is active. */
+	scrollLockClass?: string;
+}
+
+export function focusTrap(node: HTMLElement, options: FocusTrapOptions = {}) {
+	let opts = options;
+	// Captured on mount (before the consumer moves focus inward) and restored on destroy.
+	const restoreFocus = document.activeElement as HTMLElement | null;
+
+	const onKeydown = (event: KeyboardEvent) => {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			opts.onEscape?.();
+			return;
+		}
+		if (event.key !== 'Tab') {
+			return;
+		}
+		const focusables = [...node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)];
+		if (focusables.length === 0) {
+			return;
+		}
+		const first = focusables[0];
+		const last = focusables[focusables.length - 1];
+		const focused = document.activeElement;
+		if (!node.contains(focused)) {
+			event.preventDefault();
+			first.focus();
+		} else if (event.shiftKey && focused === first) {
+			event.preventDefault();
+			last.focus();
+		} else if (!event.shiftKey && focused === last) {
+			event.preventDefault();
+			first.focus();
+		}
+	};
+
+	window.addEventListener('keydown', onKeydown);
+	if (opts.scrollLockClass) {
+		document.body.classList.add(opts.scrollLockClass);
+	}
+
+	return {
+		update(next: FocusTrapOptions) {
+			// Swap the scroll-lock class if it changed (rare); options are otherwise read live.
+			if (opts.scrollLockClass !== next.scrollLockClass) {
+				if (opts.scrollLockClass) {
+					document.body.classList.remove(opts.scrollLockClass);
+				}
+				if (next.scrollLockClass) {
+					document.body.classList.add(next.scrollLockClass);
+				}
+			}
+			opts = next;
+		},
+		destroy() {
+			window.removeEventListener('keydown', onKeydown);
+			if (opts.scrollLockClass) {
+				document.body.classList.remove(opts.scrollLockClass);
+			}
+			restoreFocus?.focus();
+		}
+	};
+}

--- a/UI/src/components/nav-menu/index.ts
+++ b/UI/src/components/nav-menu/index.ts
@@ -1,2 +1,1 @@
 export { default as NavSidebar } from './NavSidebar.svelte';
-export * from './types';

--- a/UI/src/components/nav-menu/types.ts
+++ b/UI/src/components/nav-menu/types.ts
@@ -1,8 +1,0 @@
-import { Action } from '$lib/common';
-import { MouseEventHandler } from 'svelte/elements';
-
-export interface INavMenuItem {
-	text: string;
-	onClick?: Action<[Parameters<MouseEventHandler<HTMLButtonElement>>[0], INavMenuItem]>;
-	children?: INavMenuItem[];
-}

--- a/UI/src/routes/game/screens/attributes/BudgetMeter.svelte
+++ b/UI/src/routes/game/screens/attributes/BudgetMeter.svelte
@@ -5,12 +5,21 @@
 			{remaining}<span class="budget-total">&nbsp;/&nbsp;{budget}</span>
 		</span>
 	</div>
-	<div class="track">
-		<div class="fill" style="width: {pct}%"></div>
-	</div>
+	<Bar
+		value={pct}
+		presentational
+		--bar-height="4px"
+		--bar-radius="2px"
+		--bar-track-bg="color-mix(in srgb, var(--white) 7%, transparent)"
+		--bar-fill="var(--accent)"
+		--bar-fill-shadow="0 0 8px var(--accent)"
+		--bar-transition="width 220ms cubic-bezier(0.4, 0, 0.2, 1)"
+	/>
 </div>
 
 <script lang="ts">
+import Bar from '$components/Bar.svelte';
+
 interface Props {
 	remaining: number;
 	budget: number;
@@ -66,19 +75,5 @@ const pct = $derived(budget > 0 ? Math.max(0, Math.min(100, (remaining / budget)
 	font-size: 11px;
 	font-weight: 400;
 	color: var(--text-muted);
-}
-
-.track {
-	height: 4px;
-	border-radius: 2px;
-	background: color-mix(in srgb, var(--white) 7%, transparent);
-	overflow: hidden;
-}
-
-.fill {
-	height: 100%;
-	background: var(--accent);
-	box-shadow: 0 0 8px var(--accent);
-	transition: width 220ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 </style>

--- a/UI/src/routes/game/screens/fight/BattleTimer.svelte
+++ b/UI/src/routes/game/screens/fight/BattleTimer.svelte
@@ -10,11 +10,21 @@
 		<div class="caption">/ {limitText} limit</div>
 	{/if}
 	<div class="track">
-		<div class="track-fill" class:warning style:width="{fillPercent}%"></div>
+		<Bar
+			value={fillPercent}
+			presentational
+			--bar-height="2px"
+			--bar-radius="1px"
+			--bar-track-bg="color-mix(in srgb, var(--white) 9%, transparent)"
+			--bar-fill={warning ? 'var(--warning)' : 'var(--accent)'}
+			--bar-transition="width 0.12s linear, background 0.4s"
+		/>
 	</div>
 </div>
 
 <script lang="ts">
+import Bar from '$components/Bar.svelte';
+
 type Props = {
 	/** Elapsed battle time in milliseconds (the engine's `timeElapsed`). */
 	elapsedMs: number;
@@ -78,22 +88,6 @@ const limitText = $derived(formatClock(maxMs));
 
 .track {
 	width: 120px;
-	height: 2px;
 	margin-top: 3px;
-	border-radius: 1px;
-	background: color-mix(in srgb, var(--white) 9%, transparent);
-	overflow: hidden;
-}
-
-.track-fill {
-	height: 100%;
-	background: var(--accent);
-	transition:
-		width 0.12s linear,
-		background 0.4s;
-
-	&.warning {
-		background: var(--warning);
-	}
 }
 </style>

--- a/UI/src/routes/game/screens/fight/EnemyCooldown.svelte
+++ b/UI/src/routes/game/screens/fight/EnemyCooldown.svelte
@@ -6,11 +6,21 @@
 	<div class="readout">{secondsText}</div>
 	<div class="caption">next enemy</div>
 	<div class="track">
-		<div class="track-fill" style:width="{fillPercent}%"></div>
+		<Bar
+			value={fillPercent}
+			presentational
+			--bar-height="2px"
+			--bar-radius="1px"
+			--bar-track-bg="color-mix(in srgb, var(--white) 9%, transparent)"
+			--bar-fill="var(--enemy-accent)"
+			--bar-transition="width 0.12s linear"
+		/>
 	</div>
 </div>
 
 <script lang="ts">
+import Bar from '$components/Bar.svelte';
+
 type Props = {
 	/** Remaining cooldown in milliseconds (the engine's `loadingTime`). */
 	remainingMs: number;
@@ -58,16 +68,6 @@ const fillPercent = $derived(totalMs > 0 ? Math.min(100, Math.max(0, ((totalMs -
 
 .track {
 	width: 120px;
-	height: 2px;
 	margin-top: 3px;
-	border-radius: 1px;
-	background: color-mix(in srgb, var(--white) 9%, transparent);
-	overflow: hidden;
-}
-
-.track-fill {
-	height: 100%;
-	background: var(--enemy-accent);
-	transition: width 0.12s linear;
 }
 </style>

--- a/UI/src/tests/components/focus-trap.test.ts
+++ b/UI/src/tests/components/focus-trap.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { focusTrap, FOCUSABLE_SELECTOR } from '$components/focus-trap';
+
+// Each test attaches the action to a node appended to the body; track the teardown + node so the
+// window keydown listener and DOM are cleaned up between tests.
+let handle: { update(o: unknown): void; destroy(): void } | undefined;
+let node: HTMLElement | undefined;
+
+const mount = (html: string, options: Parameters<typeof focusTrap>[1] = {}) => {
+	node = document.createElement('div');
+	node.innerHTML = html;
+	document.body.appendChild(node);
+	handle = focusTrap(node, options);
+	return node;
+};
+
+const tab = (shiftKey = false) => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey }));
+
+afterEach(() => {
+	handle?.destroy();
+	handle = undefined;
+	node?.remove();
+	node = undefined;
+	document.body.classList.remove('test-lock');
+});
+
+describe('focusTrap', () => {
+	it('wraps Tab between the first and last focusables', () => {
+		const el = mount('<button data-testid="a">a</button><button data-testid="b">b</button>');
+		const [a, b] = [...el.querySelectorAll('button')];
+
+		b.focus();
+		tab();
+		expect(document.activeElement).toBe(a);
+
+		a.focus();
+		tab(true);
+		expect(document.activeElement).toBe(b);
+	});
+
+	it('pulls focus back inside when it has escaped the node', () => {
+		const el = mount('<button>a</button>');
+		const a = el.querySelector('button') as HTMLElement;
+		document.body.focus();
+		tab();
+		expect(document.activeElement).toBe(a);
+	});
+
+	it('traps non-button focusables too (links, inputs, [tabindex])', () => {
+		// The latent bug fixed here: a button-only selector would not have trapped these.
+		const el = mount('<a href="#" data-testid="link">link</a><input data-testid="field" /><span tabindex="0">x</span>');
+		const link = el.querySelector('a') as HTMLElement;
+		const span = el.querySelector('span') as HTMLElement;
+
+		span.focus();
+		tab();
+		expect(document.activeElement).toBe(link);
+
+		link.focus();
+		tab(true);
+		expect(document.activeElement).toBe(span);
+	});
+
+	it('ignores a disabled button and a tabindex="-1" element as focusables', () => {
+		const el = mount(
+			'<button data-testid="a">a</button><button disabled>skip</button><div tabindex="-1">skip</div><button data-testid="b">b</button>'
+		);
+		const [a, b] = el.querySelectorAll<HTMLElement>('[data-testid]');
+		b.focus();
+		tab();
+		expect(document.activeElement).toBe(a);
+	});
+
+	it('routes Escape to onEscape', () => {
+		const onEscape = vi.fn();
+		mount('<button>a</button>', { onEscape });
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+		expect(onEscape).toHaveBeenCalledTimes(1);
+	});
+
+	it('locks body scroll via the given class and releases it on destroy', () => {
+		mount('<button>a</button>', { scrollLockClass: 'test-lock' });
+		expect(document.body.classList.contains('test-lock')).toBe(true);
+		handle?.destroy();
+		handle = undefined;
+		expect(document.body.classList.contains('test-lock')).toBe(false);
+	});
+
+	it('restores focus to the previously focused element on destroy', () => {
+		const outside = document.createElement('button');
+		document.body.appendChild(outside);
+		outside.focus();
+		expect(document.activeElement).toBe(outside);
+
+		const el = mount('<button>a</button>');
+		(el.querySelector('button') as HTMLElement).focus();
+		expect(document.activeElement).not.toBe(outside);
+
+		handle?.destroy();
+		handle = undefined;
+		expect(document.activeElement).toBe(outside);
+		outside.remove();
+	});
+
+	it('does nothing on Tab when the node has no focusables', () => {
+		mount('<span>nothing</span>');
+		// No throw, and focus is untouched.
+		expect(() => tab()).not.toThrow();
+	});
+
+	it('exposes a focusable selector that covers the standard interactive elements', () => {
+		expect(FOCUSABLE_SELECTOR).toContain('a[href]');
+		expect(FOCUSABLE_SELECTOR).toContain('button:not([disabled])');
+		expect(FOCUSABLE_SELECTOR).toContain('input:not([disabled])');
+		expect(FOCUSABLE_SELECTOR).toContain('[tabindex]:not([tabindex="-1"])');
+	});
+});

--- a/UI/src/tests/routes/game/screens/fight/BattleTimer.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/BattleTimer.test.ts
@@ -21,17 +21,19 @@ describe('BattleTimer', () => {
 	it('sizes the progress track to the elapsed fraction', () => {
 		const { container } = render(BattleTimer, { props: { elapsedMs: 60000, maxMs: DEFAULT_MAX_BATTLE_MS } });
 		// 60s / 120s = 50%.
-		expect((container.querySelector('.track-fill') as HTMLElement).getAttribute('style')).toContain('width: 50%');
+		expect((container.querySelector('.bar-fill') as HTMLElement).getAttribute('style')).toContain('width: 50%');
 	});
 
 	it('uses the accent fill before the final seconds and the warning hue within them', () => {
 		const early = render(BattleTimer, { props: { elapsedMs: 60000, maxMs: DEFAULT_MAX_BATTLE_MS } });
-		expect((early.container.querySelector('.track-fill') as HTMLElement).classList.contains('warning')).toBe(false);
+		// The fill colour rides the Bar's --bar-fill token: accent before the warning window.
+		expect(early.container.innerHTML).toContain('--bar-fill: var(--accent)');
+		expect(early.container.innerHTML).not.toContain('--bar-fill: var(--warning)');
 		cleanup();
 
 		// Final 20 seconds (>= 100000ms of the 120000ms cap) flips to the warning hue.
 		const late = render(BattleTimer, { props: { elapsedMs: 105000, maxMs: DEFAULT_MAX_BATTLE_MS } });
-		expect((late.container.querySelector('.track-fill') as HTMLElement).classList.contains('warning')).toBe(true);
+		expect(late.container.innerHTML).toContain('--bar-fill: var(--warning)');
 	});
 
 	it('caps the readout at the limit instead of overshooting', () => {

--- a/UI/src/tests/routes/game/screens/fight/EnemyCooldown.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/EnemyCooldown.test.ts
@@ -18,7 +18,7 @@ describe('EnemyCooldown', () => {
 	it('fills the track by the elapsed fraction of the cooldown', () => {
 		const { container } = render(EnemyCooldown, { props: { remainingMs: 2000, totalMs: 5000 } });
 		// 3000ms of 5000ms elapsed = 60% filled.
-		expect((container.querySelector('.track-fill') as HTMLElement).getAttribute('style')).toContain('width: 60%');
+		expect((container.querySelector('.bar-fill') as HTMLElement).getAttribute('style')).toContain('width: 60%');
 	});
 
 	it('clamps a tiny overshoot to 0s rather than a negative count', () => {
@@ -28,6 +28,6 @@ describe('EnemyCooldown', () => {
 
 	it('guards a zero total against a divide-by-zero, showing an empty track', () => {
 		const { container } = render(EnemyCooldown, { props: { remainingMs: 0, totalMs: 0 } });
-		expect((container.querySelector('.track-fill') as HTMLElement).getAttribute('style')).toContain('width: 0%');
+		expect((container.querySelector('.bar-fill') as HTMLElement).getAttribute('style')).toContain('width: 0%');
 	});
 });

--- a/docs/frontend-overlays.md
+++ b/docs/frontend-overlays.md
@@ -22,6 +22,7 @@ Blocking confirmation dialogs are the toast system's counterpart, from the same 
 - **A queue, not a single slot** — only the head is shown, but requests queue (each with its own resolve) so two callers each get an answer.
 - **Dismissal semantics depend on kind** — backdrop-click/Escape are a cancel for `confirm`/`destructive` but an acknowledgement for `acknowledge`.
 - **The host owns the interaction model so the card stays presentational** — backdrop/Escape dismissal, a focus trap, focus capture+restore, and a scroll lock; it focuses the safe action for a destructive dialog (so a stray Enter can't confirm) and the primary action otherwise. All motion is CSS so `prefers-reduced-motion` collapses it.
+- **Tab-trap, Escape, scroll-lock, and focus restore are the shared `focusTrap` action** (`components/focus-trap.ts`), used by both `ModalHost` and `Popover`; only the per-open initial focus is component-specific (kind-aware here, first-focusable in `Popover`). Reuse the action for any new overlay rather than re-implementing the trap.
 
 ## Popover (non-blocking overlays)
 


### PR DESCRIPTION
## Summary

Extends shared primitives over copies (per `frontend.md`'s "extend a primitive rather than copy it" guidance), addressing #1239.

### Shared focus-trap action (+ latent-bug fix)
`ModalHost` and `Popover` carried a near-identical `trapTab` / focus-capture+restore / scroll-lock implementation, and both queried **only** `button:not([disabled])` for focusables — so a modal/popover containing a link, input, or `[tabindex]` element would not trap or anchor onto it.

- Added `UI/src/components/focus-trap.ts`: a `focusTrap` Svelte action owning Tab-trap, Escape→dismiss, body scroll-lock (via a caller-supplied class), and focus capture-on-mount / restore-on-destroy.
- The focusable selector is **widened** to `a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])` — fixing the latent button-only trap bug noted in the issue.
- `ModalHost` and `Popover` now use `use:focusTrap` and drop their duplicated handlers. Per-open **initial focus** stays component-specific (the modal must aim at its kind-appropriate action and re-aim per queued modal; the popover takes the first focusable), reusing the exported `FOCUSABLE_SELECTOR`.

### Bar re-implementations
`BattleTimer`, `EnemyCooldown`, and `BudgetMeter` hand-rolled `.track` / `.track-fill` percentage-width markup + styles that `Bar`'s `presentational` mode + `--bar-*` tokens already cover (the warning-hue swap is a `--bar-fill` override; the glow is `--bar-fill-shadow`). All three now compose `Bar`, matching the `MiniBar` precedent.

### Minor cleanup
- Deleted the dead `INavMenuItem` type (no consumer) and its `export *` re-export; removed the now-empty `nav-menu/types.ts`.

## How it addresses the issue
Implements the issue's primary asks verbatim — migrate `BattleTimer`/`EnemyCooldown`/`BudgetMeter` onto `Bar`, and extract a shared focus-trap with a widened selector — plus the dead-`INavMenuItem` cleanup folded in.

## Scope notes / deferred
- `TheoryRow` (delta-cursor, marked lower-priority in the issue) is left as-is.
- The `RewardPicker` / `ChallengeRewardSection` inline-overlay → `Popover` migration is **deferred to follow-up #1265**: that overlay is an in-flow expanding panel, and moving it to `Popover` (a centered backdrop dialog) is a UX change rather than a pure refactor, so it warrants its own decision.

## Test plan
- `npm run lint` (eslint + svelte-check) — clean.
- `npm run test:unit:ci` — 250 files / 2663 tests passing.
- Added `tests/components/focus-trap.test.ts`: Tab wrapping, escaped-focus recapture, the widened selector (links/inputs/`[tabindex]` trapped; disabled/`tabindex="-1"` skipped), Escape→onEscape, scroll-lock add/release, focus restore on destroy.
- Updated `BattleTimer` / `EnemyCooldown` tests for the Bar-based markup (`.bar-fill`, warning hue via the `--bar-fill` token). The existing `ModalHost`/`Popover` suites pass unchanged, pinning the refactor's behavioral parity.

Closes #1239

🤖 Generated with [Claude Code](https://claude.com/claude-code)