### PR TITLE
Reconcile DefeatEnemy's authoritative post-victory state on the client

### DIFF
--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -3,6 +3,7 @@ import { Action, createHook, delay, isZoneUnlocked, navigableZones, nextZoneByOr
 import { staticData, statistics, playerChallenges } from '$stores';
 import { battleEngine, BattleStage, onBattleStageChanged, playerManager, type PlayerBattleState } from '../';
 import { logMessage } from '../log';
+import { refreshPlayer } from '../session';
 
 const newEnemyLoadedHook = createHook<[IEnemyInstance]>();
 const notifyNewEnemyLoaded = newEnemyLoadedHook.notify;
@@ -638,9 +639,16 @@ export class EnemyManager {
 			if (enemyName) {
 				logMessage(ELogType.EnemyDefeated, enemyName + ' was defeated!');
 			}
-			playerManager.grantExp(defeatResponse.data.rewards.expReward);
+			playerManager.applyVictoryRewards(defeatResponse.data.rewards);
 		} else {
 			logMessage(ELogType.Debug, 'There was an error defeating the enemy: ' + defeatResponse.error);
+			if (defeatResponse.error) {
+				// The transport settles a lost/timed-out response as an error even when the command may have
+				// actually succeeded server-side (see docs/frontend.md's socket request lifecycle) — resync the
+				// authoritative player state rather than leaving exp/level silently diverged for the rest of
+				// the session.
+				await refreshPlayer();
+			}
 		}
 		// Guard `data` for a possible error response (absent `data`), now that this is the shared
 		// victory path for both the idle and boss loops.

--- a/UI/src/lib/engine/player/player-manager.ts
+++ b/UI/src/lib/engine/player/player-manager.ts
@@ -207,6 +207,11 @@ export class PlayerManager implements IPlayerData {
 	 * server-side — always win over the local recompute.
 	 */
 	public applyVictoryRewards(rewards: IDefeatRewards) {
+		// grantExp is invoked only for its log-message side effect (the "Earned X exp." / level-up lines);
+		// its own level/exp recompute is discarded below. `expReward` is the server's pre-clamp raw reward,
+		// so in the (effectively unreachable in normal play) case of a single grant exceeding
+		// MaxExpPerGrant, this can over-level and log phantom level-up lines before the reconcile below
+		// corrects level/exp back down to the server's actual post-clamp state.
 		this.grantExp(rewards.expReward);
 		this.level = rewards.newLevel;
 		this.exp = rewards.newExp;

--- a/UI/src/lib/engine/player/player-manager.ts
+++ b/UI/src/lib/engine/player/player-manager.ts
@@ -2,6 +2,7 @@ import {
 	ELogType,
 	IAttributeDistribution,
 	IBattlerAttribute,
+	IDefeatRewards,
 	IInventoryData,
 	ILogPreference,
 	IPlayerData,
@@ -196,6 +197,21 @@ export class PlayerManager implements IPlayerData {
 		this.statPointsGained += STAT_POINTS_PER_LEVEL;
 		logMessage(ELogType.LevelUp, 'Congratulations, you leveled up!');
 		logMessage(ELogType.LevelUp, `You are now level ${this.level}.`);
+	}
+
+	/**
+	 * Applies a battle victory's exp grant, then reconciles onto the server's authoritative post-grant
+	 * state. `grantExp` re-derives level/exp/statPointsGained locally for its log messages, but the
+	 * backend additionally clamps a single grant to `MaxExpPerGrant` (an anti-cheat backstop the frontend
+	 * deliberately doesn't mirror) and is the source of truth regardless, so `rewards`' fields — computed
+	 * server-side — always win over the local recompute.
+	 */
+	public applyVictoryRewards(rewards: IDefeatRewards) {
+		this.grantExp(rewards.expReward);
+		this.level = rewards.newLevel;
+		this.exp = rewards.newExp;
+		this.statPointsGained = rewards.statPointsGained;
+		this.statPointsUsed = rewards.statPointsUsed;
 	}
 }
 

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -19,7 +19,8 @@ const h = vi.hoisted(() => ({
 		playerBattleStateMatches: vi.fn(() => true)
 	},
 	BattleStage: { Idle: 0, Active: 1, Victorious: 2, Defeated: 3, Loading: 4, Paused: 5, Drawn: 6 },
-	playerManager: { currentZone: 3, grantExp: vi.fn() },
+	playerManager: { currentZone: 3, applyVictoryRewards: vi.fn() },
+	refreshPlayer: vi.fn(() => Promise.resolve()),
 	staticData: {
 		enemies: [{ id: 0, name: 'Catacomb Lich', isBoss: true }],
 		zones: undefined as IZone[] | undefined
@@ -41,6 +42,7 @@ vi.mock('$lib/engine', () => ({
 	}),
 	playerManager: h.playerManager
 }));
+vi.mock('$lib/engine/session', () => ({ refreshPlayer: h.refreshPlayer }));
 vi.mock('$stores', () => ({
 	staticData: h.staticData,
 	statistics: h.statistics,
@@ -65,9 +67,10 @@ const resp = <T extends 'ChallengeBoss' | 'DefeatEnemy' | 'BattleLost' | 'NewEne
 
 const challengeResponse = resp('ChallengeBoss', { enemyInstance: bossInstance });
 const challengeError = { id: '1', name: 'ChallengeBoss', error: 'no boss' } as IApiSocketResponse<'ChallengeBoss'>;
+const defeatRewards = { expReward: 50, newLevel: 1, newExp: 50, statPointsGained: 0, statPointsUsed: 0 };
 const defeatResponse = resp('DefeatEnemy', {
 	cooldown: 0,
-	rewards: { expReward: 50, newLevel: 1, newExp: 50, statPointsGained: 0, statPointsUsed: 0 }
+	rewards: defeatRewards
 });
 const lostResponse = resp('BattleLost', { cooldown: 5000 });
 const newEnemyResponse = resp('NewEnemy', { enemyInstance: normalInstance });
@@ -75,7 +78,7 @@ const newEnemyResponse = resp('NewEnemy', { enemyInstance: normalInstance });
 const bundledDefeatResponse = (cooldown: number) =>
 	resp('DefeatEnemy', {
 		cooldown,
-		rewards: { expReward: 50, newLevel: 1, newExp: 50, statPointsGained: 0, statPointsUsed: 0 },
+		rewards: defeatRewards,
 		nextEnemy: preparedInstance,
 		nextZoneId: 3
 	});
@@ -111,7 +114,8 @@ describe('EnemyManager boss mode', () => {
 		h.battleEngine.capturePlayerBattleState.mockClear();
 		h.battleEngine.playerBattleStateMatches.mockReset();
 		h.battleEngine.playerBattleStateMatches.mockReturnValue(true);
-		h.playerManager.grantExp.mockClear();
+		h.playerManager.applyVictoryRewards.mockClear();
+		h.refreshPlayer.mockClear();
 		h.statistics.markZoneCleared.mockClear();
 		// Default: no zones authored ⇒ no "next zone" to unlock; the unlock tests opt in.
 		h.staticData.zones = undefined;
@@ -271,7 +275,7 @@ describe('EnemyManager boss mode', () => {
 		await fireStage(h.BattleStage.Victorious);
 
 		expect(send).toHaveBeenCalledWith('DefeatEnemy', expect.objectContaining({ clientTotalMs: expect.any(Number) }));
-		expect(h.playerManager.grantExp).toHaveBeenCalledWith(50);
+		expect(h.playerManager.applyVictoryRewards).toHaveBeenCalledWith(defeatRewards);
 		expect(h.statistics.markZoneCleared).toHaveBeenCalledWith(3);
 		// Auto-fight off ⇒ hand back to the idle farm loop.
 		expect(manager.mode).toBe('idle');
@@ -842,7 +846,7 @@ describe('EnemyManager boss mode', () => {
 		await fireStage(h.BattleStage.Victorious);
 
 		expect(send).toHaveBeenCalledWith('DefeatEnemy', expect.objectContaining({ clientTotalMs: expect.any(Number) }));
-		expect(h.playerManager.grantExp).toHaveBeenCalledWith(50);
+		expect(h.playerManager.applyVictoryRewards).toHaveBeenCalledWith(defeatRewards);
 		expect(h.statistics.markZoneCleared).not.toHaveBeenCalled();
 		expect(send).toHaveBeenCalledWith('NewEnemy', expect.objectContaining({ newZoneId: 3 }));
 		expect(manager.mode).toBe('idle');
@@ -872,6 +876,8 @@ describe('EnemyManager boss mode', () => {
 
 		// The "X was defeated!" line is logged with the resolved enemy name once rewards are granted.
 		expect(logMessage).toHaveBeenCalledWith(ELogType.EnemyDefeated, 'Catacomb Lich was defeated!');
+		// A successful claim needs no resync — the response itself carried the authoritative state.
+		expect(h.refreshPlayer).not.toHaveBeenCalled();
 	});
 
 	it('does not log the defeat when DefeatEnemy fails (no premature "defeated" line)', async () => {
@@ -888,7 +894,11 @@ describe('EnemyManager boss mode', () => {
 
 		expect(logMessage).not.toHaveBeenCalledWith(ELogType.EnemyDefeated, expect.anything());
 		expect(logMessage).toHaveBeenCalledWith(ELogType.Debug, 'There was an error defeating the enemy: boom');
-		expect(h.playerManager.grantExp).not.toHaveBeenCalled();
+		expect(h.playerManager.applyVictoryRewards).not.toHaveBeenCalled();
+		// The transport can settle a lost/timed-out DefeatEnemy as an error even when it actually succeeded
+		// server-side, so an errored claim resyncs the authoritative player state rather than leaving the
+		// client's exp/level silently diverged.
+		expect(h.refreshPlayer).toHaveBeenCalledOnce();
 	});
 
 	it('survives a missing/retired enemy id on victory (still grants rewards, omits the name log)', async () => {
@@ -900,7 +910,7 @@ describe('EnemyManager boss mode', () => {
 
 		await expect(fireStage(h.BattleStage.Victorious)).resolves.not.toThrow();
 
-		expect(h.playerManager.grantExp).toHaveBeenCalledWith(50);
+		expect(h.playerManager.applyVictoryRewards).toHaveBeenCalledWith(defeatRewards);
 		expect(logMessage).not.toHaveBeenCalledWith(ELogType.EnemyDefeated, expect.anything());
 	});
 

--- a/UI/src/tests/lib/engine/player/player-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/player-manager.test.ts
@@ -172,6 +172,39 @@ describe('PlayerManager', () => {
 		});
 	});
 
+	describe('applyVictoryRewards', () => {
+		it('grants exp and adopts the server-authoritative post-grant fields', () => {
+			manager.initialize(makePlayerData({ level: 1, exp: 0, statPointsGained: 0, statPointsUsed: 0 }));
+
+			manager.applyVictoryRewards({ expReward: 100, newLevel: 2, newExp: 0, statPointsGained: 2, statPointsUsed: 0 });
+
+			expect(manager.level).toBe(2);
+			expect(manager.exp).toBe(0);
+			expect(manager.statPointsGained).toBe(2);
+			expect(logMessage).toHaveBeenCalledWith(ELogType.Exp, 'Earned 100 exp.');
+			expect(logMessage).toHaveBeenCalledWith(ELogType.LevelUp, 'Congratulations, you leveled up!');
+		});
+
+		it('reconciles onto the server state even when the local recompute would drift (e.g. a clamped grant)', () => {
+			// The backend clamps a single grant to MaxExpPerGrant (an anti-cheat backstop grantExp
+			// deliberately doesn't mirror); the server's returned fields must win regardless.
+			manager.initialize(makePlayerData({ level: 1, exp: 0, statPointsGained: 0, statPointsUsed: 5 }));
+
+			manager.applyVictoryRewards({
+				expReward: 1_000_000,
+				newLevel: 3,
+				newExp: 40,
+				statPointsGained: 4,
+				statPointsUsed: 5
+			});
+
+			expect(manager.level).toBe(3);
+			expect(manager.exp).toBe(40);
+			expect(manager.statPointsGained).toBe(4);
+			expect(manager.statPointsUsed).toBe(5);
+		});
+	});
+
 	describe('levelUp', () => {
 		it('increments level and grants the per-level free pool stat points', () => {
 			manager.initialize(makePlayerData({ level: 3, exp: 300, statPointsGained: 12 }));


### PR DESCRIPTION
## Summary

The backend returns post-grant authoritative state (`NewLevel`, `NewExp`, `StatPointsGained`, `StatPointsUsed`) on every victory (`BattleService.EndBattleVictory`, surfaced on the `DefeatEnemy` response), but `claimVictory` (`UI/src/lib/engine/battle/enemy-manager.ts`) only read `rewards.expReward` and re-derived level-ups locally via `playerManager.grantExp` — the server's clamp to `MaxExpPerGrant` and any other server-side authority were silently discarded. On a response error it only logged, with no reconciliation at all.

### Failure scenario this fixes

The transport settles a lost/timed-out `DefeatEnemy` as an `error` response even when the command actually succeeded server-side (per the documented socket request lifecycle — commands aren't blind-resent since they aren't idempotent). Previously, the client would skip `grantExp` entirely on that error and never resync, leaving exp/level diverged from the server for the rest of the session — causing battle-duration divergence and misclassified edge battles (a fight the server replay would score as a win could be scored a loss client-side).

## Changes

- `PlayerManager.applyVictoryRewards(rewards)` — grants exp locally via the existing `grantExp` (preserving the "Earned X exp." / level-up log messages), then reconciles `level`/`exp`/`statPointsGained`/`statPointsUsed` onto the server's authoritative response fields, since the backend's `MaxExpPerGrant` clamp is a case `grantExp` deliberately doesn't mirror.
- `EnemyManager.claimVictory` now calls `applyVictoryRewards` instead of `grantExp` directly, and calls `refreshPlayer()` (the same Login/Status resync the welcome-back gate already uses) when the claim settles with an `error` — so a lost/timed-out response no longer leaves the client silently diverged.

## A note on the issue

Existing `grantExp`/`levelUp` unit and progression-parity tests are untouched and remain meaningful — `applyVictoryRewards` calls through `grantExp` for its log-message UX before reconciling, so the parity coverage of the exp/level formula itself still guards against drift in the common (non-clamped) case; the reconciliation step is the backstop for the clamp/lost-response cases the issue describes.

## Test plan

- [x] `npx vitest --run` — full frontend suite (3190 tests) passes, including new `applyVictoryRewards` coverage in `player-manager.test.ts` and updated `enemy-manager-boss.test.ts` coverage asserting `refreshPlayer()` fires only on an errored claim.
- [x] `npx eslint .` and `npx svelte-check` — clean.

Closes #1501

---
_Generated by Claude Code_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qa6FmUrcaqwU7NnfHwwsGK)_