### PR TITLE
Make socket presence-refresh fire-and-forget so a transient Redis fault can't drop a healthy connection

### DIFF
--- a/Game.Api.Tests/Integration/SocketCommandTimeoutTests.cs
+++ b/Game.Api.Tests/Integration/SocketCommandTimeoutTests.cs
@@ -137,7 +137,7 @@ namespace Game.Api.Tests.Integration
             var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
             var context = new SocketContext(socket, playerId: 1, session, contextLogger);
             var handler = new SocketHandler(context, commandFactory, scopeFactory, handlerLogger,
-                () => Task.CompletedTask, commandTimeout);
+                () => { }, commandTimeout);
 
             return (socket, handler, scopeFactory);
         }

--- a/Game.Api.Tests/Integration/SocketDrainTests.cs
+++ b/Game.Api.Tests/Integration/SocketDrainTests.cs
@@ -170,7 +170,7 @@ namespace Game.Api.Tests.Integration
 
             var socket = new DrainableWebSocket(echoServerClose);
             var context = new SocketContext(socket, playerId: 1, session, contextLogger);
-            var handler = new SocketHandler(context, commandFactory, scopeFactory, handlerLogger, () => Task.CompletedTask);
+            var handler = new SocketHandler(context, commandFactory, scopeFactory, handlerLogger, () => { });
             return (socket, handler);
         }
 

--- a/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
@@ -138,7 +138,7 @@ namespace Game.Api.Tests.Unit
             session.CreateSession(userId: 1, playerId: 1);
             var context = new SocketContext(socket, playerId: 1, session, _loggerFactory.CreateLogger<SocketContext>());
             var handler = new SocketHandler(context, new StubCommandFactory(throwOn), _scopeFactory,
-                _loggerFactory.CreateLogger<SocketHandler>(), () => Task.CompletedTask);
+                _loggerFactory.CreateLogger<SocketHandler>(), () => { });
             return (socket, handler);
         }
 

--- a/Game.Api.Tests/Unit/SocketReadLoopTests.cs
+++ b/Game.Api.Tests/Unit/SocketReadLoopTests.cs
@@ -8,6 +8,7 @@ using Game.TestInfrastructure.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Net.WebSockets;
+using System.Text;
 using Xunit;
 
 namespace Game.Api.Tests.Unit
@@ -86,13 +87,43 @@ namespace Game.Api.Tests.Unit
             Assert.DoesNotContain(_logs.Entries, e => e.Level == LogLevel.Error);
         }
 
-        private (SocketContext Context, SocketHandler Handler) CreateHandler(WebSocket socket)
+        [Fact]
+        public async Task ReadLoop_OnActivityThrows_DoesNotTerminateTheReadLoop()
+        {
+            // Presence refresh (the on-activity callback) is best-effort: a transient Redis fault while
+            // refreshing the presence TTL must NOT be mistaken for a read fault and tear down a healthy socket.
+            // Here the callback throws on every inbound frame; the loop must log-and-continue, process the
+            // message, and keep reading rather than closing.
+            var socket = new ScriptedReadWebSocket();
+            socket.QueueMessage("ping");
+            var (_, handler) = CreateHandler(socket,
+                onActivity: () => throw new InvalidOperationException("transient Redis failure on presence refresh"));
+
+            using var drain = new CancellationTokenSource();
+            using var inactivityStop = new CancellationTokenSource();
+            handler.Listen(hostStopping: inactivityStop.Token, drainDeadline: drain.Token);
+
+            // The loop read the message, hit the throwing refresh, and still looped back to read again.
+            await socket.IdleReadReached.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
+
+            Assert.Equal(WebSocketState.Open, socket.State);
+            Assert.Equal(2, socket.ReceiveAttempts);
+            Assert.Contains(_logs.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("presence"));
+            Assert.DoesNotContain(_logs.Entries, e => e.Level == LogLevel.Error && e.Message.Contains("closing the socket"));
+
+            // Tear down: abort the blocked idle receive so the read loop completes.
+            drain.Cancel();
+            inactivityStop.Cancel();
+            await handler.Completion.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
+        }
+
+        private (SocketContext Context, SocketHandler Handler) CreateHandler(WebSocket socket, Action? onActivity = null)
         {
             var session = new SessionService(new NoOpSessionStore());
             session.CreateSession(userId: 1, playerId: 1);
             var context = new SocketContext(socket, playerId: 1, session, _loggerFactory.CreateLogger<SocketContext>());
             var handler = new SocketHandler(context, new StubCommandFactory(), _scopeFactory,
-                _loggerFactory.CreateLogger<SocketHandler>(), () => Task.CompletedTask);
+                _loggerFactory.CreateLogger<SocketHandler>(), onActivity ?? (() => { }));
             return (context, handler);
         }
 
@@ -112,14 +143,20 @@ namespace Game.Api.Tests.Unit
         {
             private Exception? _throwOnReceive;
             private bool _closeFrameQueued;
+            private byte[]? _messageQueued;
             private WebSocketState _state = WebSocketState.Open;
+            private readonly TaskCompletionSource _idleReadReached = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
             public int ReceiveAttempts { get; private set; }
             public bool CloseAsyncCalled { get; private set; }
             public WebSocketCloseStatus? CloseStatusUsed { get; private set; }
 
+            /// <summary>Completes when the loop calls receive with no scripted input left — i.e. it looped back to read again.</summary>
+            public Task IdleReadReached => _idleReadReached.Task;
+
             public void QueueThrow(Exception toThrow) => _throwOnReceive = toThrow;
             public void QueueClose() => _closeFrameQueued = true;
+            public void QueueMessage(string message) => _messageQueued = Encoding.UTF8.GetBytes(message);
 
             public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
             {
@@ -131,6 +168,14 @@ namespace Game.Api.Tests.Unit
                     return Task.FromException<WebSocketReceiveResult>(_throwOnReceive);
                 }
 
+                if (_messageQueued is not null)
+                {
+                    var payload = _messageQueued;
+                    _messageQueued = null;
+                    payload.CopyTo(buffer.Array.AsSpan(buffer.Offset));
+                    return Task.FromResult(new WebSocketReceiveResult(payload.Length, WebSocketMessageType.Text, endOfMessage: true));
+                }
+
                 if (_closeFrameQueued)
                 {
                     _closeFrameQueued = false;
@@ -138,9 +183,13 @@ namespace Game.Api.Tests.Unit
                     return Task.FromResult(new WebSocketReceiveResult(0, WebSocketMessageType.Close, endOfMessage: true));
                 }
 
-                // No further scripted input: block so a (buggy) spinning loop would be observable as repeated
-                // receive attempts rather than a completed read.
-                return new TaskCompletionSource<WebSocketReceiveResult>().Task;
+                // No further scripted input: signal that the loop looped back to read, then block (cancellable by
+                // the read token so a test can tear down) so a (buggy) spinning loop would instead be observable
+                // as repeated receive attempts.
+                _idleReadReached.TrySetResult();
+                var idle = new TaskCompletionSource<WebSocketReceiveResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+                cancellationToken.Register(() => idle.TrySetCanceled(cancellationToken));
+                return idle.Task;
             }
 
             public override Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)

--- a/Game.Api.Tests/Unit/SocketSerializationTests.cs
+++ b/Game.Api.Tests/Unit/SocketSerializationTests.cs
@@ -67,7 +67,7 @@ namespace Game.Api.Tests.Unit
             var sendGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var socket = new FakeWebSocket(sendGate.Task);
             var context = new SocketContext(socket, playerId: 1, session, NullLogger<SocketContext>.Instance);
-            var handler = new SocketHandler(context, commandFactory, countingScopeFactory, NullLogger<SocketHandler>.Instance, () => Task.CompletedTask);
+            var handler = new SocketHandler(context, commandFactory, countingScopeFactory, NullLogger<SocketHandler>.Instance, () => { });
 
             var first = handler.ExecuteCommand(new SocketCommandInfo("GetStatisticTypes") { Id = "first" });
             var second = handler.ExecuteCommand(new SocketCommandInfo("GetStatisticTypes") { Id = "second" });

--- a/Game.Api/Services/SocketManagerService.cs
+++ b/Game.Api/Services/SocketManagerService.cs
@@ -131,11 +131,14 @@ namespace Game.Api.Services
         /// Extends the player's socket-presence TTL on connection activity, so a live socket keeps its
         /// presence key from expiring (see <see cref="SocketPresenceTtl"/>). Uses an expire (not a
         /// re-set) so it only ever prolongs the currently-registered socket's key and never resurrects a
-        /// key a newer connection has since taken over.
+        /// key a newer connection has since taken over. Fire-and-forget: presence refresh is best-effort
+        /// (a missed refresh simply lets the sliding TTL lapse), so it must neither throw on a transient
+        /// Redis fault — which would tear down the live read loop — nor add a serial round-trip to the
+        /// front of every inbound command.
         /// </summary>
-        private async Task RefreshSocketPresence(int playerId)
+        private void RefreshSocketPresence(int playerId)
         {
-            await _cache.Expire(CurrentSocketKey(playerId), SocketPresenceTtl);
+            _cache.ExpireAndForget(CurrentSocketKey(playerId), SocketPresenceTtl);
         }
 
         public Task UnRegisterSocket(SocketContext context)

--- a/Game.Api/Sockets/SocketHandler.cs
+++ b/Game.Api/Sockets/SocketHandler.cs
@@ -15,7 +15,7 @@ namespace Game.Api.Sockets
         private readonly SocketCommandFactory _commandFactory;
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly ILogger<SocketHandler> _logger;
-        private readonly Func<Task> _onActivity;
+        private readonly Action _onActivity;
 
         // Serializes command execution across the two paths that reach ExecuteCommand — the client read
         // loop and the pub/sub processor (server-initiated commands) — so the documented "websocket
@@ -63,7 +63,7 @@ namespace Game.Api.Sockets
         /// <summary>Completes once both the read and inactivity loops have wound down.</summary>
         public Task Completion => _loops;
 
-        public SocketHandler(SocketContext context, SocketCommandFactory commandFactory, IServiceScopeFactory scopeFactory, ILogger<SocketHandler> logger, Func<Task> onActivity, TimeSpan? commandTimeout = null)
+        public SocketHandler(SocketContext context, SocketCommandFactory commandFactory, IServiceScopeFactory scopeFactory, ILogger<SocketHandler> logger, Action onActivity, TimeSpan? commandTimeout = null)
         {
             _context = context;
             _commandFactory = commandFactory;
@@ -289,8 +289,19 @@ namespace Game.Api.Sockets
                         _logger.LogDebug("Received socket data from playerId ({PlayerId}) on socket ({Id}): {Message}", PlayerId, Id, message);
                         Interlocked.Exchange(ref _lastResponseTicks, DateTime.UtcNow.Ticks);
                         // Any inbound message (heartbeat ping or command) marks the connection live — keep its
-                        // presence key from expiring on the same signal the inactivity check uses above.
-                        await _onActivity();
+                        // presence key from expiring on the same signal the inactivity check uses above. Presence
+                        // refresh is best-effort (the sliding TTL lapses harmlessly if a refresh is missed), so
+                        // isolate a fault here: it must never reach the terminal read-fault catch below and tear
+                        // down an otherwise-healthy connection.
+                        try
+                        {
+                            _onActivity();
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex, "Failed to refresh socket presence for player ({PlayerId}) on socket ({Id}); the read loop continues.", PlayerId, Id);
+                        }
+
                         await HandleMessage(message);
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes #1268. In `SocketHandler.ReadLoop`, every inbound frame `await`ed the on-activity callback (`SocketManagerService.RefreshSocketPresence` → `_cache.Expire`, an awaited Redis round-trip). `ICacheService.Expire` throws on a transient Redis failure, and that throw was caught by the read loop's **terminal** `catch` — which logs *"…closing the socket"* and `break`s — permanently tearing down an otherwise-healthy connection and mislabeling a presence fault as a read fault. Under a brief Redis blip this would drop every connected player on their next frame.

Presence refresh is best-effort by design: the sliding TTL is meant to lapse harmlessly if a refresh is missed (see `backend.md` → *Single active connection*). The fix makes the code match that intent.

## Changes

- **`RefreshSocketPresence` → `ICacheService.ExpireAndForget`** — fire-and-forget, no await, no throw. This is the same sliding-TTL pattern already used in `PlayerRepository`/`PlayerProgressRepository`, and it also removes a serial Redis RTT from the front of every inbound command's latency.
- **Isolate the on-activity callback in the read loop** with a log-and-continue `try/catch`, so a presence-refresh fault can never reach the terminal read-fault `catch`. Defense-in-depth: even if the callback ever throws synchronously, a best-effort refresh must not kill a live socket.
- The callback is now genuinely synchronous, so `_onActivity` is an `Action` (updated the call sites accordingly).

## How it addresses the issue

A transient Redis failure on presence refresh now lapses the sliding TTL harmlessly (the next refresh succeeds) instead of closing the live socket, and the read path's latency no longer pays an awaited Redis RTT per frame.

## Test plan

- [x] New unit regression test `ReadLoop_OnActivityThrows_DoesNotTerminateTheReadLoop`: a throwing presence callback is logged-and-continued, the message is still processed, the loop keeps reading, and the socket stays `Open` (no "closing the socket" error).
- [x] Existing read-loop / drain / serialization / command-execution / timeout socket tests updated for the `Action` callback signature.
- [x] `dotnet build` clean (0 warnings, 0 errors).
- [x] `Game.Api.Tests` green (624 passed), including the `SocketManagerService` and read-loop suites.

Closes #1268

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpS5rCietRv5at38YthMJ6)_