### PR TITLE
Reject non-boss enemy targets for boss-only challenge types

### DIFF
--- a/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
+++ b/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
@@ -132,6 +132,69 @@ namespace Game.Application.Tests.Content
             AssertHasFinding(graph, "ChallengeTarget", ContentGraphSeverity.Error, "Challenge", 0);
         }
 
+        [Fact]
+        public void Challenge_BossOnlyTypeTargetingNonBossEnemy_IsWarning()
+        {
+            // BossesDefeated records per-boss rows only; targeting non-boss enemy 0 can never progress.
+            var graph = HealthyGraph() with
+            {
+                Challenges =
+                [
+                    Challenge(0, challengeTypeId: EChallengeType.BossesDefeated,
+                        entityType: EEntityType.Enemy, targetEntityId: 0),
+                ],
+            };
+            AssertHasFinding(graph, "ChallengeTarget", ContentGraphSeverity.Warning, "Challenge", 0);
+        }
+
+        [Fact]
+        public void Challenge_BossOnlyTypeTargetingBossEnemy_ProducesNoFinding()
+        {
+            // Enemy 1 is a boss; making it zone 0's boss keeps the gate on challenge 0 reachable.
+            var graph = HealthyGraph() with
+            {
+                Zones = [Zone(0, bossEnemyId: 1), Zone(1, unlockChallengeId: 0), Zone(2, isHome: true)],
+                Challenges =
+                [
+                    Challenge(0, challengeTypeId: EChallengeType.BossesDefeated,
+                        entityType: EEntityType.Enemy, targetEntityId: 1),
+                ],
+            };
+            Assert.Empty(_checker.Check(graph));
+        }
+
+        [Fact]
+        public void Challenge_NonBossOnlyTypeTargetingNonBossEnemy_ProducesNoFinding()
+        {
+            var graph = HealthyGraph() with
+            {
+                Challenges =
+                [
+                    Challenge(0, challengeTypeId: EChallengeType.EnemiesKilled,
+                        entityType: EEntityType.Enemy, targetEntityId: 0),
+                ],
+            };
+            Assert.Empty(_checker.Check(graph));
+        }
+
+        [Fact]
+        public void Challenge_BossOnlyTypeTargetingRetiredNonBossEnemy_WarnsOnlyAboutRetirement()
+        {
+            // A retired target already gets its own warning; the boss-ness warning is skipped for it,
+            // mirroring the ZoneBoss precedent.
+            var graph = HealthyGraph() with
+            {
+                Challenges =
+                [
+                    Challenge(0, challengeTypeId: EChallengeType.BossesDefeated,
+                        entityType: EEntityType.Enemy, targetEntityId: 5),
+                ],
+                Enemies = HealthyGraph().Enemies.Append(Enemy(5, retiredAt: Retired)).ToList(),
+            };
+            var finding = Assert.Single(_checker.Check(graph), f => f.Check == "ChallengeTarget");
+            Assert.Contains("retired", finding.Message);
+        }
+
         // --- Enemies ----------------------------------------------------------------------------------
 
         [Fact]

--- a/Game.Application.Tests/DataAccess/AdminChallengesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminChallengesIntegrationTests.cs
@@ -16,8 +16,9 @@ namespace Game.Application.Tests.DataAccess
     /// <summary>
     /// Exercises <see cref="IAdminChallenges"/> <c>SaveChallenges</c>: the zero-based-id Edit-existence
     /// rejection (an out-of-range id is a not-found rejection, not an EF 0-row update), the delete-not-supported
-    /// guard, the duplicate-key rejection, and a successful Add/Edit round-trip. Seeding, the admin write, and
-    /// the assertion each use a separate DI scope so the write runs against an empty change tracker.
+    /// guard, the duplicate-key rejection, the up-front reward/target reference guards, and a successful
+    /// Add/Edit round-trip. Seeding, the admin write, and the assertion each use a separate DI scope so the
+    /// write runs against an empty change tracker.
     /// </summary>
     [Collection("Integration")]
     public class AdminChallengesIntegrationTests : ApplicationIntegrationTestBase
@@ -325,6 +326,78 @@ namespace Game.Application.Tests.DataAccess
 
             Assert.False(result.Succeeded);
             Assert.Equal("Target enemy 99999 does not exist.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SaveChallenges_BossOnlyTypeTargetingNonBossEnemy_ReturnsFailure()
+        {
+            // BossesDefeated records per-boss rows only, so a non-boss target could never track progress.
+            int enemyId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                enemyId = (await TestDataSeeder.CreateEnemyAsync(context, name: "Common Slime")).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge>
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = NewChallenge(name: "Slime Vanquisher", challengeTypeId: EChallengeType.BossesDefeated, targetEntityId: enemyId),
+                },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal($"A 'Bosses Defeated' challenge must target a boss; enemy {enemyId} is not a boss.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SaveChallenges_BossOnlyTypeTargetingBossEnemy_Succeeds()
+        {
+            int bossId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                bossId = (await TestDataSeeder.CreateEnemyAsync(context, name: "Slime King", isBoss: true)).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            var changes = new List<Change<Contracts.Challenge>>
+            {
+                new()
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = NewChallenge(name: "King Slayer", challengeTypeId: EChallengeType.BossesDefeated, targetEntityId: bossId),
+                },
+            };
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+            Assert.True(admin.SaveChallenges(changes).Succeeded);
+        }
+
+        [Fact]
+        public void SaveChallenges_BossOnlyTypeWithNoTarget_Succeeds()
+        {
+            // An untargeted BossesDefeated challenge tracks the global boss counter — no dimension to validate.
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminChallenges>();
+
+            var result = admin.SaveChallenges(
+            [
+                new Change<Contracts.Challenge>
+                {
+                    ChangeType = EChangeType.Add,
+                    Item = NewChallenge(name: "Boss Hunter", challengeTypeId: EChallengeType.BossesDefeated),
+                },
+            ]);
+
+            Assert.True(result.Succeeded);
         }
 
         [Fact]

--- a/Game.Application/Content/ProgressionGraphChecker.cs
+++ b/Game.Application/Content/ProgressionGraphChecker.cs
@@ -1,5 +1,6 @@
 using Game.Core;
 using Game.Core.Attributes;
+using Game.Core.Progress;
 using Game.Core.Skills;
 using Contracts = Game.Abstractions.Contracts;
 
@@ -127,6 +128,13 @@ namespace Game.Application.Content
                         {
                             case EEntityType.Enemy:
                                 CheckRef("ChallengeTarget", "Challenge", challenge.Id, _enemyRetire, "enemy", targetId, ContentGraphSeverity.Error, ContentGraphSeverity.Warning);
+                                // A boss-only statistic records per-boss rows only, so a non-boss target can
+                                // never track progress (mirrors the ZoneBoss non-boss warning above).
+                                if (IsBossOnlyType(challenge.ChallengeTypeId)
+                                    && _enemies.TryGetValue(targetId, out var target) && target.RetiredAt is null && !target.IsBoss)
+                                {
+                                    Warn("ChallengeTarget", "Challenge", challenge.Id, $"is a boss-only challenge targeting enemy {targetId}, which is not flagged as a boss, so it can never track progress.");
+                                }
                                 break;
                             case EEntityType.Zone:
                                 CheckRef("ChallengeTarget", "Challenge", challenge.Id, _zoneRetire, "zone", targetId, ContentGraphSeverity.Error, ContentGraphSeverity.Warning);
@@ -581,6 +589,9 @@ namespace Game.Application.Content
             }
 
             // --- Helpers ----------------------------------------------------------------------------------
+
+            private static bool IsBossOnlyType(EChallengeType challengeTypeId)
+                => new ChallengeType(challengeTypeId).StatisticType is { BossOnly: true };
 
             private bool IsPathRetired(int pathId) => !_pathRetire.TryGetValue(pathId, out var retiredAt) || retiredAt is not null;
 

--- a/Game.DataAccess/Repositories/Admin/AdminChallenges.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminChallenges.cs
@@ -144,7 +144,9 @@ namespace Game.DataAccess.Repositories.Admin
         /// <see cref="EEntityType.Enemy"/>/<see cref="EEntityType.Zone"/>/
         /// <see cref="EEntityType.Skill"/> target must reference an existing record (retirement is tolerated —
         /// unlike a reward, a retired target can't fault the runtime; it only risks an eventually-uncompletable
-        /// challenge, which the content-graph lint already flags post-hoc as a warning), and an
+        /// challenge, which the content-graph lint already flags post-hoc as a warning), a boss-only type's
+        /// enemy target must be flagged as a boss (its statistic records per-boss rows only, so a non-boss
+        /// target could never track progress), and an
         /// <see cref="EEntityType.DamageType"/> target must be a defined <see cref="EDamageTypeKey"/> (a fixed
         /// intrinsic enum, not a DB reference table). <see cref="EEntityType.None"/> carries no dimension to
         /// validate. Deletes are skipped.
@@ -172,11 +174,24 @@ namespace Game.DataAccess.Repositories.Admin
                     continue;
                 }
 
-                var entityType = new ChallengeType(item.ChallengeTypeId).StatisticType?.EntityType ?? EEntityType.None;
-                switch (entityType)
+                var challengeType = new ChallengeType(item.ChallengeTypeId);
+                switch (challengeType.StatisticType?.EntityType ?? EEntityType.None)
                 {
-                    case EEntityType.Enemy when _enemies.GetEnemy(targetId) is null:
-                        return AdminSaveResult.Failure($"Target enemy {targetId} does not exist.");
+                    case EEntityType.Enemy:
+                        var enemy = _enemies.GetEnemy(targetId);
+                        if (enemy is null)
+                        {
+                            return AdminSaveResult.Failure($"Target enemy {targetId} does not exist.");
+                        }
+
+                        // A boss-only statistic records per-boss rows only, so a non-boss target
+                        // could never track progress — an eventually-uncompletable challenge.
+                        if (challengeType.StatisticType is { BossOnly: true } && !enemy.IsBoss)
+                        {
+                            return AdminSaveResult.Failure($"A '{challengeType.Name}' challenge must target a boss; enemy {targetId} is not a boss.");
+                        }
+
+                        break;
                     case EEntityType.Zone when _zones.LookupZone(targetId) is null:
                         return AdminSaveResult.Failure($"Target zone {targetId} does not exist.");
                     case EEntityType.Skill when _skills.LookupSkill(targetId) is null:


### PR DESCRIPTION
## Summary

Follow-up to #1544. `BossesDefeated` is a `BossOnly` challenge type, but the save-time target guard only validated enemy existence, so a tampered client could author a boss-only challenge targeting a non-boss enemy — a challenge that can never track progress.

- **Save guard** (`AdminChallenges.FindTargetViolation`): an Enemy-dimension target on a challenge type whose statistic is `BossOnly` must reference an enemy flagged `IsBoss`; otherwise the batch is rejected up front with `"A 'Bosses Defeated' challenge must target a boss; enemy {id} is not a boss."` Boss-only-ness is read off the domain `ChallengeType`/`StatisticType`, so a future boss-only type is covered automatically.
- **Content-graph lint** (`ProgressionGraphChecker.CheckChallenges`): mirrors the check as a **Warning** on the Enemy target dimension, following the `ZoneBoss` non-boss precedent — including skipping the boss-ness warning for a retired target, which already gets its own retirement warning.

The committed `content/challenges.json` has no `BossesDefeated` challenges, so the CI lint allowlist is unaffected.

## Test notes

- `AdminChallengesIntegrationTests`: non-boss target rejected with the exact message; boss target accepted; untargeted `BossesDefeated` (global counter) still accepted.
- `ProgressionGraphCheckerTests`: non-boss target on a boss-only type warns; boss target is silent; non-boss-only type targeting a non-boss stays silent; retired non-boss target warns only about retirement.
- Ran: `Game.Application.Tests` filtered to `ProgressionGraphCheckerTests` (66 passed), `AdminChallengesIntegrationTests` (22 passed, Testcontainers), full `Content` namespace incl. `ContentGraphLintTests` (95 passed).

Closes #1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)