### PR TITLE
Drive battle loading cooldown off the logical clock (#1366)

### DIFF
--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -261,7 +261,7 @@ export class BattleEngine {
 	}
 
 	public startLoading(loadingTime: number) {
-		// Cancel any countdown still in flight so re-invoking can't leak the previous render hook.
+		// Cancel any countdown still in flight so re-invoking can't leak the previous logical hook.
 		this.finishLoading?.();
 		this.loadingTime = loadingTime;
 		this.loadingTotal = loadingTime;

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -88,7 +88,7 @@ export class BattleEngine {
 	private logicalUnhook?: Action;
 	private renderUnhook?: Action;
 	private enemyLoadedUnhook?: Action;
-	/** Tears down the in-flight post-victory loading countdown (removes its render hook and resolves the
+	/** Tears down the in-flight post-victory loading countdown (removes its logical hook and resolves the
 	 *  awaited promise); undefined when no countdown is active. */
 	private finishLoading?: Action;
 
@@ -143,8 +143,8 @@ export class BattleEngine {
 			// no progress on their own. Resetting here lets a return from the admin screen resume cleanly.
 			this.setBattleStage(Idle);
 		}
-		// A loading countdown is driven by the render engine independently of `running`, so cancel it
-		// unconditionally — otherwise its render hook leaks and the awaiting getNewEnemy path hangs.
+		// A loading countdown is driven by the logical engine independently of `running`, so cancel it
+		// unconditionally — otherwise its logical hook leaks and the awaiting getNewEnemy path hangs.
 		this.finishLoading?.();
 	}
 
@@ -267,14 +267,17 @@ export class BattleEngine {
 		this.loadingTotal = loadingTime;
 		this.setBattleStage(Loading);
 		const { promise, resolve } = Promise.withResolvers<void>();
-		const unhook = onRenderUpdate((delta) => {
+		// Drive the countdown off the logical clock, not the render (rAF) loop: rAF is suspended while the
+		// tab is backgrounded, which would freeze the cooldown and park the farm loop in Loading until the
+		// tab is refocused (#1366). The logical loop keeps running (throttled, with catch-up) when hidden.
+		const unhook = onLogicalUpdate((delta) => {
 			this.loadingTime -= delta;
 			if (this.loadingTime <= 0) {
 				this.finishLoading?.();
 			}
-		}, false);
+		});
 		// Single idempotent teardown shared by the natural countdown-complete path and the stop()/reset()
-		// cancellation path: remove the render hook and release the awaiting caller exactly once.
+		// cancellation path: remove the logical hook and release the awaiting caller exactly once.
 		this.finishLoading = () => {
 			this.finishLoading = undefined;
 			unhook();

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -351,64 +351,66 @@ describe('BattleEngine', () => {
 			expect(engine.loadingTotal).toBe(100);
 		});
 
-		it('counts the loading time down each render frame and resolves + unhooks at zero', async () => {
+		it('counts the loading time down each logical tick and resolves + unhooks at zero', async () => {
+			// The countdown is driven by the logical clock (not rAF), so it keeps advancing in a
+			// backgrounded tab instead of freezing the farm loop in Loading (#1366).
 			const promise = engine.startLoading(100);
-			const countdown = renderUpdateCallbacks[0];
-			expect(renderUpdateCallbacks).toHaveLength(1);
+			const countdown = logicalUpdateCallbacks[0];
+			expect(logicalUpdateCallbacks).toHaveLength(1);
 
-			// First frame doesn't reach zero — still ticking, not yet unhooked.
-			countdown(60, 0);
+			// First tick doesn't reach zero — still ticking, not yet unhooked.
+			countdown(60);
 			expect(engine.loadingTime).toBe(40);
-			expect(renderUpdateCallbacks).toHaveLength(1);
+			expect(logicalUpdateCallbacks).toHaveLength(1);
 
-			// Second frame drives it past zero — the promise resolves and the hook removes itself.
-			countdown(60, 0);
+			// Second tick drives it past zero — the promise resolves and the hook removes itself.
+			countdown(60);
 			await expect(promise).resolves.toBeUndefined();
-			expect(renderUpdateCallbacks).toHaveLength(0);
+			expect(logicalUpdateCallbacks).toHaveLength(0);
 		});
 
 		it('resolves the promise and removes the countdown hook when stopped mid-loading', async () => {
-			engine.start(); // registers the engine's own render hook
+			engine.start(); // registers the engine's own logical hook
 			const promise = engine.startLoading(1000);
-			// The engine render hook plus the loading countdown are both registered.
-			expect(renderUpdateCallbacks).toHaveLength(2);
+			// The engine logical hook plus the loading countdown are both registered.
+			expect(logicalUpdateCallbacks).toHaveLength(2);
 
 			engine.stop();
 
 			// A stop mid-cooldown must release the awaiting getNewEnemy path rather than hang it forever,
-			// and tear down every render hook so a later renderEngine.start() can't resume a stale countdown.
+			// and tear down the countdown hook so a later start() can't resume a stale countdown.
 			await expect(promise).resolves.toBeUndefined();
-			expect(renderUpdateCallbacks).toHaveLength(0);
+			expect(logicalUpdateCallbacks).toHaveLength(0);
 		});
 
 		it('resolves the promise and removes the countdown hook when reset mid-loading', async () => {
 			engine.start();
 			const promise = engine.startLoading(1000);
-			expect(renderUpdateCallbacks).toHaveLength(2);
+			expect(logicalUpdateCallbacks).toHaveLength(2);
 
 			engine.reset({ id: 1, level: 1, seed: 0, selectedSkills: [0], attributes: [] });
 
 			// Reset cancels the in-flight cooldown (releasing the awaiter) but leaves the engine's own
-			// render hook in place for the re-armed battle.
+			// logical hook in place for the re-armed battle.
 			await expect(promise).resolves.toBeUndefined();
-			expect(renderUpdateCallbacks).toHaveLength(1);
+			expect(logicalUpdateCallbacks).toHaveLength(1);
 		});
 
 		it('does not leave a stale countdown hook behind when re-invoked while one is pending', async () => {
 			const first = engine.startLoading(1000);
-			expect(renderUpdateCallbacks).toHaveLength(1);
+			expect(logicalUpdateCallbacks).toHaveLength(1);
 
 			// Re-invoking before the first countdown completes cancels it (releasing its awaiter) instead
 			// of stacking a second leaked hook.
 			const second = engine.startLoading(500);
 			await expect(first).resolves.toBeUndefined();
-			expect(renderUpdateCallbacks).toHaveLength(1);
+			expect(logicalUpdateCallbacks).toHaveLength(1);
 
 			// The new countdown still resolves normally at zero.
-			const countdown = renderUpdateCallbacks[0];
-			countdown(500, 0);
+			const countdown = logicalUpdateCallbacks[0];
+			countdown(500);
 			await expect(second).resolves.toBeUndefined();
-			expect(renderUpdateCallbacks).toHaveLength(0);
+			expect(logicalUpdateCallbacks).toHaveLength(0);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fixes #1366. The post-victory loading/cooldown countdown was driven by the **render (rAF) loop** rather than the catch-up-capable logical loop:

- `BattleEngine.startLoading` hooked `onRenderUpdate` and subtracted the **render** delta from `loadingTime` each frame.
- `requestAnimationFrame` is throttled/suspended while a tab is backgrounded, so during the loading window the countdown **froze** and the idle farm loop parked in the `Loading` stage until the tab was refocused — losing idle progress accrued between battles.

## How it addresses the issue

`startLoading` now drives the countdown off `onLogicalUpdate` (the `setInterval`-based logical clock), which keeps running — throttled, with its existing over-budget catch-up — when the tab is hidden. The cooldown now advances consistently whether or not the tab is focused, so the farm loop no longer parks in `Loading`.

The related comments (`finishLoading` doc, the `stop()` unconditional-cancel rationale) were updated from "render" to "logical" to match.

### Scope note

This is the narrow, independently-fixable defect from #1366. Time lost *beyond* the logical loop's `tickSizeX5` catch-up cap (the broader background-throttle accounting) remains the concern of spike #1073 and is out of scope here.

## Test plan

- [x] Updated the `startLoading` unit tests to exercise the **logical** hook (delta-only signature) and renamed the countdown-down test accordingly.
- [x] `battle-engine.test.ts` — 48 passed.
- [x] Full frontend unit suite — 268 files / 3012 tests passed.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.

Frontend-only change; no backend surface touched. Not parity-sensitive (the loading countdown is outside `battleStep`).

Closes #1366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWi6ZNc17JPsscUZ2LaU1z

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWi6ZNc17JPsscUZ2LaU1z)_