### PR TITLE
Verify multi-typed cross-school proficiency training end-to-end (#1387)

### DIFF
--- a/Game.Application.Tests/Game.Application.Tests.csproj
+++ b/Game.Application.Tests/Game.Application.Tests.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Game.Application\Game.Application.csproj" />
     <ProjectReference Include="..\Game.Core\Game.Core.csproj" />
+    <ProjectReference Include="..\Game.Core.TestInfrastructure\Game.Core.TestInfrastructure.csproj" />
     <ProjectReference Include="..\Game.Abstractions\Game.Abstractions.csproj" />
     <ProjectReference Include="..\Game.DataAccess\Game.DataAccess.csproj" />
     <ProjectReference Include="..\Game.TestInfrastructure\Game.TestInfrastructure.csproj" />

--- a/Game.Application.Tests/Services/MultiTypedDamageProficiencyTests.cs
+++ b/Game.Application.Tests/Services/MultiTypedDamageProficiencyTests.cs
@@ -46,8 +46,8 @@ namespace Game.Application.Tests.Services
             // Offense paths for the two schools the Flaming Sword spans. No Elemental umbrella is seeded, so the
             // Fire portion routes only to the Fire path here (applies(Fire) = [Fire, Elemental] would also feed an
             // Elemental path — covered by the umbrella tests).
-            var physical = await CreateOffenseTierAsync(context, EActivityKey.Physical, "Swordsmanship");
-            var fire = await CreateOffenseTierAsync(context, EActivityKey.Fire, "Fire Magic");
+            var physical = await CreateKeyedTierAsync(context, EActivityKey.Physical, "Swordsmanship");
+            var fire = await CreateKeyedTierAsync(context, EActivityKey.Fire, "Fire Magic");
             var playerId = await SeedPlayerAsync(context);
             await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
 
@@ -72,8 +72,8 @@ namespace Game.Application.Tests.Services
             using var scope = CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
 
-            var physical = await CreateOffenseTierAsync(context, EActivityKey.Physical, "Swordsmanship");
-            var fire = await CreateOffenseTierAsync(context, EActivityKey.Fire, "Fire Magic");
+            var physical = await CreateKeyedTierAsync(context, EActivityKey.Physical, "Swordsmanship");
+            var fire = await CreateKeyedTierAsync(context, EActivityKey.Fire, "Fire Magic");
             var playerId = await SeedPlayerAsync(context);
             await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
 
@@ -100,9 +100,9 @@ namespace Game.Application.Tests.Services
 
             // The even-split Storm Blade exercises a 3-portion hit. Each leaf gets a third of the raw damage, so
             // each of its three paths trains equally — an even split is just equal weights.
-            var wind = await CreateOffenseTierAsync(context, EActivityKey.Wind, "Aeromancy");
-            var water = await CreateOffenseTierAsync(context, EActivityKey.Water, "Hydromancy");
-            var physical = await CreateOffenseTierAsync(context, EActivityKey.Physical, "Swordsmanship");
+            var wind = await CreateKeyedTierAsync(context, EActivityKey.Wind, "Aeromancy");
+            var water = await CreateKeyedTierAsync(context, EActivityKey.Water, "Hydromancy");
+            var physical = await CreateKeyedTierAsync(context, EActivityKey.Physical, "Swordsmanship");
             var playerId = await SeedPlayerAsync(context);
             await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
 
@@ -128,8 +128,8 @@ namespace Game.Application.Tests.Services
 
             // Enemies field the same skills, so multi-typed enemy combat comes free: an enemy Flaming Sword hit
             // exposes the player to each portion's pre-mitigation typed damage, training the matching resist paths.
-            var physicalResist = await CreateOffenseTierAsync(context, EActivityKey.PhysicalResist, "Physical Warding");
-            var fireResist = await CreateOffenseTierAsync(context, EActivityKey.FireResist, "Fire Warding");
+            var physicalResist = await CreateKeyedTierAsync(context, EActivityKey.PhysicalResist, "Physical Warding");
+            var fireResist = await CreateKeyedTierAsync(context, EActivityKey.FireResist, "Fire Warding");
             var playerId = await SeedPlayerAsync(context);
             await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
 
@@ -221,7 +221,7 @@ namespace Game.Application.Tests.Services
 
         // A single-tier path bound to an activity key (offense or resist). A generous curve keeps the small per-
         // battle gains banked at level 0, so XpGained reads as the raw claim under test.
-        private static async Task<Game.Infrastructure.Entities.Proficiency> CreateOffenseTierAsync(
+        private static async Task<Game.Infrastructure.Entities.Proficiency> CreateKeyedTierAsync(
             GameContext context, EActivityKey activityKey, string name)
         {
             var path = await TestDataSeeder.CreatePathAsync(context, name: name, activityKey: activityKey);

--- a/Game.Application.Tests/Services/MultiTypedDamageProficiencyTests.cs
+++ b/Game.Application.Tests/Services/MultiTypedDamageProficiencyTests.cs
@@ -1,0 +1,254 @@
+using Game.Abstractions.DataAccess;
+using Game.Application.Services;
+using Game.Core;
+using Game.Core.Battle;
+using Game.Core.Players;
+using Game.Core.Proficiencies;
+using Game.Core.Skills;
+using Game.Core.TestInfrastructure.Builders;
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Game.Application.Tests.Services
+{
+    /// <summary>
+    /// Spike #1343 part D — the end-to-end cross-school payoff. A multi-typed skill's direct hit is split into
+    /// weighted portions by the (unmodified) battle pipeline (#1385), which books each portion's damage under its
+    /// own type (<see cref="BattleStats.TypedDamageDealt"/> / <see cref="BattleStats.TypedDamageExposure"/>); the
+    /// (unmodified) proficiency accrual (#1318) then claims each path's XP from those per-type books. So the
+    /// authored split ratio <em>becomes</em> the cross-school proficiency contribution weight with <b>no
+    /// accrual-code change</b> — the verification this issue exists to make.
+    ///
+    /// These tests author the spike's example content in-memory (a "Flaming Sword" 60% Physical / 40% Fire and an
+    /// even-split "Storm Blade" across Wind / Water / Physical, plus a fire-resistant enemy) because static content
+    /// is not source-controlled — it lives in the admin Workbench / DB (source-controlled seed/export tooling is
+    /// the separate spike #1390). They drive the real <see cref="BattleContext"/> to produce genuine per-portion
+    /// books, then run the DB-backed <see cref="ProficiencyRewardService"/> over those books, so the whole chain —
+    /// pipeline → typed books → per-path XP — is exercised against live reference data exactly as a won battle does.
+    /// The per-portion battle math itself is pinned separately by the BattleContext multi-portion suite (#1385).
+    /// </summary>
+    [Collection("Integration")]
+    public class MultiTypedDamageProficiencyTests : ApplicationIntegrationTestBase
+    {
+        public MultiTypedDamageProficiencyTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        [Fact]
+        public async Task FlamingSwordOffense_TrainsEachPortionsPathInProportionToItsSplit()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // Offense paths for the two schools the Flaming Sword spans. No Elemental umbrella is seeded, so the
+            // Fire portion routes only to the Fire path here (applies(Fire) = [Fire, Elemental] would also feed an
+            // Elemental path — covered by the umbrella tests).
+            var physical = await CreateOffenseTierAsync(context, EActivityKey.Physical, "Swordsmanship");
+            var fire = await CreateOffenseTierAsync(context, EActivityKey.Fire, "Fire Magic");
+            var playerId = await SeedPlayerAsync(context);
+            await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
+
+            // A raw-100 Flaming Sword hit against an unresisting enemy: the offense book is 60 Physical / 40 Fire —
+            // the authored split, undisturbed.
+            var stats = FirePlayerHit(raw: 100, FlamingSword, enemyFireResistance: 0);
+            Assert.Equal(60, TypedDealt(stats, EDamageType.Physical), 0.001);
+            Assert.Equal(40, TypedDealt(stats, EDamageType.Fire), 0.001);
+
+            var accrual = await AccrueAsync(scope, playerId, stats);
+
+            // Each path claims pie × clamp(book ÷ power): Physical 60/100 → 6.0, Fire 40/100 → 4.0. The XP ratio is
+            // exactly the authored 60:40 split — the split ratio is the cross-school contribution weight, with no
+            // accrual change.
+            Assert.Equal(ExpectedXp(60), XpFor(accrual, physical));
+            Assert.Equal(ExpectedXp(40), XpFor(accrual, fire));
+        }
+
+        [Fact]
+        public async Task FlamingSwordOffense_AgainstAFireResistantEnemy_TrainsTheFirePathLess()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var physical = await CreateOffenseTierAsync(context, EActivityKey.Physical, "Swordsmanship");
+            var fire = await CreateOffenseTierAsync(context, EActivityKey.Fire, "Fire Magic");
+            var playerId = await SeedPlayerAsync(context);
+            await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
+
+            // The same hit against an enemy that resists Fire (0.5) but not Physical: the offense book is post-
+            // mitigation, so the Fire portion's net halves to 20 while Physical is unchanged at 60 — the per-portion
+            // resistance the cross-school payoff turns on (the enemy "resists one of a hybrid skill's types").
+            var stats = FirePlayerHit(raw: 100, FlamingSword, enemyFireResistance: 0.5);
+            Assert.Equal(60, TypedDealt(stats, EDamageType.Physical), 0.001);
+            Assert.Equal(20, TypedDealt(stats, EDamageType.Fire), 0.001);
+
+            var accrual = await AccrueAsync(scope, playerId, stats);
+
+            // Physical trains the same 6.0; Fire trains half as much (20/100 → 2.0) as against the neutral enemy —
+            // the resisted portion contributes, and therefore trains, less.
+            Assert.Equal(ExpectedXp(60), XpFor(accrual, physical));
+            Assert.Equal(ExpectedXp(20), XpFor(accrual, fire));
+        }
+
+        [Fact]
+        public async Task StormBladeOffense_EvenSplitTrainsAllThreePathsEqually()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // The even-split Storm Blade exercises a 3-portion hit. Each leaf gets a third of the raw damage, so
+            // each of its three paths trains equally — an even split is just equal weights.
+            var wind = await CreateOffenseTierAsync(context, EActivityKey.Wind, "Aeromancy");
+            var water = await CreateOffenseTierAsync(context, EActivityKey.Water, "Hydromancy");
+            var physical = await CreateOffenseTierAsync(context, EActivityKey.Physical, "Swordsmanship");
+            var playerId = await SeedPlayerAsync(context);
+            await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
+
+            // Raw 90 split evenly → 30 Wind / 30 Water / 30 Physical (no resistance).
+            var stats = FirePlayerHit(raw: 90, StormBlade, enemyFireResistance: 0);
+            Assert.Equal(30, TypedDealt(stats, EDamageType.Wind), 0.001);
+            Assert.Equal(30, TypedDealt(stats, EDamageType.Water), 0.001);
+            Assert.Equal(30, TypedDealt(stats, EDamageType.Physical), 0.001);
+
+            var accrual = await AccrueAsync(scope, playerId, stats);
+
+            // All three paths claim the identical 30/100 → 3.0 — equal weights, equal training.
+            Assert.Equal(ExpectedXp(30), XpFor(accrual, wind));
+            Assert.Equal(ExpectedXp(30), XpFor(accrual, water));
+            Assert.Equal(ExpectedXp(30), XpFor(accrual, physical));
+        }
+
+        [Fact]
+        public async Task EnemyFlamingSword_TrainsThePlayersResistPathsPerPortion()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // Enemies field the same skills, so multi-typed enemy combat comes free: an enemy Flaming Sword hit
+            // exposes the player to each portion's pre-mitigation typed damage, training the matching resist paths.
+            var physicalResist = await CreateOffenseTierAsync(context, EActivityKey.PhysicalResist, "Physical Warding");
+            var fireResist = await CreateOffenseTierAsync(context, EActivityKey.FireResist, "Fire Warding");
+            var playerId = await SeedPlayerAsync(context);
+            await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
+
+            // The incoming book is pre-resist, so the player's own resistance never throttles the training signal:
+            // exposure is 60 Physical / 40 Fire regardless of how much the player mitigates.
+            var stats = FireEnemyHit(raw: 100, FlamingSword);
+            Assert.Equal(60, Exposure(stats, EDamageType.Physical), 0.001);
+            Assert.Equal(40, Exposure(stats, EDamageType.Fire), 0.001);
+
+            var accrual = await AccrueAsync(scope, playerId, stats);
+
+            // The resist paths train in proportion to each portion's exposure — the same 60:40 split, on the
+            // incoming side.
+            Assert.Equal(ExpectedXp(60), XpFor(accrual, physicalResist));
+            Assert.Equal(ExpectedXp(40), XpFor(accrual, fireResist));
+        }
+
+        // ── The example content (#1343 part D) ──────────────────────────────────
+
+        // A flaming sword: 60% Physical, 40% Fire (the spike's worked example). Generic Physical (not a weapon
+        // leaf) keeps the routing to a single Physical key, isolating the cross-school split from weapon-gate /
+        // Physical-umbrella concerns covered elsewhere.
+        private static readonly IReadOnlyList<SkillDamagePortion> FlamingSword = Portions(
+            (EDamageType.Physical, 60), (EDamageType.Fire, 40));
+
+        // A storm blade evenly split across three schools (the spike's second example) — equal weights.
+        private static readonly IReadOnlyList<SkillDamagePortion> StormBlade = Portions(
+            (EDamageType.Wind, 1), (EDamageType.Water, 1), (EDamageType.Physical, 1));
+
+        // ── Battle-pipeline harness (real BattleContext) ────────────────────────
+
+        // The player's power the accrual normalizes each path's activity by. Fixed at 100 so a portion's book value
+        // reads directly as its share of the pie (e.g. a 60-damage portion → 0.6 × pie), keeping the assertions the
+        // plain proportions the test is about.
+        private const double Power = 100.0;
+
+        // Runs one real player fire of a multi-typed hit through the unmodified battle pipeline and returns the
+        // resulting stats (the offense book). The enemy optionally resists Fire so the per-portion mitigation shows
+        // up in the Fire portion's net.
+        private static BattleStats FirePlayerHit(
+            double raw, IReadOnlyList<SkillDamagePortion> portions, double enemyFireResistance)
+        {
+            var player = MakeBattler();
+            var enemy = MakeBattler((EAttribute.FireResistance, enemyFireResistance));
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+            context.DamageTarget(raw, portions);
+            return context.Stats;
+        }
+
+        // Runs one real enemy fire of a multi-typed hit at the player and returns the stats (the incoming exposure
+        // book). The player never dodges (no DodgeChance), so every portion's pre-resist exposure is recorded.
+        private static BattleStats FireEnemyHit(double raw, IReadOnlyList<SkillDamagePortion> portions)
+        {
+            var player = MakeBattler();
+            var enemy = MakeBattler();
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+            context.SwapActiveAndTargetBattlers();
+            context.DamageTarget(raw, portions);
+            return context.Stats;
+        }
+
+        private static Battler MakeBattler(params (EAttribute Attribute, double Amount)[] attributes)
+        {
+            var allocations = attributes
+                .Select(a => new StatAllocation { Attribute = a.Attribute, Amount = a.Amount })
+                .ToList();
+            return BattlerFactory.FromPlayer(new PlayerBuilder().WithStatAllocations(allocations).Build());
+        }
+
+        // ── Proficiency-accrual harness (DB-backed service) ─────────────────────
+
+        // Accrues the produced battle stats onto a fresh player's progress through the real reward service, exactly
+        // as the battle-completion path does, and returns the result for per-path assertions.
+        private async Task<ProficiencyAccrualResult> AccrueAsync(IServiceScope scope, int playerId, BattleStats stats)
+        {
+            var service = scope.ServiceProvider.GetRequiredService<ProficiencyRewardService>();
+            var player = await scope.ServiceProvider.GetRequiredService<IPlayerRepository>().GetPlayer(playerId);
+            Assert.NotNull(player);
+            var progress = await scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>().Load(player);
+            return service.AccrueAndApply(progress, stats, totalAttributes: Power, player, notify: false);
+        }
+
+        private static async Task<int> SeedPlayerAsync(GameContext context)
+        {
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+            return player.Id;
+        }
+
+        // A single-tier path bound to an activity key (offense or resist). A generous curve keeps the small per-
+        // battle gains banked at level 0, so XpGained reads as the raw claim under test.
+        private static async Task<Game.Infrastructure.Entities.Proficiency> CreateOffenseTierAsync(
+            GameContext context, EActivityKey activityKey, string name)
+        {
+            var path = await TestDataSeeder.CreatePathAsync(context, name: name, activityKey: activityKey);
+            return await TestDataSeeder.CreateProficiencyAsync(context, name: name, pathId: path.Id, pathOrdinal: 0);
+        }
+
+        // ── Assertion helpers ───────────────────────────────────────────────────
+
+        // The XP a path claims for an activity quantity: pie × clamp(activity ÷ power), rounded to the persisted
+        // scale exactly as the reward service does — the calculator's formula, with the test's fixed power.
+        private static decimal ExpectedXp(double activity) =>
+            Math.Round(
+                (decimal)(ServerGameConstants.ProficiencyXpPerVictory
+                    * Math.Min(activity / Power, ServerGameConstants.MaxExpRewardMultiplier)),
+                3,
+                MidpointRounding.AwayFromZero);
+
+        private static decimal XpFor(ProficiencyAccrualResult accrual, Game.Infrastructure.Entities.Proficiency proficiency) =>
+            Assert.Single(accrual.Results, r => r.ProficiencyId == proficiency.Id).XpGained;
+
+        private static IReadOnlyList<SkillDamagePortion> Portions(params (EDamageType Type, double Weight)[] portions) =>
+            portions.Select(p => new SkillDamagePortion { Type = p.Type, Weight = p.Weight }).ToList();
+
+        private static double TypedDealt(BattleStats stats, EDamageType type) =>
+            stats.TypedDamageDealt.TryGetValue(type, out var value) ? value : 0;
+
+        private static double Exposure(BattleStats stats, EDamageType type) =>
+            stats.TypedDamageExposure.TryGetValue(type, out var value) ? value : 0;
+    }
+}

--- a/docs/spikes/1343-multi-typed-damage.md
+++ b/docs/spikes/1343-multi-typed-damage.md
@@ -109,6 +109,10 @@ Created as native sub-issues of #1343:
 
 **A** is the foundation (inert data + authoring). **B** is the parity-critical core and adds the only frontend↔backend parity vectors. **C** and **D** are the player-facing surface once **B** exists. The rest carry unit/integration tests.
 
+### Verification (part D — landed)
+
+The cross-school payoff was confirmed **end-to-end with no accrual-code change** (`MultiTypedDamageProficiencyTests`): an example "Flaming Sword" (60% Physical / 40% Fire) and an even-split "Storm Blade" (Wind / Water / Physical) are driven through the unmodified battle pipeline against a fire-resistant enemy, and the per-portion typed books (`TypedDamageDealt` / `TypedDamageExposure`) it produces are fed straight into the unmodified `ProficiencyRewardService`. Each portion's path trains in proportion to its share: a 60/40 hit trains its two offense paths 6:4, the Fire path trains *half* as much against a fire-resistant target (the per-portion resistance), an even split trains all three paths equally, and an enemy fielding the same skill trains the player's per-type resist paths the same way. The split ratio is the cross-school contribution weight, exactly as the design promised — `ProficiencyXpCalculator` needed no change. Example game content (skills/enemies) is authored in the Workbench/DB, not source-controlled, so the verification realizes it in-test (source-controlled content seeding is the separate spike #1390).
+
 ## Documentation to update on landing
 
 - `docs/game-design.md` — the **Damage types** section: a skill's direct hit may carry **multiple leaf types with a split**, amplified/resisted per portion, and the split ratio is the cross-school proficiency contribution weight. Note DoT remains per-effect. (With **A**, **B**.)


### PR DESCRIPTION
## Summary

Part **D** of the multi-typed damage spike ([#1343](https://github.com/ginderjeremiah/GameServer/issues/1343)) — the example content + cross-school verification. Parts A ([#1384](https://github.com/ginderjeremiah/GameServer/issues/1384)), B ([#1385](https://github.com/ginderjeremiah/GameServer/issues/1385)), and C ([#1386](https://github.com/ginderjeremiah/GameServer/issues/1386)) have landed; this closes the loop by **verifying end-to-end, with no accrual-code change, that a multi-typed hit trains each portion's proficiency path in proportion to its split** — the payoff the spike was designed to make fall out for free.

## How it addresses the issue

Adds `MultiTypedDamageProficiencyTests` (a DB-backed integration test). It:

1. Authors the spike's worked example content **in-test** — a *Flaming Sword* (60% Physical / 40% Fire), an even-split *Storm Blade* (Wind / Water / Physical), and a fire-resistant enemy.
2. Drives the **unmodified** `BattleContext` direct-hit pipeline (#1385) to produce genuine per-portion typed books (`TypedDamageDealt` / `TypedDamageExposure`).
3. Feeds those books straight into the **unmodified** DB-backed `ProficiencyRewardService` (#1318), exactly as the battle-completion path does, and asserts each path's claimed XP.

The verification confirms:
- a 60/40 hit trains its two offense paths **6:4** — the split ratio *is* the cross-school contribution weight;
- the Fire path trains **half** as much against a fire-resistant target (per-portion resistance — the enemy "resists one of a hybrid skill's types but not the other");
- an even split trains all three paths **equally**;
- an enemy fielding the same skill trains the player's per-type **resist** paths the same way (multi-typed enemy combat comes free).

`ProficiencyXpCalculator` / `ProficiencyRewardService` are untouched — `Game.Application.Tests` gains a reference to `Game.Core.TestInfrastructure` so the test can run the real battle pipeline.

## A note on the "author through the Workbench" framing

Static game content (skills/enemies) is authored in the admin Workbench / DB and is **not source-controlled** — source-controlled content seed/export tooling is the separate spike [#1390](https://github.com/ginderjeremiah/GameServer/issues/1390). So the example skills/enemies are realized **in the verification test** rather than committed as seed data, which is also what makes the test a self-contained, reproducible proof of the cross-school payoff. The per-portion *battle math* is pinned separately by the existing BattleContext multi-portion suite (#1385); this PR adds the missing link from those books to per-path proficiency XP.

## Test plan

- [x] `dotnet build` (solution) — clean
- [x] `MultiTypedDamageProficiencyTests` — 4/4 pass
- [x] `ProficiencyRewardServiceTests` — 22/22 pass (no regression)
- [x] `BattleContextTests` (multi-portion pipeline) — 38/38 pass
- Docs: spike `docs/spikes/1343-multi-typed-damage.md` records the verification result.

Closes #1387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKUZEpKEhASNaktf41bP8G

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKUZEpKEhASNaktf41bP8G)_