### PR TITLE
Fix blank glyphs and tighten the glyph typing that hid them

### DIFF
--- a/UI/src/routes/admin/AdminGlyph.svelte
+++ b/UI/src/routes/admin/AdminGlyph.svelte
@@ -30,6 +30,10 @@
 	{:else if kind === 'tag'}
 		<path d="M2.5 2.5h5L13 8l-5 5-5.5-5.5z" stroke-linejoin="round" />
 		<circle cx="5" cy="5" r="0.9" fill={stroke} stroke="none" />
+	{:else if kind === 'gauge'}
+		<path d="M2.8 11.5a5.2 5.2 0 0110.4 0" stroke-linecap="round" />
+		<path d="M8 11.3l2.7-3" stroke-linecap="round" />
+		<circle cx="8" cy="11.3" r="1" fill={stroke} stroke="none" />
 	{:else if kind === 'back'}
 		<path d="M7 3.5L2.5 8 7 12.5M2.5 8H13" stroke-linecap="round" stroke-linejoin="round" />
 	{:else if kind === 'trophy'}
@@ -43,19 +47,24 @@
 </svg>
 
 <script lang="ts" module>
-export type AdminGlyphKind =
-	| 'skull'
-	| 'bars'
-	| 'rune'
-	| 'box'
-	| 'bolt'
-	| 'multiply'
-	| 'map'
-	| 'pin'
-	| 'tag'
-	| 'back'
-	| 'trophy'
-	| 'inbox';
+/** Runtime list of every glyph kind (each must have a branch above) — lets tests assert none render blank. */
+export const ADMIN_GLYPH_KINDS = [
+	'skull',
+	'bars',
+	'rune',
+	'box',
+	'bolt',
+	'multiply',
+	'map',
+	'pin',
+	'tag',
+	'gauge',
+	'back',
+	'trophy',
+	'inbox'
+] as const;
+
+export type AdminGlyphKind = (typeof ADMIN_GLYPH_KINDS)[number];
 </script>
 
 <script lang="ts">

--- a/UI/src/routes/admin/workbench/entities/types.ts
+++ b/UI/src/routes/admin/workbench/entities/types.ts
@@ -1,4 +1,11 @@
+import type { AdminGlyphKind } from '../../AdminGlyph.svelte';
 import type { WorkbenchIconKind } from '../WorkbenchIcon.svelte';
+
+/**
+ * An entity's headline glyph is drawn by both the sidebar ({@link AdminGlyphKind}) and the
+ * detail header ({@link WorkbenchIconKind}), so it must be a member of both glyph sets.
+ */
+export type EntityGlyphKind = Extract<WorkbenchIconKind, AdminGlyphKind>;
 
 /** Every workbench record is keyed by a numeric id (negative while unsaved). */
 export interface Identified {
@@ -223,7 +230,7 @@ export interface EntityConfig<T extends Identified> {
 	key: string;
 	label: string;
 	singular: string;
-	glyph: WorkbenchIconKind;
+	glyph: EntityGlyphKind;
 	blankName: string;
 	/**
 	 * Zero-based-id reference entity: records are <em>retired</em> (kept at their slot, resolvable by id)

--- a/UI/src/routes/admin/workbench/nav.ts
+++ b/UI/src/routes/admin/workbench/nav.ts
@@ -37,7 +37,7 @@ const workbenchToolDefs: AdminToolDef[] = workbenchGroups.flatMap((group) =>
 			key: entity.key,
 			label: entity.label,
 			group: group.key,
-			glyph: entity.glyph as AdminGlyphKind
+			glyph: entity.glyph
 		}))
 );
 

--- a/UI/src/routes/game/screens/challenges/TypeGlyph.svelte
+++ b/UI/src/routes/game/screens/challenges/TypeGlyph.svelte
@@ -30,7 +30,8 @@ interface Props {
 const { typeId, color, size = 16, strokeWidth = 1.3 }: Props = $props();
 
 // Abstract line glyphs, one per challenge type (TimeTrial draws a clock above).
-const GLYPH_PATH: Record<number, string> = {
+// Keyed exhaustively so a new EChallengeType member without a glyph fails typecheck.
+const GLYPH_PATH: Record<Exclude<EChallengeType, EChallengeType.TimeTrial>, string> = {
 	[EChallengeType.EnemiesKilled]: 'M3.5 3.5l9 9M12.5 3.5l-9 9',
 	[EChallengeType.BossesDefeated]: 'M2.5 11.5h11M3.5 11.5l.6-5.5 2.4 3L8 5l1.5 4 2.4-3 .6 5.5',
 	[EChallengeType.ZonesCleared]: 'M4 2.5v11M4 3.5h7l-1.8 2.2L11 8H4',
@@ -38,6 +39,8 @@ const GLYPH_PATH: Record<number, string> = {
 	[EChallengeType.DamageDealt]:
 		'M8 2.2v2.4M8 11.4v2.4M2.2 8h2.4M11.4 8h2.4M4.2 4.2l1.7 1.7M10.1 10.1l1.7 1.7M11.8 4.2L10.1 5.9M5.9 10.1l-1.7 1.7',
 	[EChallengeType.BattlesWon]: 'M8 2.4l5 1.8v3.6c0 3-2.4 5-5 5.8-2.6-.8-5-2.8-5-5.8V4.2zM5.8 7.9l1.7 1.7L10.4 6',
-	[EChallengeType.SkillsUsed]: 'M8 1.8l1.6 4.6 4.6 1.6-4.6 1.6L8 14.2l-1.6-4.6L1.8 8l4.6-1.6z'
+	[EChallengeType.SkillsUsed]: 'M8 1.8l1.6 4.6 4.6 1.6-4.6 1.6L8 14.2l-1.6-4.6L1.8 8l4.6-1.6z',
+	[EChallengeType.KillsByDamageType]:
+		'M8 2.4c2.5 2.9 3.8 4.9 3.8 7.1a3.8 3.8 0 11-7.6 0C4.2 7.3 5.5 5.3 8 2.4zM6.7 8.2l2.6 2.6M9.3 8.2l-2.6 2.6'
 };
 </script>

--- a/UI/src/tests/routes/admin/AdminGlyph.test.ts
+++ b/UI/src/tests/routes/admin/AdminGlyph.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+
+import AdminGlyph, { ADMIN_GLYPH_KINDS } from '$routes/admin/AdminGlyph.svelte';
+
+afterEach(cleanup);
+
+describe('AdminGlyph', () => {
+	it.each(ADMIN_GLYPH_KINDS.map((kind) => [kind] as const))('draws visible geometry for %s', (kind) => {
+		const { container } = render(AdminGlyph, { props: { kind } });
+		// Regression guard for #1502: a kind with no template branch rendered an empty <svg>.
+		expect(container.querySelectorAll('path, circle').length).toBeGreaterThan(0);
+	});
+
+	it('strokes with the accent color only when active', () => {
+		const active = render(AdminGlyph, { props: { kind: 'gauge', active: true } });
+		expect(active.container.querySelector('svg')?.getAttribute('stroke')).toBe('var(--accent)');
+		cleanup();
+
+		const idle = render(AdminGlyph, { props: { kind: 'gauge' } });
+		expect(idle.container.querySelector('svg')?.getAttribute('stroke')).not.toBe('var(--accent)');
+	});
+});

--- a/UI/src/tests/routes/admin/nav.test.ts
+++ b/UI/src/tests/routes/admin/nav.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { adminGroups, adminTools, DEAD_LETTERS_TOOL_KEY, OPS_GROUP_KEY } from '$routes/admin/workbench/nav';
+import { ADMIN_GLYPH_KINDS } from '$routes/admin/AdminGlyph.svelte';
 
 describe('admin nav config', () => {
 	it('exposes the Ops group alongside the workbench groups', () => {
@@ -22,5 +23,17 @@ describe('admin nav config', () => {
 	it('keeps the entity-authoring workbench tools', () => {
 		expect(adminTools.some((tool) => tool.key === 'enemies')).toBe(true);
 		expect(adminTools.some((tool) => tool.key === 'challenges')).toBe(true);
+	});
+
+	it('gives every tool a glyph AdminGlyph can actually draw', () => {
+		// Regression guard for #1502: the Classes tool's 'gauge' glyph rendered a blank sidebar icon.
+		const drawable: readonly string[] = ADMIN_GLYPH_KINDS;
+		for (const tool of adminTools) {
+			expect(drawable, `tool '${tool.key}' has undrawable glyph '${tool.glyph}'`).toContain(tool.glyph);
+		}
+	});
+
+	it('shows the Classes tool with the gauge glyph', () => {
+		expect(adminTools.find((tool) => tool.key === 'classes')?.glyph).toBe('gauge');
 	});
 });

--- a/UI/src/tests/routes/game/screens/challenges/TypeGlyph.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/TypeGlyph.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+
+import TypeGlyph from '$routes/game/screens/challenges/TypeGlyph.svelte';
+import { EChallengeType } from '$lib/api';
+
+afterEach(cleanup);
+
+/** Every numeric member of the enum — a new challenge type joins this matrix automatically. */
+const allTypes = Object.values(EChallengeType).filter((v): v is EChallengeType => typeof v === 'number');
+
+describe('TypeGlyph', () => {
+	it.each(allTypes.map((typeId) => [EChallengeType[typeId], typeId] as const))(
+		'draws visible geometry for %s',
+		(_name, typeId) => {
+			const { container } = render(TypeGlyph, { props: { typeId, color: 'var(--accent)' } });
+			const paths = [...container.querySelectorAll('path')];
+			// Regression guard for #1502: a type missing from GLYPH_PATH rendered <path d={undefined}>.
+			expect(paths.length).toBeGreaterThan(0);
+			for (const path of paths) {
+				expect(path.getAttribute('d')).toBeTruthy();
+			}
+		}
+	);
+
+	it('draws the TimeTrial clock (circle + hands) rather than a GLYPH_PATH entry', () => {
+		const { container } = render(TypeGlyph, {
+			props: { typeId: EChallengeType.TimeTrial, color: 'var(--accent)' }
+		});
+		expect(container.querySelector('circle')).not.toBeNull();
+	});
+
+	it('applies the accent color and sizing props to the svg', () => {
+		const { container } = render(TypeGlyph, {
+			props: { typeId: EChallengeType.EnemiesKilled, color: 'var(--challenge-enemies-killed)', size: 24 }
+		});
+		const svg = container.querySelector('svg');
+		expect(svg?.getAttribute('stroke')).toBe('var(--challenge-enemies-killed)');
+		expect(svg?.getAttribute('width')).toBe('24');
+		expect(svg?.getAttribute('height')).toBe('24');
+	});
+});


### PR DESCRIPTION
## Summary

Fixes both missing-glyph bugs from #1502 and hardens the typing so this class of drift fails typecheck instead of rendering blank icons.

**Challenges Type Rail — `KillsByDamageType` glyph.** `TypeGlyph.svelte`'s `GLYPH_PATH` was `Record<number, string>` and had no entry for `EChallengeType.KillsByDamageType`, so the rail button, hero banner/watermark, and Overview ring meters all drew an empty SVG. Added a typed-kill glyph (elemental droplet with a kill X, echoing the EnemiesKilled X) and re-keyed the record as `Record<Exclude<EChallengeType, EChallengeType.TimeTrial>, string>` — exhaustive over the enum (TimeTrial keeps its inline clock), matching the `CHALLENGE_TYPE_META` precedent, so a future challenge type without a glyph is a typecheck error.

**Admin sidebar — Classes tool icon.** `AdminGlyph.svelte` had no `gauge` branch, but `class.ts` declares `glyph: 'gauge'` and `nav.ts` force-cast it into `AdminGlyphKind`. Added the gauge icon (arc + needle + filled hub, in the file's two-tone style, matching WorkbenchIcon's gauge), removed the `as AdminGlyphKind` cast, and reconciled the two unions at the seam: `EntityConfig.glyph` is now `EntityGlyphKind = Extract<WorkbenchIconKind, AdminGlyphKind>`, since an entity's headline glyph renders through both components (sidebar + detail header). All existing entity glyphs are members of the intersection, so no other icons were missing. `AdminGlyphKind` is now derived from a runtime `ADMIN_GLYPH_KINDS` const so tests can prove every declared kind actually draws geometry.

## Tests

- New `TypeGlyph.test.ts`: renders every `EChallengeType` member (enumerated from the enum, so new members join automatically) and asserts non-empty path geometry; TimeTrial clock and color/size props covered.
- New `AdminGlyph.test.ts`: renders every `ADMIN_GLYPH_KINDS` kind and asserts visible geometry (the exact failure mode of the bug), plus the active-stroke behavior.
- `nav.test.ts`: every admin tool's glyph must be drawable by `AdminGlyph`, and the Classes tool carries `gauge`.
- Ran: `vitest` over `src/tests/routes/admin` + `src/tests/routes/game/screens/challenges` (61 files, 588 tests, all green), `npm run check` (svelte-check, 0 errors/warnings), eslint on changed files (clean). Frontend-only change; no backend impact.

Closes #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)