### PR TITLE
Validate client-supplied zone ids before resolving in StartBattle/StartBossBattle

### DIFF
--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -1414,6 +1414,40 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task StartBattle_TransitionToOutOfRangeZone_KeepsPlayerInCurrentZone()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, skill.Id);
+            var zone = await TestDataSeeder.CreateZoneAsync(context);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, skill.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+
+            // A tampered request naming an out-of-range zone id is ignored — not thrown — exactly like a
+            // locked or retired target: the player stays put and the battle proceeds in their current zone.
+            var result = await battleService.StartBattle(player, state, zoneId: zone.Id, newZoneId: 999);
+
+            Assert.NotNull(result);
+            Assert.Equal(zone.Id, player.CurrentZoneId);
+            Assert.Equal(zone.Id, state.BattleZoneId);
+        }
+
+        [Fact]
         public async Task StartBattle_TransitionToHomeZone_KeepsPlayerInCurrentZone()
         {
             using var scope = CreateScope();
@@ -1596,6 +1630,35 @@ namespace Game.Application.Tests.Services
             var state = new PlayerState();
 
             var result = await battleService.StartBossBattle(player, state, zone.Id);
+
+            Assert.Null(result);
+            Assert.False(state.HasActiveBattle);
+        }
+
+        [Fact]
+        public async Task StartBossBattle_OutOfRangeZone_ReturnsNullAndStartsNoBattle()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var playerSkill = await TestDataSeeder.CreateSkillAsync(context, name: "PlayerSkill");
+            var zone = await TestDataSeeder.CreateZoneAsync(context);
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, playerSkill.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+
+            // A tampered ChallengeBoss request naming an out-of-range zone id is a graceful no-op — not an
+            // ArgumentOutOfRangeException surfacing as an opaque 500 — like the bossless/locked/retired cases.
+            var result = await battleService.StartBossBattle(player, state, 999);
 
             Assert.Null(result);
             Assert.False(state.HasActiveBattle);

--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -998,6 +998,54 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task StartBattle_AbandoningAWonBattleWithOutOfRangeNewZoneId_CreditsVictoryWithoutThrowing()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, skill.Id);
+            // Pin the encounter level so the rolled enemy yields a deterministic, non-zero exp reward (see
+            // StartBattle_AbandoningAWonBattle_GrantsExpForTheVictory).
+            var zone = await TestDataSeeder.CreateZoneAsync(context, levelMin: 10, levelMax: 10);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, skill.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+
+            await battleService.StartBattle(player, state, zoneId: zone.Id);
+            Assert.True(state.HasActiveBattle);
+
+            var expBefore = player.Exp;
+
+            // Backdate the battle start so the abandon (triggered below) resolves as a real win.
+            state.BattleStartTime = DateTime.UtcNow.AddMinutes(-10);
+
+            // Before the #1495 fix, a tampered out-of-range newZoneId reached GetDomainZone and threw
+            // ArgumentOutOfRangeException *after* AbandonBattle had already credited the win in-memory —
+            // stranding the credited-but-unsaved state (the caller's SavePlayerState never runs on a
+            // fault) so a reconnect would re-abandon and re-credit the same victory. The out-of-range
+            // target must now be silently ignored so the command completes normally and the win is
+            // credited exactly once.
+            await battleService.StartBattle(player, state, zoneId: zone.Id, newZoneId: 999);
+
+            Assert.True(player.Exp > expBefore);
+            Assert.True(state.HasActiveBattle);
+            Assert.Equal(zone.Id, player.CurrentZoneId);
+        }
+
+        [Fact]
         public async Task StartBattle_AbandoningAnUnresolvedBattle_RecordsAbandonedNotLost()
         {
             using var scope = CreateScope();

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -77,14 +77,14 @@ namespace Game.Application.Services
                 await AbandonBattle(player, state, clientBattleMs, cancellationToken);
             }
 
-            // A real zone change is gated on the target being unlocked, in circulation, and a combat zone
-            // (anti-cheat). A legitimate client never navigates a battle into a locked, retired, or Home zone —
-            // the UI gates all three (and never spawns a battle in Home at all) — so such a target is ignored
-            // and the battle simply proceeds in the player's current zone. Refusing the Home target keeps the
-            // "fake zone" invariant the offline path relies on: a player's persisted CurrentZoneId is never the
-            // no-combat Home sanctuary, so offline rewards always replay their last real combat zone. Same-zone
-            // re-requests skip the check (and the redundant save) entirely.
-            if (newZoneId.HasValue && newZoneId.Value != player.CurrentZoneId)
+            // A real zone change is gated on the target being in range, unlocked, in circulation, and a combat
+            // zone (anti-cheat). A legitimate client never navigates a battle into an out-of-range, locked,
+            // retired, or Home zone — the UI gates all four (and never spawns a battle in Home at all) — so
+            // such a target is ignored and the battle simply proceeds in the player's current zone. Refusing
+            // the Home target keeps the "fake zone" invariant the offline path relies on: a player's persisted
+            // CurrentZoneId is never the no-combat Home sanctuary, so offline rewards always replay their last
+            // real combat zone. Same-zone re-requests skip the check (and the redundant save) entirely.
+            if (newZoneId.HasValue && newZoneId.Value != player.CurrentZoneId && _zones.ValidateZoneId(newZoneId.Value))
             {
                 var targetZone = _zones.GetDomainZone(newZoneId.Value);
                 if (!_zones.IsZoneRetired(newZoneId.Value)
@@ -178,6 +178,14 @@ namespace Game.Application.Services
         /// </summary>
         public async Task<BattleStartResult?> StartBossBattle(Player player, PlayerState state, int zoneId, int? clientBattleMs = null, CancellationToken cancellationToken = default)
         {
+            // Out-of-range is a true no-op, same as the bossless/locked/retired checks below: validate before
+            // touching the active battle (abandoning is not a cheap no-op) and before resolving the domain
+            // zone, which throws on an out-of-range id.
+            if (!_zones.ValidateZoneId(zoneId))
+            {
+                return null;
+            }
+
             var zone = _zones.GetDomainZone(zoneId);
 
             // Validate the challenge before touching the active battle: abandoning is not a cheap no-op


### PR DESCRIPTION
## Summary

Both battle-start paths resolved a client-supplied zone id via `_zones.GetDomainZone(id)` **before** any bounds check. `Zones.GetDomainZone` throws `ArgumentOutOfRangeException` on an out-of-range id, so a tampered client could trigger an opaque "Internal Server Error" instead of a graceful no-op:

- `BattleService.StartBattle` — reached from `NewEnemy` with an unvalidated `Parameters.NewZoneId`.
- `BattleService.StartBossBattle` — reached from `ChallengeBoss.Parameters.ZoneId`.

On the `StartBattle` path this was also the worse hazard described in the issue: `StartBattle` runs `AbandonBattle` first, which can credit a win in-memory via `RecordVictory`/`SavePlayer`. If the subsequent `GetDomainZone` then throws on a bad `newZoneId`, the command faults before `SavePlayerState()` runs, so the Redis session still shows the already-credited battle as active — a reconnect then re-credits it (exp/statistics duplication).

## Fix

Guarded both paths with `IZones.ValidateZoneId` before resolving, matching the pattern already used by the sibling anti-cheat path `SetAutoChallengeBoss`:

- `StartBattle`: an out-of-range `newZoneId` is now ignored, same as a locked/retired/Home target — the battle proceeds in the player's current zone (matches the documented behavior).
- `StartBossBattle`: an out-of-range `zoneId` now returns `null` before touching the active battle, same as the existing bossless/locked/retired no-op checks — `ChallengeBoss` already handles a `null` result gracefully.

## Test plan

- [x] New integration test `StartBattle_TransitionToOutOfRangeZone_KeepsPlayerInCurrentZone` — mirrors the existing locked/retired-zone tests, asserting the player stays in their current zone and the battle still starts.
- [x] New integration test `StartBossBattle_OutOfRangeZone_ReturnsNullAndStartsNoBattle` — mirrors `StartBossBattle_RetiredZone_ReturnsNullAndStartsNoBattle`.
- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] Full backend suite: `dotnet test --no-build --no-restore` — 2741 tests passing.

Closes #1495


---
_Generated by [Claude Code](https://claude.ai/code/session_01GKeM8Wkah9MUj64bJGihKp)_