### PR TITLE
Share a NotSupportedException IPubSubService test fake base

### DIFF
--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -447,39 +447,22 @@ namespace Game.Api.Tests.Unit
             public void ReclaimAndForget(string key, string ownerValue, TimeSpan expiry) => throw new NotSupportedException();
         }
 
-        /// <summary>A pub/sub whose <c>Subscribe</c> throws, to drive the registration-rollback path.</summary>
-        private sealed class ThrowingSubscribePubSubService(Exception toThrow) : IPubSubService
+        /// <summary>A pub/sub whose <c>Subscribe</c> throws, to drive the registration-rollback path
+        /// (whose best-effort unsubscribe steps are tolerated as no-ops).</summary>
+        private sealed class ThrowingSubscribePubSubService(Exception toThrow) : NotSupportedPubSubService
         {
-            public Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => throw toThrow;
+            public override Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => throw toThrow;
 
-            public Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => throw new NotSupportedException();
-            public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => throw new NotSupportedException();
-            public Task Publish(string channel, string message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task Publish(string channel, string queueName, string queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task Publish<T>(string channel, string queueName, T queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task Wake(string channel) => throw new NotSupportedException();
-            public Task UnSubscribe(string channel) => Task.CompletedTask;
-            public Task UnSubscribe(string channel, string id) => Task.CompletedTask;
-            public IPubSubQueue GetQueue(string queueName) => throw new NotSupportedException();
+            public override Task UnSubscribe(string channel) => Task.CompletedTask;
+            public override Task UnSubscribe(string channel, string id) => Task.CompletedTask;
         }
 
         /// <summary>A pub/sub whose <c>Subscribe</c> succeeds but <c>UnSubscribe</c> throws, to drive the
         /// guarded-teardown path where the presence-key release must still run after an unsubscribe fault.</summary>
-        private sealed class ThrowingUnsubscribePubSubService(Exception toThrow) : IPubSubService
+        private sealed class ThrowingUnsubscribePubSubService(Exception toThrow) : NotSupportedPubSubService
         {
-            public Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => Task.CompletedTask;
-            public Task UnSubscribe(string channel, string id) => throw toThrow;
-
-            public Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => throw new NotSupportedException();
-            public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => throw new NotSupportedException();
-            public Task Publish(string channel, string message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task Publish(string channel, string queueName, string queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task Publish<T>(string channel, string queueName, T queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task Wake(string channel) => throw new NotSupportedException();
-            public Task UnSubscribe(string channel) => throw new NotSupportedException();
-            public IPubSubQueue GetQueue(string queueName) => throw new NotSupportedException();
+            public override Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => Task.CompletedTask;
+            public override Task UnSubscribe(string channel, string id) => throw toThrow;
         }
 
         /// <summary>Records the presence-key writes and releases so a rollback test can assert the exact

--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -1361,19 +1361,11 @@ namespace Game.Application.Tests.DataAccess
         /// A minimal <see cref="IPubSubService"/> stub whose <c>Subscribe</c> overloads always throw, used to verify
         /// that <see cref="DataProviderSynchronizer.StartAsync"/> propagates a subscribe failure rather than swallowing it.
         /// </summary>
-        private sealed class ThrowingPubSubService : IPubSubService
+        private sealed class ThrowingPubSubService : NotSupportedPubSubService
         {
-            public Task Publish(string channel, string message, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task Publish(string channel, string queueName, string queueData, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task Publish<T>(string channel, string queueName, T queueData, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task Wake(string channel) => Task.CompletedTask;
-            public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => throw new InvalidOperationException("Simulated subscribe failure.");
-            public Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => throw new InvalidOperationException("Simulated subscribe failure.");
-            public Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => throw new InvalidOperationException("Simulated subscribe failure.");
-            public Task UnSubscribe(string channel) => Task.CompletedTask;
-            public Task UnSubscribe(string channel, string id) => Task.CompletedTask;
-            public IPubSubQueue GetQueue(string queueName) => throw new NotSupportedException();
+            public override Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => throw new InvalidOperationException("Simulated subscribe failure.");
+            public override Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => throw new InvalidOperationException("Simulated subscribe failure.");
+            public override Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => throw new InvalidOperationException("Simulated subscribe failure.");
         }
 
         /// <summary>
@@ -1400,23 +1392,18 @@ namespace Game.Application.Tests.DataAccess
         /// <summary>
         /// An <see cref="IPubSubService"/> that exposes a single fixed queue for the player update queue (and a
         /// throwaway in-memory queue for any other name, e.g. the dead-letter queue) and treats every subscribe
-        /// as a no-op, so a test can drive only the startup drain over a queue it fully controls.
+        /// (and the id-scoped unsubscribe StopAsync issues) as a no-op, so a test can drive only the startup
+        /// drain over a queue it fully controls.
         /// </summary>
-        private sealed class SingleQueuePubSubService(IPubSubQueue playerQueue) : IPubSubService
+        private sealed class SingleQueuePubSubService(IPubSubQueue playerQueue) : NotSupportedPubSubService
         {
-            public IPubSubQueue GetQueue(string queueName) =>
+            public override IPubSubQueue GetQueue(string queueName) =>
                 queueName == Constants.PUBSUB_PLAYER_QUEUE ? playerQueue : new InMemoryPubSubQueue();
 
-            public Task Publish(string channel, string message, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task Publish(string channel, string queueName, string queueData, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task Publish<T>(string channel, string queueName, T queueData, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task Wake(string channel) => Task.CompletedTask;
-            public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => Task.CompletedTask;
-            public Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => Task.CompletedTask;
-            public Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => Task.CompletedTask;
-            public Task UnSubscribe(string channel) => Task.CompletedTask;
-            public Task UnSubscribe(string channel, string id) => Task.CompletedTask;
+            public override Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => Task.CompletedTask;
+            public override Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => Task.CompletedTask;
+            public override Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => Task.CompletedTask;
+            public override Task UnSubscribe(string channel, string id) => Task.CompletedTask;
         }
 
         /// <summary>

--- a/Game.Application.Tests/DataAccess/PlayerUpdateBatchTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerUpdateBatchTests.cs
@@ -1,5 +1,5 @@
-using Game.Abstractions.Infrastructure;
 using Game.DataAccess;
+using Game.TestInfrastructure.Helpers;
 using Xunit;
 
 namespace Game.Application.Tests.DataAccess
@@ -100,43 +100,21 @@ namespace Game.Application.Tests.DataAccess
 
         // Records each PublishBatch call's items rather than verifying call behavior via a mocking framework,
         // matching this project's classical (state-based) testing style.
-        private sealed class RecordingPubSubService : IPubSubService
+        private sealed class RecordingPubSubService : NotSupportedPubSubService
         {
             public List<List<object?>> Calls { get; } = [];
 
-            public Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default)
+            public override Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default)
             {
                 Calls.Add(queueData.Select(data => (object?)data).ToList());
                 return Task.CompletedTask;
             }
-
-            public Task Publish(string channel, string message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task Publish(string channel, string queueName, string queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task Publish<T>(string channel, string queueName, T queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task Wake(string channel) => throw new NotSupportedException();
-            public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => throw new NotSupportedException();
-            public Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => throw new NotSupportedException();
-            public Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => throw new NotSupportedException();
-            public Task UnSubscribe(string channel) => throw new NotSupportedException();
-            public Task UnSubscribe(string channel, string id) => throw new NotSupportedException();
-            public IPubSubQueue GetQueue(string queueName) => throw new NotSupportedException();
         }
 
-        private sealed class ThrowingPubSubService : IPubSubService
+        private sealed class ThrowingPubSubService : NotSupportedPubSubService
         {
-            public Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default)
+            public override Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default)
                 => throw new InvalidOperationException("Simulated transient publish failure.");
-
-            public Task Publish(string channel, string message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task Publish(string channel, string queueName, string queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task Publish<T>(string channel, string queueName, T queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task Wake(string channel) => throw new NotSupportedException();
-            public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => throw new NotSupportedException();
-            public Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => throw new NotSupportedException();
-            public Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => throw new NotSupportedException();
-            public Task UnSubscribe(string channel) => throw new NotSupportedException();
-            public Task UnSubscribe(string channel, string id) => throw new NotSupportedException();
-            public IPubSubQueue GetQueue(string queueName) => throw new NotSupportedException();
         }
     }
 }

--- a/Game.TestInfrastructure/Helpers/NotSupportedPubSubService.cs
+++ b/Game.TestInfrastructure/Helpers/NotSupportedPubSubService.cs
@@ -1,0 +1,24 @@
+using Game.Abstractions.Infrastructure;
+
+namespace Game.TestInfrastructure.Helpers
+{
+    /// <summary>
+    /// Base <see cref="IPubSubService"/> test fake whose every member throws <see cref="NotSupportedException"/>.
+    /// A test double derives from it and overrides only the members it means to exercise, so its intent stays
+    /// obvious and any accidental call to an unexercised member fails loudly instead of silently no-oping.
+    /// </summary>
+    public abstract class NotSupportedPubSubService : IPubSubService
+    {
+        public virtual Task Publish(string channel, string message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public virtual Task Publish(string channel, string queueName, string queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public virtual Task Publish<T>(string channel, string queueName, T queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public virtual Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public virtual Task Wake(string channel) => throw new NotSupportedException();
+        public virtual Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => throw new NotSupportedException();
+        public virtual Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => throw new NotSupportedException();
+        public virtual Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => throw new NotSupportedException();
+        public virtual Task UnSubscribe(string channel) => throw new NotSupportedException();
+        public virtual Task UnSubscribe(string channel, string id) => throw new NotSupportedException();
+        public virtual IPubSubQueue GetQueue(string queueName) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the duplicated `IPubSubService` test-fake stubs (#1541) into a single abstract base, `NotSupportedPubSubService`, in `Game.TestInfrastructure/Helpers`. Every member is `virtual` and throws `NotSupportedException`, so each fake now overrides only the members it means to exercise — its intent (record vs. throw vs. single-queue) is obvious at a glance, and any accidental call to an unexercised member fails loudly instead of silently no-oping.

Converted fakes:

- **PlayerUpdateBatchTests** — `RecordingPubSubService` and `ThrowingPubSubService` override only `PublishBatch` (the issue's original target).
- **DataProviderSynchronizerTests** — `ThrowingPubSubService` overrides only the three `Subscribe` overloads; `SingleQueuePubSubService` overrides `GetQueue`, the `Subscribe` overloads, and the id-scoped `UnSubscribe` that `StopAsync` issues. This also tightens both fakes: members the synchronizer never touches were silent `Task.CompletedTask` no-ops before and now throw. `SubscribeSuppressingPubSubService` is deliberately untouched — it delegates to a real inner service.
- **SocketCommandProcessorTests** (`Game.Api.Tests`) — the same duplication existed here, which is why the base lives in the shared `Game.TestInfrastructure` (the `FakeWebSocket`/`CapturingLogger` precedent) rather than `Game.Application.Tests`. `ThrowingSubscribePubSubService` and `ThrowingUnsubscribePubSubService` keep only their exercised members. `CapturingPubSubService` is left as a direct implementation: it deliberately no-ops nearly every member, so deriving would save nothing and would mislabel its intent.

Net effect: -79 lines of copy-pasted stubs across three test files for one 24-line shared base. Test-only change, no user-facing effect.

## Test notes

- `dotnet build` of `Game.Application.Tests` and `Game.Api.Tests`: clean, 0 warnings.
- `dotnet test` (existing suites are the coverage, no new tests):
  - `Game.Application.Tests` filtered to `PlayerUpdateBatchTests` + `DataProviderSynchronizerTests` (Testcontainers-backed): 33/33 passed.
  - `Game.Api.Tests` filtered to `SocketCommandProcessorTests`: 10/10 passed.

Closes #1541

🤖 Generated with [Claude Code](https://claude.com/claude-code)