### PR TITLE
Blended multi-typed damage floater + skill-tooltip portion mix (#1386)

### DIFF
--- a/UI/src/components/DamageRatioBar.svelte
+++ b/UI/src/components/DamageRatioBar.svelte
@@ -1,0 +1,41 @@
+<!-- A thin segmented bar encoding a skill's weighted damage-type split (#1343): one segment per
+     portion, in authored order, sized proportionally to its weight and tinted by the portion's leaf-type
+     hue (the same `--dmg-*` tokens the floater and breakdown read). Surfaces the exact multi-typed mix
+     beneath the primary-coloured floater and in the skill tooltips. Purely presentational. -->
+<div class="ratio-bar" style:--ratio-bar-height="{height}px" role="presentation">
+	{#each portions as portion, i (i)}
+		<span class="seg" style:flex-grow={portion.weight} style:background-color={damageTypeColor(portion.type)}></span>
+	{/each}
+</div>
+
+<script lang="ts">
+import type { ISkillDamagePortion } from '$lib/api';
+import { damageTypeColor } from '$lib/common';
+
+interface Props {
+	/** The weighted leaf-type portions, in authored order; each becomes a segment sized by its weight. */
+	portions: readonly ISkillDamagePortion[];
+	/** Bar thickness in px. */
+	height?: number;
+}
+
+const { portions, height = 4 }: Props = $props();
+</script>
+
+<style lang="scss">
+.ratio-bar {
+	display: flex;
+	gap: 1px;
+	width: 100%;
+	height: var(--ratio-bar-height);
+	border-radius: 999px;
+	overflow: hidden;
+}
+
+// Each segment grows in proportion to its portion weight (flex-grow set inline); a zero flex-basis keeps
+// the growth purely weight-driven, and min-width: 0 lets a tiny portion still shrink to its share.
+.seg {
+	flex-basis: 0;
+	min-width: 0;
+}
+</style>

--- a/UI/src/components/SkillDamageTypes.svelte
+++ b/UI/src/components/SkillDamageTypes.svelte
@@ -1,0 +1,87 @@
+<!-- The portion mix of a skill's direct hit (#1343): the segmented ratio bar (multi-typed only) plus
+     one labelled row per leaf type with its share of the hit. A single-typed skill shows just its type
+     — no percentage, no bar — so the common case stays clean. Shared by the combat skill tooltip and
+     the Skills-screen inspector so both read the same way. Colour / icon / name are a pure frontend
+     concern, resolved through the `damage-type-display` helpers. -->
+<div class="dmg-types">
+	{#if multi}
+		<DamageRatioBar {portions} />
+	{/if}
+	<div class="dt-list" class:multi>
+		{#each portions as portion, i (i)}
+			<div class="dt-row">
+				<img class="dt-ico" src={damageTypeIcon(portion.type)} alt="" />
+				<span class="dt-name" style:color={damageTypeColor(portion.type)}>{damageTypeName(portion.type)}</span>
+				{#if multi}
+					<span class="dt-pct">{percent(portion.weight)}%</span>
+				{/if}
+			</div>
+		{/each}
+	</div>
+</div>
+
+<script lang="ts">
+import type { ISkillDamagePortion } from '$lib/api';
+import { damageTypeColor, damageTypeIcon, damageTypeName } from '$lib/common';
+import DamageRatioBar from './DamageRatioBar.svelte';
+
+interface Props {
+	/** The skill's weighted leaf-type portions, in authored order. */
+	portions: readonly ISkillDamagePortion[];
+}
+
+const { portions }: Props = $props();
+
+const multi = $derived(portions.length > 1);
+const totalWeight = $derived(portions.reduce((sum, portion) => sum + portion.weight, 0));
+
+/** A portion's share of the hit as a rounded percentage; an even split is the fallback when weights sum
+ *  to a non-positive total (a malformed authoring state the Workbench editor's validation prevents). */
+const percent = (weight: number): number =>
+	totalWeight > 0 ? Math.round((weight / totalWeight) * 100) : Math.round(100 / portions.length);
+</script>
+
+<style lang="scss">
+.dmg-types {
+	display: flex;
+	flex-direction: column;
+	gap: 7px;
+}
+
+.dt-list {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+
+	// A multi-typed mix labels each share, so give the rows a touch more breathing room.
+	&.multi {
+		gap: 5px;
+	}
+}
+
+.dt-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+}
+
+.dt-ico {
+	width: 14px;
+	height: 14px;
+	object-fit: contain;
+	flex-shrink: 0;
+}
+
+.dt-name {
+	color: var(--text-secondary);
+}
+
+.dt-pct {
+	margin-left: auto;
+	font-family: var(--mono);
+	font-size: 11px;
+	color: var(--text-tertiary);
+	letter-spacing: 0.3px;
+}
+</style>

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -1,7 +1,7 @@
 import { Battler, battleStep, resistanceTotal, type BattleStepLog, type AttributeModifier } from '$lib/battle';
 import { Mulberry32 } from '$lib/engine/mulberry32';
 import { staticData, playerProficiencies } from '$stores';
-import { ELogType, EDamageType, IBattlerAttribute, IEnemyInstance } from '$lib/api';
+import { ELogType, EDamageType, IBattlerAttribute, IEnemyInstance, ISkillDamagePortion } from '$lib/api';
 import { DEFAULT_MAX_BATTLE_MS } from '$lib/api/types/game-constants';
 import { logMessage } from '../log';
 import {
@@ -52,6 +52,10 @@ export interface CombatFloatEvent {
 	kind: 'hit' | 'crit' | 'dodge' | 'reflect';
 	amount?: number;
 	damageType?: EDamageType;
+	/** The hit's weighted leaf-type split (#1343), present for a damaging `hit`/`crit` so the floater
+	 *  can draw the segmented ratio bar; `damageType` above is its `PrimaryDamageType` (number colour /
+	 *  icon). A single-portion hit needs no bar, so consumers render it only for a multi-typed split. */
+	portions?: readonly ISkillDamagePortion[];
 }
 
 const combatFloatHook = createHook<[CombatFloatEvent]>();
@@ -321,7 +325,7 @@ export class BattleEngine {
 					outcome,
 					resist === 'normal' ? undefined : resist
 				);
-				notifyCombatFloat(combatFloatEvent(outcome, damage, damageType));
+				notifyCombatFloat(combatFloatEvent(outcome, damage, damageType, skill.damagePortions));
 				// Deterministic reflection (#1330): the defender returned part of this hit to the attacker. The
 				// reflector is the opposite side of the activation — a player hit is reflected by the enemy, and an
 				// enemy hit by the player — and it deals raw, untyped damage, so the line carries no resist note.
@@ -438,16 +442,22 @@ function damageLogOutcome(byPlayer: boolean, crit: boolean, dodged: boolean): Di
  *  the combat-log line are both driven by the single {@link damageLogOutcome} classifier rather than a
  *  parallel copy of the flag branching. A player hit/crit floats over the enemy; an incoming enemy hit
  *  floats over the player as a dodge (no number) or a plain hit. `damageType` rides every damaging
- *  kind (not a dodge) so the floater can tint by type (#1320, Area F). */
-function combatFloatEvent(outcome: DirectHitOutcome, damage: number, damageType: EDamageType): CombatFloatEvent {
+ *  kind (not a dodge) so the floater can tint by type (#1320, Area F); `portions` rides the same
+ *  damaging kinds so it can draw the multi-typed ratio bar (#1343). */
+function combatFloatEvent(
+	outcome: DirectHitOutcome,
+	damage: number,
+	damageType: EDamageType,
+	portions: readonly ISkillDamagePortion[]
+): CombatFloatEvent {
 	switch (outcome) {
 		case 'player-crit':
-			return { target: 'enemy', kind: 'crit', amount: damage, damageType };
+			return { target: 'enemy', kind: 'crit', amount: damage, damageType, portions };
 		case 'player-hit':
-			return { target: 'enemy', kind: 'hit', amount: damage, damageType };
+			return { target: 'enemy', kind: 'hit', amount: damage, damageType, portions };
 		case 'player-dodge':
 			return { target: 'player', kind: 'dodge' };
 		case 'enemy-hit':
-			return { target: 'player', kind: 'hit', amount: damage, damageType };
+			return { target: 'player', kind: 'hit', amount: damage, damageType, portions };
 	}
 }

--- a/UI/src/routes/game/screens/fight/CombatFloaters.svelte
+++ b/UI/src/routes/game/screens/fight/CombatFloaters.svelte
@@ -14,15 +14,22 @@
 			style:color={floater.color}
 			style:font-size="{floater.size}px"
 		>
-			{#if floater.glyph}
-				<span class="floater-glyph"
-					><LogGlyph glyph={floater.glyph} color={floater.color} size={Math.round(floater.size * 0.85)} /></span
-				>
-			{:else if floater.icon}
-				<img class="floater-icon" src={floater.icon} alt="" />
+			<span class="floater-main">
+				{#if floater.glyph}
+					<span class="floater-glyph"
+						><LogGlyph glyph={floater.glyph} color={floater.color} size={Math.round(floater.size * 0.85)} /></span
+					>
+				{:else if floater.icon}
+					<img class="floater-icon" src={floater.icon} alt="" />
+				{/if}
+				{#if floater.amount}<span>{floater.amount}</span>{/if}
+				{#if floater.label}<span class="floater-label">{floater.label}</span>{/if}
+			</span>
+			<!-- A multi-typed hit (#1343) shows the exact split as a thin ratio bar under the primary-coloured
+			     number; a single-typed hit stays a clean number, exactly as before. -->
+			{#if floater.portions.length > 1}
+				<div class="floater-ratio"><DamageRatioBar portions={floater.portions} height={3} /></div>
 			{/if}
-			{#if floater.amount}<span>{floater.amount}</span>{/if}
-			{#if floater.label}<span class="floater-label">{floater.label}</span>{/if}
 		</div>
 	{/each}
 </div>
@@ -31,8 +38,9 @@
 import { onMount } from 'svelte';
 import { formatNum, damageTypeColor, damageTypeIcon } from '$lib/common';
 import { onCombatFloat, type CombatFloatEvent } from '$lib/engine';
-import { EDamageType } from '$lib/api';
+import { EDamageType, type ISkillDamagePortion } from '$lib/api';
 import LogGlyph from '$components/log-panel/LogGlyph.svelte';
+import DamageRatioBar from '$components/DamageRatioBar.svelte';
 import type { GlyphKind } from '$components/log-panel/log-kind';
 
 type Props = {
@@ -56,6 +64,9 @@ interface Floater {
 	glyph: GlyphKind | '';
 	amount: string;
 	label: string;
+	/** The hit's weighted leaf-type split (#1343); rendered as a ratio bar only for a multi-typed hit
+	 *  (2+ portions), empty otherwise so a single-typed hit stays a clean number. */
+	portions: readonly ISkillDamagePortion[];
 }
 
 /** Clean per-outcome icon art (in `static/img`) for the crit/dodge floaters; a plain hit shows its
@@ -157,7 +168,8 @@ const spawn = (event: CombatFloatEvent) => {
 		icon: iconOf(event),
 		glyph: glyphOf(event),
 		amount: amountOf(event),
-		label: labelFor(event.kind)
+		label: labelFor(event.kind),
+		portions: event.portions ?? []
 	});
 	const timer = setTimeout(() => {
 		removalTimers.delete(timer);
@@ -192,6 +204,9 @@ onMount(() => {
 .floater {
 	position: absolute;
 	top: 54%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 	font-family: var(--mono);
 	font-weight: 700;
 	white-space: nowrap;
@@ -203,6 +218,19 @@ onMount(() => {
 			0 1px 4px color-mix(in srgb, var(--black) 85%, transparent),
 			0 0 6px currentColor;
 	}
+}
+
+// The number line (icon/glyph + amount + label) on its own row, so the ratio bar can stack beneath it.
+// Kept a plain inline-content block (not flex) so the icon/glyph `vertical-align` baseline tweaks hold.
+.floater-main {
+	display: block;
+}
+
+// The multi-typed split bar, sized to roughly the number's width and centred beneath it.
+.floater-ratio {
+	width: 80%;
+	min-width: 24px;
+	margin-top: 2px;
 }
 
 // Per-outcome / damage-type combat icon; sized in em so it tracks the floater's font-size.

--- a/UI/src/routes/game/screens/fight/SkillTooltip.svelte
+++ b/UI/src/routes/game/screens/fight/SkillTooltip.svelte
@@ -11,6 +11,10 @@
 		<DamageBreakdown base={baseDamage} {multipliers} {crit} mitigated={opponent ? mitigated : undefined} {total} />
 	</TooltipSection>
 
+	<TooltipSection label="Damage types">
+		<SkillDamageTypes {portions} />
+	</TooltipSection>
+
 	<TooltipSection label="Tempo" last={effectLines.length === 0}>
 		<TempoMetrics cooldown={adjustedCd} dps={damagePerSecond(total, adjustedCd)} />
 	</TooltipSection>
@@ -44,6 +48,7 @@ import { staticData } from '$stores';
 import TooltipShell from '$components/tooltip/TooltipShell.svelte';
 import TooltipSection from '$components/tooltip/TooltipSection.svelte';
 import TooltipTitle from '$components/tooltip/TooltipTitle.svelte';
+import SkillDamageTypes from '$components/SkillDamageTypes.svelte';
 import CooldownPill from './skill-tooltip/CooldownPill.svelte';
 import DamageBreakdown from './skill-tooltip/DamageBreakdown.svelte';
 import EffectLines from './skill-tooltip/EffectLines.svelte';
@@ -68,6 +73,8 @@ const opponent = $derived(skill?.owner ? battleEngine.getOpponent(skill.owner) :
 const rarityAccent = $derived(skill ? rarityColor(skill.rarityId) : 'var(--accent)');
 
 const baseDamage = $derived(skill?.baseDamage ?? 0);
+// The skill's weighted leaf-type split, surfaced as the portion-mix section (#1343).
+const portions = $derived(skill?.damagePortions ?? []);
 const multipliers = $derived(
 	(skill ? skillContributions(skill, skill.owner.attributes) : []).map((contribution) => ({
 		attributeId: contribution.attributeId,

--- a/UI/src/routes/game/screens/skills/SkillInspector.svelte
+++ b/UI/src/routes/game/screens/skills/SkillInspector.svelte
@@ -30,6 +30,11 @@
 		</div>
 		<div class="rawnote">{rawNote}</div>
 
+		<div class="d-sec">
+			<div class="label">Damage types</div>
+			<div class="dt-host"><SkillDamageTypes portions={metrics.skill.damagePortions} /></div>
+		</div>
+
 		<SkillDamageBreakdown {view} {metrics} />
 
 		{#if effects.length}
@@ -73,6 +78,7 @@ import { staticData } from '$stores';
 import SkillIcon from './SkillIcon.svelte';
 import SkillCta from './SkillCta.svelte';
 import SkillDamageBreakdown from './SkillDamageBreakdown.svelte';
+import SkillDamageTypes from '$components/SkillDamageTypes.svelte';
 import RarityTagBox from '$components/RarityTagBox.svelte';
 import type { SkillMetrics, SkillsView } from './skills-view.svelte';
 
@@ -260,6 +266,10 @@ const rawNote = $derived.by(() => {
 	letter-spacing: 1.6px;
 	text-transform: uppercase;
 	color: var(--text-muted);
+}
+
+.dt-host {
+	margin-top: 8px;
 }
 
 .effect-row {

--- a/UI/src/tests/components/DamageRatioBar.test.ts
+++ b/UI/src/tests/components/DamageRatioBar.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EDamageType } from '$lib/api';
+import DamageRatioBar from '$components/DamageRatioBar.svelte';
+
+afterEach(cleanup);
+
+describe('DamageRatioBar', () => {
+	it('renders one segment per portion, tinted by its leaf-type hue', () => {
+		const { container } = render(DamageRatioBar, {
+			props: {
+				portions: [
+					{ type: EDamageType.Physical, weight: 60 },
+					{ type: EDamageType.Fire, weight: 40 }
+				]
+			}
+		});
+
+		const segments = container.querySelectorAll('.seg');
+		expect(segments).toHaveLength(2);
+		expect(segments[0].getAttribute('style')).toContain('var(--dmg-physical)');
+		expect(segments[1].getAttribute('style')).toContain('var(--dmg-fire)');
+	});
+
+	it('sizes each segment in proportion to its weight via flex-grow', () => {
+		const { container } = render(DamageRatioBar, {
+			props: {
+				portions: [
+					{ type: EDamageType.Physical, weight: 3 },
+					{ type: EDamageType.Water, weight: 1 }
+				]
+			}
+		});
+
+		const segments = container.querySelectorAll('.seg');
+		expect((segments[0] as HTMLElement).style.flexGrow).toBe('3');
+		expect((segments[1] as HTMLElement).style.flexGrow).toBe('1');
+	});
+
+	it('scales to a three-portion split', () => {
+		const { container } = render(DamageRatioBar, {
+			props: {
+				portions: [
+					{ type: EDamageType.Physical, weight: 1 },
+					{ type: EDamageType.Fire, weight: 1 },
+					{ type: EDamageType.Wind, weight: 1 }
+				]
+			}
+		});
+
+		expect(container.querySelectorAll('.seg')).toHaveLength(3);
+	});
+
+	it('drives the bar thickness from the height prop', () => {
+		const { container } = render(DamageRatioBar, {
+			props: { portions: [{ type: EDamageType.Physical, weight: 1 }], height: 3 }
+		});
+
+		const bar = container.querySelector('.ratio-bar') as HTMLElement;
+		expect(bar.style.getPropertyValue('--ratio-bar-height')).toBe('3px');
+	});
+});

--- a/UI/src/tests/components/SkillDamageTypes.test.ts
+++ b/UI/src/tests/components/SkillDamageTypes.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { EDamageType } from '$lib/api';
+import SkillDamageTypes from '$components/SkillDamageTypes.svelte';
+
+afterEach(cleanup);
+
+describe('SkillDamageTypes', () => {
+	it('shows a single-typed skill as one clean row — no percentage, no ratio bar', () => {
+		const { container } = render(SkillDamageTypes, {
+			props: { portions: [{ type: EDamageType.Fire, weight: 1 }] }
+		});
+
+		const rows = container.querySelectorAll('.dt-row');
+		expect(rows).toHaveLength(1);
+		expect(rows[0].querySelector('.dt-name')?.textContent).toBe('Fire');
+		expect(rows[0].querySelector('.dt-ico')?.getAttribute('src')).toContain('Fire.png');
+		// A lone type has no meaningful split, so neither the percentage nor the bar is shown.
+		expect(container.querySelector('.dt-pct')).toBeNull();
+		expect(container.querySelector('.ratio-bar')).toBeNull();
+	});
+
+	it('shows a two-typed mix as the ratio bar plus a labelled, percentage-tagged row per type', () => {
+		const { container } = render(SkillDamageTypes, {
+			props: {
+				portions: [
+					{ type: EDamageType.Physical, weight: 60 },
+					{ type: EDamageType.Fire, weight: 40 }
+				]
+			}
+		});
+
+		expect(container.querySelectorAll('.ratio-bar .seg')).toHaveLength(2);
+
+		const rows = container.querySelectorAll('.dt-row');
+		expect(rows).toHaveLength(2);
+		expect(rows[0].querySelector('.dt-name')?.textContent).toBe('Physical');
+		expect(rows[0].querySelector('.dt-pct')?.textContent).toBe('60%');
+		expect(rows[1].querySelector('.dt-name')?.textContent).toBe('Fire');
+		expect(rows[1].querySelector('.dt-pct')?.textContent).toBe('40%');
+	});
+
+	it('normalizes raw weights to percentages', () => {
+		const { container } = render(SkillDamageTypes, {
+			props: {
+				portions: [
+					{ type: EDamageType.Physical, weight: 3 },
+					{ type: EDamageType.Water, weight: 1 }
+				]
+			}
+		});
+
+		const pcts = [...container.querySelectorAll('.dt-pct')].map((el) => el.textContent);
+		expect(pcts).toEqual(['75%', '25%']);
+	});
+
+	it('scales to a three-portion mix', () => {
+		const { container } = render(SkillDamageTypes, {
+			props: {
+				portions: [
+					{ type: EDamageType.Physical, weight: 1 },
+					{ type: EDamageType.Fire, weight: 1 },
+					{ type: EDamageType.Wind, weight: 1 }
+				]
+			}
+		});
+
+		expect(container.querySelectorAll('.ratio-bar .seg')).toHaveLength(3);
+		expect(container.querySelectorAll('.dt-row')).toHaveLength(3);
+		// Even thirds round to 33% each (independent rounding; players read the bar for the exact split).
+		expect([...container.querySelectorAll('.dt-pct')].map((el) => el.textContent)).toEqual(['33%', '33%', '33%']);
+	});
+});

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -759,6 +759,25 @@ describe('BattleEngine', () => {
 				expect(hit?.damageType).toBe(EDamageType.Fire);
 			});
 
+			it("carries the skill's weighted split and its PrimaryDamageType on a multi-typed hit float (#1343)", () => {
+				mockSkills[0].damagePortions = [
+					{ type: EDamageType.Physical, weight: 60 },
+					{ type: EDamageType.Fire, weight: 40 }
+				];
+				engine.start();
+				enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, selectedSkills: [0], attributes: [] });
+
+				logicalUpdateCallbacks[0](500);
+
+				const hit = events.find((event) => event.target === 'enemy');
+				// The number reads as the highest-weight portion; the floater draws the bar from the full split.
+				expect(hit?.damageType).toBe(EDamageType.Physical);
+				expect(hit?.portions).toEqual([
+					{ type: EDamageType.Physical, weight: 60 },
+					{ type: EDamageType.Fire, weight: 40 }
+				]);
+			});
+
 			it('emits an enemy-targeted crit when the player crits', () => {
 				forcePlayerChance(EAttribute.CriticalChance);
 				engine.start();

--- a/UI/src/tests/routes/game/screens/fight/CombatFloaters.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/CombatFloaters.test.ts
@@ -154,6 +154,91 @@ describe('CombatFloaters', () => {
 		});
 	});
 
+	describe('multi-typed split bar (#1343)', () => {
+		it('draws a segmented ratio bar beneath a multi-typed hit, tinted per portion', () => {
+			const { getByTestId } = render(CombatFloaters, { props: { side: 'enemy', testId: 'enemy-floaters' } });
+			emit({
+				target: 'enemy',
+				kind: 'hit',
+				amount: 50,
+				// The number reads as its PrimaryDamageType; the bar carries the exact split.
+				damageType: EDamageType.Physical,
+				portions: [
+					{ type: EDamageType.Physical, weight: 60 },
+					{ type: EDamageType.Fire, weight: 40 }
+				]
+			});
+
+			const floater = getByTestId('enemy-floaters').querySelector('.floater') as HTMLElement;
+			expect(floater.textContent).toContain('50');
+			// The number stays coloured by the primary type, like a single-typed hit.
+			expect(floater.getAttribute('style')).toContain('var(--dmg-physical)');
+			const segments = floater.querySelectorAll('.floater-ratio .seg');
+			expect(segments).toHaveLength(2);
+			expect(segments[0].getAttribute('style')).toContain('var(--dmg-physical)');
+			expect(segments[1].getAttribute('style')).toContain('var(--dmg-fire)');
+		});
+
+		it('keeps a single-typed hit clean — no ratio bar', () => {
+			const { getByTestId } = render(CombatFloaters, { props: { side: 'enemy', testId: 'enemy-floaters' } });
+			emit({
+				target: 'enemy',
+				kind: 'hit',
+				amount: 12,
+				damageType: EDamageType.Fire,
+				portions: [{ type: EDamageType.Fire, weight: 1 }]
+			});
+
+			const floater = getByTestId('enemy-floaters').querySelector('.floater') as HTMLElement;
+			expect(floater.querySelector('.floater-ratio')).toBeNull();
+		});
+
+		it('omits the bar entirely when an event carries no portions (a reflect/dodge)', () => {
+			const { getByTestId } = render(CombatFloaters, { props: { side: 'enemy', testId: 'enemy-floaters' } });
+			emit({ target: 'enemy', kind: 'hit', amount: 30, damageType: EDamageType.Water });
+
+			const floater = getByTestId('enemy-floaters').querySelector('.floater') as HTMLElement;
+			expect(floater.querySelector('.floater-ratio')).toBeNull();
+		});
+
+		it('scales the bar to a three-portion split', () => {
+			const { getByTestId } = render(CombatFloaters, { props: { side: 'enemy', testId: 'enemy-floaters' } });
+			emit({
+				target: 'enemy',
+				kind: 'hit',
+				amount: 70,
+				damageType: EDamageType.Physical,
+				portions: [
+					{ type: EDamageType.Physical, weight: 1 },
+					{ type: EDamageType.Fire, weight: 1 },
+					{ type: EDamageType.Wind, weight: 1 }
+				]
+			});
+
+			const floater = getByTestId('enemy-floaters').querySelector('.floater') as HTMLElement;
+			expect(floater.querySelectorAll('.floater-ratio .seg')).toHaveLength(3);
+		});
+
+		it('still draws the split (and crit styling) on a multi-typed crit', () => {
+			const { getByTestId } = render(CombatFloaters, { props: { side: 'enemy', testId: 'enemy-floaters' } });
+			emit({
+				target: 'enemy',
+				kind: 'crit',
+				amount: 120,
+				damageType: EDamageType.Fire,
+				portions: [
+					{ type: EDamageType.Fire, weight: 70 },
+					{ type: EDamageType.Water, weight: 30 }
+				]
+			});
+
+			const floater = getByTestId('enemy-floaters').querySelector('.floater') as HTMLElement;
+			expect(floater.classList.contains('crit')).toBe(true);
+			expect(floater.querySelector('.floater-label')?.textContent).toBe('CRIT');
+			expect(floater.querySelectorAll('.floater-ratio .seg')).toHaveLength(2);
+		});
+	});
+
 	it('removes a floater after its animation completes', () => {
 		vi.useFakeTimers();
 		const { getByTestId } = render(CombatFloaters, { props: { side: 'enemy', testId: 'enemy-floaters' } });


### PR DESCRIPTION
## Summary

Part **C** of the multi-typed damage spike (#1343) — the player-facing UX. Frontend-only; builds on the data model (#1384) and direct-hit pipeline (#1385), both already merged. Surfaces a skill's weighted leaf-type split **without clutter**.

### Damage floater
- The single number stays coloured and icon-tagged by the skill's **`PrimaryDamageType`**, so a mostly-physical hit still reads physical at a glance — exactly like today.
- A new thin **segmented ratio bar** is drawn beneath the number for a multi-typed hit, one segment per portion sized by weight and tinted by its leaf-type hue.
- A **single-typed hit stays a clean number** (no bar). A **crit** keeps its existing styling and still draws the split.
- The combat-float event now carries the hit's `portions` alongside its primary type.

### Skill tooltips / Skills screen
- A new shared **`SkillDamageTypes`** section shows the portion mix (icon + name; a percentage and the ratio bar for a multi-typed skill, or one clean row for a single type), wired into **both** the combat `SkillTooltip` and the Skills-screen `SkillInspector` so the two read the same way.

### Combat log
- **Unchanged** — it already reports the whole hit under its primary type (the engine passes `PrimaryDamageType` to the line builder), which reads sensibly for a multi-typed hit. Per the spike, it is deliberately not itemized per portion.

### Shared primitive
- New **`DamageRatioBar`** renders the segmented bar; colour / icon / name stay a pure frontend concern resolved through the existing `damage-type-display` helpers (the documented "one display module" pattern).

## How it addresses the issue
Implements the issue's two display surfaces (blended floater + skill-tooltip portion mix) keyed off `PrimaryDamageType` + the portion list, and confirms the combat log still reads sensibly — matching decision 7 of the spike.

## Test plan
- `DamageRatioBar`: one segment per portion, weight-proportional sizing, per-type tint, scales to 3 portions, height prop.
- `SkillDamageTypes`: single type → one clean row (no %/bar); 2-type mix → bar + percentage-tagged rows; raw-weight → percentage normalization; 3-portion mix.
- `CombatFloaters`: segmented bar for a multi-typed hit (primary-coloured number + per-portion segments), no bar for a single-typed hit or a portion-less event, scales to 3 portions, and still draws the split (with crit styling) on a multi-typed crit.
- `BattleEngine`: the float event carries the skill's weighted split and its `PrimaryDamageType` on a multi-typed hit.
- Full frontend suite green (`3120 passed`), `eslint` + `svelte-check` clean (`0 errors`).

Closes #1386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEMtMNTgqp1X8sEHm53ffw)_