### PR TITLE
Add typed BattleStats aggregates for proficiency accrual (#1337)

### DIFF
--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -2,6 +2,7 @@ using Game.Abstractions.DataAccess;
 using Game.Application;
 using Game.Application.Services;
 using Game.Core;
+using Game.Core.Battle;
 using Game.Core.Players;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Base;
@@ -289,6 +290,53 @@ namespace Game.Application.Tests.Services
 
             Assert.NotNull(result);
             Assert.Equal(100, result.ExpReward);
+        }
+
+        [Fact]
+        public async Task RecordVictory_SnapshotsPlayerPowerOntoStats_FromSnapshotNotLiveAggregate()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // Player power 100 (Strength 50 + Endurance 50) is frozen into the battle snapshot at StartBattle.
+            var playerSkill = await TestDataSeeder.CreateSkillAsync(context, "Smash", baseDamage: 1000m, cooldownMs: 500);
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context,
+                strengthBase: 50m, strengthPerLevel: 0m, enduranceBase: 50m, endurancePerLevel: 0m);
+            var zone = await TestDataSeeder.CreateZoneAsync(context, levelMin: 1, levelMax: 1);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, playerSkill.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var player = await scope.ServiceProvider.GetRequiredService<IPlayerRepository>().GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+            await battleService.StartBattle(player, state, zoneId: zone.Id);
+
+            // Deflate the LIVE player's power to ~2 after the snapshot is frozen (a valid mid-battle stat
+            // reallocation). The accrual must normalize by the snapshot-era power (100), so a regression
+            // sourcing PlayerPower from the live aggregate — or dropping the assignment — would read 2 or 0.
+            foreach (var allocation in player.StatPoints.StatAllocations)
+            {
+                allocation.Amount = 1;
+            }
+
+            var coreEnemy = scope.ServiceProvider.GetRequiredService<IEnemies>().GetDomainEnemy(enemy.Id, level: 1);
+            Assert.NotNull(coreEnemy);
+            var result = new BattleResult(Victory: true, PlayerDied: false, TotalMs: 1000, new BattleStats());
+
+            var rewards = battleService.RecordVictory(player, coreEnemy, result, state, DateTime.UtcNow);
+
+            // The reward measures the snapshot-era power (the full pre-deflation spread, ≥ 100), not the
+            // deflated live aggregate (a handful of 1s) — so sourcing PlayerPower from live state would read
+            // far below 100, and dropping the assignment would leave the stats at the default 0.
+            Assert.True(rewards.PlayerPower >= 100, $"Expected the snapshot power, got {rewards.PlayerPower}.");
+            Assert.Equal(rewards.PlayerPower, result.Stats.PlayerPower, precision: 9);
         }
 
         [Fact]

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -666,6 +666,11 @@ namespace Game.Application.Services
             var rewards = new DefeatRewards(
                 snapshot.GetModifiersWithSignaturePassive(_items.GetItem, _itemMods.GetItemMod, _proficiencies.GetProficiency, ResolveClass), enemy);
 
+            // Snapshot the player's power onto the battle stats so the proficiency accrual normalizes activity
+            // by the identical measure the difficulty curve uses (spike #1318) — captured here from the same
+            // snapshot modifiers, not the live aggregate.
+            result.Stats.PlayerPower = rewards.PlayerPower;
+
             player.GrantExp(rewards.ExpReward);
             // Thread the difficulty multiplier onto the battle-completed event so the progress handler can
             // scale the proficiency-XP pie by it — the same curve the exp reward above used (spike #982).

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -650,7 +650,11 @@ namespace Game.Application.Services
         // (AbandonBattle's elapsedMs) — a win only resolves if the enemy died within time the server itself
         // observed, so the server-measured cap is the (stronger) control there and a client timestamp adds
         // nothing. Both paths therefore require a server-validated timeline; neither can be claimed early.
-        private DefeatRewards RecordVictory(Player player, CoreEnemy enemy, BattleResult result, PlayerState state, DateTime timestamp)
+        // internal (not private) so an integration test can assert the live PlayerPower snapshot directly:
+        // EndBattleVictory returns only a client-facing DefeatResult, and the BattleStats this mutates is
+        // carried on the BattleCompletedEvent, which the dispatcher clears after handling — leaving no other
+        // seam to observe that result.Stats.PlayerPower is set from the snapshot rather than the live aggregate.
+        internal DefeatRewards RecordVictory(Player player, CoreEnemy enemy, BattleResult result, PlayerState state, DateTime timestamp)
         {
             // Measure the player's power for the reward from the same frozen snapshot the battle was simulated
             // against, not the live aggregate. Valid mid-battle socket commands (stat reallocation, gear swaps)

--- a/Game.Core.Tests/Battle/BattleContextTests.cs
+++ b/Game.Core.Tests/Battle/BattleContextTests.cs
@@ -334,7 +334,146 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(50 - 10, enemy.CurrentHealth, 0.001);
         }
 
+        // ── DamageTarget: typed damage dealt (offense book, #1337) ───────────
+
+        [Fact]
+        public void DamageTarget_PlayerHit_RecordsTypedDamageDealtMatchingPlayerDamageDealt()
+        {
+            var player = MakeBattlerWith((Endurance, 0));
+            var enemy = MakeBattlerWith((Endurance, 0)); // Defense 2
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+
+            context.DamageTarget(20, EDamageType.Fire); // 20 − 2 Defense = 18 dealt
+
+            // The typed offense book sums the same post-mitigation figure each hit booked into PlayerDamageDealt.
+            Assert.Equal(18, context.Stats.PlayerDamageDealt, 0.001);
+            Assert.Equal(18, TypedDealt(context, EDamageType.Fire), 0.001);
+        }
+
+        [Fact]
+        public void DamageTarget_PlayerHitsDifferentTypes_AccumulatedPerType()
+        {
+            var player = MakeBattlerWith((Endurance, 0));
+            var enemy = MakeBattlerWith((Endurance, 0));
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+
+            context.DamageTarget(20, EDamageType.Fire);     // 18
+            context.DamageTarget(10, EDamageType.Fire);     // 8
+            context.DamageTarget(30, EDamageType.Physical); // 28
+
+            Assert.Equal(26, TypedDealt(context, EDamageType.Fire), 0.001); // 18 + 8
+            Assert.Equal(28, TypedDealt(context, EDamageType.Physical), 0.001);
+        }
+
+        [Fact]
+        public void DamageTarget_PlayerCrit_TypedDamageDealtUsesPostMitigationActual()
+        {
+            var player = MakeBattlerWith((CriticalChance, 1), (CriticalDamage, 0.5)); // CriticalDamage 2
+            var enemy = MakeBattlerWith((Endurance, 0)); // Defense 2
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+
+            context.DamageTarget(20, EDamageType.Physical); // 20×2 = 40, − 2 Defense = 38
+
+            Assert.Equal(38, TypedDealt(context, EDamageType.Physical), 0.001);
+        }
+
+        [Fact]
+        public void DamageTarget_EnemyAttacking_RecordsNoTypedDamageDealt()
+        {
+            // The offense book is the player's; an enemy hit never adds to it (it feeds the incoming book).
+            var player = MakeBattlerWith((Endurance, 0));
+            var enemy = MakeBattlerWith((Endurance, 0));
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+            context.SwapActiveAndTargetBattlers();
+
+            context.DamageTarget(20, EDamageType.Physical);
+
+            Assert.Empty(context.Stats.TypedDamageDealt);
+        }
+
+        // ── DamageTarget: pre-mitigation typed exposure (incoming book, #1337) ─
+
+        [Fact]
+        public void DamageTarget_EnemyHit_RecordsExposureBeforeResistanceAndDefense()
+        {
+            // Exposure is the pre-mitigation hit (40 Fire), captured before the player's FireResistance and
+            // Defense reduce the damage actually taken (40 × 0.5 − 2 = 18).
+            var player = MakeBattlerWith((Endurance, 0), (FireResistance, 0.5)); // Defense 2
+            var enemy = MakeBattlerWith((Endurance, 0));
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+            context.SwapActiveAndTargetBattlers();
+
+            context.DamageTarget(40, EDamageType.Fire);
+
+            Assert.Equal(18, context.Stats.PlayerDamageTaken, 0.001);
+            Assert.Equal(40, Exposure(context, EDamageType.Fire), 0.001);
+        }
+
+        [Fact]
+        public void DamageTarget_EnemyAmplifiedHit_ExposureReflectsAmplifiedPreMitigationValue()
+        {
+            // Exposure is captured after the attacker's amplification (it sizes the incoming hit) but before
+            // the defender's resistance: enemy FireAmplification 0.5 → 40 × 1.5 = 60 exposure.
+            var player = MakeBattlerWith((Endurance, 0));
+            var enemy = MakeBattlerWith((Endurance, 0), (FireAmplification, 0.5));
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+            context.SwapActiveAndTargetBattlers();
+
+            context.DamageTarget(40, EDamageType.Fire);
+
+            Assert.Equal(60, Exposure(context, EDamageType.Fire), 0.001);
+        }
+
+        [Fact]
+        public void DamageTarget_PlayerBlock_RecordsFullPreMitigationExposure()
+        {
+            // A block is mitigation, so the player was still exposed to the full pre-mitigation hit (20),
+            // even though the block reduces the damage actually taken.
+            var player = MakeBattlerWith((BlockChance, 1), (BlockReduction, 8));
+            var enemy = MakeBattlerWith((Endurance, 0));
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+            context.SwapActiveAndTargetBattlers();
+
+            context.DamageTarget(20, EDamageType.Physical);
+
+            Assert.Equal(20, Exposure(context, EDamageType.Physical), 0.001);
+        }
+
+        [Fact]
+        public void DamageTarget_PlayerDodge_RecordsNoExposure()
+        {
+            // A dodged hit was evaded, not mitigated — it does not train the resist (incoming) book; its
+            // avoided damage trains evasion instead.
+            var player = MakeBattlerWith((DodgeChance, 1));
+            var enemy = MakeBattlerWith((Endurance, 0));
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+            context.SwapActiveAndTargetBattlers();
+
+            context.DamageTarget(20, EDamageType.Physical);
+
+            Assert.Empty(context.Stats.TypedDamageExposure);
+        }
+
+        [Fact]
+        public void DamageTarget_PlayerActive_RecordsNoExposure()
+        {
+            // The incoming book is the player's exposure; the player's own hits never add to it.
+            var player = MakeBattlerWith((Endurance, 0));
+            var enemy = MakeBattlerWith((Endurance, 0));
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+
+            context.DamageTarget(20, EDamageType.Physical);
+
+            Assert.Empty(context.Stats.TypedDamageExposure);
+        }
+
         // ── Helpers ──────────────────────────────────────────────────────────
+
+        private static double TypedDealt(BattleContext context, EDamageType type) =>
+            context.Stats.TypedDamageDealt.TryGetValue(type, out var value) ? value : 0;
+
+        private static double Exposure(BattleContext context, EDamageType type) =>
+            context.Stats.TypedDamageExposure.TryGetValue(type, out var value) ? value : 0;
 
         private static BattleContext MakeContext()
         {

--- a/Game.Core.Tests/Battle/BattleDamageOverTimeTests.cs
+++ b/Game.Core.Tests/Battle/BattleDamageOverTimeTests.cs
@@ -284,6 +284,63 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(4, context.Stats.PlayerDamageHealed);
         }
 
+        // ── Pre-mitigation exposure recorder (incoming book, #1337) ──────────
+
+        [Fact]
+        public void ApplyDamageOverTime_RecordExposure_ReportsPreMitigationPerType()
+        {
+            // The recorder receives each DoT type's PRE-resistance tick (50 → 2) while the dealt value is the
+            // post-resistance 1, so a resist never throttles the exposure training signal.
+            var battler = MakeBattler(Stat(Strength, 10), Stat(BleedDamagePerSecond, 50), Stat(BleedResistance, 0.5));
+            var exposure = new Dictionary<EDamageType, double>();
+
+            var dealt = battler.ApplyDamageOverTime(40, (type, amount) => exposure[type] = amount);
+
+            Assert.Equal(1, dealt);                       // post-resistance (mitigated)
+            Assert.Equal(2, exposure[EDamageType.Bleed]); // pre-mitigation (exposure)
+        }
+
+        [Fact]
+        public void ApplyDamageOverTime_RecordExposure_ReportsOnlyActiveTypes()
+        {
+            // Each authored DoT type reports its pre-mitigation tick; a type with a zero accumulator is skipped.
+            var battler = MakeBattler(
+                Stat(Strength, 10), Stat(BleedDamagePerSecond, 50), Stat(BurnDamagePerSecond, 250));
+            var exposure = new Dictionary<EDamageType, double>();
+
+            battler.ApplyDamageOverTime(40, (type, amount) => exposure[type] = amount);
+
+            Assert.Equal(2, exposure[EDamageType.Bleed]); // 50 → 2
+            Assert.Equal(10, exposure[EDamageType.Burn]); // 250 → 10
+            Assert.False(exposure.ContainsKey(EDamageType.Poison));
+        }
+
+        [Fact]
+        public void ApplyDamageOverTime_NoRecorder_DealsIdenticalDamage()
+        {
+            // The recorder is a pure side channel: omitting it leaves the dealt damage (and health math) unchanged.
+            var battler = MakeBattler(Stat(Strength, 10), Stat(BleedDamagePerSecond, 50), Stat(BleedResistance, 0.5));
+
+            var dealt = battler.ApplyDamageOverTime(40);
+
+            Assert.Equal(1, dealt);
+        }
+
+        [Fact]
+        public void ResolveDamageOverTime_RecordsPlayerDotExposure_NotEnemyDotAsExposure()
+        {
+            // The player's incoming DoT records pre-mitigation exposure into the incoming book; the enemy's DoT
+            // (the player's DoT damage dealt) is the offense book (#1338) and is NOT recorded as exposure.
+            var player = MakeBattler(Stat(Strength, 0), Stat(BurnDamagePerSecond, 250)); // player takes Burn
+            var enemy = MakeBattler(Stat(Strength, 0), Stat(BleedDamagePerSecond, 50));  // enemy takes Bleed
+            var context = new BattleContext(player, enemy, 40, new Mulberry32(0));
+
+            context.ResolveDamageOverTime();
+
+            Assert.Equal(10, context.Stats.TypedDamageExposure[EDamageType.Burn], 0.001); // 250 → 10 pre-mitigation
+            Assert.False(context.Stats.TypedDamageExposure.ContainsKey(EDamageType.Bleed));
+        }
+
         // ── Helpers ──────────────────────────────────────────────────────────
 
         private static Battler MakeBattler(params AttributeModifier[] modifiers) =>

--- a/Game.Core.Tests/Battle/DefeatRewardsTests.cs
+++ b/Game.Core.Tests/Battle/DefeatRewardsTests.cs
@@ -239,6 +239,37 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(int.MaxValue, rewards.ExpReward);
         }
 
+        [Fact]
+        public void PlayerPower_EqualsSumOfCoreAdditiveModifiers()
+        {
+            var player = MakePlayer(allocations: [(Strength, 10), (Endurance, 5)]);
+            var enemy = MakeEnemy(strength: 1);
+
+            var rewards = new DefeatRewards(player.GetAllModifiers(), enemy);
+
+            // The effect-based proficiency accrual normalizes activity by this measure (spike #1318), so it
+            // must equal the difficulty system's player-power sum (core additive modifiers) to avoid diverging.
+            Assert.Equal(15, rewards.PlayerPower, precision: 9);
+        }
+
+        [Fact]
+        public void PlayerPower_ExcludesDerivedAndMultiplicativeModifiers()
+        {
+            var player = MakePlayer(allocations: [(Strength, 15)]);
+            EquipAccessory(player,
+            [
+                Modifier(MaxHealth, 100, EModifierType.Additive),      // derived attribute → excluded
+                Modifier(Strength, 1.5, EModifierType.Multiplicative), // scaling factor → excluded
+            ]);
+            var enemy = MakeEnemy(strength: 1);
+
+            var rewards = new DefeatRewards(player.GetAllModifiers(), enemy);
+
+            // Only the additive core Strength (15) counts — the same exclusion the difficulty power measure
+            // applies, so power normalization and the difficulty curve share one definition of "power".
+            Assert.Equal(15, rewards.PlayerPower, precision: 9);
+        }
+
         private static Player MakePlayer(
             (EAttribute Attribute, double Amount)[] allocations,
             int statPointsGained = 0) =>

--- a/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
@@ -356,6 +356,31 @@ namespace Game.Core.Tests.Battle.Offline
             });
         }
 
+        [Fact]
+        public void Simulate_SnapshotsPlayerPowerOntoEachVictoryStats()
+        {
+            // The effect-based proficiency accrual normalizes activity by the player's power, so the simulator
+            // snapshots it onto each won battle's stats — the same core-additive sum DefeatRewards measures
+            // from the stationary modifiers (here Strength 100 + Endurance 100 = 200).
+            var result = _simulator.Simulate(IdleParameters(ManyStepsBudget(), StrongPlayerWinScenario()));
+
+            Assert.True(result.Wins > 1);
+            Assert.Equal(result.BattlesSimulated, result.Wins); // the strong player wins every battle
+            Assert.All(result.Battles, battle => Assert.Equal(200, battle.Result.Stats.PlayerPower, precision: 9));
+        }
+
+        [Fact]
+        public void Simulate_LeavesPlayerPowerAtZeroForLosses()
+        {
+            // A loss earns no DefeatRewards, so (like the live path) its stats carry no power snapshot — the
+            // default 0. Accrual is victory-only, so a loss's power is never read.
+            var result = _simulator.Simulate(BossParameters(ManyStepsBudget(), AlwaysLoseBossScenario()));
+
+            Assert.True(result.Losses > 1);
+            Assert.Equal(result.BattlesSimulated, result.Losses);
+            Assert.All(result.Battles, battle => Assert.Equal(0, battle.Result.Stats.PlayerPower));
+        }
+
         // ── Cancellation ─────────────────────────────────────────────────────
 
         [Fact]

--- a/Game.Core/Battle/BattleContext.cs
+++ b/Game.Core/Battle/BattleContext.cs
@@ -13,6 +13,11 @@ namespace Game.Core.Battle
         private Battler _targetBattler;
         private bool _isPlayerActive;
 
+        // The player's typed-exposure recorder, cached once (a method group converts to a fresh delegate on
+        // each use) so the per-tick DoT phase can hand it to ApplyDamageOverTime without allocating on the
+        // replay hot path.
+        private readonly Action<EDamageType, double> _recordPlayerExposure;
+
         public int TimeDelta { get; set; }
         public BattleStats Stats { get; } = new();
 
@@ -25,6 +30,7 @@ namespace Game.Core.Battle
             _targetBattler = enemyBattler;
             _isPlayerActive = true;
             TimeDelta = timeDelta;
+            _recordPlayerExposure = Stats.AddTypedDamageExposure;
         }
 
         public void SwapActiveAndTargetBattlers()
@@ -83,6 +89,9 @@ namespace Game.Core.Battle
         /// </summary>
         public void ResolveDamageOverTime()
         {
+            // The enemy's DoT (the player's DoT damage dealt) is the offense DoT book, tracked separately
+            // (#1338), so no exposure recorder is passed here; the player's incoming DoT records its
+            // pre-mitigation exposure into the incoming book via the cached recorder.
             Stats.PlayerDamageDealt += _enemyBattler.ApplyDamageOverTime(TimeDelta);
             _enemyBattler.ApplyHealOverTime(TimeDelta);
             if (_enemyBattler.IsDead)
@@ -90,7 +99,7 @@ namespace Game.Core.Battle
                 return;
             }
 
-            Stats.PlayerDamageTaken += _playerBattler.ApplyDamageOverTime(TimeDelta);
+            Stats.PlayerDamageTaken += _playerBattler.ApplyDamageOverTime(TimeDelta, _recordPlayerExposure);
             Stats.PlayerDamageHealed += _playerBattler.ApplyHealOverTime(TimeDelta);
         }
 
@@ -130,6 +139,7 @@ namespace Game.Core.Battle
                 actualDamage = _targetBattler.TakeDamage(damage, damageType);
 
                 Stats.PlayerDamageDealt += actualDamage;
+                Stats.AddTypedDamageDealt(damageType, actualDamage);
                 if (isCrit)
                 {
                     Stats.CriticalHits++;
@@ -159,15 +169,22 @@ namespace Game.Core.Battle
                     Stats.AttacksDodged++;
                     Stats.DamageDodged += afterDefense;
                 }
-                else if (isBlock)
-                {
-                    actualDamage = _targetBattler.TakeDamage(dealt, damageType, _targetBattler.GetAttributeValue(BlockReduction));
-                    Stats.AttacksBlocked++;
-                    Stats.DamageBlocked += afterDefense - actualDamage;
-                }
                 else
                 {
-                    actualDamage = _targetBattler.TakeDamage(dealt, damageType);
+                    // The hit landed (blocked or not), so the player was exposed to its full pre-mitigation
+                    // typed damage — recorded for the incoming book before resistance/Defense. A dodge above
+                    // evaded the hit entirely, so it is excluded (its avoided damage trains evasion instead).
+                    Stats.AddTypedDamageExposure(damageType, dealt);
+                    if (isBlock)
+                    {
+                        actualDamage = _targetBattler.TakeDamage(dealt, damageType, _targetBattler.GetAttributeValue(BlockReduction));
+                        Stats.AttacksBlocked++;
+                        Stats.DamageBlocked += afterDefense - actualDamage;
+                    }
+                    else
+                    {
+                        actualDamage = _targetBattler.TakeDamage(dealt, damageType);
+                    }
                 }
 
                 Stats.PlayerDamageTaken += actualDamage;

--- a/Game.Core/Battle/BattleStats.cs
+++ b/Game.Core/Battle/BattleStats.cs
@@ -19,6 +19,45 @@ namespace Game.Core.Battle
         public double DamageBlocked { get; set; }
 
         public Dictionary<int, SkillStats> SkillStats { get; set; } = [];
+
+        /// <summary>
+        /// Per-leaf-type direct-hit damage the player dealt this battle — the proficiency offense "output book"
+        /// (spike #1318). Sums the same post-mitigation amount each hit booked into <see cref="PlayerDamageDealt"/>,
+        /// so a focused build trains its damage type fully while a dabbled one trains it proportionally. Typed
+        /// DoT damage dealt is the incoming/offense DoT binding's concern (#1338); only direct hits land here.
+        /// </summary>
+        public Dictionary<EDamageType, double> TypedDamageDealt { get; set; } = [];
+
+        /// <summary>
+        /// Per-leaf-type incoming damage the player was exposed to this battle — the proficiency "incoming book"
+        /// (spike #1318) — captured <b>before</b> the player's type-resistance and Defense, so a resist never
+        /// throttles its own training signal. Covers both direct hits and typed DoT; a fully dodged hit is
+        /// excluded (it was evaded, not mitigated — dodged damage trains evasion instead).
+        /// </summary>
+        public Dictionary<EDamageType, double> TypedDamageExposure { get; set; } = [];
+
+        /// <summary>
+        /// The player's power for this battle — the sum of core additive attribute modifiers, the same measure
+        /// <see cref="DefeatRewards"/> uses for the difficulty curve. The effect-based proficiency accrual
+        /// normalizes each activity by this (spike #1318), so it must be the identical measure to avoid
+        /// double-counting power. Populated at battle completion from <see cref="DefeatRewards.PlayerPower"/>
+        /// (victory-only, like the rewards); <c>0</c> until then.
+        /// </summary>
+        public double PlayerPower { get; set; }
+
+        /// <summary>Accumulates a direct hit of <paramref name="amount"/> into the typed offense book.</summary>
+        public void AddTypedDamageDealt(EDamageType type, double amount)
+        {
+            TypedDamageDealt.TryGetValue(type, out var existing);
+            TypedDamageDealt[type] = existing + amount;
+        }
+
+        /// <summary>Accumulates a pre-mitigation hit of <paramref name="amount"/> into the typed incoming book.</summary>
+        public void AddTypedDamageExposure(EDamageType type, double amount)
+        {
+            TypedDamageExposure.TryGetValue(type, out var existing);
+            TypedDamageExposure[type] = existing + amount;
+        }
     }
 
     public class SkillStats

--- a/Game.Core/Battle/Battler.cs
+++ b/Game.Core/Battle/Battler.cs
@@ -166,7 +166,14 @@ namespace Game.Core.Battle
         /// bit-for-bit. A single typed DoT with no resistance reduces to <c>perSec × ms/1000</c> — byte-identical
         /// to the former single-accumulator outcome (the reduce-to-today identity).
         /// </remarks>
-        public double ApplyDamageOverTime(int ms)
+        /// <param name="ms">The elapsed simulated time this tick.</param>
+        /// <param name="recordExposure">
+        /// Optional per-type <b>pre-mitigation</b> recorder for the proficiency incoming book (spike #1337) —
+        /// invoked with each DoT type and its tick damage <em>before</em> this battler's resistance. Supplied
+        /// only when this battler's exposure is tracked (the player); <c>null</c> leaves the loop unchanged. It
+        /// is a backend-only side channel that never touches the health math, so it adds no parity surface.
+        /// </param>
+        public double ApplyDamageOverTime(int ms, Action<EDamageType, double>? recordExposure = null)
         {
             var dot = 0.0;
             var accumulators = DamageTypes.DotAccumulators;
@@ -178,6 +185,12 @@ namespace Game.Core.Battle
                     continue;
                 }
 
+                // The pre-mitigation tick (before this battler's resistance) is its exposure to this DoT type;
+                // record it for the incoming book when a recorder is supplied. Folded out of the dot sum below
+                // so the recorded value and the mitigated value share one multiplication (no parity drift).
+                var preMitigation = perSecond * ms / 1000.0;
+                recordExposure?.Invoke(accumulators[i].Type, preMitigation);
+
                 var resistance = 0.0;
                 var resistanceAttributes = DamageTypes.ResistanceAttributes(accumulators[i].Type);
                 for (var j = 0; j < resistanceAttributes.Count; j++)
@@ -185,7 +198,7 @@ namespace Game.Core.Battle
                     resistance += _attributes[resistanceAttributes[j]];
                 }
 
-                dot += perSecond * ms / 1000.0 * (1 - resistance);
+                dot += preMitigation * (1 - resistance);
             }
 
             CurrentHealth -= dot;

--- a/Game.Core/Battle/DefeatRewards.cs
+++ b/Game.Core/Battle/DefeatRewards.cs
@@ -21,6 +21,14 @@ namespace Game.Core.Battle
         public double DifficultyMultiplier { get; }
 
         /// <summary>
+        /// The player's power for this battle — the sum of core additive attribute modifiers (the same measure
+        /// the difficulty ratio above is built from). Exposed so the effect-based proficiency accrual can
+        /// normalize each activity by the <em>identical</em> power measure the difficulty curve uses
+        /// (spike #1318), rather than re-deriving it and risking divergence.
+        /// </summary>
+        public double PlayerPower { get; }
+
+        /// <summary>
         /// Computes the rewards for defeating <paramref name="enemy"/>. The player's power is measured from
         /// <paramref name="playerModifiers"/> — the modifier set reconstructed from the battle snapshot
         /// (<see cref="BattleSnapshot.GetModifiers"/>) — rather than the live player aggregate, so the reward
@@ -29,8 +37,8 @@ namespace Game.Core.Battle
         public DefeatRewards(IEnumerable<AttributeModifier> playerModifiers, Enemy enemy)
         {
             var enemyAttTotal = SumCoreAttributes(enemy.GetAttributeModifiers());
-            var playerAttTotal = SumCoreAttributes(playerModifiers);
-            DifficultyMultiplier = GetDifficultyMultiplier(enemyAttTotal, playerAttTotal);
+            PlayerPower = SumCoreAttributes(playerModifiers);
+            DifficultyMultiplier = GetDifficultyMultiplier(enemyAttTotal, PlayerPower);
             ExpReward = ToIntReward(enemyAttTotal * DifficultyMultiplier);
         }
 

--- a/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
+++ b/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
@@ -54,6 +54,13 @@ namespace Game.Core.Battle.Offline
                 // path. The same DefeatRewards yields both the exp and the difficulty multiplier the offline
                 // proficiency-XP accrual scales its pie by, so the two payouts share one curve evaluation.
                 var rewards = result.Victory ? new DefeatRewards(playerModifiers, enemy) : null;
+                if (rewards is not null)
+                {
+                    // Snapshot the player's power onto this battle's stats so the offline accrual normalizes by
+                    // the identical measure the live path does (spike #1318) — victory-only, like the rewards.
+                    result.Stats.PlayerPower = rewards.PlayerPower;
+                }
+
                 outcomes.Add(new OfflineBattleOutcome(
                     enemy, result, rewards?.ExpReward ?? 0, rewards?.DifficultyMultiplier ?? 0));
 


### PR DESCRIPTION
## Summary

Extends `BattleStats` with the backend-only aggregates the effect-based proficiency accrual (spike #1318) consumes, now that the #1320 direct-hit typing dependency (`Skill.DamageType`, PR #1348) has merged. This is the **tracking** sub-issue — it produces the data the accrual engine (#1336) and the resist/DoT bindings (#1338) will read; it wires no XP itself.

Three additions, all keyed by leaf `EDamageType`:

- **`TypedDamageDealt`** — per-type direct-hit damage the player dealt (the offense "output book"). Recorded at the `DamageTarget` site so each entry sums the same post-mitigation figure already booked into `PlayerDamageDealt`. Typed **DoT-dealt** is deliberately left to #1338 (which owns the per-type DoT-dealt aggregate), so the offense book here is direct hits only.
- **`TypedDamageExposure`** — per-type **pre-mitigation** incoming damage (the "incoming book"), captured *before* the player's type-resistance and Defense so a resist never throttles its own training signal. Covers:
  - direct hits — recorded only when the hit **lands** (a dodge is evasion, not mitigation, so it's excluded; its avoided damage trains evasion instead). A blocked hit still records the full pre-mitigation value.
  - typed DoT — via an optional pre-mitigation recorder threaded into `Battler.ApplyDamageOverTime`. This is a parity-safe side channel: the DoT health math is byte-identical (`perSec×ms/1000` is just folded out and reused), and the recorder is only passed for the player (the enemy's DoT is the player's offense, not exposure).
- **`PlayerPower`** — the player's core-attribute power snapshot, exposed off `DefeatRewards` (the *identical* measure the difficulty curve uses, so power-normalization and the difficulty system can't diverge) and set onto the battle stats at both completion sites — live (`RecordVictory`) and offline (`OfflineProgressSimulator`) — victory-only, matching the rewards.

## How it addresses the issue

Implements #1337's three listed aggregates against the damage-application sites in `BattleContext`/`Battler` and the completion plumbing, exactly as scoped. The pre-mitigation exposure and the asymmetry (incoming book covers DoT; the DoT-*dealt* offense aggregate is #1338's) follow the spike's two-book division.

## Notes / deliberate choices

- **No parity / serialization surface.** `BattleStats` is pure backend domain — not mapped, persisted, or sent to the client, and the frontend↔backend parity tests compare only victory/playerDied/totalMs. The accrual runs off the tick loop, so nothing here is mirrored on the frontend. No frontend changes.
- **Allocation discipline.** The player's DoT-exposure recorder is a delegate cached once per `BattleContext` (not a per-tick method-group conversion), keeping the replay hot path allocation-free.
- **Docs deferred.** The spike lists the `docs/backend.md` / `game-design.md` updates as landing *with* the accrual engine (#1336) and authoring (#1341); updating them now would describe a half-wired model, so they're left to those issues. The design is captured in `docs/spikes/1318-proficiency-progression-avenues.md`.

## Test plan

- `dotnet build Game.sln` — clean (0 warnings).
- `Game.Core.Tests` — **1018 passed** (incl. the battle-simulation parity suites, unchanged).
- `Game.Application.Tests` — **632 passed** (BattleService completion paths).

New unit tests:
- `BattleContextTests` — typed dealt per type (accumulation, crit uses post-mitigation actual, enemy hits add nothing); exposure pre-mitigation (before resistance/Defense, amplified value, block records full, dodge/player-active record nothing).
- `BattleDamageOverTimeTests` — DoT exposure recorder reports pre-mitigation per active type; no-recorder path unchanged; `ResolveDamageOverTime` records player DoT exposure but not the enemy's.
- `DefeatRewardsTests` — `PlayerPower` equals the core-additive sum and excludes derived/multiplicative.
- `OfflineProgressSimulatorTests` — power snapshot set on each victory's stats; left at 0 for losses.

Closes #1337

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARGdLt7JLPEdb4GWkPafTM)_