### PR TITLE
Collect dictionary key-type imports in CodeGen (#1304)

### DIFF
--- a/Game.Api.Tests/CodeGen/CodeGenTypeFormatterTests.cs
+++ b/Game.Api.Tests/CodeGen/CodeGenTypeFormatterTests.cs
@@ -288,6 +288,67 @@ namespace Game.Api.Tests.CodeGen
         }
 
         [Fact]
+        public void GetImportTexts_Class_ReturnsSingleImport()
+        {
+            var descriptor = GetPropertyDescriptor<NestedModel>("Child");
+            Assert.Equal(["ISimpleModel"], CodeGenTypeFormatter.GetImportTexts(descriptor));
+        }
+
+        [Fact]
+        public void GetImportTexts_Primitive_ReturnsEmpty()
+        {
+            var descriptor = GetPropertyDescriptor<SimpleModel>("Name");
+            Assert.Empty(CodeGenTypeFormatter.GetImportTexts(descriptor));
+        }
+
+        [Fact]
+        public void GetImportTexts_ListOfClass_ReturnsElementImport()
+        {
+            var descriptor = GetPropertyDescriptor<ModelWithList>("Items");
+            Assert.Equal(["ISimpleModel"], CodeGenTypeFormatter.GetImportTexts(descriptor));
+        }
+
+        [Fact]
+        public void GetImportTexts_DictionaryWithPrimitiveKeyAndValue_ReturnsEmpty()
+        {
+            var descriptor = GetPropertyDescriptor<ModelWithDictionary>("StringToInt");
+            Assert.Empty(CodeGenTypeFormatter.GetImportTexts(descriptor));
+        }
+
+        [Fact]
+        public void GetImportTexts_DictionaryWithClassValue_ReturnsValueImport()
+        {
+            var descriptor = GetPropertyDescriptor<ModelWithDictionary>("StringToClass");
+            Assert.Equal(["ISimpleModel"], CodeGenTypeFormatter.GetImportTexts(descriptor));
+        }
+
+        [Fact]
+        public void GetImportTexts_DictionaryWithEnumKey_IncludesKeyImport()
+        {
+            // The key type is an enum that needs importing; the value is a primitive. The old value-only
+            // collection dropped the key, emitting a Record<TestEnum, number> with no TestEnum import.
+            var descriptor = GetPropertyDescriptor<ModelWithDictionary>("EnumToInt");
+            Assert.Equal(["TestEnum"], CodeGenTypeFormatter.GetImportTexts(descriptor));
+        }
+
+        [Fact]
+        public void GetImportTexts_DictionaryWithEnumKeyAndClassValue_IncludesBothImports()
+        {
+            var descriptor = GetPropertyDescriptor<ModelWithDictionary>("EnumToClass");
+            Assert.Equal(["TestEnum", "ISimpleModel"], CodeGenTypeFormatter.GetImportTexts(descriptor));
+        }
+
+        [Fact]
+        public void GetImportText_Multiple_DictionaryWithEnumKey_ImportsKeyType()
+        {
+            // End-to-end through the import-statement formatter: the enum key must appear in the emitted
+            // import list so the generated Record<TestEnum, number> reference resolves.
+            var descriptors = new[] { GetPropertyDescriptor<ModelWithDictionary>("EnumToInt") };
+            var result = CodeGenTypeFormatter.GetImportText(descriptors);
+            Assert.Contains("TestEnum", result);
+        }
+
+        [Fact]
         public void GetTypeText_UnmappedByte_Throws()
         {
             // byte has no TypeScript mapping and is rejected by NeedsInterface (it is a primitive), so the

--- a/Game.Api.Tests/CodeGen/TestFixtures.cs
+++ b/Game.Api.Tests/CodeGen/TestFixtures.cs
@@ -115,6 +115,8 @@ namespace Game.Api.Tests.CodeGen
         public Dictionary<string, SimpleModel> StringToClass { get; set; } = [];
         public Dictionary<int, string> IntToString { get; set; } = [];
         public Dictionary<string, SimpleModel?> StringToNullableClass { get; set; } = [];
+        public Dictionary<TestEnum, int> EnumToInt { get; set; } = [];
+        public Dictionary<TestEnum, SimpleModel> EnumToClass { get; set; } = [];
     }
 
     [Route("/api/[controller]/[action]")]

--- a/Game.Api/CodeGen/CodeGenTypeFormatter.cs
+++ b/Game.Api/CodeGen/CodeGenTypeFormatter.cs
@@ -7,12 +7,40 @@ namespace Game.Api.CodeGen
     {
         public static string GetImportText(IEnumerable<CodeGenTypeDescriptor> typeDescriptors, string importPath = "./")
         {
-            var typeStrings = typeDescriptors.SelectNotNull(GetImportText).Distinct().OrderBy(t => t).ToList();
+            var typeStrings = typeDescriptors.SelectMany(GetImportTexts).Distinct().OrderBy(t => t).ToList();
             return typeStrings.Count > 3
                 ? $"import type {{{Environment.NewLine}\t{string.Join($",{Environment.NewLine}\t", typeStrings)}{Environment.NewLine}}} from '{importPath}';{Environment.NewLine}"
                 : $"import type {{ {string.Join(", ", typeStrings)} }} from '{importPath}';{Environment.NewLine}";
         }
 
+        /// <summary>
+        /// Every interface/enum import a descriptor's rendered TypeScript type requires, walking through
+        /// enumerable elements and <b>both</b> dictionary type arguments. A <c>Record&lt;K, V&gt;</c> names
+        /// both K and V, so an enum (or otherwise importable) key needs its import collected just like the
+        /// value — collecting only the value would emit an unimported reference and break the frontend build.
+        /// </summary>
+        public static IEnumerable<string> GetImportTexts(CodeGenTypeDescriptor descriptor)
+        {
+            if (descriptor.UnderlyingType.IsEnumerable())
+            {
+                if (descriptor.UnderlyingType.IsDictionary())
+                {
+                    return GetImportTexts(descriptor.GenericArgumentDescriptors[0])
+                        .Concat(GetImportTexts(descriptor.GenericArgumentDescriptors[1]));
+                }
+
+                return GetImportTexts(descriptor.GenericArgumentDescriptors[0]);
+            }
+
+            var leaf = GetLeafImportText(descriptor);
+            return leaf is null ? [] : [leaf];
+        }
+
+        /// <summary>
+        /// A single descriptor's own import name, used as a stable identity key by the interface writer's
+        /// de-duplication. Unlike <see cref="GetImportTexts"/> this collapses a dictionary to its value
+        /// import only, so it must not be used to collect the full import set (see <see cref="GetImportTexts"/>).
+        /// </summary>
         public static string? GetImportText(CodeGenTypeDescriptor descriptor)
         {
             if (descriptor.UnderlyingType.IsEnumerable())
@@ -24,7 +52,15 @@ namespace Game.Api.CodeGen
 
                 return GetImportText(descriptor.GenericArgumentDescriptors[0]);
             }
-            else if (descriptor.IsEnum)
+
+            return GetLeafImportText(descriptor);
+        }
+
+        // The import name for a single non-enumerable descriptor: its enum name, its I-prefixed interface
+        // name, or null when it maps to a primitive that needs no import.
+        private static string? GetLeafImportText(CodeGenTypeDescriptor descriptor)
+        {
+            if (descriptor.IsEnum)
             {
                 return descriptor.TypeName;
             }


### PR DESCRIPTION
## Summary

The TypeScript client codegen renders a `Record<K, V>` for a dictionary wire model but only ever collected the **value** type's import, never the **key**'s. A dictionary keyed by an enum (or any type that `NeedsInterface()`) would emit a `Record<SomeEnum, …>` referencing `SomeEnum` without importing it, silently breaking the frontend build. This is **latent** today — no wire model uses a `Dictionary<,>` — so nothing is broken now; this closes the trap.

Closes #1304.

## How it addresses the issue

The issue suggested concatenating `GetImportText([0])` and `GetImportText([1])` in the dictionary branch. That can't be done literally: the single-descriptor `GetImportText` returns one `string?` and is reused as a **key selector** by `ApiInterfaceWriter`'s `DistinctBy`/`ExceptBy`, so concatenating two import names into one string would produce a garbage dedup key (`"SomeEnumISimpleModel"`). The author's underlying intent — *"the caller already `Distinct()`s and filters nulls"* — points at the collection path, so the fix lives there:

- New **`GetImportTexts(descriptor) : IEnumerable<string>`** — the recursive import collector. It walks the enumerable element and, for a dictionary, **both** type arguments (`Concat` of key and value), returning each leaf's enum/interface import.
- The plural `GetImportText(IEnumerable<…>)` now flows through `SelectMany(GetImportTexts)` instead of `SelectNotNull(GetImportText)`, so a dictionary's key import is collected.
- The single-descriptor **`GetImportText(descriptor) : string?`** is kept unchanged as the single-identity key selector the interface writer's de-duplication relies on, with a doc comment clarifying the split.
- A shared private `GetLeafImportText` keeps the enum/interface leaf logic DRY between the two.

Because no current wire model uses `Dictionary<,>`, the generated output is **unchanged today** — for every non-dictionary descriptor the two paths produce identical results.

## Test plan

- [x] `dotnet build Game.Api.Tests` — clean (0 warnings / 0 errors)
- [x] **New unit tests** in `CodeGenTypeFormatterTests` for `GetImportTexts` (class, primitive→empty, list element, dict with primitive key+value→empty, dict with class value, **dict with enum key → key import included**, dict with enum key + class value → both), plus an end-to-end assertion through the plural `GetImportText` that an enum-keyed dictionary emits the key in the import statement. Two `Dictionary<TestEnum, …>` fixtures added to `ModelWithDictionary`.
- [x] `Game.Api.Tests` full suite — **633 passed**, 0 failed.

## Notes / follow-up

While verifying the issue I found two **parallel, entangled** latent gaps in the same dictionary-on-the-wire path that are out of scope here (fixing one in isolation surfaces the other): `Extensions.NeedsInterface` has the same key-vs-value asymmetry, and `ApiInterfaceWriter` would try to generate a bogus `IDictionary` interface for a `Dictionary<_, IFoo>` descriptor. Filed as a follow-up issue (#1311) rather than expanding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)