### PR TITLE
Move Trace logging and the dev CORS origin out of base appsettings.json

### DIFF
--- a/Game.Api/appsettings.Development.json
+++ b/Game.Api/appsettings.Development.json
@@ -1,4 +1,9 @@
 {
+  "Logging": {
+    "LogLevel": {
+      "Default": "Trace"
+    }
+  },
   "Jwt": {
     "SigningKey": "dev-only-jwt-signing-key-change-me-at-least-32-bytes-long",
     "Issuer": "game-server-api",

--- a/Game.Api/appsettings.json
+++ b/Game.Api/appsettings.json
@@ -1,13 +1,10 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Trace",
+      "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
       "Microsoft.EntityFrameworkCore": "Information"
     }
-  },
-  "Cors": {
-    "AllowedOrigins": [ "http://localhost:5174" ]
   },
   "RateLimiting": {
     "Auth": {

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -69,6 +69,9 @@ services:
       Jwt__SigningKey: local-dev-jwt-signing-key-change-me-at-least-32-bytes-long
       Jwt__Issuer: game-server-api
       Jwt__Audience: game-server-api
+      # Origin of the SvelteKit dev server that fronts this stack (UI/vite.config.ts). Required:
+      # startup validation fails fast when no CORS origin is configured.
+      Cors__AllowedOrigins__0: "http://localhost:5174"
       # 1 = Postgres, 0 = Redis (see Game.Abstractions/Infrastructure/Enums.cs).
       DataAccessOptions__DatabaseSystem: "1"
       DataAccessOptions__CacheSystem: "0"


### PR DESCRIPTION
## Summary

`Game.Api/appsettings.json` (the environment-agnostic base config) shipped two Development-only defaults:

- **`Logging.LogLevel.Default: "Trace"`** — any non-Development deployment without an explicit override logged every socket frame's full payload plus per-command traces on the hottest path. Base default is now `Information`; `appsettings.Development.json` gains the `Trace` default so Development behavior is completely unchanged.
- **`Cors.AllowedOrigins: ["http://localhost:5174"]`** — duplicated in `appsettings.Development.json`, and its presence in the base file silently satisfied the `ValidateOnStart` non-empty check in `Startup.cs`, defeating the documented fail-fast for unconfigured deployments (docs/backend.md, "CORS allowed origins") while leaving a credentialed localhost origin allowed everywhere. Removed from the base file; the Development copy stays.

Verified no other consumer relied on the base values: the docker-compose e2e stack supplies `Cors__AllowedOrigins__0` via env var, integration tests supply `Cors:AllowedOrigins:0` in `GameServerFactory`, and every launchSettings profile runs as Development.

## Test notes

- `dotnet build Game.Api` — clean.
- `dotnet test Game.Api.Tests -- --filter-class Game.Api.Tests.Unit.CorsOptionsTests` — 5/5 passed. These already cover the fail-fast validation path with in-memory config, so no test changes were needed for this pure config move.
- Simulated the config layering (base + Development) to confirm Development still resolves `Default=Trace` with the base category overrides intact.

Closes #1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)