### PR TITLE
Extract the shared challengeable-boss zone gate in BattleService

### DIFF
--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -1861,5 +1861,33 @@ namespace Game.Application.Tests.Services
             Assert.False(success);
             Assert.False(player.AutoChallengeBoss);
         }
+
+        [Fact]
+        public async Task SetAutoChallengeBoss_OutOfRangeCurrentZone_ReturnsFalseAndLeavesModeIdle()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var zone = await TestDataSeeder.CreateZoneAsync(context);
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            // A stale/corrupt CurrentZoneId (e.g. after a content reseed) must be a graceful rejection, not an
+            // ArgumentOutOfRangeException from resolving the domain zone.
+            player.ChangeZone(999);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+
+            var success = await battleService.SetAutoChallengeBoss(player, enabled: true);
+
+            Assert.False(success);
+            Assert.False(player.AutoChallengeBoss);
+        }
     }
 }

--- a/Game.Application.Tests/Services/BattleServiceOfflineProgressIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceOfflineProgressIntegrationTests.cs
@@ -304,6 +304,108 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task SimulateOfflineProgress_BossModeInBosslessZone_FallsBackToIdleInSameZone()
+        {
+            using var scope = CreateScope();
+            var setup = await SeedWinningScenarioAsync(scope);
+
+            var (player, state) = await LoadAsync(scope, setup.PlayerId);
+
+            // The persisted mode is boss-farming, but the current zone has no dedicated boss (e.g. it was
+            // unauthored since the mode was enabled): the loop must fall back to idle rather than stall.
+            player.SetAutoChallengeBoss(true);
+            player.LastActivity = DateTime.UtcNow.AddMinutes(-30);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var summary = await battleService.SimulateOfflineProgress(player, state, CancellationToken);
+
+            Assert.False(summary.AutoChallengeBoss);
+            // The zone is still viable for idling, so no relocation happens.
+            Assert.Equal(setup.ZoneId, summary.ZoneId);
+            Assert.True(summary.BattlesWon > 1);
+        }
+
+        [Fact]
+        public async Task SimulateOfflineProgress_BossModeInRetiredZone_FallsBackToIdleInViableZone()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // The player parked boss-farming in a zone that has since been retired. Its boss is no longer
+            // challengeable (out of circulation), so the loop falls back to idle — and the retired zone is
+            // not viable either, so the idle fallback relocates to the nearest viable, unlocked zone.
+            var playerSkill = await TestDataSeeder.CreateSkillAsync(context, "Smash", baseDamage: 1000m, cooldownMs: 500);
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context,
+                strengthBase: 50m, strengthPerLevel: 0m, enduranceBase: 50m, endurancePerLevel: 0m);
+            var enemySkill = await TestDataSeeder.CreateSkillAsync(context, "Poke", baseDamage: 1m, cooldownMs: 2000);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, enemySkill.Id);
+
+            var viableZone = await TestDataSeeder.CreateZoneAsync(context, "Viable", levelMin: 1, levelMax: 1, order: 0);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, viableZone.Id, enemy.Id);
+
+            var boss = await TestDataSeeder.CreateEnemyAsync(context, "Boss", isBoss: true);
+            var retiredZone = await TestDataSeeder.CreateZoneAsync(
+                context, "Retired Boss Zone", levelMin: 1, levelMax: 1, order: 1,
+                bossEnemyId: boss.Id, bossLevel: 1, retiredAt: DateTime.UtcNow);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: retiredZone.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, playerSkill.Id);
+            await ReloadReferenceCachesAsync();
+
+            var (player, state) = await LoadAsync(scope, playerEntity.Id);
+            player.SetAutoChallengeBoss(true);
+            player.LastActivity = DateTime.UtcNow.AddMinutes(-30);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var summary = await battleService.SimulateOfflineProgress(player, state, CancellationToken);
+
+            Assert.False(summary.AutoChallengeBoss);
+            Assert.Equal(viableZone.Id, summary.ZoneId);
+            Assert.Equal(viableZone.Id, player.CurrentZoneId);
+            Assert.True(summary.BattlesWon > 1);
+        }
+
+        [Fact]
+        public async Task SimulateOfflineProgress_BossModeInLockedZone_FallsBackToIdleInSameZone()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // The current zone has a boss but is gated behind a challenge the player has not completed, so
+            // its boss is not challengeable and the loop falls back to idle. The zone itself is viable
+            // (spawnable enemies), so the idle fallback runs in place without relocating.
+            var playerSkill = await TestDataSeeder.CreateSkillAsync(context, "Smash", baseDamage: 1000m, cooldownMs: 500);
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context,
+                strengthBase: 50m, strengthPerLevel: 0m, enduranceBase: 50m, endurancePerLevel: 0m);
+            var enemySkill = await TestDataSeeder.CreateSkillAsync(context, "Poke", baseDamage: 1m, cooldownMs: 2000);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, enemySkill.Id);
+
+            var boss = await TestDataSeeder.CreateEnemyAsync(context, "Boss", isBoss: true);
+            var gate = await TestDataSeeder.CreateChallengeAsync(context, "Reach the boss zone");
+            var zone = await TestDataSeeder.CreateZoneAsync(
+                context, "Locked Boss Zone", levelMin: 1, levelMax: 1,
+                bossEnemyId: boss.Id, bossLevel: 1, unlockChallengeId: gate.Id);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, playerSkill.Id);
+            await ReloadReferenceCachesAsync();
+
+            var (player, state) = await LoadAsync(scope, playerEntity.Id);
+            player.SetAutoChallengeBoss(true);
+            player.LastActivity = DateTime.UtcNow.AddMinutes(-30);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var summary = await battleService.SimulateOfflineProgress(player, state, CancellationToken);
+
+            Assert.False(summary.AutoChallengeBoss);
+            Assert.Equal(zone.Id, summary.ZoneId);
+            Assert.True(summary.BattlesWon > 1);
+        }
+
+        [Fact]
         public async Task SimulateSwitchProgress_SubThresholdAway_StillCreditsAndReanchors()
         {
             // A deliberate character switch drops the 5-minute floor: an away window the login path would treat

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -178,28 +178,13 @@ namespace Game.Application.Services
         /// </summary>
         public async Task<BattleStartResult?> StartBossBattle(Player player, PlayerState state, int zoneId, int? clientBattleMs = null, CancellationToken cancellationToken = default)
         {
-            // Out-of-range is a true no-op, same as the bossless/locked/retired checks below: validate before
-            // touching the active battle (abandoning is not a cheap no-op) and before resolving the domain
-            // zone, which throws on an out-of-range id.
-            if (!_zones.ValidateZoneId(zoneId))
-            {
-                return null;
-            }
-
-            var zone = _zones.GetDomainZone(zoneId);
-
-            // Validate the challenge before touching the active battle: abandoning is not a cheap no-op
-            // (it force-resolves and persists the current battle), so a challenge against a bossless or
-            // locked zone must be a true no-op rather than silently ending the player's in-progress fight.
-            if (zone.BossEnemyId is not int bossEnemyId)
-            {
-                return null;
-            }
-
-            // Anti-cheat / out of circulation: a locked or retired zone's boss cannot be challenged. A
-            // legitimate client can never be in a locked or retired zone to begin with (the idle loop
-            // relocates out of a retired one), so this only blocks tampered requests.
-            if (_zones.IsZoneRetired(zoneId) || !await IsZoneUnlocked(player.Id, zone, cancellationToken))
+            // Validate the whole challenge before touching the active battle: abandoning is not a cheap no-op
+            // (it force-resolves and persists the current battle), so a challenge against an out-of-range,
+            // bossless, retired, or locked zone must be a true no-op rather than silently ending the player's
+            // in-progress fight. A legitimate client can never be in a locked or retired zone to begin with
+            // (the idle loop relocates out of a retired one), so those gates only block tampered requests.
+            var zone = await ResolveChallengeableBossZone(player.Id, zoneId, cancellationToken);
+            if (zone is null)
             {
                 return null;
             }
@@ -212,11 +197,7 @@ namespace Game.Application.Services
             var now = DateTime.UtcNow;
             var seed = CreateBattleSeed();
 
-            var enemy = _battleFactory.CreateBossEnemy(
-                zone,
-                level => _enemies.GetDomainEnemy(bossEnemyId, level)
-                    ?? throw new InvalidOperationException(
-                        $"Zone {zone.Id} references boss enemy {bossEnemyId}, which does not exist."));
+            var enemy = _battleFactory.CreateBossEnemy(zone, BossEnemyResolver(zone));
 
             var enemySkillIds = enemy.BattleSkills.Select(skill => skill.Id).ToList();
             var snapshot = BattleSnapshot.FromPlayer(player, await CaptureProficiencyLevels(player.Id, cancellationToken));
@@ -251,14 +232,7 @@ namespace Game.Application.Services
             // Anti-cheat: a retired, locked, or bossless current zone cannot be boss-farmed. The zone is the
             // player's own CurrentZoneId (not client-supplied), so a tampered client can't farm a zone it
             // isn't in; the meaningful gate is that the current zone actually has a challengeable boss.
-            var zoneId = player.CurrentZoneId;
-            if (!_zones.ValidateZoneId(zoneId) || _zones.IsZoneRetired(zoneId))
-            {
-                return false;
-            }
-
-            var zone = _zones.GetDomainZone(zoneId);
-            if (zone.BossEnemyId is null || !await IsZoneUnlocked(player.Id, zone, cancellationToken))
+            if (await ResolveChallengeableBossZone(player.Id, player.CurrentZoneId, cancellationToken) is null)
             {
                 return false;
             }
@@ -492,14 +466,9 @@ namespace Game.Application.Services
         {
             var currentZoneId = player.CurrentZoneId;
             if (player.AutoChallengeBoss
-                && _zones.ValidateZoneId(currentZoneId)
-                && !_zones.IsZoneRetired(currentZoneId))
+                && ResolveChallengeableBossZone(currentZoneId, completedChallengeIds) is { } bossZone)
             {
-                var bossZone = _zones.GetDomainZone(currentZoneId);
-                if (bossZone.BossEnemyId is not null && bossZone.IsUnlocked(completedChallengeIds))
-                {
-                    return (OfflineLoopMode.Boss, bossZone);
-                }
+                return (OfflineLoopMode.Boss, bossZone);
             }
 
             var idleZoneId = await EnsureViableZone(player, currentZoneId, completedChallengeIds, cancellationToken);
@@ -540,13 +509,14 @@ namespace Game.Application.Services
             };
         }
 
-        // The boss resolver for a boss-mode run: the zone's dedicated boss at the requested (fixed boss) level.
-        // ResolveOfflineLoop only selects boss mode for a zone whose BossEnemyId is set, so the null check here
-        // is a defensive invariant rather than a reachable state.
+        // The dedicated-boss resolver shared by the live boss challenge and the offline boss loop: the zone's
+        // authored boss at the requested (fixed boss) level. Callers only reach this for a zone the
+        // challengeable-boss gate resolved (BossEnemyId set), so the null check here is a defensive invariant
+        // rather than a reachable state.
         private Func<int, CoreEnemy> BossEnemyResolver(CoreZone zone)
         {
             var bossEnemyId = zone.BossEnemyId
-                ?? throw new InvalidOperationException($"Boss offline loop for zone {zone.Id} has no boss enemy.");
+                ?? throw new InvalidOperationException($"Zone {zone.Id} has no dedicated boss enemy authored.");
             return level => _enemies.GetDomainEnemy(bossEnemyId, level)
                 ?? throw new InvalidOperationException(
                     $"Zone {zone.Id} references boss enemy {bossEnemyId}, which does not exist.");
@@ -761,6 +731,42 @@ namespace Game.Application.Services
             }
 
             return newZoneId;
+        }
+
+        // Shared challengeable-boss gate (StartBossBattle / SetAutoChallengeBoss / ResolveOfflineLoop): resolves
+        // the zone iff its boss can actually be challenged — the id is in range (checked before GetDomainZone,
+        // which throws on an out-of-range id), the zone is in circulation, and a dedicated boss is authored.
+        // The unlock check differs per caller, so it lives on the two overloads below.
+        private CoreZone? ResolveBossZone(int zoneId)
+        {
+            if (!_zones.ValidateZoneId(zoneId) || _zones.IsZoneRetired(zoneId))
+            {
+                return null;
+            }
+
+            var zone = _zones.GetDomainZone(zoneId);
+            return zone.BossEnemyId is null ? null : zone;
+        }
+
+        // Live-path gate: the unlock check reads the player's completed challenges through IsZoneUnlocked,
+        // incurred only once the cheaper range/retired/boss checks have passed.
+        private async Task<CoreZone?> ResolveChallengeableBossZone(int playerId, int zoneId, CancellationToken cancellationToken)
+        {
+            var zone = ResolveBossZone(zoneId);
+            if (zone is null || !await IsZoneUnlocked(playerId, zone, cancellationToken))
+            {
+                return null;
+            }
+
+            return zone;
+        }
+
+        // Offline-pass gate: unlocks against a completed-challenge set the caller already holds (the loaded
+        // progress aggregate), so the check re-reads no progress cache key.
+        private CoreZone? ResolveChallengeableBossZone(int zoneId, IReadOnlySet<int> completedChallengeIds)
+        {
+            var zone = ResolveBossZone(zoneId);
+            return zone is not null && zone.IsUnlocked(completedChallengeIds) ? zone : null;
         }
 
         // Whether a zone is unlocked for the player. An ungated zone is always open and pays no read cost;


### PR DESCRIPTION
## Summary

Follow-up to #1537: the "resolve a client-supplied zone id, treating out-of-range / retired / bossless / locked as a no-op" preamble recurred across three `BattleService` call sites. This extracts it as a small `ResolveChallengeableBossZone` gate:

- **`ResolveBossZone(zoneId)`** — the shared synchronous core: in range (checked before `GetDomainZone`, which throws on an out-of-range id), in circulation (not retired), and a dedicated boss authored.
- **`ResolveChallengeableBossZone(playerId, zoneId, ct)`** — live-path overload (`StartBossBattle`, `SetAutoChallengeBoss`); the unlock check goes through `IsZoneUnlocked`, still deferred behind the cheap checks so a bossless/retired target never pays the completion read.
- **`ResolveChallengeableBossZone(zoneId, completedChallengeIds)`** — set-taking overload for `ResolveOfflineLoop`, which already holds the loaded progress aggregate's completed-challenge set (no re-read of the progress cache key).

`StartBossBattle` also now reuses `BossEnemyResolver` instead of duplicating the boss-enemy resolving lambda inline, and the resolver's defensive throw message is generalised since it is no longer offline-only.

Deliberately **not** unified, per the issue's guidance: `StartBattle`'s zone-change guard (Home-zone check, ignore-and-continue semantics) and `IsZoneViable`/`EnsureViableZone` (spawn-table presence, relocation semantics) have genuinely different follow-on behavior. Kept conservative and local given #1516 plans to split this file later.

No user-facing effect — behavior-preserving; the check reordering inside `StartBossBattle` (retired before bossless) changes no outcome and adds no reads.

## Test notes

- All 59 tests in `BattleServiceIntegrationTests` + `BattleServiceOfflineProgressIntegrationTests` pass (55 pre-existing unchanged, 4 new).
- New edge coverage for the gate through its public paths:
  - `SimulateOfflineProgress_BossModeInBosslessZone_FallsBackToIdleInSameZone`
  - `SimulateOfflineProgress_BossModeInRetiredZone_FallsBackToIdleInViableZone` (asserts the relocation too)
  - `SimulateOfflineProgress_BossModeInLockedZone_FallsBackToIdleInSameZone`
  - `SetAutoChallengeBoss_OutOfRangeCurrentZone_ReturnsFalseAndLeavesModeIdle`
  (Out-of-range/retired/locked/bossless were already pinned for `StartBossBattle`, and retired/locked/bossless for `SetAutoChallengeBoss`.)
- Socket-level suites (`SetAutoChallengeBossSocketTests`, `ChallengeBoss*`) pass.
- No battle-simulation logic touched (server-side orchestration only), so no mirrored frontend scenarios are required.

Closes #1540

🤖 Generated with [Claude Code](https://claude.com/claude-code)