### PR TITLE
Remove stale falloff clause from Proficiency PathId comment (#1369)

### DIFF
--- a/Game.Core/Proficiencies/Proficiency.cs
+++ b/Game.Core/Proficiencies/Proficiency.cs
@@ -14,8 +14,7 @@ namespace Game.Core.Proficiencies
         public required string Description { get; init; }
 
         /// <summary>The path this proficiency is a tier of, and its 0-based position (tier) within it. The
-        /// battle XP accrual reads these to route a path's contribution to its current frontier tier and to
-        /// scale an off-tier skill's pull by the home-tier falloff.</summary>
+        /// battle XP accrual reads these to route a path's contribution to its current frontier tier.</summary>
         public required int PathId { get; init; }
         public required int PathOrdinal { get; init; }
 


### PR DESCRIPTION
## Summary

Comment-only cleanup from #1369. The `PathId`/`PathOrdinal` doc summary in `Game.Core/Proficiencies/Proficiency.cs` still described scaling "an off-tier skill's pull by the home-tier falloff" — a mechanic that no longer exists. Spike #1318 (decisions 6-7) removed `SkillPathContribution`, `HomeTier`, and `FalloffBase`; XP routing is now purely activity-key → frontier tier. The stale second clause was dropped, leaving:

> The battle XP accrual reads these to route a path's contribution to its current frontier tier.

## Note on the issue's second item

The issue also flagged `Game.Core/Battle/BattleSkill.cs:30` for a "post-crit/post-mitigation/**block**" comment. **That was already resolved independently** — the comment was rewritten by the #1343 multi-typed-damage work and now reads "post-crit/post-mitigation damage" with no `block` reference. I confirmed the only remaining `Block` mention in that area is in `Battler.cs` (~line 100), which legitimately explains *why* Block was removed (spike #1330) and is correctly left in place per the issue's own note.

I also re-verified `SkillPathContribution`/`HomeTier`/`FalloffBase` now appear only in EF migration files (historical artifacts) and docs/spikes — the source is otherwise clean.

## Test plan

- [x] `dotnet build Game.Core` — succeeds, 0 warnings / 0 errors. (Comment-only change; no behavior change, so no new tests.)

Closes #1369

---
_Generated by [Claude Code](https://claude.ai/code/session_015m2iZxaUUX3Goz91s7Rjpm)_