### PR TITLE
Fix Workbench editor state bugs: phantom dirty, save-selection jump, dirty-token color

### DIFF
--- a/UI/src/routes/admin/workbench/Workbench.svelte
+++ b/UI/src/routes/admin/workbench/Workbench.svelte
@@ -76,9 +76,17 @@ const flagged = $derived.by(() => {
 	return s ? liveItems.filter((it) => s.stateOf(it).warnings.length > 0).length : 0;
 });
 
-// If the selected record was removed (e.g. deleted then saved), fall back to the first.
+// After a save, a selected-but-unsaved record's temporary negative id no longer matches any
+// item — follow it to its persisted id first, and only fall back to the first record (e.g.
+// the selection was actually deleted then saved) when no remap exists for it.
 $effect(() => {
-	if (store && selected && selected.id !== selId) {
+	if (!store) {
+		return;
+	}
+	const persistedId = store.lastIdMap.get(selId);
+	if (persistedId !== undefined) {
+		selId = persistedId;
+	} else if (selected && selected.id !== selId) {
 		selId = selected.id;
 	}
 });

--- a/UI/src/routes/admin/workbench/components/challenge/ChallengeRewardSection.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/ChallengeRewardSection.svelte
@@ -85,6 +85,7 @@ import { ERarity, type IChallenge } from '$lib/api';
 import { Popover } from '$components';
 import { reference } from '../../reference.svelte';
 import type { EntityStore } from '../../entity-store.svelte';
+import { recordsEqual } from '../../entity-store.svelte';
 import type { Identified } from '../../entities/types';
 import { claimedItemMap, claimedModMap } from '../../entities/challenge-helpers';
 import WorkbenchIcon from '../../WorkbenchIcon.svelte';
@@ -116,8 +117,8 @@ const liveChallenges = $derived(store.items.filter((it) => store.status(it) !== 
 const claimedItems = $derived(claimedItemMap(liveChallenges, challenge.id));
 const claimedMods = $derived(claimedModMap(liveChallenges, challenge.id));
 
-const itemDirty = $derived(base ? challenge.rewardItemId !== base.rewardItemId : false);
-const modDirty = $derived(base ? challenge.rewardItemModId !== base.rewardItemModId : false);
+const itemDirty = $derived(base ? !recordsEqual(challenge.rewardItemId, base.rewardItemId) : false);
+const modDirty = $derived(base ? !recordsEqual(challenge.rewardItemModId, base.rewardItemModId) : false);
 const none = $derived(challenge.rewardItemId == null && challenge.rewardItemModId == null);
 
 // Retired records drop out of the pick list (can't be newly granted) unless they're the

--- a/UI/src/routes/admin/workbench/components/challenge/RewardSlot.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/RewardSlot.svelte
@@ -63,8 +63,8 @@ const { kind, label, valueId, name, sub, color, retired = false, dirty, open, on
 	height: 5px;
 	margin-left: 7px;
 	border-radius: 50%;
-	background: var(--warning);
-	box-shadow: 0 0 5px var(--warning);
+	background: var(--change-modified);
+	box-shadow: 0 0 5px var(--change-modified);
 }
 .ch-reward-name.retired {
 	text-decoration: line-through;

--- a/UI/src/routes/admin/workbench/components/challenge/ScopeField.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/ScopeField.svelte
@@ -17,7 +17,8 @@
 	</div>
 {:else}
 	<div class="fld scope-fld">
-		<span class="lbl" class:warn={dirty}>Scope · {entityTypeName(challenge.entityType)}</span>
+		<span class="lbl">Scope · {entityTypeName(challenge.entityType)}</span>
+		{#if dirty}<DirtyDot />{/if}
 		<div class="scope-row">
 			<div class="eswitch">
 				<button type="button" class:active={!specific} onclick={setGlobal}>Global</button>
@@ -50,8 +51,10 @@ import { reference } from '../../reference.svelte';
 import type { EntityStore } from '../../entity-store.svelte';
 import type { Identified } from '../../entities/types';
 import { entityTypeName, trackedKind, typeBossOnly } from '../../entities/challenge-helpers';
+import { recordsEqual } from '../../entity-store.svelte';
 import SelectCaret from '../SelectCaret.svelte';
 import WorkbenchIcon from '../../WorkbenchIcon.svelte';
+import DirtyDot from '../DirtyDot.svelte';
 
 interface Props {
 	challenge: IChallenge;
@@ -68,7 +71,7 @@ const specific = $derived(challenge.targetEntityId != null);
 const bossOnly = $derived(typeBossOnly(reference.challengeTypes, challenge.challengeTypeId));
 // Pass the current target so a now-retired authored target stays selectable/visible.
 const options = $derived(reference.entityOptions(challenge.entityType, bossOnly, challenge.targetEntityId));
-const dirty = $derived(baseline ? challenge.targetEntityId !== baseline.targetEntityId : false);
+const dirty = $derived(baseline ? !recordsEqual(challenge.targetEntityId, baseline.targetEntityId) : false);
 
 const setGlobal = () => store.patch(challenge.id, (d) => ((d as unknown as IChallenge).targetEntityId = undefined));
 const setSpecific = () =>

--- a/UI/src/routes/admin/workbench/entity-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/entity-store.svelte.ts
@@ -1,6 +1,6 @@
-import { SvelteSet } from 'svelte/reactivity';
+import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { toastError } from '$stores';
-import { canonicalEqual, PersistFailedError } from './save-helpers';
+import { canonicalEqual, PersistFailedError, resolveNewIds } from './save-helpers';
 import { entityWarnings } from './validation';
 import type { EntityConfig, Identified, SaveDiff } from './entities/types';
 
@@ -29,6 +29,10 @@ export class EntityStore<T extends Identified> {
 	private deleted = new SvelteSet<number>();
 	saved = $state(false);
 	saving = $state(false);
+	/** Maps a just-saved record's local (negative) id to its persisted id, so a caller tracking a
+	 *  selection by id (the Workbench detail pane) can follow a newly-added record across a save
+	 *  instead of losing it to the "record no longer found" fallback. Replaced wholesale each save. */
+	lastIdMap = $state<SvelteMap<number, number>>(new SvelteMap());
 	private nextId = -1;
 	#flashTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -194,7 +198,9 @@ export class EntityStore<T extends Identified> {
 		}
 		this.saving = true;
 		try {
-			const fresh = await this.config.persist(this.diff());
+			const diff = this.diff();
+			const fresh = await this.config.persist(diff);
+			this.lastIdMap = new SvelteMap(resolveNewIds(fresh, diff.existingIds, diff.added));
 			this.items = fresh.map(clone);
 			this.base = fresh.map(clone);
 			this.deleted.clear();

--- a/UI/src/routes/admin/workbench/progression/DetailHeader.svelte
+++ b/UI/src/routes/admin/workbench/progression/DetailHeader.svelte
@@ -40,7 +40,7 @@
 				{t.label}
 				{#if t.count != null}<span class="count-badge">{t.count}</span>{/if}
 				{#if t.warn}<WorkbenchIcon kind="warn" size={11} stroke="var(--warning)" />{/if}
-				{#if t.dirty}<span class="tab-dot" aria-hidden="true"></span>{/if}
+				{#if t.dirty}<span class="tab-dot" aria-hidden="true"></span><span class="sr-only">Unsaved changes</span>{/if}
 			</button>
 		{/each}
 	</div>

--- a/UI/src/routes/admin/workbench/progression/progression-helpers.ts
+++ b/UI/src/routes/admin/workbench/progression/progression-helpers.ts
@@ -247,27 +247,3 @@ export const diffCatalogue = <T extends { id: number }>(current: T[], baseline: 
 	}
 	return { added, modified };
 };
-
-/**
- * Map the local (negative) ids of added records to their persisted ids. The backend appends adds in
- * send order, so the k-th added record maps to the k-th lowest id absent from the pre-save set.
- */
-export const resolveNewIds = (
-	fresh: { id: number }[],
-	existingIds: Iterable<number>,
-	added: { id: number }[]
-): Map<number, number> => {
-	const existing = new Set(existingIds);
-	const newlyPersisted = fresh.filter((record) => !existing.has(record.id)).sort((a, b) => a.id - b.id);
-	const idFor = new Map<number, number>();
-	added.forEach((record, index) => {
-		const persisted = newlyPersisted[index];
-		if (persisted) {
-			idFor.set(record.id, persisted.id);
-		}
-	});
-	return idFor;
-};
-
-/** Resolve a possibly-local id through the new-id map (returns the input when already persisted). */
-export const resolveId = (id: number, idMap: Map<number, number>): number => idMap.get(id) ?? id;

--- a/UI/src/routes/admin/workbench/progression/progression-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/progression/progression-store.svelte.ts
@@ -1,7 +1,7 @@
 import { ApiRequest, EChangeType, fetchSocketData, type IChange, type IPath, type IProficiency } from '$lib/api';
 import { staticData, toastError } from '$stores';
 import { reference } from '../reference.svelte';
-import { childChanged, canonicalEqual } from '../save-helpers';
+import { childChanged, canonicalEqual, resolveId, resolveNewIds } from '../save-helpers';
 import { firstFree } from '../entities/helpers';
 import {
 	blankModifier,
@@ -11,8 +11,6 @@ import {
 	pathIdentityDto,
 	profIdentityDto,
 	renumberTiers,
-	resolveId,
-	resolveNewIds,
 	tiersOfPath
 } from './progression-helpers';
 import { NO_SKILL, type WorkbenchPath, type WorkbenchProficiency } from './types';

--- a/UI/src/routes/admin/workbench/save-helpers.ts
+++ b/UI/src/routes/admin/workbench/save-helpers.ts
@@ -37,6 +37,30 @@ export const listsEqual = canonicalEqual;
 export const childChanged = <T>(current: T, baseline: T | undefined): boolean =>
 	baseline === undefined || !listsEqual(current, baseline);
 
+/**
+ * Map the local (negative) ids of added records to their persisted ids. The backend appends adds in
+ * send order, so the k-th added record maps to the k-th lowest id absent from the pre-save set.
+ */
+export const resolveNewIds = (
+	fresh: { id: number }[],
+	existingIds: Iterable<number>,
+	added: { id: number }[]
+): Map<number, number> => {
+	const existing = new Set(existingIds);
+	const newlyPersisted = fresh.filter((record) => !existing.has(record.id)).sort((a, b) => a.id - b.id);
+	const idFor = new Map<number, number>();
+	added.forEach((record, index) => {
+		const persisted = newlyPersisted[index];
+		if (persisted) {
+			idFor.set(record.id, persisted.id);
+		}
+	});
+	return idFor;
+};
+
+/** Resolve a possibly-local id through the new-id map (returns the input when already persisted). */
+export const resolveId = (id: number, idMap: Map<number, number>): number => idMap.get(id) ?? id;
+
 type ChildSaver<T> = (id: number, record: T, baseline: T | undefined) => Promise<void>;
 
 interface PersistOptions<T extends Identified, D> {
@@ -104,18 +128,8 @@ export async function persistEntity<T extends Identified, D>(opts: PersistOption
 
 		const fresh = await refresh();
 
-		// Records present after save but absent before are the persisted adds; the
-		// backend inserts them in send order, so the k-th added record maps to the
-		// k-th lowest new id.
-		const existing = new Set(diff.existingIds);
-		const newlyPersisted = fresh.filter((record) => !existing.has(record.id)).sort((a, b) => a.id - b.id);
-		const idFor = new Map<number, number>();
-		diff.added.forEach((record, index) => {
-			const persisted = newlyPersisted[index];
-			if (persisted) {
-				idFor.set(record.id, persisted.id);
-			}
-		});
+		// Records present after save but absent before are the persisted adds.
+		const idFor = resolveNewIds(fresh, diff.existingIds, diff.added);
 
 		const childTargets: { id: number; record: T; baseline: T | undefined }[] = [
 			...diff.added.map((record) => ({ id: idFor.get(record.id) ?? record.id, record, baseline: undefined })),

--- a/UI/src/tests/routes/admin/workbench/Workbench.test.ts
+++ b/UI/src/tests/routes/admin/workbench/Workbench.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { render, cleanup, screen, waitFor } from '@testing-library/svelte';
+import { render, cleanup, screen, waitFor, fireEvent } from '@testing-library/svelte';
 
 vi.mock('$stores', () => ({
 	staticData: {
@@ -85,5 +85,27 @@ describe('Workbench', () => {
 		render(Workbench, { props: { entity: makeConfig(), groupLabel: 'Combat' } });
 		await waitFor(() => expect(screen.getByTestId('workbench-title')).toBeTruthy());
 		expect(screen.getByText('Admin Console · Combat')).toBeTruthy();
+	});
+
+	it('follows a newly-added record to its persisted id after save, instead of jumping to the first record', async () => {
+		const persist = vi.fn(async (diff: { added: Identified[] }) => [
+			...seed,
+			...diff.added.map((record, i) => ({ ...record, id: 3 + i }))
+		]);
+		render(Workbench, { props: { entity: makeConfig({ persist }) } });
+		await waitFor(() => expect(screen.getByTestId('workbench-title')).toBeTruthy());
+
+		await fireEvent.click(screen.getByTestId('workbench-new'));
+		const selectedBeforeSave = screen.getAllByTestId('workbench-row').find((row) => row.classList.contains('selected'));
+		expect(selectedBeforeSave?.textContent).toContain('Unnamed');
+
+		await fireEvent.click(screen.getByText('Save Changes'));
+		await waitFor(() => expect(screen.getByText('Changes saved')).toBeTruthy());
+
+		// The just-created record (now persisted at id 3) stays selected — the temporary negative id
+		// it was selected under no longer matches anything, but the selection must follow the remap
+		// rather than falling back to the first record (Alpha).
+		const selectedAfterSave = screen.getAllByTestId('workbench-row').find((row) => row.classList.contains('selected'));
+		expect(selectedAfterSave?.textContent).toContain('Unnamed');
 	});
 });

--- a/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
@@ -169,6 +169,26 @@ describe('ChallengeRewardSection', () => {
 		expect(container.querySelector('.ch-picker')).toBeNull();
 	});
 
+	it('is not dirty when a local clear (undefined) matches a server baseline stored as null', () => {
+		// The server baseline serializes an unset reward as null; a local clear leaves the field
+		// simply absent. The two must compare equal, not phantom-dirty.
+		const { store, baseline } = setup({ rewardItemId: null as unknown as number });
+		store.patch(1, (d) => ((d as unknown as IChallenge).rewardItemId = undefined));
+		const record = store.items[0];
+
+		const { container } = render(ChallengeRewardSection, { props: { record, baseline, store } });
+		expect(container.querySelector('.ch-reward-dot')).toBeNull();
+	});
+
+	it('is dirty when the reward actually differs from baseline', () => {
+		const { store, baseline } = setup({ rewardItemId: 0 });
+		store.patch(1, (d) => ((d as unknown as IChallenge).rewardItemId = 1));
+		const record = store.items[0];
+
+		const { container } = render(ChallengeRewardSection, { props: { record, baseline, store } });
+		expect(container.querySelector('.ch-reward-dot')).toBeTruthy();
+	});
+
 	it('collapses an open picker when the rendered record switches to a different challenge', async () => {
 		// Two sibling challenges in the same store; the section is reused as the detail
 		// pane switches between them, and its $effect must reset the open picker on switch.

--- a/UI/src/tests/routes/admin/workbench/challenge/ScopeField.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ScopeField.test.ts
@@ -113,3 +113,28 @@ describe('ScopeField — entity-scoped statistic', () => {
 		expect((store.items[0] as unknown as IChallenge).targetEntityId).toBe(1);
 	});
 });
+
+describe('ScopeField — dirty state', () => {
+	it('is not dirty when a local clear (undefined) matches a server baseline stored as null', () => {
+		// The server baseline serializes an unset optional as null, while `setGlobal` (and a fresh
+		// clone) leaves the field simply absent — the two must read as equal, not phantom-dirty.
+		const { store, baseline } = setup({
+			entityType: EEntityType.Enemy,
+			targetEntityId: null as unknown as number
+		});
+		store.patch(1, (d) => ((d as unknown as IChallenge).targetEntityId = undefined));
+		const challenge = store.items[0] as unknown as IChallenge;
+
+		const { container } = render(ScopeField, { props: { challenge, baseline, store } });
+		expect(container.querySelector('.dirty-dot')).toBeNull();
+	});
+
+	it('is dirty when the target actually differs from baseline', () => {
+		const { store, baseline } = setup({ entityType: EEntityType.Enemy, targetEntityId: 0 });
+		store.patch(1, (d) => ((d as unknown as IChallenge).targetEntityId = 1));
+		const challenge = store.items[0] as unknown as IChallenge;
+
+		const { container } = render(ScopeField, { props: { challenge, baseline, store } });
+		expect(container.querySelector('.dirty-dot')).toBeTruthy();
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/entity-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entity-store.test.ts
@@ -135,6 +135,37 @@ describe('EntityStore', () => {
 		expect(store.saved).toBe(true);
 	});
 
+	it("maps a saved record's temporary negative id to its persisted id", async () => {
+		const fresh: Row[] = [
+			{ id: 0, name: 'Alpha', value: 1 },
+			{ id: 1, name: 'Beta', value: 2 },
+			{ id: 2, name: 'Gamma', value: 3 }
+		];
+		const store = new EntityStore(
+			makeConfig(async () => fresh),
+			seed
+		);
+		const newId = store.addItem();
+
+		await store.save();
+
+		expect(store.lastIdMap.get(newId)).toBe(2);
+	});
+
+	it('replaces the id map wholesale on a later save with no added records', async () => {
+		const fresh: Row[] = [...seed, { id: 2, name: 'Gamma', value: 3 }];
+		const persist = vi.fn(async () => fresh);
+		const store = new EntityStore(makeConfig(persist), seed);
+
+		store.addItem();
+		await store.save();
+		expect(store.lastIdMap.size).toBe(1);
+
+		store.patch(0, (draft) => (draft.value = 42));
+		await store.save();
+		expect(store.lastIdMap.size).toBe(0);
+	});
+
 	it('re-seeds from server truth on a partial (committed) failure, so a retry cannot re-add duplicates', async () => {
 		// A partial failure: the add committed server-side (now id 2) but a child saver then threw,
 		// surfacing as PersistFailedError.

--- a/UI/src/tests/routes/admin/workbench/progression/DetailHeader.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/DetailHeader.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/svelte';
+
+vi.mock('$stores', () => ({ toastError: vi.fn() }));
+
+import DetailHeader from '$routes/admin/workbench/progression/DetailHeader.svelte';
+import type { ProgressionTab } from '$routes/admin/workbench/progression/types';
+
+const baseProps = {
+	idLabel: '#1',
+	isNew: false,
+	name: 'Fire',
+	blank: 'Unnamed',
+	status: 'clean' as const,
+	retired: false,
+	activeTab: 'identity',
+	onTab: vi.fn(),
+	onRetire: vi.fn(),
+	onReinstate: vi.fn(),
+	onRemove: vi.fn()
+};
+
+afterEach(cleanup);
+
+describe('DetailHeader', () => {
+	it('pairs a dirty tab dot with visually-hidden "Unsaved changes" text, mirroring the Workbench tab dot', () => {
+		const tabs: ProgressionTab[] = [{ key: 'identity', label: 'Identity', dirty: true }];
+		const { container } = render(DetailHeader, { props: { ...baseProps, tabs } });
+		expect(container.querySelector('.tab-dot')).toBeTruthy();
+		expect(screen.getByText('Unsaved changes')).toBeTruthy();
+	});
+
+	it('renders no dot or hidden text for a clean tab', () => {
+		const tabs: ProgressionTab[] = [{ key: 'identity', label: 'Identity', dirty: false }];
+		const { container } = render(DetailHeader, { props: { ...baseProps, tabs } });
+		expect(container.querySelector('.tab-dot')).toBeNull();
+		expect(screen.queryByText('Unsaved changes')).toBeNull();
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
@@ -16,8 +16,6 @@ import {
 	profIdentityDto,
 	proficiencyWarnings,
 	renumberTiers,
-	resolveId,
-	resolveNewIds,
 	rewardAtLevel,
 	tiersOfPath,
 	xpCostCurve
@@ -166,22 +164,6 @@ describe('diffCatalogue', () => {
 		const diff = diffCatalogue(current, [a, b]);
 		expect(diff.added.map((r) => r.id)).toEqual([-1]);
 		expect(diff.modified.map((m) => m.record.id)).toEqual([1]);
-	});
-});
-
-describe('resolveNewIds & resolveId', () => {
-	it('maps added local ids to the persisted ids absent before the save, in send order', () => {
-		const added = [{ id: -1 }, { id: -2 }];
-		const fresh = [{ id: 0 }, { id: 1 }, { id: 2 }]; // 0 existed; 1,2 are new
-		const map = resolveNewIds(fresh, [0], added);
-		expect(map.get(-1)).toBe(1);
-		expect(map.get(-2)).toBe(2);
-	});
-
-	it('resolveId passes through an already-persisted id', () => {
-		const map = new Map([[-1, 7]]);
-		expect(resolveId(-1, map)).toBe(7);
-		expect(resolveId(3, map)).toBe(3);
 	});
 });
 

--- a/UI/src/tests/routes/admin/workbench/save-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/save-helpers.test.ts
@@ -14,6 +14,8 @@ import {
 	modSlotChanges,
 	persistEntity,
 	PersistFailedError,
+	resolveId,
+	resolveNewIds,
 	skillEffectChanges
 } from '../../../../routes/admin/workbench/save-helpers';
 import type { Identified, SaveDiff } from '../../../../routes/admin/workbench/entities/types';
@@ -137,6 +139,22 @@ describe('skillEffectChanges', () => {
 			skillEffectChanges([makeEffect(1, { modifierTypeId: EModifierType.Multiplicative })], [makeEffect(1)])
 		).toHaveLength(1);
 		expect(skillEffectChanges([makeEffect(1, { durationMs: 5000 })], [makeEffect(1)])).toHaveLength(1);
+	});
+});
+
+describe('resolveNewIds & resolveId', () => {
+	it('maps added local ids to the persisted ids absent before the save, in send order', () => {
+		const added = [{ id: -1 }, { id: -2 }];
+		const fresh = [{ id: 0 }, { id: 1 }, { id: 2 }]; // 0 existed; 1,2 are new
+		const map = resolveNewIds(fresh, [0], added);
+		expect(map.get(-1)).toBe(1);
+		expect(map.get(-2)).toBe(2);
+	});
+
+	it('resolveId passes through an already-persisted id', () => {
+		const map = new Map([[-1, 7]]);
+		expect(resolveId(-1, map)).toBe(7);
+		expect(resolveId(3, map)).toBe(3);
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes the three verified admin-Workbench state/styling bugs from #1509:

1. **Phantom per-field dirty state from `undefined !== null`.** `ScopeField.svelte` and `ChallengeRewardSection.svelte` compared optional fields (`targetEntityId`, `rewardItemId`, `rewardItemModId`) with raw `!==`, but a server baseline serializes an unset optional as `null` while a local clear (`setGlobal`, `setItem(undefined)`) leaves the field simply absent — so the field showed dirty while the save bar (via the null-collapsing `canonicalEqual`/`recordsEqual`) simultaneously said "No unsaved changes". Both now use `recordsEqual`, matching `FieldControl.svelte`'s existing convention.

2. **Post-save selection jump to the first record.** `Workbench.svelte`'s `selId` still held a just-saved record's temporary negative id after the save re-seeded from the server, so `items.find(...)` failed and the fallback yanked the admin to the first record instead of the one they just created. `persistEntity` computed this local→persisted id map internally and discarded it — the progression editor already followed its own copy of this remap correctly (`resolveNewIds`/`resolveId` in `progression-helpers.ts`).

   Rather than threading the map through every entity's `persist()` return type, I moved `resolveNewIds`/`resolveId` into the shared `save-helpers.ts` (deduping the two identical copies), had `persistEntity` use it, and added `EntityStore.lastIdMap` — populated from the same diff/fresh-list data the store already has after every save. `Workbench.svelte`'s selection-tracking effect now consults `lastIdMap` before falling back to the head of the list.

3. **Dirty state styled with the validation token.** `ScopeField.svelte` styled a dirty scope with the `--warning` label class (and rendered no `DirtyDot`), and `RewardSlot.svelte`'s dirty dot used `var(--warning)` instead of `--change-modified` — frontend.md is explicit that dirty (`--change-*` + dot) and validation (`--warning` + triangle) never overlap. Fixed both. Also picked up the noted nit: the progression `DetailHeader.svelte` tab-dot was missing the `sr-only` "Unsaved changes" text its Workbench counterpart has.

## Test plan

- [x] Added regression tests for the phantom-dirty case (local `undefined` vs. baseline `null`) in `ScopeField.test.ts` and `ChallengeRewardSection.test.ts`
- [x] Added `EntityStore` tests for `lastIdMap` (maps a new record's temp id to its persisted id; replaced wholesale each save)
- [x] Added a `Workbench.svelte` integration test driving a full add → save → verify-selection-follows-remap flow
- [x] Added `DetailHeader.test.ts` covering the sr-only dirty-tab text
- [x] Moved the `resolveNewIds`/`resolveId` unit tests from `progression-helpers.test.ts` to `save-helpers.test.ts` alongside their new home
- [x] `npx vitest run` — 282 files / 3294 tests pass
- [x] `npm run lint` (eslint + svelte-check) — clean

Closes #1509


---
_Generated by [Claude Code](https://claude.ai/code/session_01QYksGvCL3BNud4NRbHUqLG)_