### PR TITLE
Harden the dictionary-on-the-wire CodeGen path (#1311)

### DIFF
--- a/Game.Api.Tests/CodeGen/ApiInterfaceWriterTests.cs
+++ b/Game.Api.Tests/CodeGen/ApiInterfaceWriterTests.cs
@@ -175,6 +175,31 @@ namespace Game.Api.Tests.CodeGen
         }
 
         [Fact]
+        public void WriteApiInterfaces_DictionaryWireModel_GeneratesLeafTypesNotContainerInterface()
+        {
+            var writer = new ApiInterfaceWriter(_options);
+            var descriptor = GetDescriptorForClass<ModelWithDictionary>();
+
+            writer.WriteApiInterfaces([descriptor], "// Auto-generated");
+
+            var interfaceFiles = Directory.GetFiles(Path.Combine(_options.TargetDirectory, "interfaces"), "*.ts");
+            var interfaceContent = string.Join(Environment.NewLine, interfaceFiles.Select(File.ReadAllText));
+            var enumContent = File.ReadAllText(Path.Combine(_options.TargetDirectory, "enums.ts"));
+            var allContent = interfaceContent + Environment.NewLine + enumContent;
+
+            // The leaf type arguments become real types...
+            Assert.Contains("export interface ISimpleModel {", interfaceContent);
+            Assert.Contains("export enum TestEnum {", enumContent);
+            // ...the owning model renders the dictionaries as Records referencing those leaves...
+            Assert.Contains("export interface IModelWithDictionary {", interfaceContent);
+            Assert.Contains("Record<TestEnum, number>", interfaceContent);
+            Assert.Contains("Record<TestEnum, ISimpleModel>", interfaceContent);
+            // ...but the Dictionary<,> container itself is never emitted as an interface or its own file.
+            Assert.DoesNotContain("IDictionary", allContent);
+            Assert.False(File.Exists(Path.Combine(_options.TargetDirectory, "interfaces", "dictionary.ts")));
+        }
+
+        [Fact]
         public void WriteApiInterfaces_RemovesStaleFiles()
         {
             var interfacesDir = Path.Combine(_options.TargetDirectory, "interfaces");

--- a/Game.Api.Tests/CodeGen/CodeGenExtensionsTests.cs
+++ b/Game.Api.Tests/CodeGen/CodeGenExtensionsTests.cs
@@ -224,6 +224,26 @@ namespace Game.Api.Tests.CodeGen
             Assert.False(typeof(Dictionary<string, int>).NeedsInterface());
         }
 
+        [Fact]
+        public void NeedsInterface_DictionaryWithEnumKey_ReturnsTrue()
+        {
+            // The key needs an import even though the value does not; checking only the value would
+            // under-report this (the asymmetry that mirrored the dropped-key-import trap).
+            Assert.True(typeof(Dictionary<TestEnum, int>).NeedsInterface());
+        }
+
+        [Fact]
+        public void NeedsInterface_DictionaryWithClassKey_ReturnsTrue()
+        {
+            Assert.True(typeof(Dictionary<SimpleModel, int>).NeedsInterface());
+        }
+
+        [Fact]
+        public void NeedsInterface_DictionaryWithEnumKeyAndClassValue_ReturnsTrue()
+        {
+            Assert.True(typeof(Dictionary<TestEnum, SimpleModel>).NeedsInterface());
+        }
+
         [Theory]
         [InlineData("HelloWorld", "helloWorld")]
         [InlineData("A", "a")]

--- a/Game.Api/CodeGen/Extensions.cs
+++ b/Game.Api/CodeGen/Extensions.cs
@@ -60,7 +60,11 @@ namespace Game.Api.CodeGen
             {
                 if (type.IsDictionary())
                 {
-                    return type.GetGenericArguments()[1].NeedsInterface();
+                    // Both the key and value can need an import (e.g. an enum key), so consider both —
+                    // matching GetImportTexts, which collects both type arguments. Checking only the value
+                    // would under-report a dictionary keyed by a type that NeedsInterface.
+                    var arguments = type.GetGenericArguments();
+                    return arguments[0].NeedsInterface() || arguments[1].NeedsInterface();
                 }
 
                 return type.GetGenericArguments()[0].NeedsInterface();

--- a/Game.Api/CodeGen/Writers/ApiInterfaceWriter.cs
+++ b/Game.Api/CodeGen/Writers/ApiInterfaceWriter.cs
@@ -34,9 +34,14 @@ namespace Game.Api.CodeGen.Writers
                 Directory.CreateDirectory(interfacesDir);
             }
 
+            // Enumerable/dictionary descriptors are containers, not named types: only their leaf type
+            // arguments (collected separately by GetAllUsedDescriptors) become files. Excluding them here
+            // stops a Dictionary<,>/List<> descriptor — whose NeedsInterface tracks its element/value —
+            // from emitting a bogus IDictionary/IList interface and colliding with the real leaf in the
+            // DistinctBy identity. Relying on enumeration order to drop the container was always fragile.
             var allDescriptors = descriptors
                 .SelectMany(GetAllUsedDescriptors)
-                .Where(d => d.NeedsInterface)
+                .Where(d => d.NeedsInterface && !d.UnderlyingType.IsEnumerable())
                 .DistinctBy(CodeGenTypeFormatter.GetImportText);
 
             // Materialized once: the grouping is enumerated by the foreach below and again by


### PR DESCRIPTION
## Summary

Closes the two entangled latent gaps in the dictionary-on-the-wire codegen path identified as follow-ups to #1304 / PR #1310. Both are latent today (no wire model uses a `Dictionary<,>` — `grep` over `Game.Api/Models` and `Game.Abstractions/Contracts` finds none), so this is hardening, not a live-bug fix. The regenerated TypeScript client is byte-identical (zero drift).

## How it addresses the issue

**2. `ApiInterfaceWriter` would emit a bogus `IDictionary` interface (the primary fix)**

`WriteApiInterfaces` now excludes enumerable/dictionary descriptors when selecting which descriptors become interface/enum files:

```csharp
.Where(d => d.NeedsInterface && !d.UnderlyingType.IsEnumerable())
```

A `Dictionary<,>`/`List<>` descriptor is a *container*, not a named type — only its leaf type arguments (already collected separately by `GetAllUsedDescriptors`) should become files. Previously a `Dictionary<_, IFoo>` descriptor passed `NeedsInterface` (value is a class) and was dropped only because its `DistinctBy(GetImportText)` identity (its value import, `IFoo`) happened to collide with the real `IFoo` leaf, which enumeration order placed first. That ordering reliance was fragile and, once fix #1 below pulled more dictionary descriptors through the filter, would have generated a nonsense `IDictionary` interface and risked dropping the genuine `IFoo`. `IsEnumerable()` covers both lists and dictionaries (a dictionary is a generic `IEnumerable`), so both container kinds are now excluded explicitly. The leaf enum/class files are unaffected — they are reached through the descriptor's generic-argument walk.

**1. `NeedsInterface` key-vs-value asymmetry**

`NeedsInterface`'s dictionary branch now considers both type arguments:

```csharp
var arguments = type.GetGenericArguments();
return arguments[0].NeedsInterface() || arguments[1].NeedsInterface();
```

It previously checked only the value (`[1]`), so `Dictionary<TestEnum, int>` reported `NeedsInterface == false` even though the enum key needs an import. The key import was still defended today because the map writers independently walk the generic arguments (`GetSelfAndGenericArgumentReferences` / `GetImportTexts`), but the asymmetry was the same trap as #1304. This aligns `NeedsInterface` with `GetImportTexts` (added in #1310), which already collects both. With fix #2 in place, the extra dictionary descriptors this pulls through the map-writer filters contribute only their (deduped) key/value imports and never an `IDictionary` interface.

### Why they're entangled

Fixing #1 alone makes more dictionary descriptors pass `NeedsInterface`, which directly worsens #2. So #2 (teaching the interface writer to treat a dictionary/enumerable descriptor as a container) is the load-bearing change and is applied first.

## Test plan

- [x] **Unit (`CodeGenExtensionsTests`)** — `NeedsInterface` now returns `true` for `Dictionary<TestEnum, int>` (enum key), `Dictionary<SimpleModel, int>` (class key), and `Dictionary<TestEnum, SimpleModel>`; the existing primitive-key/value cases still return `false`.
- [x] **End-to-end (`ApiInterfaceWriterTests`)** — a `Dictionary` wire model (`ModelWithDictionary`) driven through `WriteApiInterfaces` asserts `TestEnum` and `ISimpleModel` are emitted, the `Record<TestEnum, number>` / `Record<TestEnum, ISimpleModel>` references resolve, and **no** `IDictionary` interface or file is produced.
- [x] `GetImportTexts` enum-key/both-import coverage already exists from #1310 and stays green.
- [x] Full `Game.Api.Tests` codegen suite green (637 tests); `dotnet format --verify-no-changes` clean on `Game.Api` and `Game.Api.Tests`.
- [x] Codegen regenerated (`dotnet run --project Game.Api -- codegen`) with **no drift**.

Closes #1311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGedoKoPWTh81cyPj3dqT5)_