### PR TITLE
Remove null-forgiving operator from Battler stack-scan helpers

### DIFF
--- a/Game.Core/Battle/Battler.cs
+++ b/Game.Core/Battle/Battler.cs
@@ -203,27 +203,12 @@ namespace Game.Core.Battle
             var resistanceAttributes = DamageTypes.ResistanceAttributes(damageType);
             for (var i = 0; i < resistanceAttributes.Count; i++)
             {
-                contribution += StackVulnerabilityContribution(resistanceAttributes[i]);
+                contribution += StackContribution(resistanceAttributes[i], stack => stack.VulnerabilityContribution);
             }
 
             // Contributions are the signed resistance deltas the opponent applied (negative for a debuff); the
             // vulnerability is their reduction, so negate and clamp — an opponent that only raised resistance is 0.
             return contribution < 0 ? -contribution : 0;
-        }
-
-        // The vulnerability-tracked resistance delta the opponent has applied to one attribute, or 0 when no
-        // effect stack for it is active. A linear scan over the affected-attribute count, like GetOrCreateStack.
-        private double StackVulnerabilityContribution(EAttribute attribute)
-        {
-            foreach (var stack in _attributeStacks!)
-            {
-                if (stack.Attribute == attribute)
-                {
-                    return stack.VulnerabilityContribution;
-                }
-            }
-
-            return 0;
         }
 
         /// <summary>
@@ -245,21 +230,28 @@ namespace Game.Core.Battle
             var amplificationAttributes = DamageTypes.AmplificationAttributes(damageType);
             for (var i = 0; i < amplificationAttributes.Count; i++)
             {
-                contribution += StackMomentumContribution(amplificationAttributes[i]);
+                contribution += StackContribution(amplificationAttributes[i], stack => stack.MomentumContribution);
             }
 
             return contribution > 0 ? contribution : 0;
         }
 
-        // The ramp-tracked amplification this battler has applied to one of its own attributes, or 0 when no
-        // effect stack for it is active. A linear scan over the affected-attribute count, like GetOrCreateStack.
-        private double StackMomentumContribution(EAttribute attribute)
+        // The tracked contribution (selected via <paramref name="selector"/>) an active effect stack has
+        // accrued for one attribute, or 0 when no stack for it exists yet. A linear scan over the
+        // affected-attribute count, like GetOrCreateStack. Shared by the per-overlay applied-* readers
+        // (AppliedVulnerability, AppliedMomentum, ...) so each just supplies its own contribution field.
+        private double StackContribution(EAttribute attribute, Func<AttributeEffectStack, double> selector)
         {
-            foreach (var stack in _attributeStacks!)
+            if (_attributeStacks is null)
+            {
+                return 0;
+            }
+
+            foreach (var stack in _attributeStacks)
             {
                 if (stack.Attribute == attribute)
                 {
-                    return stack.MomentumContribution;
+                    return selector(stack);
                 }
             }
 
@@ -449,7 +441,6 @@ namespace Game.Core.Battle
         public void ApplyEffect(
             SkillEffect effect, double amount, bool tracksVulnerability = false, bool tracksMomentum = false)
         {
-            _attributeStacks ??= [];
             var stack = GetOrCreateStack(effect.AttributeId);
 
             // Re-applying any effect on this attribute resets the whole stack's shared expiry to the new
@@ -546,11 +537,13 @@ namespace Game.Core.Battle
             }
         }
 
-        // Returns the stack for the given attribute, creating it on first use. The scan is over the
-        // affected-attribute count (≤ the attribute count), never the application count, so it stays cheap.
+        // Returns the stack for the given attribute, creating it (and the backing list) on first use. The scan
+        // is over the affected-attribute count (≤ the attribute count), never the application count, so it
+        // stays cheap.
         private AttributeEffectStack GetOrCreateStack(EAttribute attribute)
         {
-            foreach (var stack in _attributeStacks!)
+            _attributeStacks ??= [];
+            foreach (var stack in _attributeStacks)
             {
                 if (stack.Attribute == attribute)
                 {


### PR DESCRIPTION
## Summary

Implements #1460: `Battler.StackVulnerabilityContribution` and `Battler.StackMomentumContribution` both opened with `foreach (var stack in _attributeStacks!)`, relying on their callers (`AppliedVulnerability` / `AppliedMomentum`) having already null-guarded `_attributeStacks`. `CLAUDE.md` calls out avoiding the null-forgiving operator (`!`) in favor of proper nullability handling, so both are restructured to guard internally instead.

## Changes

- **`Battler.cs`**: consolidated the two near-identical scan helpers into a single `StackContribution(EAttribute, Func<AttributeEffectStack, double>)` helper with its own `_attributeStacks is null` guard, rather than fixing each one individually. `AppliedVulnerability`/`AppliedMomentum` now each just pass a selector for their own contribution field.
- Also fixed the same pattern in `GetOrCreateStack` (`foreach (var stack in _attributeStacks!)`), which had the identical caller-guards-first-then-`!`-inside issue via `ApplyEffect`'s `_attributeStacks ??= [];`. Moved the lazy-init into `GetOrCreateStack` itself so the guard travels with the usage, and dropped the now-redundant line from `ApplyEffect`. Small enough to fold into the same change rather than filing a separate issue.

## Why consolidate instead of two local guards

A [review comment on the issue](https://github.com/ginderjeremiah/GameServer/issues/1460#issuecomment-4863336401) noted that once the Sunder overlay (#1462, still open) lands, there will be a third near-identical helper (`StackSunderContribution`) and suggested folding all three into one parameterized helper at that point. Rather than wait on an unmerged PR, I built the parameterized helper now — it already takes a selector, so wiring in a third `Func` for Sunder later is a one-line addition, no further refactor needed.

## Test plan

- [x] `dotnet build` (whole solution) — clean, 0 warnings/errors
- [x] `dotnet test` (whole solution) — all 4 backend suites green (Game.Core.Tests 1156, Game.Infrastructure.Tests 60, Game.Application.Tests 784, Game.Api.Tests 652)
- [x] `dotnet format --verify-no-changes` — clean
- No behavior change (pure internal refactor), no new tests needed — existing `Battler`/`BattleContext` coverage (Hex/Momentum scenarios) exercises these paths unchanged.
- No frontend changes — this is backend-only domain code with no battle-parity surface.

Closes #1460


---
_Generated by [Claude Code](https://claude.ai/code/session_01DM1LSr2oETXWewkA6CSXvS)_