### PR TITLE
Surface battle-assembly modifiers in the attribute-breakdown inspector

### DIFF
--- a/UI/src/lib/battle/attribute-collection.ts
+++ b/UI/src/lib/battle/attribute-collection.ts
@@ -141,14 +141,19 @@ export interface SourceGroup<T extends AttributeModifier = AttributeModifier> {
 	lines: AppliedModifier<T>[];
 }
 
-/** The display order sources are grouped/stacked in (base → points → gear →
- *  mods → derived), matching the backend's `EAttributeModifierSource` intent. */
+/** The display order sources are grouped/stacked in (base → class locked base → points → proficiency →
+ *  gear → mods → derived → class signature passive), matching the backend's `EAttributeModifierSource`
+ *  intent. A source absent here is dropped from the by-source view, so every player-facing source must
+ *  be listed. */
 export const SOURCE_ORDER: readonly EAttributeModifierSource[] = [
 	EAttributeModifierSource.BaseValue,
+	EAttributeModifierSource.AttributeDistribution,
 	EAttributeModifierSource.PlayerStatPoints,
+	EAttributeModifierSource.Proficiency,
 	EAttributeModifierSource.Item,
 	EAttributeModifierSource.ItemMod,
-	EAttributeModifierSource.Derived
+	EAttributeModifierSource.Derived,
+	EAttributeModifierSource.Class
 ];
 
 /** A computed attribute's additive lines bucketed by source (in {@link SOURCE_ORDER}),

--- a/UI/src/routes/+layout.svelte
+++ b/UI/src/routes/+layout.svelte
@@ -263,9 +263,12 @@ $effect(() => {
 	// the breakdown). Consumed via the helpers in the attribute-breakdown screen's
 	// source-display.
 	--source-base: #{colors.$source-base};
+	--source-distribution: #{colors.$source-distribution};
 	--source-points: #{colors.$source-points};
+	--source-proficiency: #{colors.$source-proficiency};
 	--source-item: #{colors.$source-item};
 	--source-mod: #{colors.$source-mod};
 	--source-derived: #{colors.$source-derived};
+	--source-class: #{colors.$source-class};
 }
 </style>

--- a/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
+++ b/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
@@ -31,7 +31,7 @@ import {
 } from '$lib/battle';
 import { attributeName } from '$lib/common';
 import { playerManager, inventoryManager } from '$lib/engine';
-import { staticData } from '$stores';
+import { staticData, playerProficiencies } from '$stores';
 
 /** An {@link AttributeModifier} carrying display-only provenance so the
  *  breakdown can label each contribution (which item/mod it came from). The core
@@ -150,7 +150,9 @@ export function fmtSigned(n: number, dec?: number, pct = false): string {
 
 /** Shared shape of a contribution-line label: both the full and the short variants resolve a derived
  *  line to its source attribute and any gear line to the item/mod name, differing only in the fixed
- *  phrasing used for the base-value and stat-point sources (`base`/`statPoints`). */
+ *  phrasing used for the base-value and stat-point sources (`base`/`statPoints`). The class
+ *  battle-assembly sources (locked base / proficiency / signature passive) have no per-line provenance
+ *  to surface, so each gets a fixed phrase shared by both variants. */
 function contributionLabel(line: AppliedModifier<LabeledModifier>, base: string, statPoints: string): string {
 	switch (line.source) {
 		case EAttributeModifierSource.Derived:
@@ -159,6 +161,12 @@ function contributionLabel(line: AppliedModifier<LabeledModifier>, base: string,
 			return statPoints;
 		case EAttributeModifierSource.BaseValue:
 			return base;
+		case EAttributeModifierSource.AttributeDistribution:
+			return 'Class base';
+		case EAttributeModifierSource.Proficiency:
+			return 'Proficiency';
+		case EAttributeModifierSource.Class:
+			return 'Signature passive';
 		default:
 			return line.label ?? '';
 	}
@@ -177,11 +185,22 @@ export function traceLabel(line: AppliedModifier<LabeledModifier>): string {
 	return contributionLabel(line, 'Base', 'Stat points');
 }
 
-/* ── modifier assembly (mirrors Player.GetAllModifiers + static modifiers) ──── */
+/* ── modifier assembly (mirrors the player battler's BattleSnapshot.ToBattler) ─ */
 
-/** Builds the player's full modifier list from their live allocations and
- *  equipped loadout, then appends the engine's static base/derived modifiers —
- *  the same composition the backend's `AttributeCollection` is built from. */
+/** Whether a modifier makes a real contribution to its attribute — a `+0` additive or a `×1`
+ *  multiplicative changes no total, so it is omitted from the breakdown. It would otherwise add an
+ *  empty row and, for the class signature passive's flat no-op default, spuriously self-select its
+ *  attribute into the inspector (any non-combat line marks an attribute as displayed). */
+function contributes(modifier: AttributeModifier): boolean {
+	return modifier.type === EModifierType.Multiplicative ? modifier.amount !== 1 : modifier.amount !== 0;
+}
+
+/** Builds the player's full modifier list the exact way the live player battler is assembled
+ *  (`BattleEngine.resetPlayer` → the backend's `BattleSnapshot.ToBattler`): allocated stat points →
+ *  equipped gear → class locked base → proficiency bonuses → engine static base/derived → the class
+ *  signature passive last. Keeping this order identical to the battler is what lets the inspector
+ *  aggregate (through `computeAttributes`) to the same totals the simulation uses — float addition is
+ *  not associative, so the apply order is load-bearing. */
 export function buildPlayerModifiers(): LabeledModifier[] {
 	const mods: LabeledModifier[] = [];
 
@@ -230,9 +249,36 @@ export function buildPlayerModifiers(): LabeledModifier[] {
 		}
 	}
 
+	// Class locked base (the level-scaled attribute fingerprint, source `AttributeDistribution`) then the
+	// proficiency bonuses (source `Proficiency`) — both composed before the static engine modifiers, the
+	// order the battler assembles them in.
+	for (const mod of playerManager.battleLockedBaseModifiers) {
+		if (contributes(mod)) {
+			mods.push({ ...mod });
+		}
+	}
+	for (const mod of playerProficiencies.battleModifiers) {
+		if (contributes(mod)) {
+			mods.push({ ...mod });
+		}
+	}
+
 	// Engine base values + derived formulas.
 	for (const stat of STATIC_ATTRIBUTE_MODIFIERS) {
 		mods.push({ ...stat });
+	}
+
+	// The class signature passive is composed LAST (after the locked base, proficiency, and statics),
+	// resolved against the already-assembled value of its scaling attribute — the same two-pass the
+	// battler does (build the set, then add the passive reading the resolved scaling value, like a skill
+	// effect reads its caster). The resolve pass is lazy so a flat (non-scaled) passive skips it.
+	let resolved: Map<EAttribute, ComputedAttribute<LabeledModifier>> | undefined;
+	const passive = playerManager.battleSignaturePassiveModifier((attribute) => {
+		resolved ??= computeAttributes(mods);
+		return resolved.get(attribute)?.total ?? 0;
+	});
+	if (contributes(passive)) {
+		mods.push({ ...passive });
 	}
 
 	return mods;

--- a/UI/src/routes/game/screens/attribute-breakdown/source-display.ts
+++ b/UI/src/routes/game/screens/attribute-breakdown/source-display.ts
@@ -16,18 +16,16 @@ const SOURCE_KEY: Record<EAttributeModifierSource, string> = {
 	[EAttributeModifierSource.Item]: 'item',
 	[EAttributeModifierSource.ItemMod]: 'mod',
 	[EAttributeModifierSource.Derived]: 'derived',
-	// AttributeDistribution is an enemy/NPC source that never appears in a
-	// player's breakdown; it falls back to the neutral base hue if ever shown.
-	[EAttributeModifierSource.AttributeDistribution]: 'base',
+	// The player's class locked base — the level-scaled, non-reallocatable attribute fingerprint (#1126
+	// area D). Shares the source enum with an enemy/NPC distribution but only ever appears as the player's
+	// own locked base in this breakdown.
+	[EAttributeModifierSource.AttributeDistribution]: 'distribution',
 	// SkillEffect is a timed battle modifier; it falls back to the derived hue.
 	[EAttributeModifierSource.SkillEffect]: 'derived',
-	// Proficiency is a permanent progression bonus; it is not yet surfaced in the player breakdown (that
-	// lands with the proficiency client work), so it falls back to the stat-points hue until then.
-	[EAttributeModifierSource.Proficiency]: 'points',
-	// Class is the signature-passive bonus composed at battler assembly (#1126 area E); like the locked base
-	// and proficiency bonuses it is not yet surfaced in the player breakdown, so it falls back to the
-	// stat-points hue (rather than minting a speculative token) until #1261 wires those modifiers in.
-	[EAttributeModifierSource.Class]: 'points'
+	// Permanent proficiency progression bonus (#982 area E).
+	[EAttributeModifierSource.Proficiency]: 'proficiency',
+	// The class signature passive composed at battler assembly (#1126 area E).
+	[EAttributeModifierSource.Class]: 'class'
 };
 
 const SOURCE_LABEL: Record<EAttributeModifierSource, string> = {
@@ -36,10 +34,10 @@ const SOURCE_LABEL: Record<EAttributeModifierSource, string> = {
 	[EAttributeModifierSource.Item]: 'Equipment',
 	[EAttributeModifierSource.ItemMod]: 'Item mods',
 	[EAttributeModifierSource.Derived]: 'Derived',
-	[EAttributeModifierSource.AttributeDistribution]: 'Distribution',
+	[EAttributeModifierSource.AttributeDistribution]: 'Class base',
 	[EAttributeModifierSource.SkillEffect]: 'Skill effect',
 	[EAttributeModifierSource.Proficiency]: 'Proficiency',
-	[EAttributeModifierSource.Class]: 'Class'
+	[EAttributeModifierSource.Class]: 'Signature passive'
 };
 
 /** Themeable source accent hue, e.g. `var(--source-points)`. */

--- a/UI/src/styles/_colors.scss
+++ b/UI/src/styles/_colors.scss
@@ -88,11 +88,15 @@ $attr-dexterity: #f0d28a;
 $attr-luck: #8fded0;
 
 // attribute-modifier-source accents (one hue per EAttributeModifierSource shown
-// in the breakdown: base / stat points / equipment / item mods / derived) —
-// consumed via the helpers in the attribute-breakdown screen's source-display.
-// Most reuse an existing palette hue; only the neutral base value is its own.
+// in the breakdown: base / class locked base / stat points / proficiency /
+// equipment / item mods / derived / class signature passive) — consumed via the
+// helpers in the attribute-breakdown screen's source-display. Each must stay
+// visually distinct so the stacked bar and legend disambiguate the sources.
 $source-base: #8b919e;
+$source-distribution: #8fded0;
 $source-points: $accent;
+$source-proficiency: #cf7a9e;
 $source-item: $success;
 $source-mod: $attr-intellect;
 $source-derived: $warning;
+$source-class: #d9a441;

--- a/UI/src/tests/routes/game/screens/attribute-breakdown/AttributeBreakdown.test.ts
+++ b/UI/src/tests/routes/game/screens/attribute-breakdown/AttributeBreakdown.test.ts
@@ -1,15 +1,25 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
-import { EAttribute, type IBattlerAttribute } from '$lib/api';
+import { EAttribute, EModifierType, type IBattlerAttribute } from '$lib/api';
+import { EAttributeModifierSource, type AttributeModifier } from '$lib/battle';
 
-const { mockPlayerManager, mockInventoryManager, staticData } = vi.hoisted(() => ({
-	mockPlayerManager: { attributes: [] as IBattlerAttribute[], name: 'Aelara', level: 12 },
+const { mockPlayerManager, mockInventoryManager, staticData, playerProficiencies } = vi.hoisted(() => ({
+	mockPlayerManager: {
+		attributes: [] as IBattlerAttribute[],
+		name: 'Aelara',
+		level: 12,
+		battleLockedBaseModifiers: [] as AttributeModifier[],
+		battleSignaturePassiveModifier: undefined as unknown as (
+			resolve: (attribute: EAttribute) => number
+		) => AttributeModifier
+	},
 	mockInventoryManager: { equippedSlots: [] as unknown[] },
-	staticData: { attributes: undefined as unknown }
+	staticData: { attributes: undefined as unknown },
+	playerProficiencies: { battleModifiers: [] as AttributeModifier[] }
 }));
 
 vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager, inventoryManager: mockInventoryManager }));
-vi.mock('$stores', () => ({ staticData }));
+vi.mock('$stores', () => ({ staticData, playerProficiencies }));
 
 import AttributeBreakdown from '$routes/game/screens/attribute-breakdown/AttributeBreakdown.svelte';
 
@@ -18,7 +28,16 @@ beforeEach(() => {
 		{ attributeId: EAttribute.Strength, amount: 14 },
 		{ attributeId: EAttribute.Endurance, amount: 12 }
 	];
+	mockPlayerManager.battleLockedBaseModifiers = [];
+	// A flat no-op signature passive — contributes nothing, so the breakdown omits it.
+	mockPlayerManager.battleSignaturePassiveModifier = () => ({
+		attribute: EAttribute.Strength,
+		amount: 0,
+		type: EModifierType.Additive,
+		source: EAttributeModifierSource.Class
+	});
 	mockInventoryManager.equippedSlots = [];
+	playerProficiencies.battleModifiers = [];
 	staticData.attributes = undefined;
 });
 

--- a/UI/src/tests/routes/game/screens/attribute-breakdown/attribute-breakdown-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attribute-breakdown/attribute-breakdown-view.test.ts
@@ -1,19 +1,46 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { EAttribute, EAttributeType, EItemModType, type IAttribute, type IBattlerAttribute } from '$lib/api';
-import { EAttributeModifierSource, EModifierType, type AppliedModifier, type ComputedAttribute } from '$lib/battle';
+import {
+	EAttribute,
+	EAttributeType,
+	EItemModType,
+	type IAttribute,
+	type IBattlerAttribute,
+	type ISignaturePassive
+} from '$lib/api';
+import {
+	BattleAttributes,
+	EAttributeModifierSource,
+	EModifierType,
+	type AppliedModifier,
+	type AttributeModifier,
+	type ComputedAttribute
+} from '$lib/battle';
+import { classLockedBaseModifiers, classSignaturePassiveModifier } from '$lib/battle/class-modifiers';
+import { proficiencyModifiers } from '$lib/battle/proficiency-modifiers';
 
-// Stand-ins for the player + inventory managers and the static reference data.
-// `buildPlayerModifiers` reads the player's allocations and equipped loadout
-// from these; the view aggregates them through the real attribute pipeline and
-// reads the display taxonomy / precision off `staticData.attributes`.
-const { mockPlayerManager, mockInventoryManager, staticData } = vi.hoisted(() => ({
-	mockPlayerManager: { attributes: [] as IBattlerAttribute[], name: 'Aelara', level: 12 },
+// Stand-ins for the player + inventory managers, proficiency store, and static reference data.
+// `buildPlayerModifiers` reads the player's allocations, equipped loadout, class locked base /
+// signature passive, and proficiency bonuses from these; the view aggregates them through the real
+// attribute pipeline and reads the display taxonomy / precision off `staticData.attributes`.
+const { mockPlayerManager, mockInventoryManager, staticData, playerProficiencies } = vi.hoisted(() => ({
+	mockPlayerManager: {
+		attributes: [] as IBattlerAttribute[],
+		name: 'Aelara',
+		level: 12,
+		battleLockedBaseModifiers: [] as AttributeModifier[],
+		// Reassigned per-test (and to a flat no-op in beforeEach); the placeholder keeps the property
+		// present so the hoisted factory needn't reference the not-yet-imported enums.
+		battleSignaturePassiveModifier: undefined as unknown as (
+			resolve: (attribute: EAttribute) => number
+		) => AttributeModifier
+	},
 	mockInventoryManager: { equippedSlots: [] as unknown[] },
-	staticData: { attributes: undefined as IAttribute[] | undefined }
+	staticData: { attributes: undefined as IAttribute[] | undefined },
+	playerProficiencies: { battleModifiers: [] as AttributeModifier[] }
 }));
 
 vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager, inventoryManager: mockInventoryManager }));
-vi.mock('$stores', () => ({ staticData }));
+vi.mock('$stores', () => ({ staticData, playerProficiencies }));
 
 import { attributeName } from '$lib/common';
 import {
@@ -99,9 +126,22 @@ const computedWithSources = (
 	})) as AppliedModifier<LabeledModifier>[]
 });
 
+// A flat no-op signature passive — the default a player whose class has no passive carries. It
+// contributes nothing, so the breakdown must omit it (and not let it self-select Strength).
+const noOpPassive: ISignaturePassive = {
+	attributeId: EAttribute.Strength,
+	amount: 0,
+	scalingAmount: 0,
+	modifierType: EModifierType.Additive
+};
+
 beforeEach(() => {
 	mockPlayerManager.attributes = [];
+	mockPlayerManager.level = 12;
+	mockPlayerManager.battleLockedBaseModifiers = [];
+	mockPlayerManager.battleSignaturePassiveModifier = (resolve) => classSignaturePassiveModifier(noOpPassive, resolve);
 	mockInventoryManager.equippedSlots = [];
+	playerProficiencies.battleModifiers = [];
 	staticData.attributes = refAttributes;
 });
 
@@ -151,6 +191,59 @@ describe('buildPlayerModifiers', () => {
 		expect(
 			mods.some((m) => m.source === EAttributeModifierSource.Derived && m.derivedSource === EAttribute.Endurance)
 		).toBe(true);
+	});
+
+	it('composes the class locked base and proficiency bonuses after gear and before the static modifiers', () => {
+		mockInventoryManager.equippedSlots = [mockItem('Aegis', [{ attributeId: EAttribute.Defense, amount: 14 }])];
+		mockPlayerManager.battleLockedBaseModifiers = classLockedBaseModifiers(
+			[{ attributeId: EAttribute.Strength, baseAmount: 5, amountPerLevel: 1 }],
+			mockPlayerManager.level // 5 + 1×12 = 17
+		);
+		playerProficiencies.battleModifiers = proficiencyModifiers(
+			[{ level: 1, attributeId: EAttribute.Endurance, amount: 6, modifierTypeId: EModifierType.Additive }],
+			3
+		);
+		const sources = buildPlayerModifiers().map((m) => m.source);
+		const gear = sources.indexOf(EAttributeModifierSource.Item);
+		const locked = sources.indexOf(EAttributeModifierSource.AttributeDistribution);
+		const prof = sources.indexOf(EAttributeModifierSource.Proficiency);
+		const firstStatic = sources.findIndex(
+			(s) => s === EAttributeModifierSource.BaseValue || s === EAttributeModifierSource.Derived
+		);
+		// Apply order: gear → locked base → proficiency → statics.
+		expect(gear).toBeLessThan(locked);
+		expect(locked).toBeLessThan(prof);
+		expect(prof).toBeLessThan(firstStatic);
+		const mods = buildPlayerModifiers();
+		expect(mods[locked]).toMatchObject({ attribute: EAttribute.Strength, amount: 17 });
+		expect(mods[prof]).toMatchObject({ attribute: EAttribute.Endurance, amount: 6 });
+	});
+
+	it('composes the class signature passive last, resolved against the assembled scaling value', () => {
+		mockPlayerManager.attributes = [{ attributeId: EAttribute.Strength, amount: 20 }];
+		mockPlayerManager.battleSignaturePassiveModifier = (resolve) =>
+			classSignaturePassiveModifier(
+				{
+					attributeId: EAttribute.Defense,
+					amount: 0,
+					scalingAmount: 0.5,
+					scalingAttributeId: EAttribute.Strength,
+					modifierType: EModifierType.Additive
+				},
+				resolve
+			);
+		const mods = buildPlayerModifiers();
+		const last = mods[mods.length - 1];
+		// Strength resolves to 20 (allocation; no static base), so the passive adds 0.5 × 20 = 10 to Defense.
+		expect(last).toMatchObject({ source: EAttributeModifierSource.Class, attribute: EAttribute.Defense });
+		expect(last.amount).toBeCloseTo(10);
+	});
+
+	it('omits the class signature passive when it is a flat no-op (the default)', () => {
+		// The beforeEach default passive contributes nothing, so no Class line is emitted — otherwise it
+		// would spuriously self-select Strength into the inspector.
+		const mods = buildPlayerModifiers();
+		expect(mods.some((m) => m.source === EAttributeModifierSource.Class)).toBe(false);
 	});
 });
 
@@ -246,6 +339,86 @@ describe('AttributeBreakdownView', () => {
 	});
 });
 
+describe('battle-assembly parity', () => {
+	// A scenario exercising all three battle-assembly sources at once.
+	const distributions = [{ attributeId: EAttribute.Strength, baseAmount: 5, amountPerLevel: 1 }]; // STR +17 at lvl 12
+	const proficiency = [
+		{ level: 1, attributeId: EAttribute.Endurance, amount: 6, modifierTypeId: EModifierType.Additive }
+	]; // END +6
+	const scaledPassive: ISignaturePassive = {
+		attributeId: EAttribute.Defense,
+		amount: 0,
+		scalingAmount: 0.5,
+		scalingAttributeId: EAttribute.Strength,
+		modifierType: EModifierType.Additive
+	};
+
+	function arrangeScenario() {
+		mockPlayerManager.level = 12;
+		mockPlayerManager.attributes = [
+			{ attributeId: EAttribute.Strength, amount: 14 },
+			{ attributeId: EAttribute.Endurance, amount: 12 }
+		];
+		mockInventoryManager.equippedSlots = [
+			mockItem(
+				'Aegis Greathelm',
+				[{ attributeId: EAttribute.Defense, amount: 14 }],
+				[
+					{
+						name: 'Tempered',
+						itemModTypeId: EItemModType.Prefix,
+						attributes: [{ attributeId: EAttribute.Endurance, amount: 10 }]
+					}
+				]
+			)
+		];
+		mockPlayerManager.battleLockedBaseModifiers = classLockedBaseModifiers(distributions, mockPlayerManager.level);
+		playerProficiencies.battleModifiers = proficiencyModifiers(proficiency, 3);
+		mockPlayerManager.battleSignaturePassiveModifier = (resolve) =>
+			classSignaturePassiveModifier(scaledPassive, resolve);
+	}
+
+	it('aggregates to the same totals the live battler (BattleAttributes) resolves', () => {
+		arrangeScenario();
+		const view = new AttributeBreakdownView();
+
+		// Oracle: assemble the identical inputs the way BattleEngine.resetPlayer builds the player battler —
+		// free pool + gear as the base data, locked base + proficiency as additional modifiers (before the
+		// statics setData appends), then the signature passive added last, resolved against the assembled set.
+		const atts: IBattlerAttribute[] = [
+			...mockPlayerManager.attributes,
+			{ attributeId: EAttribute.Defense, amount: 14 },
+			{ attributeId: EAttribute.Endurance, amount: 10 }
+		];
+		const battler = new BattleAttributes();
+		battler.setData(atts, true, [
+			...classLockedBaseModifiers(distributions, 12),
+			...proficiencyModifiers(proficiency, 3)
+		]);
+		battler.addModifier(classSignaturePassiveModifier(scaledPassive, (a) => battler.getValue(a)));
+
+		for (const attr of [EAttribute.Strength, EAttribute.Endurance, EAttribute.Defense, EAttribute.MaxHealth]) {
+			expect(view.computedFor(attr).total).toBeCloseTo(battler.getValue(attr), 10);
+		}
+		// Sanity-check the load-bearing numbers: STR = 14 + 17 locked base = 31; the passive then adds
+		// 0.5 × 31 = 15.5 to Defense (2 base + 1×END + 14 gear + 15.5 = 59.5, END = 12 + 10 + 6 = 28).
+		expect(view.computedFor(EAttribute.Strength).total).toBe(31);
+		expect(view.computedFor(EAttribute.Defense).total).toBeCloseTo(59.5);
+	});
+
+	it('surfaces the locked base, proficiency, and signature passive in the by-source grouping', () => {
+		arrangeScenario();
+		const view = new AttributeBreakdownView();
+		const sourcesFor = (attr: EAttribute) => {
+			view.select(attr);
+			return view.selectedGrouped.groups.map((g) => g.source);
+		};
+		expect(sourcesFor(EAttribute.Strength)).toContain(EAttributeModifierSource.AttributeDistribution);
+		expect(sourcesFor(EAttribute.Endurance)).toContain(EAttributeModifierSource.Proficiency);
+		expect(sourcesFor(EAttribute.Defense)).toContain(EAttributeModifierSource.Class);
+	});
+});
+
 describe('self-selecting membership', () => {
 	it('treats a combat-only (SkillEffect) contributor as not a real, non-combat modifier', () => {
 		const combatOnly = computedWithSources(EAttribute.DamageTakenPerSecond, [EAttributeModifierSource.SkillEffect]);
@@ -298,6 +471,9 @@ describe('formatting + labels', () => {
 		expect(
 			modifierLabel({ source: EAttributeModifierSource.Derived, derivedSource: EAttribute.Endurance } as never)
 		).toBe('Endurance');
+		expect(modifierLabel({ source: EAttributeModifierSource.AttributeDistribution } as never)).toBe('Class base');
+		expect(modifierLabel({ source: EAttributeModifierSource.Proficiency } as never)).toBe('Proficiency');
+		expect(modifierLabel({ source: EAttributeModifierSource.Class } as never)).toBe('Signature passive');
 	});
 });
 


### PR DESCRIPTION
## Summary

The read-only **attribute-breakdown inspector** assembled the player's modifier set from **allocations + equipped gear + static engine modifiers only**. It did **not** include the battle-assembly modifiers the *actual* battler now carries:

- the class **locked base** (`AttributeDistribution`, area D),
- the **proficiency** bonuses (`Proficiency`, #982 area E), and
- the class **signature passive** (`Class`, #1224 / area E).

So the inspector — whose header promises it "can never disagree with the totals the simulation actually uses" — had become a **stale mirror**, under-reporting any attribute those three contribute to.

## How it addresses the issue (#1261)

- **`buildPlayerModifiers` now composes the same set the live player battler does** (`BattleEngine.resetPlayer` → backend `BattleSnapshot.ToBattler`), in the identical apply order: allocated stat points → gear → **class locked base** → **proficiency** → engine statics → the **class signature passive last**.
- The passive is **attribute-scaled off the resolved value of its scaling attribute**, so it's composed via a **lazy two-pass** within the builder (build the set, then add the passive reading the assembled scaling value — like a skill effect reads its caster), matching where the battler appends it. Float addition isn't associative, so this order is load-bearing for parity.
- Non-contributing (`+0` / `×1`) modifiers are skipped, so the **flat no-op signature-passive default** can't spuriously self-select its attribute into the inspector.
- **Display wiring:** the three sources are added to `SOURCE_ORDER` (a source absent there is silently dropped from the by-source view), given contribution-line labels (`Class base` / `Proficiency` / `Signature passive`), and — since they previously fell back to existing hues — given **distinct `--source-distribution` / `--source-proficiency` / `--source-class` theme tokens** so the stacked bar and legend stay disambiguated (three sources no longer share the stat-points hue). The prior `source-display.ts` comments anticipated minting these "until #1261 wires those modifiers in."

Pure read-only inspector + theming change — no battle-logic or parity-surface change (the battler already composes all three correctly; this only makes the *inspector* faithful again).

## Test plan

- [x] New **parity test** pinning `view.computedFor(attr).total` to `BattleAttributes` (the live battle path, used as an independent oracle) for a scenario exercising all three sources, including a scaled passive.
- [x] Unit coverage for the apply order (gear → locked base → proficiency → statics), the scaled-passive resolution + last-position, the no-op skip, the by-source grouping surfacing the new sources, and the new source labels.
- [x] Updated the `AttributeBreakdown` component test's mocks for the new manager/store surfaces.
- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors / 0 warnings.
- [x] `npm run test:unit:ci` — full suite green.

## Notes

- No `docs` change warranted: the inspector↔`BattleAttributes` parity invariant and the locked-base/proficiency/passive assembly order are already documented in `frontend.md`; this restores faithfulness to those documented patterns rather than establishing a new one.
- Per-proficiency provenance on the line labels (e.g. the proficiency name) was intentionally **not** added — the inspector consumes the parity-guaranteed `playerProficiencies.battleModifiers` array directly (no provenance) to avoid duplicating the flattening logic and risking drift from the parity source; lines are labelled by source group instead. A follow-up could thread proficiency names through if desired.

Closes #1261

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhtosZvDYMbKb4fCW9AC4q

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhtosZvDYMbKb4fCW9AC4q)_