### PR TITLE
Add integration coverage for the class signature passive (#1272)

### DIFF
--- a/Game.Api.Tests/Integration/LoginControllerTests.cs
+++ b/Game.Api.Tests/Integration/LoginControllerTests.cs
@@ -196,6 +196,60 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task SelectPlayer_DeliversClassLockedBaseAndSignaturePassive()
+        {
+            // The logged-in player payload (LoginController.BuildPlayerData) projects the character's class
+            // into LockedBaseDistribution + SignaturePassive — the parity-sensitive class data the live
+            // frontend battler composes its attributes from (#1126 areas D/E). The end-to-end class-delivery
+            // assertions otherwise live only on CharacterCreationData, not the logged-in payload, so a
+            // regression in this projection would load fine while desyncing the FE/BE anti-cheat surface.
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context, "classdelivery", "classpass");
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+            // A distinctive locked-base fingerprint and an attribute-scaled signature passive, so every
+            // projected field (incl. the scaling fields and modifier type) is pinned, not just the defaults.
+            var @class = await TestDataSeeder.CreateClassWithKitAsync(
+                context,
+                starterSkillIds: [],
+                attributeDistributions:
+                [
+                    (EAttribute.Strength, 12m, 2m),
+                    (EAttribute.Endurance, 8m, 1m),
+                ],
+                passiveAttribute: EAttribute.Endurance,
+                passiveAmount: 7m,
+                passiveScalingAttribute: EAttribute.Strength,
+                passiveScalingAmount: 0.5m,
+                passiveModifierType: EModifierType.Additive);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id, classId: @class.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
+            await ReloadReferenceCachesAsync();
+
+            var login = await LoginAsync("classdelivery", "classpass");
+            var summary = Assert.Single(login.PlayerSummaries);
+            var select = await SelectPlayerAsync(login.Tokens, summary.Id);
+
+            // The signature passive is delivered verbatim from the class.
+            var passive = select.Player.SignaturePassive;
+            Assert.Equal(EAttribute.Endurance, passive.AttributeId);
+            Assert.Equal(7m, passive.Amount);
+            Assert.Equal(EAttribute.Strength, passive.ScalingAttributeId);
+            Assert.Equal(0.5m, passive.ScalingAmount);
+            Assert.Equal(EModifierType.Additive, passive.ModifierType);
+
+            // The locked-base fingerprint is delivered as the authored distribution (base + per-level), so the
+            // client can rescale it on level-up. Asserted by attribute to stay independent of projection order.
+            Assert.Equal(2, select.Player.LockedBaseDistribution.Count);
+            var strength = Assert.Single(select.Player.LockedBaseDistribution, d => d.AttributeId == EAttribute.Strength);
+            Assert.Equal(12m, strength.BaseAmount);
+            Assert.Equal(2m, strength.AmountPerLevel);
+            var endurance = Assert.Single(select.Player.LockedBaseDistribution, d => d.AttributeId == EAttribute.Endurance);
+            Assert.Equal(8m, endurance.BaseAmount);
+            Assert.Equal(1m, endurance.AmountPerLevel);
+        }
+
+        [Fact]
         public async Task SelectPlayer_CharacterOfAnotherAccount_IsRejected()
         {
             using var scope = CreateScope();

--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -345,6 +345,55 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task EndBattleVictory_RewardIncludesClassSignaturePassiveInPlayerPower()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // The class signature passive (#1126 area E) is folded into the player's battle power via
+            // GetModifiersWithSignaturePassive, so a flat-core passive must count in the snapshot-measured
+            // difficulty ratio exactly like the locked base. A one-shot skill makes the victory certain.
+            var playerSkill = await TestDataSeeder.CreateSkillAsync(context, "Smash", baseDamage: 1000m, cooldownMs: 500);
+            // Enemy power 200 (Strength 100 + Endurance 100, no per-level scaling).
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context,
+                strengthBase: 100m, strengthPerLevel: 0m, enduranceBase: 100m, endurancePerLevel: 0m);
+            var enemySkill = await TestDataSeeder.CreateSkillAsync(context, "Poke", baseDamage: 1m, cooldownMs: 2000);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, enemySkill.Id);
+            var zone = await TestDataSeeder.CreateZoneAsync(context, levelMin: 1, levelMax: 1);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
+
+            // A class with no locked-base distribution but a flat Strength 100 signature passive. The seeded
+            // free pool is Strength 50 + Endurance 50 = 100, so the passive lifts the player's measured power
+            // to 200 — matching the enemy's 200 for a difficulty ratio of 1 (reward = enemy total = 200).
+            // Without the passive counting, the ratio would be 200/100 = 2, paying the capped 800.
+            var passiveClass = await TestDataSeeder.CreateClassAsync(context,
+                passiveAttribute: EAttribute.Strength, passiveAmount: 100m);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(
+                context, user.Id, zoneId: zone.Id, classId: passiveClass.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, playerSkill.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+
+            await battleService.StartBattle(player, state, zoneId: zone.Id);
+            Assert.True(state.HasActiveBattle);
+            state.BattleStartTime = DateTime.UtcNow.AddMinutes(-10);
+
+            var result = await battleService.EndBattleVictory(player, state);
+
+            Assert.NotNull(result);
+            Assert.Equal(200, result.ExpReward);
+        }
+
+        [Fact]
         public async Task EndBattleVictory_ClaimedBeforeBattleCouldFinish_ReturnsNull()
         {
             using var scope = CreateScope();

--- a/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
@@ -606,14 +606,14 @@ namespace Game.Core.Tests.Battle.Offline
 
         private static CoreClass MakeClass(
             int id, ClassSignaturePassive passive, params AttributeDistribution[] distributions) => new()
-        {
-            Id = id,
-            Name = $"Class {id}",
-            StarterSkillIds = [],
-            StarterEquipment = [],
-            AttributeDistributions = distributions,
-            SignaturePassive = passive,
-        };
+            {
+                Id = id,
+                Name = $"Class {id}",
+                StarterSkillIds = [],
+                StarterEquipment = [],
+                AttributeDistributions = distributions,
+                SignaturePassive = passive,
+            };
 
         private static ClassSignaturePassive NoopPassive() => new()
         {

--- a/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
@@ -411,6 +411,32 @@ namespace Game.Core.Tests.Battle.Offline
             Assert.True(withFingerprint.Wins > 0);
         }
 
+        [Fact]
+        public void Simulate_AppliesClassSignaturePassive_FromTheFrozenSnapshot()
+        {
+            // The signature passive (#1126 area E) feeds the same attribute pipeline as the locked base, so a
+            // strong flat-core passive lets the player win idle battles it wins none of without one — proving
+            // the offline path composes the passive, not just the locked base. The class carries no locked-base
+            // distribution, so the wins are attributable to the passive alone.
+            var zone = MakeZone(levelMin: 1, levelMax: 1);
+            var snapshot = ClassPlayerSnapshot(level: 1, classId: 2);
+
+            OfflineProgressResult Run(ClassSignaturePassive passive)
+            {
+                var scenario = new Scenario { Zone = zone, Snapshot = snapshot, ResolveEnemy = level => WeakEnemy(level) };
+                return _simulator.Simulate(IdleParameters(ManyStepsBudget(), scenario) with
+                {
+                    ResolveClass = ClassResolver(2, passive),
+                });
+            }
+
+            var withoutPassive = Run(NoopPassive());
+            var withPassive = Run(FlatPassive(Strength, 100m));
+
+            Assert.Equal(0, withoutPassive.Wins);
+            Assert.True(withPassive.Wins > 0);
+        }
+
         // ── Scenario plumbing ────────────────────────────────────────────────
 
         private const int EnemyId = 1;
@@ -570,25 +596,41 @@ namespace Game.Core.Tests.Battle.Offline
         };
 
         private static Func<int, CoreClass> ClassResolver(int classId, params AttributeDistribution[] distributions) =>
+            ClassResolver(classId, NoopPassive(), distributions);
+
+        private static Func<int, CoreClass> ClassResolver(
+            int classId, ClassSignaturePassive passive, params AttributeDistribution[] distributions) =>
             id => id == classId
-                ? MakeClass(classId, distributions)
+                ? MakeClass(classId, passive, distributions)
                 : throw new InvalidOperationException($"Unexpected class resolve for {id}");
 
-        private static CoreClass MakeClass(int id, params AttributeDistribution[] distributions) => new()
+        private static CoreClass MakeClass(
+            int id, ClassSignaturePassive passive, params AttributeDistribution[] distributions) => new()
         {
             Id = id,
             Name = $"Class {id}",
             StarterSkillIds = [],
             StarterEquipment = [],
             AttributeDistributions = distributions,
-            SignaturePassive = new ClassSignaturePassive
-            {
-                Attribute = Strength,
-                Amount = 0m,
-                ScalingAttribute = null,
-                ScalingAmount = 0m,
-                ModifierType = EModifierType.Additive,
-            },
+            SignaturePassive = passive,
+        };
+
+        private static ClassSignaturePassive NoopPassive() => new()
+        {
+            Attribute = Strength,
+            Amount = 0m,
+            ScalingAttribute = null,
+            ScalingAmount = 0m,
+            ModifierType = EModifierType.Additive,
+        };
+
+        private static ClassSignaturePassive FlatPassive(EAttribute attribute, decimal amount) => new()
+        {
+            Attribute = attribute,
+            Amount = amount,
+            ScalingAttribute = null,
+            ScalingAmount = 0m,
+            ModifierType = EModifierType.Additive,
         };
 
         private static AttributeDistribution Distribution(EAttribute attribute, decimal baseAmount, decimal amountPerLevel = 0m) =>

--- a/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
+++ b/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
@@ -456,9 +456,22 @@ namespace Game.TestInfrastructure.Helpers
             IReadOnlyList<(EAttribute Attribute, decimal BaseAmount, decimal AmountPerLevel)>? attributeDistributions = null,
             string name = "Test Class",
             DateTime? retiredAt = null,
-            IReadOnlyList<(int ItemId, EEquipmentSlot Slot)>? starterEquipment = null)
+            IReadOnlyList<(int ItemId, EEquipmentSlot Slot)>? starterEquipment = null,
+            EAttribute passiveAttribute = EAttribute.Strength,
+            decimal passiveAmount = 5m,
+            EAttribute? passiveScalingAttribute = null,
+            decimal passiveScalingAmount = 0m,
+            EModifierType passiveModifierType = EModifierType.Additive)
         {
-            var @class = await CreateClassAsync(context, name: name, retiredAt: retiredAt);
+            var @class = await CreateClassAsync(
+                context,
+                name: name,
+                retiredAt: retiredAt,
+                passiveAttribute: passiveAttribute,
+                passiveAmount: passiveAmount,
+                passiveScalingAttribute: passiveScalingAttribute,
+                passiveScalingAmount: passiveScalingAmount,
+                passiveModifierType: passiveModifierType);
 
             foreach (var skillId in starterSkillIds)
             {


### PR DESCRIPTION
## Summary

Closes #1272.

The class **signature passive** was unit-tested in isolation (`BattleSnapshotTests`, the parity matrices) and the class **locked base** has integration coverage at every layer, but the passive was missing the parallel integration coverage at three seams. Each underlying computation is already sound; these were completeness gaps that would let a regression in the orchestration/delivery wiring slip past the suite. This PR fills all three with the assertions the issue suggested.

## What's added

1. **Client delivery projection** — `Game.Api.Tests/Integration/LoginControllerTests.cs`
   - `SelectPlayer_DeliversClassLockedBaseAndSignaturePassive`: drives the real login → SelectPlayer flow for a character whose class has a **distinctive locked-base fingerprint and an attribute-scaled signature passive**, then asserts the returned `PlayerData.SignaturePassive` (attribute, amount, **scaling attribute, scaling amount, modifier type**) and `PlayerData.LockedBaseDistribution` (base + per-level, asserted by attribute so it's order-independent) reflect the class. Previously the only end-to-end class-delivery assertions lived on `CharacterCreationData`, not the logged-in player payload — the live path the frontend battler composes its parity-sensitive attributes from.

2. **Offline simulation** — `Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs`
   - `Simulate_AppliesClassSignaturePassive_FromTheFrozenSnapshot`: a flat-core (Strength) signature passive flips otherwise-lost idle battles to wins, mirroring the existing locked-base offline test. The class carries no locked-base distribution, so the wins are attributable to the passive alone. The existing `MakeClass` helpers hardcoded a no-op passive, so this path was never exercised with a non-trivial passive; the helpers were refactored to take a passive (`NoopPassive()` / `FlatPassive(...)`) with the existing no-op behavior preserved for all current callers.

3. **Reward-power inclusion** — `Game.Application.Tests/Services/BattleServiceIntegrationTests.cs`
   - `EndBattleVictory_RewardIncludesClassSignaturePassiveInPlayerPower`: mirrors `EndBattleVictory_RewardIncludesClassLockedBaseInPlayerPower` with a passive-bearing class. The free pool (100) + a flat Strength-100 passive lifts measured power to 200, matching the enemy (200) for a difficulty ratio of 1 → reward 200; without the passive counting the ratio would be 2 → the capped 800. So the assertion pins that `GetModifiersWithSignaturePassive` actually folds the passive into the `DefeatRewards` power measure.

### Supporting change

`Game.TestInfrastructure/Helpers/TestDataSeeder.CreateClassWithKitAsync` gained optional signature-passive params (`passiveAttribute`/`passiveAmount`/`passiveScalingAttribute`/`passiveScalingAmount`/`passiveModifierType`) that pass through to `CreateClassAsync`. The defaults match the prior behavior, so all existing callers are unaffected; it just lets a class's passive be authored alongside its kit (used by seam 1).

## Note on the corrupt-cache throw

The issue also flagged that `BuildPlayerData`'s unresolvable-class throw is untested. That branch is a defensive guard reachable only by corrupting the in-memory class cache (FK + zero-based-id contiguity make a player's `ClassId` always resolvable in practice). Per `docs/backend.md`'s testing guidance ("branches reachable only by disrupting process-wide shared infrastructure are accepted as measure-only"), I deliberately left it uncovered rather than forcing a brittle cache-corruption test. Happy to add one if you'd prefer.

## Test plan
- [x] `dotnet build Game.sln` — clean
- [x] `dotnet test Game.Core.Tests` — 843 passed (incl. new offline passive test)
- [x] `dotnet test Game.Application.Tests` — 588 passed (incl. new reward-power passive test)
- [x] `dotnet test Game.Api.Tests` — 624 passed (incl. new client-delivery test)

These are coverage-only additions at orchestration/delivery seams — no production code or battle logic changed, so no frontend parity mirror is required (the passive's battle-parity surface is already pinned by `ClassSignaturePassiveParityTests` / `class-signature-passive-parity.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQje5TauSJPxAmi7nV25ZM)_