### PR TITLE
Reject malformed class AttributeDistributions at admin save time

### DIFF
--- a/Game.Application.Tests/DataAccess/AdminClassesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminClassesIntegrationTests.cs
@@ -262,6 +262,62 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SetAttributeDistributions_DuplicateAttribute_ReturnsFailure()
+        {
+            int classId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                classId = (await TestDataSeeder.CreateClassAsync(context, "Warrior")).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminClasses>();
+
+            var result = admin.SetAttributeDistributions(new SetClassAttributeDistributionsData
+            {
+                ClassId = classId,
+                AttributeDistributions =
+                [
+                    new Contracts.AttributeDistribution { AttributeId = EAttribute.Strength, BaseAmount = 10m, AmountPerLevel = 2m },
+                    new Contracts.AttributeDistribution { AttributeId = EAttribute.Strength, BaseAmount = 5m, AmountPerLevel = 1m },
+                ],
+            });
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("more than one distribution", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SetAttributeDistributions_NonCoreAttribute_ReturnsFailure()
+        {
+            int classId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                classId = (await TestDataSeeder.CreateClassAsync(context, "Warrior")).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminClasses>();
+
+            // MaxHealth is a derived (non-core) attribute; only core attributes are seeded as the locked base.
+            var result = admin.SetAttributeDistributions(new SetClassAttributeDistributionsData
+            {
+                ClassId = classId,
+                AttributeDistributions =
+                [
+                    new Contracts.AttributeDistribution { AttributeId = EAttribute.MaxHealth, BaseAmount = 10m, AmountPerLevel = 2m },
+                ],
+            });
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("not a core attribute", result.ErrorMessage);
+        }
+
+        [Fact]
         public async Task SetStarterSkills_MissingClass_ReturnsNotFound()
         {
             using var scope = CreateScope();

--- a/Game.DataAccess/Repositories/Admin/AdminClasses.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminClasses.cs
@@ -129,6 +129,15 @@ namespace Game.DataAccess.Repositories.Admin
                 return AdminSaveResult.NotFound("Class");
             }
 
+            // Authoring guard: NewPlayerFactory reads these as the class's level-scaled locked base, keyed by
+            // attribute and seeded core-only. A duplicate attribute would throw at character creation (the
+            // downstream ToDictionary), and a non-core distribution would be silently dropped — so both are
+            // rejected here, at save time, rather than surfacing as a 500 or a silent no-op at creation.
+            if (FindAttributeDistributionViolation(data.AttributeDistributions) is { } rejection)
+            {
+                return rejection;
+            }
+
             return ChildCollectionReconciler.Reconcile(
                 existing: @class.AttributeDistributions,
                 desired: data.AttributeDistributions,
@@ -163,6 +172,29 @@ namespace Game.DataAccess.Repositories.Admin
                 BaseAmount = distribution.BaseAmount,
                 AmountPerLevel = distribution.AmountPerLevel,
             };
+        }
+
+        /// <summary>Returns a rejection for the first desired distribution that targets a non-core attribute or
+        /// repeats an attribute already in the set, or null when the desired set is well-formed.</summary>
+        private static AdminSaveResult? FindAttributeDistributionViolation(IEnumerable<Contracts.AttributeDistribution> distributions)
+        {
+            var seen = new HashSet<EAttribute>();
+            foreach (var distribution in distributions)
+            {
+                if (!Game.Core.Attributes.Attribute.IsCore(distribution.AttributeId))
+                {
+                    return AdminSaveResult.Failure(
+                        $"Attribute '{distribution.AttributeId}' is not a core attribute and cannot have a class distribution.");
+                }
+
+                if (!seen.Add(distribution.AttributeId))
+                {
+                    return AdminSaveResult.Failure(
+                        $"Attribute '{distribution.AttributeId}' has more than one distribution; each attribute may appear at most once.");
+                }
+            }
+
+            return null;
         }
 
         /// <summary>Returns a rejection for the first desired skill that does not exist or is not


### PR DESCRIPTION
## Summary

`NewPlayerFactory.Create` reads a class's `AttributeDistributions` as its level-scaled **locked base** — keyed by attribute (`ToDictionary`) and seeded **core-only** (`Where(Attribute.IsCore)`). Two malformed authoring shapes were unguarded at save time:

1. **Duplicate-attribute distribution → 500 at character creation.** Two rows for the same `AttributeId` make the downstream `ToDictionary` throw `ArgumentException` during character creation.
2. **Non-core distribution → silently dropped.** Only core attributes are read downstream, so a distribution authored against a derived attribute (e.g. `MaxHealth`) is ignored without warning, losing the authored intent.

Unlike the skill/enemy authoring paths (which already reject non-`Enemy`-flagged enemy skills, category-mismatched starter equipment, etc.), the class attribute-distribution save had no such guard.

## How it addresses the issue

Adds an authoring guard in `AdminClasses.SetAttributeDistributions` (`FindAttributeDistributionViolation`) that rejects a desired set that:
- targets a **non-core** (`!Attribute.IsCore`) attribute, or
- **repeats** an attribute,

returning an `AdminSaveResult.Failure` with a clear message — mirroring the existing anti-tamper guards in the same file. A malformed class is now rejected at **save time** rather than surfacing as a 500 (duplicate) or a silent no-op (non-core) at character creation.

Scope is the Content Authoring admin path only — no runtime/battle change.

## Test plan

- [x] `SetAttributeDistributions_DuplicateAttribute_ReturnsFailure` — two rows for `Strength` rejected with "more than one distribution".
- [x] `SetAttributeDistributions_NonCoreAttribute_ReturnsFailure` — a `MaxHealth` (derived) distribution rejected with "not a core attribute".
- [x] Existing `SetAttributeDistributions_ReconcilesDistributions` (the happy path) still passes.
- [x] `dotnet build` clean (0 warnings, 0 errors).
- [x] `Game.Application.Tests` green (589 passed).

## Notes

- No `docs/backend.md` change: the authoring-guard / anti-tamper pattern and the locked base's core-only seeding are already documented there; this guard is a small extension of those documented patterns rather than a new design decision.

Closes #1247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ezT3sRdggLNEBC5Z1F5RX

---
_Generated by [Claude Code](https://claude.ai/code/session_013ezT3sRdggLNEBC5Z1F5RX)_