### PR TITLE
Frontend dead-code sweep: retired by-entity statistics leftovers, unused Workbench skillOptions, hooks nextNotification

### DIFF
--- a/UI/src/lib/common/hooks.ts
+++ b/UI/src/lib/common/hooks.ts
@@ -10,16 +10,9 @@ interface HookTracker<T extends unknown[]> {
 export const createHook = <T extends unknown[] = []>() => {
 	let dispatching = false;
 	let hasPendingRemovals = false;
-	let promiseResolvers: Action<[T]>[] = [];
 	const trackers: HookTracker<T>[] = [];
 
 	const notify = (...data: T) => {
-		for (const resolve of promiseResolvers) {
-			resolve(data);
-		}
-
-		promiseResolvers = [];
-
 		// Iterate by index without allocating a snapshot (this is one of the hottest
 		// game-loop paths). Removals and additions during dispatch are both deferred so
 		// the index walk isn't disturbed: an unhook only tombstones (`removed`) instead
@@ -83,15 +76,8 @@ export const createHook = <T extends unknown[] = []>() => {
 		return unhook;
 	};
 
-	const nextNotification = () => {
-		const { promise, resolve } = Promise.withResolvers<T>();
-		promiseResolvers.push(resolve);
-		return promise;
-	};
-
 	return {
 		notify,
-		onNotified,
-		nextNotification
+		onNotified
 	};
 };

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -187,8 +187,6 @@ class WorkbenchReference {
 	};
 
 	// ── Progression (paths & proficiencies) ──
-	/** Any active skill (plus the current value if retired) — the contribution skill picker. */
-	skillOptions = (keep?: number): SelectOption[] => this.retireableOptions(staticData.skills ?? [], keep);
 	/**
 	 * Player-acquirable skills, with a "None" sentinel (-1). Backs the milestone-reward picker, which the
 	 * backend restricts to `ESkillAcquisition.Player` skills. The current value stays visible even if it

--- a/UI/src/routes/game/screens/challenges/Challenges.svelte
+++ b/UI/src/routes/game/screens/challenges/Challenges.svelte
@@ -1,4 +1,4 @@
-<div class="challenges-frame" data-testid="challenges-screen" bind:this={frame}>
+<div class="challenges-frame" data-testid="challenges-screen">
 	<!-- Header -->
 	<div class="chal-header">
 		<div>
@@ -73,7 +73,6 @@ import TypeRail from './TypeRail.svelte';
 
 const view = new ChallengesView();
 
-let frame: HTMLDivElement;
 let tooltip = $state<TooltipComponent>();
 let hoveredReward = $state<ResolvedReward>();
 

--- a/UI/src/routes/game/screens/stats/UnderlineTabs.svelte
+++ b/UI/src/routes/game/screens/stats/UnderlineTabs.svelte
@@ -1,6 +1,5 @@
-<!-- The shared underline tab bar used by both the category tabs ("by statistic")
-     and the entity-kind tabs ("by entity"), so the two views read as one system.
-     Each tab carries its own accent colour and an optional count pill / glyph. -->
+<!-- The Statistics screen's underline tab bar (the category tabs). Each tab
+     carries its own accent colour and an optional count pill. -->
 <div class="tabs" role="tablist">
 	{#each tabs as tab (tab.key)}
 		{@const on = tab.key === active}
@@ -16,9 +15,6 @@
 			style:--tab-color={tab.color}
 			onclick={() => onChange(tab.key)}
 		>
-			{#if tab.glyphKind}
-				<StatGlyph kind={tab.glyphKind} size={13} color={on ? tab.color : 'var(--text-tertiary)'} />
-			{/if}
 			<span class="label">{tab.label}</span>
 			{#if tab.count != null}
 				<span class="count">{tab.count}</span>
@@ -31,17 +27,12 @@
 </div>
 
 <script lang="ts">
-import StatGlyph from './StatGlyph.svelte';
-import type { StatEntityKind } from './statistics-view.svelte';
-
 export interface Tab {
 	key: string;
 	label: string;
 	count?: number;
 	/** Accent colour (a `var(--…)` token). */
 	color: string;
-	/** Optional entity glyph rendered before the label. */
-	glyphKind?: StatEntityKind;
 }
 
 interface Props {

--- a/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
+++ b/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
@@ -36,10 +36,6 @@ export type StatCategory = 'combat' | 'survival' | 'exploration' | 'time';
 export interface StatEntity {
 	id: number;
 	name: string;
-	/** Boss flag (enemies only). */
-	boss?: boolean;
-	/** Zone order number (zones only). */
-	zoneNum?: number;
 }
 
 export interface StatType {
@@ -146,8 +142,8 @@ export function buildStatTypes(statisticTypes: IStatisticType[]): StatType[] {
  *  damage-type keys (a fixed enum, not reference data) using the shared player-facing labels. */
 export function buildStatEntities(): Record<StatBreakdownKind, StatEntity[]> {
 	return {
-		enemy: (staticData.enemies ?? []).filter(Boolean).map((e) => ({ id: e.id, name: e.name, boss: e.isBoss })),
-		zone: (staticData.zones ?? []).filter(Boolean).map((z) => ({ id: z.id, name: z.name, zoneNum: z.order })),
+		enemy: (staticData.enemies ?? []).filter(Boolean).map((e) => ({ id: e.id, name: e.name })),
+		zone: (staticData.zones ?? []).filter(Boolean).map((z) => ({ id: z.id, name: z.name })),
 		skill: (staticData.skills ?? []).filter(Boolean).map((s) => ({ id: s.id, name: s.name })),
 		damageType: DAMAGE_TYPE_KEYS.map((key) => ({ id: key, name: damageTypeKeyName(key) }))
 	};
@@ -232,10 +228,6 @@ export class StatisticsData {
 		return cat === 'all' ? this.statTypes : this.statTypes.filter((s) => s.cat === cat);
 	}
 
-	entityList(kind: StatBreakdownKind): StatEntity[] {
-		return this.entities[kind] ?? [];
-	}
-
 	entity(kind: StatBreakdownKind, id: number): StatEntity | undefined {
 		return this.entityById[kind]?.get(id);
 	}
@@ -243,18 +235,6 @@ export class StatisticsData {
 	/** The memoised display summary for a statistic (rows + bar max + headline). */
 	summaryFor(type: EStatisticType): StatSummary {
 		return this.summaries.get(type) ?? EMPTY_SUMMARY;
-	}
-
-	/** Per-entity rows for a statistic, resolved and sorted best-first (ascending
-	 *  for "min" aggregates, where lower is better). Empty for `none` stats. */
-	rowsForStat(type: EStatisticType): StatRow[] {
-		return this.summaryFor(type).rows;
-	}
-
-	/** The grand-total headline for a statistic: the backend's null-entity row if
-	 *  present, otherwise the aggregate of its per-entity rows. */
-	statHeadline(type: EStatisticType): number {
-		return this.summaryFor(type).headline;
 	}
 
 	/** Every statistic that references the given entity, with the entity's value

--- a/UI/src/tests/common/hooks.test.ts
+++ b/UI/src/tests/common/hooks.test.ts
@@ -105,38 +105,6 @@ describe('createHook', () => {
 		expect(onDestroy).toHaveBeenCalledWith(expect.any(Function));
 	});
 
-	it('nextNotification resolves on next notify', async () => {
-		const hook = createHook<[string]>();
-
-		const promise = hook.nextNotification();
-		hook.notify('result');
-
-		const value = await promise;
-		expect(value).toEqual(['result']);
-	});
-
-	it('nextNotification only resolves once', async () => {
-		const hook = createHook<[number]>();
-
-		const promise = hook.nextNotification();
-		hook.notify(1);
-		hook.notify(2);
-
-		const value = await promise;
-		expect(value).toEqual([1]);
-	});
-
-	it('multiple nextNotification promises all resolve on same notify', async () => {
-		const hook = createHook<[number]>();
-
-		const p1 = hook.nextNotification();
-		const p2 = hook.nextNotification();
-		hook.notify(99);
-
-		expect(await p1).toEqual([99]);
-		expect(await p2).toEqual([99]);
-	});
-
 	it('works with zero-arg hooks', () => {
 		const hook = createHook();
 		const cb = vi.fn();

--- a/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
@@ -14,11 +14,6 @@ const { postMock, fetchMock, staticDataMock, toastErrorMock, referenceMock } = v
 	staticDataMock: {} as any,
 	toastErrorMock: vi.fn(),
 	referenceMock: {
-		skillOptions: () => [
-			{ value: 0, text: 's0' },
-			{ value: 1, text: 's1' },
-			{ value: 2, text: 's2' }
-		],
 		attributeOptions: () => [
 			{ value: 0, text: 'a0' },
 			{ value: 1, text: 'a1' }

--- a/UI/src/tests/routes/game/screens/stats/statistics-view.test.ts
+++ b/UI/src/tests/routes/game/screens/stats/statistics-view.test.ts
@@ -25,9 +25,9 @@ const statTypes: StatType[] = buildStatTypes(SERVER_STAT_TYPES);
 const entities: Record<StatBreakdownKind, StatEntity[]> = {
 	enemy: [
 		{ id: 0, name: 'Cave Bat' },
-		{ id: 1, name: 'Goblin', boss: true }
+		{ id: 1, name: 'Goblin' }
 	],
-	zone: [{ id: 0, name: 'Verdant Hollow', zoneNum: 1 }],
+	zone: [{ id: 0, name: 'Verdant Hollow' }],
 	skill: [{ id: 0, name: 'Cleave' }],
 	damageType: [
 		{ id: EDamageTypeKey.Physical, name: 'Physical' },
@@ -52,10 +52,10 @@ const data = () => new StatisticsData(statTypes, stats, entities);
 function seedStaticData(): void {
 	staticData.statisticTypes = SERVER_STAT_TYPES;
 	staticData.enemies = [
-		{ id: 0, name: 'Cave Bat', isBoss: false },
-		{ id: 1, name: 'Goblin', isBoss: true }
+		{ id: 0, name: 'Cave Bat' },
+		{ id: 1, name: 'Goblin' }
 	];
-	staticData.zones = [{ id: 0, name: 'Verdant Hollow', order: 1 }];
+	staticData.zones = [{ id: 0, name: 'Verdant Hollow' }];
 	staticData.skills = [{ id: 0, name: 'Cleave' }];
 }
 
@@ -140,20 +140,30 @@ describe('buildStatTypes', () => {
 	});
 });
 
-describe('StatisticsData.rowsForStat', () => {
+describe('StatisticsData.summaryFor', () => {
+	it('bundles the rows, bar max, and headline for a statistic', () => {
+		const summary = data().summaryFor(EStatisticType.EnemiesKilled);
+		expect(summary.rows.map((r) => r.entityId)).toEqual([0, 1]);
+		expect(summary.maxVal).toBe(100); // the leading row's value
+		expect(summary.headline).toBe(120); // null-entity grand total
+	});
+
 	it('sorts a sum/max statistic best-first (descending)', () => {
-		const rows = data().rowsForStat(EStatisticType.EnemiesKilled);
+		const rows = data().summaryFor(EStatisticType.EnemiesKilled).rows;
 		expect(rows.map((r) => r.entityId)).toEqual([0, 1]);
 		expect(rows[0].entity.name).toBe('Cave Bat');
 	});
 
 	it('sorts a min statistic best-first (ascending — lower is better)', () => {
-		const rows = data().rowsForStat(EStatisticType.FastestVictory);
+		const rows = data().summaryFor(EStatisticType.FastestVictory).rows;
 		expect(rows.map((r) => r.value)).toEqual([2.0, 5.0]);
 	});
 
-	it('returns no rows for a total-only (none) statistic', () => {
-		expect(data().rowsForStat(EStatisticType.PlayerDeaths)).toEqual([]);
+	it('returns an empty (rows-less) summary for a total-only statistic', () => {
+		const summary = data().summaryFor(EStatisticType.PlayerDeaths);
+		expect(summary.rows).toEqual([]);
+		expect(summary.maxVal).toBe(1);
+		expect(summary.headline).toBe(7);
 	});
 
 	it('drops rows whose entity cannot be resolved', () => {
@@ -162,20 +172,13 @@ describe('StatisticsData.rowsForStat', () => {
 			[{ statisticTypeId: EStatisticType.EnemiesKilled, entityId: 99, value: 5 }],
 			entities
 		);
-		expect(d.rowsForStat(EStatisticType.EnemiesKilled)).toEqual([]);
+		expect(d.summaryFor(EStatisticType.EnemiesKilled).rows).toEqual([]);
 	});
 
 	it('resolves a damage-type breakdown by key, sorted best-first', () => {
-		const rows = data().rowsForStat(EStatisticType.KillsByDamageType);
+		const rows = data().summaryFor(EStatisticType.KillsByDamageType).rows;
 		expect(rows.map((r) => r.entityId)).toEqual([EDamageTypeKey.Fire, EDamageTypeKey.Physical]);
 		expect(rows[0].entity.name).toBe('Fire');
-	});
-});
-
-describe('StatisticsData.statHeadline', () => {
-	it('uses the null-entity grand-total row when present', () => {
-		expect(data().statHeadline(EStatisticType.EnemiesKilled)).toBe(120);
-		expect(data().statHeadline(EStatisticType.PlayerDeaths)).toBe(7);
 	});
 
 	it('falls back to aggregating per-entity rows when there is no total row', () => {
@@ -187,23 +190,7 @@ describe('StatisticsData.statHeadline', () => {
 			],
 			entities
 		);
-		expect(d.statHeadline(EStatisticType.EnemiesKilled)).toBe(120); // summed
-	});
-});
-
-describe('StatisticsData.summaryFor', () => {
-	it('bundles the rows, bar max, and headline for a statistic', () => {
-		const summary = data().summaryFor(EStatisticType.EnemiesKilled);
-		expect(summary.rows.map((r) => r.entityId)).toEqual([0, 1]);
-		expect(summary.maxVal).toBe(100); // the leading row's value
-		expect(summary.headline).toBe(120); // null-entity grand total
-	});
-
-	it('returns an empty (rows-less) summary for a total-only statistic', () => {
-		const summary = data().summaryFor(EStatisticType.PlayerDeaths);
-		expect(summary.rows).toEqual([]);
-		expect(summary.maxVal).toBe(1);
-		expect(summary.headline).toBe(7);
+		expect(d.summaryFor(EStatisticType.EnemiesKilled).headline).toBe(120); // summed
 	});
 
 	it('memoises a single summary instance per statistic', () => {
@@ -276,17 +263,15 @@ describe('StatisticsView data wiring', () => {
 	it('builds the catalogue + entities from staticData once stats arrive', () => {
 		const view = seededView();
 		expect(view.data.statTypes).toHaveLength(20);
-		expect(view.data.entityList('enemy').map((e) => e.name)).toEqual(['Cave Bat', 'Goblin']);
-		// isBoss / order are resolved from the raw reference data.
-		expect(view.data.entity('enemy', 1)?.boss).toBe(true);
-		expect(view.data.entity('zone', 0)?.zoneNum).toBe(1);
-		expect(view.data.statHeadline(EStatisticType.EnemiesKilled)).toBe(120);
+		expect(view.data.entities.enemy.map((e) => e.name)).toEqual(['Cave Bat', 'Goblin']);
+		expect(view.data.entity('zone', 0)?.name).toBe('Verdant Hollow');
+		expect(view.data.summaryFor(EStatisticType.EnemiesKilled).headline).toBe(120);
 	});
 
 	it('builds the damage-type breakdown from the fixed enum, not staticData', () => {
 		const view = seededView();
-		expect(view.data.entityList('damageType')).toHaveLength(16);
+		expect(view.data.entities.damageType).toHaveLength(16);
 		expect(view.data.entity('damageType', EDamageTypeKey.Fire)?.name).toBe('Fire');
-		expect(view.data.statHeadline(EStatisticType.KillsByDamageType)).toBe(40);
+		expect(view.data.summaryFor(EStatisticType.KillsByDamageType).headline).toBe(40);
 	});
 });


### PR DESCRIPTION
## Summary

Removes verified-unused frontend code flagged in #1519 (all claims re-verified against a repo-wide reference search before removal):

- **`stats/UnderlineTabs.svelte`** — drops `Tab.glyphKind` and the `StatGlyph` render path (never supplied by the sole consumer, `ByStatisticView`), the then-unused `StatGlyph`/`StatEntityKind` imports, and rewrites the stale header comment that still described the retired "by entity" tab bar. `StatGlyph.svelte` itself stays — `StatCardRow` and `KindBadge` use it.
- **`stats/statistics-view.svelte.ts`** — removes `StatEntity.boss`/`zoneNum` (produced but never consumed in production) and the test-only `entityList`/`rowsForStat`/`statHeadline` wrappers. Since those were thin wrappers over the still-used `summaryFor`, their test scenarios were **ported onto `summaryFor`** (sort order incl. min-ascending, none-kind emptiness, unresolvable-entity drops, damage-type breakdown, headline fallback aggregation) rather than deleted, so no coverage was lost.
- **`challenges/Challenges.svelte`** — removes the unused `bind:this={frame}` binding.
- **`admin/workbench/reference.svelte.ts`** — removes the orphaned `skillOptions` picker (the proficiency "contributions" concept it served was replaced by `activityKey`) plus its matching stub in the progression-store test mock.
- **`$lib/common/hooks.ts`** — removes `createHook().nextNotification` and the `promiseResolvers` array it fed (zero callers outside its own unit tests). `notify` — one of the hottest game-loop paths (25×/sec logical + per-frame render) — no longer walks and reallocates an always-empty resolver list on every dispatch. The three orphaned tests are removed with it.

## Test notes

- `npx vitest run` on the three directly-affected suites (hooks, statistics-view, progression-store): 54 passed.
- Broader neighboring suites (`stats`, `challenges`, `codex` — the `StatisticsData` consumers): 18 files, 219 passed.
- `npm run check` (svelte-check): 0 errors / 0 warnings across 1134 files.
- ESLint on all changed files: clean.

Closes #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)