### PR TITLE
Load PlayerProgress once in the offline-progress path (#1368)

### DIFF
--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -429,15 +429,22 @@ namespace Game.Application.Services
             // (here) rather than being re-abandoned by the first live StartBattle after the gate.
             await ResolveStaleBattle(player, state, cancellationToken);
 
-            var (mode, zone) = await ResolveOfflineLoop(player, cancellationToken);
-            var proficiencyLevels = await CaptureProficiencyLevels(player.Id, cancellationToken);
+            // Load the progress aggregate once for the whole offline pass. Its completed challenges (loop/zone
+            // gating), proficiency levels (battle snapshot), and statistics (reward application) all read the
+            // same Progress_{playerId} cache key, so threading one aggregate down replaces 3-4 serial round-trips.
+            // Loaded after ResolveStaleBattle so it reflects the settled stale battle's progress mutation.
+            var progress = await _progressRepo.Load(player, cancellationToken);
+            var completedChallengeIds = progress.CompletedChallengeIds();
+
+            var (mode, zone) = await ResolveOfflineLoop(player, completedChallengeIds, cancellationToken);
+            var proficiencyLevels = ToProficiencyLevels(progress.Proficiencies);
             var parameters = BuildSimulationParameters(player, mode, zone, awayMs, proficiencyLevels);
 
             var result = _offlineSimulator.Simulate(parameters, cancellationToken);
 
             var levelBefore = player.Level;
             var statPointsBefore = player.StatPoints.StatPointsGained;
-            var rewards = await ApplyOfflineRewards(player, result, cancellationToken);
+            var rewards = await ApplyOfflineRewards(player, progress, result, cancellationToken);
 
             // Re-anchor the away clock and persist the player (exp/levels/unlocks) in one save. The exp batch
             // already raised its own single core update in ApplyOfflineRewards; this re-anchor raises one more.
@@ -467,7 +474,8 @@ namespace Game.Application.Services
         // when the persisted flag is set and the current zone still has a challengeable boss (in circulation,
         // unlocked, boss authored); otherwise the loop falls back to idle in the nearest viable zone (the same
         // lazy-relocation the live idle loop uses, so a retired/empty current zone never stalls the sim).
-        private async Task<(OfflineLoopMode Mode, CoreZone Zone)> ResolveOfflineLoop(Player player, CancellationToken cancellationToken)
+        private async Task<(OfflineLoopMode Mode, CoreZone Zone)> ResolveOfflineLoop(
+            Player player, IReadOnlySet<int> completedChallengeIds, CancellationToken cancellationToken)
         {
             var currentZoneId = player.CurrentZoneId;
             if (player.AutoChallengeBoss
@@ -475,13 +483,13 @@ namespace Game.Application.Services
                 && !_zones.IsZoneRetired(currentZoneId))
             {
                 var bossZone = _zones.GetDomainZone(currentZoneId);
-                if (bossZone.BossEnemyId is not null && await IsZoneUnlocked(player.Id, bossZone, cancellationToken))
+                if (bossZone.BossEnemyId is not null && bossZone.IsUnlocked(completedChallengeIds))
                 {
                     return (OfflineLoopMode.Boss, bossZone);
                 }
             }
 
-            var idleZoneId = await EnsureViableZone(player, currentZoneId, cancellationToken);
+            var idleZoneId = await EnsureViableZone(player, currentZoneId, completedChallengeIds, cancellationToken);
             return (OfflineLoopMode.Idle, _zones.GetDomainZone(idleZoneId));
         }
 
@@ -537,14 +545,13 @@ namespace Game.Application.Services
         // and the affected challenges are evaluated once at the end with the live per-challenge push suppressed
         // (the summary is the notification). Returns the completed challenges and the folded proficiency gains
         // (spike #982 decision 9 — the offline accrual's notification rides the summary, not a per-battle push).
-        private async Task<OfflineRewards> ApplyOfflineRewards(Player player, OfflineProgressResult result, CancellationToken cancellationToken)
+        private async Task<OfflineRewards> ApplyOfflineRewards(
+            Player player, PlayerProgress progress, OfflineProgressResult result, CancellationToken cancellationToken)
         {
             if (result.BattlesSimulated == 0)
             {
                 return OfflineRewards.Empty;
             }
-
-            var progress = await _progressRepo.Load(player, cancellationToken);
 
             var victoryExpRewards = new List<int>();
             var proficiencyGains = new ProficiencyGainAccumulator();
@@ -697,10 +704,8 @@ namespace Game.Application.Services
                 && _enemies.HasSpawnableEnemies(zoneId);
         }
 
-        // Relocates the player when their resolved zone is no longer viable, returning the zone the battle
-        // should run in. "Nearest" is the lowest-Order zone the player has unlocked that is viable, falling
-        // back to the starting zone. A no-op (no save) when the current zone is already viable, so the idle
-        // hot path pays only the cheap viability check; the completion lookup and scan run only on a relocate.
+        // Live-path overload: defers reading the completed-challenge set until a relocation is actually needed
+        // (the viability check short-circuits first), so the idle hot path never pays the read.
         private async Task<int> EnsureViableZone(Player player, int zoneId, CancellationToken cancellationToken)
         {
             // An out-of-range zone id is corruption/tampering, not a relocation case: leave it for the
@@ -711,6 +716,22 @@ namespace Game.Application.Services
             }
 
             var completedChallengeIds = await _progressRepo.GetCompletedChallengeIds(player.Id, cancellationToken);
+            return await EnsureViableZone(player, zoneId, completedChallengeIds, cancellationToken);
+        }
+
+        // Relocates the player when their resolved zone is no longer viable, returning the zone the battle
+        // should run in. "Nearest" is the lowest-Order zone the player has unlocked that is viable, falling
+        // back to the starting zone. A no-op (no save) when the current zone is already viable. Takes the
+        // completed-challenge set so a caller holding a loaded progress aggregate (the offline pass) gates
+        // without re-reading the progress cache key.
+        private async Task<int> EnsureViableZone(
+            Player player, int zoneId, IReadOnlySet<int> completedChallengeIds, CancellationToken cancellationToken)
+        {
+            if (!_zones.ValidateZoneId(zoneId) || IsZoneViable(zoneId))
+            {
+                return zoneId;
+            }
+
             // Filter to viable candidates before ordering, then resolve each domain zone once (lazily, so the
             // resolve stops at the first unlocked match) rather than re-resolving it inside the predicate.
             var destination = _zones.All()
@@ -758,10 +779,16 @@ namespace Game.Application.Services
         private async Task<List<ProficiencyLevelSnapshot>> CaptureProficiencyLevels(int playerId, CancellationToken cancellationToken)
         {
             var proficiencies = await _progressRepo.GetProficiencies(playerId, cancellationToken);
-            return proficiencies
+            return ToProficiencyLevels(proficiencies);
+        }
+
+        // Projects proficiency progress to the battle-snapshot's level-only view, shared by the live capture
+        // (which reads through the lean accessor) and the offline pass (which derives it from the progress
+        // aggregate it already loaded), so the two cannot drift.
+        private static List<ProficiencyLevelSnapshot> ToProficiencyLevels(IEnumerable<PlayerProficiency> proficiencies) =>
+            proficiencies
                 .Select(p => new ProficiencyLevelSnapshot { ProficiencyId = p.ProficiencyId, Level = p.Level })
                 .ToList();
-        }
 
         // Shared anti-cheat preamble for the three battle-end paths: guards that a battle is active, resolves
         // the snapshotted enemy, and replays the fight once. Returns false (with no outputs) when there is no

--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -882,6 +882,31 @@ namespace Game.Core.Tests.Progress
             Assert.DoesNotContain(progress.DirtyProficiencies, p => p.ProficiencyId == 4);
         }
 
+        // ── CompletedChallengeIds ────────────────────────────────────────────
+
+        [Fact]
+        public void CompletedChallengeIds_ReturnsOnlyCompletedChallenges()
+        {
+            var completed = new PlayerChallenge(
+                MakeChallenge(id: 7, EChallengeType.EnemiesKilled, goal: 3m), progress: 3m, completed: true,
+                completedAt: DateTime.UtcNow);
+            var inProgress = new PlayerChallenge(
+                MakeChallenge(id: 9, EChallengeType.EnemiesKilled, goal: 5m), progress: 2m, completed: false);
+            var progress = MakeProgress(challenges: [completed, inProgress]);
+
+            var ids = progress.CompletedChallengeIds();
+
+            Assert.Equal(7, Assert.Single(ids));
+        }
+
+        [Fact]
+        public void CompletedChallengeIds_NoChallenges_ReturnsEmpty()
+        {
+            var progress = MakeProgress();
+
+            Assert.Empty(progress.CompletedChallengeIds());
+        }
+
         // ── Helpers ──────────────────────────────────────────────────────────
 
         private static PlayerProgress MakeProgress(

--- a/Game.Core/Progress/PlayerProgress.cs
+++ b/Game.Core/Progress/PlayerProgress.cs
@@ -191,6 +191,14 @@ namespace Game.Core.Progress
             return completed;
         }
 
+        /// <summary>
+        /// The ids of the challenges the player has completed — the in-aggregate equivalent of
+        /// <c>IPlayerProgressRepository.GetCompletedChallengeIds</c>, for callers that already hold a loaded
+        /// aggregate (e.g. the offline pass) so they need not re-read the progress cache key just to gate on it.
+        /// </summary>
+        public HashSet<int> CompletedChallengeIds() =>
+            [.. _challenges.Values.Where(c => c.Completed).Select(c => c.Challenge.Id)];
+
         public decimal GetStatisticValue(EStatisticType type, int? entityId)
         {
             TryGetStatisticValue(type, entityId, out var value);


### PR DESCRIPTION
## Summary

`GetOfflineProgress` (the offline-rewards / character-switch path) re-read the same `Progress_{playerId}` Redis key 3–4 times within a single command:

- `CaptureProficiencyLevels` → `GetProficiencies`
- `ResolveOfflineLoop` → `IsZoneUnlocked` / `EnsureViableZone` → `GetCompletedChallengeIds`
- `ApplyOfflineRewards` → `Load`

Each is a full Redis round-trip (plus a fire-and-forget `ExpireAndForget`). They're warm cache hits, so this was never a correctness bug — just avoidable serial latency on a login-time path.

This loads the `PlayerProgress` aggregate **once** at the top of `SimulateProgress` and threads it down, collapsing the 3–4 reads into one.

## How it addresses the issue

- `SimulateProgress` now does a single `_progressRepo.Load` and derives everything from it: completed-challenge ids (loop/zone gating) via the new `PlayerProgress.CompletedChallengeIds()`, proficiency levels (battle snapshot) via a shared `ToProficiencyLevels` projection, and statistics (reward application) by passing the same aggregate into `ApplyOfflineRewards` instead of having it reload.
- **Ordering preserved:** the load happens *after* `ResolveStaleBattle`. That step settles the disconnected battle, which fires `BattleCompletedEvent` → `BattleStatisticsEventHandler` synchronously (via the awaited dispatcher in `SavePlayer`), mutating the progress cache. Loading before it would snapshot stale progress and overwrite the cache on save, dropping the settled battle's stats. The comment documents this.
- **Live hot paths untouched:** `StartBattle` / `StartBossBattle` / `SetAutoChallengeBoss` keep reading via the existing accessors. `EnsureViableZone` retains a lazy-read overload that only hits Redis on an actual relocation, so the idle loop never pays the read on the common case; a new overload takes the pre-resolved set for the offline caller.
- A shared `ToProficiencyLevels` projection keeps the live and offline proficiency-snapshot derivations from drifting.

## Test plan

- **New unit tests** for `PlayerProgress.CompletedChallengeIds()` (returns only completed challenges; empty when none).
- **Existing offline integration tests** (`BattleServiceOfflineProgressIntegrationTests`, 10 tests) pass unchanged — they cover multi-battle exp/levels, below-threshold no-op, second-call no-op, mid-window challenge completion + reward unlock, proficiency accrual, and zone resolution, which are exactly the behaviors this refactor must preserve.
- `BattleServiceIntegrationTests` + `BattleStatisticsEventHandlerTests` (53 tests) and the full `Game.Core.Tests` suite (1111 tests) pass.
- `dotnet build` clean (0 warnings, 0 errors).

### Note for the reviewer

No regression test pins the *read count* itself: the integration test base (`ApplicationIntegrationTestBase`) builds its provider with no service-override seam, so wrapping `ICacheService` with a counting decorator would mean retrofitting shared infrastructure — out of scope for this small change. Behavioral preservation is covered by the existing integration suite. Happy to add a cache-spy seam as a follow-up if wanted.

Closes #1368


---
_Generated by [Claude Code](https://claude.ai/code/session_01FmHbn28nokHJWgCNN9VXtb)_