### PR TITLE
Close accessibility gaps across radar, login, card-game, admin and tablists (#1240)

### DIFF
--- a/UI/src/routes/+page.svelte
+++ b/UI/src/routes/+page.svelte
@@ -15,6 +15,7 @@
 				onblur={() => (touched.username = true)}
 				error={!!usernameError}
 				valid={!!username && usernameValid}
+				describedById={usernameError ? STATUS_LINE_ID : undefined}
 			>
 				{#snippet trailing()}
 					{#if username}
@@ -36,6 +37,7 @@
 				onkeyup={detectCapsLock}
 				error={!!passwordError}
 				valid={!!password && passwordValid}
+				describedById={passwordError ? STATUS_LINE_ID : undefined}
 			>
 				{#snippet trailing()}
 					<button
@@ -68,6 +70,7 @@
 					onblur={() => (touched.confirm = true)}
 					error={!!confirmError}
 					valid={!!confirm && confirmValid}
+					describedById={confirmError ? STATUS_LINE_ID : undefined}
 				>
 					{#snippet trailing()}
 						{#if confirm}
@@ -77,7 +80,7 @@
 				</UnderlineInput>
 			{/if}
 
-			<StatusLine type={statusLine.type} text={statusLine.text} />
+			<StatusLine id={STATUS_LINE_ID} type={statusLine.type} text={statusLine.text} />
 
 			<SubmitButton ready={formValid} {submitting} label={mode === 'login' ? 'Sign In' : 'Create'} />
 		</form>
@@ -109,6 +112,9 @@ import {
 	type LoginMode
 } from './login/login-validation';
 import { playerSelectHandoff } from './select/player-select-handoff';
+
+// The live status line doubles as each field's error description (aria-describedby).
+const STATUS_LINE_ID = 'login-status-line';
 
 let mode = $state<LoginMode>('login');
 let username = $state('');

--- a/UI/src/routes/admin/workbench/components/DirtyDot.svelte
+++ b/UI/src/routes/admin/workbench/components/DirtyDot.svelte
@@ -1,0 +1,18 @@
+<!-- The amber unsaved-change indicator. Pairs the decorative dot (`.dirty-dot`, styled in workbench.scss)
+     with visually-hidden text, so the change state isn't conveyed by colour/shape alone. -->
+<span class="dirty-dot" aria-hidden="true"></span>
+<span class="sr-only">Unsaved change</span>
+
+<style lang="scss">
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+</style>

--- a/UI/src/routes/admin/workbench/components/FieldControl.svelte
+++ b/UI/src/routes/admin/workbench/components/FieldControl.svelte
@@ -27,7 +27,7 @@
 			value={value as string}
 			oninput={(e) => set(e.currentTarget.value)}
 		></textarea>
-		{#if dirty}<span class="dirty-dot"></span>{/if}
+		{#if dirty}<DirtyDot />{/if}
 	</div>
 {:else if field.type === 'number'}
 	<div class="fld" style:width="{field.width ?? 150}px">
@@ -42,7 +42,7 @@
 			/>
 			{#if field.suffix}<span class="suffix">{field.suffix}</span>{/if}
 		</div>
-		{#if dirty}<span class="dirty-dot"></span>{/if}
+		{#if dirty}<DirtyDot />{/if}
 	</div>
 {:else if field.type === 'flags'}
 	<div class="fld" style:flex="1 1 100%" style:width="100%">
@@ -62,7 +62,7 @@
 					<span>{flag.label}</span>
 				</button>
 			{/each}
-			{#if dirty}<span class="dirty-dot"></span>{/if}
+			{#if dirty}<DirtyDot />{/if}
 		</div>
 	</div>
 {:else if field.type === 'select'}
@@ -82,7 +82,7 @@
 				{/each}
 			</select>
 			<SelectCaret />
-			{#if dirty}<span class="dirty-dot"></span>{/if}
+			{#if dirty}<DirtyDot />{/if}
 		</div>
 	</div>
 {:else}
@@ -97,7 +97,7 @@
 			value={value as string}
 			oninput={(e) => set(e.currentTarget.value)}
 		/>
-		{#if dirty}<span class="dirty-dot"></span>{/if}
+		{#if dirty}<DirtyDot />{/if}
 	</div>
 {/if}
 
@@ -117,6 +117,7 @@ import { fieldsOf, type FieldConfig, type Identified } from '../entities/types';
 import { fieldWarn } from '../validation';
 import SelectCaret from './SelectCaret.svelte';
 import NumInput from './NumInput.svelte';
+import DirtyDot from './DirtyDot.svelte';
 
 interface Props {
 	field: FieldConfig<Identified>;

--- a/UI/src/routes/admin/workbench/components/TableCell.svelte
+++ b/UI/src/routes/admin/workbench/components/TableCell.svelte
@@ -9,7 +9,7 @@
 				{/each}
 			</select>
 			<SelectCaret />
-			{#if dirty}<span class="dirty-dot"></span>{/if}
+			{#if dirty}<DirtyDot />{/if}
 		</div>
 	</td>
 {:else if col.type === 'number'}
@@ -21,7 +21,7 @@
 				allowNegative={col.allowNegative}
 				onChange={(n) => onChange(n)}
 			/>
-			{#if dirty}<span class="dirty-dot"></span>{/if}
+			{#if dirty}<DirtyDot />{/if}
 		</div>
 	</td>
 {:else}
@@ -38,6 +38,7 @@ import type { ColumnConfig } from '../entities/types';
 import Bar from '$components/Bar.svelte';
 import NumInput from './NumInput.svelte';
 import SelectCaret from './SelectCaret.svelte';
+import DirtyDot from './DirtyDot.svelte';
 
 interface Props {
 	col: ColumnConfig;

--- a/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
+++ b/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
@@ -69,7 +69,7 @@
 						{section.label}
 						{#if count !== null}<span class="count-badge">{count}</span>{/if}
 						{#if incomplete}<WarnTriangle size={12} />{/if}
-						{#if dirty}<span class="tab-dot" title="Unsaved changes"></span>{/if}
+						{#if dirty}<span class="tab-dot" aria-hidden="true"></span><span class="sr-only">unsaved changes</span>{/if}
 					</button>
 				{/each}
 			</div>
@@ -265,5 +265,16 @@ const sectionDirty = (section: EntityConfig<Identified>['sections'][number]): bo
 .pips {
 	display: inline-flex;
 	gap: 12px;
+}
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
 }
 </style>

--- a/UI/src/routes/admin/workbench/components/challenge/ChallengeConditionSection.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/ChallengeConditionSection.svelte
@@ -22,7 +22,7 @@
 					{/each}
 				</select>
 				<SelectCaret />
-				{#if typeDirty}<span class="dirty-dot"></span>{/if}
+				{#if typeDirty}<DirtyDot />{/if}
 			</div>
 		</div>
 		<StatReadout {challenge} />
@@ -44,6 +44,7 @@ import type { EntityStore } from '../../entity-store.svelte';
 import type { Identified } from '../../entities/types';
 import { deriveFromType } from '../../entities/challenge-helpers';
 import SelectCaret from '../SelectCaret.svelte';
+import DirtyDot from '../DirtyDot.svelte';
 import WorkbenchIcon from '../../WorkbenchIcon.svelte';
 import StatReadout from './StatReadout.svelte';
 import GoalField from './GoalField.svelte';

--- a/UI/src/routes/admin/workbench/components/challenge/GoalField.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/GoalField.svelte
@@ -11,7 +11,7 @@
 		/>
 		<span class="suffix">{unit}</span>
 	</div>
-	{#if dirty}<span class="dirty-dot"></span>{/if}
+	{#if dirty}<DirtyDot />{/if}
 </div>
 
 <script lang="ts">
@@ -21,6 +21,7 @@ import type { EntityStore } from '../../entity-store.svelte';
 import type { Identified } from '../../entities/types';
 import { goalComparisonOf, goalUnit } from '../../entities/challenge-helpers';
 import NumInput from '../NumInput.svelte';
+import DirtyDot from '../DirtyDot.svelte';
 
 interface Props {
 	challenge: IChallenge;

--- a/UI/src/routes/game/screens/attributes/Attributes.svelte
+++ b/UI/src/routes/game/screens/attributes/Attributes.svelte
@@ -20,7 +20,13 @@
 	</div>
 
 	<!-- main -->
-	<div class="main" class:theory={view.mode === 'theory'}>
+	<div
+		class="main"
+		class:theory={view.mode === 'theory'}
+		id="attr-main-panel"
+		role="tabpanel"
+		aria-labelledby="attr-mode-{view.mode}"
+	>
 		{#if view.mode === 'theory'}
 			<div class="alloc-table">
 				<div class="table-head">

--- a/UI/src/routes/game/screens/attributes/AttributesRadar.svelte
+++ b/UI/src/routes/game/screens/attributes/AttributesRadar.svelte
@@ -4,7 +4,7 @@
 	height={size}
 	viewBox="0 0 {size} {size}"
 	class="radar"
-	role="img"
+	role="group"
 	aria-label="Attribute build radar"
 >
 	{#each rings as f (f)}

--- a/UI/src/routes/game/screens/attributes/ModeToggle.svelte
+++ b/UI/src/routes/game/screens/attributes/ModeToggle.svelte
@@ -2,8 +2,10 @@
 	{#each options as opt (opt.key)}
 		<button
 			type="button"
+			id="attr-mode-{opt.key}"
 			role="tab"
 			aria-selected={mode === opt.key}
+			aria-controls="attr-main-panel"
 			class="opt"
 			class:on={mode === opt.key}
 			onclick={() => onPick(opt.key)}

--- a/UI/src/routes/game/screens/card-game/loom/Controls.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/Controls.svelte
@@ -3,7 +3,20 @@
 		class="btn reflex"
 		class:on={view.game.slow}
 		title="Hold to slow time (Agility reserve)"
+		aria-pressed={view.game.slow}
 		onpointerdown={() => view.setReflex(true)}
+		onkeydown={(e) => {
+			// Make the focused button a press-and-hold control for keyboard users too (Space/Enter).
+			if ((e.key === ' ' || e.key === 'Enter') && !e.repeat) {
+				e.preventDefault();
+				view.setReflex(true);
+			}
+		}}
+		onkeyup={(e) => {
+			if (e.key === ' ' || e.key === 'Enter') {
+				view.setReflex(false);
+			}
+		}}
 	>
 		⏳ REFLEX
 	</button>

--- a/UI/src/routes/game/screens/card-game/loom/OutcomeBanner.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/OutcomeBanner.svelte
@@ -1,4 +1,4 @@
-<div class="banner {outcome}">
+<div class="banner {outcome}" role="status" aria-live="polite">
 	<h2>{outcome === 'win' ? 'VICTORY' : 'DOWNED'}</h2>
 	<span class="bsub">{sub}</span>
 </div>

--- a/UI/src/routes/game/screens/codex/Codex.svelte
+++ b/UI/src/routes/game/screens/codex/Codex.svelte
@@ -10,7 +10,7 @@
 
 	<CodexTabBar {view} />
 
-	<div class="content">
+	<div class="content" id="codex-panel" role="tabpanel" aria-labelledby="codex-tab-{view.tab}">
 		{#if view.tab === 'enemies'}
 			<EnemiesTab {view} />
 		{:else if view.tab === 'zones'}

--- a/UI/src/routes/game/screens/codex/CodexTabBar.svelte
+++ b/UI/src/routes/game/screens/codex/CodexTabBar.svelte
@@ -4,8 +4,10 @@
 	{#each view.tabs as tab (tab.key)}
 		<button
 			type="button"
+			id="codex-tab-{tab.key}"
 			role="tab"
 			aria-selected={tab.active}
+			aria-controls="codex-panel"
 			class="tab"
 			class:active={tab.active}
 			style:--tab-accent={tab.accent}

--- a/UI/src/routes/game/screens/codex/EnemyDossier.svelte
+++ b/UI/src/routes/game/screens/codex/EnemyDossier.svelte
@@ -14,8 +14,10 @@
 			{#each view.subTabs as tab (tab.key)}
 				<button
 					type="button"
+					id="codex-subtab-{tab.key}"
 					role="tab"
 					aria-selected={view.sub === tab.key}
+					aria-controls="codex-subpanel"
 					class="sub-tab"
 					class:active={view.sub === tab.key}
 					data-testid="codex-subtab-{tab.key}"
@@ -27,7 +29,7 @@
 			{/each}
 		</div>
 
-		<div class="body">
+		<div class="body" id="codex-subpanel" role="tabpanel" aria-labelledby="codex-subtab-{view.sub}">
 			{#if view.sub === 'attributes'}
 				<AttributesPanel {view} />
 			{:else if view.sub === 'statistics'}

--- a/UI/src/routes/game/screens/stats/ByStatisticView.svelte
+++ b/UI/src/routes/game/screens/stats/ByStatisticView.svelte
@@ -1,8 +1,13 @@
 <!-- "By statistic" view: category tabs over a grid of stat cards. Clicking an
      entity row in a card pivots to that entity's dossier. -->
 <div class="by-stat">
-	<UnderlineTabs {tabs} active={view.statCat} onChange={(k) => view.setStatCat(k as StatCategory | 'all')} />
-	<div class="scroll">
+	<UnderlineTabs
+		{tabs}
+		active={view.statCat}
+		onChange={(k) => view.setStatCat(k as StatCategory | 'all')}
+		panelId="by-stat-panel"
+	/>
+	<div class="scroll" id="by-stat-panel" role="tabpanel" aria-labelledby="by-stat-panel-tab-{view.statCat}">
 		<div class="grid" data-testid="stat-card-grid">
 			{#each view.shownStats as stat (stat.id)}
 				<StatCard

--- a/UI/src/routes/game/screens/stats/UnderlineTabs.svelte
+++ b/UI/src/routes/game/screens/stats/UnderlineTabs.svelte
@@ -10,6 +10,8 @@
 			class:on
 			role="tab"
 			aria-selected={on}
+			id={panelId ? `${panelId}-tab-${tab.key}` : undefined}
+			aria-controls={panelId}
 			data-testid="tab-{tab.key}"
 			style:--tab-color={tab.color}
 			onclick={() => onChange(tab.key)}
@@ -46,9 +48,12 @@ interface Props {
 	tabs: Tab[];
 	active: string;
 	onChange: (key: string) => void;
+	/** Id of the `role="tabpanel"` these tabs control; when set, each tab gets a stable id +
+	 *  `aria-controls` so the panel can point its `aria-labelledby` back at the active tab. */
+	panelId?: string;
 }
 
-let { tabs, active, onChange }: Props = $props();
+let { tabs, active, onChange, panelId }: Props = $props();
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/login/StatusLine.svelte
+++ b/UI/src/routes/login/StatusLine.svelte
@@ -1,4 +1,4 @@
-<div class="status-line" data-testid="status-line" style:color>
+<div {id} class="status-line" data-testid="status-line" role="status" aria-live="polite" style:color>
 	{#if type === 'ok' || type === 'err'}
 		<ValidationIcon {type} size={14} {color} />
 	{/if}
@@ -17,7 +17,8 @@ const COLORS: Record<StatusType, string> = {
 	idle: 'var(--text-tertiary)'
 };
 
-let { type, text }: { type: StatusType; text: string } = $props();
+// `id` lets fields associate their error with this live region via `aria-describedby`.
+let { type, text, id }: { type: StatusType; text: string; id?: string } = $props();
 
 const color = $derived(COLORS[type]);
 </script>

--- a/UI/src/routes/login/UnderlineInput.svelte
+++ b/UI/src/routes/login/UnderlineInput.svelte
@@ -9,6 +9,8 @@
 		{autocomplete}
 		bind:value
 		data-testid={testid}
+		aria-invalid={error || undefined}
+		aria-describedby={describedById}
 		{onblur}
 		{onkeydown}
 		{onkeyup}
@@ -42,10 +44,12 @@ interface Props {
 	label?: string;
 	/** Autofill hint for password managers (e.g. 'username', 'current-password', 'new-password'). */
 	autocomplete?: HTMLInputAttributes['autocomplete'];
-	/** Applies the error accent to the underline. */
+	/** Applies the error accent to the underline (and sets `aria-invalid`). */
 	error?: boolean;
 	/** Applies the valid accent to the underline. */
 	valid?: boolean;
+	/** Id of the live status element describing this field's current error, wired to `aria-describedby`. */
+	describedById?: string;
 	onblur?: (event: FocusEvent) => void;
 	onkeydown?: (event: KeyboardEvent) => void;
 	onkeyup?: (event: KeyboardEvent) => void;
@@ -65,6 +69,7 @@ let {
 	autocomplete,
 	error = false,
 	valid = false,
+	describedById,
 	onblur,
 	onkeydown,
 	onkeyup,

--- a/UI/src/routes/login/login-validation.ts
+++ b/UI/src/routes/login/login-validation.ts
@@ -156,7 +156,9 @@ export const deriveStatusLine = (state: StatusLineState): { type: StatusType; te
 	if (state.capsLock) {
 		return { type: 'warn', text: 'Caps Lock is on' };
 	}
-	if (state.mode === 'signup' && state.password) {
+	// Strength is advisory while the form is still incomplete; once everything validates, yield to the
+	// "Ready" resting state below (otherwise signup, which always has a password here, never reaches it).
+	if (state.mode === 'signup' && state.password && !state.formValid) {
 		return { type: 'info', text: `Strength · ${state.strengthLabel.toLowerCase()}` };
 	}
 	if (state.formValid && state.username) {

--- a/UI/src/tests/routes/game/screens/card-game/loom/Controls.test.ts
+++ b/UI/src/tests/routes/game/screens/card-game/loom/Controls.test.ts
@@ -15,6 +15,29 @@ describe('Controls', () => {
 		expect(setReflex).toHaveBeenCalledWith(true);
 	});
 
+	it('begins a held Reflex on keyboard activation of the focused reflex button (Space/Enter)', async () => {
+		const view = new CardGameView();
+		const setReflex = vi.spyOn(view, 'setReflex');
+		const { container } = render(Controls, { props: { view } });
+		const btn = container.querySelector('.btn.reflex') as HTMLElement;
+
+		await fireEvent.keyDown(btn, { key: ' ' });
+		expect(setReflex).toHaveBeenLastCalledWith(true);
+		await fireEvent.keyUp(btn, { key: ' ' });
+		expect(setReflex).toHaveBeenLastCalledWith(false);
+	});
+
+	it('reflects the slow-time state on the reflex button via aria-pressed', () => {
+		const idle = render(Controls, { props: { view: new CardGameView() } });
+		expect((idle.container.querySelector('.btn.reflex') as HTMLElement).getAttribute('aria-pressed')).toBe('false');
+		cleanup();
+
+		const held = new CardGameView();
+		held.setReflex(true); // reserve starts full, so this engages slow-time
+		const { container } = render(Controls, { props: { view: held } });
+		expect((container.querySelector('.btn.reflex') as HTMLElement).getAttribute('aria-pressed')).toBe('true');
+	});
+
 	it('exposes the reflex meter as a 0-100 progressbar of the agility reserve', () => {
 		const view = new CardGameView();
 		view.game.reflex = 60.7;

--- a/UI/src/tests/routes/game/screens/card-game/loom/OutcomeBanner.test.ts
+++ b/UI/src/tests/routes/game/screens/card-game/loom/OutcomeBanner.test.ts
@@ -20,4 +20,11 @@ describe('OutcomeBanner', () => {
 		expect(banner.classList.contains('lose')).toBe(true);
 		expect(banner.querySelector('h2')?.textContent).toBe('DOWNED');
 	});
+
+	it('announces the outcome as a polite live region', () => {
+		const { container } = render(OutcomeBanner, { props: { outcome: 'win', sub: 'The Warden unravels.' } });
+		const banner = container.querySelector('.banner') as HTMLElement;
+		expect(banner.getAttribute('role')).toBe('status');
+		expect(banner.getAttribute('aria-live')).toBe('polite');
+	});
 });

--- a/UI/src/tests/routes/login/login-validation.test.ts
+++ b/UI/src/tests/routes/login/login-validation.test.ts
@@ -177,6 +177,20 @@ describe('deriveStatusLine', () => {
 		expect(deriveStatusLine({ ...base, formValid: true, username: 'hero' })).toEqual({ type: 'ok', text: 'Ready' });
 	});
 
+	it('yields strength to Ready when a signup form fully validates', () => {
+		// Signup always has a password here; strength must not pin the line off "Ready" once everything validates.
+		expect(
+			deriveStatusLine({
+				...base,
+				mode: 'signup',
+				password: 'Abcd1234',
+				strengthLabel: 'Strong',
+				formValid: true,
+				username: 'hero'
+			})
+		).toEqual({ type: 'ok', text: 'Ready' });
+	});
+
 	it('falls back to an idle placeholder when nothing applies', () => {
 		expect(deriveStatusLine(base)).toEqual({ type: 'idle', text: ' ' });
 	});


### PR DESCRIPTION
## Summary

Resolves the accessibility cluster in #1240 — a set of inconsistencies against a11y patterns the app already uses well (real `<button>`s, `describedByTooltip`, `PasswordStrengthMeter` live regions).

### 1. Radar — focusable vertices pruned under a `role="img"` leaf
`AttributesRadar.svelte` wrapped the allocation vertices in `role="img"`. As a leaf role, AT may prune its descendants — hiding the only keyboard path to allocate/refund points. Switched the wrapper to `role="group"` (keeping the label); the vertex `role="button"` controls now stay reachable. This matches `frontend.md`, which already documents the SVG vertices as an accepted native-button exception.

### 2. Login — validation not announced or associated
- `StatusLine.svelte` is now `role="status"` + `aria-live="polite"`, so messages are announced.
- `UnderlineInput.svelte` gained `aria-invalid` (driven by its `error` prop) and an optional `describedById` → `aria-describedby`.
- `+page.svelte` gives the status line a stable id and points each field's `aria-describedby` at it while that field is in error, tying the error to the input.
- **Logic fix** (the minor note in the issue): `deriveStatusLine` checked the signup strength branch before the `Ready` branch, so a signup form — which always has a password here — never reached `Ready`. Gated the strength branch on `!formValid`, with a new unit test.

### 3. Card-game — outcome + Reflex control not exposed
- `OutcomeBanner.svelte` announces via `role="status"` / `aria-live="polite"`.
- `Controls.svelte` Reflex button now exposes `aria-pressed={view.game.slow}` and handles Space/Enter as a press-and-hold, so the focused control itself is keyboard-operable (the global Space binding in `loom-input.ts` continues to work; the calls are idempotent).

### 4. Admin — change indicators were colour/shape-only
- Added a shared `DirtyDot.svelte` that pairs the decorative dot (now `aria-hidden`) with visually-hidden text, replacing the inline `<span class="dirty-dot">` across `FieldControl`, `TableCell`, `GoalField`, and `ChallengeConditionSection` (the last shares the same pattern and was folded in).
- Gave the `WorkbenchDetail` tab-dot a visually-hidden label.

### 5. Tablists — missing tabpanel wiring
Completed the WAI-ARIA pattern (the issue's "complete the pattern" option) with `aria-controls` + `role="tabpanel"` + `aria-labelledby` for: codex sections (`CodexTabBar` → `Codex`), enemy-dossier sub-tabs (`EnemyDossier`, self-contained), the attributes mode toggle (`ModeToggle` → `Attributes`), and the statistics category tabs (`UnderlineTabs` gained an opt-in `panelId` prop → `ByStatisticView`).

## Note / judgment call
`AttributeChip` (cited in part 1 as "worth aligning") is **left as `role="img"`**: it's a single labelled leaf with no nested interactive controls — defensible per the issue's own wording, and an existing test pins that role. Changing it would be churn without an a11y benefit.

## Test plan
- `npm run lint` (eslint + svelte-check) — clean.
- `npm run test:unit:ci` — 249 files / 2658 tests passing.
- Added: `deriveStatusLine` reaches `Ready` on a fully-valid signup; the Reflex button starts a held Reflex on Space/Enter and reflects state via `aria-pressed`; the outcome banner is a polite live region. Existing radar / codex / mode-toggle / field-control / goal-field suites pass unchanged, pinning the markup additions.

Closes #1240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcBwBpUyiDmA27SkjFcmrU)_