### PR TITLE
Unify tooltip controllers behind shared DescribedTooltipController (#1279)

### DIFF
--- a/UI/src/components/tooltip/attribute-tooltip.svelte.ts
+++ b/UI/src/components/tooltip/attribute-tooltip.svelte.ts
@@ -1,11 +1,7 @@
 import { getContext, setContext } from 'svelte';
 import type { EAttribute, EModifierType } from '$lib/api';
-import {
-	anchorPosition,
-	registerTooltipComponent,
-	type TooltipAnchor,
-	type TooltipComponent
-} from '$stores/tooltip.svelte';
+import { anchorPosition, registerTooltipComponent, type TooltipComponent } from '$stores/tooltip.svelte';
+import type { DescribedTooltipController } from './tooltip-hover';
 
 /** One contributing source skill within a stacked effect, for the tooltip's per-source breakdown.
  *  Applications are aggregated by source (not listed individually) so the breakdown stays bounded by the
@@ -54,16 +50,10 @@ export interface AttributeEffectContext {
  * directly (so the countdown pill stays live); the controller only governs which attribute is shown
  * and where.
  *
- * `show`/`move` accept a {@link TooltipAnchor} — a pointer event (positioned at the cursor) or a
- * focused element (positioned off its box) — so a trigger is reachable by mouse and keyboard alike.
+ * `show`/`move` accept a `TooltipAnchor` — a pointer event (positioned at the cursor) or a focused
+ * element (positioned off its box) — so a trigger is reachable by mouse and keyboard alike.
  */
-export interface AttributeTooltipController {
-	/** Stable DOM id of the shared panel, for wiring a focusable trigger's `aria-describedby`. */
-	readonly describedById: string;
-	show: (attributeId: EAttribute, anchor: TooltipAnchor) => void;
-	move: (anchor: TooltipAnchor) => void;
-	hide: () => void;
-}
+export type AttributeTooltipController = DescribedTooltipController<EAttribute>;
 
 /** The reactive render state of the tooltip plus its {@link AttributeTooltipController}. */
 export interface AttributeTooltipHandle {

--- a/UI/src/components/tooltip/tooltip-hover.ts
+++ b/UI/src/components/tooltip/tooltip-hover.ts
@@ -12,6 +12,16 @@ export interface TooltipHoverController<P> {
 	hide: () => void;
 }
 
+/**
+ * A {@link TooltipHoverController} for a single shared panel that also exposes that panel's stable DOM
+ * id, for wiring a focusable trigger's `aria-describedby` (via the `describedByTooltip` action). The
+ * common shape of the concrete per-surface controllers (attribute pills, words of power).
+ */
+export interface DescribedTooltipController<P> extends TooltipHoverController<P> {
+	/** Stable DOM id of the shared panel, for wiring a focusable trigger's `aria-describedby`. */
+	readonly describedById: string;
+}
+
 export interface TooltipHoverParams<P> {
 	/** The shared tooltip controller, or `undefined` to no-op (a screen may not provide one). */
 	controller: TooltipHoverController<P> | undefined;

--- a/UI/src/routes/game/screens/proficiencies/proficiencies-lexicon.ts
+++ b/UI/src/routes/game/screens/proficiencies/proficiencies-lexicon.ts
@@ -13,7 +13,7 @@
    cross-path it also needs every `prerequisiteId` maxed. A tampered client reading ahead is an accepted
    non-goal. */
 
-import type { TooltipHoverController } from '$components/tooltip/tooltip-hover';
+import type { DescribedTooltipController } from '$components/tooltip/tooltip-hover';
 import type {
 	IPath,
 	IPlayerProficiency,
@@ -82,10 +82,7 @@ export interface PathView {
  *  generic `tooltipHover` action with a {@link TierView} payload. The Proficiencies screen owns the panel
  *  and builds this, then passes it down to the spine cards / inspector (mirroring the challenges reward
  *  tooltip) so they don't thread hover handlers back up. */
-export interface WordTooltipController extends TooltipHoverController<TierView> {
-	/** Stable DOM id of the shared panel, for wiring a focusable card's `aria-describedby`. */
-	readonly describedById: string;
-}
+export type WordTooltipController = DescribedTooltipController<TierView>;
 
 /** The decipher stage for a tier at `level` of `maxLevel`: `undeciphered` below `ceil(maxLevel / 2)`,
  *  `pronunciation` from there up to (but not including) `maxLevel`, `translated` at `maxLevel`. */


### PR DESCRIPTION
## Summary

Follow-up from #1277 (which closed #1252). After the hover actions were consolidated behind the generic `tooltipHover<P>` / `TooltipHoverController<P>`, the two concrete tooltip controllers had become identical in shape — a `TooltipHoverController` plus a duplicated `readonly describedById: string`:

- `AttributeTooltipController` (`components/tooltip/attribute-tooltip.svelte.ts`)
- `WordTooltipController` (`routes/game/screens/proficiencies/proficiencies-lexicon.ts`)

This introduces a shared `DescribedTooltipController<P>` interface (in `components/tooltip/tooltip-hover.ts`, alongside the action/controller it extends) and reduces both concrete controllers to **type aliases** over it, removing the duplicated `describedById` declaration.

## How it addresses the issue

- New `DescribedTooltipController<P> extends TooltipHoverController<P> { readonly describedById: string }` lives next to the action it builds on, exactly as the issue suggested.
- `AttributeTooltipController` (which was structurally `TooltipHoverController<EAttribute>` + `describedById` — its `show(id: EAttribute, anchor)` matches the generic `show`) becomes `type AttributeTooltipController = DescribedTooltipController<EAttribute>`.
- `WordTooltipController` becomes `type WordTooltipController = DescribedTooltipController<TierView>`.
- Removed the now-unused `TooltipHoverController` / `TooltipAnchor` imports left behind.

I used **type aliases** rather than empty `interface … extends … {}` declarations because the project's ESLint config (`typescript-eslint/recommended`) enables `no-empty-object-type`, which would flag an interface with no added members. The aliases are structurally identical and preserve the named types for all existing imports/stubs.

Pure type-level cleanup — no runtime/behaviour change.

## Test plan

- [x] `npm run lint` (ESLint + `svelte-check`) — clean, 0 errors / 0 warnings.
- [x] `npx vitest run src/tests/routes/game/screens/proficiencies/` — 9 files, 113 tests pass (these stub `WordTooltipController` directly, so they exercise the alias).
- [x] Type-check confirms both controllers remain assignable everywhere they're consumed (controllers, contexts, and test stubs).

Closes #1279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ScKRRyZQ7LWr2NmgJ61Lx

---
_Generated by [Claude Code](https://claude.ai/code/session_015ScKRRyZQ7LWr2NmgJ61Lx)_