### PR TITLE
Forward the in-scope CancellationToken to LoadPlayer in the Status and socket-handshake paths (#1269)

### DIFF
--- a/Game.Api/Controllers/LoginController.cs
+++ b/Game.Api/Controllers/LoginController.cs
@@ -297,7 +297,7 @@ namespace Game.Api.Controllers
 
             // A still-valid token whose player can't be loaded (deleted/archived between requests) is a
             // graceful error, not a 500 — mirroring the structured ApiResponse.Error its sibling endpoints use.
-            var player = await _playerService.LoadPlayer(_sessionService.SelectedPlayerId);
+            var player = await _playerService.LoadPlayer(_sessionService.SelectedPlayerId, HttpContext.RequestAborted);
             if (player is null)
             {
                 return ApiResponse.Error("Player data not found", ApiErrorCategory.NotFound);

--- a/Game.Api/Middleware/SocketInterceptorMiddleware.cs
+++ b/Game.Api/Middleware/SocketInterceptorMiddleware.cs
@@ -63,7 +63,7 @@ namespace Game.Api.Middleware
 
             using var scope = scopeFactory.CreateScope();
             var player = await scope.ServiceProvider.GetRequiredService<PlayerService>()
-                .LoadPlayer(sessionService.SelectedPlayerId);
+                .LoadPlayer(sessionService.SelectedPlayerId, cancellationToken);
             if (player is null)
             {
                 return false;


### PR DESCRIPTION
## Summary

Two player-load call sites had a `CancellationToken` in scope and forwarded it to the sibling `EnsureSessionLoaded` call directly above, but dropped it on the `LoadPlayer` call. `PlayerService.LoadPlayer(int playerId, CancellationToken cancellationToken = default)` already accepts the token (and EF/Npgsql honour it natively, per `docs/backend.md`), so this just uses the cooperative-cancellation plumbing already in place.

- **`Game.Api/Controllers/LoginController.cs`** (`Status`) — `LoadPlayer(_sessionService.SelectedPlayerId)` now passes `HttpContext.RequestAborted`, matching the preceding `EnsureSessionLoaded(HttpContext.RequestAborted)` and the sibling `SwitchPlayer` path which already forwards the token.
- **`Game.Api/Middleware/SocketInterceptorMiddleware.cs`** (`TryLoadPlayer`) — `LoadPlayer(sessionService.SelectedPlayerId)` now passes the in-scope `cancellationToken`, matching the preceding `EnsureSessionLoaded(cancellationToken)`.

## How it addresses the issue

An aborted/disconnected client request no longer drives the cache/DB load to completion, and these two sites are now consistent with every other load in their files (and with the documented intent that the per-request/per-command cancellation token is plumbed through the application services and data tier). Neither site had a comment marking the omission as deliberate — unlike the genuinely-deliberate no-token paths elsewhere — so this was an oversight, not an intentional choice.

## Verification of the issue's claims

Both claims were checked against the code before implementing:
- `LoadPlayer`'s signature accepts the token with a default ✓
- The `Status` and socket-handshake sites dropped it while their sibling `EnsureSessionLoaded` calls forwarded it, and the `SwitchPlayer` load already passes the token ✓

## Test plan

- [x] `dotnet build Game.Api` — clean (0 warnings, 0 errors).
- [x] `dotnet test Game.Api.Tests` — **624 passed**, 0 failed.
- No new tests: this is pure cancellation-token plumbing with no new behaviour or domain logic. Cooperative cancellation here isn't observably testable without contrived infrastructure, and the existing integration tests already exercise both the `Status` and socket-handshake load paths.

Closes #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcGatNmGNBcDXt28PqwfKG)_