### PR TITLE
Widen Workbench ChipsSectionConfig to carry typed catalogue meta (#1321)

### DIFF
--- a/UI/src/routes/admin/workbench/entities/class.ts
+++ b/UI/src/routes/admin/workbench/entities/class.ts
@@ -3,7 +3,7 @@ import { hasFlag } from '$lib/common';
 import { reference } from '../reference.svelte';
 import { childChanged, persistEntity } from '../save-helpers';
 import { firstFree } from './helpers';
-import type { EntityConfig } from './types';
+import { chipsSection, type EntityConfig } from './types';
 
 /**
  * A class with its optional signature-passive scaling attribute widened to a plain number so the select can
@@ -117,7 +117,7 @@ export const classEntity: EntityConfig<WorkbenchClass> = {
 				{ key: 'passiveScalingAmount', label: 'Scaling Amount', type: 'number', width: 150, allowNegative: true }
 			]
 		},
-		{
+		chipsSection<WorkbenchClass>()({
 			key: 'starterSkills',
 			label: 'Starter Skills',
 			glyph: 'rune',
@@ -131,12 +131,12 @@ export const classEntity: EntityConfig<WorkbenchClass> = {
 			catalogue: () =>
 				reference.skillCatalogue().map((s) => ({ ...s, addable: hasFlag(s.acquisition, ESkillAcquisition.Player) })),
 			labelOf: (s) => s.name,
-			metaOf: (s) => `${(s as unknown as { baseDamage: number }).baseDamage} dmg`,
+			metaOf: (s) => `${s.baseDamage} dmg`,
 			emptyIcon: 'rune',
 			emptyTitle: 'No starter skills',
 			emptySub: 'This class grants no skills at creation.',
 			addLabel: 'Add starter skill…'
-		},
+		}),
 		{
 			key: 'starterEquipment',
 			label: 'Starter Equipment',

--- a/UI/src/routes/admin/workbench/entities/enemy.ts
+++ b/UI/src/routes/admin/workbench/entities/enemy.ts
@@ -4,7 +4,7 @@ import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import { childChanged, persistEntity } from '../save-helpers';
 import { firstFree } from './helpers';
-import type { EntityConfig } from './types';
+import { chipsSection, type EntityConfig } from './types';
 
 /** An enemy plus the zones it is the dedicated boss of, derived from the zones' boss FK. */
 export interface WorkbenchEnemy extends IEnemy {
@@ -112,7 +112,7 @@ export const enemyEntity: EntityConfig<WorkbenchEnemy> = {
 				{ key: 'amountPerLevel', label: 'Per Level', type: 'number', align: 'r', width: 110, allowNegative: true }
 			]
 		},
-		{
+		chipsSection<WorkbenchEnemy>()({
 			key: 'skills',
 			label: 'Skills',
 			glyph: 'rune',
@@ -126,12 +126,12 @@ export const enemyEntity: EntityConfig<WorkbenchEnemy> = {
 			catalogue: () =>
 				reference.skillCatalogue().map((s) => ({ ...s, addable: hasFlag(s.acquisition, ESkillAcquisition.Enemy) })),
 			labelOf: (s) => s.name,
-			metaOf: (s) => `${(s as unknown as { baseDamage: number }).baseDamage} dmg`,
+			metaOf: (s) => `${s.baseDamage} dmg`,
 			emptyIcon: 'rune',
 			emptyTitle: 'No skills in pool',
 			emptySub: "Enemies with no skills can't act in battle.",
 			addLabel: 'Add skill from pool…'
-		},
+		}),
 		{
 			key: 'spawns',
 			label: 'Spawns',

--- a/UI/src/routes/admin/workbench/entities/skill-recipe.ts
+++ b/UI/src/routes/admin/workbench/entities/skill-recipe.ts
@@ -2,7 +2,7 @@ import { ApiRequest, fetchSocketData, type ISkillRecipe } from '$lib/api';
 import { reference } from '../reference.svelte';
 import { childChanged, persistEntity } from '../save-helpers';
 import { firstFree } from './helpers';
-import type { EntityConfig } from './types';
+import { chipsSection, type EntityConfig } from './types';
 
 /**
  * The admin Workbench editor for skill-synthesis recipes (spike #1125, area A). A recipe is nameless
@@ -66,7 +66,7 @@ export const skillRecipeEntity: EntityConfig<ISkillRecipe> = {
 				}
 			]
 		},
-		{
+		chipsSection<ISkillRecipe>()({
 			key: 'inputs',
 			label: 'Inputs',
 			glyph: 'box',
@@ -84,12 +84,12 @@ export const skillRecipeEntity: EntityConfig<ISkillRecipe> = {
 			// can't be newly added (the backend rejects a retired input too).
 			catalogue: () => reference.skillCatalogue().map((s) => ({ ...s, addable: !s.retired })),
 			labelOf: (s) => s.name,
-			metaOf: (s) => `${(s as unknown as { baseDamage: number }).baseDamage} dmg`,
+			metaOf: (s) => `${s.baseDamage} dmg`,
 			emptyIcon: 'box',
 			emptyTitle: 'No input skills',
 			emptySub: 'A recipe combines at least one owned skill.',
 			addLabel: 'Add input skill…'
-		},
+		}),
 		{
 			key: 'conditions',
 			label: 'Conditions',

--- a/UI/src/routes/admin/workbench/entities/types.ts
+++ b/UI/src/routes/admin/workbench/entities/types.ts
@@ -121,22 +121,48 @@ export interface TableSectionConfig<T> extends BaseSection<T> {
 	columns: ColumnConfig[];
 }
 
-export interface ChipsSectionConfig<T> extends BaseSection<T> {
+/**
+ * The minimum a `chips` catalogue entry carries — what the renderer itself needs (id to key/match a
+ * chip, name to fall back on, retired/addable to style and gate the add-list). A section may supply a
+ * wider entry (see {@link ChipsSectionConfig}'s `E`) so `labelOf`/`metaOf` can read extra meta fields.
+ */
+export interface ChipCatalogueEntry {
+	id: number;
+	name: string;
+	retired?: boolean;
+	addable?: boolean;
+}
+
+export interface ChipsSectionConfig<T, E extends ChipCatalogueEntry = ChipCatalogueEntry> extends BaseSection<T> {
 	kind: 'chips';
 	itemsKey: keyof T & string;
 	/**
 	 * Catalogue of addable entries. A `retired` entry, or one with `addable: false` (e.g. a skill not
 	 * flagged for this channel), stays available for display of an already-assigned chip but can't be
-	 * newly added.
+	 * newly added. `E` lets a section declare a richer entry shape that its `labelOf`/`metaOf` read.
 	 */
-	catalogue: () => { id: number; name: string; retired?: boolean; addable?: boolean }[];
-	labelOf: (entry: { id: number; name: string }) => string;
-	metaOf: (entry: { id: number; name: string }) => string;
+	catalogue: () => E[];
+	// Method shorthand (not arrow properties) so the entry parameter is compared bivariantly: a section
+	// built on a wider `E` stays assignable to the base `ChipsSectionConfig<T>` the renderer consumes.
+	labelOf(entry: E): string;
+	metaOf(entry: E): string;
 	emptyIcon: WorkbenchIconKind;
 	emptyTitle: string;
 	emptySub: string;
 	addLabel: string;
 }
+
+/**
+ * Builds a {@link ChipsSectionConfig} whose catalogue carries entity-specific meta (e.g. a skill's
+ * `baseDamage`), inferring the entry type `E` from `catalogue` so `labelOf`/`metaOf` read those fields
+ * type-safely — no casting back through `as unknown as`. Curried so the record type `T` is given
+ * explicitly while `E` is inferred. The result erases `E` to the base entry for storage in the record's
+ * section list; the renderer only needs the base contract.
+ */
+export const chipsSection =
+	<T>() =>
+	<E extends ChipCatalogueEntry>(section: ChipsSectionConfig<T, E>): ChipsSectionConfig<T> =>
+		section;
 
 export interface TagsSectionConfig<T> extends BaseSection<T> {
 	kind: 'tags';

--- a/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
@@ -11,14 +11,22 @@ interface Row extends Identified {
 	skillPool: number[];
 }
 
-const CATALOGUE: { id: number; name: string; baseDamage: number; retired?: boolean }[] = [
+interface SkillEntry {
+	id: number;
+	name: string;
+	baseDamage: number;
+	retired?: boolean;
+}
+
+const CATALOGUE: SkillEntry[] = [
 	{ id: 1, name: 'Cleave', baseDamage: 12 },
 	{ id: 2, name: 'Fireball', baseDamage: 25 },
 	{ id: 3, name: 'Heal', baseDamage: 0 },
 	{ id: 4, name: 'Smite', baseDamage: 18, retired: true }
 ];
 
-const section: ChipsSectionConfig<Row> = {
+// Declaring the catalogue entry type lets `metaOf` read `baseDamage` directly — no cast back in.
+const section: ChipsSectionConfig<Row, SkillEntry> = {
 	key: 'skills',
 	label: 'Skills',
 	glyph: 'rune',
@@ -26,7 +34,7 @@ const section: ChipsSectionConfig<Row> = {
 	itemsKey: 'skillPool',
 	catalogue: () => CATALOGUE,
 	labelOf: (e) => e.name,
-	metaOf: (e) => `${(e as unknown as { baseDamage: number }).baseDamage} dmg`,
+	metaOf: (e) => `${e.baseDamage} dmg`,
 	emptyIcon: 'rune',
 	emptyTitle: 'No skills in pool',
 	emptySub: "Enemies with no skills can't act.",


### PR DESCRIPTION
## Summary

Follow-up from PR #1319 review (#1321). A `chips` section's `metaOf` read a meta field off the catalogue entry through an `as unknown as { baseDamage }` double cast, defeating type-safety on the `labelOf`/`metaOf` accessors. The cast was copied across `class.ts` (starter-skills), `enemy.ts` (skill-pool), and `skill-recipe.ts` (recipe inputs).

This widens `ChipsSectionConfig` so the catalogue **entry type is a generic parameter**, letting each entity declare the concrete entry shape its `catalogue`/`labelOf`/`metaOf` share.

## How it addresses the issue

- **`ChipsSectionConfig<T, E extends ChipCatalogueEntry = ChipCatalogueEntry>`** — new `ChipCatalogueEntry` base captures what the renderer itself needs (`id`/`name`/`retired`/`addable`); `E` lets a section supply a richer entry. The default preserves every existing single-arg `ChipsSectionConfig<T>` use (the renderer prop, the `SectionConfig<T>` union member).
- **`labelOf`/`metaOf` switched to method shorthand** so the entry parameter is compared bivariantly — a section built on a wider `E` stays assignable to the base `ChipsSectionConfig<T>` the entity-agnostic renderer consumes. (Project runs `strict`, so function-typed *properties* would be contravariant and reject the widening.)
- **`chipsSection<T>()` factory** infers `E` from `catalogue` and erases it back to the base for storage in the record's section list, so each entity gets type-checked `labelOf`/`metaOf` without naming the entry type.
- **Dropped the `as unknown as { baseDamage }` casts** in `class.ts`, `enemy.ts`, `skill-recipe.ts` — `metaOf` now reads `s.baseDamage` directly — and the mirrored cast in `ChipsSection.test.ts`.

No user-facing change — purely a type-safety/maintainability cleanup.

### Note for review

There's no runtime behaviour to assert for a type-level change; the safety is verified by `svelte-check` (the previously-cast `metaOf` accessors now type-check against the inferred entry shape). The render-boundary `as unknown as ChipsSectionConfig<Identified>` / `EntityStore<Identified>` casts in the test are a separate, already-documented concern (the renderer is intentionally typed against `Identified`) and were left in place.

## Test plan

- [x] `npm run lint` (ESLint + `svelte-check`) — clean, 0 errors / 0 warnings across 1087 files.
- [x] `npm run test:unit:ci` — 2772 tests pass (255 files), including the reworked `ChipsSection.test.ts`.

Closes #1321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSEF3szQ8iQA9sbRsnwQMS)_