### PR TITLE
Fix flaky AsyncWorker_SignaledRepeatedlyDuringRun infrastructure test

### DIFF
--- a/Game.Infrastructure.Tests/BackgroundWorkerTests.cs
+++ b/Game.Infrastructure.Tests/BackgroundWorkerTests.cs
@@ -383,7 +383,12 @@ namespace Game.Infrastructure.Tests
             }
 
             releaseFirstRun.SetResult();
-            WaitUntil(() => !worker.IsRunning && Volatile.Read(ref active) == 0);
+            // The mid-run signals must produce at least one trailing run — coalesced into the in-flight run, or
+            // dispatched as a fresh run once it exits — and the worker must then settle for good. Wait for a *stable*
+            // non-running terminal state with that trailing run observed: sampling once could otherwise land in the
+            // brief gap after the first run exits but before the coalesced/leftover pass runs, reading totalRuns == 1
+            // or a transient IsRunning.
+            WaitUntilStablyNotRunning(worker, () => Volatile.Read(ref active) == 0 && Volatile.Read(ref totalRuns) >= 2);
 
             // Two loopAction calls never ran at once.
             Assert.Equal(1, Volatile.Read(ref maxActive));
@@ -465,6 +470,35 @@ namespace Game.Infrastructure.Tests
             }
 
             Assert.True(condition(), "The expected condition was not met within the timeout.");
+        }
+
+        // Waits until the worker is not running and <paramref name="alsoRequire"/> holds, and that combined state
+        // stays stable across several consecutive polls. The async loop re-arms its wait mid-run, so the burst of
+        // signals can leave the AutoResetEvent with a leftover pass that dispatches a moment after the worker first
+        // looks idle; requiring a run of stable observations rules out sampling that transient between-runs gap.
+        private static void WaitUntilStablyNotRunning(BackgroundWorker worker, Func<bool> alsoRequire)
+        {
+            const int requiredStablePolls = 10;
+            var deadline = DateTime.UtcNow + WaitTimeout;
+            var stablePolls = 0;
+            while (DateTime.UtcNow < deadline)
+            {
+                if (!worker.IsRunning && alsoRequire())
+                {
+                    if (++stablePolls >= requiredStablePolls)
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    stablePolls = 0;
+                }
+
+                Thread.Sleep(5);
+            }
+
+            Assert.Fail("The worker did not settle into a stable non-running state with the coalesced trailing run executed.");
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure in `BackgroundWorkerTests.AsyncWorker_SignaledRepeatedlyDuringRun_NeverOverlapsAndSettlesNotRunning`, which failed with:

> The coalesced trailing run did not execute.

The failure is a **test-timing bug, not a production defect**. `BackgroundWorker`'s async gate (added for #1136) is correct: no signal is lost and no overlap occurs.

## Root cause

The test suspends the first async run mid-`await`, fires 20 `Start()` signals while it is suspended, releases the run, then waited for the worker to settle with a **single sample**:

```csharp
WaitUntil(() => !worker.IsRunning && Volatile.Read(ref active) == 0);
Assert.True(Volatile.Read(ref totalRuns) >= 2, "The coalesced trailing run did not execute.");
```

The trailing run is delivered one of two ways, both correct:
- **coalesced** — a burst callback sets `_runPending` before the first run's final lock, so the loop makes an extra pass; or
- **fresh** — the burst callback runs *after* the first run already exited, so it starts a new run.

Under CI load the first run's continuation can complete before the burst callbacks are dispatched. The worker then transiently reaches `!IsRunning && active == 0` while `totalRuns` is still `1`, and the fresh trailing run happens *after* that window. `WaitUntil` returns in the gap, and `Assert.True(totalRuns >= 2)` fires with the reported message.

A related, narrower race exists on the terminal `Assert.False(worker.IsRunning)`: the `AutoResetEvent` can retain one leftover signal from the burst that dispatches a late pass just after the worker first looks idle.

## Fix

Wait for a **stable** non-running terminal state with the trailing run already observed, instead of sampling once:

```csharp
WaitUntilStablyNotRunning(worker, () => Volatile.Read(ref active) == 0 && Volatile.Read(ref totalRuns) >= 2);
```

`WaitUntilStablyNotRunning` requires `!IsRunning` plus the supplied condition to hold across several consecutive polls, so neither the transient between-runs gap nor a leftover pass can be mistaken for the settled state. All three original assertions are kept and are now race-free (`totalRuns` is monotonic and the state is stable when they run).

Only the test changed — `BackgroundWorker.cs` is untouched.

## Verification

- Built a stress harness that reproduces the exact interleaving (forcing the first-run continuation to win the race). The **old** condition would have flaked in **410/500** worst-case iterations; the **new** wait passed **1000/1000** (500 worst-case + 500 realistic).
- The fixed test passed **50/50** runs, including **20/20 under full CPU load**.
- Full `Game.Infrastructure.Tests` suite: **60/60 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WVZoUYcBr6WjgdYW1VaSw)_