### PR TITLE
Cancel orphaned reference-cache reloads on timeout (#1367)

### DIFF
--- a/Game.Api.Tests/Unit/AdminCacheReloadFilterTests.cs
+++ b/Game.Api.Tests/Unit/AdminCacheReloadFilterTests.cs
@@ -13,10 +13,29 @@ namespace Game.Api.Tests.Unit
     /// <summary>
     /// Covers the post-admin-write reload gate: on a successful write the filter broadcasts the change and
     /// reloads every cache; a broadcast failure is swallowed so the local read-your-writes reload still runs;
-    /// and a faulted action skips both the broadcast and the reload entirely.
+    /// a faulted action skips both the broadcast and the reload entirely; and a wedged reload is cancelled and
+    /// surfaced as a <see cref="TimeoutException"/> rather than orphaned.
     /// </summary>
     public class AdminCacheReloadFilterTests
     {
+        private static ActionExecutingContext BuildExecutingContext()
+        {
+            var httpContext = new DefaultHttpContext();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+            return new ActionExecutingContext(actionContext, [], new Dictionary<string, object?>(), controller: new object());
+        }
+
+        private static ActionExecutedContext BuildExecutedContext(Exception? exception, bool exceptionHandled)
+        {
+            var httpContext = new DefaultHttpContext();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+            return new ActionExecutedContext(actionContext, [], controller: new object())
+            {
+                Exception = exception!,
+                ExceptionHandled = exceptionHandled,
+            };
+        }
+
         private static async Task<(int notified, int reloaded)> RunAsync(
             Exception? exception, bool exceptionHandled, bool broadcastThrows = false)
         {
@@ -24,16 +43,8 @@ namespace Game.Api.Tests.Unit
             var notifier = new RecordingNotifier(broadcastThrows);
             var filter = new AdminCacheReloadFilter([cache], notifier, NullLogger<AdminCacheReloadFilter>.Instance);
 
-            var httpContext = new DefaultHttpContext();
-            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
-            var executing = new ActionExecutingContext(actionContext, [], new Dictionary<string, object?>(), controller: new object());
-            var executed = new ActionExecutedContext(actionContext, [], controller: new object())
-            {
-                Exception = exception!,
-                ExceptionHandled = exceptionHandled,
-            };
-
-            await filter.OnActionExecutionAsync(executing, () => Task.FromResult(executed));
+            var executed = BuildExecutedContext(exception, exceptionHandled);
+            await filter.OnActionExecutionAsync(BuildExecutingContext(), () => Task.FromResult(executed));
 
             return (notifier.NotifyCount, cache.ReloadCount);
         }
@@ -64,14 +75,63 @@ namespace Game.Api.Tests.Unit
             Assert.Equal(0, reloaded);
         }
 
+        [Fact]
+        public async Task PassesACancellableToken_ToEachReload()
+        {
+            // The reload must run under its own timeout-linked token (not CancellationToken.None) so a wedged
+            // query can be cancelled; assert the filter hands the cache a token that can actually be cancelled.
+            var cache = new RecordingCache();
+            var filter = new AdminCacheReloadFilter([cache], new RecordingNotifier(throws: false), NullLogger<AdminCacheReloadFilter>.Instance);
+
+            var executed = BuildExecutedContext(exception: null, exceptionHandled: false);
+            await filter.OnActionExecutionAsync(BuildExecutingContext(), () => Task.FromResult(executed));
+
+            Assert.True(cache.LastToken.CanBeCanceled);
+        }
+
+        [Fact]
+        public async Task ThrowsTimeoutAndCancelsTheReload_WhenAReloadWedges()
+        {
+            // A reload that never completes on its own must be cancelled by the timeout and surface as a
+            // TimeoutException — not hang or leave the query orphaned holding its gate.
+            var cache = new WedgedCache();
+            var filter = new AdminCacheReloadFilter(
+                [cache], new RecordingNotifier(throws: false), NullLogger<AdminCacheReloadFilter>.Instance,
+                reloadTimeout: TimeSpan.FromMilliseconds(50));
+
+            var executed = BuildExecutedContext(exception: null, exceptionHandled: false);
+
+            await Assert.ThrowsAsync<TimeoutException>(
+                () => filter.OnActionExecutionAsync(BuildExecutingContext(), () => Task.FromResult(executed)));
+            // The reload's token must actually be cancelled on timeout (so its query/gate are released) rather
+            // than orphaned; awaiting the cancellation signal confirms it without racing on a plain flag.
+            await cache.Cancelled.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
         private sealed class RecordingCache : IReloadableReferenceCache
         {
             public int ReloadCount { get; private set; }
+            public CancellationToken LastToken { get; private set; }
 
             public Task ReloadAsync(CancellationToken cancellationToken = default)
             {
                 ReloadCount++;
+                LastToken = cancellationToken;
                 return Task.CompletedTask;
+            }
+        }
+
+        private sealed class WedgedCache : IReloadableReferenceCache
+        {
+            private readonly TaskCompletionSource _cancelled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // Completes when the reload's token is cancelled — i.e. the wedged reload was released, not orphaned.
+            public Task Cancelled => _cancelled.Task;
+
+            public async Task ReloadAsync(CancellationToken cancellationToken = default)
+            {
+                using var registration = cancellationToken.Register(() => _cancelled.TrySetResult());
+                await Task.Delay(Timeout.Infinite, cancellationToken);
             }
         }
 

--- a/Game.Api/Filters/AdminCacheReloadFilter.cs
+++ b/Game.Api/Filters/AdminCacheReloadFilter.cs
@@ -20,7 +20,8 @@ namespace Game.Api.Filters
     public class AdminCacheReloadFilter(
         IEnumerable<IReloadableReferenceCache> caches,
         IReferenceDataChangeNotifier changeNotifier,
-        ILogger<AdminCacheReloadFilter> logger) : IAsyncActionFilter
+        ILogger<AdminCacheReloadFilter> logger,
+        TimeSpan? reloadTimeout = null) : IAsyncActionFilter
     {
         /// <summary>
         /// Ordered to run outermost among action filters so this filter's post-action reload executes AFTER
@@ -33,10 +34,11 @@ namespace Game.Api.Filters
         /// <summary>
         /// Upper bound on the awaited local reload. The reload queries the database on a fresh context, so a
         /// wedged connection would otherwise hold the admin request open indefinitely (no request-token tie —
-        /// see below). On timeout the reload is abandoned and a <see cref="TimeoutException"/> surfaces as an
+        /// see below). On timeout the reload is cancelled and a <see cref="TimeoutException"/> surfaces as an
         /// error on the admin response; the write persisted, so the admin can retry the reload by re-saving.
+        /// Injectable (defaulting to 30s) only so tests can exercise the timeout path without the full wait.
         /// </summary>
-        private static readonly TimeSpan ReloadTimeout = TimeSpan.FromSeconds(30);
+        private readonly TimeSpan _reloadTimeout = reloadTimeout ?? TimeSpan.FromSeconds(30);
 
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
@@ -67,9 +69,22 @@ namespace Game.Api.Filters
                 // own DI-scoped context and swaps it atomically, and no holder depends on another's reload
                 // order, so a serial pass only adds latency and could leave some sets fresh and some stale if
                 // one query failed mid-list. Not tied to the request's cancellation token: the write has
-                // committed, so the caches must reflect it even if the client has disconnected — but bounded by
-                // ReloadTimeout so a wedged database connection can't hold the admin request open forever.
-                await Task.WhenAll(caches.Select(cache => cache.ReloadAsync())).WaitAsync(ReloadTimeout);
+                // committed, so the caches must reflect it even if the client has disconnected — instead a
+                // standalone timeout source bounds the wait AND drives the cancellation, so a wedged reload's
+                // query and reload gate are actually released (Npgsql honors the token) rather than orphaned in
+                // the background. On timeout the cancellation surfaces as a TimeoutException on the admin
+                // response; the write persisted, so the admin can retry the reload by re-saving.
+                using var timeoutSource = new CancellationTokenSource(_reloadTimeout);
+                try
+                {
+                    await Task.WhenAll(caches.Select(cache => cache.ReloadAsync(timeoutSource.Token)))
+                        .WaitAsync(timeoutSource.Token);
+                }
+                catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
+                {
+                    throw new TimeoutException(
+                        "Reloading the reference caches timed out; the write persisted — retry the save to refresh the caches.");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

`AdminCacheReloadFilter` bounded its post-write reload with `WaitAsync(ReloadTimeout)` but invoked `ReloadAsync()` with **no cancellation token**. `WaitAsync` only abandons the *await* — on timeout every holder's reload query kept running to completion against its own scoped context, each holding its `_reloadGate` semaphore until it finished. The admin saw a `TimeoutException` while a swap could still land afterward (a resource leak on the rare timeout path, plus a confusing "it timed out but the data updated anyway" outcome).

## How it addresses the issue

- Introduce a standalone, timeout-linked `CancellationTokenSource(ReloadTimeout)` — deliberately **independent of the request token** (the committed write must still land even if the client disconnected, preserving read-your-writes) — and pass its token into `ReloadAsync(...)`.
- The token now both **bounds the await** and **drives cancellation**, so on timeout the underlying queries and per-holder gates are actually released (`ReferenceCacheHolder.ReloadAsync` already threads the token to the gate wait and the EF/Npgsql query) instead of being orphaned in the background.
- The cancellation is re-surfaced as the same `TimeoutException` the admin response already expected, so the externally observed behavior is unchanged.
- The 30s timeout became an optional constructor parameter (defaults to 30s, resolved by DI since the type isn't registered) purely so the timeout path is testable without the full wait.

## Test plan

- [x] `dotnet build Game.Api.Tests`
- [x] Full `Game.Api.Tests` suite green (652 passed)
- [x] New unit tests on the filter:
  - `PassesACancellableToken_ToEachReload` — the reload runs under a cancellable token, not `CancellationToken.None`.
  - `ThrowsTimeoutAndCancelsTheReload_WhenAReloadWedges` — a wedged reload is cancelled on timeout (verified deterministically via a cancellation callback) and surfaces as a `TimeoutException`, rather than hanging or orphaning the query.
  - Existing broadcast/reload/skip-on-fault tests still pass.

Closes #1367

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9PanivAfMBKT5xb14CfNM)_