### PR TITLE
Consolidate duplicated `.sr-only` CSS into a shared utility

### DIFF
--- a/UI/src/components/Loading.svelte
+++ b/UI/src/components/Loading.svelte
@@ -63,19 +63,6 @@ $outer-rotation-count: 3;
 	background: color-mix(in srgb, var(--black) 50%, transparent);
 }
 
-// Accessible label for screen readers without showing visible text.
-.sr-only {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	margin: -1px;
-	padding: 0;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	white-space: nowrap;
-	border: 0;
-}
-
 .loading-spinner-container {
 	position: absolute;
 	top: 50%;

--- a/UI/src/routes/BootSplash.svelte
+++ b/UI/src/routes/BootSplash.svelte
@@ -21,17 +21,4 @@ import DiamondMark from '$components/DiamondMark.svelte';
 	align-items: center;
 	justify-content: center;
 }
-
-// Accessible label for screen readers without showing visible text.
-.sr-only {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	margin: -1px;
-	padding: 0;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	white-space: nowrap;
-	border: 0;
-}
 </style>

--- a/UI/src/routes/admin/workbench/components/DirtyDot.svelte
+++ b/UI/src/routes/admin/workbench/components/DirtyDot.svelte
@@ -1,18 +1,4 @@
 <!-- The amber unsaved-change indicator. Pairs the decorative dot (`.dirty-dot`, styled in workbench.scss)
      with visually-hidden text, so the change state isn't conveyed by colour/shape alone. -->
 <span class="dirty-dot" aria-hidden="true"></span>
-<span class="sr-only">Unsaved change</span>
-
-<style lang="scss">
-.sr-only {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	margin: -1px;
-	padding: 0;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	white-space: nowrap;
-	border: 0;
-}
-</style>
+<span class="sr-only">Unsaved changes</span>

--- a/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
+++ b/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
@@ -69,7 +69,7 @@
 						{section.label}
 						{#if count !== null}<span class="count-badge">{count}</span>{/if}
 						{#if incomplete}<WarnTriangle size={12} />{/if}
-						{#if dirty}<span class="tab-dot" aria-hidden="true"></span><span class="sr-only">unsaved changes</span>{/if}
+						{#if dirty}<span class="tab-dot" aria-hidden="true"></span><span class="sr-only">Unsaved changes</span>{/if}
 					</button>
 				{/each}
 			</div>
@@ -265,16 +265,5 @@ const sectionDirty = (section: EntityConfig<Identified>['sections'][number]): bo
 .pips {
 	display: inline-flex;
 	gap: 12px;
-}
-.sr-only {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	margin: -1px;
-	padding: 0;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	white-space: nowrap;
-	border: 0;
 }
 </style>

--- a/UI/src/routes/login/UnderlineInput.svelte
+++ b/UI/src/routes/login/UnderlineInput.svelte
@@ -84,19 +84,6 @@ let {
 	margin-bottom: 22px;
 }
 
-// Accessible label for screen readers without showing visible text.
-.sr-only {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	margin: -1px;
-	padding: 0;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	white-space: nowrap;
-	border: 0;
-}
-
 .underline-input {
 	width: 100%;
 	height: 44px;

--- a/UI/src/styles/common.scss
+++ b/UI/src/styles/common.scss
@@ -132,6 +132,21 @@ h1 {
 	}
 }
 
+// Visually-hidden accessible label: removed from the visual layout but kept in the
+// accessibility tree so a state conveyed by colour/shape alone (e.g. a dirty dot) still
+// has text for screen readers. Promoted from ~5 byte-identical scoped copies.
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
 input::placeholder {
 	color: var(--text-tertiary);
 }


### PR DESCRIPTION
## Summary

Closes #1274.

The visually-hidden `.sr-only` block was copied byte-for-byte across five components (`BootSplash`, `UnderlineInput`, `Loading`, `DirtyDot`, and `WorkbenchDetail`). `frontend.md` calls for shared chrome/utilities to live once in `common.scss` (the same pattern already used for `.mono-label`, "Promoted from ~10 byte-identical scoped copies"). This applies that pattern to `.sr-only`.

## Changes

- Add a single `.sr-only` utility to `UI/src/styles/common.scss` (globally imported in `+layout.svelte`).
- Remove the five per-component scoped copies. `DirtyDot.svelte`'s `<style>` block held only that rule, so it's gone entirely.
- Standardize the hidden change-indicator wording to **"Unsaved changes"** — it previously read "Unsaved change" in `DirtyDot` vs "unsaved changes" in `WorkbenchDetail`.

No user-facing visual change — the class definition is identical, just relocated; markup that references `.sr-only` is untouched.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors/warnings
- [x] `npm run test:unit:ci` — 251 files / 2717 tests pass
- No backend or battle-logic changes, so the dotnet suite is unaffected.

## Notes

- `WorkbenchDetail`'s tab dot uses an inline `.tab-dot` + `.sr-only` rather than the shared `DirtyDot` component, because its dot is styled differently (tab-sized) from `DirtyDot`'s `.dirty-dot`. Merging those two indicators would be a visual/behavioural change beyond this DRY cleanup, so it was left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmGvQwDM8MZDe2pDYzSK8v)_