### PR TITLE
Wire proc/heal proficiency activity bindings (#1339)

### DIFF
--- a/Game.Application.Tests/Services/ProficiencyRewardServiceTests.cs
+++ b/Game.Application.Tests/Services/ProficiencyRewardServiceTests.cs
@@ -359,6 +359,25 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task ZeroEventActivity_TrainsNothing()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // The AddEvent amount > 0 guard: a battle with no crit damage produces no Crit activity, so a
+            // Crit-keyed path is not even routed to (no zero-activity slice reaches the calculator).
+            var path = await TestDataSeeder.CreatePathAsync(context, name: "Precision", activityKey: EActivityKey.Crit);
+            await TestDataSeeder.CreateProficiencyAsync(
+                context, name: "Precision", maxLevel: 10, baseXp: 1m, xpGrowth: 1m, pathId: path.Id, pathOrdinal: 0);
+            var playerId = await SeedPlayerAsync(context);
+            await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
+
+            var (_, accrual) = await AccrueStatsAsync(scope, playerId, new BattleStats { CriticalDamageDealt = 0 });
+
+            Assert.Empty(accrual.Results);
+        }
+
+        [Fact]
         public async Task OffenseAndEventAxes_TrainInParallel_WithoutDilution()
         {
             using var scope = CreateScope();

--- a/Game.Application.Tests/Services/ProficiencyRewardServiceTests.cs
+++ b/Game.Application.Tests/Services/ProficiencyRewardServiceTests.cs
@@ -270,6 +270,126 @@ namespace Game.Application.Tests.Services
             Assert.Single(player.Skills);
         }
 
+        [Fact]
+        public async Task CritDamage_TrainsThePrecisionPath()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // A path keyed on the Crit event trains from the battle's crit damage — no skill contribution and no
+            // damage-type routing involved (Precision is a single global, type-neutral track; spike #1318).
+            var path = await TestDataSeeder.CreatePathAsync(context, name: "Precision", activityKey: EActivityKey.Crit);
+            var tier = await TestDataSeeder.CreateProficiencyAsync(
+                context, name: "Precision", maxLevel: 10, baseXp: 1m, xpGrowth: 1m, pathId: path.Id, pathOrdinal: 0);
+            var playerId = await SeedPlayerAsync(context);
+            await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
+
+            var (_, accrual) = await AccrueStatsAsync(scope, playerId, new BattleStats { CriticalDamageDealt = FiredDamage });
+
+            var result = Assert.Single(accrual.Results);
+            Assert.Equal(tier.Id, result.ProficiencyId);
+            Assert.True(result.NewLevel >= 1);
+        }
+
+        [Fact]
+        public async Task DodgedDamage_TrainsTheEvasionPath()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // The Evasion track trains from dodged damage (the avoided post-Defense hit) — incoming-book event,
+            // type-neutral like Precision.
+            var path = await TestDataSeeder.CreatePathAsync(context, name: "Evasion", activityKey: EActivityKey.Dodge);
+            var tier = await TestDataSeeder.CreateProficiencyAsync(
+                context, name: "Evasion", maxLevel: 10, baseXp: 1m, xpGrowth: 1m, pathId: path.Id, pathOrdinal: 0);
+            var playerId = await SeedPlayerAsync(context);
+            await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
+
+            var (_, accrual) = await AccrueStatsAsync(scope, playerId, new BattleStats { DamageDodged = FiredDamage });
+
+            var result = Assert.Single(accrual.Results);
+            Assert.Equal(tier.Id, result.ProficiencyId);
+            Assert.True(result.NewLevel >= 1);
+        }
+
+        [Fact]
+        public async Task HealingDone_TrainsTheRestorationPath()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // Restoration trains from healing done (PlayerDamageHealed) — an output-book event.
+            var path = await TestDataSeeder.CreatePathAsync(context, name: "Restoration", activityKey: EActivityKey.Heal);
+            var tier = await TestDataSeeder.CreateProficiencyAsync(
+                context, name: "Restoration", maxLevel: 10, baseXp: 1m, xpGrowth: 1m, pathId: path.Id, pathOrdinal: 0);
+            var playerId = await SeedPlayerAsync(context);
+            await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
+
+            var (_, accrual) = await AccrueStatsAsync(scope, playerId, new BattleStats { PlayerDamageHealed = FiredDamage });
+
+            var result = Assert.Single(accrual.Results);
+            Assert.Equal(tier.Id, result.ProficiencyId);
+            Assert.True(result.NewLevel >= 1);
+        }
+
+        [Fact]
+        public async Task ReflectedDamage_IsNotYetWired_SoARetributionPathTrainsNothing()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // Retribution waits on the reflection rework (#1330) — no reflected-damage signal is produced yet, so
+            // a Reflect-keyed path accrues nothing even from a battle full of every other event activity.
+            var path = await TestDataSeeder.CreatePathAsync(context, name: "Retribution", activityKey: EActivityKey.Reflect);
+            await TestDataSeeder.CreateProficiencyAsync(
+                context, name: "Retribution", maxLevel: 10, baseXp: 1m, xpGrowth: 1m, pathId: path.Id, pathOrdinal: 0);
+            var playerId = await SeedPlayerAsync(context);
+            await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
+
+            var stats = new BattleStats
+            {
+                CriticalDamageDealt = FiredDamage,
+                DamageDodged = FiredDamage,
+                PlayerDamageHealed = FiredDamage,
+            };
+            var (_, accrual) = await AccrueStatsAsync(scope, playerId, stats);
+
+            // Only a Reflect path exists, and Reflect is unwired — nothing trains.
+            Assert.Empty(accrual.Results);
+        }
+
+        [Fact]
+        public async Task OffenseAndEventAxes_TrainInParallel_WithoutDilution()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // Spike #1318 decision 4: axes do not share a pie. A battle that both deals fire damage and lands
+            // crits trains the Fire offense path and the Precision event path each at activity ÷ power = 1 — with
+            // identical curves they reach the same level, proving neither axis dilutes the other.
+            var firePath = await TestDataSeeder.CreatePathAsync(context, name: "Fire", activityKey: EActivityKey.Fire);
+            var fireTier = await TestDataSeeder.CreateProficiencyAsync(
+                context, name: "Fire", maxLevel: 10, baseXp: 1m, xpGrowth: 1m, pathId: firePath.Id, pathOrdinal: 0);
+            var critPath = await TestDataSeeder.CreatePathAsync(context, name: "Precision", activityKey: EActivityKey.Crit);
+            var critTier = await TestDataSeeder.CreateProficiencyAsync(
+                context, name: "Precision", maxLevel: 10, baseXp: 1m, xpGrowth: 1m, pathId: critPath.Id, pathOrdinal: 0);
+
+            var fireSkill = await TestDataSeeder.CreateSkillAsync(context, name: "Firebolt", damageType: EDamageType.Fire);
+            var playerId = await SeedPlayerAsync(context);
+            await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
+
+            // Full-power fire damage and full-power crit damage in the same battle.
+            var stats = new BattleStats { CriticalDamageDealt = FiredDamage };
+            stats.SkillStats[fireSkill.Id] = new SkillStats { Uses = 1, TotalDamage = FiredDamage };
+            var (_, accrual) = await AccrueStatsAsync(scope, playerId, stats);
+
+            var fireResult = Assert.Single(accrual.Results, r => r.ProficiencyId == fireTier.Id);
+            var critResult = Assert.Single(accrual.Results, r => r.ProficiencyId == critTier.Id);
+            Assert.True(fireResult.NewLevel >= 1);
+            Assert.Equal(fireResult.NewLevel, critResult.NewLevel);
+            Assert.Equal(fireResult.XpGained, critResult.XpGained);
+        }
+
         // The damage a fired skill deals in these tests, equal to the power passed to the accrual — so
         // activity ÷ power = 1 and each won battle claims the full pie (ServerGameConstants.ProficiencyXpPerVictory),
         // keeping the per-level math identical to the assertions below.
@@ -307,6 +427,27 @@ namespace Game.Application.Tests.Services
             var progress = await scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>().Load(player);
             var accrual = service.AccrueAndApply(progress, FireSkill(firedSkillId), totalAttributes: FiredDamage, player, notify);
             return (player, accrual);
+        }
+
+        // Accrues an arbitrary battle's stats (the event bindings build their own BattleStats rather than firing a
+        // skill), normalized by the default power so a full-power activity claims the whole pie.
+        private async Task<(Player Player, ProficiencyAccrualResult Accrual)> AccrueStatsAsync(
+            IServiceScope scope, int playerId, BattleStats stats, bool notify = false)
+        {
+            var service = scope.ServiceProvider.GetRequiredService<ProficiencyRewardService>();
+            var player = await LoadPlayerAsync(scope, playerId);
+            var progress = await scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>().Load(player);
+            var accrual = service.AccrueAndApply(progress, stats, totalAttributes: FiredDamage, player, notify);
+            return (player, accrual);
+        }
+
+        // Seeds a bare player (no skills) — the event bindings train from BattleStats event fields, not from any
+        // fired skill, so no loadout is needed.
+        private static async Task<int> SeedPlayerAsync(GameContext context)
+        {
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+            return player.Id;
         }
 
         private static async Task<Player> LoadPlayerAsync(IServiceScope scope, int playerId)

--- a/Game.Application/Services/ProficiencyRewardService.cs
+++ b/Game.Application/Services/ProficiencyRewardService.cs
@@ -19,11 +19,14 @@ namespace Game.Application.Services
     /// result through the progress aggregate. Both the live battle-completion handler and the offline-rewards
     /// batch run it, so the accrual is computed identically on both paths (the "offline == live" invariant).
     /// <para>
-    /// Offense is the activity wired here: per-skill direct-hit damage grouped by the skill's resolved damage
-    /// type, folded across each type's applicable keys (<see cref="DamageTypes.Applies"/>). The incoming book,
-    /// DoT-dealt, and proc/heal/reflect activities are wired by later sub-issues (#1337–#1339). The
-    /// <c>notify</c> flag drives the live client push: the live path notifies (a per-battle push), the offline
-    /// batch suppresses it (the welcome-back summary is the notification — spike #982 decision 9).
+    /// Two output-book axes are wired here: per-skill direct-hit damage grouped by the skill's resolved damage
+    /// type and folded across each type's applicable keys (<see cref="DamageTypes.Applies"/>), and the event-keyed
+    /// combat magnitudes — crit damage (Precision), dodged damage (Evasion), and healing done (Restoration) —
+    /// which are damage-type-neutral and map straight to a single activity key. The remaining avenues are wired by
+    /// sibling sub-issues: the incoming book and typed DoT-dealt (#1338), and Retribution (reflected damage), which
+    /// waits on the mitigation rework (#1330). The <c>notify</c> flag drives the live client push: the live path
+    /// notifies (a per-battle push), the offline batch suppresses it (the welcome-back summary is the
+    /// notification — spike #982 decision 9).
     /// </para>
     /// </summary>
     public class ProficiencyRewardService(IProficiencies proficiencies, ISkills skills)
@@ -159,13 +162,16 @@ namespace Game.Application.Services
             return true;
         }
 
-        // The per-path activity for the battle, routed to each path's frontier tier. Offense is the only
-        // activity wired here (incoming/DoT/proc come in #1337–#1339): per-skill direct-hit damage
+        // The per-path activity for the battle, routed to each path's frontier tier. Two output-book axes are
+        // wired here (the incoming book and typed DoT-dealt come in #1338). Offense: per-skill direct-hit damage
         // (SkillStats.TotalDamage) grouped by the firing skill's resolved damage type, then folded across each
         // type's applicable keys (DamageTypes.Applies) so a fire hit feeds both the Fire path and the Elemental
-        // path. Each key's summed damage is the activity of every (non-retired) path bound to it; the path
-        // trains in proportion to the share of damage its key captures, so focus beats spread. A fully-maxed
-        // path (no frontier) banks nothing; a retired path is absent from the index (frozen).
+        // path. Events: crit damage, dodged damage, and healing done — damage-type-neutral magnitudes that map
+        // straight to a single activity key (Crit / Dodge / Heal) without routing through applies(); Retribution
+        // (Reflect) stays inert until the reflection rework (#1330) produces a reflected-damage signal. Each key's
+        // summed activity is shared by every (non-retired) path bound to it; the path trains in proportion to the
+        // share its key captures, so focus beats spread. A fully-maxed path (no frontier) banks nothing; a retired
+        // path is absent from the index (frozen).
         private List<PathActivity> BuildActivities(BattleStats stats, PlayerProgress progress)
         {
             int LevelOf(int proficiencyId) =>
@@ -195,6 +201,22 @@ namespace Game.Application.Services
                     activityByKey[activityKey] = activityByKey.GetValueOrDefault(activityKey) + damage;
                 }
             }
+
+            // Event-keyed activities: combat magnitudes that are not typed damage, so each maps straight to a
+            // single global activity key (no applies() routing, no per-type split). Only positive amounts are
+            // recorded — a battle with no crit / dodge / healing trains none of these. Reflect (Retribution) is
+            // deliberately omitted: nothing produces a reflected-damage figure until the mitigation rework (#1330).
+            void AddEvent(EActivityKey key, double amount)
+            {
+                if (amount > 0)
+                {
+                    activityByKey[key] = activityByKey.GetValueOrDefault(key) + amount;
+                }
+            }
+
+            AddEvent(EActivityKey.Crit, stats.CriticalDamageDealt);
+            AddEvent(EActivityKey.Dodge, stats.DamageDodged);
+            AddEvent(EActivityKey.Heal, stats.PlayerDamageHealed);
 
             // Route each key's activity to the frontier tier of every path bound to it.
             var activities = new List<PathActivity>();

--- a/Game.Core/Enums.cs
+++ b/Game.Core/Enums.cs
@@ -305,21 +305,20 @@ namespace Game.Core
         /// <summary>All damage-over-time (bleed / poison / burn) damage dealt. Mirrors <see cref="EDamageTypeKey.Dot"/>.</summary>
         Dot = 9,
 
-        // The four combat-event keys — not damage types, so absent from EDamageTypeKey. Defined here so the
-        // decided activity-key set (spike #1318) is stable on the contract/column, but deliberately inert:
-        // nothing routes to them until the proc / heal / reflect bindings wire them (#1339; Retribution also
-        // depends on the reflection rework #1330). A path keyed on one simply accrues nothing until then.
+        // The four combat-event keys — not damage types, so absent from EDamageTypeKey. The proc / heal bindings
+        // (#1339) wire crit / dodge / heal; Reflect stays inert until the reflection rework (#1330) produces a
+        // reflected-damage signal. A path keyed on an unwired key simply accrues nothing until its binding lands.
 
-        /// <summary>Critical damage dealt (the Precision mastery). Inert until #1339.</summary>
+        /// <summary>Critical damage dealt (the Precision mastery).</summary>
         Crit = 10,
 
-        /// <summary>Damage dodged (the Evasion mastery). Inert until #1339.</summary>
+        /// <summary>Damage dodged (the Evasion mastery).</summary>
         Dodge = 11,
 
-        /// <summary>Healing done (the Restoration mastery). Inert until #1339.</summary>
+        /// <summary>Healing done (the Restoration mastery).</summary>
         Heal = 12,
 
-        /// <summary>Reflected damage (the Retribution mastery). Inert until #1339 / #1330.</summary>
+        /// <summary>Reflected damage (the Retribution mastery). Inert until the reflection rework #1330.</summary>
         Reflect = 13,
     }
 


### PR DESCRIPTION
## Summary

Wires the **event-keyed** proficiency activity bindings from spike #1318 onto the now-shipped effect-based accrual engine (#1336):

- **Precision** ← crit damage (`stats.CriticalDamageDealt`)
- **Evasion** ← dodged damage (`stats.DamageDodged`)
- **Restoration** ← healing done (`stats.PlayerDamageHealed`)

These are damage-type-neutral combat magnitudes, so each maps straight to a single `EActivityKey` (`Crit`/`Dodge`/`Heal`) in `ProficiencyRewardService.BuildActivities` — no `applies()` routing, no per-type split. The existing routing loop then routes each key's activity to the frontier tier of every path bound to it, exactly as it does for the typed offense book.

## How it addresses the issue

#1339 asked for the four event bindings. Three are delivered here. **Retribution** (reflected damage) is deliberately left **inert**: nothing produces a reflected-damage figure until the mitigation rework **#1330** lands, which the issue itself calls out ("Precision/Evasion/Restoration can land without #1330"). The `EActivityKey.Reflect` member and its doc note remain, so a Retribution-keyed path simply accrues nothing until #1330 wires it.

Because both the live path (`BattleStatisticsEventHandler`) and the offline batch (`BattleService`) call the same `AccrueAndApply` with a `BattleStats` produced by the same simulator, the new avenues accrue identically on both paths — the "offline == live" invariant holds with no extra wiring.

## Test plan

- [x] `dotnet build` — clean
- [x] `Game.Application.Tests` — 636 passed (integration, DB-backed reference data)
- [x] `Game.Core.Tests` — 1000 passed

New tests in `ProficiencyRewardServiceTests`:
- `CritDamage_TrainsThePrecisionPath`
- `DodgedDamage_TrainsTheEvasionPath`
- `HealingDone_TrainsTheRestorationPath`
- `ReflectedDamage_IsNotYetWired_SoARetributionPathTrainsNothing` (inertness guard for Retribution / #1330)
- `OffenseAndEventAxes_TrainInParallel_WithoutDilution` (spike decision 4: axes don't share a pie)

## Notes / follow-ups

- **Docs were intentionally not touched.** The spike assigns the `docs/game-design.md` Proficiency rewrite (effect-based accrual, the full activity-key set, two-book model) to the dedicated tooling/docs sub-issue **#1341**, so folding it in here would duplicate that scope.
- The `Retribution` binding remains tracked by #1339's relationship to **#1330**; this PR does not close out that avenue.

Closes #1339

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpoeubmyhbkU6WVeD6cp4Z)_