### PR TITLE
Standardize admin RewardPicker overlay on Popover (#1265)

### DIFF
--- a/UI/src/routes/admin/workbench/components/challenge/ChallengeRewardSection.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/ChallengeRewardSection.svelte
@@ -46,25 +46,31 @@
 		/>
 	</div>
 
-	{#if open === 'item'}
-		<RewardPicker
-			kind="item"
-			records={itemPickRecords}
-			currentId={challenge.rewardItemId}
-			claimed={claimedItems}
-			onPick={setItem}
-			onClose={() => (open = null)}
-		/>
-	{:else if open === 'mod'}
-		<RewardPicker
-			kind="mod"
-			records={modPickRecords}
-			currentId={challenge.rewardItemModId}
-			claimed={claimedMods}
-			onPick={setMod}
-			onClose={() => (open = null)}
-		/>
-	{/if}
+	<Popover
+		open={open !== null}
+		onClose={() => (open = null)}
+		label={open === 'mod' ? 'Select item mod reward' : 'Select item reward'}
+	>
+		{#if open === 'item'}
+			<RewardPicker
+				kind="item"
+				records={itemPickRecords}
+				currentId={challenge.rewardItemId}
+				claimed={claimedItems}
+				onPick={setItem}
+				onClose={() => (open = null)}
+			/>
+		{:else if open === 'mod'}
+			<RewardPicker
+				kind="mod"
+				records={modPickRecords}
+				currentId={challenge.rewardItemModId}
+				claimed={claimedMods}
+				onPick={setMod}
+				onClose={() => (open = null)}
+			/>
+		{/if}
+	</Popover>
 
 	{#if none}
 		<div class="ch-reward-warn">
@@ -76,6 +82,7 @@
 
 <script lang="ts">
 import { ERarity, type IChallenge } from '$lib/api';
+import { Popover } from '$components';
 import { reference } from '../../reference.svelte';
 import type { EntityStore } from '../../entity-store.svelte';
 import type { Identified } from '../../entities/types';

--- a/UI/src/routes/admin/workbench/workbench.scss
+++ b/UI/src/routes/admin/workbench/workbench.scss
@@ -1085,12 +1085,14 @@
 		margin-top: 5px;
 		font-style: italic;
 	}
+	// Centered overlay card (mounted in a Popover), so it owns a fixed width rather
+	// than the in-flow spacing it previously needed below the reward slots.
 	.ch-picker {
-		margin-top: 16px;
+		width: 720px;
+		max-width: 100%;
 		border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
 		border-radius: 8px;
 		overflow: hidden;
-		max-width: 760px;
 		box-shadow: 0 12px 36px color-mix(in srgb, var(--black) 35%, transparent);
 	}
 	.ch-picker-bar {

--- a/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
@@ -148,6 +148,27 @@ describe('ChallengeRewardSection', () => {
 		expect(container.querySelector('.ch-picker')).toBeNull();
 	});
 
+	it('dismisses the picker on Escape without changing the reward (Popover-owned)', async () => {
+		const { store, record, baseline } = setup();
+		const { container } = render(ChallengeRewardSection, { props: { record, baseline, store } });
+		await fireEvent.click(screen.getByText('Choose item…'));
+		expect(container.querySelector('.ch-picker')).toBeTruthy();
+
+		await fireEvent.keyDown(window, { key: 'Escape' });
+		expect(container.querySelector('.ch-picker')).toBeNull();
+		expect((store.items[0] as unknown as IChallenge).rewardItemId).toBeUndefined();
+	});
+
+	it('dismisses the picker on a backdrop click (Popover-owned)', async () => {
+		const { store, record, baseline } = setup();
+		const { container } = render(ChallengeRewardSection, { props: { record, baseline, store } });
+		await fireEvent.click(screen.getByText('Choose item…'));
+		expect(container.querySelector('.ch-picker')).toBeTruthy();
+
+		await fireEvent.click(container.querySelector('.popover-backdrop') as HTMLElement);
+		expect(container.querySelector('.ch-picker')).toBeNull();
+	});
+
 	it('collapses an open picker when the rendered record switches to a different challenge', async () => {
 		// Two sibling challenges in the same store; the section is reused as the detail
 		// pane switches between them, and its $effect must reset the open picker on switch.


### PR DESCRIPTION
## Summary

Moves the admin challenge **reward picker** (`RewardPicker.svelte`, opened from `ChallengeRewardSection.svelte`) from a hand-rolled in-flow overlay — dismissable only via its close button or by re-toggling the slot, with **no Escape handling and no focus management** — onto the shared `components/Popover.svelte` primitive. It now gets backdrop/Escape dismissal, the shared `focusTrap` (Tab-trap + focus capture/restore), and a body scroll lock for free, closing the accessibility gap described in #1265.

Per the owner's decision on the issue (comment: _"Let's go with option 2 for now and fully adopt `Popover`"_), this is the **full `Popover` adoption** — relocating the picker from an in-flow panel below the reward slots to a centered overlay — rather than the lighter-weight in-flow `focusTrap` option.

## How it addresses the issue

- **`ChallengeRewardSection.svelte`** now wraps the conditional `RewardPicker` in a single `<Popover open={open !== null} onClose={…} label={…}>`. The `open` state machine (`'item' | 'mod' | null`) is unchanged, so toggling a slot still opens/closes the right picker and a pick/record-switch still collapses it.
- **`workbench.scss`** — `.ch-picker` swaps its in-flow `margin-top: 16px` for a fixed centered-modal width (`width: 720px; max-width: 100%`); the border/shadow card styling already suited an overlay.
- **No extra positioning wrapper needed.** `Popover` overlays its nearest positioned ancestor, which here is the existing `.admin-shell` (`position: relative; overflow: hidden`) — every intermediate container (`.detail-pane`, `.detail-body`, `.workbench`, `.admin-workspace`) is unpositioned, so the picker centers over the full admin workspace and `.detail-body`'s `overflow-y: auto` doesn't clip it.

## Scan for other inline admin pickers

The issue noted this pattern may apply elsewhere. I scanned the admin tree: `RewardPicker` was the only hand-rolled dismissable overlay. `WorkbenchDetail` and `DeadLetterConsole` already use the modal helpers, and `ScopeField` is a plain select field, not an overlay. Nothing else needs converting.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors / 0 warnings.
- [x] `npm run test:unit:ci` — full suite green (2743 tests).
- [x] Added integration tests to `ChallengeRewardSection.test.ts` covering the two new Popover-owned dismissal paths (Escape closes the picker without mutating the reward; backdrop click closes it). Existing picker open/pick/clear/record-switch tests continue to pass unchanged.

Closes #1265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S83q39142zrEBCqApXLdGw)_