### PR TITLE
Deliver skill recipes to client as reference data (#1298)

### DIFF
--- a/Game.Api.Tests/Integration/ReferenceDataSocketTests.cs
+++ b/Game.Api.Tests/Integration/ReferenceDataSocketTests.cs
@@ -107,6 +107,43 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task GetSkillRecipes_ReturnsSeededSkillRecipesWithInputsAndConditions()
+        {
+            int userId, recipeId, resultSkillId, inputSkillId, proficiencyId;
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                resultSkillId = (await TestDataSeeder.CreateSkillAsync(context, "RefSynthResult",
+                    acquisition: ESkillAcquisition.Synthesis)).Id;
+                inputSkillId = (await TestDataSeeder.CreateSkillAsync(context, "RefSynthInput")).Id;
+                proficiencyId = (await TestDataSeeder.CreateProficiencyAsync(context, "RefSynthGate")).Id;
+                recipeId = (await TestDataSeeder.CreateSkillRecipeAsync(context, resultSkillId, [inputSkillId],
+                    [(proficiencyId, 3)])).Id;
+
+                var user = await TestDataSeeder.CreateUserAsync(context, "recipesocketuser", "recipesocketpass");
+                await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+                userId = user.Id;
+            }
+
+            await ReloadReferenceCachesAsync();
+            await LoginAsync("recipesocketuser", "recipesocketpass");
+
+            await using var socketClient = await ConnectAsync(userId);
+
+            var response = await socketClient.SendCommandAsync<List<SkillRecipe>>("GetSkillRecipes");
+
+            Assert.Null(response.Error);
+            Assert.NotNull(response.Data);
+            var recipe = Assert.Single(response.Data, r => r.Id == recipeId);
+            Assert.Equal(resultSkillId, recipe.ResultSkillId);
+            Assert.Equal([inputSkillId], recipe.InputSkillIds);
+            var condition = Assert.Single(recipe.Conditions);
+            Assert.Equal(proficiencyId, condition.ProficiencyId);
+            Assert.Equal(3, condition.MinLevel);
+            Assert.Null(recipe.RetiredAt);
+        }
+
+        [Fact]
         public async Task GetItems_ReturnsSeededItems()
         {
             var userId = await SeedReferenceDataAndLoginAsync();
@@ -322,7 +359,7 @@ namespace Game.Api.Tests.Integration
             // One entry per Get* reference-data command the loading screen pulls.
             Assert.Equal(
                 ["GetAttributes", "GetChallengeTypes", "GetChallenges", "GetClasses", "GetEnemies", "GetItemMods",
-                 "GetItems", "GetPaths", "GetProficiencies", "GetSkills", "GetStatisticTypes", "GetZones"],
+                 "GetItems", "GetPaths", "GetProficiencies", "GetSkillRecipes", "GetSkills", "GetStatisticTypes", "GetZones"],
                 response.Data.Select(v => v.Command).OrderBy(c => c, StringComparer.Ordinal));
             Assert.All(response.Data, v => Assert.False(string.IsNullOrEmpty(v.Version)));
         }

--- a/Game.Api/Sockets/Commands/GetSkillRecipes.cs
+++ b/Game.Api/Sockets/Commands/GetSkillRecipes.cs
@@ -1,0 +1,29 @@
+using Game.Abstractions.Contracts;
+using Game.Abstractions.DataAccess;
+
+namespace Game.Api.Sockets.Commands
+{
+    /// <summary>
+    /// Serves the full skill-synthesis recipe reference-data set over the socket (spike #1125). The client
+    /// derives each recipe's availability and hint state from this set plus the player's owned skills and
+    /// proficiency levels, so no separate player-data command is needed.
+    /// </summary>
+    public class GetSkillRecipes : AbstractReferenceDataCommand<SkillRecipe>
+    {
+        private readonly ISkillRecipes _skillRecipes;
+
+        public override string Name { get; set; } = nameof(GetSkillRecipes);
+
+        public GetSkillRecipes(ISkillRecipes skillRecipes)
+        {
+            _skillRecipes = skillRecipes;
+        }
+
+        protected override IEnumerable<SkillRecipe> GetReferenceData()
+        {
+            return _skillRecipes.AllSkillRecipes();
+        }
+
+        protected override object VersionKey => _skillRecipes.VersionKey;
+    }
+}

--- a/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
+++ b/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
@@ -107,6 +107,29 @@ namespace Game.TestInfrastructure.Helpers
             return skill;
         }
 
+        /// <summary>
+        /// Seeds a skill-synthesis recipe producing <paramref name="resultSkillId"/> from the given
+        /// <paramref name="inputSkillIds"/>, with optional proficiency-level conditions.
+        /// </summary>
+        public static async Task<SkillRecipe> CreateSkillRecipeAsync(
+            GameContext context,
+            int resultSkillId,
+            IEnumerable<int> inputSkillIds,
+            IEnumerable<(int ProficiencyId, int MinLevel)>? conditions = null)
+        {
+            var recipe = new SkillRecipe { ResultSkillId = resultSkillId };
+            context.SkillRecipes.Add(recipe);
+            await context.SaveChangesAsync();
+
+            context.SkillRecipeInputs.AddRange(inputSkillIds.Select(skillId =>
+                new SkillRecipeInput { RecipeId = recipe.Id, SkillId = skillId }));
+            context.SkillRecipeConditions.AddRange((conditions ?? []).Select(c =>
+                new SkillRecipeCondition { RecipeId = recipe.Id, ProficiencyId = c.ProficiencyId, MinLevel = c.MinLevel }));
+            await context.SaveChangesAsync();
+
+            return recipe;
+        }
+
         public static async Task<Item> CreateItemAsync(
             GameContext context,
             string name = "Test Item",

--- a/UI/src/lib/api/types/api-socket-type-map.ts
+++ b/UI/src/lib/api/types/api-socket-type-map.ts
@@ -33,6 +33,7 @@ import type {
 	IServerCommandFailedModel,
 	ISetItemFavoriteRequest,
 	ISkill,
+	ISkillRecipe,
 	IStatisticType,
 	IZone
 } from './';
@@ -58,6 +59,7 @@ export type ApiSocketResponseTypes = {
 	'GetPlayerStatistics': IPlayerStatistic[];
 	'GetProficiencies': IProficiency[];
 	'GetReferenceDataVersions': IReferenceDataVersion[];
+	'GetSkillRecipes': ISkillRecipe[];
 	'GetSkills': ISkill[];
 	'GetStatisticTypes': IStatisticType[];
 	'GetZones': IZone[];

--- a/UI/src/lib/engine/reference-data.ts
+++ b/UI/src/lib/engine/reference-data.ts
@@ -135,6 +135,13 @@ export const REFERENCE_DATA: RefDataSource[] = [
 		'GetClasses',
 		() => staticData.classes,
 		(d) => (staticData.classes = d)
+	),
+	refSource(
+		'skillRecipes',
+		'Skill Recipes',
+		'GetSkillRecipes',
+		() => staticData.skillRecipes,
+		(d) => (staticData.skillRecipes = d)
 	)
 ];
 

--- a/UI/src/stores/static-data.svelte.ts
+++ b/UI/src/stores/static-data.svelte.ts
@@ -9,6 +9,7 @@ import {
 	IPath,
 	IProficiency,
 	ISkill,
+	ISkillRecipe,
 	IStatisticType,
 	IZone
 } from '$lib/api';
@@ -25,6 +26,7 @@ let statisticTypes = $state<IStatisticType[]>();
 let proficiencies = $state<IProficiency[]>();
 let paths = $state<IPath[]>();
 let classes = $state<IClass[]>();
+let skillRecipes = $state<ISkillRecipe[]>();
 
 /* The backing `$state` slots are genuinely `undefined` until the loading screen (or the silent
    session-resume path) populates them, so the getters honestly expose `T[] | undefined` rather than
@@ -104,6 +106,12 @@ export const staticData = {
 	set classes(value: IClass[] | undefined) {
 		classes = value;
 	},
+	get skillRecipes(): ISkillRecipe[] | undefined {
+		return skillRecipes;
+	},
+	set skillRecipes(value: ISkillRecipe[] | undefined) {
+		skillRecipes = value;
+	},
 	get loaded(): boolean {
 		return [
 			zones,
@@ -117,7 +125,8 @@ export const staticData = {
 			statisticTypes,
 			proficiencies,
 			paths,
-			classes
+			classes,
+			skillRecipes
 		].every((set) => set != null);
 	}
 };

--- a/UI/src/tests/lib/engine/reference-data.test.ts
+++ b/UI/src/tests/lib/engine/reference-data.test.ts
@@ -42,7 +42,8 @@ const SETS = [
 	'statisticTypes',
 	'proficiencies',
 	'paths',
-	'classes'
+	'classes',
+	'skillRecipes'
 ];
 
 const COMMANDS = [
@@ -57,7 +58,8 @@ const COMMANDS = [
 	'GetStatisticTypes',
 	'GetProficiencies',
 	'GetPaths',
-	'GetClasses'
+	'GetClasses',
+	'GetSkillRecipes'
 ];
 
 /** Builds the GetReferenceDataVersions payload, defaulting every set to "v1". */

--- a/UI/src/tests/routes/loading/loading-view.test.ts
+++ b/UI/src/tests/routes/loading/loading-view.test.ts
@@ -47,7 +47,8 @@ const SETS = [
 	'statisticTypes',
 	'proficiencies',
 	'paths',
-	'classes'
+	'classes',
+	'skillRecipes'
 ];
 
 const COMMANDS = [
@@ -62,7 +63,8 @@ const COMMANDS = [
 	'GetStatisticTypes',
 	'GetProficiencies',
 	'GetPaths',
-	'GetClasses'
+	'GetClasses',
+	'GetSkillRecipes'
 ];
 
 /** Builds the GetReferenceDataVersions payload, defaulting every set to "v1". */

--- a/UI/src/tests/stores/static-data.test.ts
+++ b/UI/src/tests/stores/static-data.test.ts
@@ -15,7 +15,8 @@ const SLOTS = [
 	'statisticTypes',
 	'proficiencies',
 	'paths',
-	'classes'
+	'classes',
+	'skillRecipes'
 ] as const;
 
 const clearAll = () => {


### PR DESCRIPTION
## Summary

Implements the client reference-data delivery for skill synthesis (spike #1125, **area D**). It builds on the `SkillRecipe` reference-data foundation merged in #1295, which already provides the cache holder, contract projection (`ISkillRecipes.AllSkillRecipes()`), and version key — so this change is the thin delivery layer that puts that set on the wire and into the client's cached static data.

## How it addresses the issue

- **`GetSkillRecipes` socket command** — a new `AbstractReferenceDataCommand<SkillRecipe>` mirroring `GetSkills`, served over the authenticated socket and version-keyed off `ISkillRecipes.VersionKey`. The reference-data assembly scan picks it up automatically, so it's included in `GetReferenceDataVersions` (the per-set content hash) with no extra wiring.
- **Codegen contracts** — regenerated the TypeScript client. `ISkillRecipe`/`ISkillRecipeCondition` already existed (the admin HTTP authoring path emits them), so the only generated delta is the `'GetSkillRecipes': ISkillRecipe[]` socket-response-map entry.
- **`staticData` slot** — a `skillRecipes` slot added to the static-data store (getter/setter + `loaded` set), and a `skillRecipes` row in `REFERENCE_DATA`, so the loading screen and the silent session-resume path version-check, download-on-change, and locally cache the set exactly like every other reference set.
- **No separate player-data command** — per the issue, recipe availability + hint state is derived client-side from this set plus the player's already-delivered owned skills and proficiency levels. That derivation lands in the synthesis screen / feedback sub-issues (#1300, #1301), not here.

The admin Workbench reference loader (`reference.svelte.ts`) is deliberately left untouched — wiring recipes into the authoring picker set is the recipe-editor sub-issue (#1299), not this delivery.

## Test plan

- [x] **Backend integration** (`ReferenceDataSocketTests`) — new `GetSkillRecipes_ReturnsSeededSkillRecipesWithInputsAndConditions` (self-contained seed → command returns the recipe with its inputs/conditions/result), and the `GetReferenceDataVersions` exact-command-set assertion extended to include `GetSkillRecipes`. Full class green (16 tests). Added a `TestDataSeeder.CreateSkillRecipeAsync` helper.
- [x] **Frontend unit** — `static-data`, `reference-data` (version-key cache invalidation / hydrate), and `loading-view` set lists extended to cover `skillRecipes`/`GetSkillRecipes`. Full suite green (2755 tests).
- [x] `dotnet format --verify-no-changes` clean; `npm run lint` (ESLint + svelte-check) clean; codegen produces no unexpected drift.

Closes #1298

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvxGyQnwxBUDxWccch1zHJ)_