### PR TITLE
Share the signature-passive-last step between the battle engine and composePlayerBattleAttributes

### DIFF
--- a/UI/src/lib/battle/player-battle-composition.ts
+++ b/UI/src/lib/battle/player-battle-composition.ts
@@ -25,12 +25,26 @@ export function playerBattleModifiers(
 	return [...lockedBaseModifiers, ...proficiencyModifiers];
 }
 
+/** The composition's LAST step — adds the class signature passive to `attrs`, resolved against that same
+ *  just-assembled set so an attribute-scaled passive reads the final value of its scaling attribute
+ *  (snapshot state, like a skill effect reads its caster). Callers must apply it after every other
+ *  modifier — float addition is not associative, so the anti-cheat replay depends on this apply order
+ *  matching the backend `BattleSnapshot.ToBattler`. `resolveSignaturePassive` is
+ *  `PlayerManager.battleSignaturePassiveModifier`, threaded through so the module stays pure. The
+ *  attribute-breakdown screen mirrors this step inline (it needs the labeled modifier itself, resolved
+ *  over its `computeAttributes` fold); keep that copy in lockstep with this one. */
+export function applySignaturePassive(
+	attrs: BattleAttributes,
+	resolveSignaturePassive: (resolveScalingValue: (attribute: EAttribute) => number) => AttributeModifier
+): void {
+	attrs.addModifier(resolveSignaturePassive((attribute) => attrs.getValue(attribute)));
+}
+
 /** Builds the player's full live {@link BattleAttributes}: allocation + equipped gear, the class locked
- *  base and proficiency bonuses, and the class signature passive composed last against the resolved set.
- *  Any surface displaying live battle numbers must read off this rather than a partial hand-rolled copy,
- *  so a composition change can't silently desync one surface from what the player actually fights with.
- *  `resolveSignaturePassive` is `PlayerManager.battleSignaturePassiveModifier`, threaded through so this
- *  stays pure — it is invoked with a resolver over the just-assembled set, as the live battler does. */
+ *  base and proficiency bonuses, and the class signature passive composed last against the resolved set
+ *  ({@link applySignaturePassive}). Any surface displaying live battle numbers must read off this rather
+ *  than a partial hand-rolled copy, so a composition change can't silently desync one surface from what
+ *  the player actually fights with. */
 export function composePlayerBattleAttributes(
 	attributes: readonly IBattlerAttribute[],
 	equipmentStats: readonly IBattlerAttribute[],
@@ -44,6 +58,6 @@ export function composePlayerBattleAttributes(
 		true,
 		playerBattleModifiers(lockedBaseModifiers, proficiencyModifiers)
 	);
-	attrs.addModifier(resolveSignaturePassive((attribute) => attrs.getValue(attribute)));
+	applySignaturePassive(attrs, resolveSignaturePassive);
 	return attrs;
 }

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -2,6 +2,7 @@ import {
 	Battler,
 	battleStep,
 	resistanceTotal,
+	applySignaturePassive,
 	playerBattleModifiers,
 	type BattleStepLog,
 	type AttributeModifier
@@ -247,15 +248,11 @@ export class BattleEngine {
 			inventoryManager.equippedWeaponType,
 			inventoryManager.counterSkillId
 		);
-		// Compose the class signature passive LAST — after the locked base, proficiency bonuses, and the static
-		// engine modifiers the rebuild just assembled — so an attribute-scaled passive reads the fully-resolved
-		// value of its scaling attribute (snapshot state, like a skill effect reads its caster) and lands in the
-		// same per-attribute apply order the backend's BattleSnapshot.ToBattler appends it in; float addition is
-		// not associative, so the anti-cheat replay depends on that order matching. The data-less re-arm above
-		// keeps this modifier (setData isn't re-run), so it is composed only here, on a full rebuild.
-		this.player.attributes.addModifier(
-			playerManager.battleSignaturePassiveModifier((attribute) => this.player.attributes.getValue(attribute))
-		);
+		// The signature passive lands LAST — after the locked base, proficiency bonuses, and static engine
+		// modifiers the rebuild just assembled — via the shared applySignaturePassive step, the same ordering
+		// composePlayerBattleAttributes canonicalises. The data-less re-arm above keeps this modifier (setData
+		// isn't re-run), so it is applied only here, on a full rebuild.
+		applySignaturePassive(this.player.attributes, (resolve) => playerManager.battleSignaturePassiveModifier(resolve));
 		this.lastEquipmentStats = equipmentStats;
 		this.lastPlayerAttributes = attributes;
 		this.lastSelectedSkills = selectedSkills;

--- a/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
+++ b/UI/src/routes/game/screens/attribute-breakdown/attribute-breakdown-view.svelte.ts
@@ -316,9 +316,10 @@ export function buildPlayerModifiers(): LabeledModifier[] {
 	}
 
 	// The class signature passive is composed LAST (after the locked base, proficiency, and statics),
-	// resolved against the already-assembled value of its scaling attribute — the same two-pass the
-	// battler does (build the set, then add the passive reading the resolved scaling value, like a skill
-	// effect reads its caster). The resolve pass is lazy so a flat (non-scaled) passive skips it.
+	// resolved against the already-assembled set — an inline mirror of `applySignaturePassive`
+	// ($lib/battle/player-battle-composition, the canonical ordering the battler and skills screen share),
+	// kept inline because this surface needs the labeled modifier itself, resolved over the
+	// `computeAttributes` fold (lazily, so a flat non-scaled passive skips the resolve pass).
 	let resolved: Map<EAttribute, ComputedAttribute<LabeledModifier>> | undefined;
 	const passive = playerManager.battleSignaturePassiveModifier((attribute) => {
 		resolved ??= computeAttributes(mods);

--- a/UI/src/tests/lib/battle/player-battle-composition.test.ts
+++ b/UI/src/tests/lib/battle/player-battle-composition.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, vi } from 'vitest';
 import { EAttribute, EModifierType, type IAttribute } from '$lib/api';
 import { BattleAttributes } from '$lib/battle/battle-attributes';
 import { EAttributeModifierSource, type AttributeModifier } from '$lib/battle/attribute-modifier';
-import { composePlayerBattleAttributes, playerBattleModifiers } from '$lib/battle/player-battle-composition';
+import {
+	applySignaturePassive,
+	composePlayerBattleAttributes,
+	playerBattleModifiers
+} from '$lib/battle/player-battle-composition';
 
 // BattleAttributes resolves attribute names through the static-data store; an empty mock is enough here
 // since these assertions read raw values, not names.
@@ -37,6 +41,26 @@ describe('playerBattleModifiers', () => {
 
 	it('returns an empty array when both inputs are empty', () => {
 		expect(playerBattleModifiers([], [])).toEqual([]);
+	});
+});
+
+describe('applySignaturePassive', () => {
+	it('adds a flat passive to the supplied set', () => {
+		const attrs = new BattleAttributes();
+		attrs.setData(makeAttrs([EAttribute.Strength, 10]), true, []);
+		applySignaturePassive(attrs, () => additive(EAttribute.Strength, 4, EAttributeModifierSource.Class));
+		expect(attrs.getValue(EAttribute.Strength)).toBe(14);
+	});
+
+	it('resolves an attribute-scaled passive against the set it is applied to', () => {
+		const attrs = new BattleAttributes();
+		attrs.setData(makeAttrs([EAttribute.Endurance, 6]), true, [
+			additive(EAttribute.Endurance, 2, EAttributeModifierSource.AttributeDistribution)
+		]);
+		applySignaturePassive(attrs, (resolveScalingValue) =>
+			additive(EAttribute.Luck, resolveScalingValue(EAttribute.Endurance) * 2, EAttributeModifierSource.Class)
+		);
+		expect(attrs.getValue(EAttribute.Luck)).toBe(16); // 8 (resolved Endurance) × 2
 	});
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #1545. The signature-passive-added-last step existed as three copies: inside `composePlayerBattleAttributes`, inline in `BattleEngine.resetPlayer`, and inline in the attribute-breakdown modifier builder.

- Extracted `applySignaturePassive` into `$lib/battle/player-battle-composition` — the single "resolve the passive against the just-assembled set, add it last" step. `composePlayerBattleAttributes` and the engine's full-rebuild path (which can't consume the whole composer because of the data-less re-arm optimization, #811) now both call it, so the ordering is structural for those two surfaces rather than comment-guarded.
- The attribute-breakdown copy stays inline by design — it needs the labeled modifier itself, resolved lazily over its `computeAttributes` fold — and its comment now points at `applySignaturePassive` as the canonical ordering to keep in lockstep.
- No behavior change; the parity suites pass unchanged.

## Testing

- `vitest run` on `player-battle-composition.test.ts` (incl. two new `applySignaturePassive` cases: flat passive, and attribute-scaled passive resolved against the supplied set), `class-signature-passive-parity.test.ts`, `battle-engine-parity.test.ts`, `battle-engine.test.ts`, `battle-simulation-parity.test.ts`, `attribute-breakdown-view.test.ts`, `skills-view.test.ts` — all passing.
- `npm run check` (svelte-check): 0 errors / 0 warnings; eslint + prettier clean on touched files.
- Backend untouched (the backend composition lives in `BattleSnapshot.ToBattler` and is unchanged), so no mirrored backend scenario is required — the FE/BE parity scenarios themselves are unmodified.

Closes #1549

🤖 Generated with [Claude Code](https://claude.com/claude-code)