### PR TITLE
Warn on unequipping a weapon that dims selected skills (#1405)

### DIFF
--- a/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
+++ b/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
@@ -167,18 +167,20 @@ export class InventoryView {
 		return newlyDormantSkills(selected, inventoryManager.equippedWeaponType, nextWeaponType);
 	}
 
-	/** Prompts the player before a weapon equip that would dim part of the saved loadout, naming the affected
-	 *  `dormant` skills. Returns true to proceed (the player accepted), false to abort. The loadout itself is
-	 *  never edited — the skills simply go dormant until a matching weapon is re-equipped. */
-	private confirmWeaponSwap(item: Item, dormant: ISkill[]): Promise<boolean> {
+	/** Prompts the player before a weapon-slot change that would dim part of the saved loadout, naming the
+	 *  affected `dormant` skills. `action` is the sentence lead-in ("Equipping Foo" / "Unequipping your weapon")
+	 *  and `confirmLabel` the proceed button. Returns true to proceed (the player accepted), false to abort. The
+	 *  loadout itself is never edited — the skills simply go dormant until a matching weapon is re-equipped.
+	 *  Shared by the equip and unequip paths so the two warnings can't drift. */
+	private confirmWeaponSwap(action: string, confirmLabel: string, dormant: ISkill[]): Promise<boolean> {
 		const single = dormant.length === 1;
 		const names = dormant.map((s) => s.name).join(', ');
 		return confirmModal({
 			title: 'Some skills will go dormant',
 			body:
-				`Equipping ${item.name} will leave ${single ? 'this skill' : `these ${dormant.length} skills`} ` +
+				`${action} will leave ${single ? 'this skill' : `these ${dormant.length} skills`} ` +
 				`dormant until you re-equip a matching weapon: ${names}. Your loadout stays saved.`,
-			confirmLabel: 'Equip anyway',
+			confirmLabel,
 			cancelLabel: 'Keep current weapon'
 		});
 	}
@@ -198,7 +200,7 @@ export class InventoryView {
 		// The dormant set is computed synchronously, so the no-conflict path never awaits a modal.
 		if (item && slotId === EEquipmentSlot.WeaponSlot) {
 			const dormant = this.weaponSwapDormantSkills(item.weaponType ?? EDamageType.Unarmed);
-			if (dormant.length > 0 && !(await this.confirmWeaponSwap(item, dormant))) {
+			if (dormant.length > 0 && !(await this.confirmWeaponSwap(`Equipping ${item.name}`, 'Equip anyway', dormant))) {
 				return;
 			}
 		}
@@ -208,6 +210,16 @@ export class InventoryView {
 	}
 
 	async unequip(slotId: EEquipmentSlot) {
+		// Weapon-match warning (#1342): unequipping the weapon resets the weapon type to Unarmed, dimming any
+		// off-weapon selected skills — the same silent surprise the equip warning guards against, reached via a
+		// different action. Warn (and let the player back out) before the optimistic apply. The dormant set is
+		// computed synchronously, so the no-conflict path never awaits a modal.
+		if (slotId === EEquipmentSlot.WeaponSlot) {
+			const dormant = this.weaponSwapDormantSkills(EDamageType.Unarmed);
+			if (dormant.length > 0 && !(await this.confirmWeaponSwap('Unequipping your weapon', 'Unequip anyway', dormant))) {
+				return;
+			}
+		}
 		if (!(await inventoryManager.unequipItem(slotId))) {
 			toastError('Your equipment change could not be saved. Please try again.');
 		}

--- a/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
@@ -606,3 +606,95 @@ describe('InventoryView weapon-swap warning', () => {
 		expect(equipItem).toHaveBeenCalledWith(8, 0);
 	});
 });
+
+/* Unequipping the weapon resets the weapon type to Unarmed, which dims every weapon-leaf selected skill that
+   isn't Unarmed — the same silent surprise the equip warning guards against, reached via a different action.
+   The unequip path runs the same gate against `nextWeaponType = Unarmed`. */
+describe('InventoryView weapon-unequip warning', () => {
+	const makeSkill = (id: number, name: string, type: EDamageType): ISkill =>
+		({ id, name, damagePortions: [{ type, weight: 1 }] }) as unknown as ISkill;
+
+	it('warns before unequipping a weapon that dims a fielded selected skill, naming it', async () => {
+		// Wielding a Sword (a Sword skill is fielded); unequipping leaves that Sword skill dormant.
+		weaponState.equippedWeaponType = EDamageType.Sword;
+		staticData.skills = [makeSkill(0, 'Slash', EDamageType.Sword)];
+		playerState.selectedSkills = [0];
+
+		await new InventoryView().unequip(4); // WeaponSlot
+
+		expect(confirmModal).toHaveBeenCalledTimes(1);
+		const opts = confirmModal.mock.calls[0][0] as { title: string; body: string };
+		expect(opts.title).toMatch(/dormant/i);
+		expect(opts.body).toContain('Slash');
+		expect(opts.body).toMatch(/unequip/i);
+		expect(unequipItem).toHaveBeenCalledWith(4);
+	});
+
+	it('aborts the unequip when the player declines the warning', async () => {
+		confirmModal.mockResolvedValue(false);
+		weaponState.equippedWeaponType = EDamageType.Sword;
+		staticData.skills = [makeSkill(0, 'Slash', EDamageType.Sword)];
+		playerState.selectedSkills = [0];
+
+		await new InventoryView().unequip(4);
+
+		expect(confirmModal).toHaveBeenCalledTimes(1);
+		expect(unequipItem).not.toHaveBeenCalled();
+	});
+
+	it('uses singular phrasing for one skill and a count for several', async () => {
+		// Two fielded Sword skills dim when unequipping; the agnostic skill never does.
+		weaponState.equippedWeaponType = EDamageType.Sword;
+		staticData.skills = [
+			makeSkill(0, 'Slash', EDamageType.Sword),
+			makeSkill(1, 'Parry', EDamageType.Sword),
+			makeSkill(2, 'Strike', EDamageType.Physical)
+		];
+		playerState.selectedSkills = [0, 1, 2];
+
+		await new InventoryView().unequip(4);
+
+		const opts = confirmModal.mock.calls[0][0] as { body: string };
+		expect(opts.body).toContain('these 2 skills');
+		expect(opts.body).toContain('Slash');
+		expect(opts.body).toContain('Parry');
+		expect(opts.body).not.toContain('Strike'); // agnostic skill is never dormant
+	});
+
+	it('does not warn when every selected skill is weapon-agnostic', async () => {
+		weaponState.equippedWeaponType = EDamageType.Sword;
+		staticData.skills = [makeSkill(0, 'Strike', EDamageType.Physical), makeSkill(1, 'Ember', EDamageType.Fire)];
+		playerState.selectedSkills = [0, 1];
+
+		await new InventoryView().unequip(4);
+
+		expect(confirmModal).not.toHaveBeenCalled();
+		expect(unequipItem).toHaveBeenCalledWith(4);
+	});
+
+	it('does not run the weapon warning when unequipping a non-weapon slot', async () => {
+		weaponState.equippedWeaponType = EDamageType.Sword;
+		staticData.skills = [makeSkill(0, 'Slash', EDamageType.Sword)];
+		playerState.selectedSkills = [0];
+
+		await new InventoryView().unequip(0); // HelmSlot
+
+		expect(confirmModal).not.toHaveBeenCalled();
+		expect(unequipItem).toHaveBeenCalledWith(0);
+	});
+
+	it('warns through toggleEquip when unequipping an equipped weapon dims a fielded skill', async () => {
+		weaponState.equippedWeaponType = EDamageType.Sword;
+		staticData.skills = [makeSkill(0, 'Slash', EDamageType.Sword)];
+		playerState.selectedSkills = [0];
+		const equippedWeapon = makeItem(2, 'Alpha Blade', EItemCategory.Weapon, ERarity.Legendary, {
+			equipped: true,
+			equipmentSlotId: 4
+		});
+
+		await new InventoryView().toggleEquip(equippedWeapon);
+
+		expect(confirmModal).toHaveBeenCalledTimes(1);
+		expect(unequipItem).toHaveBeenCalledWith(4);
+	});
+});


### PR DESCRIPTION
## Summary

Closes the consistency gap left by PR #1404 (issue #1374, spike #1342): the inventory pre-swap warning only fired on the weapon **equip** path. Unequipping a weapon resets `equippedWeaponType` to `Unarmed`, which dims every weapon-leaf selected skill that isn't `Unarmed` (Sword/Axe/Bow/Club/Dagger) — exactly the "silent surprise" the feature was added to prevent, just reached via a different action. A player with a full Sword loadout who removes their sword saw the whole loadout go dormant with no prompt.

## How it addresses the issue

- **Shared helper, no drift.** Generalized `confirmWeaponSwap` to take a sentence lead-in (`"Equipping ⟨item⟩"` / `"Unequipping your weapon"`) and a confirm label instead of an `Item`, so the equip and unequip paths build their warning through one code path and can't diverge.
- **Unequip warning.** `InventoryView.unequip`, for `EEquipmentSlot.WeaponSlot`, runs the same `newlyDormantSkills` gate (via the existing `weaponSwapDormantSkills`) against `nextWeaponType = Unarmed` and surfaces the same blocking `confirmModal`, naming the skills that go dormant and letting the player back out.
- **No behaviour change to the no-conflict path.** The dormant set is still computed synchronously and the modal is only awaited when there's an actual conflict (`dormant.length > 0 && await …`), so a clean unequip stays prompt-free and synchronous, exactly like the equip path. This also keeps the existing synchronous delegation tests valid.
- **Non-destructive.** The saved loadout is never edited — the skills go dormant until a matching weapon is re-equipped, and the Skills-screen grey-out still surfaces the state afterward.

Because the warning derives from the same weapon-match gate (`isFielded`) the live battle assembly uses, the dimmed set the player sees can't disagree with what the battle actually fields.

## Test plan

Added a `InventoryView weapon-unequip warning` suite mirroring the existing equip suite in `inventory-view.test.ts`:

- warns before unequipping a weapon that dims a fielded selected skill, naming it;
- decline aborts the unequip;
- singular vs. count phrasing for one vs. several dormant skills;
- no warn when every selected skill is weapon-agnostic;
- no warn when unequipping a non-weapon slot;
- warns through `toggleEquip` when removing an equipped weapon dims a fielded skill.

- [x] `npx vitest run inventory-view.test.ts` — 56/56 pass
- [x] `npm run lint` — clean
- [x] `npm run check` — 0 errors / 0 warnings

## Notes

This PR also resolves the duplicate issue #1407, which describes the same gap and suggested approach. The warning is intentionally scoped to the player's **selected** skills (not item-granted ones), matching the equip path's existing behaviour — the grey-out still dims granted skills.

Closes #1405
Closes #1407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3u2j1jqhqGY1GmQSwo9Dj)_