### PR TITLE
Fix broken main: thread baseCriticalChance through resist-split tests

### DIFF
--- a/Game.Core.Tests/Battle/BattleContextTests.cs
+++ b/Game.Core.Tests/Battle/BattleContextTests.cs
@@ -570,7 +570,7 @@ namespace Game.Core.Tests.Battle
             var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
             context.SwapActiveAndTargetBattlers();
 
-            context.DamageTarget(40, Single(EDamageType.Fire));
+            context.DamageTarget(40, Single(EDamageType.Fire), 0);
 
             Assert.Equal(20, context.Stats.PlayerDamageTaken, 0.001);
             Assert.Equal(20, Mitigated(context, EDamageType.Fire), 0.001);
@@ -588,7 +588,7 @@ namespace Game.Core.Tests.Battle
             var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
             context.SwapActiveAndTargetBattlers();
 
-            context.DamageTarget(40, Single(EDamageType.Fire));
+            context.DamageTarget(40, Single(EDamageType.Fire), 0);
 
             Assert.True(context.Stats.PlayerDamageTaken < 40);
             Assert.Equal(0, Mitigated(context, EDamageType.Fire), 0.001);
@@ -604,7 +604,7 @@ namespace Game.Core.Tests.Battle
             var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
             context.SwapActiveAndTargetBattlers();
 
-            context.DamageTarget(40, Single(EDamageType.Fire));
+            context.DamageTarget(40, Single(EDamageType.Fire), 0);
 
             Assert.Equal(0, Mitigated(context, EDamageType.Fire), 0.001);
         }
@@ -621,7 +621,7 @@ namespace Game.Core.Tests.Battle
             var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
             context.SwapActiveAndTargetBattlers();
 
-            context.DamageTarget(40, Single(EDamageType.Fire));
+            context.DamageTarget(40, Single(EDamageType.Fire), 0);
 
             Assert.Equal(40, Mitigated(context, EDamageType.Fire), 0.001);
         }
@@ -635,7 +635,7 @@ namespace Game.Core.Tests.Battle
             var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
             context.SwapActiveAndTargetBattlers();
 
-            context.DamageTarget(40, Single(EDamageType.Fire));
+            context.DamageTarget(40, Single(EDamageType.Fire), 0);
 
             Assert.Empty(context.Stats.TypedDamageResistanceMitigated);
         }


### PR DESCRIPTION
## Summary

`main` (`7288dfd`) does not compile. Two individually-green PRs collided semantically:

- **#1458** (#1453, native per-skill crit chance) added a required `baseCriticalChance` parameter to `BattleContext.DamageTarget`.
- **#1467** (#1454, resist-proficiency split) was branched *before* #1458 and added new resist-split tests calling the old two-arg `DamageTarget` signature.

GitHub's textual merge found no conflict (the two changes touch different regions), but the combined result fails to build:

```
Game.Core.Tests/Battle/BattleContextTests.cs(573,21): error CS7036:
There is no argument given that corresponds to the required parameter
'baseCriticalChance' of 'BattleContext.DamageTarget(double, IReadOnlyList<SkillDamagePortion>, double)'
```

(five call sites: lines 573, 591, 607, 624, 638)

## Fix

Pass `baseCriticalChance: 0` at the five resist-split test call sites. Those tests assert exact type-resistance mitigation amounts where crit is irrelevant, so `0` (no crit) is the correct value — it matches the adjacent exposure test that already passes `0`.

Production code is unaffected; only these test call sites needed updating.

## Test plan

- [x] `dotnet build Game.Core.Tests` — clean
- [x] `dotnet test Game.Core.Tests` — 1167 passed, 0 failed
- [x] `dotnet test Game.Application.Tests` — 796 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHZtZS9X7LBsMRTFmmAsnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHZtZS9X7LBsMRTFmmAsnZ)_