### PR TITLE
Fix socket presence refresh unable to resurrect a lost key

### DIFF
--- a/Game.Abstractions/Infrastructure/ICacheService.cs
+++ b/Game.Abstractions/Infrastructure/ICacheService.cs
@@ -56,5 +56,14 @@
         /// update is never silently lost. The optimistic-concurrency counterpart to <see cref="CompareAndDelete"/>.
         /// </summary>
         public Task<bool> CompareAndSet(string key, string? expectedValue, string newValue, TimeSpan expiry, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Fire-and-forget "SET NX + expire": if <paramref name="key"/> is currently unset, claims it as
+        /// <paramref name="ownerValue"/> with <paramref name="expiry"/> as its TTL; otherwise just extends the
+        /// TTL of whatever value is already there (matching <see cref="ExpireAndForget"/>'s existing
+        /// don't-care-who-asked refresh — it never overwrites a value that isn't <paramref name="ownerValue"/>).
+        /// Unlike <see cref="ExpireAndForget"/> (a bare TTL bump that no-ops on a missing key), this can
+        /// resurrect a claim that expired or was rolled back out from under a still-live owner.
+        /// </summary>
+        public void ReclaimAndForget(string key, string ownerValue, TimeSpan expiry);
     }
 }

--- a/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
+++ b/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
@@ -146,6 +146,35 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task RefreshSocketPresence_AfterItsKeyLapsesWhileStillLive_ResurrectsItsOwnClaim()
+        {
+            var (userId, playerId) = await SeedAndLoginAsync();
+            var key = PresenceKey(playerId);
+
+            await using var socketA = new TestSocketClient();
+            await socketA.ConnectAsync(Factory.Server.CreateWebSocketClient(), userId);
+            await socketA.SendCommandAsync<object>("GetStatisticTypes");
+            var idA = await ReadPresenceValueAsync(playerId);
+            Assert.NotNull(idA);
+
+            // Simulate the presence key lapsing out from under a still-live socket — an inbound stall past the
+            // 30s TTL, or a rolled-back superseding registration — by deleting it directly (#1497).
+            using (var scope = CreateScope())
+            {
+                var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+                await cache.Delete(key);
+            }
+            Assert.Null(await ReadPresenceValueAsync(playerId));
+
+            // The next heartbeat on the still-live socket must resurrect its own claim rather than leaving the
+            // key permanently gone (a bare ExpireAndForget is a no-op on a missing key and never recovers).
+            await socketA.SendCommandAsync<object>("GetStatisticTypes");
+
+            Assert.True(await WaitUntilAsync(async () => await ReadPresenceValueAsync(playerId) == idA),
+                "Expected the live socket's next heartbeat to resurrect its own presence claim.");
+        }
+
+        [Fact]
         public async Task HasActiveSocket_AfterPresenceTtlExpires_ReturnsFalse()
         {
             // HasActiveSocket is a pure presence-key read, so a directly-seeded key with a short TTL

--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -420,6 +420,7 @@ namespace Game.Api.Tests.Unit
             public void DeleteAndForget(string key) => throw new NotSupportedException();
             public Task CompareAndDelete(string key, string deleteIfValue, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<bool> CompareAndSet(string key, string? expectedValue, string newValue, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public void ReclaimAndForget(string key, string ownerValue, TimeSpan expiry) => throw new NotSupportedException();
         }
 
         /// <summary>A pub/sub whose <c>Subscribe</c> throws, to drive the registration-rollback path.</summary>
@@ -490,6 +491,7 @@ namespace Game.Api.Tests.Unit
             public Task Delete(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void DeleteAndForget(string key) => throw new NotSupportedException();
             public Task<bool> CompareAndSet(string key, string? expectedValue, string newValue, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public void ReclaimAndForget(string key, string ownerValue, TimeSpan expiry) => throw new NotSupportedException();
         }
 
         private sealed class NoOpHostLifetime : IHostApplicationLifetime

--- a/Game.Api/Services/SocketManagerService.cs
+++ b/Game.Api/Services/SocketManagerService.cs
@@ -41,7 +41,7 @@ namespace Game.Api.Services
         {
             var playerId = sessionService.SelectedPlayerId;
             var socketContext = new SocketContext(socket, playerId, sessionService, isAdmin, _loggerFactory.CreateLogger<SocketContext>());
-            var socketHandler = new SocketHandler(socketContext, _commandFactory, _scopeFactory, _loggerFactory.CreateLogger<SocketHandler>(), () => RefreshSocketPresence(playerId));
+            var socketHandler = new SocketHandler(socketContext, _commandFactory, _scopeFactory, _loggerFactory.CreateLogger<SocketHandler>(), () => RefreshSocketPresence(playerId, socketContext.SocketId));
             var presenceKey = CurrentSocketKey(playerId);
             // Claim the presence key with its TTL atomically so a fault here can never leave the key without an
             // expiry — a TTL-less key would defeat the heartbeat design and report a permanent ghost session.
@@ -129,16 +129,19 @@ namespace Game.Api.Services
 
         /// <summary>
         /// Extends the player's socket-presence TTL on connection activity, so a live socket keeps its
-        /// presence key from expiring (see <see cref="SocketPresenceTtl"/>). Uses an expire (not a
-        /// re-set) so it only ever prolongs the currently-registered socket's key and never resurrects a
-        /// key a newer connection has since taken over. Fire-and-forget: presence refresh is best-effort
-        /// (a missed refresh simply lets the sliding TTL lapse), so it must neither throw on a transient
-        /// Redis fault — which would tear down the live read loop — nor add a serial round-trip to the
-        /// front of every inbound command.
+        /// presence key from expiring (see <see cref="SocketPresenceTtl"/>). Reclaims the key as this
+        /// socket's own id if it is currently unset, so a live socket can restore a claim that lapsed (a TTL
+        /// lapse from an inbound stall) or was rolled back out from under it (a superseding registration
+        /// that later failed) — a bare expire is a no-op on a missing key and can never resurrect it. If the
+        /// key already holds a different (newer) socket's id, the refresh still just extends that key's TTL
+        /// without touching its value, so it can never clobber a takeover. Fire-and-forget: presence refresh
+        /// is best-effort (a missed refresh simply lets the sliding TTL lapse), so it must neither throw on a
+        /// transient Redis fault — which would tear down the live read loop — nor add a serial round-trip to
+        /// the front of every inbound command.
         /// </summary>
-        private void RefreshSocketPresence(int playerId)
+        private void RefreshSocketPresence(int playerId, string socketId)
         {
-            _cache.ExpireAndForget(CurrentSocketKey(playerId), SocketPresenceTtl);
+            _cache.ReclaimAndForget(CurrentSocketKey(playerId), socketId, SocketPresenceTtl);
         }
 
         public Task UnRegisterSocket(SocketContext context)

--- a/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
@@ -109,6 +109,82 @@ namespace Game.Application.Tests.DataAccess
             Assert.Fail($"Expected the fire-and-forget null write to delete key '{key}' within the timeout.");
         }
 
+        [Fact]
+        public async Task ReclaimAndForget_OnAMissingKey_ClaimsItWithTtl()
+        {
+            // Mirrors a live socket's presence key having lapsed (TTL expiry or a registration rollback) while
+            // it is still the genuine owner — the resurrection case ExpireAndForget can't handle (#1497).
+            var key = $"redis-reclaim-{Guid.NewGuid()}";
+            using var scope = CreateScope();
+            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+
+            cache.ReclaimAndForget(key, "owner-a", TimeSpan.FromSeconds(30));
+
+            Assert.True(await WaitUntilValueEqualsAsync(cache, key, "owner-a"));
+            var ttl = await ReadTtlAsync(key);
+            Assert.NotNull(ttl);
+            Assert.True(ttl > TimeSpan.Zero && ttl <= TimeSpan.FromSeconds(30), $"Expected a positive TTL within 30s but was {ttl}.");
+        }
+
+        [Fact]
+        public async Task ReclaimAndForget_OnAKeyItAlreadyOwns_RefreshesTtlWithoutChangingValue()
+        {
+            var key = $"redis-reclaim-{Guid.NewGuid()}";
+            using var scope = CreateScope();
+            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+            await cache.Set(key, "owner-a", TimeSpan.FromSeconds(2));
+
+            cache.ReclaimAndForget(key, "owner-a", TimeSpan.FromSeconds(30));
+
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            TimeSpan? ttl = null;
+            while (DateTime.UtcNow < deadline)
+            {
+                ttl = await ReadTtlAsync(key);
+                if (ttl > TimeSpan.FromSeconds(10))
+                {
+                    break;
+                }
+
+                await Task.Delay(25);
+            }
+
+            Assert.True(ttl > TimeSpan.FromSeconds(10), $"Expected the TTL to be extended past its 2s seed but was {ttl}.");
+            Assert.Equal("owner-a", await cache.Get(key));
+        }
+
+        [Fact]
+        public async Task ReclaimAndForget_OnAKeyOwnedBySomeoneElse_DoesNotOverwriteIt()
+        {
+            // The no-clobber guarantee: a stale owner's heartbeat must never steal the key back from a newer
+            // claimant, exactly like the existing takeover-safety behavior on ExpireAndForget.
+            var key = $"redis-reclaim-{Guid.NewGuid()}";
+            using var scope = CreateScope();
+            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+            await cache.Set(key, "owner-b", TimeSpan.FromSeconds(30));
+
+            cache.ReclaimAndForget(key, "owner-a", TimeSpan.FromSeconds(30));
+
+            await Task.Delay(500);
+            Assert.Equal("owner-b", await cache.Get(key));
+        }
+
+        private static async Task<bool> WaitUntilValueEqualsAsync(ICacheService cache, string key, string expected, int timeoutMs = 5000)
+        {
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            while (DateTime.UtcNow < deadline)
+            {
+                if (await cache.Get(key) == expected)
+                {
+                    return true;
+                }
+
+                await Task.Delay(25);
+            }
+
+            return await cache.Get(key) == expected;
+        }
+
         private async Task<TimeSpan?> ReadTtlAsync(string key)
         {
             await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(Containers.CacheConnectionString);

--- a/Game.Infrastructure/Cache/Redis/RedisService.cs
+++ b/Game.Infrastructure/Cache/Redis/RedisService.cs
@@ -103,6 +103,19 @@ namespace Game.Infrastructure.Cache.Redis
             await ObserveWrite(Redis.ScriptEvaluateAsync("if redis.call('get', KEYS[1]) == ARGV[1] then redis.call('del', KEYS[1]) end", [key], [deleteIfValue]), cancellationToken);
         }
 
+        public void ReclaimAndForget(string key, string ownerValue, TimeSpan expiry)
+        {
+            // "SET NX + expire" in one Lua script: claim the key as ownerValue only if it is currently unset
+            // (the resurrection path ExpireAndForget lacks — a bare expire no-ops on a missing key), otherwise
+            // just extend the TTL of whatever is already there, mirroring ExpireAndForget's existing
+            // don't-care-who-asked refresh so a stale caller still can't overwrite a newer claim's value.
+            // CommandFlags.FireAndForget keeps it off the hot inbound-message path the same way ExpireAndForget is.
+            Redis.ScriptEvaluate(
+                "if redis.call('exists', KEYS[1]) == 0 then redis.call('set', KEYS[1], ARGV[1], 'PX', ARGV[2]) else redis.call('pexpire', KEYS[1], ARGV[2]) end",
+                [key], [(RedisValue)ownerValue, (RedisValue)(long)expiry.TotalMilliseconds],
+                flags: CommandFlags.FireAndForget);
+        }
+
         public async Task<bool> CompareAndSet(string key, string? expectedValue, string newValue, TimeSpan expiry, CancellationToken cancellationToken = default)
         {
             // Compare-and-set in one Lua script (mirroring CompareAndDelete) so the read and the conditional


### PR DESCRIPTION
## Summary

`SocketManagerService.RefreshSocketPresence` refreshed the per-player presence claim with `ICacheService.ExpireAndForget`, a bare TTL bump that **no-ops on a missing key**. Once the presence key was gone while the socket was still live, no inbound heartbeat could ever recreate it:

- **TTL lapse** — any inbound stall past the 30s presence TTL (the socket itself survives up to the 60s inactivity close) expires the key; every later heartbeat no-ops forever.
- **Rollback of a superseding registration** — `RegisterSocket`'s `GetSet` displaces a live old socket's claim; if the new registration's later step fails, the rollback compare-and-deletes the *new* id, leaving the displaced-but-still-live old socket with no key at all.

With the key permanently gone, every server push (`ChallengeCompleted`, `ProficiencyXpGained`) silently dropped, `Login/ActiveSession` reported no active session, `SwitchPlayer`'s `HasActiveSocket` guard was defeated, and the next real handshake's `GetSet` returned null — leaving two concurrent live sockets for one player.

## Fix

Added `ICacheService.ReclaimAndForget(key, ownerValue, expiry)` — a fire-and-forget "SET NX + expire" in one Lua script:

- If the key is currently **unset**, claims it as `ownerValue` with a fresh TTL (the resurrection path `ExpireAndForget` lacked).
- If the key is **already set**, it just extends the TTL of whatever value is there — matching `ExpireAndForget`'s existing "don't-care-who-asked" refresh behavior, so a stale caller still can never overwrite a *different* (newer) claim's value.

`RefreshSocketPresence` now calls this with the socket's own id instead of blind-expiring, so a live socket can restore its own claim after either failure mode above, while a genuine takeover is still never clobbered.

## Test plan

- [x] New unit-level integration tests on `RedisServiceIntegrationTests` covering all three `ReclaimAndForget` branches (missing key claims, owned key refreshes TTL without changing value, someone-else's key is left untouched).
- [x] New integration test `SocketManagerServiceTests.RefreshSocketPresence_AfterItsKeyLapsesWhileStillLive_ResurrectsItsOwnClaim` — deletes the presence key under a live socket and asserts the next heartbeat restores it under the same socket id.
- [x] Existing `RefreshSocketPresence_FromConnectionThatWasTakenOver_ProlongsCurrentKeyWithoutResurrectingOldSocketId` still passes unchanged — a stale connection's heartbeat still can't resurrect its own id over a newer claim.
- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] Full backend suite: `dotnet test --no-build --no-restore` — 2743 tests passing.

Closes #1497


---
_Generated by [Claude Code](https://claude.ai/code/session_01WXHscu11ZMdbMdxjuHk192)_