### PR TITLE
Measure the tooltip after render so first-show edge flips work

### DIFF
--- a/UI/src/components/Tooltip.svelte
+++ b/UI/src/components/Tooltip.svelte
@@ -1,4 +1,4 @@
-<div id={tooltipElementId(id)} role="tooltip" class="tooltip-container" {style} bind:this={container}>
+<div id={tooltipElementId(id)} role="tooltip" class="tooltip-container" bind:this={container}>
 	<!-- The tooltip content is rendered directly into the container, so it is not present in the markup here. -->
 </div>
 
@@ -23,30 +23,42 @@ $effect(() => {
 	}
 });
 
-const style = $derived.by(() => {
+// Positioning is an $effect writing inline styles (not a derived style attribute): the edge-flip
+// logic needs the panel's rendered size, which measures 0x0 until `display: block` reaches the DOM.
+// A derived evaluates before the DOM updates, so the first show — the only positioning a
+// keyboard-focus trigger gets — would never flip and could clip offscreen at viewport edges.
+$effect(() => {
 	const mouseX = position?.x ?? 0;
 	const mouseY = position?.y ?? 0;
 
-	if (!container || !visible) {
+	if (!container) {
 		return;
 	}
 
-	let vertical = '';
-	let horizontal = '';
+	if (!visible) {
+		// Clear the inline display so the scoped `display: none` takes back over.
+		container.style.display = '';
+		return;
+	}
+
+	// Make the panel renderable first so offsetWidth/offsetHeight measure the real box.
+	container.style.display = 'block';
 
 	if (container.offsetWidth + mouseX + 15 < window.innerWidth) {
-		horizontal = `left: ${mouseX + 15}px`;
+		container.style.left = `${mouseX + 15}px`;
+		container.style.right = '';
 	} else {
-		horizontal = `right: ${window.innerWidth - mouseX + 15}px`;
+		container.style.right = `${window.innerWidth - mouseX + 15}px`;
+		container.style.left = '';
 	}
 
 	if (container.offsetHeight + mouseY + 15 < window.innerHeight) {
-		vertical = `top: ${mouseY + 15}px`;
+		container.style.top = `${mouseY + 15}px`;
+		container.style.bottom = '';
 	} else {
-		vertical = `bottom: ${window.innerHeight - mouseY + 15}px`;
+		container.style.bottom = `${window.innerHeight - mouseY + 15}px`;
+		container.style.top = '';
 	}
-
-	return `${vertical}; ${horizontal}; display: block;`;
 });
 </script>
 

--- a/UI/src/tests/components/Tooltip.test.ts
+++ b/UI/src/tests/components/Tooltip.test.ts
@@ -6,7 +6,7 @@ import Tooltip from '$components/Tooltip.svelte';
 afterEach(cleanup);
 
 interface TooltipProps {
-	component: () => { getBaseNode: () => HTMLDivElement };
+	component: () => { getBaseNode: () => HTMLDivElement } | undefined;
 	visible: boolean;
 	position?: { x: number; y: number };
 	id: number;
@@ -14,11 +14,25 @@ interface TooltipProps {
 
 const makeProps = (overrides: Partial<TooltipProps> = {}): TooltipProps => ({
 	id: 1,
-	component: () => undefined!,
+	component: () => undefined,
 	visible: false,
 	position: undefined,
 	...overrides
 });
+
+// Emulate real layout in jsdom (which always reports 0): a panel inside `display: none`
+// measures 0x0 and only reports its real box once `display: block` has hit the DOM. This is
+// the distinction the fix rests on — positioning must measure after the panel renders.
+const stubLayout = (el: HTMLElement, width: number, height: number) => {
+	Object.defineProperty(el, 'offsetWidth', {
+		get: () => (el.style.display === 'block' ? width : 0),
+		configurable: true
+	});
+	Object.defineProperty(el, 'offsetHeight', {
+		get: () => (el.style.display === 'block' ? height : 0),
+		configurable: true
+	});
+};
 
 describe('Tooltip', () => {
 	it('renders a container with role="tooltip"', () => {
@@ -59,8 +73,8 @@ describe('Tooltip', () => {
 			window.innerHeight = 800;
 		});
 
-		// Toggle `visible` after mount — mirroring the real store — so the style derived recomputes
-		// with the bound container in place.
+		// Toggle `visible` after mount — mirroring the real store — so the positioning effect
+		// re-runs with the bound container in place.
 		const renderVisible = async (position: { x: number; y: number }) => {
 			const props = makeProps({ visible: false, position });
 			const result = render(Tooltip, { props });
@@ -89,6 +103,82 @@ describe('Tooltip', () => {
 			expect(tooltip.style.bottom).toBe('20px');
 			expect(tooltip.style.left).toBe('');
 			expect(tooltip.style.top).toBe('');
+		});
+	});
+
+	// The first show is the only positioning a keyboard-focus trigger gets (hover self-heals via
+	// mousemove), so the edge flip must already see the panel's real size on that evaluation.
+	describe('first-show measurement', () => {
+		beforeEach(() => {
+			window.innerWidth = 1000;
+			window.innerHeight = 800;
+		});
+
+		// Always mounts hidden (mirroring the real store) so the stub is in place before the
+		// first positioning; callers then flip `visible` via rerender.
+		const renderStubbed = (position: { x: number; y: number }) => {
+			const props = makeProps({ visible: false, position });
+			const result = render(Tooltip, { props });
+			const tooltip = result.container.querySelector('[role="tooltip"]') as HTMLElement;
+			stubLayout(tooltip, 280, 180);
+			return { props, tooltip, rerender: result.rerender };
+		};
+
+		it('flips off the far edges on the very first show once the panel size is measurable', async () => {
+			// Well inside the viewport for a 0x0 panel, but a 280x180 panel overflows both edges.
+			const { props, tooltip, rerender } = renderStubbed({ x: 850, y: 700 });
+
+			await rerender({ ...props, visible: true });
+			flushSync();
+
+			expect(tooltip.style.display).toBe('block');
+			// right = 1000 - 850 + 15; bottom = 800 - 700 + 15
+			expect(tooltip.style.right).toBe('165px');
+			expect(tooltip.style.bottom).toBe('115px');
+			expect(tooltip.style.left).toBe('');
+			expect(tooltip.style.top).toBe('');
+		});
+
+		it('keeps the top-left anchor on first show when the measured panel still fits', async () => {
+			const { props, tooltip, rerender } = renderStubbed({ x: 100, y: 100 });
+
+			await rerender({ ...props, visible: true });
+			flushSync();
+
+			expect(tooltip.style.left).toBe('115px');
+			expect(tooltip.style.top).toBe('115px');
+			expect(tooltip.style.right).toBe('');
+			expect(tooltip.style.bottom).toBe('');
+		});
+
+		it('clears the stale sides when a reposition flips the anchor', async () => {
+			const { props, tooltip, rerender } = renderStubbed({ x: 850, y: 700 });
+
+			await rerender({ ...props, visible: true });
+			flushSync();
+			expect(tooltip.style.right).toBe('165px');
+			expect(tooltip.style.bottom).toBe('115px');
+
+			await rerender({ ...props, visible: true, position: { x: 100, y: 100 } });
+			flushSync();
+
+			expect(tooltip.style.left).toBe('115px');
+			expect(tooltip.style.top).toBe('115px');
+			expect(tooltip.style.right).toBe('');
+			expect(tooltip.style.bottom).toBe('');
+		});
+
+		it('clears the inline display on hide so the stylesheet display:none takes back over', async () => {
+			const { props, tooltip, rerender } = renderStubbed({ x: 100, y: 100 });
+
+			await rerender({ ...props, visible: true });
+			flushSync();
+			expect(tooltip.style.display).toBe('block');
+
+			await rerender({ ...props, visible: false });
+			flushSync();
+
+			expect(tooltip.style.display).toBe('');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

`Tooltip.svelte` computed its positioning in a `$derived.by` bound to the `style` attribute. A derived evaluates **before** Svelte writes the attribute to the DOM, so on the evaluation that first makes the panel visible it read `offsetWidth`/`offsetHeight` while the container was still `display: none` — both measured 0x0 and the viewport-edge flip logic never fired. Mouse hover self-healed because continuous `mousemove` repositioning re-evaluated with the panel now visible; keyboard focus (`tooltip-hover.ts`) positions exactly once, so near the right/bottom edges the ~280px panel clipped offscreen — precisely the focus-anchored accessibility path.

Positioning is now an `$effect` that owns the container's inline styles: it applies `display: block` to the DOM first, measures the real box, then writes the anchor side per axis, clearing the stale opposite side on a flip. Hiding clears the inline display so the scoped `display: none` takes back over. Content injection (the sibling `$effect`) is declared first, so the panel is measured with its content in place on first show.

## Tests

- `UI/src/tests/components/Tooltip.test.ts` — all pre-existing scenarios kept passing unchanged; new `first-show measurement` block stubs `offsetWidth`/`offsetHeight` via `Object.defineProperty` to emulate real layout (0 until `display: block` is actually applied — jsdom otherwise always reports 0, which is why the existing clamp tests couldn't catch this). Verified the two new flip/reposition tests **fail against the old implementation** and pass with the fix.
- Ran the full `src/tests/components` + `src/tests/stores` suites (45 files, 367 tests) — all pass.
- `npm run check` (svelte-check) and eslint on the changed files — clean.
- Skipped the optional Playwright e2e pin: it requires the full backend stack running and the jsdom layout-emulation stub already pins the render-then-measure ordering the fix rests on.

No backend changes.

Closes #1504

🤖 Generated with [Claude Code](https://claude.com/claude-code)