### PR TITLE
Fix combat log entrance animation and per-entry scroll nudge

### DIFF
--- a/UI/src/components/log-panel/LogPanel.svelte
+++ b/UI/src/components/log-panel/LogPanel.svelte
@@ -33,9 +33,9 @@
 		<span class="log-count">{eventCount} events</span>
 	</div>
 
-	<div class="log-body" bind:this={scrollEl} onscroll={onScroll}>
+	<div class="log-body" data-testid="log-body" bind:this={scrollEl} onscroll={onScroll}>
 		{#each allLogs as log, i (log.id)}
-			<LogRow {log} index={i} isLatest={i === 0} animate={i === 0 && isNew && atTop} {rowHeight} />
+			<LogRow {log} index={i} isLatest={i === 0} animate={ready && atTop} {rowHeight} />
 		{/each}
 		{#if allLogs.length === 0}
 			<div class="log-empty">No combat activity yet.</div>
@@ -98,10 +98,11 @@ let scrollEl: HTMLDivElement | undefined;
 // `atTop` is read inside the effect via `untrack` so scroll changes don't
 // re-run the pinning effect — we only want it to react to new entries.
 let atTop = $state(true);
-// Tracks the id we've already processed, so the entrance animation plays only
-// for a freshly-arrived top row — not every time the list re-renders.
-let seenId = $state(0);
-const isNew = $derived(newestId !== seenId);
+// False during the first render so rows already in the store mount without the
+// entrance animation; keyed rows mounted afterwards are genuinely new entries.
+let ready = $state(false);
+// Newest id the pinning effect has already positioned for (plain — nothing reacts to it).
+let seenId = 0;
 
 const onScroll = () => {
 	if (scrollEl) {
@@ -109,22 +110,29 @@ const onScroll = () => {
 	}
 };
 
-// When a new entry arrives: if the user is pinned at the top, keep them there
-// and let the new row animate in (the stack slides down). If they've scrolled
-// back to read history, nudge scrollTop by one row so their view stays put.
+// When new entries arrive: if the user is pinned at the top, keep them there and
+// let the new rows animate in (the stack slides down). If they've scrolled back
+// to read history, nudge scrollTop one row per entry so their view stays put.
 $effect(() => {
 	const el = scrollEl;
+	const id = newestId;
 	if (el) {
 		if (untrack(() => atTop)) {
 			el.scrollTop = 0;
 		} else {
-			el.scrollTop += rowHeight;
+			// Ids are monotonic, so the delta counts this flush's new entries (one battle
+			// tick can append several); clamped because resetLogs() restarts the counter.
+			el.scrollTop += rowHeight * Math.max(0, id - seenId);
 		}
 	}
-	seenId = newestId; // mark this entry consumed (after positioning)
+	seenId = id;
 });
 
 onMount(() => {
+	// Mounted rows sample `animate` at creation, so flipping this after the first
+	// render arms the entrance animation for new rows only.
+	ready = true;
+
 	// Restore the persisted height after mount so SSR markup and the first client
 	// render agree (no hydration mismatch on the inline height). Clamp it against
 	// the live container so a height saved on a larger viewport can't overflow here.

--- a/UI/src/components/log-panel/LogRow.svelte
+++ b/UI/src/components/log-panel/LogRow.svelte
@@ -1,7 +1,7 @@
 <div
 	class="manifest-row"
 	class:latest={isLatest}
-	class:animate-in={animate}
+	class:animate-in={playEntrance}
 	style:height="{rowHeight}px"
 	style:opacity={rowOpacity}
 	style:background={isLatest
@@ -34,12 +34,17 @@ interface Props {
 	/** Position from the top (0 = newest). */
 	index: number;
 	isLatest: boolean;
-	/** Play the slide/grow entrance (only the newest row when pinned at top). */
+	/** Play the slide/grow entrance. Sampled once at mount — the animation is a
+	 *  mount-time effect, so later prop changes neither cancel nor replay it. */
 	animate: boolean;
 	rowHeight: number;
 }
 
 const { log, index, isLatest, animate, rowHeight }: Props = $props();
+
+// Deliberately non-reactive: captures whether this row was new when it appeared.
+// svelte-ignore state_referenced_locally
+const playEntrance = animate;
 
 const kind = $derived(logKind(log));
 // Newest row is fully prominent; older rows fade gently so the top reads as "now".

--- a/UI/src/tests/components/log-panel/LogPanel.test.ts
+++ b/UI/src/tests/components/log-panel/LogPanel.test.ts
@@ -1,20 +1,56 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+import { flushSync } from 'svelte';
 import { ELogType } from '$lib/api';
-import type { LogMessage } from '$lib/engine/log';
 import { MIN_LOG_PANEL_HEIGHT, DEFAULT_LOG_PANEL_HEIGHT } from '../../../components/log-panel/log-panel-view.svelte';
 
-const logData: LogMessage[] = [];
+// The panel reads `logs` from the store barrel; route the barrel to the real logs store so
+// tests can drive reactive updates via addLog/resetLogs without pulling in the rest of `$stores`.
+vi.mock('$stores', async () => await vi.importActual('$stores/logs.svelte'));
 
-vi.mock('$stores', () => ({
-	logs: () => logData
-}));
-
+import { addLog, resetLogs } from '$stores';
 import LogPanel from '../../../components/log-panel/LogPanel.svelte';
+
+// Mirrors the panel's fixed row height; the nudge arithmetic is asserted against it.
+const rowHeight = 30;
+
+// jsdom has no layout, so back scrollTop with a real read/write property the
+// pinning effect can add to and the scroll handler can read.
+const stubScrollTop = (el: HTMLElement, initial = 0) => {
+	let value = initial;
+	Object.defineProperty(el, 'scrollTop', {
+		configurable: true,
+		get: () => value,
+		set: (v: number) => {
+			value = v;
+		}
+	});
+};
+
+const renderPanel = () => {
+	render(LogPanel);
+	const body = screen.getByTestId('log-body');
+	stubScrollTop(body);
+	return body;
+};
+
+const scrollTo = async (el: HTMLElement, top: number) => {
+	el.scrollTop = top;
+	await fireEvent.scroll(el);
+};
+
+const addEntries = (count: number, message = 'You used Cleave and dealt 10 damage!') => {
+	for (let i = 0; i < count; i++) {
+		addLog(ELogType.Damage, message);
+	}
+	flushSync();
+};
+
+const rowClasses = (el: HTMLElement) => [...el.querySelectorAll('.manifest-row')].map((row) => row.classList);
 
 afterEach(() => {
 	cleanup();
-	logData.length = 0;
+	resetLogs();
 });
 
 describe('LogPanel', () => {
@@ -29,9 +65,8 @@ describe('LogPanel', () => {
 	});
 
 	it('renders log messages and the event count', () => {
-		// Stored newest-first (unshift), so id 2 is the newest entry.
-		logData.unshift({ id: 1, logType: ELogType.Damage, message: 'You used Cleave and dealt 10 damage!', timestamp: 0 });
-		logData.unshift({ id: 2, logType: ELogType.ItemFound, message: 'Unlocked: Iron Helm!', timestamp: 0 });
+		addLog(ELogType.Damage, 'You used Cleave and dealt 10 damage!');
+		addLog(ELogType.ItemFound, 'Unlocked: Iron Helm!');
 
 		render(LogPanel);
 		const panel = screen.getByTestId('log-panel');
@@ -41,12 +76,7 @@ describe('LogPanel', () => {
 	});
 
 	it('renders a skill-effect message with its dedicated glyph', () => {
-		logData.unshift({
-			id: 3,
-			logType: ELogType.SkillEffect,
-			message: 'You are empowered: +15 Strength for 5s',
-			timestamp: 0
-		});
+		addLog(ELogType.SkillEffect, 'You are empowered: +15 Strength for 5s');
 
 		render(LogPanel);
 		expect(screen.getByTestId('log-panel').textContent).toContain('You are empowered: +15 Strength for 5s');
@@ -93,5 +123,95 @@ describe('LogPanel', () => {
 		const handle = screen.getByTestId('log-resize-handle');
 		const notCancelled = await fireEvent.keyDown(handle, { key: 'a' });
 		expect(notCancelled).toBe(true); // default not prevented
+	});
+
+	describe('entrance animation', () => {
+		it('does not animate rows already in the store at first render', () => {
+			addLog(ELogType.Damage, 'old entry A');
+			addLog(ELogType.Damage, 'old entry B');
+
+			const body = renderPanel();
+			for (const classes of rowClasses(body)) {
+				expect(classes.contains('animate-in')).toBe(false);
+			}
+		});
+
+		it('animates every row of a burst arriving while pinned at the top', () => {
+			addLog(ELogType.Damage, 'pre-existing');
+			const body = renderPanel();
+
+			addEntries(2);
+			const classes = rowClasses(body);
+			expect(classes).toHaveLength(3);
+			expect(classes[0].contains('animate-in')).toBe(true); // newest
+			expect(classes[1].contains('animate-in')).toBe(true); // same burst
+			expect(classes[2].contains('animate-in')).toBe(false); // pre-existing row
+		});
+
+		it('does not animate rows arriving while the reader is scrolled back', async () => {
+			addEntries(5);
+			const body = renderPanel();
+			await scrollTo(body, 100);
+
+			addEntries(1, 'arrived off-screen');
+			expect(rowClasses(body)[0].contains('animate-in')).toBe(false);
+		});
+
+		it('does not retroactively animate a row when the reader scrolls back to the top', async () => {
+			addEntries(5);
+			const body = renderPanel();
+			await scrollTo(body, 100);
+			addEntries(1, 'arrived off-screen');
+
+			// Returning to the top must not re-add the class and replay the entrance.
+			await scrollTo(body, 0);
+			addEntries(1, 'arrived at top');
+			const classes = rowClasses(body);
+			expect(classes[0].contains('animate-in')).toBe(true); // new while pinned
+			expect(classes[1].contains('animate-in')).toBe(false); // still the off-screen arrival
+		});
+	});
+
+	describe('scroll pinning', () => {
+		it('keeps a top-pinned reader at the top across a multi-entry flush', () => {
+			addLog(ELogType.Damage, 'pre-existing');
+			const body = renderPanel();
+
+			addEntries(3);
+			expect(body.scrollTop).toBe(0);
+		});
+
+		it('nudges a back-scrolled reader one row per new entry in a flush', async () => {
+			addEntries(5);
+			const body = renderPanel();
+			await scrollTo(body, 100);
+
+			addEntries(3);
+			expect(body.scrollTop).toBe(100 + 3 * rowHeight);
+		});
+
+		it('nudges by new-entry count, not list length, once the store cap trims the tail', async () => {
+			addEntries(40); // store cap: further adds pop the oldest, keeping length at 40
+			const body = renderPanel();
+			await scrollTo(body, 100);
+
+			addEntries(2);
+			expect(body.scrollTop).toBe(100 + 2 * rowHeight);
+		});
+
+		it('clamps the nudge when resetLogs restarts the id counter', async () => {
+			addEntries(5);
+			const body = renderPanel();
+			await scrollTo(body, 100);
+
+			// Ids restart below the last seen id — the delta must clamp to zero, not jump backwards.
+			resetLogs();
+			addEntries(2);
+			expect(body.scrollTop).toBe(100);
+
+			// And the next entry nudges from the fresh baseline again.
+			addEntries(1);
+			expect(body.scrollTop).toBe(100 + rowHeight);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Two fixes to the combat log panel (`UI/src/components/log-panel`):

**1. Entrance animation self-cancelled before paint.** `animate` derived from `newestId !== seenId`, but the pinning `$effect` set `seenId = newestId` in the same flush, stripping the class before the browser ever painted it. The animation is now a mount-time effect: each keyed row (`log.id`) samples its `animate` prop once at creation, gated only by `atTop`. A first-render guard (`ready`, flipped in `onMount`) keeps a panel mounting over existing entries from flash-animating every row, and the mount-time sampling means scrolling back to the top can't retroactively replay a row's entrance. A side effect of the simpler gating: every row of a multi-entry burst animates in (previously only index 0), so the stack slides down smoothly instead of jumping N−1 rows.

**2. Back-scrolled readers were under-nudged on bursty ticks.** The effect nudged `scrollTop += rowHeight` once per flush, but one battle tick often appends several entries. The nudge now multiplies by the new-entry count computed from the monotonic log-id delta — clamped to zero because `resetLogs()` restarts the counter — and deliberately ignores array-length changes so the store's 40-entry tail-pop can't skew the math.

`LogRow`'s other consumer (the Options screen's `LivePreview`) already passes a mount-time-stable `animate` value, so its behavior is unchanged.

## Test notes

- `LogPanel.test.ts` now routes the `$stores` mock to the real logs store so tests drive reactive updates through `addLog`/`resetLogs`; `scrollTop` is property-stubbed since jsdom has no layout (per the issue triage, jsdom can't assert real animation playback, so the tests cover the animate-class gating and the nudge arithmetic).
- New cases: no animation on first render, burst rows animate while pinned, no animation while back-scrolled, no retroactive replay on scroll-to-top, pinned reader stays at top across a burst, N-entry burst nudges N×rowHeight, id-delta (not length) math at the 40-entry cap, and clamping across `resetLogs()`.
- Ran `vitest` over `src/tests/components` + `src/tests/routes/game` (1377 tests) plus the logs-store suite: all pass. `svelte-check`: 0 errors/warnings. ESLint on touched files: clean.
- Frontend-only visual fix — no battle-logic arithmetic changed, so no mirrored backend scenarios apply.

Closes #1510

🤖 Generated with [Claude Code](https://claude.com/claude-code)