### PR TITLE
Fix Synthesis Web view input handling: recenter-on-push, wheel preventDefault, pointer capture

### DIFF
--- a/UI/src/routes/game/screens/synthesis/SynthesisGraph.svelte
+++ b/UI/src/routes/game/screens/synthesis/SynthesisGraph.svelte
@@ -12,7 +12,6 @@
 	onpointermove={onPointerMove}
 	onpointerup={endDrag}
 	onpointerleave={endDrag}
-	onwheel={onWheel}
 	role="application"
 	aria-label="Recipe graph — drag to pan, scroll to zoom"
 >
@@ -43,8 +42,9 @@
 </div>
 
 <script lang="ts">
+import { onMount } from 'svelte';
 import { recipeStateAccent } from './synthesis';
-import { type SynthesisGraphLayout, type Viewport, zoomAt } from './synthesis-graph';
+import { isDragPastThreshold, type SynthesisGraphLayout, type Viewport, zoomAt } from './synthesis-graph';
 import SynthesisGraphNode from './SynthesisGraphNode.svelte';
 
 type Props = {
@@ -58,8 +58,12 @@ const { layout, selectedRecipeId, onSelect }: Props = $props();
 let container = $state<HTMLDivElement>();
 let vp = $state<Viewport>({ x: 0, y: 0, scale: 1 });
 
-// Drag-to-pan state. The pointer is captured so a drag that leaves the node still pans the canvas.
+// Drag-to-pan state. The pointer is captured only once the drag threshold is crossed — capturing on the
+// bare press would retarget the tail click away from the node/reset buttons and eat their activation.
 let dragging = false;
+let captured = false;
+let startX = 0;
+let startY = 0;
 let lastX = 0;
 let lastY = 0;
 
@@ -88,28 +92,47 @@ const lines = $derived(
 	})
 );
 
+// The content extent as primitive deriveds: the layout object is re-derived (new identity) on every
+// proficiency-XP push, so the recenter effect keys on these values, not the object.
+const layoutWidth = $derived(layout.width);
+const layoutHeight = $derived(layout.height);
+
 /** Centre the content in the container at scale 1 (the initial view + the reset action). */
 function recenter(): void {
-	if (!container || !layout.width) {
+	if (!container || !layoutWidth) {
 		return;
 	}
 	vp = {
 		scale: 1,
-		x: (container.clientWidth - layout.width) / 2,
-		y: (container.clientHeight - layout.height) / 2
+		x: (container.clientWidth - layoutWidth) / 2,
+		y: (container.clientHeight - layoutHeight) / 2
 	};
 }
 
 function onPointerDown(event: PointerEvent): void {
+	if (event.button !== 0) {
+		return;
+	}
 	dragging = true;
+	captured = false;
+	startX = event.clientX;
+	startY = event.clientY;
 	lastX = event.clientX;
 	lastY = event.clientY;
-	container?.setPointerCapture(event.pointerId);
 }
 
 function onPointerMove(event: PointerEvent): void {
 	if (!dragging) {
 		return;
+	}
+	// The press stays a plain click until the threshold; the first pan step then applies the accumulated
+	// delta (lastX/lastY still sit at the press point) so no travel is lost.
+	if (!captured) {
+		if (!isDragPastThreshold(startX, startY, event.clientX, event.clientY)) {
+			return;
+		}
+		captured = true;
+		container?.setPointerCapture(event.pointerId);
 	}
 	vp = { ...vp, x: vp.x + (event.clientX - lastX), y: vp.y + (event.clientY - lastY) };
 	lastX = event.clientX;
@@ -118,6 +141,7 @@ function onPointerMove(event: PointerEvent): void {
 
 function endDrag(event: PointerEvent): void {
 	dragging = false;
+	captured = false;
 	if (container?.hasPointerCapture(event.pointerId)) {
 		container.releasePointerCapture(event.pointerId);
 	}
@@ -135,12 +159,23 @@ function onWheel(event: WheelEvent): void {
 }
 
 // Recentre on mount (this runs once after the initial render, when `container` is bound) and whenever the
-// graph's content extent changes (recipe set / view switched). Reads only the layout dims + container, so
-// writing `vp` here can't loop.
+// graph's content extent *actually* changes (recipe set / view switched). Keying on the primitive dims —
+// never the layout object — keeps a same-extent re-derivation from stomping the user's pan/zoom.
 $effect(() => {
-	void layout.width;
-	void layout.height;
+	void layoutWidth;
+	void layoutHeight;
 	recenter();
+});
+
+// Registered manually with an explicit `passive: false`: the zoom relies on preventDefault to stop
+// ancestor scroll, and Svelte's forced-passive list has included `wheel` before — don't depend on it.
+onMount(() => {
+	const el = container;
+	if (!el) {
+		return;
+	}
+	el.addEventListener('wheel', onWheel, { passive: false });
+	return () => el.removeEventListener('wheel', onWheel);
 });
 </script>
 

--- a/UI/src/routes/game/screens/synthesis/synthesis-graph.ts
+++ b/UI/src/routes/game/screens/synthesis/synthesis-graph.ts
@@ -269,6 +269,15 @@ export interface Viewport {
 export const ZOOM_MIN = 0.4;
 export const ZOOM_MAX = 2.5;
 
+/** Pointer travel (px) below which a press stays a click; at or past it the press becomes a pan drag. */
+export const DRAG_THRESHOLD_PX = 4;
+
+/** True once the pointer has strayed far enough from the press point to count as a drag rather than a
+ *  click (Euclidean distance, so diagonal travel counts fully). */
+export function isDragPastThreshold(startX: number, startY: number, x: number, y: number): boolean {
+	return Math.hypot(x - startX, y - startY) >= DRAG_THRESHOLD_PX;
+}
+
 /** Clamp a zoom scale into the allowed band. */
 export const clampScale = (scale: number): number => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, scale));
 

--- a/UI/src/tests/routes/game/screens/synthesis/SynthesisGraph.test.ts
+++ b/UI/src/tests/routes/game/screens/synthesis/SynthesisGraph.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import SynthesisGraph from '$routes/game/screens/synthesis/SynthesisGraph.svelte';
+import type { SynthesisGraphLayout } from '$routes/game/screens/synthesis/synthesis-graph';
+
+/* Interaction contract of the graph canvas (issue #1505): the recenter effect keys on the content extent
+   (not the layout object identity, which changes on every proficiency-XP push), the pointer is captured
+   only once a real drag starts (so node/reset clicks aren't retargeted away), and wheel zoom runs through
+   a manual non-passive listener. jsdom can't assert passive-ness itself — that part is browser-only. */
+
+// jsdom lacks the pointer-capture API; install no-ops so the component's calls are observable via spies.
+if (typeof Element.prototype.setPointerCapture !== 'function') {
+	Element.prototype.setPointerCapture = () => {};
+}
+if (typeof Element.prototype.releasePointerCapture !== 'function') {
+	Element.prototype.releasePointerCapture = () => {};
+}
+if (typeof Element.prototype.hasPointerCapture !== 'function') {
+	Element.prototype.hasPointerCapture = () => false;
+}
+const setCapture = vi.spyOn(Element.prototype, 'setPointerCapture').mockImplementation(() => {});
+vi.spyOn(Element.prototype, 'releasePointerCapture').mockImplementation(() => {});
+vi.spyOn(Element.prototype, 'hasPointerCapture').mockImplementation(() => false);
+
+/** A minimal two-node layout; width/height drive the recenter math, so tests control them directly. */
+const makeLayout = (width: number, height: number): SynthesisGraphLayout => ({
+	nodes: [
+		{ key: 'f0', kind: 'fusion', x: 40, y: 40, recipeId: 0, state: 'ready', masked: false, selectable: true },
+		{ key: 'm0', kind: 'result', x: 120, y: 40, recipeId: 0, state: 'ready', masked: true, selectable: true }
+	],
+	edges: [{ key: 'f0->m0', from: 'f0', to: 'm0', state: 'ready' }],
+	width,
+	height
+});
+
+const setup = (layout: SynthesisGraphLayout = makeLayout(300, 200)) => {
+	const onSelect = vi.fn();
+	const rendered = render(SynthesisGraph, { props: { layout, selectedRecipeId: null, onSelect } });
+	const canvas = rendered.getByTestId('synthesis-graph');
+	const viewport = canvas.querySelector('.viewport') as HTMLElement;
+	return { ...rendered, onSelect, canvas, viewport };
+};
+
+/** Drag the pointer on the canvas from `from` to `to` (primary button) without releasing. */
+const drag = async (canvas: HTMLElement, from: [number, number], to: [number, number]) => {
+	await fireEvent.pointerDown(canvas, { button: 0, pointerId: 1, clientX: from[0], clientY: from[1] });
+	await fireEvent.pointerMove(canvas, { pointerId: 1, clientX: to[0], clientY: to[1] });
+};
+
+beforeEach(() => setCapture.mockClear());
+afterEach(() => cleanup());
+
+describe('SynthesisGraph — recenter vs pan', () => {
+	// jsdom containers have zero clientWidth/Height, so recenter yields translate(-w/2, -h/2) at scale 1.
+	it('recenters on mount from the layout extent', () => {
+		const { viewport } = setup(makeLayout(300, 200));
+		expect(viewport.style.transform).toBe('translate(-150px, -100px) scale(1)');
+	});
+
+	it('preserves the user pan when the layout is re-derived with the same extent', async () => {
+		const { canvas, viewport, rerender } = setup(makeLayout(300, 200));
+		await drag(canvas, [100, 100], [140, 120]);
+		await fireEvent.pointerUp(canvas, { pointerId: 1 });
+		expect(viewport.style.transform).toBe('translate(-110px, -80px) scale(1)');
+
+		// A new layout object with the identical extent — the idle loop's XP-push re-derivation shape.
+		await rerender({ layout: makeLayout(300, 200) });
+		expect(viewport.style.transform).toBe('translate(-110px, -80px) scale(1)');
+	});
+
+	it('still recenters when the content extent actually changes', async () => {
+		const { canvas, viewport, rerender } = setup(makeLayout(300, 200));
+		await drag(canvas, [100, 100], [140, 120]);
+		await fireEvent.pointerUp(canvas, { pointerId: 1 });
+
+		await rerender({ layout: makeLayout(400, 300) });
+		expect(viewport.style.transform).toBe('translate(-200px, -150px) scale(1)');
+	});
+});
+
+describe('SynthesisGraph — pointer capture and node clicks', () => {
+	it('does not capture the pointer on a plain press, so a node click still selects', async () => {
+		const { canvas, viewport, onSelect, getByTestId } = setup();
+		const node = getByTestId('graph-node-result-0');
+		const before = viewport.style.transform;
+
+		await fireEvent.pointerDown(node, { button: 0, pointerId: 1, clientX: 10, clientY: 10 });
+		// Sub-threshold jitter stays a click: no capture, no pan.
+		await fireEvent.pointerMove(canvas, { pointerId: 1, clientX: 12, clientY: 11 });
+		await fireEvent.pointerUp(canvas, { pointerId: 1 });
+		await fireEvent.click(node);
+
+		expect(setCapture).not.toHaveBeenCalled();
+		expect(viewport.style.transform).toBe(before);
+		expect(onSelect).toHaveBeenCalledWith(0);
+	});
+
+	it('captures the pointer only once the drag threshold is crossed', async () => {
+		const { canvas } = setup();
+		await fireEvent.pointerDown(canvas, { button: 0, pointerId: 1, clientX: 100, clientY: 100 });
+		await fireEvent.pointerMove(canvas, { pointerId: 1, clientX: 101, clientY: 100 });
+		expect(setCapture).not.toHaveBeenCalled();
+
+		await fireEvent.pointerMove(canvas, { pointerId: 1, clientX: 110, clientY: 100 });
+		expect(setCapture).toHaveBeenCalledTimes(1);
+	});
+
+	it('ignores non-primary-button presses entirely', async () => {
+		const { canvas, viewport } = setup();
+		const before = viewport.style.transform;
+
+		await fireEvent.pointerDown(canvas, { button: 2, pointerId: 1, clientX: 100, clientY: 100 });
+		await fireEvent.pointerMove(canvas, { pointerId: 1, clientX: 200, clientY: 180 });
+
+		expect(setCapture).not.toHaveBeenCalled();
+		expect(viewport.style.transform).toBe(before);
+	});
+});
+
+describe('SynthesisGraph — wheel zoom', () => {
+	it('zooms via the manually registered wheel listener and cancels the event', async () => {
+		const { canvas, viewport } = setup();
+		// fireEvent returns false when preventDefault was called — proof the handler cancels the scroll.
+		const notPrevented = await fireEvent.wheel(canvas, { deltaY: -100, clientX: 50, clientY: 50 });
+		expect(notPrevented).toBe(false);
+		expect(viewport.style.transform).toContain('scale(1.1)');
+	});
+});

--- a/UI/src/tests/routes/game/screens/synthesis/synthesis-graph.test.ts
+++ b/UI/src/tests/routes/game/screens/synthesis/synthesis-graph.test.ts
@@ -3,6 +3,8 @@ import { EDamageType, ERarity, ESkillAcquisition, type IProficiency, type ISkill
 import { buildSynthesis, type RecipeView } from '$routes/game/screens/synthesis/synthesis';
 import {
 	clampScale,
+	DRAG_THRESHOLD_PX,
+	isDragPastThreshold,
 	layoutSynthesisGraph,
 	NODE_SIZE,
 	ZOOM_MAX,
@@ -202,5 +204,27 @@ describe('pan / zoom helpers', () => {
 		const vp = { x: 30, y: -10, scale: ZOOM_MAX };
 		// Already at max — zooming in further is a clamped no-op, so the viewport is unchanged.
 		expect(zoomAt(vp, 2, 100, 100)).toEqual(vp);
+	});
+});
+
+describe('isDragPastThreshold', () => {
+	it('keeps sub-threshold jitter a click', () => {
+		expect(isDragPastThreshold(100, 100, 102, 101)).toBe(false);
+		expect(isDragPastThreshold(100, 100, 100, 100)).toBe(false);
+	});
+
+	it('crosses exactly at the threshold distance', () => {
+		expect(isDragPastThreshold(100, 100, 100 + DRAG_THRESHOLD_PX, 100)).toBe(true);
+	});
+
+	it('measures Euclidean distance so diagonal travel counts fully', () => {
+		// 3px on each axis is ~4.24px of travel — past the threshold even though neither axis alone is.
+		expect(isDragPastThreshold(0, 0, 3, 3)).toBe(true);
+		expect(isDragPastThreshold(0, 0, 2, 2)).toBe(false);
+	});
+
+	it('is direction-agnostic', () => {
+		expect(isDragPastThreshold(10, 10, 10 - DRAG_THRESHOLD_PX, 10)).toBe(true);
+		expect(isDragPastThreshold(10, 10, 10, 10 - DRAG_THRESHOLD_PX)).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the three interaction bugs in `UI/src/routes/game/screens/synthesis/SynthesisGraph.svelte` from #1505:

1. **Recenter no longer stomps pan/zoom on every XP push.** The recenter `$effect` read `layout.width`/`layout.height` off the `layout` prop, so every `ProficiencyXpGained` push (which re-derives `SynthesisView.graph` as a new object identity) re-fired it and reset the viewport. The extent is now exposed as primitive `$derived` values (`layoutWidth`/`layoutHeight`) that the effect and `recenter()` key on — a same-extent re-derivation leaves the user's pan/zoom alone, while a real extent change (recipe set changed) still recenters.
2. **Wheel zoom uses a manual non-passive listener.** The template `onwheel` is replaced with an `addEventListener('wheel', onWheel, { passive: false })` in `onMount` (with cleanup), the same pattern as `ManifestWindow.svelte`. One honest note on the issue's premise: the currently installed Svelte (5.56.3) no longer forces `wheel` into its passive-event list (`PASSIVE_EVENTS` is just `touchstart`/`touchmove` now), so `preventDefault` was not an active no-op on this version. Earlier Svelte 5 releases *did* force it passive, and the zoom depends on `preventDefault` stopping ancestor scroll, so the explicit `passive: false` registration pins that contract rather than leaning on a framework default that has already flipped once.
3. **Pointer capture is guarded and deferred.** `onPointerDown` ignores non-primary buttons and no longer calls `setPointerCapture` on the bare press. Capture is taken only once the pointer travels past a small threshold (`isDragPastThreshold`, 4px Euclidean, extracted as a pure helper in `synthesis-graph.ts`), so a plain click reaches the graph-node and reset-view buttons instead of being retargeted to the canvas; once a drag really starts, capture keeps the pan alive off-element and the post-drag click retargets away from the node (no accidental select after a pan). The first pan step applies the accumulated pre-threshold delta so no travel is lost.

## Tests

- `synthesis-graph.test.ts`: unit tests for `isDragPastThreshold` (sub-threshold jitter, exact threshold, Euclidean diagonals, direction-agnostic). Existing layout/zoom tests unchanged and passing.
- `SynthesisGraph.test.ts` (new component suite): recenter on mount; pan preserved across a same-extent layout identity change (the XP-push shape); recenter still fires on a real extent change; plain press + sub-threshold jitter takes no capture and the node click still selects; capture only after the threshold; non-primary-button presses ignored; wheel zooms through the manually registered listener and cancels the event (`fireEvent.wheel` returning `false` proves `preventDefault` ran).
- Whether the listener is *non-passive* is not assertable in jsdom (jsdom ignores passive semantics), so that specific property is deliberately untested rather than covered by a vacuous test.
- Ran: `npx vitest run src/tests/routes/game/screens/synthesis` (6 files, 64 tests, all passing), `npm run check` (0 errors/warnings), eslint + prettier on the changed files. Frontend-only change — no backend/battle-logic surface touched.

Closes #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)