### PR TITLE
Correct rationale comment on class AttributeDistributions authoring guard

### DIFF
--- a/Game.DataAccess/Repositories/Admin/AdminClasses.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminClasses.cs
@@ -129,10 +129,12 @@ namespace Game.DataAccess.Repositories.Admin
                 return AdminSaveResult.NotFound("Class");
             }
 
-            // Authoring guard: NewPlayerFactory reads these as the class's level-scaled locked base, keyed by
-            // attribute and seeded core-only. A duplicate attribute would throw at character creation (the
-            // downstream ToDictionary), and a non-core distribution would be silently dropped — so both are
-            // rejected here, at save time, rather than surfacing as a 500 or a silent no-op at creation.
+            // Authoring guard: these distributions become the class's level-scaled locked base, folded into the
+            // battler's AttributeCollection at assembly (BattleSnapshot.GetModifiers), which sums per-attribute
+            // modifiers. A duplicate attribute would silently double-count its locked-base modifier, and a
+            // non-core attribute's modifier would silently take effect (while being omitted from the
+            // reward-power heuristic, DefeatRewards.SumCoreAttributes) — neither is intended, so both are
+            // rejected here at save time.
             if (FindAttributeDistributionViolation(data.AttributeDistributions) is { } rejection)
             {
                 return rejection;


### PR DESCRIPTION
## Summary

Corrects the misleading in-code comment justifying the `FindAttributeDistributionViolation` guard in `AdminClasses.SetAttributeDistributions`. The guard is correct and unchanged; only the comment is fixed. Closes #1280.

## The problem

The old comment described two downstream failure modes that **do not exist** in the current code:

1. *"A duplicate attribute would throw at character creation (the downstream `ToDictionary`)."* — There is no attribute-keyed `ToDictionary` on the class-distribution consumption path. `NewPlayerFactory.Create` never reads `AttributeDistributions` (it only seeds zero-amount **core** `StatAllocation` rows). The locked base is consumed in `BattleSnapshot.GetModifiers` (`.Select(d => d.GetDistributionModifier(Level))` + `.Concat`) and folded into `AttributeCollection`, which **sums** per-attribute modifiers. So a duplicate would silently **double-count** the modifier at battler assembly — not throw at creation.
2. *"A non-core distribution would be silently dropped."* — There is no `Where(IsCore)` filter on the consumption path. `GetDistributionModifier` emits a modifier for whatever `AttributeId` is authored, so a non-core distribution is actually **honored / applied** (and only omitted from the reward-power heuristic in `DefeatRewards.SumCoreAttributes`).

## Verification

I confirmed each claim against the code before editing:
- `NewPlayerFactory.cs` — seeds only zero-amount core `StatAllocation` rows; never reads `AttributeDistributions`.
- `BattleSnapshot.cs:231-232` — distributions become locked-base modifiers, no core filter.
- `AttributeDistribution.GetDistributionModifier` — emits a modifier for any `AttributeId`.
- `AttributeCollection` — sums additive per-attribute modifiers (no `ToDictionary`).
- `PlayerStatPoints.cs:30` — the only attribute-keyed `ToDictionary`, on the reallocation path (not creation).
- `DefeatRewards.cs:77` — `SumCoreAttributes` filters core only for the reward-power heuristic.

## New comment

The corrected comment describes the real consequences the guard prevents:
- duplicate attribute → double-counted locked-base modifier at battler assembly;
- non-core attribute → an unintended modifier silently taking effect (and being omitted from the reward-power heuristic).

## Test plan

- [x] `dotnet build Game.DataAccess` succeeds (0 warnings, 0 errors). Comment-only change — no behavior altered, so no test changes are needed.

Closes #1280

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZpfmE23RWWGhyduuEoF2v)_