### PR TITLE
Document direct-2-cycle-only guarantee of the derived-modifier circular guard (#1271)

### DIFF
--- a/Game.Core/Attributes/AttributeCircularDerivedModifierException.cs
+++ b/Game.Core/Attributes/AttributeCircularDerivedModifierException.cs
@@ -3,8 +3,18 @@
 namespace Game.Core.Attributes
 {
     /// <summary>
-    /// An exception that is thrown when adding an <see cref="AttributeModifier"/> that causes a circular dependency.
+    /// Thrown when adding a derived <see cref="AttributeModifier"/> would create a <b>direct</b>
+    /// (length-2) cycle between two attributes — the target already derives from the modifier's
+    /// source while the new modifier makes that source derive back from the target.
     /// </summary>
+    /// <remarks>
+    /// This guard intentionally detects only direct 2-cycles, not longer derived chains
+    /// (e.g. A→B→C→A). That is sufficient because the only derived modifiers today come from the
+    /// static, acyclic <see cref="StaticAttributeModifiers"/>, so a longer cycle is unreachable in
+    /// practice. If derived modifiers ever become authorable (e.g. gear- or skill-effect-sourced),
+    /// this must be upgraded to a full cycle check — an undetected longer cycle would otherwise
+    /// recurse unbounded during attribute evaluation and end in a stack overflow.
+    /// </remarks>
     public class AttributeCircularDerivedModifierException : Exception
     {
         /// <summary>

--- a/Game.Core/Attributes/AttributeCollection.cs
+++ b/Game.Core/Attributes/AttributeCollection.cs
@@ -118,6 +118,11 @@ namespace Game.Core.Attributes
             if (modifier.Source is EAttributeModifierSource.Derived)
             {
                 var sourceNode = GetOrCreateNode((int)modifier.DerivedSource);
+                // Detects only a direct (length-2) cycle: the target already derives from this
+                // modifier's source. Longer derived chains (A→B→C→A) are not detected — acceptable
+                // only because derived modifiers come solely from the static, acyclic
+                // StaticAttributeModifiers. See AttributeCircularDerivedModifierException for the
+                // full rationale and the upgrade trigger if derived modifiers become authorable.
                 if (node.DerivedNodes?.Contains(sourceNode) == true)
                 {
                     throw new AttributeCircularDerivedModifierException(modifier);


### PR DESCRIPTION
## Summary

Closes #1271.

`AttributeCircularDerivedModifierException` and the guard in
`AttributeCollection.AddModifierWithoutCacheInvalidation` (`Game.Core/Attributes/AttributeCollection.cs`)
advertised general circular-dependency protection, but the check —
`node.DerivedNodes?.Contains(sourceNode) == true` — only catches a **direct (length-2)** cycle
(A derives from B while the new modifier makes B derive back from A). A longer derived chain
(A→B→C→A) is not detected and would recurse unbounded in `GetAttributeValue`/`SetCachedValue`,
ending in a stack overflow.

As the issue notes, this is **not a live bug**: the only derived modifiers today come from the
hardcoded, acyclic `StaticAttributeModifiers`, so a longer cycle is unreachable in practice. The
problem is purely that the names/comments over-promise a guarantee the code doesn't provide.

Per the issue's recommendation (documentation is sufficient until authorable derived modifiers are
on the roadmap — implementing full cycle detection now would be premature), this PR narrows the docs
to state the **actual** guarantee:

- **Exception XML doc** — describes the direct-2-cycle scope and adds a `<remarks>` covering the
  justification (static-only acyclic derived modifiers) and the upgrade trigger (if derived
  modifiers become authorable, this must become a full cycle check or a longer cycle stack-overflows).
- **Inline guard comment** — states that only a direct cycle is detected, why that's acceptable, and
  points to the exception for the full rationale.

No behavior change.

## Test plan

- [x] `dotnet build Game.Core/Game.Core.csproj` — clean, 0 warnings (the new `<see cref>` references resolve)
- [x] `dotnet test Game.Core.Tests` — 843 passed, including the existing direct-cycle throw test (`Constructor_DuplicateDerivedModifierSameSourceTarget_Throws`)

No new tests were added: this is a doc-only change with no new domain logic, and the existing test
already pins the detected (direct) cycle behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXVxiynD9ax6eExcNnjt8M)_