### PR TITLE
Strengthen Codex projection memoization tests to assert non-recompute (#1288)

### DIFF
--- a/UI/src/tests/routes/game/screens/codex/codex-view.svelte.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/codex-view.svelte.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { flushSync } from 'svelte';
 import {
 	EAttribute,
 	EChallengeType,
@@ -31,7 +32,7 @@ const { staticData, playerChallenges, navigation, statistics } = vi.hoisted(() =
 }));
 vi.mock('$stores', () => ({ staticData, playerChallenges, navigation, statistics }));
 
-import { CodexView } from '$routes/game/screens/codex/codex-view.svelte';
+import { CodexView, type EnemyRowVM, type ZoneProjectionVM } from '$routes/game/screens/codex/codex-view.svelte';
 
 const dist = () => [
 	{ attributeId: EAttribute.Strength, baseAmount: 10, amountPerLevel: 1 },
@@ -257,6 +258,43 @@ describe('CodexView enemy projections', () => {
 		});
 		expect(view.enemyProjections.find((p) => p.id === 0)?.searchText).toContain('emberreach');
 	});
+
+	it('memoizes the projection on a single instance: the same reference survives search / sort / filter changes', () => {
+		// The cross-instance value test above proves the projection's *value* ignores interaction state.
+		// This asserts the actual perf guarantee the projection/row split exists for: on one live instance,
+		// the heavy projection is not rebuilt when the cheap interaction state the rows layer reads moves —
+		// it returns the *same reference*. Run inside an effect root so the deriveds stay live and memoized.
+		const view = new CodexView();
+		let projection: EnemyRowVM[] | undefined;
+		let rows: EnemyRowVM[] | undefined;
+		const cleanup = $effect.root(() => {
+			$effect(() => {
+				projection = view.enemyProjections;
+			});
+			$effect(() => {
+				rows = view.enemyRows;
+			});
+		});
+
+		flushSync();
+		const projectionBefore = projection;
+		const rowsBefore = rows;
+
+		// Mutate the reactive interaction state (`filter`/`search`/`sort` are `$state`) the row layer reads.
+		view.setFilter('boss');
+		view.search = 'griffin';
+		view.sort = 'name';
+		flushSync();
+
+		// The interaction change genuinely moved the reactive graph — the thin row layer recomputed…
+		expect(rows).not.toBe(rowsBefore);
+		expect(rows).toEqual([]); // boss filter + a query that matches nothing
+		// …yet the projection was memoized: the same array reference, never rebuilt.
+		expect(projection).toBe(projectionBefore);
+		expect(view.enemyProjections).toBe(projectionBefore);
+
+		cleanup();
+	});
 });
 
 describe('CodexView enemy search', () => {
@@ -478,11 +516,30 @@ describe('CodexView zone projections', () => {
 		expect(rows[0]).not.toHaveProperty('status');
 	});
 
-	it('stays stable when a zone is cleared or its gate opens (only the status overlay reacts)', () => {
-		const before = new CodexView().zoneProjections;
+	it('memoizes the projection on a single instance: the same reference survives a zone clear / gate open', () => {
+		// Asserts the perf guarantee the projection/row split exists for — not just that two fresh instances
+		// agree by value. On one live instance the heavy O(zones×enemies) projection must return the *same
+		// reference* when the live status the rail overlays moves; only `zoneRows` reacts. Run inside an
+		// effect root so the derived stays live and its memoization (referential identity) holds.
+		const view = new CodexView();
+		let projection: ZoneProjectionVM[] | undefined;
+		const cleanup = $effect.root(() => {
+			$effect(() => {
+				projection = view.zoneProjections;
+			});
+		});
+
+		flushSync();
+		const before = projection;
+
+		// Move only the live status inputs the rail overlays (zone cleared + gate opened) — the projection
+		// reads neither, so it must not be rebuilt.
 		statistics.isZoneCleared.mockImplementation(() => true);
 		playerChallenges.all = [{ challengeId: 0, progress: 100, completed: true }];
-		expect(new CodexView().zoneProjections).toEqual(before);
+		flushSync();
+
+		expect(view.zoneProjections).toBe(before);
+		cleanup();
 	});
 });
 


### PR DESCRIPTION
## Summary

Follow-up from #1283 (closed #1270), which split the Codex `enemyRows`/`zoneRows` into a reference-data-only **projection** derived + a thin interaction-state **row** derived. The whole point of the split is memoization: the heavy projection must not recompute when cheap interaction state (search/sort/filter, zone status) moves.

As #1288 notes, the existing stability tests constructed **two separate `CodexView` instances** and compared by value (`toEqual`). That proves the projection's *value* is independent of interaction state, but not the memoization claim — that a *single* instance's projection derived does not re-run when interaction state changes on that same instance. A fresh `new CodexView()` rebuilds everything, so a cross-instance compare passes even if the derived were (hypothetically) recomputing on every change.

This PR upgrades both projection-stability tests to assert the actual perf guarantee on **one live instance, inside a Svelte effect root**:

- **`zoneProjections`** — replaced the cross-instance value test with a single-instance test: capture the projection in an effect root, then move only the live status inputs the rail overlays (zone cleared + gate opened) and assert the projection is the **same reference** (`toBe`).
- **`enemyProjections`** — added a single-instance test alongside the existing value-independence one. It mutates the genuinely-reactive `$state` interaction inputs (`filter`/`search`/`sort`), asserts the thin `enemyRows` layer **recomputed** (proving the reactive graph actually moved), and asserts `enemyProjections` returned the **same reference** — i.e. the heavy projection was memoized, not rebuilt.

The file was renamed `codex-view.test.ts` → `codex-view.svelte.test.ts` so the runes (`$effect.root`/`$effect`) compile, matching the project convention (every rune-using test in the suite uses the `.svelte.test.ts` infix).

## How it addresses the issue

It closes the exact gap #1288 describes: a single-instance, in-effect-root, referential-identity (`toBe`) assertion across the interaction-state mutation for both projections, directly pinning the memoization guarantee rather than the weaker value-independence. As #1288 flags, severity is low — the memoization is correct by Svelte 5 `$derived` semantics; this only strengthens the regression guard so a future change that accidentally pulls interaction state into a projection would fail.

## Note on scope

The strongest of the two is the **enemy** test: its interaction state (`search`/`sort`/`filter`) is reactive `$state`, so a regression reading it inside `enemyProjections` would dirty the projection and fail the `toBe`. The zone rail's status flows through the `statistics`/`playerChallenges` stores, which are plain (non-reactive) mocks in this suite — so the zone test pins the projection's referential identity across the status change but is a softer guard than the enemy one. Making it as strong would mean reactive store mocks; out of scope here and not worth the harness churn for a low-severity guard.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors / 0 warnings.
- [x] `vitest` codex-view suite — 58 passed (incl. the two new single-instance referential-identity tests).
- [x] Full unit suite — **2718 passed**, coverage floors hold.

Closes #1288

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vd13upnXiJ8dFZ8boj5hSs)_