### PR TITLE
Fix Workbench guardrail gaps: incomplete retire references, silent unsaved-change discard

### DIFF
--- a/UI/src/routes/admin/+page.svelte
+++ b/UI/src/routes/admin/+page.svelte
@@ -58,7 +58,8 @@ import {
 } from './workbench/nav';
 import { reference } from './workbench/reference.svelte';
 import { ensureAdminAccess } from './admin-access';
-import { dangerModal, toastError } from '$stores';
+import { confirmDiscard, guardBeforeUnload } from './discard-guard';
+import { toastError } from '$stores';
 
 let active = $state('enemies');
 let sidebarPinned = $state(false);
@@ -80,43 +81,23 @@ onMount(() => {
 	}
 });
 
-/** Prompts to discard pending edits when the active Workbench/Progression surface is dirty. */
-const confirmDiscard = async (): Promise<boolean> => {
-	const pending = workbenchDirty.total;
-	if (pending === 0) {
-		return true;
-	}
-	return dangerModal({
-		title: 'Discard unsaved changes?',
-		body: `You have ${pending} unsaved ${pending === 1 ? 'change' : 'changes'}. Leaving now will discard ${pending === 1 ? 'it' : 'them'}.`,
-		confirmLabel: 'Discard and continue'
-	});
-};
-
 const handleNavigate = async (key: string) => {
 	if (key === active) {
 		return;
 	}
-	if (await confirmDiscard()) {
+	if (await confirmDiscard(workbenchDirty.total)) {
 		active = key;
 	}
 };
 
 const backToGame = async () => {
-	if (await confirmDiscard()) {
+	if (await confirmDiscard(workbenchDirty.total)) {
 		goto(resolve('/game'));
 	}
 };
 
-// Backstop for a full page unload (refresh, close, external link) — client-side navigation away
-// (tool switch, "Return to Game") is guarded by confirmDiscard above instead.
 $effect(() => {
-	const handler = (event: BeforeUnloadEvent) => {
-		if (workbenchDirty.total > 0) {
-			event.preventDefault();
-			event.returnValue = '';
-		}
-	};
+	const handler = (event: BeforeUnloadEvent) => guardBeforeUnload(event, workbenchDirty.total);
 	window.addEventListener('beforeunload', handler);
 	return () => window.removeEventListener('beforeunload', handler);
 });

--- a/UI/src/routes/admin/+page.svelte
+++ b/UI/src/routes/admin/+page.svelte
@@ -48,6 +48,7 @@ import DeadLetterConsole from './ops/DeadLetterConsole.svelte';
 import ContentHealthConsole from './ops/ContentHealthConsole.svelte';
 import Progression from './workbench/progression/Progression.svelte';
 import { entityByKey, groupLabelFor } from './workbench/entities';
+import { workbenchDirty } from './workbench/dirty.svelte';
 import {
 	adminGroups,
 	adminTools,
@@ -57,7 +58,7 @@ import {
 } from './workbench/nav';
 import { reference } from './workbench/reference.svelte';
 import { ensureAdminAccess } from './admin-access';
-import { toastError } from '$stores';
+import { dangerModal, toastError } from '$stores';
 
 let active = $state('enemies');
 let sidebarPinned = $state(false);
@@ -79,11 +80,46 @@ onMount(() => {
 	}
 });
 
-const handleNavigate = (key: string) => {
-	active = key;
+/** Prompts to discard pending edits when the active Workbench/Progression surface is dirty. */
+const confirmDiscard = async (): Promise<boolean> => {
+	const pending = workbenchDirty.total;
+	if (pending === 0) {
+		return true;
+	}
+	return dangerModal({
+		title: 'Discard unsaved changes?',
+		body: `You have ${pending} unsaved ${pending === 1 ? 'change' : 'changes'}. Leaving now will discard ${pending === 1 ? 'it' : 'them'}.`,
+		confirmLabel: 'Discard and continue'
+	});
 };
 
-const backToGame = () => goto(resolve('/game'));
+const handleNavigate = async (key: string) => {
+	if (key === active) {
+		return;
+	}
+	if (await confirmDiscard()) {
+		active = key;
+	}
+};
+
+const backToGame = async () => {
+	if (await confirmDiscard()) {
+		goto(resolve('/game'));
+	}
+};
+
+// Backstop for a full page unload (refresh, close, external link) — client-side navigation away
+// (tool switch, "Return to Game") is guarded by confirmDiscard above instead.
+$effect(() => {
+	const handler = (event: BeforeUnloadEvent) => {
+		if (workbenchDirty.total > 0) {
+			event.preventDefault();
+			event.returnValue = '';
+		}
+	};
+	window.addEventListener('beforeunload', handler);
+	return () => window.removeEventListener('beforeunload', handler);
+});
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/admin/discard-guard.ts
+++ b/UI/src/routes/admin/discard-guard.ts
@@ -1,0 +1,30 @@
+import { dangerModal } from '$stores';
+
+/**
+ * Prompts to discard pending edits (via a danger modal) when `pending` unsaved changes exist;
+ * resolves `true` immediately, without prompting, when there is nothing to lose. Shared by every
+ * way the admin shell can leave a dirty Workbench/Progression surface — a sidebar tool switch or
+ * "Return to Game" — so the count-based pluralization and confirm copy live in one place.
+ */
+export async function confirmDiscard(pending: number): Promise<boolean> {
+	if (pending === 0) {
+		return true;
+	}
+	return dangerModal({
+		title: 'Discard unsaved changes?',
+		body: `You have ${pending} unsaved ${pending === 1 ? 'change' : 'changes'}. Leaving now will discard ${pending === 1 ? 'it' : 'them'}.`,
+		confirmLabel: 'Discard and continue'
+	});
+}
+
+/**
+ * Blocks a full page unload (refresh, close, external navigation) while `pending` unsaved changes
+ * exist. Client-side navigation away from `/admin` (tool switch, "Return to Game") is guarded by
+ * {@link confirmDiscard} instead — this is the backstop for the case that skips the SPA router.
+ */
+export function guardBeforeUnload(event: BeforeUnloadEvent, pending: number): void {
+	if (pending > 0) {
+		event.preventDefault();
+		event.returnValue = '';
+	}
+}

--- a/UI/src/routes/admin/workbench/Workbench.svelte
+++ b/UI/src/routes/admin/workbench/Workbench.svelte
@@ -38,6 +38,7 @@ import { onMount, onDestroy } from 'svelte';
 import { Loading } from '$components';
 import './workbench.scss';
 import type { EntityConfig, Identified } from './entities/types';
+import { workbenchDirty } from './dirty.svelte';
 import { EntityStore } from './entity-store.svelte';
 import WorkbenchIcon from './WorkbenchIcon.svelte';
 import WorkbenchList from './components/WorkbenchList.svelte';
@@ -63,7 +64,15 @@ onMount(async () => {
 
 // Cancel any pending "saved" flash timer so a save that lands near unmount can't
 // write into a torn-down store.
-onDestroy(() => store?.dispose());
+onDestroy(() => {
+	store?.dispose();
+	workbenchDirty.set(0);
+});
+
+// Surface this store's pending-change count to the admin shell's tool-switch/unload guard.
+$effect(() => {
+	workbenchDirty.set(store?.counts.total ?? 0);
+});
 
 const selected = $derived(store ? (store.items.find((it) => it.id === selId) ?? store.items[0]) : undefined);
 const selectedBaseline = $derived(store && selected ? store.baselineOf(selected.id) : undefined);

--- a/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
+++ b/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
@@ -130,11 +130,12 @@
 {/if}
 
 <script lang="ts">
-import { dangerModal, staticData } from '$stores';
+import { staticData } from '$stores';
 import { fieldsOf, type EntityConfig, type Identified } from '../entities/types';
 import type { EntityStore } from '../entity-store.svelte';
 import { recordsEqual } from '../entity-store.svelte';
-import { computeReferences, formatReferenceBody } from '../references';
+import type { ReferenceSources } from '../references';
+import { retireWithConfirm } from '../retire-confirm';
 import { sectionWarnings } from '../validation';
 import WorkbenchIcon from '../WorkbenchIcon.svelte';
 import SectionRenderer from './SectionRenderer.svelte';
@@ -152,30 +153,33 @@ interface Props {
 
 const { entity, store, record, baseline, tab, onTab, onNew }: Props = $props();
 
+/** The cached reference sets used to compute what points at a record being retired (last-saved state). */
+const referenceSources = (): ReferenceSources => ({
+	enemies: staticData.enemies ?? [],
+	zones: staticData.zones ?? [],
+	challenges: staticData.challenges ?? [],
+	items: staticData.items ?? [],
+	classes: staticData.classes ?? [],
+	skillRecipes: staticData.skillRecipes ?? [],
+	proficiencies: staticData.proficiencies ?? [],
+	skills: staticData.skills ?? []
+});
+
 /**
  * Retire a saved reference record, first surfacing what currently references it. The referenced-by
  * surface is computed from the cached reference sets (no backend round-trip); an unreferenced record
  * retires without an extra prompt. Advisory only — confirming proceeds, and the record stays
  * resolvable by id either way (see references.ts).
  */
-const onRetire = async (rec: Identified) => {
-	const groups = computeReferences(entity.key, rec.id, {
-		enemies: staticData.enemies ?? [],
-		zones: staticData.zones ?? [],
-		challenges: staticData.challenges ?? []
+const onRetire = (rec: Identified) =>
+	retireWithConfirm({
+		entityKey: entity.key,
+		id: rec.id,
+		name: entity.title?.(rec) || rec.name || entity.blankName,
+		title: `Retire ${entity.singular}?`,
+		sources: referenceSources(),
+		onConfirmed: () => store.setRetired(rec.id, true)
 	});
-	if (groups.length > 0) {
-		const confirmed = await dangerModal({
-			title: `Retire ${entity.singular}?`,
-			body: formatReferenceBody(entity.key, entity.title?.(rec) || rec.name || entity.blankName, groups),
-			confirmLabel: 'Retire anyway'
-		});
-		if (!confirmed) {
-			return;
-		}
-	}
-	store.setRetired(rec.id, true);
-};
 
 const sectionDirty = (section: EntityConfig<Identified>['sections'][number]): boolean => {
 	if (!record || !baseline) {

--- a/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
+++ b/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
@@ -130,12 +130,10 @@
 {/if}
 
 <script lang="ts">
-import { staticData } from '$stores';
 import { fieldsOf, type EntityConfig, type Identified } from '../entities/types';
 import type { EntityStore } from '../entity-store.svelte';
 import { recordsEqual } from '../entity-store.svelte';
-import type { ReferenceSources } from '../references';
-import { retireWithConfirm } from '../retire-confirm';
+import { referenceSourcesFromStatic, retireWithConfirm } from '../retire-confirm';
 import { sectionWarnings } from '../validation';
 import WorkbenchIcon from '../WorkbenchIcon.svelte';
 import SectionRenderer from './SectionRenderer.svelte';
@@ -153,18 +151,6 @@ interface Props {
 
 const { entity, store, record, baseline, tab, onTab, onNew }: Props = $props();
 
-/** The cached reference sets used to compute what points at a record being retired (last-saved state). */
-const referenceSources = (): ReferenceSources => ({
-	enemies: staticData.enemies ?? [],
-	zones: staticData.zones ?? [],
-	challenges: staticData.challenges ?? [],
-	items: staticData.items ?? [],
-	classes: staticData.classes ?? [],
-	skillRecipes: staticData.skillRecipes ?? [],
-	proficiencies: staticData.proficiencies ?? [],
-	skills: staticData.skills ?? []
-});
-
 /**
  * Retire a saved reference record, first surfacing what currently references it. The referenced-by
  * surface is computed from the cached reference sets (no backend round-trip); an unreferenced record
@@ -177,7 +163,7 @@ const onRetire = (rec: Identified) =>
 		id: rec.id,
 		name: entity.title?.(rec) || rec.name || entity.blankName,
 		title: `Retire ${entity.singular}?`,
-		sources: referenceSources(),
+		sources: referenceSourcesFromStatic(),
 		onConfirmed: () => store.setRetired(rec.id, true)
 	});
 

--- a/UI/src/routes/admin/workbench/dirty.svelte.ts
+++ b/UI/src/routes/admin/workbench/dirty.svelte.ts
@@ -1,0 +1,17 @@
+let total = $state(0);
+
+/**
+ * Cross-surface unsaved-change count for the admin Workbench. Only one editing surface (a
+ * single-entity Workbench panel, or the bespoke Progression editor) is ever mounted at a time, so
+ * each one reports its own pending-change count here rather than the admin shell reaching into
+ * per-surface stores it otherwise has no reason to know about. Read by the shell to confirm before
+ * a tool switch or leaving `/admin` discards unsaved work.
+ */
+export const workbenchDirty = {
+	get total(): number {
+		return total;
+	},
+	set(value: number) {
+		total = value;
+	}
+};

--- a/UI/src/routes/admin/workbench/progression/Progression.svelte
+++ b/UI/src/routes/admin/workbench/progression/Progression.svelte
@@ -103,6 +103,7 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
 import Loading from '$components/Loading.svelte';
+import { workbenchDirty } from '../dirty.svelte';
 import WorkbenchIcon from '../WorkbenchIcon.svelte';
 import { ProgressionStore } from './progression-store.svelte';
 import ProgressionList from './ProgressionList.svelte';
@@ -120,6 +121,12 @@ onMount(() => {
 
 onDestroy(() => {
 	store.dispose();
+	workbenchDirty.set(0);
+});
+
+// Surface this store's pending-change count to the admin shell's tool-switch/unload guard.
+$effect(() => {
+	workbenchDirty.set(store.totalChanges);
 });
 </script>
 

--- a/UI/src/routes/admin/workbench/progression/TierDetail.svelte
+++ b/UI/src/routes/admin/workbench/progression/TierDetail.svelte
@@ -16,7 +16,7 @@
 		activeTab={store.tierTab}
 		onTab={(k) => store.setTierTab(k as TierTab)}
 		onReset={store.profStatus(tier) === 'modified' ? () => store.resetProf(tier.id) : undefined}
-		onRetire={() => store.retireProf(tier.id, true)}
+		onRetire={() => onRetire(tier)}
 		onReinstate={() => store.retireProf(tier.id, false)}
 		onRemove={() => store.removeTier(tier.id)}
 	>
@@ -60,7 +60,10 @@
 {/if}
 
 <script lang="ts">
+import { staticData } from '$stores';
 import { childChanged } from '../save-helpers';
+import type { ReferenceSources } from '../references';
+import { retireWithConfirm } from '../retire-confirm';
 import type { ProgressionStore, TierTab } from './progression-store.svelte';
 import { payoutLevels, proficiencyWarnings } from './progression-helpers';
 import DetailHeader from './DetailHeader.svelte';
@@ -68,6 +71,7 @@ import ConlangIdentity from './ConlangIdentity.svelte';
 import XpCurve from './XpCurve.svelte';
 import MilestonesEditor from './MilestonesEditor.svelte';
 import GatewaysEditor from './GatewaysEditor.svelte';
+import type { WorkbenchProficiency } from './types';
 
 interface Props {
 	store: ProgressionStore;
@@ -76,6 +80,30 @@ interface Props {
 const { store }: Props = $props();
 
 const tier = $derived(store.drilledTier);
+
+/**
+ * Retire a tier, first surfacing what references it — a gear gate (item `requiredProficiencyId`), a
+ * synthesis-recipe condition, or another tier's cross-path prerequisite. The progression editor isn't
+ * a generic `EntityConfig`, so it can't go through `WorkbenchDetail`'s onRetire; this mirrors it.
+ */
+const onRetire = (rec: WorkbenchProficiency) =>
+	retireWithConfirm({
+		entityKey: 'proficiencies',
+		id: rec.id,
+		name: rec.name || 'Unnamed tier',
+		title: 'Retire tier?',
+		sources: {
+			enemies: staticData.enemies ?? [],
+			zones: staticData.zones ?? [],
+			challenges: staticData.challenges ?? [],
+			items: staticData.items ?? [],
+			classes: staticData.classes ?? [],
+			skillRecipes: staticData.skillRecipes ?? [],
+			proficiencies: staticData.proficiencies ?? [],
+			skills: staticData.skills ?? []
+		} satisfies ReferenceSources,
+		onConfirmed: () => store.retireProf(rec.id, true)
+	});
 const baseline = $derived(tier ? store.profBaseline(tier.id) : undefined);
 const isRoot = $derived(tier?.pathOrdinal === 0);
 const payoutCount = $derived(tier ? payoutLevels(tier).length : 0);

--- a/UI/src/routes/admin/workbench/progression/TierDetail.svelte
+++ b/UI/src/routes/admin/workbench/progression/TierDetail.svelte
@@ -60,10 +60,8 @@
 {/if}
 
 <script lang="ts">
-import { staticData } from '$stores';
 import { childChanged } from '../save-helpers';
-import type { ReferenceSources } from '../references';
-import { retireWithConfirm } from '../retire-confirm';
+import { referenceSourcesFromStatic, retireWithConfirm } from '../retire-confirm';
 import type { ProgressionStore, TierTab } from './progression-store.svelte';
 import { payoutLevels, proficiencyWarnings } from './progression-helpers';
 import DetailHeader from './DetailHeader.svelte';
@@ -92,16 +90,7 @@ const onRetire = (rec: WorkbenchProficiency) =>
 		id: rec.id,
 		name: rec.name || 'Unnamed tier',
 		title: 'Retire tier?',
-		sources: {
-			enemies: staticData.enemies ?? [],
-			zones: staticData.zones ?? [],
-			challenges: staticData.challenges ?? [],
-			items: staticData.items ?? [],
-			classes: staticData.classes ?? [],
-			skillRecipes: staticData.skillRecipes ?? [],
-			proficiencies: staticData.proficiencies ?? [],
-			skills: staticData.skills ?? []
-		} satisfies ReferenceSources,
+		sources: referenceSourcesFromStatic(),
 		onConfirmed: () => store.retireProf(rec.id, true)
 	});
 const baseline = $derived(tier ? store.profBaseline(tier.id) : undefined);

--- a/UI/src/routes/admin/workbench/references.ts
+++ b/UI/src/routes/admin/workbench/references.ts
@@ -1,4 +1,14 @@
-import { EEntityType, type IChallenge, type IEnemy, type IZone } from '$lib/api';
+import {
+	EEntityType,
+	type IChallenge,
+	type IClass,
+	type IEnemy,
+	type IItem,
+	type IProficiency,
+	type ISkill,
+	type ISkillRecipe,
+	type IZone
+} from '$lib/api';
 
 /**
  * Computes the "referenced by" surface for a retire confirm dialog, entirely from the cached
@@ -14,6 +24,11 @@ export interface ReferenceSources {
 	enemies: IEnemy[];
 	zones: IZone[];
 	challenges: IChallenge[];
+	items: IItem[];
+	classes: IClass[];
+	skillRecipes: ISkillRecipe[];
+	proficiencies: IProficiency[];
+	skills: ISkill[];
 }
 
 /** A category of inbound reference and the names of the records that make it. */
@@ -32,10 +47,22 @@ export type ReferenceKind =
 	| 'challengeTarget'
 	| 'unlockGate'
 	| 'challengeReward'
-	| 'enemySkill';
+	| 'enemySkill'
+	| 'grantedSkillOf'
+	| 'starterSkillOf'
+	| 'starterEquipmentOf'
+	| 'recipeResult'
+	| 'recipeInput'
+	| 'milestoneReward'
+	| 'gearGate'
+	| 'recipeCondition'
+	| 'prerequisiteOf';
 
 /** Zero-based-id lookup honouring the retirement Id-as-index invariant (a retired record keeps its slot). */
 const nameByIndex = (records: { name: string }[], id: number): string => records[id]?.name ?? `#${id}`;
+
+/** A skill-synthesis recipe is nameless — identify it in a reference list by the result skill it produces. */
+const recipeName = (recipe: ISkillRecipe, skills: ISkill[]): string => nameByIndex(skills, recipe.resultSkillId);
 
 const group = (kind: ReferenceKind, names: string[], strong = false): ReferenceGroup[] =>
 	names.length ? [{ kind, names, ...(strong ? { strong } : {}) }] : [];
@@ -62,23 +89,59 @@ const challengeReferences = (id: number, { zones }: ReferenceSources): Reference
 	return group('unlockGate', unlockGate, true);
 };
 
-const skillReferences = (id: number, { enemies, challenges }: ReferenceSources): ReferenceGroup[] => {
+const skillReferences = (
+	id: number,
+	{ enemies, challenges, items, classes, skillRecipes, proficiencies, skills }: ReferenceSources
+): ReferenceGroup[] => {
 	const inPool = enemies.filter((e) => e.skillPool.includes(id)).map((e) => e.name);
 	const targetOf = challenges
 		.filter((c) => c.entityType === EEntityType.Skill && c.targetEntityId === id)
 		.map((c) => c.name);
-	return [...group('enemySkill', inPool), ...group('challengeTarget', targetOf)];
+	const grantedSkillOf = items.filter((i) => i.grantedSkillId === id).map((i) => i.name);
+	const starterSkillOf = classes.filter((c) => c.starterSkillIds.includes(id)).map((c) => c.name);
+	const recipeResultOf = skillRecipes.filter((r) => r.resultSkillId === id).map((r) => recipeName(r, skills));
+	const recipeInputOf = skillRecipes.filter((r) => r.inputSkillIds.includes(id)).map((r) => recipeName(r, skills));
+	const milestoneRewardOf = proficiencies
+		.filter((p) => p.levelRewards.some((reward) => reward.rewardSkillId === id))
+		.map((p) => p.name);
+	return [
+		...group('enemySkill', inPool),
+		...group('challengeTarget', targetOf),
+		...group('grantedSkillOf', grantedSkillOf),
+		...group('starterSkillOf', starterSkillOf),
+		...group('recipeResult', recipeResultOf),
+		...group('recipeInput', recipeInputOf),
+		...group('milestoneReward', milestoneRewardOf)
+	];
 };
 
-const rewardReferences = (
-	id: number,
-	{ challenges }: ReferenceSources,
-	key: 'rewardItemId' | 'rewardItemModId'
-): ReferenceGroup[] =>
+const itemReferences = (id: number, { challenges, classes }: ReferenceSources): ReferenceGroup[] => {
+	const rewardOf = challenges.filter((c) => c.rewardItemId === id).map((c) => c.name);
+	const starterEquipmentOf = classes.filter((c) => c.starterEquipment.some((e) => e.itemId === id)).map((c) => c.name);
+	return [...group('challengeReward', rewardOf), ...group('starterEquipmentOf', starterEquipmentOf)];
+};
+
+const itemModReferences = (id: number, { challenges }: ReferenceSources): ReferenceGroup[] =>
 	group(
 		'challengeReward',
-		challenges.filter((c) => c[key] === id).map((c) => c.name)
+		challenges.filter((c) => c.rewardItemModId === id).map((c) => c.name)
 	);
+
+const proficiencyReferences = (
+	id: number,
+	{ items, skillRecipes, proficiencies, skills }: ReferenceSources
+): ReferenceGroup[] => {
+	const gearGate = items.filter((i) => i.requiredProficiencyId === id).map((i) => i.name);
+	const recipeCondition = skillRecipes
+		.filter((r) => r.conditions.some((c) => c.proficiencyId === id))
+		.map((r) => recipeName(r, skills));
+	const prerequisiteOf = proficiencies.filter((p) => p.prerequisiteIds.includes(id)).map((p) => p.name);
+	return [
+		...group('gearGate', gearGate),
+		...group('recipeCondition', recipeCondition),
+		...group('prerequisiteOf', prerequisiteOf)
+	];
+};
 
 /** Every record that references the given retireable record, grouped by relationship (empty when none). */
 export function computeReferences(entityKey: string, id: number, sources: ReferenceSources): ReferenceGroup[] {
@@ -90,11 +153,13 @@ export function computeReferences(entityKey: string, id: number, sources: Refere
 		case 'challenges':
 			return challengeReferences(id, sources);
 		case 'items':
-			return rewardReferences(id, sources, 'rewardItemId');
+			return itemReferences(id, sources);
 		case 'itemMods':
-			return rewardReferences(id, sources, 'rewardItemModId');
+			return itemModReferences(id, sources);
 		case 'skills':
 			return skillReferences(id, sources);
+		case 'proficiencies':
+			return proficiencyReferences(id, sources);
 		default:
 			return [];
 	}
@@ -136,6 +201,24 @@ const clauseFor = (entityKey: string, ref: ReferenceGroup): string => {
 			return `the reward for ${count(n, 'challenge')} (${names})`;
 		case 'enemySkill':
 			return `in the skill pool of ${count(n, 'enemy', 'enemies')} (${names})`;
+		case 'grantedSkillOf':
+			return `the skill granted by ${count(n, 'item')} (${names})`;
+		case 'starterSkillOf':
+			return `a starter skill of ${count(n, 'class', 'classes')} (${names})`;
+		case 'starterEquipmentOf':
+			return `starter equipment for ${count(n, 'class', 'classes')} (${names})`;
+		case 'recipeResult':
+			return `the result of ${count(n, 'synthesis recipe')} (${names})`;
+		case 'recipeInput':
+			return `an input of ${count(n, 'synthesis recipe')} (${names})`;
+		case 'milestoneReward':
+			return `a milestone reward of ${count(n, 'proficiency', 'proficiencies')} (${names})`;
+		case 'gearGate':
+			return `the required proficiency for ${count(n, 'item')} (${names})`;
+		case 'recipeCondition':
+			return `a condition of ${count(n, 'synthesis recipe')} (${names})`;
+		case 'prerequisiteOf':
+			return `a prerequisite for ${count(n, 'proficiency', 'proficiencies')} (${names})`;
 	}
 };
 

--- a/UI/src/routes/admin/workbench/retire-confirm.ts
+++ b/UI/src/routes/admin/workbench/retire-confirm.ts
@@ -1,5 +1,24 @@
-import { dangerModal } from '$stores';
+import { dangerModal, staticData } from '$stores';
 import { computeReferences, formatReferenceBody, type ReferenceSources } from './references';
+
+/**
+ * Builds a {@link ReferenceSources} snapshot from the cached last-saved catalogues in `staticData`
+ * — the one place both retire-confirm call sites (the generic Workbench detail pane and the
+ * progression editor) assemble the full set, so a new reference-carrying catalogue only needs
+ * adding here.
+ */
+export function referenceSourcesFromStatic(): ReferenceSources {
+	return {
+		enemies: staticData.enemies ?? [],
+		zones: staticData.zones ?? [],
+		challenges: staticData.challenges ?? [],
+		items: staticData.items ?? [],
+		classes: staticData.classes ?? [],
+		skillRecipes: staticData.skillRecipes ?? [],
+		proficiencies: staticData.proficiencies ?? [],
+		skills: staticData.skills ?? []
+	};
+}
 
 /**
  * Shared retire flow: compute the referenced-by surface for a record, confirm via a danger modal

--- a/UI/src/routes/admin/workbench/retire-confirm.ts
+++ b/UI/src/routes/admin/workbench/retire-confirm.ts
@@ -1,0 +1,33 @@
+import { dangerModal } from '$stores';
+import { computeReferences, formatReferenceBody, type ReferenceSources } from './references';
+
+/**
+ * Shared retire flow: compute the referenced-by surface for a record, confirm via a danger modal
+ * only when something actually references it, then run the retire action. Used by both the
+ * generic Workbench detail pane and the bespoke progression editor (paths/proficiencies aren't a
+ * generic `EntityConfig`, so they can't go through {@link ../components/WorkbenchDetail.svelte}).
+ */
+export async function retireWithConfirm(options: {
+	entityKey: string;
+	id: number;
+	/** Display name used in the confirm dialog body. */
+	name: string;
+	/** Confirm dialog title, e.g. "Retire Item?". */
+	title: string;
+	sources: ReferenceSources;
+	onConfirmed: () => void;
+}): Promise<void> {
+	const { entityKey, id, name, title, sources, onConfirmed } = options;
+	const groups = computeReferences(entityKey, id, sources);
+	if (groups.length > 0) {
+		const confirmed = await dangerModal({
+			title,
+			body: formatReferenceBody(entityKey, name, groups),
+			confirmLabel: 'Retire anyway'
+		});
+		if (!confirmed) {
+			return;
+		}
+	}
+	onConfirmed();
+}

--- a/UI/src/tests/routes/admin/discard-guard.test.ts
+++ b/UI/src/tests/routes/admin/discard-guard.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { dangerModal } = vi.hoisted(() => ({ dangerModal: vi.fn() }));
+vi.mock('$stores', () => ({ dangerModal }));
+
+import { confirmDiscard, guardBeforeUnload } from '$routes/admin/discard-guard';
+
+beforeEach(() => dangerModal.mockReset());
+
+describe('confirmDiscard', () => {
+	it('resolves true without prompting when there is nothing pending', async () => {
+		await expect(confirmDiscard(0)).resolves.toBe(true);
+		expect(dangerModal).not.toHaveBeenCalled();
+	});
+
+	it('prompts with singular copy for exactly one pending change', async () => {
+		dangerModal.mockResolvedValue(true);
+		await confirmDiscard(1);
+
+		expect(dangerModal).toHaveBeenCalledOnce();
+		const call = dangerModal.mock.calls[0][0];
+		expect(call.title).toBe('Discard unsaved changes?');
+		expect(call.body).toBe('You have 1 unsaved change. Leaving now will discard it.');
+	});
+
+	it('prompts with plural copy for more than one pending change', async () => {
+		dangerModal.mockResolvedValue(true);
+		await confirmDiscard(3);
+
+		const call = dangerModal.mock.calls[0][0];
+		expect(call.body).toBe('You have 3 unsaved changes. Leaving now will discard them.');
+	});
+
+	it('resolves to whatever the modal resolves to', async () => {
+		dangerModal.mockResolvedValue(true);
+		await expect(confirmDiscard(2)).resolves.toBe(true);
+
+		dangerModal.mockResolvedValue(false);
+		await expect(confirmDiscard(2)).resolves.toBe(false);
+	});
+});
+
+describe('guardBeforeUnload', () => {
+	// A sentinel starting value (real events default returnValue to true, not '') so an assignment
+	// by the guard is observable regardless of what string it assigns.
+	const fakeEvent = () =>
+		({ preventDefault: vi.fn(), returnValue: true }) as unknown as BeforeUnloadEvent & {
+			preventDefault: ReturnType<typeof vi.fn>;
+		};
+
+	it('does nothing when there is nothing pending', () => {
+		const event = fakeEvent();
+		guardBeforeUnload(event, 0);
+
+		expect(event.preventDefault).not.toHaveBeenCalled();
+		expect(event.returnValue).toBe(true);
+	});
+
+	it('prevents the default and sets returnValue when changes are pending', () => {
+		const event = fakeEvent();
+		guardBeforeUnload(event, 1);
+
+		expect(event.preventDefault).toHaveBeenCalledOnce();
+		expect(event.returnValue).not.toBe(true);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/Workbench.test.ts
+++ b/UI/src/tests/routes/admin/workbench/Workbench.test.ts
@@ -19,6 +19,7 @@ vi.mock('$stores', () => ({
 }));
 
 import Workbench from '$routes/admin/workbench/Workbench.svelte';
+import { workbenchDirty } from '$routes/admin/workbench/dirty.svelte';
 import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
 
 const seed: Identified[] = [
@@ -49,6 +50,27 @@ const makeConfig = (overrides: Partial<EntityConfig<Identified>> = {}): EntityCo
 });
 
 afterEach(cleanup);
+
+describe('Workbench — unsaved-change reporting', () => {
+	it("reports the store's pending-change count to the shared workbenchDirty tracker", async () => {
+		render(Workbench, { props: { entity: makeConfig() } });
+		await waitFor(() => expect(screen.getByTestId('workbench-title')).toBeTruthy());
+		expect(workbenchDirty.total).toBe(0);
+
+		await fireEvent.click(screen.getByTestId('workbench-new'));
+		await waitFor(() => expect(workbenchDirty.total).toBe(1));
+	});
+
+	it('resets the tracker on unmount so a stale count cannot block navigation elsewhere', async () => {
+		const { unmount } = render(Workbench, { props: { entity: makeConfig() } });
+		await waitFor(() => expect(screen.getByTestId('workbench-title')).toBeTruthy());
+		await fireEvent.click(screen.getByTestId('workbench-new'));
+		await waitFor(() => expect(workbenchDirty.total).toBe(1));
+
+		unmount();
+		expect(workbenchDirty.total).toBe(0);
+	});
+});
 
 describe('Workbench', () => {
 	it('does not show workbench content before the entity data is fetched', () => {

--- a/UI/src/tests/routes/admin/workbench/dirty.test.ts
+++ b/UI/src/tests/routes/admin/workbench/dirty.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { workbenchDirty } from '$routes/admin/workbench/dirty.svelte';
+
+beforeEach(() => workbenchDirty.set(0));
+
+describe('workbenchDirty', () => {
+	it('starts at zero', () => {
+		expect(workbenchDirty.total).toBe(0);
+	});
+
+	it('reports the value it was last set to', () => {
+		workbenchDirty.set(3);
+		expect(workbenchDirty.total).toBe(3);
+
+		workbenchDirty.set(0);
+		expect(workbenchDirty.total).toBe(0);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/progression/Progression.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/Progression.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, waitFor, fireEvent } from '@testing-library/svelte';
+
+// Mirrors progression-store.test.ts's fake in-memory backend — Progression.svelte owns its own
+// ProgressionStore instance (no store prop to inject), so the socket-read layer is mocked the same
+// way to drive it through a real load().
+const { postMock, fetchMock, staticDataMock, toastErrorMock, referenceMock, dangerModalMock } = vi.hoisted(() => ({
+	postMock: vi.fn(),
+	fetchMock: vi.fn(),
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	staticDataMock: {} as any,
+	toastErrorMock: vi.fn(),
+	referenceMock: { attributeOptions: () => [] },
+	dangerModalMock: vi.fn()
+}));
+
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return { ...actual, ApiRequest: { get: vi.fn(), post: postMock }, fetchSocketData: fetchMock };
+});
+vi.mock('$stores', () => ({ staticData: staticDataMock, toastError: toastErrorMock, dangerModal: dangerModalMock }));
+vi.mock('$routes/admin/workbench/reference.svelte', () => ({ reference: referenceMock }));
+
+import Progression from '$routes/admin/workbench/progression/Progression.svelte';
+import { workbenchDirty } from '$routes/admin/workbench/dirty.svelte';
+
+beforeEach(() => {
+	postMock.mockReset();
+	fetchMock.mockReset();
+	fetchMock.mockResolvedValue([]);
+	workbenchDirty.set(0);
+});
+
+afterEach(cleanup);
+
+describe('Progression — unsaved-change reporting', () => {
+	it("reports the store's pending-change count to the shared workbenchDirty tracker", async () => {
+		render(Progression);
+		await waitFor(() => expect(screen.getByTestId('progression-new-path')).toBeTruthy());
+		expect(workbenchDirty.total).toBe(0);
+
+		await fireEvent.click(screen.getByTestId('progression-new-path'));
+		await waitFor(() => expect(workbenchDirty.total).toBeGreaterThan(0));
+	});
+
+	it('resets the tracker on unmount so a stale count cannot block navigation elsewhere', async () => {
+		const { unmount } = render(Progression);
+		await waitFor(() => expect(screen.getByTestId('progression-new-path')).toBeTruthy());
+		await fireEvent.click(screen.getByTestId('progression-new-path'));
+		await waitFor(() => expect(workbenchDirty.total).toBeGreaterThan(0));
+
+		unmount();
+		expect(workbenchDirty.total).toBe(0);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { EAttribute, EModifierType } from '$lib/api';
+
+// Hoisted so individual tests can seed staticData and assert the retire-confirm flow, mirroring
+// WorkbenchDetail.test.ts's pattern for the generic Workbench's retire dialog.
+const { staticData, dangerModal } = vi.hoisted(() => ({
+	staticData: {
+		enemies: [] as unknown[],
+		zones: [] as unknown[],
+		challenges: [] as unknown[],
+		items: [] as unknown[],
+		classes: [] as unknown[],
+		skillRecipes: [] as unknown[],
+		proficiencies: [] as unknown[],
+		skills: [] as unknown[]
+	},
+	dangerModal: vi.fn()
+}));
+vi.mock('$stores', () => ({ staticData, dangerModal }));
+
+import TierDetail from '$routes/admin/workbench/progression/TierDetail.svelte';
+import type { ProgressionStore } from '$routes/admin/workbench/progression/progression-store.svelte';
+import type { WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+
+const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency => ({
+	id: 5,
+	name: 'Blades',
+	description: '',
+	iconPath: 'i.png',
+	word: 'sijren',
+	pronunciation: 'sij-ren',
+	translation: 'The Riven Frost',
+	pathId: 0,
+	pathOrdinal: 0,
+	maxLevel: 10,
+	baseXp: 100,
+	xpGrowth: 1.4,
+	designerNotes: '',
+	levelModifiers: [],
+	levelRewards: [],
+	prerequisiteIds: [],
+	...over
+});
+
+// A fake store exposing exactly what TierDetail + ConlangIdentity (the 'identity' tab) read —
+// mirrors ProgressionMap.test.ts's fake-store pattern rather than driving the real ProgressionStore
+// through a socket-backed load(), since only TierDetail's own wiring (header, tabs, retire) is under
+// test here.
+const makeStore = (drilledTier: WorkbenchProficiency, overrides: Record<string, unknown> = {}) =>
+	({
+		drilledTier,
+		tierTab: 'identity',
+		selectedPath: { name: 'Fire Path' },
+		selectedLevel: 1,
+		profStatus: vi.fn(() => 'clean'),
+		isRetired: vi.fn(() => false),
+		setTierTab: vi.fn(),
+		resetProf: vi.fn(),
+		retireProf: vi.fn(),
+		back: vi.fn(),
+		profBaseline: vi.fn(() => drilledTier),
+		patchProf: vi.fn(),
+		selectLevel: vi.fn(),
+		updateModifier: vi.fn(),
+		removeModifier: vi.fn(),
+		addModifier: vi.fn(),
+		setReward: vi.fn(),
+		addPayout: vi.fn(),
+		removePayout: vi.fn(),
+		addPrerequisite: vi.fn(),
+		removePrerequisite: vi.fn(),
+		...overrides
+	}) as unknown as ProgressionStore;
+
+beforeEach(() => {
+	dangerModal.mockReset();
+	staticData.enemies = [];
+	staticData.zones = [];
+	staticData.challenges = [];
+	staticData.items = [];
+	staticData.classes = [];
+	staticData.skillRecipes = [];
+	staticData.proficiencies = [];
+	staticData.skills = [];
+});
+afterEach(cleanup);
+
+describe('TierDetail', () => {
+	it('renders the tier name and path/ordinal headline', () => {
+		const store = makeStore(tier());
+		render(TierDetail, { props: { store } });
+
+		expect(screen.getByRole('heading', { level: 2 }).textContent).toBe('Blades');
+		expect(screen.getByText(/Fire Path · Tier 0/)).toBeTruthy();
+	});
+
+	it('switches tabs through the store', async () => {
+		const store = makeStore(tier());
+		render(TierDetail, { props: { store } });
+
+		await fireEvent.click(screen.getByText('XP Curve'));
+		expect(store.setTierTab).toHaveBeenCalledWith('xp');
+	});
+
+	it('navigates back to the path via the breadcrumb', async () => {
+		const store = makeStore(tier());
+		render(TierDetail, { props: { store } });
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Fire Path' }));
+		expect(store.back).toHaveBeenCalledOnce();
+	});
+});
+
+describe('TierDetail — retire confirm dialog', () => {
+	it('retires immediately when nothing references the tier', async () => {
+		const store = makeStore(tier());
+		render(TierDetail, { props: { store } });
+
+		await fireEvent.click(screen.getByText('Retire'));
+
+		expect(dangerModal).not.toHaveBeenCalled();
+		expect(store.retireProf).toHaveBeenCalledWith(5, true);
+	});
+
+	it('prompts before retiring a tier gating an item, and retires on confirm', async () => {
+		dangerModal.mockResolvedValue(true);
+		staticData.items = [{ id: 0, name: 'Iron Helm', requiredProficiencyId: 5 }];
+
+		const store = makeStore(tier());
+		render(TierDetail, { props: { store } });
+
+		await fireEvent.click(screen.getByText('Retire'));
+
+		expect(dangerModal).toHaveBeenCalledOnce();
+		const body = dangerModal.mock.calls[0][0].body as string;
+		expect(body).toContain('Iron Helm');
+		await waitFor(() => expect(store.retireProf).toHaveBeenCalledWith(5, true));
+	});
+
+	it('does not retire when the confirm dialog is cancelled', async () => {
+		dangerModal.mockResolvedValue(false);
+		staticData.items = [{ id: 0, name: 'Iron Helm', requiredProficiencyId: 5 }];
+
+		const store = makeStore(tier());
+		render(TierDetail, { props: { store } });
+
+		await fireEvent.click(screen.getByText('Retire'));
+
+		expect(dangerModal).toHaveBeenCalledOnce();
+		expect(store.retireProf).not.toHaveBeenCalled();
+	});
+
+	it('offers Reinstate for an already-retired tier', async () => {
+		const store = makeStore(tier(), { isRetired: vi.fn(() => true) });
+		render(TierDetail, { props: { store } });
+
+		expect(screen.queryByText('Retire')).toBeNull();
+		await fireEvent.click(screen.getByText('Reinstate'));
+		expect(store.retireProf).toHaveBeenCalledWith(5, false);
+	});
+});
+
+describe('TierDetail — tab bodies', () => {
+	it('renders the XP curve tab', () => {
+		const store = makeStore(tier(), { tierTab: 'xp' });
+		render(TierDetail, { props: { store } });
+
+		expect(screen.getByText('Max level')).toBeTruthy();
+		expect(screen.getByText(/Derived per-level cost/)).toBeTruthy();
+	});
+
+	it('renders the milestones tab and adds a payout at the selected level', async () => {
+		const store = makeStore(tier(), { tierTab: 'milestones' });
+		render(TierDetail, { props: { store } });
+
+		await fireEvent.click(screen.getByTestId('progression-add-payout'));
+		expect(store.addPayout).toHaveBeenCalledWith(5, 1);
+	});
+
+	it('renders an existing payout at the selected level and edits/removes it', async () => {
+		const payoutTier = tier({
+			levelModifiers: [
+				{ level: 1, attributeId: EAttribute.Strength, modifierTypeId: EModifierType.Additive, amount: 5 }
+			],
+			levelRewards: [{ level: 1, rewardSkillId: 2 }]
+		});
+		const store = makeStore(payoutTier, { tierTab: 'milestones' });
+		render(TierDetail, { props: { store } });
+
+		expect(screen.getByText('Milestone')).toBeTruthy();
+		await fireEvent.click(screen.getByLabelText('Remove modifier'));
+		expect(store.removeModifier).toHaveBeenCalledWith(5, 0);
+
+		await fireEvent.click(screen.getByText(/Remove this payout level/));
+		expect(store.removePayout).toHaveBeenCalledWith(5, 1);
+
+		await fireEvent.click(screen.getByText('+ Add modifier'));
+		expect(store.addModifier).toHaveBeenCalledWith(5, 1);
+	});
+
+	it('renders the gateways tab for a root tier with no prerequisites', () => {
+		const store = makeStore(tier({ pathOrdinal: 0, prerequisiteIds: [] }), { tierTab: 'gateways' });
+		render(TierDetail, { props: { store } });
+
+		expect(screen.getByText(/Prerequisite proficiencies/)).toBeTruthy();
+		expect(screen.getByText(/Starter tier/)).toBeTruthy();
+	});
+
+	it('lists an existing prerequisite chip, removes it, and adds a new one', async () => {
+		// staticData.proficiencies is index-addressed (the zero-based-id/index invariant), so each
+		// entry must sit at its own id as the array index.
+		const byId: unknown[] = [];
+		byId[3] = { id: 3, name: 'Basics' };
+		byId[7] = { id: 7, name: 'Advanced' };
+		staticData.proficiencies = byId;
+		const store = makeStore(tier({ prerequisiteIds: [3] }), { tierTab: 'gateways' });
+		render(TierDetail, { props: { store } });
+
+		expect(screen.getByText('Basics')).toBeTruthy();
+		await fireEvent.click(screen.getByLabelText('Remove prerequisite'));
+		expect(store.removePrerequisite).toHaveBeenCalledWith(5, 3);
+
+		await fireEvent.change(screen.getByLabelText('Add prerequisite'), { target: { value: '7' } });
+		expect(store.addPrerequisite).toHaveBeenCalledWith(5, 7);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/references.test.ts
+++ b/UI/src/tests/routes/admin/workbench/references.test.ts
@@ -1,5 +1,21 @@
 import { describe, it, expect } from 'vitest';
-import { EChallengeType, EEntityType, type IChallenge, type IEnemy, type IZone } from '$lib/api';
+import {
+	EAttribute,
+	EChallengeType,
+	EEntityType,
+	EItemCategory,
+	EModifierType,
+	ERarity,
+	ESkillAcquisition,
+	type IChallenge,
+	type IClass,
+	type IEnemy,
+	type IItem,
+	type IProficiency,
+	type ISkill,
+	type ISkillRecipe,
+	type IZone
+} from '$lib/api';
 import {
 	computeReferences,
 	formatReferenceBody,
@@ -42,7 +58,97 @@ const challenge = (id: number, name: string, opts: Partial<IChallenge> = {}): IC
 	...opts
 });
 
-// Id-aligned reference sets shared across the computation cases.
+const item = (id: number, name: string, opts: Partial<IItem> = {}): IItem => ({
+	id,
+	name,
+	description: '',
+	itemCategoryId: EItemCategory.Helm,
+	rarityId: ERarity.Common,
+	iconPath: '',
+	attributes: [],
+	modSlots: [],
+	tags: [],
+	requiredProficiencyLevel: 1,
+	designerNotes: '',
+	...opts
+});
+
+const wclass = (id: number, name: string, opts: Partial<IClass> = {}): IClass => ({
+	id,
+	name,
+	description: '',
+	word: '',
+	passiveAttributeId: EAttribute.Strength,
+	passiveAmount: 0,
+	passiveScalingAmount: 0,
+	passiveModifierType: EModifierType.Additive,
+	starterSkillIds: [],
+	starterEquipment: [],
+	attributeDistributions: [],
+	designerNotes: '',
+	...opts
+});
+
+const recipe = (id: number, resultSkillId: number, opts: Partial<ISkillRecipe> = {}): ISkillRecipe => ({
+	id,
+	resultSkillId,
+	designerNotes: '',
+	inputSkillIds: [],
+	conditions: [],
+	...opts
+});
+
+const proficiency = (id: number, name: string, opts: Partial<IProficiency> = {}): IProficiency => ({
+	id,
+	name,
+	description: '',
+	iconPath: '',
+	word: '',
+	pronunciation: '',
+	translation: '',
+	pathId: 0,
+	pathOrdinal: 0,
+	maxLevel: 10,
+	baseXp: 100,
+	xpGrowth: 1.4,
+	designerNotes: '',
+	levelModifiers: [],
+	levelRewards: [],
+	prerequisiteIds: [],
+	...opts
+});
+
+/** Places each record at its own id as the array index, honouring the zero-based-id/index invariant. */
+const bySlot = <T extends { id: number }>(...items: T[]): T[] => {
+	const arr: T[] = [];
+	for (const item of items) {
+		arr[item.id] = item;
+	}
+	return arr;
+};
+
+const skill = (id: number, name: string): ISkill => ({
+	id,
+	name,
+	baseDamage: 10,
+	criticalChance: 0,
+	damageMultipliers: [],
+	effects: [],
+	damagePortions: [],
+	description: '',
+	cooldownMs: 1000,
+	iconPath: '',
+	rarityId: ERarity.Common,
+	word: '',
+	pronunciation: '',
+	translation: '',
+	acquisition: ESkillAcquisition.Player,
+	designerNotes: ''
+});
+
+// Id-aligned reference sets shared across the computation cases. Only enemies/zones/challenges carry
+// cross-referencing fixture data by default — the item/class/recipe/proficiency describes below layer
+// their own scenario-specific entries on top via spread so they can't perturb the base assertions.
 const sources = (): ReferenceSources => ({
 	enemies: [
 		enemy(0, 'Cave Bat', {
@@ -69,7 +175,12 @@ const sources = (): ReferenceSources => ({
 		}),
 		challenge(2, 'Zone Clearer', { entityType: EEntityType.Zone, targetEntityId: 1 }),
 		challenge(3, 'Skill Spammer', { entityType: EEntityType.Skill, targetEntityId: 1 })
-	]
+	],
+	items: [],
+	classes: [],
+	skillRecipes: [],
+	proficiencies: [],
+	skills: []
 });
 
 describe('computeReferences — enemies', () => {
@@ -148,6 +259,110 @@ describe('computeReferences — skills', () => {
 	});
 });
 
+describe('computeReferences — skills, extended (item grant, starter kit, recipes, milestones)', () => {
+	it('lists the item that grants the skill', () => {
+		const src = { ...sources(), items: [item(0, 'Runed Blade', { grantedSkillId: 5 })] };
+		expect(computeReferences('skills', 5, src)).toEqual([{ kind: 'grantedSkillOf', names: ['Runed Blade'] }]);
+	});
+
+	it('lists the class the skill is a starter skill of', () => {
+		const src = { ...sources(), classes: [wclass(0, 'Warden', { starterSkillIds: [5] })] };
+		expect(computeReferences('skills', 5, src)).toEqual([{ kind: 'starterSkillOf', names: ['Warden'] }]);
+	});
+
+	it('lists the synthesis recipe the skill is the result of, named by its own result skill', () => {
+		const src = {
+			...sources(),
+			skillRecipes: [recipe(0, 5)],
+			skills: bySlot(skill(0, 'Fire Bolt'), skill(1, 'Ice Shard'), skill(2, 'Slam'), skill(5, 'Meteor'))
+		};
+		expect(computeReferences('skills', 5, src)).toEqual([{ kind: 'recipeResult', names: ['Meteor'] }]);
+	});
+
+	it('lists the synthesis recipe the skill is an input of', () => {
+		const src = {
+			...sources(),
+			skillRecipes: [recipe(0, 6, { inputSkillIds: [5] })],
+			skills: bySlot(skill(0, 'Fire Bolt'), skill(1, 'Ice Shard'), skill(2, 'Slam'), skill(6, 'Meteor'))
+		};
+		expect(computeReferences('skills', 5, src)).toEqual([{ kind: 'recipeInput', names: ['Meteor'] }]);
+	});
+
+	it('lists the proficiency that grants the skill as a milestone reward', () => {
+		const src = {
+			...sources(),
+			proficiencies: [proficiency(0, 'Blades', { levelRewards: [{ level: 3, rewardSkillId: 5 }] })]
+		};
+		expect(computeReferences('skills', 5, src)).toEqual([{ kind: 'milestoneReward', names: ['Blades'] }]);
+	});
+
+	it('combines every skill-referencing kind together', () => {
+		const src: ReferenceSources = {
+			...sources(),
+			items: [item(0, 'Runed Blade', { grantedSkillId: 5 })],
+			classes: [wclass(0, 'Warden', { starterSkillIds: [5] })],
+			skillRecipes: [recipe(0, 6, { inputSkillIds: [5] })],
+			skills: bySlot(skill(6, 'Meteor')),
+			proficiencies: [proficiency(0, 'Blades', { levelRewards: [{ level: 3, rewardSkillId: 5 }] })]
+		};
+		expect(computeReferences('skills', 5, src)).toEqual([
+			{ kind: 'grantedSkillOf', names: ['Runed Blade'] },
+			{ kind: 'starterSkillOf', names: ['Warden'] },
+			{ kind: 'recipeInput', names: ['Meteor'] },
+			{ kind: 'milestoneReward', names: ['Blades'] }
+		]);
+	});
+});
+
+describe('computeReferences — items, extended (starter equipment)', () => {
+	it('lists the class that equips the item at character creation', () => {
+		const src = {
+			...sources(),
+			classes: [wclass(0, 'Warden', { starterEquipment: [{ itemId: 7, equipmentSlot: 0 }] })]
+		};
+		expect(computeReferences('items', 7, src)).toEqual([{ kind: 'starterEquipmentOf', names: ['Warden'] }]);
+	});
+
+	it('combines the challenge-reward and starter-equipment kinds together', () => {
+		const src: ReferenceSources = {
+			...sources(),
+			classes: [wclass(0, 'Warden', { starterEquipment: [{ itemId: 0, equipmentSlot: 0 }] })]
+		};
+		// Item 0 is already the reward for "First Steps" in the base fixture.
+		expect(computeReferences('items', 0, src)).toEqual([
+			{ kind: 'challengeReward', names: ['First Steps'] },
+			{ kind: 'starterEquipmentOf', names: ['Warden'] }
+		]);
+	});
+});
+
+describe('computeReferences — proficiencies', () => {
+	it('lists the item that gates on the proficiency', () => {
+		const src = { ...sources(), items: [item(0, 'Iron Helm', { requiredProficiencyId: 5 })] };
+		expect(computeReferences('proficiencies', 5, src)).toEqual([{ kind: 'gearGate', names: ['Iron Helm'] }]);
+	});
+
+	it('lists the synthesis recipe conditioned on the proficiency', () => {
+		const src = {
+			...sources(),
+			skillRecipes: [recipe(0, 9, { conditions: [{ proficiencyId: 5, minLevel: 3 }] })],
+			skills: bySlot(skill(9, 'Meteor'))
+		};
+		expect(computeReferences('proficiencies', 5, src)).toEqual([{ kind: 'recipeCondition', names: ['Meteor'] }]);
+	});
+
+	it('lists the other tier that gates on this one as a cross-path prerequisite', () => {
+		const src = { ...sources(), proficiencies: [proficiency(6, 'Advanced Blades', { prerequisiteIds: [5] })] };
+		expect(computeReferences('proficiencies', 5, src)).toEqual([
+			{ kind: 'prerequisiteOf', names: ['Advanced Blades'] }
+		]);
+	});
+
+	it('returns nothing for an unreferenced proficiency', () => {
+		expect(computeReferences('proficiencies', 5, sources())).toEqual([]);
+	});
+});
+
 describe('computeReferences — unknown entity', () => {
 	it('returns no references for an unrecognized entity key', () => {
 		expect(computeReferences('widgets', 0, sources())).toEqual([]);
@@ -215,5 +430,35 @@ describe('formatReferenceBody', () => {
 		const names = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
 		const body = formatReferenceBody('zones', 'Verdant Hollow', [{ kind: 'spawnedBy', names }]);
 		expect(body).toContain('the spawn location for 8 enemies (A, B, C, D, E, F +2 more)');
+	});
+
+	it('phrases the item/class/recipe/proficiency reference kinds added for #1517', () => {
+		expect(formatReferenceBody('skills', 'Meteor', [{ kind: 'grantedSkillOf', names: ['Runed Blade'] }])).toContain(
+			'the skill granted by 1 item (Runed Blade)'
+		);
+		expect(formatReferenceBody('skills', 'Meteor', [{ kind: 'starterSkillOf', names: ['Warden'] }])).toContain(
+			'a starter skill of 1 class (Warden)'
+		);
+		expect(formatReferenceBody('items', 'Iron Helm', [{ kind: 'starterEquipmentOf', names: ['Warden'] }])).toContain(
+			'starter equipment for 1 class (Warden)'
+		);
+		expect(formatReferenceBody('skills', 'Meteor', [{ kind: 'recipeResult', names: ['Meteor'] }])).toContain(
+			'the result of 1 synthesis recipe (Meteor)'
+		);
+		expect(formatReferenceBody('skills', 'Meteor', [{ kind: 'recipeInput', names: ['Meteor'] }])).toContain(
+			'an input of 1 synthesis recipe (Meteor)'
+		);
+		expect(formatReferenceBody('skills', 'Meteor', [{ kind: 'milestoneReward', names: ['Blades'] }])).toContain(
+			'a milestone reward of 1 proficiency (Blades)'
+		);
+		expect(formatReferenceBody('proficiencies', 'Blades', [{ kind: 'gearGate', names: ['Iron Helm'] }])).toContain(
+			'the required proficiency for 1 item (Iron Helm)'
+		);
+		expect(formatReferenceBody('proficiencies', 'Blades', [{ kind: 'recipeCondition', names: ['Meteor'] }])).toContain(
+			'a condition of 1 synthesis recipe (Meteor)'
+		);
+		expect(
+			formatReferenceBody('proficiencies', 'Blades', [{ kind: 'prerequisiteOf', names: ['Advanced Blades'] }])
+		).toContain('a prerequisite for 1 proficiency (Advanced Blades)');
 	});
 });

--- a/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
+++ b/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-const { dangerModal } = vi.hoisted(() => ({ dangerModal: vi.fn() }));
-vi.mock('$stores', () => ({ dangerModal }));
+const { dangerModal, staticData } = vi.hoisted(() => ({
+	dangerModal: vi.fn(),
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	staticData: {} as any
+}));
+vi.mock('$stores', () => ({ dangerModal, staticData }));
 
-import { retireWithConfirm } from '$routes/admin/workbench/retire-confirm';
+import { referenceSourcesFromStatic, retireWithConfirm } from '$routes/admin/workbench/retire-confirm';
 import type { ReferenceSources } from '$routes/admin/workbench/references';
 
 const emptySources: ReferenceSources = {
@@ -17,7 +21,28 @@ const emptySources: ReferenceSources = {
 	skills: []
 };
 
-beforeEach(() => dangerModal.mockReset());
+beforeEach(() => {
+	dangerModal.mockReset();
+	for (const key of ['enemies', 'zones', 'challenges', 'items', 'classes', 'skillRecipes', 'proficiencies', 'skills']) {
+		delete staticData[key];
+	}
+});
+
+describe('referenceSourcesFromStatic', () => {
+	it('falls back to an empty array for every slot before staticData has loaded', () => {
+		expect(referenceSourcesFromStatic()).toEqual(emptySources);
+	});
+
+	it('passes through whatever staticData currently holds for each catalogue', () => {
+		staticData.enemies = [{ id: 0, name: 'Cave Bat' }];
+		staticData.skills = [{ id: 0, name: 'Fire Bolt' }];
+
+		const sources = referenceSourcesFromStatic();
+		expect(sources.enemies).toBe(staticData.enemies);
+		expect(sources.skills).toBe(staticData.skills);
+		expect(sources.zones).toEqual([]);
+	});
+});
 
 describe('retireWithConfirm', () => {
 	it('retires immediately, without prompting, when nothing references the record', async () => {

--- a/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
+++ b/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { dangerModal } = vi.hoisted(() => ({ dangerModal: vi.fn() }));
+vi.mock('$stores', () => ({ dangerModal }));
+
+import { retireWithConfirm } from '$routes/admin/workbench/retire-confirm';
+import type { ReferenceSources } from '$routes/admin/workbench/references';
+
+const emptySources: ReferenceSources = {
+	enemies: [],
+	zones: [],
+	challenges: [],
+	items: [],
+	classes: [],
+	skillRecipes: [],
+	proficiencies: [],
+	skills: []
+};
+
+beforeEach(() => dangerModal.mockReset());
+
+describe('retireWithConfirm', () => {
+	it('retires immediately, without prompting, when nothing references the record', async () => {
+		const onConfirmed = vi.fn();
+		await retireWithConfirm({
+			entityKey: 'enemies',
+			id: 0,
+			name: 'Cave Bat',
+			title: 'Retire Enemy?',
+			sources: emptySources,
+			onConfirmed
+		});
+
+		expect(dangerModal).not.toHaveBeenCalled();
+		expect(onConfirmed).toHaveBeenCalledOnce();
+	});
+
+	it('prompts with the referenced-by body and retires only when confirmed', async () => {
+		dangerModal.mockResolvedValue(true);
+		const onConfirmed = vi.fn();
+		const sources: ReferenceSources = {
+			...emptySources,
+			zones: [{ id: 0, name: 'Frost Cavern', bossEnemyId: 1 }] as unknown as ReferenceSources['zones']
+		};
+
+		await retireWithConfirm({
+			entityKey: 'enemies',
+			id: 1,
+			name: 'Catacomb Lich',
+			title: 'Retire Enemy?',
+			sources,
+			onConfirmed
+		});
+
+		expect(dangerModal).toHaveBeenCalledOnce();
+		const call = dangerModal.mock.calls[0][0];
+		expect(call.title).toBe('Retire Enemy?');
+		expect(call.body).toContain('Frost Cavern');
+		expect(onConfirmed).toHaveBeenCalledOnce();
+	});
+
+	it('does not retire when the confirm dialog is cancelled', async () => {
+		dangerModal.mockResolvedValue(false);
+		const onConfirmed = vi.fn();
+		const sources: ReferenceSources = {
+			...emptySources,
+			zones: [{ id: 0, name: 'Frost Cavern', bossEnemyId: 1 }] as unknown as ReferenceSources['zones']
+		};
+
+		await retireWithConfirm({
+			entityKey: 'enemies',
+			id: 1,
+			name: 'Catacomb Lich',
+			title: 'Retire Enemy?',
+			sources,
+			onConfirmed
+		});
+
+		expect(dangerModal).toHaveBeenCalledOnce();
+		expect(onConfirmed).not.toHaveBeenCalled();
+	});
+
+	it('surfaces a gear-gate/recipe-condition/prerequisite reference when retiring a proficiency', async () => {
+		dangerModal.mockResolvedValue(true);
+		const onConfirmed = vi.fn();
+		const sources: ReferenceSources = {
+			...emptySources,
+			items: [{ id: 0, name: 'Iron Helm', requiredProficiencyId: 5 }] as unknown as ReferenceSources['items'],
+			proficiencies: [
+				{ id: 6, name: 'Advanced Blades', prerequisiteIds: [5] }
+			] as unknown as ReferenceSources['proficiencies']
+		};
+
+		await retireWithConfirm({
+			entityKey: 'proficiencies',
+			id: 5,
+			name: 'Blades',
+			title: 'Retire tier?',
+			sources,
+			onConfirmed
+		});
+
+		const body = dangerModal.mock.calls[0][0].body as string;
+		expect(body).toContain('Iron Helm');
+		expect(body).toContain('Advanced Blades');
+		expect(onConfirmed).toHaveBeenCalledOnce();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes two admin-Workbench guardrail gaps described in #1517.

### 1. The retire "referenced by" dialog was silently incomplete

`references.ts`'s `computeReferences` covered boss / spawn-table / challenge-target / unlock-gate / reward / skill-pool memberships, but missed several real inbound references:

- item `grantedSkillId` → skill
- class `starterSkillIds` → skill, and `starterEquipment` → item
- skill-recipe `inputSkillIds` / `resultSkillId` → skill
- proficiency `levelRewards.rewardSkillId` → skill

…and the progression editor's tier retire showed **no dialog at all**, despite items (gear gates via `requiredProficiencyId`), synthesis recipes (`conditions.proficiencyId`), and other tiers (`prerequisiteIds`) all pointing at proficiencies.

`ReferenceSources` now also carries `items`, `classes`, `skillRecipes`, `proficiencies`, and `skills`, and `computeReferences` gained a `'proficiencies'` entity case plus five new inbound-reference kinds (`grantedSkillOf`, `starterSkillOf`, `starterEquipmentOf`, `recipeResult`, `recipeInput`, `milestoneReward`, `gearGate`, `recipeCondition`, `prerequisiteOf`). Still advisory-only, per the existing design — retirement never breaks a reference, this just lets the admin see what a retire affects first.

The confirm-then-retire flow itself (compute references → confirm via `dangerModal` if any exist → run the retire) was duplicated logic waiting to happen once the progression editor needed it too, so it's extracted into a small shared `retireWithConfirm` helper, used by both `WorkbenchDetail`'s generic retire button and the progression editor's `TierDetail`.

I scoped this to the tier (proficiency) retire only — nothing in the reference model actually points at a *path*, so wiring the same confirm into `PathDetail` would just be dead code that can never trigger a dialog.

### 2. Unsaved changes were silently discarded on sidebar tool switch / leaving `/admin`

`admin/+page.svelte` remounted the active Workbench/Progression surface on every tool switch (`{#key active}` / branch swap) with no dirty check, and there was no `beforeunload` guard — one misclick could discard an entire counted editing session.

Added a small cross-surface tracker (`workbenchDirty`) that the mounted `Workbench` or `Progression` component reports its pending-change count into (and resets on unmount). The admin shell now:

- confirms via `dangerModal` before a sidebar tool switch or "Return to Game" if the tracker is non-zero,
- registers a `beforeunload` handler while dirty, as a backstop for a full page refresh/close.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npx vitest run` (full suite) — 284 files / 3315 tests pass
- [x] Added `references.test.ts` coverage for every new reference kind and the new `'proficiencies'` entity case
- [x] Added `retire-confirm.test.ts` covering the shared confirm/cancel/unreferenced-skip flow (including the proficiency gear-gate/recipe-condition/prerequisite case)
- [x] Added `dirty.test.ts` for the new tracker
- [x] Extended `Workbench.test.ts` to assert the store's pending-change count is reported to `workbenchDirty` and reset on unmount

Closes #1517


---
_Generated by [Claude Code](https://claude.ai/code/session_01PXD162yQHZKXNJzt5mM44D)_