### PR TITLE
Use var(--black) token instead of bare black literals (#1241)

### DIFF
--- a/UI/src/routes/game/screens/card-game/CardGame.svelte
+++ b/UI/src/routes/game/screens/card-game/CardGame.svelte
@@ -121,7 +121,7 @@ onMount(() => {
 	background: linear-gradient(
 		180deg,
 		color-mix(in srgb, var(--white) 4%, var(--surface)),
-		color-mix(in srgb, var(--surface) 85%, black)
+		color-mix(in srgb, var(--surface) 85%, var(--black))
 	);
 	box-shadow:
 		0 0 0 1px color-mix(in srgb, var(--black) 40%, transparent),

--- a/UI/src/routes/game/screens/card-game/loom/Combatants.svelte
+++ b/UI/src/routes/game/screens/card-game/loom/Combatants.svelte
@@ -96,7 +96,7 @@ const drawPerc = $derived((game.drawAcc / game.drawIntervalSec) * 100);
 }
 
 .combatant.enemy {
-	--bar-fill: linear-gradient(90deg, color-mix(in srgb, var(--enemy-accent) 70%, black), var(--enemy-accent));
+	--bar-fill: linear-gradient(90deg, color-mix(in srgb, var(--enemy-accent) 70%, var(--black)), var(--enemy-accent));
 	--bar-fill-shadow: 0 0 10px color-mix(in srgb, var(--enemy-accent) 50%, transparent);
 
 	.name {


### PR DESCRIPTION
## Summary

`frontend.md` (Styling): "All colours are CSS variables, used by semantic intent — never hard-coded." Two `color-mix` endpoints used a bare `black` keyword instead of the `var(--black)` token, where adjacent rules already use the token. This brings them into line so a custom theme overriding `--black` affects these surfaces too.

## Changes
- `card-game/CardGame.svelte:124` — `color-mix(in srgb, var(--surface) 85%, black)` → `var(--black)` (the same rule's `box-shadow` lines already use `var(--black)`).
- `card-game/loom/Combatants.svelte:99` — `color-mix(in srgb, var(--enemy-accent) 70%, black)` → `var(--black)`.

## How it addresses the issue
Implements the fix verbatim — replaces the only two bare `black` literals the issue's UI review surfaced. A repo-wide scan confirms no other bare `black`/`white` `color-mix` endpoints remain, and `--black` is defined in `+layout.svelte`.

## Test plan
- `npm run lint` (eslint + svelte-check) — clean (0 errors, 0 warnings).
- Pure presentational token swap: `var(--black)` resolves to the same `#…` value used before, so rendered output is unchanged for the default theme; no logic touched, so no new unit tests are warranted.

Closes #1241

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwqvJgybupaXGKtqwUSc8h)_