### PR TITLE
Share decipher-stage glyph/reveal styling across Lexicon surfaces (#1258)

### DIFF
--- a/UI/src/routes/game/screens/proficiencies/TierCard.svelte
+++ b/UI/src/routes/game/screens/proficiencies/TierCard.svelte
@@ -79,6 +79,8 @@ const reveal = $derived(decipherReveal(tier));
 </script>
 
 <style lang="scss">
+@use '../../../../styles/decipher-stage' as decipher;
+
 .tier-row {
 	display: flex;
 	gap: 16px;
@@ -183,46 +185,14 @@ const reveal = $derived(decipherReveal(tier));
 .card-body {
 	flex: 1;
 	min-width: 0;
-}
 
-// Word-of-power illumination by decipher stage. The glyph is the child WordOfPower element, so its
-// classes are reached through `:global()` (anchored under `.card-body` so the rule isn't global-leaky).
-// WordOfPower inherits its colour, so the stage hue drives both the glyph and (via currentColor) its glow.
-.card-body :global(.glyph) {
-	display: block;
-	line-height: 1.05;
-}
-
-.card-body :global(.glyph.stage-undeciphered) {
-	color: var(--text-tertiary);
-}
-
-.card-body :global(.glyph.stage-pronunciation) {
-	color: var(--accent-light);
-}
-
-.card-body :global(.glyph.stage-translated) {
-	color: var(--gold);
+	// Word-of-power illumination by decipher stage (shared with the WordDetail inspector). Anchored
+	// here so the `:global()` glyph rules stay scoped to the card and don't leak global.
+	@include decipher.glyph-illumination;
 }
 
 .reveal {
-	margin-top: 6px;
-	font-family: var(--mono);
-	font-size: 12px;
-	letter-spacing: 0.4px;
-
-	&.stage-undeciphered {
-		color: var(--text-muted);
-		font-style: italic;
-	}
-
-	&.stage-pronunciation {
-		color: var(--accent-light);
-	}
-
-	&.stage-translated {
-		color: var(--gold);
-	}
+	@include decipher.reveal-line;
 }
 
 .meta {

--- a/UI/src/routes/game/screens/proficiencies/WordDetail.svelte
+++ b/UI/src/routes/game/screens/proficiencies/WordDetail.svelte
@@ -114,6 +114,8 @@ const seedName = $derived(tier.seedSkillId !== undefined ? resolveSkill(tier.see
 </script>
 
 <style lang="scss">
+@use '../../../../styles/decipher-stage' as decipher;
+
 .inspector {
 	flex: none;
 	width: 312px;
@@ -201,45 +203,14 @@ const seedName = $derived(tier.seedSkillId !== undefined ? resolveSkill(tier.see
 		outline-offset: 3px;
 		border-radius: var(--border-radius);
 	}
-}
 
-// The glyph is the child WordOfPower element, reached through `:global()` anchored under `.word-block`
-// so the rule stays scoped here. Its colour drives both the glyph and (via currentColor) the glow.
-.word-block :global(.glyph) {
-	display: block;
-	line-height: 1.05;
-}
-
-.word-block :global(.glyph.stage-undeciphered) {
-	color: var(--text-tertiary);
-}
-
-.word-block :global(.glyph.stage-pronunciation) {
-	color: var(--accent-light);
-}
-
-.word-block :global(.glyph.stage-translated) {
-	color: var(--gold);
+	// Word-of-power illumination by decipher stage (shared with the spine TierCard). Anchored here so
+	// the `:global()` glyph rules stay scoped to the inspector and don't leak global.
+	@include decipher.glyph-illumination;
 }
 
 .reveal {
-	margin-top: 6px;
-	font-family: var(--mono);
-	font-size: 12px;
-	letter-spacing: 0.4px;
-
-	&.stage-undeciphered {
-		color: var(--text-muted);
-		font-style: italic;
-	}
-
-	&.stage-pronunciation {
-		color: var(--accent-light);
-	}
-
-	&.stage-translated {
-		color: var(--gold);
-	}
+	@include decipher.reveal-line;
 }
 
 .xp {

--- a/UI/src/styles/_decipher-stage.scss
+++ b/UI/src/styles/_decipher-stage.scss
@@ -1,0 +1,49 @@
+// Decipher-stage illumination shared by the Lexicon surfaces — the spine `TierCard` and the
+// `WordDetail` inspector. Both render a `WordOfPower` glyph that lights dim → accent → gold by
+// decipher stage over a reveal line, so these mixins keep the stage → colour mapping in one place.
+// Mixins rather than a `%placeholder`: the glyph rules must live under a per-surface parent anchor,
+// and `@extend` can't reach a placeholder across the `@use` module boundary.
+
+// Word-of-power illumination by decipher stage. The glyph is a child `WordOfPower` element, reached
+// through `:global()`; `@include` this inside the surface's anchoring parent (`.card-body` /
+// `.word-block`) so the rule stays scoped there rather than leaking global. `WordOfPower` inherits
+// its colour, so the stage hue drives both the glyph and (via currentColor) its glow.
+@mixin glyph-illumination {
+	:global(.glyph) {
+		display: block;
+		line-height: 1.05;
+	}
+
+	:global(.glyph.stage-undeciphered) {
+		color: var(--text-tertiary);
+	}
+
+	:global(.glyph.stage-pronunciation) {
+		color: var(--accent-light);
+	}
+
+	:global(.glyph.stage-translated) {
+		color: var(--gold);
+	}
+}
+
+// The reveal line beneath the glyph; `@include` on the `.reveal` element.
+@mixin reveal-line {
+	margin-top: 6px;
+	font-family: var(--mono);
+	font-size: 12px;
+	letter-spacing: 0.4px;
+
+	&.stage-undeciphered {
+		color: var(--text-muted);
+		font-style: italic;
+	}
+
+	&.stage-pronunciation {
+		color: var(--accent-light);
+	}
+
+	&.stage-translated {
+		color: var(--gold);
+	}
+}


### PR DESCRIPTION
## Summary

Extracts the duplicated decipher-stage **styling** shared by the two Lexicon surfaces — `TierCard.svelte` (spine card) and `WordDetail.svelte` (inspector) — into shared SCSS mixins, so the three-way stage → colour mapping lives in one place. Closes #1258.

The *logic* was already de-duplicated in #1255 (`decipherReveal` in `word-detail.ts`); this finishes the job on the CSS side, which was intentionally left in place at the time because Svelte's scoped styles make sharing awkward.

## How it addresses the issue

New partial `UI/src/styles/_decipher-stage.scss` exposes two mixins:

- **`glyph-illumination`** — the `:global(.glyph.stage-undeciphered|pronunciation|translated)` illumination rules (dim → `--accent-light` → `--gold`), plus the base `:global(.glyph)` block.
- **`reveal-line`** — the `.reveal.stage-*` colour rules over the shared mono typography.

Both surfaces now `@include` them. The glyph mixin is included **inside each surface's own anchoring parent** (`.card-body` in TierCard, `.word-block` in WordDetail) so the `:global()` glyph rules stay scoped exactly as before. The `undeciphered`/`pronunciation`/`translated` → `--text-tertiary`/`--accent-light`/`--gold` mapping now exists in a single file.

This is a **pure refactor** — the compiled CSS is unchanged, so there is no user-facing effect.

## Design notes / decisions

- **Mixins, not a `%placeholder`.** The issue suggested a `%decipher-stage` placeholder, but `@extend` can't reach a placeholder across a `@use` module boundary, and the glyph rules need a per-surface parent anchor (`.card-body` vs `.word-block`). Mixins `@include`d into each parent are the clean fit and produce identical output.
- **Import style.** Uses a relative `@use '../../../../styles/decipher-stage'` to match the one existing precedent (`+layout.svelte`'s `@use '../styles/colors.scss'`), rather than the `$styles` alias.
- **The admin proficiency editor was evaluated and does *not* apply** (the issue's open question). `workbench/progression/ConlangIdentity.svelte`'s "Decipher preview" is a distinct **three-step** preview (separate glyph / pronunciation / translation boxes with their own `--text-muted`/`--text-secondary`/`--text-primary` colours and per-step captions), **not** the single-glyph stage→colour illumination these two Lexicon surfaces share. Folding it in would have meant inventing a shared abstraction over two genuinely different presentations, so it's left as-is.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors / 0 warnings (svelte-check compiles the SCSS and would flag any unused-selector or preprocessing regression).
- [x] `vitest run` over `src/tests/routes/game/screens/proficiencies/` — 113 tests pass.

No new tests: this is a CSS-only refactor with no logic or DOM change, and the existing component tests cover both surfaces.

Closes #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013nDDjWSw3bQpc5pDHF1rAw)_