### PR TITLE
Add up-front reference validation to AdminChallenges.SaveChallenges

### DIFF
--- a/Game.Application.Tests/DataAccess/AdminChallengesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminChallengesIntegrationTests.cs
@@ -212,6 +212,32 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SaveChallenges_NewRewardItemModRetired_ReturnsFailure()
+        {
+            int itemModId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var itemMod = await TestDataSeeder.CreateItemModAsync(context, name: "Old Prefix");
+                itemMod.RetiredAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                await context.SaveChangesAsync(CancellationToken);
+                itemModId = itemMod.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge> { ChangeType = EChangeType.Add, Item = NewChallenge(name: "Retired Reward Mod", rewardItemModId: itemModId) },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Reward item mod 'Old Prefix' is retired and cannot be newly assigned as a challenge reward.", result.ErrorMessage);
+        }
+
+        [Fact]
         public async Task SaveChallenges_EditKeepingRetiredRewardUnchanged_Succeeds()
         {
             // A reward resolves by id forever: an item retired after being authored as a challenge's reward
@@ -337,6 +363,65 @@ namespace Game.Application.Tests.DataAccess
 
             Assert.False(result.Succeeded);
             Assert.Equal("Target skill 99999 does not exist.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SaveChallenges_TargetingRetiredEnemy_Succeeds()
+        {
+            // Unlike a reward, a retired target is tolerated: it can't fault the runtime the way a dangling id
+            // would, and only risks an eventually-uncompletable challenge, which the content-graph lint already
+            // flags post-hoc as a warning rather than a save-time rejection.
+            int enemyId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var enemy = await TestDataSeeder.CreateEnemyAsync(context, name: "Ancient Dragon");
+                enemy.RetiredAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                await context.SaveChangesAsync(CancellationToken);
+                enemyId = enemy.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            var changes = new List<Change<Contracts.Challenge>>
+            {
+                new()
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = NewChallenge(name: "Dragon Slayer", challengeTypeId: EChallengeType.EnemiesKilled, targetEntityId: enemyId),
+                },
+            };
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+            Assert.True(admin.SaveChallenges(changes).Succeeded);
+        }
+
+        [Fact]
+        public async Task SaveChallenges_ValidDamageTypeTarget_PersistsTargetEntityId()
+        {
+            var changes = new List<Change<Contracts.Challenge>>
+            {
+                new()
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = NewChallenge(name: "Fire Hunter", challengeTypeId: EChallengeType.KillsByDamageType,
+                        targetEntityId: (int)EDamageTypeKey.Fire),
+                },
+            };
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+                Assert.True(admin.SaveChallenges(changes).Succeeded);
+                await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var created = await context.Challenges.AsNoTracking().SingleAsync(c => c.Name == "Fire Hunter", CancellationToken);
+                Assert.Equal((int)EDamageTypeKey.Fire, created.TargetEntityId);
+            }
         }
 
         [Fact]

--- a/Game.Application.Tests/DataAccess/AdminChallengesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminChallengesIntegrationTests.cs
@@ -140,15 +140,259 @@ namespace Game.Application.Tests.DataAccess
             Assert.Equal("The submitted challenge change set contains duplicate entries.", result.ErrorMessage);
         }
 
+        [Fact]
+        public void SaveChallenges_UndefinedChallengeType_ReturnsFailure()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var challenge = NewChallenge(name: "Bad Type");
+            challenge.ChallengeTypeId = (EChallengeType)0;
+
+            var result = admin.SaveChallenges([new Change<Contracts.Challenge> { ChangeType = EChangeType.Add, Item = challenge }]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("0 is not a valid challenge type.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void SaveChallenges_RewardItemDoesNotExist_ReturnsFailure()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge> { ChangeType = EChangeType.Add, Item = NewChallenge(name: "Bad Reward", rewardItemId: 99999) },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Reward item 99999 does not exist.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void SaveChallenges_RewardItemModDoesNotExist_ReturnsFailure()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge> { ChangeType = EChangeType.Add, Item = NewChallenge(name: "Bad Reward Mod", rewardItemModId: 99999) },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Reward item mod 99999 does not exist.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SaveChallenges_NewRewardItemRetired_ReturnsFailure()
+        {
+            int itemId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var item = await TestDataSeeder.CreateItemAsync(context, name: "Old Sword");
+                item.RetiredAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                await context.SaveChangesAsync(CancellationToken);
+                itemId = item.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge> { ChangeType = EChangeType.Add, Item = NewChallenge(name: "Retired Reward", rewardItemId: itemId) },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Reward item 'Old Sword' is retired and cannot be newly assigned as a challenge reward.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SaveChallenges_EditKeepingRetiredRewardUnchanged_Succeeds()
+        {
+            // A reward resolves by id forever: an item retired after being authored as a challenge's reward
+            // must not block later unrelated edits to that same challenge (docs/backend.md).
+            int itemId, challengeId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var item = await TestDataSeeder.CreateItemAsync(context, name: "Legacy Blade");
+                itemId = item.Id;
+                var challenge = await TestDataSeeder.CreateChallengeAsync(context, name: "Original", rewardItemId: itemId);
+                challengeId = challenge.Id;
+
+                item.RetiredAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                await context.SaveChangesAsync(CancellationToken);
+            }
+            await ReloadReferenceCachesAsync();
+
+            var changes = new List<Change<Contracts.Challenge>>
+            {
+                new()
+                {
+                    ChangeType = EChangeType.Edit,
+                    Item = NewChallenge(id: challengeId, name: "Renamed", rewardItemId: itemId),
+                },
+            };
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+            Assert.True(admin.SaveChallenges(changes).Succeeded);
+        }
+
+        [Fact]
+        public void SaveChallenges_KillsByDamageTypeWithoutTarget_ReturnsFailure()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge>
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = NewChallenge(name: "No Target", challengeTypeId: EChallengeType.KillsByDamageType),
+                },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("A 'Kills By Damage Type' challenge must target a damage-type key.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void SaveChallenges_KillsByDamageTypeWithUndefinedTarget_ReturnsFailure()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge>
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = NewChallenge(name: "Bad Damage Type", challengeTypeId: EChallengeType.KillsByDamageType, targetEntityId: 999),
+                },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("999 is not a valid damage-type key.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void SaveChallenges_EnemyTargetDoesNotExist_ReturnsFailure()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge>
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = NewChallenge(name: "Bad Enemy Target", challengeTypeId: EChallengeType.EnemiesKilled, targetEntityId: 99999),
+                },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Target enemy 99999 does not exist.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void SaveChallenges_ZoneTargetDoesNotExist_ReturnsFailure()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge>
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = NewChallenge(name: "Bad Zone Target", challengeTypeId: EChallengeType.ZonesCleared, targetEntityId: 99999),
+                },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Target zone 99999 does not exist.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void SaveChallenges_SkillTargetDoesNotExist_ReturnsFailure()
+        {
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge>
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = NewChallenge(name: "Bad Skill Target", challengeTypeId: EChallengeType.SkillsUsed, targetEntityId: 99999),
+                },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Target skill 99999 does not exist.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SaveChallenges_ValidTargetAndReward_PersistsIds()
+        {
+            int enemyId, itemId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var enemy = await TestDataSeeder.CreateEnemyAsync(context, name: "Slime");
+                var item = await TestDataSeeder.CreateItemAsync(context, name: "Slime Fang");
+                enemyId = enemy.Id;
+                itemId = item.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            var changes = new List<Change<Contracts.Challenge>>
+            {
+                new()
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = NewChallenge(name: "Slime Hunter", challengeTypeId: EChallengeType.EnemiesKilled,
+                        targetEntityId: enemyId, rewardItemId: itemId),
+                },
+            };
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+                Assert.True(admin.SaveChallenges(changes).Succeeded);
+                await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var created = await context.Challenges.AsNoTracking().SingleAsync(c => c.Name == "Slime Hunter", CancellationToken);
+                Assert.Equal(enemyId, created.TargetEntityId);
+                Assert.Equal(itemId, created.RewardItemId);
+            }
+        }
+
         private static Contracts.Challenge NewChallenge(
-            int id = 0, string name = "Test Challenge", decimal progressGoal = 10m) => new()
+            int id = 0, string name = "Test Challenge", decimal progressGoal = 10m,
+            EChallengeType challengeTypeId = EChallengeType.EnemiesKilled, int? targetEntityId = null,
+            int? rewardItemId = null, int? rewardItemModId = null) => new()
             {
                 Id = id,
                 Name = name,
                 Description = "",
                 DesignerNotes = "",
-                ChallengeTypeId = EChallengeType.EnemiesKilled,
+                ChallengeTypeId = challengeTypeId,
+                TargetEntityId = targetEntityId,
                 ProgressGoal = progressGoal,
+                RewardItemId = rewardItemId,
+                RewardItemModId = rewardItemModId,
             };
     }
 }

--- a/Game.DataAccess/Repositories/Admin/AdminChallenges.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminChallenges.cs
@@ -143,9 +143,11 @@ namespace Game.DataAccess.Repositories.Admin
         /// derived from the challenge type (mirrors the content-graph lint's <c>CheckChallenges</c>): an
         /// <see cref="EEntityType.Enemy"/>/<see cref="EEntityType.Zone"/>/
         /// <see cref="EEntityType.Skill"/> target must reference an existing record (retirement is tolerated —
-        /// only a dangling id would fault the runtime), and an <see cref="EEntityType.DamageType"/> target must
-        /// be a defined <see cref="EDamageTypeKey"/> (a fixed intrinsic enum, not a DB reference table).
-        /// <see cref="EEntityType.None"/> carries no dimension to validate. Deletes are skipped.
+        /// unlike a reward, a retired target can't fault the runtime; it only risks an eventually-uncompletable
+        /// challenge, which the content-graph lint already flags post-hoc as a warning), and an
+        /// <see cref="EEntityType.DamageType"/> target must be a defined <see cref="EDamageTypeKey"/> (a fixed
+        /// intrinsic enum, not a DB reference table). <see cref="EEntityType.None"/> carries no dimension to
+        /// validate. Deletes are skipped.
         /// </summary>
         private AdminSaveResult? FindTargetViolation(IReadOnlyList<Change<Contracts.Challenge>> changes)
         {
@@ -179,7 +181,7 @@ namespace Game.DataAccess.Repositories.Admin
                         return AdminSaveResult.Failure($"Target zone {targetId} does not exist.");
                     case EEntityType.Skill when _skills.LookupSkill(targetId) is null:
                         return AdminSaveResult.Failure($"Target skill {targetId} does not exist.");
-                    case EEntityType.DamageType when !Enum.IsDefined(typeof(EDamageTypeKey), targetId):
+                    case EEntityType.DamageType when !Enum.IsDefined((EDamageTypeKey)targetId):
                         return AdminSaveResult.Failure($"{targetId} is not a valid damage-type key.");
                 }
             }

--- a/Game.DataAccess/Repositories/Admin/AdminChallenges.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminChallenges.cs
@@ -1,6 +1,8 @@
 using Game.Abstractions.Contracts.Admin;
 using Game.Abstractions.DataAccess;
 using Game.Abstractions.DataAccess.Admin;
+using Game.Core;
+using Game.Core.Progress;
 using Contracts = Game.Abstractions.Contracts;
 using Entities = Game.Infrastructure.Entities;
 
@@ -12,13 +14,43 @@ namespace Game.DataAccess.Repositories.Admin
     /// The contract's <c>StatisticType</c>/<c>EntityType</c> are read-only projections of the type
     /// and are ignored here — the type id is the only persisted classification.
     /// </summary>
-    internal class AdminChallenges(IChallenges challenges, IEntityStore entityStore) : IAdminChallenges
+    internal class AdminChallenges(
+        IChallenges challenges,
+        IItemEntityCache items,
+        IItemModEntityCache itemMods,
+        IEnemyEntityCache enemies,
+        IZoneEntityCache zones,
+        ISkillEntityCache skills,
+        IEntityStore entityStore) : IAdminChallenges
     {
         private readonly IChallenges _challenges = challenges;
+        private readonly IItemEntityCache _items = items;
+        private readonly IItemModEntityCache _itemMods = itemMods;
+        private readonly IEnemyEntityCache _enemies = enemies;
+        private readonly IZoneEntityCache _zones = zones;
+        private readonly ISkillEntityCache _skills = skills;
         private readonly IEntityStore _entityStore = entityStore;
 
         public AdminSaveResult SaveChallenges(IReadOnlyList<Change<Contracts.Challenge>> changes)
         {
+            // Authoring guards (rejected up front before anything is staged), mirroring the sibling admin
+            // saves: ChallengeTypeId is an enum-seeded FK, and RewardItemId/RewardItemModId/TargetEntityId
+            // would otherwise 500 on a bad FK (or an out-of-range enum) at commit.
+            if (ReferenceFieldValidation.FindUndefinedEnum(changes, c => c.ChallengeTypeId, "challenge type") is { } typeRejection)
+            {
+                return typeRejection;
+            }
+
+            if (FindRewardViolation(changes) is { } rewardRejection)
+            {
+                return rewardRejection;
+            }
+
+            if (FindTargetViolation(changes) is { } targetRejection)
+            {
+                return targetRejection;
+            }
+
             return ChangeSetProcessor.Apply(changes,
                 add: item => _entityStore.Insert(new Entities.Challenge
                 {
@@ -50,6 +82,109 @@ namespace Game.DataAccess.Repositories.Admin
                 // relationship setters), not an EF 0-row update that throws. Challenges are zero-based-id
                 // reference data, so existence is the shared in-range index check.
                 editExists: item => _challenges.ValidateChallengeId(item.Id));
+        }
+
+        /// <summary>
+        /// Returns a rejection for the first added/edited challenge whose reward newly references a
+        /// nonexistent item/item-mod, or newly references a retired one, or null when every reward is valid.
+        /// Only a <em>changed</em> reward is checked — an edit's untouched reward already passed this guard
+        /// when it was set (a reward resolves by id forever, so leaving an old reward in place as its target
+        /// is later retired is expected, not an authoring mistake; see docs/backend.md). Deletes are skipped.
+        /// </summary>
+        private AdminSaveResult? FindRewardViolation(IReadOnlyList<Change<Contracts.Challenge>> changes)
+        {
+            foreach (var change in changes)
+            {
+                if (change.ChangeType == EChangeType.Delete)
+                {
+                    continue;
+                }
+
+                var item = change.Item;
+                var previous = change.ChangeType == EChangeType.Edit && _challenges.ValidateChallengeId(item.Id)
+                    ? _challenges.GetChallenge(item.Id)
+                    : null;
+
+                if (item.RewardItemId is int rewardItemId && rewardItemId != previous?.RewardItemId)
+                {
+                    var rewardItem = _items.LookupItem(rewardItemId);
+                    if (rewardItem is null)
+                    {
+                        return AdminSaveResult.Failure($"Reward item {rewardItemId} does not exist.");
+                    }
+
+                    if (rewardItem.RetiredAt is not null)
+                    {
+                        return AdminSaveResult.Failure($"Reward item '{rewardItem.Name}' is retired and cannot be newly assigned as a challenge reward.");
+                    }
+                }
+
+                if (item.RewardItemModId is int rewardItemModId && rewardItemModId != previous?.RewardItemModId)
+                {
+                    var rewardItemMod = _itemMods.LookupItemMod(rewardItemModId);
+                    if (rewardItemMod is null)
+                    {
+                        return AdminSaveResult.Failure($"Reward item mod {rewardItemModId} does not exist.");
+                    }
+
+                    if (rewardItemMod.RetiredAt is not null)
+                    {
+                        return AdminSaveResult.Failure($"Reward item mod '{rewardItemMod.Name}' is retired and cannot be newly assigned as a challenge reward.");
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a rejection for the first added/edited challenge whose <c>TargetEntityId</c> is invalid for
+        /// its type, or null when every target is valid. The dimension a target must resolve against is
+        /// derived from the challenge type (mirrors the content-graph lint's <c>CheckChallenges</c>): an
+        /// <see cref="EEntityType.Enemy"/>/<see cref="EEntityType.Zone"/>/
+        /// <see cref="EEntityType.Skill"/> target must reference an existing record (retirement is tolerated —
+        /// only a dangling id would fault the runtime), and an <see cref="EEntityType.DamageType"/> target must
+        /// be a defined <see cref="EDamageTypeKey"/> (a fixed intrinsic enum, not a DB reference table).
+        /// <see cref="EEntityType.None"/> carries no dimension to validate. Deletes are skipped.
+        /// </summary>
+        private AdminSaveResult? FindTargetViolation(IReadOnlyList<Change<Contracts.Challenge>> changes)
+        {
+            foreach (var change in changes)
+            {
+                if (change.ChangeType == EChangeType.Delete)
+                {
+                    continue;
+                }
+
+                var item = change.Item;
+
+                // A KillsByDamageType challenge with no target can never track progress — the statistic writes
+                // only per-damage-type-key rows, no global row (#1455).
+                if (item.ChallengeTypeId == EChallengeType.KillsByDamageType && item.TargetEntityId is null)
+                {
+                    return AdminSaveResult.Failure("A 'Kills By Damage Type' challenge must target a damage-type key.");
+                }
+
+                if (item.TargetEntityId is not int targetId)
+                {
+                    continue;
+                }
+
+                var entityType = new ChallengeType(item.ChallengeTypeId).StatisticType?.EntityType ?? EEntityType.None;
+                switch (entityType)
+                {
+                    case EEntityType.Enemy when _enemies.GetEnemy(targetId) is null:
+                        return AdminSaveResult.Failure($"Target enemy {targetId} does not exist.");
+                    case EEntityType.Zone when _zones.LookupZone(targetId) is null:
+                        return AdminSaveResult.Failure($"Target zone {targetId} does not exist.");
+                    case EEntityType.Skill when _skills.LookupSkill(targetId) is null:
+                        return AdminSaveResult.Failure($"Target skill {targetId} does not exist.");
+                    case EEntityType.DamageType when !Enum.IsDefined(typeof(EDamageTypeKey), targetId):
+                        return AdminSaveResult.Failure($"{targetId} is not a valid damage-type key.");
+                }
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary

`AdminChallenges.SaveChallenges` (`Game.DataAccess/Repositories/Admin/AdminChallenges.cs`) persisted challenges without validating their references first, so a bad `ChallengeTypeId`, `RewardItemId`/`RewardItemModId`, or `TargetEntityId` would 500 on an FK `PostgresException` at commit instead of surfacing a clean `AdminSaveResult.Failure` 400 — the guard every sibling admin save (`AdminItems`, `AdminItemMods`, `AdminZones`) already has.

This adds three up-front guards, mirroring the established sibling pattern:

1. **`ChallengeTypeId` enum guard** — `ReferenceFieldValidation.FindUndefinedEnum`, same as the item rarity/category/mod-type checks.
2. **Reward existence + retirement guard** — a reward that *newly* references an item/item-mod (an Add, or an Edit that actually changes the reward) must exist and be non-retired. An edit's **unchanged** reward is left alone: per `docs/backend.md`, a reward resolves by id forever, so a reward retired *after* being authored must not permanently block later, unrelated edits to that challenge (mirrors the content-graph lint, which treats a retired-but-still-referenced reward as a `Warning`, not an `Error`).
3. **Target-dimension guard** — `TargetEntityId` must resolve against the dimension the challenge type derives (enemy/zone/skill existence for those types, or a defined `EDamageTypeKey` for `KillsByDamageType`), and a `KillsByDamageType` challenge must carry a target at all (it can never track progress otherwise — same rule the content-graph lint already enforces post-hoc). `None`-dimension types (e.g. `LevelReached`) carry no target to validate.

### Note on the issue

The issue's suggested fix said the reward check should be "non-retired for new references." I read that as requiring the diff-against-previous-state behavior in guard (2) above (see `AdminPaths.SavePaths`'s `FindRetiredPathGatingLiveGateway` for existing precedent of this "only guard the transition" pattern) rather than a blanket retirement check on every save — a blanket check would make it impossible to ever edit a challenge again once its reward is retired, which contradicts the lenient design already encoded in the content-graph lint. Flagging this interpretation in case it's not what was intended.

Target existence checks intentionally do **not** reject a *retired* target (only a nonexistent one) — same reasoning, and consistent with how `AdminItems`/`AdminZones` validate their own record-set-specific references (existence only, no retirement check, except where retirement itself would strand live content).

## Test plan

- [x] `dotnet build Game.sln`
- [x] `dotnet test Game.sln` — full backend suite (2758 tests) passes, including new coverage in `AdminChallengesIntegrationTests`:
  - undefined `ChallengeTypeId`
  - missing / retired reward item and item-mod (as a new reference)
  - an edit that keeps an already-retired reward unchanged still succeeds
  - `KillsByDamageType` with no target / an undefined damage-type key
  - missing enemy/zone/skill target
  - a valid target + reward round-trip

Closes #1499


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vv7PSBR3akFD7LicPJk1Uk)_