### PR TITLE
Fix Codex correctness gaps: retired challenges, retired deep-links, swallowed load errors

### DIFF
--- a/UI/src/routes/game/screens/codex/Codex.svelte
+++ b/UI/src/routes/game/screens/codex/Codex.svelte
@@ -23,7 +23,7 @@
 
 <script lang="ts">
 import { onMount } from 'svelte';
-import { navigation, playerChallenges, statistics } from '$stores';
+import { navigation, playerChallenges, statistics, toastError } from '$stores';
 import { CodexView, type CodexNavPayload } from './codex-view.svelte';
 import CodexTabBar from './CodexTabBar.svelte';
 import EnemiesTab from './EnemiesTab.svelte';
@@ -40,6 +40,12 @@ onMount(async () => {
 	view.stats = statistics.stats;
 	view.statsError = statistics.error;
 	view.statsLoading = false;
+	view.challengesError = playerChallenges.error;
+	if (playerChallenges.error) {
+		// Don't conflate a failed load with genuine sealed/zero-progress challenges — a dropped fetch
+		// would otherwise render every enemy-scoped challenge as if it had no progress.
+		toastError('Your challenge progress could not be loaded. Please try again later.');
+	}
 });
 </script>
 

--- a/UI/src/routes/game/screens/codex/EnemyChallengesPanel.svelte
+++ b/UI/src/routes/game/screens/codex/EnemyChallengesPanel.svelte
@@ -1,17 +1,21 @@
 <!-- Challenges sub-tab: the challenges scoped to this enemy, with the player's progress. -->
 <div class="challenges">
 	<div class="label">Related challenges · {view.challenges.length}</div>
-	<div class="list">
-		{#each view.challenges as challenge (challenge.id)}
-			<div class="challenge" style:--ch-accent={challenge.accent}>
-				<div class="text">
-					<div class="name">{challenge.name}</div>
-					<div class="type">{challenge.typeLabel}</div>
+	{#if view.challengesError}
+		<div class="note">Your challenge progress could not be loaded.</div>
+	{:else}
+		<div class="list">
+			{#each view.challenges as challenge (challenge.id)}
+				<div class="challenge" style:--ch-accent={challenge.accent}>
+					<div class="text">
+						<div class="name">{challenge.name}</div>
+						<div class="type">{challenge.typeLabel}</div>
+					</div>
+					<span class="prog" class:done={challenge.completed}>{challenge.progressText}</span>
 				</div>
-				<span class="prog" class:done={challenge.completed}>{challenge.progressText}</span>
-			</div>
-		{/each}
-	</div>
+			{/each}
+		</div>
+	{/if}
 </div>
 
 <script lang="ts">
@@ -81,5 +85,12 @@ let { view }: Props = $props();
 	&.done {
 		color: var(--success);
 	}
+}
+
+.note {
+	font-size: 12px;
+	color: var(--text-tertiary);
+	font-style: italic;
+	line-height: 1.5;
 }
 </style>

--- a/UI/src/routes/game/screens/codex/codex-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/codex-view.svelte.ts
@@ -284,6 +284,9 @@ export class CodexView {
 	stats = $state<IPlayerStatistic[]>([]);
 	statsLoading = $state(true);
 	statsError = $state(false);
+	/** Whether the mount-time challenge-progress fetch failed — surfaced so the enemy dossier's
+	 *  Challenges sub-tab doesn't render zero-progress/sealed as if it were authoritative. */
+	challengesError = $state(false);
 
 	constructor(payload?: CodexNavPayload) {
 		if (payload?.tab) {
@@ -371,9 +374,12 @@ export class CodexView {
 
 	/* ── selected enemy + dossier ──────────────────────────────────────────────── */
 
-	/** The inspected enemy, falling back to the head of the visible rows, then the full list. */
+	/** The inspected enemy: an explicitly-requested id resolves even when retired (retirement keeps a
+	 *  record's slot resolvable by design — see backend.md → _Reference Data_), so a cross-link into a
+	 *  retired enemy opens it rather than silently falling back. With no resolvable explicit id, falls
+	 *  back to the head of the visible rows, then the full live list. */
 	readonly selectedEnemy = $derived.by<IEnemy | undefined>(() => {
-		const explicit = this.enemies.find((e) => e.id === this.selectedEnemyId);
+		const explicit = (staticData.enemies ?? [])[this.selectedEnemyId];
 		if (explicit) {
 			return explicit;
 		}
@@ -467,23 +473,28 @@ export class CodexView {
 		}
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient lookup, not held state
 		const progressById = new Map(playerChallenges.all.map((pc) => [pc.challengeId, pc]));
-		return (staticData.challenges ?? [])
-			.filter((c) => c.entityType === EEntityType.Enemy && c.targetEntityId === e.id)
-			.map((c) => {
-				const pc = progressById.get(c.id);
-				const progress = pc?.progress ?? 0;
-				const completed = pc?.completed ?? false;
-				const progressText =
-					c.progressGoal === 1 ? (completed ? 'done' : 'sealed') : `${Math.round(progress)}/${c.progressGoal}`;
-				return {
-					id: c.id,
-					name: c.name,
-					typeLabel: challengeTypeName(c.challengeTypeId, staticData.challengeTypes),
-					accent: challengeTypeColor(c.challengeTypeId),
-					progressText,
-					completed
-				};
-			});
+		return (
+			(staticData.challenges ?? [])
+				.filter((c) => c.entityType === EEntityType.Enemy && c.targetEntityId === e.id)
+				// A retired challenge is out of circulation: hide it unless the player already completed it
+				// (mirrors the Challenges screen's retired-unless-completed rule).
+				.filter((c) => c.retiredAt == null || progressById.get(c.id)?.completed)
+				.map((c) => {
+					const pc = progressById.get(c.id);
+					const progress = pc?.progress ?? 0;
+					const completed = pc?.completed ?? false;
+					const progressText =
+						c.progressGoal === 1 ? (completed ? 'done' : 'sealed') : `${Math.round(progress)}/${c.progressGoal}`;
+					return {
+						id: c.id,
+						name: c.name,
+						typeLabel: challengeTypeName(c.challengeTypeId, staticData.challengeTypes),
+						accent: challengeTypeColor(c.challengeTypeId),
+						progressText,
+						completed
+					};
+				})
+		);
 	});
 
 	/** Dossier sub-tabs — Challenges only when the enemy has related challenges. */
@@ -521,10 +532,9 @@ export class CodexView {
 
 	/* ── selected zone + dossier ────────────────────────────────────────────────── */
 
-	/** The inspected zone, falling back to the head of the rail. */
-	readonly selectedZone = $derived<IZone | undefined>(
-		this.zones.find((z) => z.id === this.selectedZoneId) ?? this.zones[0]
-	);
+	/** The inspected zone: an explicitly-requested id resolves even when retired (see `selectedEnemy`),
+	 *  falling back to the head of the rail otherwise. */
+	readonly selectedZone = $derived<IZone | undefined>((staticData.zones ?? [])[this.selectedZoneId] ?? this.zones[0]);
 
 	/** The selected zone's level band (`11–22`). */
 	readonly zoneBand = $derived.by<string>(() => {
@@ -612,9 +622,10 @@ export class CodexView {
 
 	/* ── selected skill + dossier ─────────────────────────────────────────────────── */
 
-	/** The inspected skill, falling back to the head of the catalogue. */
+	/** The inspected skill: an explicitly-requested id resolves even when retired (see `selectedEnemy`),
+	 *  falling back to the head of the catalogue otherwise. */
 	readonly selectedSkill = $derived<ISkill | undefined>(
-		this.skillsCatalogue.find((s) => s.id === this.selectedSkillId) ?? this.skillsCatalogue[0]
+		(staticData.skills ?? [])[this.selectedSkillId] ?? this.skillsCatalogue[0]
 	);
 
 	/** The selected skill's rarity tier (hue + label) for the dossier header accent. */
@@ -775,22 +786,22 @@ export class CodexView {
 		}));
 	}
 
-	/** Resolve an enemy id against the catalogue, falling back to the head of the list. */
+	/** Resolve an enemy id against the full catalogue (an explicit id resolves even when retired),
+	 *  falling back to the head of the live list. */
 	private resolveEnemy(id: number): IEnemy | undefined {
-		const enemies = liveEnemies(staticData.enemies);
-		return enemies.find((e) => e.id === id) ?? enemies[0];
+		return (staticData.enemies ?? [])[id] ?? liveEnemies(staticData.enemies)[0];
 	}
 
-	/** Resolve a zone id against the rail (authored order), falling back to the head. */
+	/** Resolve a zone id against the full catalogue (an explicit id resolves even when retired),
+	 *  falling back to the head of the rail (authored order). */
 	private resolveZone(id: number): IZone | undefined {
-		const zones = liveZones(staticData.zones);
-		return zones.find((z) => z.id === id) ?? zones[0];
+		return (staticData.zones ?? [])[id] ?? liveZones(staticData.zones)[0];
 	}
 
-	/** Resolve a skill id against the catalogue, falling back to the head. */
+	/** Resolve a skill id against the full catalogue (an explicit id resolves even when retired),
+	 *  falling back to the head of the live catalogue. */
 	private resolveSkill(id: number): ISkill | undefined {
-		const skills = liveSkills(staticData.skills);
-		return skills.find((s) => s.id === id) ?? skills[0];
+		return (staticData.skills ?? [])[id] ?? liveSkills(staticData.skills)[0];
 	}
 
 	/** A zone is locked when it carries an unlock gate the player hasn't completed yet. */

--- a/UI/src/routes/game/screens/codex/codex-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/codex-view.svelte.ts
@@ -384,7 +384,7 @@ export class CodexView {
 			return explicit;
 		}
 		const firstVisible = this.enemyRows[0];
-		return (firstVisible && this.enemies.find((e) => e.id === firstVisible.id)) ?? this.enemies[0];
+		return (firstVisible && (staticData.enemies ?? [])[firstVisible.id]) ?? this.enemies[0];
 	});
 
 	readonly range = $derived.by<LevelRange | undefined>(() => {

--- a/UI/src/tests/routes/game/screens/codex/Codex.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/Codex.test.ts
@@ -15,8 +15,9 @@ import { SERVER_STAT_TYPES } from '../stats/stat-fixtures';
 // Codex fetches the player's statistics + challenges over the socket and resolves reference data
 // from staticData. Mock the socket fetch and replace staticData; keep the real statistics /
 // playerChallenges / navigation stores (the screen drives them).
-const { mockFetchSocket, staticData } = vi.hoisted(() => ({
+const { mockFetchSocket, mockToastError, staticData } = vi.hoisted(() => ({
 	mockFetchSocket: vi.fn(),
+	mockToastError: vi.fn(),
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	staticData: {} as any
 }));
@@ -27,7 +28,7 @@ vi.mock('$lib/api', async (importOriginal) => {
 });
 vi.mock('$stores', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('$stores')>();
-	return { ...actual, staticData };
+	return { ...actual, staticData, toastError: mockToastError };
 });
 
 import Codex from '$routes/game/screens/codex/Codex.svelte';
@@ -138,6 +139,7 @@ beforeEach(() => {
 	playerChallenges.reset();
 	navigation.clear();
 	navigation.consumePayload();
+	mockToastError.mockClear();
 	mockFetchSocket.mockImplementation((cmd: string) => {
 		if (cmd === 'GetPlayerStatistics') {
 			return Promise.resolve(STATS);
@@ -259,6 +261,16 @@ describe('Codex screen', () => {
 		expect(screen.getByTestId('codex-dossier').textContent).toContain('Cinder Tyrant');
 	});
 
+	it('cross-links a zone boss card into the enemy dossier even when the boss is retired', async () => {
+		// A retired boss stays resolvable by id; the boss card must open its own dossier, not
+		// silently fall back to the head of the (now filtered) enemy table.
+		staticData.enemies[2] = { ...staticData.enemies[2], retiredAt: '2026-01-01T00:00:00Z' };
+		render(Codex);
+		await fireEvent.click(screen.getByTestId('codex-tab-zones'));
+		await fireEvent.click(screen.getByTestId('codex-zone-boss'));
+		expect(screen.getByTestId('codex-dossier').textContent).toContain('Cinder Tyrant');
+	});
+
 	it('cross-links a zone spawn row into the enemy dossier', async () => {
 		render(Codex);
 		await fireEvent.click(screen.getByTestId('codex-tab-zones'));
@@ -326,5 +338,23 @@ describe('Codex screen', () => {
 		render(Codex);
 		await fireEvent.click(screen.getByTestId('codex-subtab-statistics'));
 		expect(await screen.findByText('Your statistics could not be loaded.')).toBeTruthy();
+	});
+
+	it('toasts and surfaces a load error in the challenges sub-tab instead of rendering fake progress', async () => {
+		mockFetchSocket.mockImplementation((cmd: string) =>
+			cmd === 'GetPlayerChallenges' ? Promise.reject(new Error('down')) : Promise.resolve([])
+		);
+		render(Codex);
+		await fireEvent.click(screen.getByTestId('codex-subtab-challenges'));
+		expect(await screen.findByText('Your challenge progress could not be loaded.')).toBeTruthy();
+		expect(screen.queryByText('62/100')).toBeNull();
+		expect(mockToastError).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not toast when challenge progress loads successfully', async () => {
+		render(Codex);
+		await fireEvent.click(screen.getByTestId('codex-subtab-challenges'));
+		await screen.findByText('Cull the Skitterers');
+		expect(mockToastError).not.toHaveBeenCalled();
 	});
 });

--- a/UI/src/tests/routes/game/screens/codex/codex-view.svelte.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/codex-view.svelte.test.ts
@@ -418,6 +418,29 @@ describe('CodexView dossier projections', () => {
 		expect(view.challenges[0].progressText).toBe('sealed');
 	});
 
+	it('hides a retired enemy-scoped challenge unless it was already completed', () => {
+		staticData.challenges = [
+			...staticData.challenges,
+			{
+				id: 2,
+				name: 'Old Bounty',
+				challengeTypeId: EChallengeType.EnemiesKilled,
+				entityType: EEntityType.Enemy,
+				targetEntityId: 0,
+				progressGoal: 50,
+				retiredAt: '2026-01-01T00:00:00Z'
+			}
+		];
+		const uncompleted = new CodexView();
+		uncompleted.selectEnemy(0);
+		expect(uncompleted.challenges.map((c) => c.id)).toEqual([0]);
+
+		playerChallenges.all = [...playerChallenges.all, { challengeId: 2, progress: 50, completed: true }];
+		const completed = new CodexView();
+		completed.selectEnemy(0);
+		expect(completed.challenges.map((c) => c.id)).toEqual(expect.arrayContaining([0, 2]));
+	});
+
 	it('sorts spawn shares descending and collapses a boss to a single Encounter', () => {
 		const view = new CodexView();
 		view.selectEnemy(0);
@@ -784,6 +807,50 @@ describe('CodexView skill → enemy cross-link', () => {
 		view.openEnemy(2);
 		expect(view.tab).toBe('enemies');
 		expect(view.selectedEnemyId).toBe(2);
+	});
+});
+
+describe('CodexView retired-record resolution', () => {
+	// Retirement keeps a record's slot resolvable by id (backend.md → _Reference Data_); an explicitly
+	// requested retired id must resolve to the actual record rather than silently falling back to the
+	// head of the live list.
+	it('resolves a deep-linked retired enemy id instead of falling back to the head of the list', () => {
+		staticData.enemies[1] = { ...staticData.enemies[1], retiredAt: '2026-01-01T00:00:00Z' };
+		const view = new CodexView({ tab: 'enemies', enemyId: 1 });
+		expect(view.selectedEnemy?.id).toBe(1);
+	});
+
+	it('selectEnemy resolves a retired id (a cross-link into a retired record)', () => {
+		staticData.enemies[1] = { ...staticData.enemies[1], retiredAt: '2026-01-01T00:00:00Z' };
+		const view = new CodexView();
+		view.selectEnemy(1);
+		expect(view.selectedEnemy?.id).toBe(1);
+	});
+
+	it('resolves a deep-linked retired zone id', () => {
+		staticData.zones[1] = { ...staticData.zones[1], retiredAt: '2026-01-01T00:00:00Z' };
+		const view = new CodexView({ tab: 'zones', zoneId: 1 });
+		expect(view.selectedZone?.id).toBe(1);
+	});
+
+	it('selectZone resolves a retired id', () => {
+		staticData.zones[1] = { ...staticData.zones[1], retiredAt: '2026-01-01T00:00:00Z' };
+		const view = new CodexView();
+		view.selectZone(1);
+		expect(view.selectedZone?.id).toBe(1);
+	});
+
+	it('resolves a deep-linked retired skill id', () => {
+		staticData.skills[1] = { ...staticData.skills[1], retiredAt: '2026-01-01T00:00:00Z' };
+		const view = new CodexView({ tab: 'skills', skillId: 1 });
+		expect(view.selectedSkill?.id).toBe(1);
+	});
+
+	it('selectSkill resolves a retired id', () => {
+		staticData.skills[1] = { ...staticData.skills[1], retiredAt: '2026-01-01T00:00:00Z' };
+		const view = new CodexView();
+		view.selectSkill(1);
+		expect(view.selectedSkill?.id).toBe(1);
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes three related correctness gaps in the Codex screen (`UI/src/routes/game/screens/codex/`) described in #1507:

1. **Enemy dossiers showed retired-but-uncompleted challenges forever.** `codex-view.svelte.ts`'s enemy-scoped `challenges` derivation had no `retiredAt` check, unlike the Challenges screen's documented retired-unless-completed rule. A retired incomplete challenge now hides from the dossier (still shows if the player already completed it before it retired, since that reward was already earned).
2. **Deep-links/cross-links into a retired record silently opened the wrong dossier.** `selectedEnemy`/`selectedZone`/`selectedSkill` (and the constructor's deep-link resolvers) resolved an id against the *live-filtered* catalogue, so a retired-record reference (a Statistics row, an enemy's skill-pool row, a zone boss card) fell back to the head of the list instead of opening the actual record. These now resolve an explicitly-requested id against the full catalogue first (retirement keeps a record's slot resolvable by id, per `backend.md`'s Reference Data convention), falling back to the head of the live list only when there's no explicit id.
3. **Codex swallowed challenge-progress load failures.** `Codex.svelte` never read `playerChallenges.error` or called `toastError`, so a failed load rendered every enemy-scoped challenge as authoritative "sealed"/zero-progress — the exact error-collapsed-into-friendly-state pattern `frontend-screens.md` forbids elsewhere (Statistics/Challenges both toast on this). Codex now toasts on failure, and the enemy dossier's Challenges sub-tab shows an inline "could not be loaded" note instead of the (potentially fake) progress list.

## Scope note

The zone-unlock "sealed" indicator and the zone rail's locked/unlocked status also read `playerChallenges` and would show a stale-but-safe (fail-closed) value during the same transient failure. I left those as-is rather than introducing a tri-state status, since that's a larger structural change than this bug fix calls for — the toast at least surfaces that the state may be stale. Happy to open a follow-up if a tri-state is wanted there.

## Test plan

- [x] Added/updated unit tests in `codex-view.svelte.test.ts` (retired-challenge filtering; retired-record resolution for enemy/zone/skill via deep-link payload and `selectEnemy`/`selectZone`/`selectSkill`)
- [x] Added component tests in `Codex.test.ts` (challenge-load-error toast + inline note; boss-card cross-link into a retired enemy's dossier)
- [x] `npx vitest run` — 281 files / 3295 tests pass
- [x] `npm run lint` (eslint + svelte-check) — clean

Closes #1507


---
_Generated by [Claude Code](https://claude.ai/code/session_011NAsQBz4CjmUMPtnTmJ7fJ)_