### PR TITLE
Use $styles alias for _decipher-stage.scss @use imports (#1308)

### DIFF
--- a/UI/src/routes/game/screens/proficiencies/TierCard.svelte
+++ b/UI/src/routes/game/screens/proficiencies/TierCard.svelte
@@ -79,7 +79,7 @@ const reveal = $derived(decipherReveal(tier));
 </script>
 
 <style lang="scss">
-@use '../../../../styles/decipher-stage' as decipher;
+@use '$styles/decipher-stage' as decipher;
 
 .tier-row {
 	display: flex;

--- a/UI/src/routes/game/screens/proficiencies/WordDetail.svelte
+++ b/UI/src/routes/game/screens/proficiencies/WordDetail.svelte
@@ -114,7 +114,7 @@ const seedName = $derived(tier.seedSkillId !== undefined ? resolveSkill(tier.see
 </script>
 
 <style lang="scss">
-@use '../../../../styles/decipher-stage' as decipher;
+@use '$styles/decipher-stage' as decipher;
 
 .inspector {
 	flex: none;


### PR DESCRIPTION
## Summary

Switches the two Lexicon/proficiency surfaces that import the shared decipher-stage partial (extracted in #1303) from a deep four-level relative path to the established `$styles` alias:

```scss
- @use '../../../../styles/decipher-stage' as decipher;
+ @use '$styles/decipher-stage' as decipher;
```

in `TierCard.svelte` and `WordDetail.svelte`.

## How it addresses the issue

The `$styles` alias (`svelte.config.js` → `$styles: './src/styles'`) is the project's convention and is already used elsewhere (`+layout.svelte`: `import '$styles/common.scss'`). The `../../../../` climb was fragile (breaks if either component moves) and less readable. Both `@use` statements now use the alias.

## Verification

The issue's open question was whether the SCSS preprocessor resolves the `$styles` alias inside a `@use` (the alias previously only appeared in a JS `import`, never an SCSS `@use`). Confirmed it does — note this is the first SCSS `@use` in the codebase to reference an alias:

- [x] `npm run build` — production build succeeds (SCSS compiles, alias resolves through `vitePreprocess`).
- [x] `npm run lint` — ESLint clean; `svelte-check` clean (1085 files, 0 errors, 0 warnings).

No tests added: this is a styling-only change with no logic, per the project's testing guidelines for non-interactive display.

Closes #1308

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qa21wQ6DDu6ZWtk1FvwJTy)_