### PR TITLE
Add dedicated mapper unit tests for Enemy / Zone / ItemMod ToContract (#1437)

### DIFF
--- a/Game.Application.Tests/Mapping/EnemyMapperTests.cs
+++ b/Game.Application.Tests/Mapping/EnemyMapperTests.cs
@@ -1,0 +1,86 @@
+using Game.Core;
+using Game.DataAccess.Mapping;
+using Xunit;
+using Entities = Game.Infrastructure.Entities;
+
+namespace Game.Application.Tests.Mapping
+{
+    /// <summary>
+    /// Coverage for <see cref="EnemyMapper.ToContract"/>: the scalar fields and the three child collections
+    /// (attribute distributions, the skill pool projected from <c>EnemySkills</c>, and the spawn table
+    /// projected from <c>ZoneEnemies</c>) round-trip from the entity to the client-visible reference-data
+    /// contract, which drives the enemies set's version hash.
+    /// </summary>
+    public class EnemyMapperTests
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ToContract_RoundTripsScalarFields(bool isBoss)
+        {
+            var retiredAt = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            var entity = NewEnemy(isBoss: isBoss, retiredAt: retiredAt);
+
+            var contract = EnemyMapper.ToContract(entity);
+
+            Assert.Equal(0, contract.Id);
+            Assert.Equal("Goblin", contract.Name);
+            Assert.Equal(isBoss, contract.IsBoss);
+            Assert.Equal(retiredAt, contract.RetiredAt);
+        }
+
+        [Fact]
+        public void ToContract_PreservesNullRetiredAt()
+        {
+            var contract = EnemyMapper.ToContract(NewEnemy());
+
+            Assert.Null(contract.RetiredAt);
+        }
+
+        [Fact]
+        public void ToContract_MapsChildCollections()
+        {
+            var entity = NewEnemy(
+                distributions: [(EAttribute.Strength, 5m, 1m), (EAttribute.Endurance, 3m, 2m)],
+                skillPool: [3, 7],
+                spawns: [(ZoneId: 1, Weight: 10), (ZoneId: 4, Weight: 20)]);
+
+            var contract = EnemyMapper.ToContract(entity);
+
+            Assert.Collection(contract.AttributeDistribution,
+                d => { Assert.Equal(EAttribute.Strength, d.AttributeId); Assert.Equal(5m, d.BaseAmount); Assert.Equal(1m, d.AmountPerLevel); },
+                d => { Assert.Equal(EAttribute.Endurance, d.AttributeId); Assert.Equal(3m, d.BaseAmount); Assert.Equal(2m, d.AmountPerLevel); });
+            Assert.Equal([3, 7], contract.SkillPool);
+            Assert.Collection(contract.Spawns,
+                s => { Assert.Equal(1, s.ZoneId); Assert.Equal(10, s.Weight); },
+                s => { Assert.Equal(4, s.ZoneId); Assert.Equal(20, s.Weight); });
+        }
+
+        private static Entities.Enemy NewEnemy(
+            bool isBoss = false,
+            DateTime? retiredAt = null,
+            List<(EAttribute Attribute, decimal Base, decimal PerLevel)>? distributions = null,
+            List<int>? skillPool = null,
+            List<(int ZoneId, int Weight)>? spawns = null) => new()
+            {
+                Id = 0,
+                Name = "Goblin",
+                IsBoss = isBoss,
+                RetiredAt = retiredAt,
+                AttributeDistributions = (distributions ?? []).Select(d => new Entities.AttributeDistribution
+                {
+                    EnemyId = 0,
+                    AttributeId = (int)d.Attribute,
+                    BaseAmount = d.Base,
+                    AmountPerLevel = d.PerLevel,
+                }).ToList(),
+                EnemySkills = (skillPool ?? []).Select(id => new Entities.EnemySkill { EnemyId = 0, SkillId = id }).ToList(),
+                ZoneEnemies = (spawns ?? []).Select(s => new Entities.ZoneEnemy
+                {
+                    ZoneId = s.ZoneId,
+                    EnemyId = 0,
+                    Weight = s.Weight,
+                }).ToList(),
+            };
+    }
+}

--- a/Game.Application.Tests/Mapping/ItemMapperTests.cs
+++ b/Game.Application.Tests/Mapping/ItemMapperTests.cs
@@ -1,7 +1,10 @@
 using Game.Core;
+using Game.Core.Attributes.Modifiers;
 using Game.DataAccess.Mapping;
 using Xunit;
+using Entities = Game.Infrastructure.Entities;
 using EntityItem = Game.Infrastructure.Entities.Item;
+using EntityItemMod = Game.Infrastructure.Entities.ItemMod;
 
 namespace Game.Application.Tests.Mapping
 {
@@ -9,7 +12,9 @@ namespace Game.Application.Tests.Mapping
     /// Coverage for <see cref="ItemMapper"/>: the nullable <c>GrantedSkillId</c> round-trips from the entity
     /// to both the client-visible contract (<see cref="ItemMapper.ToContract"/>) and the lean battle domain
     /// model (<see cref="ItemMapper.ToCore"/>). The contract field drives the items reference-data version
-    /// hash, and the core field is the id the battle assembly resolves a granted skill from.
+    /// hash, and the core field is the id the battle assembly resolves a granted skill from. The ItemMod
+    /// projections (<see cref="ItemMapper.ModToContract"/>/<see cref="ItemMapper.ModToCore"/>) get their own
+    /// scalar-and-attribute round-trip coverage below.
     /// </summary>
     public class ItemMapperTests
     {
@@ -92,6 +97,79 @@ namespace Game.Application.Tests.Mapping
 
             Assert.Equal((EDamageType?)weaponType, core.WeaponType);
         }
+
+        [Fact]
+        public void ModToContract_RoundTripsScalarFieldsAndTags()
+        {
+            var retiredAt = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            var entity = NewItemMod(EItemModType.Prefix, ERarity.Rare, tagIds: [2, 5], retiredAt: retiredAt);
+
+            var contract = ItemMapper.ModToContract(entity);
+
+            Assert.Equal(0, contract.Id);
+            Assert.Equal("Sharp", contract.Name);
+            Assert.Equal("Adds an edge.", contract.Description);
+            Assert.Equal(EItemModType.Prefix, contract.ItemModTypeId);
+            Assert.Equal(ERarity.Rare, contract.RarityId);
+            Assert.Equal([2, 5], contract.Tags);
+            Assert.Equal(retiredAt, contract.RetiredAt);
+        }
+
+        [Fact]
+        public void ModToContract_PreservesNullRetiredAtAndMapsAttributes()
+        {
+            var entity = NewItemMod(attributes: [(EAttribute.Strength, 5m), (EAttribute.Agility, 3m)]);
+
+            var contract = ItemMapper.ModToContract(entity);
+
+            Assert.Null(contract.RetiredAt);
+            Assert.Collection(contract.Attributes,
+                a => { Assert.Equal(EAttribute.Strength, a.AttributeId); Assert.Equal(5m, a.Amount); },
+                a => { Assert.Equal(EAttribute.Agility, a.AttributeId); Assert.Equal(3m, a.Amount); });
+        }
+
+        [Fact]
+        public void ModToCore_MapsScalarFieldsAndAttributes()
+        {
+            var entity = NewItemMod(EItemModType.Suffix, ERarity.Legendary,
+                attributes: [(EAttribute.Strength, 5m)]);
+
+            var core = ItemMapper.ModToCore(entity);
+
+            Assert.Equal(0, core.Id);
+            Assert.Equal("Sharp", core.Name);
+            Assert.Equal("Adds an edge.", core.Description);
+            Assert.Equal(EItemModType.Suffix, core.Type);
+            Assert.Equal(ERarity.Legendary, core.Rarity);
+            var attribute = Assert.Single(core.Attributes);
+            Assert.Equal(EAttribute.Strength, attribute.Attribute);
+            Assert.Equal(5d, attribute.Amount);
+            Assert.Equal(EModifierType.Additive, attribute.Type);
+            Assert.Equal(EAttributeModifierSource.ItemMod, attribute.Source);
+        }
+
+        private static EntityItemMod NewItemMod(
+            EItemModType type = EItemModType.Component,
+            ERarity rarity = ERarity.Common,
+            List<(EAttribute Attribute, decimal Amount)>? attributes = null,
+            List<int>? tagIds = null,
+            DateTime? retiredAt = null) => new()
+            {
+                Id = 0,
+                Name = "Sharp",
+                Description = "Adds an edge.",
+                ItemModTypeId = (int)type,
+                RarityId = (int)rarity,
+                RetiredAt = retiredAt,
+                ItemModAttributes = (attributes ?? []).Select(a => new Entities.ItemModAttribute
+                {
+                    ItemModId = 0,
+                    AttributeId = (int)a.Attribute,
+                    Amount = a.Amount,
+                }).ToList(),
+                Tags = (tagIds ?? []).Select(id => new Entities.Tag { Id = id, Name = "tag" }).ToList(),
+                UnlockedMods = [],
+            };
 
         private static EntityItem NewItem(int? grantedSkillId = null, int? requiredProficiencyId = null,
             int requiredProficiencyLevel = 0, int? weaponType = null) => new()

--- a/Game.Application.Tests/Mapping/ZoneMapperTests.cs
+++ b/Game.Application.Tests/Mapping/ZoneMapperTests.cs
@@ -1,0 +1,94 @@
+using Game.DataAccess.Mapping;
+using Xunit;
+using EntityZone = Game.Infrastructure.Entities.Zone;
+
+namespace Game.Application.Tests.Mapping
+{
+    /// <summary>
+    /// Coverage for <see cref="ZoneMapper"/>: the full scalar set (including the nullable boss/unlock FKs and
+    /// the <c>IsHome</c> orchestration flag) round-trips to the client-visible <see cref="ZoneMapper.ToContract"/>
+    /// contract that drives the zones set's version hash, while <see cref="ZoneMapper.ToCore"/> projects only the
+    /// lean encounter-relevant subset — the display-only and orchestration fields are structurally absent from
+    /// the battle domain model.
+    /// </summary>
+    public class ZoneMapperTests
+    {
+        [Fact]
+        public void ToContract_RoundTripsAllScalarFields()
+        {
+            var retiredAt = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            var entity = NewZone(bossEnemyId: 4, unlockChallengeId: 2, isHome: false, retiredAt: retiredAt);
+
+            var contract = ZoneMapper.ToContract(entity);
+
+            Assert.Equal(0, contract.Id);
+            Assert.Equal("Meadow", contract.Name);
+            Assert.Equal("A gentle field.", contract.Description);
+            Assert.Equal(1, contract.Order);
+            Assert.Equal(3, contract.LevelMin);
+            Assert.Equal(9, contract.LevelMax);
+            Assert.Equal(4, contract.BossEnemyId);
+            Assert.Equal(7, contract.BossLevel);
+            Assert.Equal(2, contract.UnlockChallengeId);
+            Assert.False(contract.IsHome);
+            Assert.Equal(retiredAt, contract.RetiredAt);
+        }
+
+        [Fact]
+        public void ToContract_PreservesNullOptionalFieldsAndHomeFlag()
+        {
+            var entity = NewZone(bossEnemyId: null, unlockChallengeId: null, isHome: true);
+
+            var contract = ZoneMapper.ToContract(entity);
+
+            Assert.Null(contract.BossEnemyId);
+            Assert.Null(contract.UnlockChallengeId);
+            Assert.Null(contract.RetiredAt);
+            Assert.True(contract.IsHome);
+        }
+
+        [Fact]
+        public void ToCore_MapsLeanEncounterSubset()
+        {
+            var entity = NewZone(bossEnemyId: 4, unlockChallengeId: 2);
+
+            var core = ZoneMapper.ToCore(entity);
+
+            Assert.Equal(0, core.Id);
+            Assert.Equal(3, core.LevelMin);
+            Assert.Equal(9, core.LevelMax);
+            Assert.Equal(4, core.BossEnemyId);
+            Assert.Equal(7, core.BossLevel);
+            Assert.Equal(2, core.UnlockChallengeId);
+        }
+
+        [Fact]
+        public void ToCore_PreservesNullOptionalFields()
+        {
+            var core = ZoneMapper.ToCore(NewZone(bossEnemyId: null, unlockChallengeId: null));
+
+            Assert.Null(core.BossEnemyId);
+            Assert.Null(core.UnlockChallengeId);
+        }
+
+        private static EntityZone NewZone(
+            int? bossEnemyId = null,
+            int? unlockChallengeId = null,
+            bool isHome = false,
+            DateTime? retiredAt = null) => new()
+            {
+                Id = 0,
+                Name = "Meadow",
+                Description = "A gentle field.",
+                Order = 1,
+                LevelMin = 3,
+                LevelMax = 9,
+                BossEnemyId = bossEnemyId,
+                BossLevel = 7,
+                UnlockChallengeId = unlockChallengeId,
+                IsHome = isHome,
+                RetiredAt = retiredAt,
+                ZoneEnemies = [],
+            };
+    }
+}


### PR DESCRIPTION
## Summary

Fills the pre-existing test-coverage gap called out in #1437: `EnemyMapper.ToContract`, `ZoneMapper.ToContract`, and `ItemMapper.ModToContract` were the only static-reference mapper projections with **no dedicated `*MapperTests` file** — they were covered only *indirectly* via the admin integration tests and the `ContentExportDriftGuardTests` round-trip, so a per-field mapping regression would only surface through a broader test rather than a targeted unit assertion. Closes #1437.

This is **purely additive test coverage — no production change.**

## How it addresses the issue

- **`EnemyMapperTests`** (new): `ToContract` round-trips the scalar fields (`Id`, `Name`, `IsBoss`, `RetiredAt`, incl. the null-`RetiredAt` case) and all three child collections — attribute distributions, the skill pool projected from `EnemySkills`, and the spawn table projected from `ZoneEnemies`.
- **`ZoneMapperTests`** (new): `ToContract` round-trips the full scalar set (incl. the nullable `BossEnemyId`/`UnlockChallengeId` FKs and the `IsHome` flag), and `ToCore` is asserted to project only the lean encounter-relevant subset — mirroring the `ClassMapperTests` shape where a `ToCore` exists alongside the contract.
- **`ItemMapperTests`** (extended): added an ItemMod section — `ModToContract`/`ModToCore` round-trip over the scalars, the attribute collection, and the tag-id list — alongside the existing Item-side coverage, per the issue's "to (or alongside) `ItemMapperTests`" note.

Each mirrors the established `*MapperTests` fixtures (private `NewX` entity factory, `Assert.Collection` over child collections).

## Note on `DesignerNotes` (deferred)

The issue's scope also mentions mirroring the `DesignerNotes` round-trip. That field does **not** exist on `main` — it's introduced by the still-open PR #1436 (#1421), which only added `DesignerNotes` assertions to the six mapper test files that already existed. These three new files can pick up the `DesignerNotes` round-trip once #1436 lands; adding it now would not compile against `main`. Everything else in the issue's scope (scalar fields + child collections) is covered here.

## Test plan

- [x] `dotnet build Game.Application.Tests` — clean, 0 warnings.
- [x] `dotnet test Game.Application.Tests --no-build` — 764 passed, 0 failed (incl. the new Enemy/Zone/ItemMod tests).
- [x] `dotnet format Game.Application.Tests --verify-no-changes` — clean.

Closes #1437

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAx9hELWe3g9jrdAqMnrz5)_