### PR TITLE
Settle WaitSocketClosed on an abrupt (Aborted) disconnect

### DIFF
--- a/Game.Api.Tests/Unit/SocketReadLoopTests.cs
+++ b/Game.Api.Tests/Unit/SocketReadLoopTests.cs
@@ -63,6 +63,31 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
+        public async Task ReadLoop_ReceiveThrowsWithSocketAborted_StillSettlesWaitSocketClosed()
+        {
+            // A hard disconnect (TCP reset, killed browser) throws from ReceiveAsync AND transitions the
+            // WebSocket to Aborted — unlike the still-Open throw above. The read loop must still call Close()
+            // so WaitSocketClosed settles (issue #1496): otherwise SocketInterceptorMiddleware awaits it
+            // forever and the socket registration, pub/sub subscription, and middleware task leak.
+            var socket = new ScriptedReadWebSocket();
+            socket.QueueThrow(new WebSocketException("hard disconnect"), resultingState: WebSocketState.Aborted);
+            var (context, handler) = CreateHandler(socket);
+
+            using var inactivityStop = new CancellationTokenSource();
+            handler.Listen(hostStopping: inactivityStop.Token);
+
+            await context.WaitSocketClosed().WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
+            inactivityStop.Cancel();
+            await handler.Completion.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
+
+            // Close() re-checks state and does not send a close frame on an already-Aborted socket, but
+            // WaitSocketClosed above still had to complete for this assertion to be reached.
+            Assert.Equal(1, socket.ReceiveAttempts);
+            Assert.False(socket.CloseAsyncCalled);
+            Assert.Equal(WebSocketState.Aborted, socket.State);
+        }
+
+        [Fact]
         public async Task ReadLoop_ClientCloseFrame_CompletesTheClosingHandshake()
         {
             // A client-initiated close still drives the read loop out of the CloseReceived state and completes
@@ -154,7 +179,16 @@ namespace Game.Api.Tests.Unit
             /// <summary>Completes when the loop calls receive with no scripted input left — i.e. it looped back to read again.</summary>
             public Task IdleReadReached => _idleReadReached.Task;
 
-            public void QueueThrow(Exception toThrow) => _throwOnReceive = toThrow;
+            /// <param name="resultingState">
+            /// The state the socket transitions to as part of the throw. Defaults to <see cref="WebSocketState.Open"/>
+            /// (a throw that does NOT transition state — the terminal-fault case); pass <see cref="WebSocketState.Aborted"/>
+            /// to script a hard disconnect, where the underlying WebSocket transitions itself before the read loop observes it.
+            /// </param>
+            public void QueueThrow(Exception toThrow, WebSocketState resultingState = WebSocketState.Open)
+            {
+                _throwOnReceive = toThrow;
+                _state = resultingState;
+            }
             public void QueueClose() => _closeFrameQueued = true;
             public void QueueMessage(string message) => _messageQueued = Encoding.UTF8.GetBytes(message);
 
@@ -163,8 +197,6 @@ namespace Game.Api.Tests.Unit
                 ReceiveAttempts++;
                 if (_throwOnReceive is not null)
                 {
-                    // State deliberately stays Open: the receive throws without transitioning the socket, the
-                    // exact case the read loop must treat as terminal rather than re-looping.
                     return Task.FromException<WebSocketReceiveResult>(_throwOnReceive);
                 }
 

--- a/Game.Api.Tests/Unit/SocketReadLoopTests.cs
+++ b/Game.Api.Tests/Unit/SocketReadLoopTests.cs
@@ -161,8 +161,10 @@ namespace Game.Api.Tests.Unit
         /// <summary>
         /// A <see cref="WebSocket"/> stand-in that scripts a single receive step (a thrown receive or a client
         /// close frame) and records the close frame, so the read loop's terminal-fault and clean-close paths can
-        /// be driven deterministically. A throw leaves <see cref="State"/> Open — exactly the case that would
-        /// spin the loop — and counts every receive so a test can assert the loop did not retry.
+        /// be driven deterministically. A throw defaults to leaving <see cref="State"/> Open — the case that
+        /// would spin the loop — or can be scripted to leave it Aborted via <see cref="QueueThrow"/>'s
+        /// <c>resultingState</c>, mirroring a hard disconnect. Counts every receive so a test can assert the
+        /// loop did not retry.
         /// </summary>
         private sealed class ScriptedReadWebSocket : WebSocket
         {

--- a/Game.Api/Sockets/SocketHandler.cs
+++ b/Game.Api/Sockets/SocketHandler.cs
@@ -330,13 +330,13 @@ namespace Game.Api.Sockets
             }
             while (_context.State is Open);
 
-            // Complete the closing handshake for a client-initiated close, and close a socket the read loop is
-            // abandoning while still open (the terminal-fault break above) so teardown completes instead of
-            // leaving a half-open socket. Close is a no-op on an already-closed/aborted socket.
-            if (_context.State is Open or CloseReceived)
-            {
-                await _context.Close(ESocketCloseReason.Finished);
-            }
+            // Complete the closing handshake for a client-initiated close, close a socket the read loop is
+            // abandoning while still open (the terminal-fault break above), and settle WaitSocketClosed for
+            // an abrupt disconnect (Aborted) so the middleware awaiting it always unblocks and tears down the
+            // registration. Unconditional: Close() re-checks state itself and only sends a close frame when
+            // still Open, so this is a no-op send on an already-closed/aborted socket but always settles the
+            // TCS.
+            await _context.Close(ESocketCloseReason.Finished);
         }
 
         internal async Task HandleMessage(string message)


### PR DESCRIPTION
## Summary

`SocketHandler.ReadLoop`'s terminal step only called `SocketContext.Close()` when the socket was still in the `Open` or `CloseReceived` state:

```csharp
if (_context.State is Open or CloseReceived)
{
    await _context.Close(ESocketCloseReason.Finished);
}
```

On a hard disconnect (TCP reset, killed browser, network drop), `ReceiveAsync` throws and the WebSocket transitions itself straight to `Aborted` — the guard above is then false, `Close()` is never called, and `SocketContext`'s `_socketClosedSource` TCS never settles. `SocketInterceptorMiddleware` awaits `WaitSocketClosed()` right after registering the socket, so it hangs forever on an abrupt disconnect: `UnRegisterSocket` never runs, leaking the Redis pub/sub subscription, the socket-registry entry, and the parked middleware task for the process lifetime (only an explicit shutdown drain releases them).

## Fix

Call `Close()` unconditionally after the read loop instead of gating it on state. `Close()` already re-checks `_socket.State` internally and only sends a close frame when still `Open` — its `finally` unconditionally settles the `WaitSocketClosed` TCS regardless of state — so this is a no-op send (but a real settle) on an already-closed/aborted socket, and unchanged behavior for the Open/CloseReceived cases the old guard handled.

## Test plan

- [x] New unit test `ReadLoop_ReceiveThrowsWithSocketAborted_StillSettlesWaitSocketClosed` in `SocketReadLoopTests` — scripts a receive that throws *and* transitions the socket to `Aborted` (distinct from the existing still-Open throw case), and asserts `WaitSocketClosed()` still completes.
- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] Full backend suite: `dotnet test --no-build --no-restore` — 2740 tests passing.

Closes #1496

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSuq6aJBLUxm23RGpTo2q9)_