### PR TITLE
Backend dead-code & stale-comment sweep

### DIFF
--- a/Game.Abstractions/DataAccess/ISkillRecipes.cs
+++ b/Game.Abstractions/DataAccess/ISkillRecipes.cs
@@ -5,8 +5,9 @@ namespace Game.Abstractions.DataAccess
 {
     /// <summary>
     /// Read access to the cached skill-synthesis recipe catalogue (spike #1125): the contract projection the
-    /// client and admin Workbench read, the lean domain model the synthesis command validates against, and the
-    /// input-skill → recipe-ids reverse index that drives the client's hinted reveal.
+    /// client and admin Workbench read, and the lean domain model the synthesis command validates against. The
+    /// client derives its own hinted-reveal state from the full recipe set (<see cref="AllSkillRecipes"/>) plus
+    /// owned skills/proficiencies rather than a server-computed reverse index.
     /// </summary>
     public interface ISkillRecipes
     {
@@ -19,10 +20,6 @@ namespace Game.Abstractions.DataAccess
         public bool ValidateRecipeId(int recipeId);
 
         public CoreSkillRecipe GetSkillRecipe(int recipeId);
-
-        /// <summary>The (non-retired) recipes the given skill is an input to, or empty if none — the reverse
-        /// index the client hint state consumes when the player owns the skill.</summary>
-        public IReadOnlyList<int> RecipesForInputSkill(int skillId);
 
         /// <inheritdoc cref="IItems.VersionKey"/>
         public object VersionKey { get; }

--- a/Game.Abstractions/DataAccess/IZones.cs
+++ b/Game.Abstractions/DataAccess/IZones.cs
@@ -6,8 +6,6 @@ namespace Game.Abstractions.DataAccess
     public interface IZones
     {
         public List<Contracts.Zone> All();
-        // Returns the read contract for a single zone; throws if the id is out of range.
-        public Contracts.Zone GetZone(int zoneId);
 
         /// <summary>Returns the lean gameplay <see cref="CoreZone"/> domain model for a single zone (battle
         /// setup); throws if the id is out of range.</summary>

--- a/Game.Abstractions/Infrastructure/ICacheService.cs
+++ b/Game.Abstractions/Infrastructure/ICacheService.cs
@@ -16,9 +16,8 @@
         /// as its TTL and returns the previous value (null if the key was unset). The value is required
         /// (non-null): writing a TTL implies writing a value, so unlike <see cref="Set(string, string?,
         /// TimeSpan, CancellationToken)"/> there is no null-means-delete path. Writing the value and its expiry
-        /// in a single operation (rather than a separate set followed by
-        /// <see cref="Expire(string, TimeSpan, CancellationToken)"/>) means a fault between the two can never
-        /// leave the key lingering without a TTL.
+        /// in a single operation (rather than a separate set followed by a TTL reset) means a fault between the
+        /// two can never leave the key lingering without a TTL.
         /// </summary>
         public Task<string?> GetSet(string key, string value, TimeSpan expiry, CancellationToken cancellationToken = default);
         /// <summary>
@@ -28,8 +27,6 @@
         /// </summary>
         public Task Set(string key, string? value, TimeSpan expiry, CancellationToken cancellationToken = default);
         public Task Set<T>(string key, T value, TimeSpan expiry, CancellationToken cancellationToken = default);
-        /// <summary>Resets the time-to-live on an existing key. A no-op if the key does not exist.</summary>
-        public Task Expire(string key, TimeSpan expiry, CancellationToken cancellationToken = default);
         /// <summary>
         /// Resets the time-to-live on an existing key without awaiting the result (fire-and-forget).
         /// A no-op if the key does not exist. Lets a hot read path slide a sliding-expiration TTL
@@ -43,7 +40,6 @@
         /// </summary>
         public void SetAndForget(string key, string? value, TimeSpan expiry);
         public void SetAndForget<T>(string key, T value, TimeSpan expiry);
-        public Task SetNotExists(string key, string value, CancellationToken cancellationToken = default);
         public Task Delete(string key, CancellationToken cancellationToken = default);
         public void DeleteAndForget(string key);
         public Task CompareAndDelete(string key, string deleteIfValue, CancellationToken cancellationToken = default);

--- a/Game.Abstractions/Infrastructure/IPubSubQueue.cs
+++ b/Game.Abstractions/Infrastructure/IPubSubQueue.cs
@@ -2,8 +2,6 @@
 {
     public interface IPubSubQueue
     {
-        public string? GetNext();
-        public T? GetNext<T>();
         public Task<string?> GetNextAsync(CancellationToken cancellationToken = default);
         public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default);
 
@@ -47,8 +45,6 @@
         /// </summary>
         public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default);
 
-        public void AddToQueue(string value);
-        public void AddToQueue<T>(T value);
         public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default);
         public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default);
 

--- a/Game.Abstractions/Infrastructure/IPubSubService.cs
+++ b/Game.Abstractions/Infrastructure/IPubSubService.cs
@@ -27,13 +27,11 @@
         public Task Wake(string channel);
         public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null);
 
-        // The worker-backed overloads require a non-null id: each spins up a BackgroundWorker (holding an OS wait
+        // The worker-backed overload requires a non-null id: it spins up a BackgroundWorker (holding an OS wait
         // handle) that can only be disposed via UnSubscribe(channel, id), so an id-less worker subscription could
         // never be torn down and would leak its handle (#954). The plain-action overload above creates no worker,
         // so its id stays optional.
-        public Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id);
         public Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id);
-        public Task UnSubscribe(string channel);
         public Task UnSubscribe(string channel, string id);
 
         /// <summary>

--- a/Game.Api.Tests/Integration/AdminCacheReloadBroadcastTests.cs
+++ b/Game.Api.Tests/Integration/AdminCacheReloadBroadcastTests.cs
@@ -38,7 +38,8 @@ namespace Game.Api.Tests.Integration
 
             var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
             var received = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-            await pubsub.Subscribe(ReferenceDataChannel, args => received.TrySetResult(args.message));
+            var subscriptionId = $"broadcast-test-{Guid.NewGuid()}";
+            await pubsub.Subscribe(ReferenceDataChannel, args => received.TrySetResult(args.message), subscriptionId);
             try
             {
                 var changes = new[]
@@ -69,7 +70,7 @@ namespace Game.Api.Tests.Integration
             }
             finally
             {
-                await pubsub.UnSubscribe(ReferenceDataChannel);
+                await pubsub.UnSubscribe(ReferenceDataChannel, subscriptionId);
             }
         }
     }

--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -333,10 +333,6 @@ namespace Game.Api.Tests.Unit
             public Task<long> GetLengthAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public string? GetNext() => throw new NotSupportedException();
-            public T? GetNext<T>() => throw new NotSupportedException();
-            public void AddToQueue(string value) => throw new NotSupportedException();
-            public void AddToQueue<T>(T value) => throw new NotSupportedException();
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -361,10 +357,6 @@ namespace Game.Api.Tests.Unit
             public Task<long> GetLengthAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public string? GetNext() => throw new NotSupportedException();
-            public T? GetNext<T>() => throw new NotSupportedException();
-            public void AddToQueue(string value) => throw new NotSupportedException();
-            public void AddToQueue<T>(T value) => throw new NotSupportedException();
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -383,14 +375,12 @@ namespace Game.Api.Tests.Unit
                 return Task.CompletedTask;
             }
 
-            public Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => Task.CompletedTask;
             public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => Task.CompletedTask;
             public Task Publish(string channel, string message, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task Publish(string channel, string queueName, string queueData, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task Publish<T>(string channel, string queueName, T queueData, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task Wake(string channel) => Task.CompletedTask;
-            public Task UnSubscribe(string channel) => Task.CompletedTask;
             public Task UnSubscribe(string channel, string id) => Task.CompletedTask;
             public IPubSubQueue GetQueue(string queueName) => DeadLetterQueue;
         }
@@ -407,8 +397,6 @@ namespace Game.Api.Tests.Unit
                 return Task.CompletedTask;
             }
 
-            public string? GetNext() => throw new NotSupportedException();
-            public T? GetNext<T>() => throw new NotSupportedException();
             public Task<string?> GetNextAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<string?> ReserveNextAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -418,8 +406,6 @@ namespace Game.Api.Tests.Unit
             public Task<long> GetLengthAsync(CancellationToken cancellationToken = default) => Task.FromResult((long)Added.Count);
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public void AddToQueue(string value) => throw new NotSupportedException();
-            public void AddToQueue<T>(T value) => throw new NotSupportedException();
             public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }
@@ -429,7 +415,6 @@ namespace Game.Api.Tests.Unit
         {
             public Task<string?> GetSet(string key, string value, TimeSpan expiry, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
 
-            public Task Expire(string key, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<string?> Get(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<T?> Get<T>(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<string?> GetDelete(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -439,7 +424,6 @@ namespace Game.Api.Tests.Unit
             public void ExpireAndForget(string key, TimeSpan expiry) => throw new NotSupportedException();
             public void SetAndForget(string key, string? value, TimeSpan expiry) => throw new NotSupportedException();
             public void SetAndForget<T>(string key, T value, TimeSpan expiry) => throw new NotSupportedException();
-            public Task SetNotExists(string key, string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task Delete(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void DeleteAndForget(string key) => throw new NotSupportedException();
             public Task CompareAndDelete(string key, string deleteIfValue, CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -453,7 +437,6 @@ namespace Game.Api.Tests.Unit
         {
             public override Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => throw toThrow;
 
-            public override Task UnSubscribe(string channel) => Task.CompletedTask;
             public override Task UnSubscribe(string channel, string id) => Task.CompletedTask;
         }
 
@@ -499,7 +482,6 @@ namespace Game.Api.Tests.Unit
                 Expires.Add((key, expiry));
             }
 
-            public Task Expire(string key, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<string?> Get(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<T?> Get<T>(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<string?> GetDelete(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -508,7 +490,6 @@ namespace Game.Api.Tests.Unit
             public Task Set<T>(string key, T value, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void SetAndForget(string key, string? value, TimeSpan expiry) => throw new NotSupportedException();
             public void SetAndForget<T>(string key, T value, TimeSpan expiry) => throw new NotSupportedException();
-            public Task SetNotExists(string key, string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void DeleteAndForget(string key) => throw new NotSupportedException();
             public Task<bool> CompareAndSet(string key, string? expectedValue, string newValue, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void ReclaimAndForget(string key, string ownerValue, TimeSpan expiry) => throw new NotSupportedException();

--- a/Game.Api/Models/IModel.cs
+++ b/Game.Api/Models/IModel.cs
@@ -4,14 +4,4 @@ namespace Game.Api.Models
     {
         public static abstract TModel FromSource(TSource source);
     }
-
-    public interface IModelToSource<TSource> : IModel
-    {
-        public TSource ToSource();
-    }
-
-    public interface IMappedModel<TModel, TEntity> : IModelFromSource<TModel, TEntity>, IModelToSource<TEntity> where TModel : IModel
-    {
-
-    }
 }

--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -1135,7 +1135,7 @@ namespace Game.Application.Tests.DataAccess
         {
             // Models the Redis reliable-queue semantics: items wait on _items (head = First), a reserve moves the
             // head onto _processing, and an acknowledge removes it; a reclaim restores the processing list to the
-            // queue head in order. GetNext destructively pops the queue head (used to assert the queue is drained).
+            // queue head in order. GetNextAsync destructively pops the queue head (used to assert the queue is drained).
             private readonly LinkedList<string?> _items;
             private readonly LinkedList<string?> _processing = new();
 
@@ -1144,19 +1144,17 @@ namespace Game.Application.Tests.DataAccess
                 _items = new LinkedList<string?>(items);
             }
 
-            public string? GetNext()
+            public Task<string?> GetNextAsync(CancellationToken cancellationToken = default)
             {
                 if (_items.First is null)
                 {
-                    return null;
+                    return Task.FromResult<string?>(null);
                 }
 
                 var value = _items.First.Value;
                 _items.RemoveFirst();
-                return value;
+                return Task.FromResult(value);
             }
-
-            public Task<string?> GetNextAsync(CancellationToken cancellationToken = default) => Task.FromResult(GetNext());
 
             public Task<string?> ReserveNextAsync(CancellationToken cancellationToken = default)
             {
@@ -1212,7 +1210,6 @@ namespace Game.Application.Tests.DataAccess
                 return Task.FromResult(true);
             }
 
-            public void AddToQueue(string value) => _items.AddLast(value);
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default)
             {
                 _items.AddLast(value);
@@ -1229,9 +1226,7 @@ namespace Game.Application.Tests.DataAccess
             }
 
             // Not exercised by DataProviderSynchronizer.ProcessQueue.
-            public T? GetNext<T>() => throw new NotSupportedException();
             public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public void AddToQueue<T>(T value) => throw new NotSupportedException();
             public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }
 
@@ -1315,13 +1310,9 @@ namespace Game.Application.Tests.DataAccess
             public Task<long> ReclaimProcessingAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public string? GetNext() => throw new NotSupportedException();
-            public void AddToQueue(string value) => throw new NotSupportedException();
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public T? GetNext<T>() => throw new NotSupportedException();
             public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public void AddToQueue<T>(T value) => throw new NotSupportedException();
             public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }
 
@@ -1364,7 +1355,6 @@ namespace Game.Application.Tests.DataAccess
         private sealed class ThrowingPubSubService : NotSupportedPubSubService
         {
             public override Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => throw new InvalidOperationException("Simulated subscribe failure.");
-            public override Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => throw new InvalidOperationException("Simulated subscribe failure.");
             public override Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => throw new InvalidOperationException("Simulated subscribe failure.");
         }
 
@@ -1382,9 +1372,7 @@ namespace Game.Application.Tests.DataAccess
             public Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default) => inner.PublishBatch(channel, queueName, queueData, cancellationToken);
             public Task Wake(string channel) => inner.Wake(channel);
             public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => Task.CompletedTask;
-            public Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => Task.CompletedTask;
             public Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => Task.CompletedTask;
-            public Task UnSubscribe(string channel) => inner.UnSubscribe(channel);
             public Task UnSubscribe(string channel, string id) => inner.UnSubscribe(channel, id);
             public IPubSubQueue GetQueue(string queueName) => inner.GetQueue(queueName);
         }
@@ -1401,7 +1389,6 @@ namespace Game.Application.Tests.DataAccess
                 queueName == Constants.PUBSUB_PLAYER_QUEUE ? playerQueue : new InMemoryPubSubQueue();
 
             public override Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => Task.CompletedTask;
-            public override Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => Task.CompletedTask;
             public override Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => Task.CompletedTask;
             public override Task UnSubscribe(string channel, string id) => Task.CompletedTask;
         }
@@ -1459,13 +1446,9 @@ namespace Game.Application.Tests.DataAccess
 
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public string? GetNext() => throw new NotSupportedException();
-            public void AddToQueue(string value) => throw new NotSupportedException();
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public T? GetNext<T>() => throw new NotSupportedException();
             public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public void AddToQueue<T>(T value) => throw new NotSupportedException();
             public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }
 
@@ -1493,13 +1476,9 @@ namespace Game.Application.Tests.DataAccess
 
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public string? GetNext() => throw new NotSupportedException();
-            public void AddToQueue(string value) => throw new NotSupportedException();
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public T? GetNext<T>() => throw new NotSupportedException();
             public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public void AddToQueue<T>(T value) => throw new NotSupportedException();
             public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }
 

--- a/Game.Application.Tests/DataAccess/EnemiesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/EnemiesIntegrationTests.cs
@@ -17,7 +17,7 @@ namespace Game.Application.Tests.DataAccess
             : base(containers, testOutputHelper) { }
 
         [Fact]
-        public async Task GetRandomEnemy_OnlyReturnsEnemiesAssignedToTheRequestedZone()
+        public async Task GetRandomDomainEnemy_OnlyReturnsEnemiesAssignedToTheRequestedZone()
         {
             using var scope = CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
@@ -34,15 +34,15 @@ namespace Game.Application.Tests.DataAccess
             await TestDataSeeder.LinkEnemyToZoneAsync(context, zoneB.Id, enemyB.Id, weight: 1);
             await ReloadReferenceCachesAsync();
 
-            var enemies = scope.ServiceProvider.GetRequiredService<IEnemyEntityCache>();
+            var enemies = scope.ServiceProvider.GetRequiredService<IEnemies>();
 
             var zoneAEnemyIds = new HashSet<int> { enemyA1.Id, enemyA2.Id };
 
             // Draw many times; every draw must belong to the requested zone.
             for (int i = 0; i < 100; i++)
             {
-                Assert.Contains(enemies.GetRandomEnemy(zoneA.Id).Id, zoneAEnemyIds);
-                Assert.Equal(enemyB.Id, enemies.GetRandomEnemy(zoneB.Id).Id);
+                Assert.Contains(enemies.GetRandomDomainEnemy(zoneA.Id, level: 1).Id, zoneAEnemyIds);
+                Assert.Equal(enemyB.Id, enemies.GetRandomDomainEnemy(zoneB.Id, level: 1).Id);
             }
         }
 
@@ -50,7 +50,7 @@ namespace Game.Application.Tests.DataAccess
         [InlineData(-1)]
         [InlineData(1)]
         [InlineData(999)]
-        public async Task GetRandomEnemy_InvalidZoneId_ThrowsArgumentOutOfRange(int invalidZoneId)
+        public async Task GetRandomDomainEnemy_InvalidZoneId_ThrowsArgumentOutOfRange(int invalidZoneId)
         {
             using var scope = CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
@@ -62,13 +62,13 @@ namespace Game.Application.Tests.DataAccess
             await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
             await ReloadReferenceCachesAsync();
 
-            var enemies = scope.ServiceProvider.GetRequiredService<IEnemyEntityCache>();
+            var enemies = scope.ServiceProvider.GetRequiredService<IEnemies>();
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => enemies.GetRandomEnemy(invalidZoneId));
+            Assert.Throws<ArgumentOutOfRangeException>(() => enemies.GetRandomDomainEnemy(invalidZoneId, level: 1));
         }
 
         [Fact]
-        public async Task GetRandomEnemy_ValidZoneWithNoEnemies_ThrowsInvalidOperation()
+        public async Task GetRandomDomainEnemy_ValidZoneWithNoEnemies_ThrowsInvalidOperation()
         {
             using var scope = CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
@@ -79,13 +79,13 @@ namespace Game.Application.Tests.DataAccess
             await TestDataSeeder.LinkEnemyToZoneAsync(context, populatedZone.Id, enemy.Id);
             await ReloadReferenceCachesAsync();
 
-            var enemies = scope.ServiceProvider.GetRequiredService<IEnemyEntityCache>();
+            var enemies = scope.ServiceProvider.GetRequiredService<IEnemies>();
 
-            Assert.Throws<InvalidOperationException>(() => enemies.GetRandomEnemy(emptyZone.Id));
+            Assert.Throws<InvalidOperationException>(() => enemies.GetRandomDomainEnemy(emptyZone.Id, level: 1));
         }
 
         [Fact]
-        public async Task GetRandomEnemy_ExcludesRetiredEnemiesButKeepsThemResolvable()
+        public async Task GetRandomDomainEnemy_ExcludesRetiredEnemiesButKeepsThemResolvable()
         {
             using var scope = CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
@@ -101,16 +101,17 @@ namespace Game.Application.Tests.DataAccess
             await context.SaveChangesAsync(CancellationToken);
             await ReloadReferenceCachesAsync();
 
-            var enemies = scope.ServiceProvider.GetRequiredService<IEnemyEntityCache>();
+            var enemies = scope.ServiceProvider.GetRequiredService<IEnemies>();
+            var enemyEntities = scope.ServiceProvider.GetRequiredService<IEnemyEntityCache>();
 
             // Every random draw avoids the retired enemy...
             for (int i = 0; i < 100; i++)
             {
-                Assert.Equal(active.Id, enemies.GetRandomEnemy(zone.Id).Id);
+                Assert.Equal(active.Id, enemies.GetRandomDomainEnemy(zone.Id, level: 1).Id);
             }
 
             // ...but the retired enemy still resolves by id, so existing references stay valid.
-            Assert.Equal(retired.Id, enemies.GetEnemy(retired.Id)?.Id);
+            Assert.Equal(retired.Id, enemyEntities.GetEnemy(retired.Id)?.Id);
         }
 
         [Fact]

--- a/Game.Application.Tests/DataAccess/RecordingEntityStore.cs
+++ b/Game.Application.Tests/DataAccess/RecordingEntityStore.cs
@@ -12,7 +12,6 @@ namespace Game.Application.Tests.DataAccess
         public List<object> Inserted { get; } = [];
         public List<object> Updated { get; } = [];
         public List<object> Deleted { get; } = [];
-        public List<object> Tracked { get; } = [];
 
         // Key-only deletes, each recorded as the entity type plus the supplied key values, in call order.
         public List<(Type EntityType, object[] KeyValues)> DeletedByKey { get; } = [];
@@ -22,6 +21,5 @@ namespace Game.Application.Tests.DataAccess
         public void Delete<TEntity>(TEntity entity) where TEntity : class => Deleted.Add(entity);
         public void DeleteByKey<TEntity>(params object[] keyValues) where TEntity : class =>
             DeletedByKey.Add((typeof(TEntity), keyValues));
-        public void Track<TEntity>(TEntity entity) where TEntity : class => Tracked.Add(entity);
     }
 }

--- a/Game.Application.Tests/DataAccess/RedisPubSubServiceIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisPubSubServiceIntegrationTests.cs
@@ -90,7 +90,7 @@ namespace Game.Application.Tests.DataAccess
             var channel = $"pubsub-test-{Guid.NewGuid()}";
             var queueName = $"pubsub-queue-{Guid.NewGuid()}";
             var id = $"handle-{Guid.NewGuid()}";
-            Action<(IPubSubQueue queue, string channel)> handler = _ => { };
+            Func<(IPubSubQueue queue, string channel), Task> handler = _ => Task.CompletedTask;
 
             await pubsub.Subscribe(channel, queueName, handler, id);
             try

--- a/Game.Application.Tests/DataAccess/RedisQueueIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisQueueIntegrationTests.cs
@@ -36,22 +36,6 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
-        public void TypedRoundTripSync_SerializesAndDeserializes_ThenReturnsNullWhenDrained()
-        {
-            using var scope = CreateScope();
-            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
-            var queue = pubsub.GetQueue($"redis-queue-test-{Guid.NewGuid()}");
-
-            var payload = new SamplePayload(9, "world");
-            queue.AddToQueue(payload);
-
-            var roundTripped = queue.GetNext<SamplePayload>();
-            Assert.Equal(payload, roundTripped);
-
-            Assert.Null(queue.GetNext<SamplePayload>());
-        }
-
-        [Fact]
         public async Task PreservesFifoOrder()
         {
             using var scope = CreateScope();

--- a/Game.Application.Tests/DataAccess/SkillRecipesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/SkillRecipesIntegrationTests.cs
@@ -10,9 +10,9 @@ using Entities = Game.Infrastructure.Entities;
 namespace Game.Application.Tests.DataAccess
 {
     /// <summary>
-    /// Exercises the skill-recipe reference repo against a real database: the contract projection, the shared
-    /// lean core model, and the derived input-skill → recipe-ids reverse index (including its exclusion of
-    /// retired recipes, which stay resolvable by id).
+    /// Exercises the skill-recipe reference repo against a real database: the contract projection and the
+    /// shared lean core model, including a retired recipe's exclusion from live authoring while staying
+    /// resolvable by id.
     /// </summary>
     [Collection("Integration")]
     public class SkillRecipesIntegrationTests : ApplicationIntegrationTestBase
@@ -21,7 +21,7 @@ namespace Game.Application.Tests.DataAccess
             : base(containers, testOutputHelper) { }
 
         [Fact]
-        public async Task GetSkillRecipe_AssemblesInputsAndConditions_AndReverseIndexIsExposed()
+        public async Task GetSkillRecipe_AssemblesInputsAndConditions()
         {
             int recipeId, resultSkillId, inputA, inputB, proficiencyId;
             using (var seedScope = CreateScope())
@@ -61,12 +61,6 @@ namespace Game.Application.Tests.DataAccess
             Assert.Equal(proficiencyId, condition.ProficiencyId);
             Assert.Equal(3, condition.MinLevel);
 
-            // The reverse index maps each input skill to the recipes it feeds.
-            Assert.Equal([recipeId], recipes.RecipesForInputSkill(inputA));
-            Assert.Equal([recipeId], recipes.RecipesForInputSkill(inputB));
-            // The result skill is not an input, so it feeds nothing.
-            Assert.Empty(recipes.RecipesForInputSkill(resultSkillId));
-
             var contract = Assert.Single(recipes.AllSkillRecipes());
             Assert.Equal(resultSkillId, contract.ResultSkillId);
             Assert.Equal([inputA, inputB], contract.InputSkillIds.OrderBy(id => id));
@@ -74,7 +68,7 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
-        public async Task RetiredRecipe_IsExcludedFromReverseIndex_ButResolvableById()
+        public async Task RetiredRecipe_IsExcludedFromLiveAuthoring_ButResolvableById()
         {
             int recipeId, resultSkillId, inputSkillId;
             using (var seedScope = CreateScope())
@@ -96,12 +90,11 @@ namespace Game.Application.Tests.DataAccess
             using var scope = CreateScope();
             var recipes = scope.ServiceProvider.GetRequiredService<ISkillRecipes>();
 
-            // Out of circulation: a retired recipe is never offered or hinted.
-            Assert.Empty(recipes.RecipesForInputSkill(inputSkillId));
-            // But it stays resolvable by id (already-synthesized results persist).
+            // A retired recipe stays resolvable by id (already-synthesized results persist)...
             var core = recipes.GetSkillRecipe(recipeId);
             Assert.True(core.IsRetired);
             Assert.Equal(resultSkillId, core.ResultSkillId);
+            // ...but is flagged retired rather than silently dropped, so a caller must check IsRetired before offering it.
         }
 
         private async Task<Entities.Skill> SeedSkillAsync(GameContext context, ESkillAcquisition acquisition)

--- a/Game.Application.Tests/DataAccess/ZonesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/ZonesIntegrationTests.cs
@@ -10,79 +10,15 @@ using Xunit;
 namespace Game.Application.Tests.DataAccess
 {
     /// <summary>
-    /// Verifies the <see cref="IZones"/> read paths: <see cref="IZones.GetZone"/> projects a zone to its
-    /// read contract, and the two not-found behaviours (<see cref="IZones.GetZone"/> throws on a bad id;
-    /// <see cref="IZoneEntityCache.LookupZone"/> returns <c>null</c>).
+    /// Verifies the <see cref="IZones"/> read paths — <see cref="IZones.GetDomainZone"/>'s bounds check and
+    /// domain-model projection, and the not-found behaviour of <see cref="IZoneEntityCache.LookupZone"/>
+    /// (returns <c>null</c>). The read-contract field mapping itself is covered by <c>ZoneMapperTests</c>.
     /// </summary>
     [Collection("Integration")]
     public class ZonesIntegrationTests : ApplicationIntegrationTestBase
     {
         public ZonesIntegrationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
             : base(containers, testOutputHelper) { }
-
-        [Fact]
-        public async Task GetZone_ReturnsZoneAsContract()
-        {
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-
-            var zone = await TestDataSeeder.CreateZoneAsync(context, "Read Zone", levelMin: 3, levelMax: 9, order: 2);
-            await ReloadReferenceCachesAsync();
-
-            var zones = scope.ServiceProvider.GetRequiredService<IZones>();
-
-            var result = zones.GetZone(zone.Id);
-
-            Assert.Equal(zone.Id, result.Id);
-            Assert.Equal("Read Zone", result.Name);
-            Assert.Equal(3, result.LevelMin);
-            Assert.Equal(9, result.LevelMax);
-            Assert.Equal(2, result.Order);
-        }
-
-        [Fact]
-        public async Task GetZone_WithDedicatedBoss_ReturnsBossFields()
-        {
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-
-            var boss = await TestDataSeeder.CreateEnemyAsync(context, "Catacomb Lich", isBoss: true);
-            var zone = await TestDataSeeder.CreateZoneAsync(
-                context, "Forgotten Catacombs", levelMin: 8, levelMax: 11, bossEnemyId: boss.Id, bossLevel: 18);
-            await ReloadReferenceCachesAsync();
-
-            var zones = scope.ServiceProvider.GetRequiredService<IZones>();
-
-            var result = zones.GetZone(zone.Id);
-
-            Assert.Equal(boss.Id, result.BossEnemyId);
-            Assert.Equal(18, result.BossLevel);
-        }
-
-        [Fact]
-        public async Task GetZone_WithoutBoss_ReturnsNullBossEnemyId()
-        {
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-
-            var zone = await TestDataSeeder.CreateZoneAsync(context, "Bossless Glade");
-            await ReloadReferenceCachesAsync();
-
-            var zones = scope.ServiceProvider.GetRequiredService<IZones>();
-
-            var result = zones.GetZone(zone.Id);
-
-            Assert.Null(result.BossEnemyId);
-        }
-
-        [Fact]
-        public void GetZone_InvalidId_Throws()
-        {
-            using var scope = CreateScope();
-            var zones = scope.ServiceProvider.GetRequiredService<IZones>();
-
-            Assert.Throws<ArgumentOutOfRangeException>(() => zones.GetZone(99999));
-        }
 
         [Fact]
         public async Task GetDomainZone_ReturnsZoneAsDomainModelWithBossFields()
@@ -183,9 +119,6 @@ namespace Game.Application.Tests.DataAccess
 
             Assert.False(zones.IsHomeZone(combat.Id));
             Assert.True(zones.IsHomeZone(home.Id));
-            // The flag also rides the read contract so the client can identify the Home zone.
-            Assert.True(zones.GetZone(home.Id).IsHome);
-            Assert.False(zones.GetZone(combat.Id).IsHome);
         }
 
         [Fact]

--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -1581,7 +1581,7 @@ namespace Game.Application.Tests.Services
             await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, skill.Id);
 
             // emptyZone is live but has no enemies assigned, so it has no spawn table — the runtime safety net
-            // relocates rather than throwing on GetRandomEnemy.
+            // relocates rather than throwing on GetRandomDomainEnemy.
             var viableZone = await TestDataSeeder.CreateZoneAsync(context, "Viable", order: 0);
             var emptyZone = await TestDataSeeder.CreateZoneAsync(context, "Empty", order: 1);
             await TestDataSeeder.LinkEnemyToZoneAsync(context, viableZone.Id, enemy.Id);
@@ -1619,7 +1619,7 @@ namespace Game.Application.Tests.Services
             // strippedZone is live, but its only assigned enemy has been retired — a retired enemy is filtered
             // out of the spawn tables, so the zone has no spawnable enemies. This is the exact #1051 trigger
             // (an admin retired every active enemy of a live zone); the runtime safety net must relocate rather
-            // than throw on GetRandomEnemy.
+            // than throw on GetRandomDomainEnemy.
             var retiredEnemy = await TestDataSeeder.CreateEnemyAsync(context, "Retired Foe");
             retiredEnemy.RetiredAt = DateTime.UtcNow;
             await context.SaveChangesAsync(CancellationToken);

--- a/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
@@ -4,6 +4,7 @@ using Game.Application.Services;
 using Game.Core;
 using Game.Core.Attributes.Modifiers;
 using Game.Core.Players;
+using Game.Core.TestInfrastructure.Builders;
 using Game.DataAccess;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Base;

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -634,12 +634,13 @@ namespace Game.Application.Services
         // out the same way, regardless of how the battle was ended.
         //
         // Anti-cheat note: the two callers gate this payout differently and that asymmetry is intentional.
-        // EndBattleVictory validates the *client-supplied* claimed timestamp (within one logical tick of the
-        // simulated earliest defeat, and not in the future) before paying out. The won-abandon path performs no such
-        // timestamp check because it re-simulates capped at the *server-measured* elapsed wall-clock time
+        // EndBattleVictory validates that enough *server-clock* wall time has elapsed since battle start for
+        // the replayed battle to have actually finished (immune to client/server clock skew, since no
+        // client-supplied timestamp is trusted) before paying out. The won-abandon path performs no such
+        // elapsed-time check because it re-simulates capped at the *server-measured* elapsed wall-clock time
         // (AbandonBattle's elapsedMs) — a win only resolves if the enemy died within time the server itself
-        // observed, so the server-measured cap is the (stronger) control there and a client timestamp adds
-        // nothing. Both paths therefore require a server-validated timeline; neither can be claimed early.
+        // observed, so the server-measured cap is the (stronger) control there and nothing else is needed.
+        // Both paths therefore require a server-validated timeline; neither can be claimed early.
         // internal (not private) so an integration test can assert the live PlayerPower snapshot directly:
         // EndBattleVictory returns only a client-facing DefeatResult, and the BattleStats this mutates is
         // carried on the BattleCompletedEvent, which the dispatcher clears after handling — leaving no other

--- a/Game.Core.TestInfrastructure/Builders/PlayerAttributeTestExtensions.cs
+++ b/Game.Core.TestInfrastructure/Builders/PlayerAttributeTestExtensions.cs
@@ -1,0 +1,41 @@
+using Game.Core.Attributes;
+using Game.Core.Attributes.Modifiers;
+using Game.Core.Players;
+using Game.Core.Players.Inventories;
+
+namespace Game.Core.TestInfrastructure.Builders
+{
+    /// <summary>
+    /// Test-only attribute composition shortcut for a live <see cref="Player"/> aggregate, mirroring
+    /// <see cref="BattlerFactory"/>'s rationale: production never composes attributes this way — every
+    /// production battler is reconstructed from a frozen <see cref="Battle.BattleSnapshot"/>
+    /// (<see cref="Battle.BattleSnapshot.GetModifiers"/>), which additionally layers the class locked base,
+    /// proficiency bonuses, and signature passive that this shortcut omits. Used only by
+    /// <see cref="BattlerFactory"/> and unit tests that need a battler/attribute set straight off stat
+    /// allocations + equipped gear with no other setup.
+    /// </summary>
+    public static class PlayerAttributeTestExtensions
+    {
+        public static IEnumerable<AttributeModifier> GetAllModifiers(this Player player)
+        {
+            return player.StatPoints.ToAttributeModifiers()
+                .Concat(player.Inventory.GetEquippedAttributeModifiers());
+        }
+
+        public static AttributeCollection GetAttributes(this Player player)
+        {
+            return new AttributeCollection(player.GetAllModifiers());
+        }
+
+        public static IEnumerable<AttributeModifier> GetEquippedAttributeModifiers(this Inventory inventory)
+        {
+            return inventory.EquipmentSlots.SelectNotNull(slot => slot.Item)
+                .SelectMany(item => item.GetAttributeModifiers(GetAppliedMods(inventory, item.Id)));
+        }
+
+        private static IEnumerable<Items.ItemMod> GetAppliedMods(Inventory inventory, int itemId)
+        {
+            return inventory.GetUnlockedItem(itemId)?.AppliedMods.Select(applied => applied.ItemMod) ?? [];
+        }
+    }
+}

--- a/Game.Core.Tests/Players/InventoryTests.cs
+++ b/Game.Core.Tests/Players/InventoryTests.cs
@@ -1,6 +1,7 @@
 using Game.Core.Attributes.Modifiers;
 using Game.Core.Items;
 using Game.Core.Players.Inventories;
+using Game.Core.TestInfrastructure.Builders;
 using Xunit;
 
 namespace Game.Core.Tests.Players

--- a/Game.Core/Attributes/AttributeCollection.cs
+++ b/Game.Core/Attributes/AttributeCollection.cs
@@ -100,6 +100,8 @@ namespace Game.Core.Attributes
 
         /// <summary>
         /// Retrieves all the <see cref="AttributeModifier"/> instances contained in the collection.
+        /// Test-only today (no production caller) — kept as an instance member rather than moved out since
+        /// it needs the private per-attribute node storage.
         /// </summary>
         /// <returns></returns>
         public IEnumerable<AttributeModifier> AllModifiers()

--- a/Game.Core/Battle/BattleSnapshot.cs
+++ b/Game.Core/Battle/BattleSnapshot.cs
@@ -105,12 +105,12 @@ namespace Game.Core.Battle
 
         /// <summary>
         /// Reconstructs the player's <see cref="Battler"/> from this snapshot, resolving the captured IDs
-        /// against the in-memory catalogs via the supplied resolvers. The same modifier-composition rules the
-        /// live <see cref="Player.GetAllModifiers"/> path uses are reused here (<see cref="StatAllocation.ToModifier"/>
-        /// and <see cref="Item.GetAttributeModifiers"/>), so a battle validated from a snapshot is guaranteed to
-        /// match the player's live attributes — the frontend/backend battle-parity guarantee. The caller provides
-        /// the resolvers so the domain stays independent of the data-access layer that owns catalog lookups,
-        /// mirroring <see cref="BattleFactory"/>'s enemy resolver.
+        /// against the in-memory catalogs via the supplied resolvers. The same modifier-composition primitives
+        /// production uses (<see cref="StatAllocation.ToModifier"/> and <see cref="Item.GetAttributeModifiers"/>)
+        /// are reused here, so a battle validated from a snapshot is guaranteed to match the player's live
+        /// attributes — the frontend/backend battle-parity guarantee. The caller provides the resolvers so the
+        /// domain stays independent of the data-access layer that owns catalog lookups, mirroring
+        /// <see cref="BattleFactory"/>'s enemy resolver.
         /// </summary>
         public Battler ToBattler(
             Func<int, Item> resolveItem, Func<int, ItemMod> resolveMod, Func<int, Skill?> resolveSkill,

--- a/Game.Core/Battle/DefeatRewards.cs
+++ b/Game.Core/Battle/DefeatRewards.cs
@@ -76,9 +76,8 @@ namespace Game.Core.Battle
         /// Sums the additive amounts of the core attributes in <paramref name="modifiers"/>. Both
         /// combatants' power is measured the same way so the difficulty ratio compares like with like:
         /// derived attributes (e.g. MaxHealth) are excluded because they are computed from the core
-        /// attributes and never appear in a player's <see cref="Player.GetAllModifiers"/>, and
-        /// multiplicative modifiers are excluded because their amount is a scaling factor, not a flat
-        /// point total that can be meaningfully summed.
+        /// attributes and never appear as their own modifier, and multiplicative modifiers are excluded
+        /// because their amount is a scaling factor, not a flat point total that can be meaningfully summed.
         /// </summary>
         private static double SumCoreAttributes(IEnumerable<AttributeModifier> modifiers)
         {

--- a/Game.Core/Items/Item.cs
+++ b/Game.Core/Items/Item.cs
@@ -71,9 +71,9 @@ namespace Game.Core.Items
         /// <summary>
         /// The attribute modifiers this item contributes when equipped: its own <see cref="Attributes"/>
         /// plus the attributes of the given <paramref name="appliedMods"/>. Single source of truth for the
-        /// item + applied-mods composition rule, shared by the live
-        /// <see cref="Players.Inventories.Inventory.GetEquippedAttributeModifiers"/> path and the
-        /// battle-snapshot reconstruction (<see cref="Battle.BattleSnapshot.ToBattler"/>).
+        /// item + applied-mods composition rule, shared by the live battle-snapshot reconstruction
+        /// (<see cref="Battle.BattleSnapshot.ToBattler"/>) and the test-only <c>GetEquippedAttributeModifiers</c>
+        /// shortcut (<c>Game.Core.TestInfrastructure</c>) used to build a battler straight off a live player.
         /// </summary>
         public IEnumerable<AttributeModifier> GetAttributeModifiers(IEnumerable<ItemMod> appliedMods)
         {

--- a/Game.Core/Players/Inventories/Inventory.cs
+++ b/Game.Core/Players/Inventories/Inventory.cs
@@ -1,4 +1,3 @@
-using Game.Core.Attributes.Modifiers;
 using Game.Core.Items;
 
 namespace Game.Core.Players.Inventories
@@ -53,28 +52,6 @@ namespace Game.Core.Players.Inventories
         public UnlockedItemSlot? GetUnlockedItem(int itemId)
         {
             return _unlockedItems.GetValueOrDefault(itemId);
-        }
-
-        public IEnumerable<AttributeModifier> GetEquippedAttributeModifiers()
-        {
-            return EquipmentSlots.SelectNotNull(slot => slot.Item)
-                .SelectMany(item => item.GetAttributeModifiers(GetAppliedMods(item.Id)));
-        }
-
-        /// <summary>
-        /// Resolves the mods currently applied to the equipped item with the given
-        /// <paramref name="itemId"/>. Applied mods live on the player's <see cref="UnlockedItemSlot"/>
-        /// rather than on the shared, reference-data <see cref="Item.ModSlots"/>.
-        /// </summary>
-        private IEnumerable<ItemMod> GetAppliedMods(int itemId)
-        {
-            var unlocked = GetUnlockedItem(itemId);
-            if (unlocked is null)
-            {
-                return [];
-            }
-
-            return unlocked.AppliedMods.Select(applied => applied.ItemMod);
         }
 
         public bool TryEquipItem(int itemId, EEquipmentSlot slot, IReadOnlyDictionary<int, int> proficiencyLevels)

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -1,5 +1,3 @@
-using Game.Core.Attributes;
-using Game.Core.Attributes.Modifiers;
 using Game.Core.Battle;
 using Game.Core.Battle.Events;
 using Game.Core.Enemies;
@@ -450,17 +448,6 @@ namespace Game.Core.Players
         {
             LastActivity = timestamp;
             RaiseCoreUpdated();
-        }
-
-        public IEnumerable<AttributeModifier> GetAllModifiers()
-        {
-            return StatPoints.ToAttributeModifiers()
-                .Concat(Inventory.GetEquippedAttributeModifiers());
-        }
-
-        public AttributeCollection GetAttributes()
-        {
-            return new AttributeCollection(GetAllModifiers());
         }
 
         private void RaiseCoreUpdated()

--- a/Game.Core/ServerGameConstants.cs
+++ b/Game.Core/ServerGameConstants.cs
@@ -28,12 +28,14 @@ namespace Game.Core
         public const int MaxExpPerGrant = 100_000;
 
         /// <summary>
-        /// The fixed pie of proficiency XP a won battle pays out at difficulty multiplier 1 (spike #982
-        /// decision 4). The total is constant per victory — scaled by the <c>DefeatRewards</c> difficulty
-        /// curve and then split across the proficiencies represented in the fight — so diversifying a
-        /// loadout dilutes each track rather than minting more total XP. Computed server-side at battle
-        /// completion (never in the seeded simulation), so it is server-authoritative and not mirrored to
-        /// the client. A strawman magnitude, tunable against the authored per-proficiency XP curves.
+        /// The base pie (<c>basePie</c>) each proficiency path independently claims against on a won battle:
+        /// <c>XP_path = basePie × clamp(pathActivity ÷ totalAttributes)</c> (spike #1318). Power-normalization
+        /// is the difficulty curve, so the banded <c>DefeatRewards</c> difficulty multiplier is deliberately
+        /// <em>not</em> applied again. Claims across axes (offense/defense/proc) don't share a pie — they are
+        /// independent, overlapping claims — so a multi-axis loadout mints <em>more</em> total proficiency XP
+        /// rather than diluting each track. Computed server-side at battle completion (never in the seeded
+        /// simulation), so it is server-authoritative and not mirrored to the client. A strawman magnitude,
+        /// tunable against the authored per-proficiency XP curves.
         /// </summary>
         public const double ProficiencyXpPerVictory = 10.0;
 

--- a/Game.DataAccess/Repositories/Caching/SkillRecipesCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/SkillRecipesCacheHolder.cs
@@ -9,20 +9,12 @@ namespace Game.DataAccess.Repositories.Caching
 {
     /// <summary>
     /// An immutable snapshot of the skill-recipe reference set (spike #1125): the ordered recipe entity list
-    /// (contract projection and admin entity lookups), the pre-materialized lean <see cref="CoreSkillRecipe"/>
-    /// domain models, and the derived input-skill → recipe-ids reverse index. All are built and published
-    /// together so a reader can never observe a new entity list against a stale index.
-    /// <para>
-    /// The reverse index drives the client's conservative hinted reveal (areas D/E): a skill the player owns
-    /// maps to the recipes it feeds. Retired recipes are excluded from the index — a retired recipe is no
-    /// longer offered or hinted — but stay resolvable by id in the entity/core lists (already-synthesized
-    /// results persist).
-    /// </para>
+    /// (contract projection and admin entity lookups) and the pre-materialized lean <see cref="CoreSkillRecipe"/>
+    /// domain models, built and published together so a reader can never observe a torn pair.
     /// </summary>
     internal sealed record SkillRecipeSnapshot(
         IReadOnlyList<SkillRecipe> Entities,
-        IReadOnlyList<CoreSkillRecipe> CoreRecipes,
-        IReadOnlyDictionary<int, IReadOnlyList<int>> RecipeIdsByInputSkill);
+        IReadOnlyList<CoreSkillRecipe> CoreRecipes);
 
     /// <summary>Singleton snapshot holder for the cached skill-recipe entity list and its derived structures.</summary>
     internal sealed class SkillRecipesCacheHolder(IServiceScopeFactory scopeFactory)
@@ -53,20 +45,9 @@ namespace Game.DataAccess.Repositories.Caching
                     $"Skill recipe graph contains a cycle (a skill cannot be synthesized from itself): {string.Join(" -> ", cycle)}.");
             }
 
-            // The reverse index the client hint state consumes: each input skill → the recipes it feeds. Retired
-            // recipes are excluded so a retired recipe is never offered or hinted.
-            var recipeIdsByInputSkill = entities
-                .Where(r => r.RetiredAt is null)
-                .SelectMany(r => r.Inputs.Select(i => (i.SkillId, r.Id)))
-                .GroupBy(x => x.SkillId)
-                .ToDictionary(
-                    g => g.Key,
-                    g => (IReadOnlyList<int>)g.Select(x => x.Id).OrderBy(id => id).ToList());
-
             return new SkillRecipeSnapshot(
                 entities,
-                entities.Select(SkillRecipeMapper.ToCore).ToList(),
-                recipeIdsByInputSkill);
+                entities.Select(SkillRecipeMapper.ToCore).ToList());
         }
     }
 }

--- a/Game.DataAccess/Repositories/Enemies.cs
+++ b/Game.DataAccess/Repositories/Enemies.cs
@@ -24,12 +24,6 @@ namespace Game.DataAccess.Repositories
             return Snapshot.Enemies.Lookup(enemyId);
         }
 
-        public Enemy GetRandomEnemy(int zoneId)
-        {
-            var snapshot = Snapshot;
-            return snapshot.Enemies[GetRandomEnemyId(snapshot, zoneId)];
-        }
-
         public CoreEnemy? GetDomainEnemy(int enemyId, int level)
         {
             // Clones the snapshot's pre-mapped, level-independent template rather than re-mapping the enemy's

--- a/Game.DataAccess/Repositories/EntityStore.cs
+++ b/Game.DataAccess/Repositories/EntityStore.cs
@@ -41,11 +41,6 @@ namespace Game.DataAccess.Repositories
             _context.Entry(entity).State = EntityState.Modified;
         }
 
-        public void Track<TEntity>(TEntity entity) where TEntity : class
-        {
-            _context.Entry(entity).State = EntityState.Unchanged;
-        }
-
         // Builds a stub carrying only the primary key. The instance is created uninitialized — `required`
         // is a compile-time guard the runtime doesn't enforce, the same way EF's own materializer
         // constructs entities — so a key-only delete never has to fabricate a value for an unrelated

--- a/Game.DataAccess/Repositories/IEnemyEntityCache.cs
+++ b/Game.DataAccess/Repositories/IEnemyEntityCache.cs
@@ -12,8 +12,5 @@ namespace Game.DataAccess.Repositories
     {
         /// <summary>The cached enemy entity at <paramref name="enemyId"/> (its zero-based index), or null if out of range.</summary>
         EnemyEntity? GetEnemy(int enemyId);
-
-        /// <summary>A random enemy entity drawn from the requested zone's spawn table.</summary>
-        EnemyEntity GetRandomEnemy(int zoneId);
     }
 }

--- a/Game.DataAccess/Repositories/IEntityStore.cs
+++ b/Game.DataAccess/Repositories/IEntityStore.cs
@@ -17,6 +17,5 @@ namespace Game.DataAccess.Repositories
         /// </summary>
         void DeleteByKey<TEntity>(params object[] keyValues) where TEntity : class;
         void Update<TEntity>(TEntity entity) where TEntity : class;
-        void Track<TEntity>(TEntity entity) where TEntity : class;
     }
 }

--- a/Game.DataAccess/Repositories/SkillRecipes.cs
+++ b/Game.DataAccess/Repositories/SkillRecipes.cs
@@ -32,13 +32,6 @@ namespace Game.DataAccess.Repositories
             return Snapshot.CoreRecipes.GetById(recipeId, "skill recipe");
         }
 
-        public IReadOnlyList<int> RecipesForInputSkill(int skillId)
-        {
-            return Snapshot.RecipeIdsByInputSkill.TryGetValue(skillId, out var recipeIds)
-                ? recipeIds
-                : [];
-        }
-
         public SkillRecipe? LookupSkillRecipe(int recipeId)
         {
             return Snapshot.Entities.Lookup(recipeId);

--- a/Game.DataAccess/Repositories/Zones.cs
+++ b/Game.DataAccess/Repositories/Zones.cs
@@ -20,14 +20,6 @@ namespace Game.DataAccess.Repositories
             return [.. Snapshot.Entities.Select(ZoneMapper.ToContract)];
         }
 
-        public Contracts.Zone GetZone(int zoneId)
-        {
-            var entities = Snapshot.Entities;
-            return IsValidZoneId(entities, zoneId)
-                ? ZoneMapper.ToContract(entities[zoneId])
-                : throw new ArgumentOutOfRangeException(nameof(zoneId));
-        }
-
         public Core.Zones.Zone GetDomainZone(int zoneId)
         {
             // Hands back the snapshot's shared, pre-materialized domain model rather than mapping a fresh

--- a/Game.Infrastructure.Tests/RedisPubSubSubscribeRollbackTests.cs
+++ b/Game.Infrastructure.Tests/RedisPubSubSubscribeRollbackTests.cs
@@ -28,13 +28,6 @@ namespace Game.Infrastructure.Tests
         private const string DeadEndpoint = "127.0.0.1:1,abortConnect=false,connectTimeout=500,connectRetry=0";
 
         [Fact]
-        public async Task Subscribe_ActionOverload_WhenSubscribeAsyncFails_RollsBackIdForRetry()
-        {
-            await AssertFailedSubscribeFreesId((service, id) =>
-                service.Subscribe("rollback-channel", "rollback-queue", (Action<(IPubSubQueue queue, string channel)>)(_ => { }), id));
-        }
-
-        [Fact]
         public async Task Subscribe_AsyncOverload_WhenSubscribeAsyncFails_RollsBackIdForRetry()
         {
             await AssertFailedSubscribeFreesId((service, id) =>
@@ -48,17 +41,15 @@ namespace Game.Infrastructure.Tests
                 service.Subscribe("rollback-channel", (Action<(string message, string channel)>)(_ => { }), id));
         }
 
-        // The worker-backed overloads require a non-null id (a worker tracked under no id could never be disposed
+        // The worker-backed overload requires a non-null id (a worker tracked under no id could never be disposed
         // via UnSubscribe and would leak its OS wait handle, #954). A null id is rejected up front — before the
         // worker is even created, so the misuse can't leak it — and the connection is never touched.
         [Fact]
-        public async Task Subscribe_WorkerOverloads_NullId_ThrowAndNeverConnect()
+        public async Task Subscribe_WorkerOverload_NullId_ThrowAndNeverConnect()
         {
             await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(DeadEndpoint);
             var service = new RedisPubSubService(multiplexer, NullLoggerFactory.Instance);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                service.Subscribe("channel", "queue", (Action<(IPubSubQueue queue, string channel)>)(_ => { }), null!));
             await Assert.ThrowsAsync<ArgumentNullException>(() =>
                 service.Subscribe("channel", "queue", (Func<(IPubSubQueue queue, string channel), Task>)(_ => Task.CompletedTask), null!));
         }

--- a/Game.Infrastructure/Cache/Redis/RedisService.cs
+++ b/Game.Infrastructure/Cache/Redis/RedisService.cs
@@ -73,11 +73,6 @@ namespace Game.Infrastructure.Cache.Redis
             await Set(key, value?.Serialize(), expiry, cancellationToken);
         }
 
-        public async Task Expire(string key, TimeSpan expiry, CancellationToken cancellationToken = default)
-        {
-            await ObserveWrite(Redis.KeyExpireAsync(key, expiry), cancellationToken);
-        }
-
         public void ExpireAndForget(string key, TimeSpan expiry)
         {
             Redis.KeyExpire(key, expiry, CommandFlags.FireAndForget);
@@ -91,11 +86,6 @@ namespace Game.Infrastructure.Cache.Redis
         public void SetAndForget<T>(string key, T value, TimeSpan expiry)
         {
             SetAndForget(key, value?.Serialize(), expiry);
-        }
-
-        public async Task SetNotExists(string key, string value, CancellationToken cancellationToken = default)
-        {
-            await StringSetAsync(key, value, when: When.NotExists, cancellationToken: cancellationToken);
         }
 
         public async Task CompareAndDelete(string key, string deleteIfValue, CancellationToken cancellationToken = default)

--- a/Game.Infrastructure/Database/GameContextFactory.cs
+++ b/Game.Infrastructure/Database/GameContextFactory.cs
@@ -9,6 +9,14 @@ namespace Game.Infrastructure.Database
         public static GameContext GetGameContext(IDatabaseOptions config, ILoggerFactory loggerFactory)
         {
             var optionsBuilder = new DbContextOptionsBuilder<GameContext>();
+            Configure(optionsBuilder, config, loggerFactory);
+            return new GameContext(optionsBuilder.Options);
+        }
+
+        // Shared with the DI registration (AddDbContextPool), which builds its DbContextOptions once at
+        // startup rather than per resolution/pooled-instance rent.
+        internal static void Configure(DbContextOptionsBuilder optionsBuilder, IDatabaseOptions config, ILoggerFactory loggerFactory)
+        {
             optionsBuilder.UseLoggerFactory(loggerFactory);
 
             switch (config.DatabaseSystem)
@@ -29,8 +37,6 @@ namespace Game.Infrastructure.Database
                         + $"{nameof(Postgres)} (DataAccessOptions:DatabaseSystem = {(int)Postgres}); a missing or "
                         + "unrecognized value is rejected rather than defaulted because there is no other supported provider.");
             }
-
-            return new GameContext(optionsBuilder.Options);
         }
     }
 }

--- a/Game.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Game.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using Game.Infrastructure.Database;
 using Game.Infrastructure.PubSub;
 using Game.Infrastructure.Redis;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -15,17 +16,21 @@ namespace Game.Infrastructure.DependencyInjection
     public static class ServiceCollectionExtensions
     {
         /// <summary>
-        /// Adds a <see cref="GameContext"/> to the <see cref="IServiceCollection"/>.  Requires a configured <see cref="InfrastructureOptions"/> service
-        /// to be registered in the <see cref="IServiceCollection"/>.
+        /// Adds a pooled <see cref="GameContext"/> to the <see cref="IServiceCollection"/>.  Requires a configured
+        /// <see cref="InfrastructureOptions"/> service to be registered in the <see cref="IServiceCollection"/>.
+        /// The options builder runs once at startup (not per resolution), and <see cref="GameContext"/> instances
+        /// are rented from a pool rather than allocated fresh — cheaper on the per-scope resolution path
+        /// (including the drain-loop's scope-per-event pattern) since <c>GameContext</c> has no per-scope state
+        /// beyond the pooled options.
         /// </summary>
         /// <param name="services"> The dependency injection container to configure.</param>
         public static IServiceCollection AddGameContext(this IServiceCollection services)
         {
-            return services.AddScoped(sp =>
+            return services.AddDbContextPool<GameContext>((sp, optionsBuilder) =>
             {
                 var options = sp.GetRequiredService<InfrastructureOptions>();
                 var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
-                return GameContextFactory.GetGameContext(options, loggerFactory);
+                GameContextFactory.Configure(optionsBuilder, options, loggerFactory);
             });
         }
 

--- a/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
@@ -114,20 +114,6 @@ namespace Game.Infrastructure.PubSub.Redis
             }
         }
 
-        public async Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id)
-        {
-            // Validate the id before creating the worker so a misuse can't leak the worker's wait handle (#954).
-            ArgumentNullException.ThrowIfNull(id);
-            _logger.LogInformation("Creating redis subscriber on channel '{Channel}' with queue '{QueueName}'.", channel, queueName);
-            var queue = GetQueue(queueName);
-            var worker = new BackgroundWorker(_loggerFactory.CreateLogger<BackgroundWorker>(), () => action((queue, channel)))
-            {
-                Name = $"RedisSubWorker_{queueName}"
-            };
-
-            await SubscribeWithWorker(channel, worker, id);
-        }
-
         public async Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id)
         {
             // Validate the id before creating the worker so a misuse can't leak the worker's wait handle (#954).
@@ -170,11 +156,6 @@ namespace Game.Infrastructure.PubSub.Redis
             {
                 worker.Start();
             }
-        }
-
-        public async Task UnSubscribe(string channel)
-        {
-            await Subscriber.UnsubscribeAsync(RedisChannel.Literal(channel));
         }
 
         public async Task UnSubscribe(string channel, string id)

--- a/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
@@ -32,22 +32,6 @@ namespace Game.Infrastructure.PubSub.Redis
             _logger = logger;
         }
 
-        public string? GetNext()
-        {
-            var value = _redis.ListLeftPop(QueueName);
-            if (value.HasValue)
-            {
-                _logger.LogTrace("Retrieved value from RedisQueue: {QueueName}, value: {Value}", QueueName, value);
-            }
-
-            return value;
-        }
-
-        public T? GetNext<T>()
-        {
-            return GetNext().Deserialize<T>();
-        }
-
         public async Task<string?> GetNextAsync(CancellationToken cancellationToken = default)
         {
             // LPOP is a destructive read (it removes the head), so it takes the write path: like RedisService.GetDelete
@@ -144,17 +128,6 @@ namespace Game.Infrastructure.PubSub.Redis
         {
             // LREM count 1 removes a single matching occurrence; returns false (a no-op) when none remain.
             return await ObserveWrite(_redis.ListRemoveAsync(QueueName, value, 1), cancellationToken) > 0;
-        }
-
-        public void AddToQueue(string value)
-        {
-            _logger.LogTrace("Added value to RedisQueue: {QueueName}, value: {Value}", QueueName, value);
-            _redis.ListRightPush(QueueName, value);
-        }
-
-        public void AddToQueue<T>(T value)
-        {
-            AddToQueue(value.Serialize());
         }
 
         public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default)

--- a/Game.TestInfrastructure/Helpers/NotSupportedPubSubService.cs
+++ b/Game.TestInfrastructure/Helpers/NotSupportedPubSubService.cs
@@ -15,9 +15,7 @@ namespace Game.TestInfrastructure.Helpers
         public virtual Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public virtual Task Wake(string channel) => throw new NotSupportedException();
         public virtual Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => throw new NotSupportedException();
-        public virtual Task Subscribe(string channel, string queueName, Action<(IPubSubQueue queue, string channel)> action, string id) => throw new NotSupportedException();
         public virtual Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => throw new NotSupportedException();
-        public virtual Task UnSubscribe(string channel) => throw new NotSupportedException();
         public virtual Task UnSubscribe(string channel, string id) => throw new NotSupportedException();
         public virtual IPubSubQueue GetQueue(string queueName) => throw new NotSupportedException();
     }


### PR DESCRIPTION
## Summary

Implements #1514 — a backend dead-code & stale-comment cleanup basket (same pattern as #937/#1192). I independently re-verified every claim in the issue via repo-wide reference search before deleting anything (per CLAUDE.md's "don't trust the issue, verify" guidance) and found one discrepancy, noted below.

### Dead cache/queue/pub-sub surface removed
- `ICacheService.SetNotExists` — also the only setter that wrote a key with no TTL.
- `ICacheService.Expire` (awaited overload) — only `ExpireAndForget` was used.
- `IPubSubQueue`'s sync `GetNext()`/`GetNext<T>()`/`AddToQueue(string)`/`AddToQueue<T>()`.
- `IPubSubService.Subscribe(channel, queueName, Action<...>, id)` (the sync-Action worker overload) — no production caller (both real call sites use the `Func` overload).
- `IPubSubService.UnSubscribe(string channel)` (no-id overload) — **the issue claimed this was unused, but it wasn't**: `AdminCacheReloadBroadcastTests.cs` called it for cleanup. I switched that test to the safer id-scoped `Subscribe`/`UnSubscribe(channel, id)` pattern every other test in the suite already uses, then removed the hazardous unsubscribe-every-handler-on-the-channel method.

### Dead repository/domain members removed
- `Enemies.GetRandomEnemy` + `IEnemyEntityCache.GetRandomEnemy` — its dedicated integration tests (invalid zone, empty zone, retired-exclusion) were ported onto `GetRandomDomainEnemy`, which shares the same underlying zone-validation/spawn-table logic, so that edge-case coverage isn't lost.
- `EntityStore.Track` + `IEntityStore.Track`.
- `Zones.GetZone` + `IZones.GetZone` — its field-mapping assertions were redundant with `ZoneMapperTests` (already covers the full contract, including `IsHome`), so those tests were removed rather than ported; the bounds-check behavior stays pinned via `GetDomainZone`'s tests (same shared validation helper).
- `SkillRecipes.RecipesForInputSkill` + the cache's `RecipeIdsByInputSkill` reverse index — the issue flagged this as a possible deliberate seam from spike #1125, so I checked: the spike's design doc says the reverse index was meant to drive the client's hinted reveal, but the shipped implementation (`GetSkillRecipes` command) sends the full recipe set and the client derives hints itself — the reverse index was never actually wired to anything. Confirmed dead.
- `IModelToSource<TSource>` / `IMappedModel<TModel, TEntity>` — zero implementations solution-wide (`IModelFromSource`, which many models do implement, is untouched).

### Test-only modifier path (footgun) fixed
`Player.GetAllModifiers()`/`GetAttributes()` and `Inventory.GetEquippedAttributeModifiers()` were called only by `BattlerFactory` (test infra) and unit tests — every production battler composition goes through `BattleSnapshot.GetModifiers*`, which additionally layers the class locked base, proficiency bonuses, and signature passive. Moved the chain into `Game.Core.TestInfrastructure` (`PlayerAttributeTestExtensions`) as extension methods so a future production caller can no longer reach for the lesser composition by accident. `AttributeCollection.AllModifiers()` has the same shape but needs the collection's private per-attribute node storage, so it couldn't move without adding new public surface for a test-only accessor — left in place with a doc comment flagging it as test-only instead.

Fixed the stale doc comments this uncovered/it referenced:
- `BattleSnapshot.cs`, `DefeatRewards.cs`, `Item.cs` — no longer describe the moved methods as "the live path."
- `ServerGameConstants.ProficiencyXpPerVictory` — was still describing the retired pre-#1318 band/dilution model; now describes the actual independent-overlapping-claims, no-difficulty-multiplier, multi-axis-mints-more model.
- `BattleService.RecordVictory` — claimed `EndBattleVictory` validates a *client-supplied* timestamp; it's actually server-clock-only (matches the accurate comment a few lines above it in the same file).

### Misc
`GameContext`'s DI registration switched from a per-resolution factory (rebuilding `DbContextOptions` from scratch on every scope, including the write-behind drain loop's scope-per-event path) to `AddDbContextPool`, which builds options once at startup and pools `GameContext` instances. `GameContext` has no per-scope state beyond `DbContextOptions`, so it's safe to pool. `GameContextFactory.GetGameContext` (used directly by a couple of unit tests) is unchanged in behavior — the options-building logic was extracted into a shared `Configure` method both paths call.

## Test plan
- [x] `dotnet build` — clean, 0 warnings/errors
- [x] `dotnet test --no-build --no-restore` — full suite green (2791 tests: Core 1231, Infrastructure 59, Application 824, Api 677), including the integration suites that exercise `GameContext` through the new pooled DI registration
- [x] Repo-wide reference search on every deleted member before removal to confirm no production caller

Closes #1514


---
_Generated by [Claude Code](https://claude.ai/code/session_01UpjjF8hpvJkG26UxR9RJCA)_