### PR TITLE
Consolidate the three PrimaryDamageType tie-break implementations

### DIFF
--- a/Game.Application/Content/ProgressionGraphChecker.cs
+++ b/Game.Application/Content/ProgressionGraphChecker.cs
@@ -1,5 +1,6 @@
 using Game.Core;
 using Game.Core.Attributes;
+using Game.Core.Skills;
 using Contracts = Game.Abstractions.Contracts;
 
 namespace Game.Application.Content
@@ -271,32 +272,11 @@ namespace Game.Application.Content
                     return;
                 }
 
-                var signatureType = PrimaryDamageType(skill);
+                var signatureType = PrimaryDamageTypeResolver.Resolve(skill.DamagePortions.ToList(), p => p.Weight, p => p.Type);
                 if (DamageTypes.IsWeaponLeaf(signatureType) && signatureType != weaponType)
                 {
                     Error("WeaponStranding", "Item", item.Id, $"grants signature skill {grantedSkillId} of weapon type {signatureType}, which the equipped {weaponType} weapon dims — the weapon fields no usable signature.");
                 }
-            }
-
-            // Mirrors Game.Core.Skills.Skill.PrimaryDamageType over the read contract: highest-weight portion,
-            // first-authored on a tie, Physical for an empty split.
-            private static EDamageType PrimaryDamageType(Contracts.Skill skill)
-            {
-                var portions = skill.DamagePortions.ToList();
-                if (portions.Count == 0)
-                {
-                    return EDamageType.Physical;
-                }
-
-                var primary = portions[0];
-                foreach (var portion in portions)
-                {
-                    if (portion.Weight > primary.Weight)
-                    {
-                        primary = portion;
-                    }
-                }
-                return primary.Type;
             }
 
             private void CheckProficiencyGate(Contracts.Item item, int proficiencyId)

--- a/Game.Core.Tests/Skills/PrimaryDamageTypeResolverTests.cs
+++ b/Game.Core.Tests/Skills/PrimaryDamageTypeResolverTests.cs
@@ -1,0 +1,55 @@
+using Game.Core;
+using Game.Core.Skills;
+using Xunit;
+
+namespace Game.Core.Tests.Skills
+{
+    /// <summary>
+    /// Coverage for <see cref="PrimaryDamageTypeResolver"/> — the shared tie-break rule <see
+    /// cref="Skill.PrimaryDamageType"/>, <c>ProgressionGraphChecker</c>, and <c>AdminItems</c> all resolve
+    /// through. <see cref="SkillTests"/> already pins these scenarios via <see cref="Skill"/> (double
+    /// weights); this exercises the resolver directly with a <c>decimal</c> weight selector, as the read
+    /// contract and persisted entity call sites use.
+    /// </summary>
+    public class PrimaryDamageTypeResolverTests
+    {
+        private sealed record Portion(EDamageType Type, decimal Weight);
+
+        [Fact]
+        public void Resolve_PicksTheHighestWeightPortion()
+        {
+            var portions = new[]
+            {
+                new Portion(EDamageType.Physical, 0.4m),
+                new Portion(EDamageType.Fire, 0.6m),
+            };
+
+            var result = PrimaryDamageTypeResolver.Resolve(portions, p => p.Weight, p => p.Type);
+
+            Assert.Equal(EDamageType.Fire, result);
+        }
+
+        [Fact]
+        public void Resolve_OnWeightTie_PicksTheFirstAuthoredPortion()
+        {
+            var portions = new[]
+            {
+                new Portion(EDamageType.Water, 1.0m),
+                new Portion(EDamageType.Fire, 1.0m),
+            };
+
+            var result = PrimaryDamageTypeResolver.Resolve(portions, p => p.Weight, p => p.Type);
+
+            Assert.Equal(EDamageType.Water, result);
+        }
+
+        [Fact]
+        public void Resolve_NoPortions_FallsBackToPhysical()
+        {
+            var result = PrimaryDamageTypeResolver.Resolve(
+                Array.Empty<Portion>(), p => p.Weight, p => p.Type);
+
+            Assert.Equal(EDamageType.Physical, result);
+        }
+    }
+}

--- a/Game.Core/Skills/PrimaryDamageTypeResolver.cs
+++ b/Game.Core/Skills/PrimaryDamageTypeResolver.cs
@@ -1,0 +1,36 @@
+namespace Game.Core.Skills
+{
+    /// <summary>
+    /// The shared "primary damage type" tie-break rule: the highest-weight portion wins, the first-authored
+    /// portion wins a weight tie, and an empty split falls back to <see cref="EDamageType.Physical"/>. Generic
+    /// over the three skill representations that each carry a portion split under different property names and
+    /// weight numeric types (the domain <see cref="Skill.DamagePortions"/>, the read contract, and the
+    /// persisted entity) so all three resolve through one implementation instead of drifting independently.
+    /// Takes an indexable list (not <see cref="IEnumerable{T}"/>) so the domain call site — on the per-fire
+    /// hot path — allocates nothing.
+    /// </summary>
+    public static class PrimaryDamageTypeResolver
+    {
+        public static EDamageType Resolve<TPortion, TWeight>(
+            IReadOnlyList<TPortion> portions,
+            Func<TPortion, TWeight> weightSelector,
+            Func<TPortion, EDamageType> typeSelector)
+            where TWeight : IComparable<TWeight>
+        {
+            if (portions.Count == 0)
+            {
+                return EDamageType.Physical;
+            }
+
+            var primary = portions[0];
+            for (var i = 1; i < portions.Count; i++)
+            {
+                if (weightSelector(portions[i]).CompareTo(weightSelector(primary)) > 0)
+                {
+                    primary = portions[i];
+                }
+            }
+            return typeSelector(primary);
+        }
+    }
+}

--- a/Game.Core/Skills/Skill.cs
+++ b/Game.Core/Skills/Skill.cs
@@ -45,29 +45,11 @@
         /// highest-weight portion, the first in authored order on a tie. Falls back to
         /// <see cref="EDamageType.Physical"/> for a malformed skill carrying no portions, so a display read
         /// never throws. The direct-hit pipeline reads the full <see cref="DamagePortions"/> split, not this
-        /// single primary type.
+        /// single primary type. Resolved by the shared <see cref="PrimaryDamageTypeResolver"/> — also used by
+        /// the read-contract and persisted-entity mirrors of this accessor.
         /// </summary>
-        public EDamageType PrimaryDamageType
-        {
-            get
-            {
-                // Index loop with a strict '>' so the first portion wins a weight tie (first-authored), and so
-                // the read allocates nothing on the per-fire hot path.
-                if (DamagePortions.Count == 0)
-                {
-                    return EDamageType.Physical;
-                }
-                var primary = DamagePortions[0];
-                for (var i = 1; i < DamagePortions.Count; i++)
-                {
-                    if (DamagePortions[i].Weight > primary.Weight)
-                    {
-                        primary = DamagePortions[i];
-                    }
-                }
-                return primary.Type;
-            }
-        }
+        public EDamageType PrimaryDamageType =>
+            PrimaryDamageTypeResolver.Resolve(DamagePortions, p => p.Weight, p => p.Type);
 
         public required IReadOnlyList<DamageMultiplier> DamageMultipliers { get; init; }
 

--- a/Game.DataAccess/Repositories/Admin/AdminItems.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminItems.cs
@@ -2,6 +2,7 @@ using Game.Abstractions.Contracts.Admin;
 using Game.Abstractions.DataAccess.Admin;
 using Game.Core;
 using Game.Core.Attributes;
+using Game.Core.Skills;
 using Contracts = Game.Abstractions.Contracts;
 using Entities = Game.Infrastructure.Entities;
 
@@ -145,7 +146,8 @@ namespace Game.DataAccess.Repositories.Admin
                     // next; skip the signature-type check here rather than duplicating that rejection.
                     if (_skills.LookupSkill(grantedSkillId) is { } grantedSkill)
                     {
-                        var signatureType = PrimaryDamageType(grantedSkill);
+                        var signatureType = PrimaryDamageTypeResolver.Resolve(
+                            grantedSkill.SkillDamagePortions, p => p.Weight, p => (EDamageType)p.DamageType);
                         if (DamageTypes.IsWeaponLeaf(signatureType) && signatureType != weaponType)
                         {
                             return AdminSaveResult.Failure(
@@ -160,29 +162,6 @@ namespace Game.DataAccess.Repositories.Admin
             }
 
             return null;
-        }
-
-        // Mirrors Game.Core.Skills.Skill.PrimaryDamageType over the persisted entity (highest-weight portion,
-        // first-authored on a tie, Physical for an unauthored/malformed skill) — the entity layer has no such
-        // computed accessor of its own.
-        private static EDamageType PrimaryDamageType(Entities.Skill skill)
-        {
-            var portions = skill.SkillDamagePortions;
-            if (portions.Count == 0)
-            {
-                return EDamageType.Physical;
-            }
-
-            var primary = portions[0];
-            for (var i = 1; i < portions.Count; i++)
-            {
-                if (portions[i].Weight > primary.Weight)
-                {
-                    primary = portions[i];
-                }
-            }
-
-            return (EDamageType)primary.DamageType;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

The "primary damage type" tie-break rule (highest-weight portion, first-authored wins a tie, `Physical` fallback for an empty split) was implemented three times, once per skill representation:

- `Game.Core.Skills.Skill.PrimaryDamageType` — the canonical domain accessor (hot path).
- `Game.Application/Content/ProgressionGraphChecker.PrimaryDamageType(Contracts.Skill)` — over the read contract.
- `Game.DataAccess/Repositories/Admin/AdminItems.PrimaryDamageType(Entities.Skill)` — over the persisted entity.

All three had to stay in lockstep since the weapon no-stranding save guard and the content lint key on the same primary-type resolution the battle/display layer uses — a future tweak to the tie-break rule risked being mirrored in only some of the three.

## How it addresses the issue

Extracted a single generic helper, `Game.Core.Skills.PrimaryDamageTypeResolver`, parameterized over the portion type and its weight type (`double` for the domain model, `decimal` for the contract/entity):

```csharp
public static EDamageType Resolve<TPortion, TWeight>(
    IReadOnlyList<TPortion> portions,
    Func<TPortion, TWeight> weightSelector,
    Func<TPortion, EDamageType> typeSelector)
    where TWeight : IComparable<TWeight>
```

It lives in `Game.Core` (the domain layer every other project already references), takes an indexable `IReadOnlyList<T>` rather than `IEnumerable<T>`, and loops by index — preserving the zero-allocation behavior the domain `Skill.PrimaryDamageType` accessor's doc comment calls out for its per-fire hot path. All three call sites now route through it with the appropriate selectors instead of duplicating the loop.

Per the issue's note, I checked whether the admin-side mirror already had multi-portion test coverage (it flagged this as a gap from #1470) — it turned out a multi-portion test (`SaveItems_WeaponGrantingMultiPortionSignature_ResolvesPrimaryTypeByWeight_ReturnsFailure`) was already added since, likely by #1456, so no additional coverage was needed there. I did add a small dedicated `PrimaryDamageTypeResolverTests` suite exercising the resolver directly with a `decimal` weight selector (the existing `SkillTests` only exercises the domain `double` path via `Skill`).

Behavior is unchanged — this is a pure refactor to remove the drift risk the issue describes.

## Test plan

- [x] `dotnet build` — clean, 0 warnings/errors
- [x] `dotnet test` — all 4 backend suites green (Game.Core.Tests 1179, Game.Infrastructure.Tests 60, Game.Application.Tests 796, Game.Api.Tests 652)
- [x] `dotnet format --verify-no-changes` — clean
- [x] Added `Game.Core.Tests/Skills/PrimaryDamageTypeResolverTests.cs` covering the resolver directly (highest-weight pick, tie-break, empty-split fallback) with a `decimal` selector

Closes #1471


---
_Generated by [Claude Code](https://claude.ai/code/session_012hoskQBGiDVMCtzPPAygdB)_