### PR TITLE
Dedupe Codex dossier shells, spawn-row lists, and table chrome

### DIFF
--- a/UI/src/routes/game/screens/codex/DossierShell.svelte
+++ b/UI/src/routes/game/screens/codex/DossierShell.svelte
@@ -1,0 +1,95 @@
+<!-- Shared dossier chrome for the Codex right panel: the fixed-width surface, the accent border, the
+     kind marker + name header. Enemy/Zone/Skill dossiers differ below the header (sub-tabs vs. stacked
+     sections), so only that header/wrapper — not the body — lives here. -->
+{#if selectedItem}
+	<div class="dossier" data-testid={testid} style:--dossier-accent={accent}>
+		<div class="head" style:border-left-color={borderAccent}>
+			<div class="kind-line">
+				<span class="kind-dot"></span>
+				<span class="kind">{kind}</span>
+				{@render headExtra?.()}
+			</div>
+			<div class="name">{name}</div>
+			{#if description}
+				<div class="desc">{description}</div>
+			{/if}
+		</div>
+
+		{@render children()}
+	</div>
+{/if}
+
+<script lang="ts">
+import type { Snippet } from 'svelte';
+
+interface Props {
+	/** Gates the whole shell like each dossier's own `{#if}` did — pass the selected record (or null). */
+	selectedItem: unknown;
+	testid: string;
+	/** Accent for the kind dot/label, and the head border unless `borderAccent` overrides it. */
+	accent: string;
+	/** Skill's rarity-tinted border is independent of the (fixed) kind-label accent; omit to reuse `accent`. */
+	borderAccent?: string;
+	kind: string;
+	name: string;
+	description?: string;
+	headExtra?: Snippet;
+	children: Snippet;
+}
+
+let { selectedItem, testid, accent, borderAccent, kind, name, description, headExtra, children }: Props = $props();
+</script>
+
+<style lang="scss">
+.dossier {
+	width: 380px;
+	flex: none;
+	background: var(--surface);
+	border-left: 1px solid var(--border-subtle);
+	display: flex;
+	flex-direction: column;
+}
+
+.head {
+	border-left: 3px solid var(--dossier-accent);
+	padding: 18px 20px 14px;
+	flex: none;
+}
+
+.kind-line {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	margin-bottom: 6px;
+}
+
+.kind-dot {
+	width: 6px;
+	height: 6px;
+	transform: rotate(45deg);
+	background: var(--dossier-accent);
+	flex: none;
+}
+
+.kind {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 1.6px;
+	text-transform: uppercase;
+	color: var(--dossier-accent);
+}
+
+.name {
+	font-size: 21px;
+	font-weight: 500;
+	letter-spacing: -0.3px;
+	line-height: 1.05;
+}
+
+.desc {
+	margin-top: 7px;
+	font-size: 12px;
+	line-height: 1.5;
+	color: var(--text-tertiary);
+}
+</style>

--- a/UI/src/routes/game/screens/codex/EnemyDossier.svelte
+++ b/UI/src/routes/game/screens/codex/EnemyDossier.svelte
@@ -1,58 +1,55 @@
 <!-- The enemy dossier (right panel): a section-accented header (kind + name), a row of sub-tabs, and
      the active sub-tab's body. Sub-tab content lives in its own small panel component. -->
-{#if view.selectedEnemy}
-	<div class="dossier" data-testid="codex-dossier" style:--dossier-accent={view.dossierAccent}>
-		<div class="head">
-			<div class="kind-line">
-				<span class="kind-dot"></span>
-				<span class="kind">{view.dossierKind}</span>
-			</div>
-			<div class="name">{view.selectedEnemy.name}</div>
-		</div>
-
-		<div class="sub-tabs" role="tablist" aria-label="Enemy detail">
-			{#each view.subTabs as tab (tab.key)}
-				<button
-					type="button"
-					id="codex-subtab-{tab.key}"
-					role="tab"
-					aria-selected={view.sub === tab.key}
-					aria-controls="codex-subpanel"
-					class="sub-tab"
-					class:active={view.sub === tab.key}
-					data-testid="codex-subtab-{tab.key}"
-					onclick={() => view.selectSub(tab.key)}
-				>
-					{tab.label}
-					<span class="underline"></span>
-				</button>
-			{/each}
-		</div>
-
-		<div class="body" id="codex-subpanel" role="tabpanel" aria-labelledby="codex-subtab-{view.sub}">
-			{#if view.sub === 'attributes'}
-				<AttributesPanel {view} />
-			{:else if view.sub === 'statistics'}
-				<StatisticsPanel
-					stats={view.statistics}
-					loading={view.statsLoading}
-					error={view.statsError}
-					emptyMessage="No battles recorded against this enemy yet."
-					testid="codex-enemy-stats"
-				/>
-			{:else if view.sub === 'skills'}
-				<EnemySkillsPanel {view} />
-			{:else if view.sub === 'spawns'}
-				<EnemySpawnsPanel {view} />
-			{:else if view.sub === 'challenges'}
-				<EnemyChallengesPanel {view} />
-			{/if}
-		</div>
+<DossierShell
+	selectedItem={view.selectedEnemy}
+	testid="codex-dossier"
+	accent={view.dossierAccent}
+	kind={view.dossierKind}
+	name={view.selectedEnemy?.name ?? ''}
+>
+	<div class="sub-tabs" role="tablist" aria-label="Enemy detail">
+		{#each view.subTabs as tab (tab.key)}
+			<button
+				type="button"
+				id="codex-subtab-{tab.key}"
+				role="tab"
+				aria-selected={view.sub === tab.key}
+				aria-controls="codex-subpanel"
+				class="sub-tab"
+				class:active={view.sub === tab.key}
+				data-testid="codex-subtab-{tab.key}"
+				onclick={() => view.selectSub(tab.key)}
+			>
+				{tab.label}
+				<span class="underline"></span>
+			</button>
+		{/each}
 	</div>
-{/if}
+
+	<div class="body" id="codex-subpanel" role="tabpanel" aria-labelledby="codex-subtab-{view.sub}">
+		{#if view.sub === 'attributes'}
+			<AttributesPanel {view} />
+		{:else if view.sub === 'statistics'}
+			<StatisticsPanel
+				stats={view.statistics}
+				loading={view.statsLoading}
+				error={view.statsError}
+				emptyMessage="No battles recorded against this enemy yet."
+				testid="codex-enemy-stats"
+			/>
+		{:else if view.sub === 'skills'}
+			<EnemySkillsPanel {view} />
+		{:else if view.sub === 'spawns'}
+			<EnemySpawnsPanel {view} />
+		{:else if view.sub === 'challenges'}
+			<EnemyChallengesPanel {view} />
+		{/if}
+	</div>
+</DossierShell>
 
 <script lang="ts">
 import type { CodexView } from './codex-view.svelte';
+import DossierShell from './DossierShell.svelte';
 import AttributesPanel from './AttributesPanel.svelte';
 import StatisticsPanel from './StatisticsPanel.svelte';
 import EnemySkillsPanel from './EnemySkillsPanel.svelte';
@@ -67,51 +64,6 @@ let { view }: Props = $props();
 </script>
 
 <style lang="scss">
-.dossier {
-	width: 380px;
-	flex: none;
-	background: var(--surface);
-	border-left: 1px solid var(--border-subtle);
-	display: flex;
-	flex-direction: column;
-}
-
-.head {
-	border-left: 3px solid var(--dossier-accent);
-	padding: 18px 20px 14px;
-	flex: none;
-}
-
-.kind-line {
-	display: flex;
-	align-items: center;
-	gap: 9px;
-	margin-bottom: 6px;
-}
-
-.kind-dot {
-	width: 6px;
-	height: 6px;
-	transform: rotate(45deg);
-	background: var(--dossier-accent);
-	flex: none;
-}
-
-.kind {
-	font-family: var(--mono);
-	font-size: 9px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--dossier-accent);
-}
-
-.name {
-	font-size: 21px;
-	font-weight: 500;
-	letter-spacing: -0.3px;
-	line-height: 1.05;
-}
-
 .sub-tabs {
 	display: flex;
 	gap: 2px;

--- a/UI/src/routes/game/screens/codex/EnemySpawnsPanel.svelte
+++ b/UI/src/routes/game/screens/codex/EnemySpawnsPanel.svelte
@@ -1,31 +1,20 @@
 <!-- Spawns sub-tab: the zones this enemy spawns in (with its share of each zone's spawn table), or a
      single "Encounter" row for a boss. Each row cross-links into that zone's dossier. -->
-<div class="spawns">
-	<div class="label">{view.spawnHeading}</div>
-	<div class="list">
-		{#each view.spawns as spawn (spawn.zoneId)}
-			<button
-				type="button"
-				class="spawn"
-				data-testid="codex-enemy-spawn-{spawn.zoneId}"
-				onclick={() => view.openZone(spawn.zoneId)}
-			>
-				<div class="top">
-					<span class="zone">{spawn.zoneName}</span>
-					<span class="share">{spawn.share}%</span>
-				</div>
-				<div class="bottom">
-					<span class="bar-wrap"><Bar value={spawn.share} presentational /></span>
-					<span class="weight">{spawn.weightLabel}</span>
-				</div>
-			</button>
-		{/each}
-	</div>
-</div>
+<SpawnRowList
+	heading={view.spawnHeading}
+	rows={view.spawns.map((spawn) => ({
+		id: spawn.zoneId,
+		name: spawn.zoneName,
+		share: spawn.share,
+		weightLabel: spawn.weightLabel
+	}))}
+	testidPrefix="codex-enemy-spawn"
+	onSelect={(id) => view.openZone(id)}
+/>
 
 <script lang="ts">
-import { Bar } from '$components';
 import type { CodexView } from './codex-view.svelte';
+import SpawnRowList from './SpawnRowList.svelte';
 
 interface Props {
 	view: CodexView;
@@ -33,76 +22,3 @@ interface Props {
 
 let { view }: Props = $props();
 </script>
-
-<style lang="scss">
-.label {
-	font-family: var(--mono);
-	font-size: 9px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-	margin-bottom: 10px;
-}
-
-.list {
-	display: flex;
-	flex-direction: column;
-	gap: 11px;
-}
-
-.spawn {
-	display: block;
-	width: 100%;
-	text-align: left;
-	background: transparent;
-	border: none;
-	border-radius: 4px;
-	padding: 4px;
-	margin: -4px;
-	cursor: pointer;
-	font-family: var(--sans);
-
-	&:hover {
-		background: color-mix(in srgb, var(--white) 4%, transparent);
-	}
-}
-
-.top {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	margin-bottom: 5px;
-}
-
-.zone {
-	font-size: 12.5px;
-	color: var(--text-primary);
-}
-
-.share {
-	font-family: var(--mono);
-	font-size: 10px;
-	color: var(--accent-light);
-}
-
-.bottom {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-}
-
-.bar-wrap {
-	flex: 1;
-	--bar-height: 6px;
-	--bar-radius: 3px;
-	--bar-fill: var(--accent);
-	--bar-track-bg: color-mix(in srgb, var(--white) 6%, transparent);
-}
-
-.weight {
-	font-family: var(--mono);
-	font-size: 8.5px;
-	color: var(--text-muted);
-	white-space: nowrap;
-}
-</style>

--- a/UI/src/routes/game/screens/codex/EnemyTable.svelte
+++ b/UI/src/routes/game/screens/codex/EnemyTable.svelte
@@ -45,73 +45,34 @@ let { view }: Props = $props();
 </script>
 
 <style lang="scss">
+@use '$styles/codex-table' as table;
+
 .table {
-	flex: 1;
-	min-height: 0;
-	display: flex;
-	flex-direction: column;
+	@include table.frame;
 }
 
 .head {
-	display: flex;
-	align-items: center;
-	font-family: var(--mono);
-	font-size: 8.5px;
-	letter-spacing: 1.4px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-	padding: 0 14px 8px;
-	border-bottom: 1px solid var(--border-subtle);
-	margin-right: 14px;
+	@include table.head-row;
 }
 
 .c-name {
-	flex: 2.4;
-	min-width: 0;
+	@include table.col-name;
 }
 
 .c-num {
-	flex: 1;
-	text-align: right;
+	@include table.col-num;
 }
 
 .narrow {
-	flex: 0.9;
+	@include table.col-narrow;
 }
 
 .rows {
-	flex: 1;
-	min-height: 0;
-	overflow-y: auto;
-	padding-right: 6px;
+	@include table.rows-list;
 }
 
 .row {
-	width: 100%;
-	text-align: left;
-	display: flex;
-	align-items: center;
-	padding: 9px 14px;
-	border: none;
-	border-left: 2px solid transparent;
-	border-bottom: 1px solid color-mix(in srgb, var(--white) 5%, transparent);
-	background: transparent;
-	cursor: pointer;
-	font-family: var(--sans);
-
-	&:hover {
-		background: color-mix(in srgb, var(--white) 3%, transparent);
-	}
-
-	&.selected {
-		border-left-color: var(--enemy-accent);
-		background: color-mix(in srgb, var(--enemy-accent) 10%, transparent);
-
-		.name {
-			color: var(--white);
-			font-weight: 600;
-		}
-	}
+	@include table.row(var(--enemy-accent));
 
 	&.selected.boss {
 		border-left-color: var(--boss-accent);
@@ -120,10 +81,7 @@ let { view }: Props = $props();
 }
 
 .name-cell {
-	display: flex;
-	align-items: center;
-	gap: 11px;
-	min-width: 0;
+	@include table.name-cell;
 }
 
 .mark {
@@ -142,11 +100,7 @@ let { view }: Props = $props();
 }
 
 .name {
-	font-size: 13.5px;
-	color: var(--text-primary);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+	@include table.row-name;
 }
 
 .boss-tag {
@@ -167,8 +121,6 @@ let { view }: Props = $props();
 }
 
 .muted {
-	font-family: var(--mono);
-	font-size: 10.5px;
-	color: var(--text-tertiary);
+	@include table.muted-num;
 }
 </style>

--- a/UI/src/routes/game/screens/codex/SkillDossier.svelte
+++ b/UI/src/routes/game/screens/codex/SkillDossier.svelte
@@ -7,20 +7,20 @@
 {#if view.selectedSkill}
 	{@const skill = view.selectedSkill}
 	{@const rarity = view.selectedSkillRarity}
-	<div class="dossier" data-testid="codex-skill-dossier">
-		<div class="head" style:border-left-color={rarity?.color}>
-			<div class="kind-line">
-				<span class="kind-dot"></span>
-				<span class="kind">Skill</span>
-				{#if rarity}
-					<RarityTagBox color={rarity.color} label={rarity.label} />
-				{/if}
-			</div>
-			<div class="name">{skill.name}</div>
-			{#if skill.description}
-				<div class="desc">{skill.description}</div>
+	<DossierShell
+		selectedItem={skill}
+		testid="codex-skill-dossier"
+		accent="var(--attr-intellect)"
+		borderAccent={rarity?.color}
+		kind="Skill"
+		name={skill.name}
+		description={skill.description}
+	>
+		{#snippet headExtra()}
+			{#if rarity}
+				<RarityTagBox color={rarity.color} label={rarity.label} />
 			{/if}
-		</div>
+		{/snippet}
 
 		<div class="body">
 			<div class="meta">
@@ -117,12 +117,13 @@
 				/>
 			</div>
 		</div>
-	</div>
+	</DossierShell>
 {/if}
 
 <script lang="ts">
 import type { CodexView } from './codex-view.svelte';
 import { formatBaseDamage, formatCooldown } from './codex-display';
+import DossierShell from './DossierShell.svelte';
 import StatisticsPanel from './StatisticsPanel.svelte';
 import RarityTagBox from '$components/RarityTagBox.svelte';
 
@@ -134,104 +135,30 @@ let { view }: Props = $props();
 </script>
 
 <style lang="scss">
-.dossier {
-	width: 380px;
-	flex: none;
-	background: var(--surface);
-	border-left: 1px solid var(--border-subtle);
-	display: flex;
-	flex-direction: column;
-}
-
-.head {
-	border-left: 3px solid var(--attr-intellect);
-	padding: 18px 20px 14px;
-	flex: none;
-}
-
-.kind-line {
-	display: flex;
-	align-items: center;
-	gap: 9px;
-	margin-bottom: 6px;
-}
-
-.kind-dot {
-	width: 6px;
-	height: 6px;
-	transform: rotate(45deg);
-	background: var(--attr-intellect);
-	flex: none;
-}
-
-.kind {
-	font-family: var(--mono);
-	font-size: 9px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--attr-intellect);
-}
-
-.name {
-	font-size: 21px;
-	font-weight: 500;
-	letter-spacing: -0.3px;
-	line-height: 1.05;
-}
-
-.desc {
-	margin-top: 7px;
-	font-size: 12px;
-	line-height: 1.5;
-	color: var(--text-tertiary);
-}
+@use '$styles/codex-dossier' as dossier;
 
 .body {
-	flex: 1;
-	min-height: 0;
-	overflow-y: auto;
-	padding: 16px 20px 20px;
-	display: flex;
-	flex-direction: column;
-	gap: 18px;
+	@include dossier.stacked-body;
 }
 
 .meta {
-	display: flex;
-	gap: 10px;
+	@include dossier.meta-row;
 }
 
 .meta-card {
-	flex: 1;
-	background: var(--panel);
-	border: 1px solid var(--border-subtle);
-	border-radius: 4px;
-	padding: 9px 11px;
+	@include dossier.meta-card;
 }
 
 .meta-label {
-	font-family: var(--mono);
-	font-size: 8px;
-	letter-spacing: 1px;
-	text-transform: uppercase;
-	color: var(--text-muted);
+	@include dossier.meta-label;
 }
 
 .meta-val {
-	font-family: var(--mono);
-	font-size: 15px;
-	font-weight: 500;
-	margin-top: 3px;
-	color: var(--text-primary);
+	@include dossier.meta-val;
 }
 
 .section-label {
-	font-family: var(--mono);
-	font-size: 9px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-	margin-bottom: 10px;
+	@include dossier.section-label;
 }
 
 .chips {
@@ -377,8 +304,6 @@ let { view }: Props = $props();
 }
 
 .empty {
-	font-size: 12px;
-	color: var(--text-muted);
-	font-style: italic;
+	@include dossier.empty-note;
 }
 </style>

--- a/UI/src/routes/game/screens/codex/SkillTable.svelte
+++ b/UI/src/routes/game/screens/codex/SkillTable.svelte
@@ -40,80 +40,38 @@ let { view }: Props = $props();
 </script>
 
 <style lang="scss">
+@use '$styles/codex-table' as table;
+
 .table {
-	flex: 1;
-	min-height: 0;
-	display: flex;
-	flex-direction: column;
+	@include table.frame;
 }
 
 .head {
-	display: flex;
-	align-items: center;
-	font-family: var(--mono);
-	font-size: 8.5px;
-	letter-spacing: 1.4px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-	padding: 0 14px 8px;
-	border-bottom: 1px solid var(--border-subtle);
-	margin-right: 14px;
+	@include table.head-row;
 }
 
 .c-name {
-	flex: 2.4;
-	min-width: 0;
+	@include table.col-name;
 }
 
 .c-num {
-	flex: 1;
-	text-align: right;
+	@include table.col-num;
 }
 
 .narrow {
-	flex: 0.9;
+	@include table.col-narrow;
 }
 
 .rows {
-	flex: 1;
-	min-height: 0;
-	overflow-y: auto;
-	padding-right: 6px;
+	@include table.rows-list;
 }
 
 .row {
-	width: 100%;
-	text-align: left;
-	display: flex;
-	align-items: center;
-	padding: 9px 14px;
-	border: none;
-	border-left: 2px solid transparent;
-	border-bottom: 1px solid color-mix(in srgb, var(--white) 5%, transparent);
-	background: transparent;
-	cursor: pointer;
-	font-family: var(--sans);
-
-	&:hover {
-		background: color-mix(in srgb, var(--white) 3%, transparent);
-	}
-
-	&.selected {
-		border-left-color: var(--attr-intellect);
-		background: color-mix(in srgb, var(--attr-intellect) 10%, transparent);
-
-		.name {
-			color: var(--white);
-			font-weight: 600;
-		}
-	}
+	@include table.row(var(--attr-intellect));
 }
 
 .name-cell {
-	display: flex;
-	align-items: center;
-	gap: 11px;
-	min-width: 0;
+	@include table.name-cell;
 }
 
 .mark {
@@ -127,11 +85,7 @@ let { view }: Props = $props();
 }
 
 .name {
-	font-size: 13.5px;
-	color: var(--text-primary);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+	@include table.row-name;
 }
 
 .val {
@@ -141,8 +95,6 @@ let { view }: Props = $props();
 }
 
 .muted {
-	font-family: var(--mono);
-	font-size: 10.5px;
-	color: var(--text-tertiary);
+	@include table.muted-num;
 }
 </style>

--- a/UI/src/routes/game/screens/codex/SpawnRowList.svelte
+++ b/UI/src/routes/game/screens/codex/SpawnRowList.svelte
@@ -1,0 +1,121 @@
+<!-- Shared share-bar row list backing the Spawns sub-tab (enemy → zones) and the zone dossier's spawn
+     table (zone → enemies): a heading, then each target's share of the pool as a name/percent row over
+     a fill bar, cross-linking into that target's own dossier. -->
+<div class="spawns">
+	<div class="label">{heading}</div>
+	{#if rows.length > 0}
+		<div class="list">
+			{#each rows as row (row.id)}
+				<button type="button" class="spawn" data-testid="{testidPrefix}-{row.id}" onclick={() => onSelect(row.id)}>
+					<div class="top">
+						<span class="name">{row.name}</span>
+						<span class="share">{row.share}%</span>
+					</div>
+					<div class="bottom">
+						<span class="bar-wrap"><Bar value={row.share} presentational /></span>
+						<span class="weight">{row.weightLabel}</span>
+					</div>
+				</button>
+			{/each}
+		</div>
+	{:else if emptyMessage}
+		<div class="empty">{emptyMessage}</div>
+	{/if}
+</div>
+
+<script lang="ts">
+import { Bar } from '$components';
+
+export interface SpawnRowVM {
+	id: number;
+	name: string;
+	share: number;
+	weightLabel: string;
+}
+
+interface Props {
+	heading: string;
+	rows: SpawnRowVM[];
+	/** Shown only when `rows` is empty; omit to render nothing (the enemy panel always has a row). */
+	emptyMessage?: string;
+	/** Prefix for each row's `data-testid`, e.g. `codex-enemy-spawn` / `codex-zone-spawn`. */
+	testidPrefix: string;
+	onSelect: (id: number) => void;
+}
+
+let { heading, rows, emptyMessage, testidPrefix, onSelect }: Props = $props();
+</script>
+
+<style lang="scss">
+@use '$styles/codex-dossier' as dossier;
+
+.label {
+	@include dossier.section-label;
+}
+
+.list {
+	display: flex;
+	flex-direction: column;
+	gap: 11px;
+}
+
+.spawn {
+	display: block;
+	width: 100%;
+	text-align: left;
+	background: transparent;
+	border: none;
+	border-radius: 4px;
+	padding: 4px;
+	margin: -4px;
+	cursor: pointer;
+	font-family: var(--sans);
+
+	&:hover {
+		background: color-mix(in srgb, var(--white) 4%, transparent);
+	}
+}
+
+.top {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 5px;
+}
+
+.name {
+	font-size: 12.5px;
+	color: var(--text-primary);
+}
+
+.share {
+	font-family: var(--mono);
+	font-size: 10px;
+	color: var(--accent-light);
+}
+
+.bottom {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.bar-wrap {
+	flex: 1;
+	--bar-height: 6px;
+	--bar-radius: 3px;
+	--bar-fill: var(--accent);
+	--bar-track-bg: color-mix(in srgb, var(--white) 6%, transparent);
+}
+
+.weight {
+	font-family: var(--mono);
+	font-size: 8.5px;
+	color: var(--text-muted);
+	white-space: nowrap;
+}
+
+.empty {
+	@include dossier.empty-note;
+}
+</style>

--- a/UI/src/routes/game/screens/codex/ZoneDossier.svelte
+++ b/UI/src/routes/game/screens/codex/ZoneDossier.svelte
@@ -1,94 +1,94 @@
 <!-- The zone dossier (right panel): a section-accented header (Zone + progression seal + name), the
      level band / spawn-pool meta, the zone boss card, the spawn table and the unlock condition. The
      boss card and spawn rows cross-link into the enemy dossier. -->
-{#if view.selectedZone}
-	<div class="dossier" data-testid="codex-zone-dossier" style:--status-color={zoneStatusColor(view.selectedZoneStatus)}>
-		<div class="head">
-			<div class="kind-line">
-				<span class="kind-dot"></span>
-				<span class="kind">Zone</span>
-				<span class="spacer"></span>
-				<span class="seal" data-testid="codex-zone-status">{ZONE_STATUS_LABELS[view.selectedZoneStatus]}</span>
+<DossierShell
+	selectedItem={view.selectedZone}
+	testid="codex-zone-dossier"
+	accent="var(--accent)"
+	kind="Zone"
+	name={view.selectedZone?.name ?? ''}
+	description={view.selectedZone?.description}
+>
+	{#snippet headExtra()}
+		<span class="spacer"></span>
+		<span class="seal" data-testid="codex-zone-status" style:--status-color={zoneStatusColor(view.selectedZoneStatus)}
+			>{ZONE_STATUS_LABELS[view.selectedZoneStatus]}</span
+		>
+	{/snippet}
+
+	<div class="body">
+		<div class="meta">
+			<div class="meta-card">
+				<div class="meta-label">Level Range</div>
+				<div class="meta-val">{view.zoneBand}</div>
 			</div>
-			<div class="name">{view.selectedZone.name}</div>
-			{#if view.selectedZone.description}
-				<div class="desc">{view.selectedZone.description}</div>
+			<div class="meta-card">
+				<div class="meta-label">Spawn Pool</div>
+				<div class="meta-val">{view.zoneSpawnCount} {view.zoneSpawnCount === 1 ? 'enemy' : 'enemies'}</div>
+			</div>
+		</div>
+
+		{#if view.zoneBoss}
+			{@const boss = view.zoneBoss}
+			<div class="section">
+				<div class="section-label">Zone boss</div>
+				<button
+					type="button"
+					class="boss-card"
+					data-testid="codex-zone-boss"
+					onclick={() => view.openEnemy(boss.enemyId)}
+				>
+					<span class="boss-mark"></span>
+					<span class="boss-text">
+						<span class="boss-name">{boss.name}</span>
+						<span class="boss-meta">Boss · LVL {boss.level}</span>
+					</span>
+					<span class="chev" aria-hidden="true">›</span>
+				</button>
+			</div>
+		{/if}
+
+		<div class="section">
+			<ZoneSpawnPanel {view} />
+		</div>
+
+		<div class="section">
+			<div class="section-label">Unlock condition</div>
+			{#if view.zoneUnlock}
+				{@const unlock = view.zoneUnlock}
+				<div class="unlock" class:sealed={unlock.sealed}>
+					<span class="unlock-text">
+						<span class="unlock-lead">Complete challenge</span>
+						<span class="unlock-name">{unlock.challengeName}</span>
+					</span>
+					<span class="unlock-chip">{unlock.sealed ? 'Sealed' : 'Met'}</span>
+				</div>
+			{:else}
+				<div class="unlock open">
+					<span class="unlock-text">
+						<span class="unlock-name">Always open</span>
+						<span class="unlock-lead">No challenge gates this zone</span>
+					</span>
+				</div>
 			{/if}
 		</div>
 
-		<div class="body">
-			<div class="meta">
-				<div class="meta-card">
-					<div class="meta-label">Level Range</div>
-					<div class="meta-val">{view.zoneBand}</div>
-				</div>
-				<div class="meta-card">
-					<div class="meta-label">Spawn Pool</div>
-					<div class="meta-val">{view.zoneSpawnCount} {view.zoneSpawnCount === 1 ? 'enemy' : 'enemies'}</div>
-				</div>
-			</div>
-
-			{#if view.zoneBoss}
-				{@const boss = view.zoneBoss}
-				<div class="section">
-					<div class="section-label">Zone boss</div>
-					<button
-						type="button"
-						class="boss-card"
-						data-testid="codex-zone-boss"
-						onclick={() => view.openEnemy(boss.enemyId)}
-					>
-						<span class="boss-mark"></span>
-						<span class="boss-text">
-							<span class="boss-name">{boss.name}</span>
-							<span class="boss-meta">Boss · LVL {boss.level}</span>
-						</span>
-						<span class="chev" aria-hidden="true">›</span>
-					</button>
-				</div>
-			{/if}
-
-			<div class="section">
-				<ZoneSpawnPanel {view} />
-			</div>
-
-			<div class="section">
-				<div class="section-label">Unlock condition</div>
-				{#if view.zoneUnlock}
-					{@const unlock = view.zoneUnlock}
-					<div class="unlock" class:sealed={unlock.sealed}>
-						<span class="unlock-text">
-							<span class="unlock-lead">Complete challenge</span>
-							<span class="unlock-name">{unlock.challengeName}</span>
-						</span>
-						<span class="unlock-chip">{unlock.sealed ? 'Sealed' : 'Met'}</span>
-					</div>
-				{:else}
-					<div class="unlock open">
-						<span class="unlock-text">
-							<span class="unlock-name">Always open</span>
-							<span class="unlock-lead">No challenge gates this zone</span>
-						</span>
-					</div>
-				{/if}
-			</div>
-
-			<div class="section">
-				<StatisticsPanel
-					stats={view.zoneStatistics}
-					loading={view.statsLoading}
-					error={view.statsError}
-					emptyMessage="No statistics recorded for this zone yet."
-					testid="codex-zone-stats"
-				/>
-			</div>
+		<div class="section">
+			<StatisticsPanel
+				stats={view.zoneStatistics}
+				loading={view.statsLoading}
+				error={view.statsError}
+				emptyMessage="No statistics recorded for this zone yet."
+				testid="codex-zone-stats"
+			/>
 		</div>
 	</div>
-{/if}
+</DossierShell>
 
 <script lang="ts">
 import type { CodexView } from './codex-view.svelte';
 import { ZONE_STATUS_LABELS, zoneStatusColor } from './codex-display';
+import DossierShell from './DossierShell.svelte';
 import ZoneSpawnPanel from './ZoneSpawnPanel.svelte';
 import StatisticsPanel from './StatisticsPanel.svelte';
 
@@ -100,43 +100,7 @@ let { view }: Props = $props();
 </script>
 
 <style lang="scss">
-.dossier {
-	width: 380px;
-	flex: none;
-	background: var(--surface);
-	border-left: 1px solid var(--border-subtle);
-	display: flex;
-	flex-direction: column;
-}
-
-.head {
-	border-left: 3px solid var(--accent);
-	padding: 18px 20px 14px;
-	flex: none;
-}
-
-.kind-line {
-	display: flex;
-	align-items: center;
-	gap: 9px;
-	margin-bottom: 6px;
-}
-
-.kind-dot {
-	width: 6px;
-	height: 6px;
-	transform: rotate(45deg);
-	background: var(--accent);
-	flex: none;
-}
-
-.kind {
-	font-family: var(--mono);
-	font-size: 9px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--accent);
-}
+@use '$styles/codex-dossier' as dossier;
 
 .spacer {
 	flex: 1;
@@ -153,66 +117,28 @@ let { view }: Props = $props();
 	padding: 2px 9px;
 }
 
-.name {
-	font-size: 21px;
-	font-weight: 500;
-	letter-spacing: -0.3px;
-	line-height: 1.05;
-}
-
-.desc {
-	margin-top: 7px;
-	font-size: 12px;
-	line-height: 1.5;
-	color: var(--text-tertiary);
-}
-
 .body {
-	flex: 1;
-	min-height: 0;
-	overflow-y: auto;
-	padding: 16px 20px 20px;
-	display: flex;
-	flex-direction: column;
-	gap: 18px;
+	@include dossier.stacked-body;
 }
 
 .meta {
-	display: flex;
-	gap: 10px;
+	@include dossier.meta-row;
 }
 
 .meta-card {
-	flex: 1;
-	background: var(--panel);
-	border: 1px solid var(--border-subtle);
-	border-radius: 4px;
-	padding: 9px 11px;
+	@include dossier.meta-card;
 }
 
 .meta-label {
-	font-family: var(--mono);
-	font-size: 8px;
-	letter-spacing: 1px;
-	text-transform: uppercase;
-	color: var(--text-muted);
+	@include dossier.meta-label;
 }
 
 .meta-val {
-	font-family: var(--mono);
-	font-size: 15px;
-	font-weight: 500;
-	margin-top: 3px;
-	color: var(--text-primary);
+	@include dossier.meta-val;
 }
 
 .section-label {
-	font-family: var(--mono);
-	font-size: 9px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-	margin-bottom: 10px;
+	@include dossier.section-label;
 }
 
 .boss-card {

--- a/UI/src/routes/game/screens/codex/ZoneSpawnPanel.svelte
+++ b/UI/src/routes/game/screens/codex/ZoneSpawnPanel.svelte
@@ -1,36 +1,21 @@
 <!-- Zone dossier spawn table: every non-retired enemy that spawns in the zone, with its share of the
      zone's total spawn weight. Each row is a cross-link into that enemy's dossier. -->
-<div class="spawns">
-	<div class="label">Spawn table · {view.zoneSpawnCount}</div>
-
-	{#if view.zoneSpawns.length > 0}
-		<div class="list">
-			{#each view.zoneSpawns as spawn (spawn.enemyId)}
-				<button
-					type="button"
-					class="spawn"
-					data-testid="codex-zone-spawn-{spawn.enemyId}"
-					onclick={() => view.openEnemy(spawn.enemyId)}
-				>
-					<div class="top">
-						<span class="enemy">{spawn.enemyName}</span>
-						<span class="share">{spawn.share}%</span>
-					</div>
-					<div class="bottom">
-						<span class="bar-wrap"><Bar value={spawn.share} presentational /></span>
-						<span class="weight">{spawn.weightLabel}</span>
-					</div>
-				</button>
-			{/each}
-		</div>
-	{:else}
-		<div class="empty">No spawns — encounter-only zone</div>
-	{/if}
-</div>
+<SpawnRowList
+	heading={`Spawn table · ${view.zoneSpawnCount}`}
+	rows={view.zoneSpawns.map((spawn) => ({
+		id: spawn.enemyId,
+		name: spawn.enemyName,
+		share: spawn.share,
+		weightLabel: spawn.weightLabel
+	}))}
+	emptyMessage="No spawns — encounter-only zone"
+	testidPrefix="codex-zone-spawn"
+	onSelect={(id) => view.openEnemy(id)}
+/>
 
 <script lang="ts">
-import { Bar } from '$components';
 import type { CodexView } from './codex-view.svelte';
+import SpawnRowList from './SpawnRowList.svelte';
 
 interface Props {
 	view: CodexView;
@@ -38,82 +23,3 @@ interface Props {
 
 let { view }: Props = $props();
 </script>
-
-<style lang="scss">
-.label {
-	font-family: var(--mono);
-	font-size: 9px;
-	letter-spacing: 1.6px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-	margin-bottom: 10px;
-}
-
-.list {
-	display: flex;
-	flex-direction: column;
-	gap: 11px;
-}
-
-.spawn {
-	display: block;
-	width: 100%;
-	text-align: left;
-	background: transparent;
-	border: none;
-	border-radius: 4px;
-	padding: 4px;
-	margin: -4px;
-	cursor: pointer;
-	font-family: var(--sans);
-
-	&:hover {
-		background: color-mix(in srgb, var(--white) 4%, transparent);
-	}
-}
-
-.top {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	margin-bottom: 5px;
-}
-
-.enemy {
-	font-size: 12.5px;
-	color: var(--text-primary);
-}
-
-.share {
-	font-family: var(--mono);
-	font-size: 10px;
-	color: var(--accent-light);
-}
-
-.bottom {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-}
-
-.bar-wrap {
-	flex: 1;
-	--bar-height: 6px;
-	--bar-radius: 3px;
-	--bar-fill: var(--accent);
-	--bar-track-bg: color-mix(in srgb, var(--white) 6%, transparent);
-}
-
-.weight {
-	font-family: var(--mono);
-	font-size: 8.5px;
-	color: var(--text-muted);
-	white-space: nowrap;
-}
-
-.empty {
-	font-size: 12px;
-	color: var(--text-muted);
-	font-style: italic;
-}
-</style>

--- a/UI/src/styles/_codex-dossier.scss
+++ b/UI/src/styles/_codex-dossier.scss
@@ -1,0 +1,58 @@
+// Shared body-section chrome for Codex dossiers that stack labelled sections (Zone, Skill) rather
+// than tabbing between sub-panels (Enemy — see `DossierShell` for the header/wrapper the three share).
+// Mixins rather than a shared component: Svelte scopes styles per source file, so a rule only applies
+// to markup declared in that same file — these are `@include`d into each dossier's own `<style>`.
+
+@mixin stacked-body {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 16px 20px 20px;
+	display: flex;
+	flex-direction: column;
+	gap: 18px;
+}
+
+@mixin meta-row {
+	display: flex;
+	gap: 10px;
+}
+
+@mixin meta-card {
+	flex: 1;
+	background: var(--panel);
+	border: 1px solid var(--border-subtle);
+	border-radius: 4px;
+	padding: 9px 11px;
+}
+
+@mixin meta-label {
+	font-family: var(--mono);
+	font-size: 8px;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+}
+
+@mixin meta-val {
+	font-family: var(--mono);
+	font-size: 15px;
+	font-weight: 500;
+	margin-top: 3px;
+	color: var(--text-primary);
+}
+
+@mixin section-label {
+	font-family: var(--mono);
+	font-size: 9px;
+	letter-spacing: 1.6px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+	margin-bottom: 10px;
+}
+
+@mixin empty-note {
+	font-size: 12px;
+	color: var(--text-muted);
+	font-style: italic;
+}

--- a/UI/src/styles/_codex-table.scss
+++ b/UI/src/styles/_codex-table.scss
@@ -1,0 +1,96 @@
+// Shared column-header + selectable-row chrome for the Codex reference tables (EnemyTable, SkillTable).
+// Row marks and the selected accent stay per-table (boss diamond vs. rarity tier), so those are
+// `@include`d locally alongside this frame rather than folded in — see `_codex-dossier.scss` for why
+// mixins rather than a shared component.
+
+@mixin frame {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+}
+
+@mixin head-row {
+	display: flex;
+	align-items: center;
+	font-family: var(--mono);
+	font-size: 8.5px;
+	letter-spacing: 1.4px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+	padding: 0 14px 8px;
+	border-bottom: 1px solid var(--border-subtle);
+	margin-right: 14px;
+}
+
+@mixin col-name {
+	flex: 2.4;
+	min-width: 0;
+}
+
+@mixin col-num {
+	flex: 1;
+	text-align: right;
+}
+
+@mixin col-narrow {
+	flex: 0.9;
+}
+
+@mixin rows-list {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding-right: 6px;
+}
+
+// $selected-accent is the CSS colour (usually a `var(--...)` token) applied to the selected row's
+// left border/tint; pass the table's own accent (boss/enemy vs. rarity/intellect).
+@mixin row($selected-accent) {
+	width: 100%;
+	text-align: left;
+	display: flex;
+	align-items: center;
+	padding: 9px 14px;
+	border: none;
+	border-left: 2px solid transparent;
+	border-bottom: 1px solid color-mix(in srgb, var(--white) 5%, transparent);
+	background: transparent;
+	cursor: pointer;
+	font-family: var(--sans);
+
+	&:hover {
+		background: color-mix(in srgb, var(--white) 3%, transparent);
+	}
+
+	&.selected {
+		border-left-color: $selected-accent;
+		background: color-mix(in srgb, $selected-accent 10%, transparent);
+
+		.name {
+			color: var(--white);
+			font-weight: 600;
+		}
+	}
+}
+
+@mixin name-cell {
+	display: flex;
+	align-items: center;
+	gap: 11px;
+	min-width: 0;
+}
+
+@mixin row-name {
+	font-size: 13.5px;
+	color: var(--text-primary);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+@mixin muted-num {
+	font-family: var(--mono);
+	font-size: 10.5px;
+	color: var(--text-tertiary);
+}


### PR DESCRIPTION
## Summary

Follow-up tech-debt cleanup identified in #1520, picked up after its prerequisite (#1507's retired-record fixes) landed.

The Codex dossier chrome was copy-pasted three ways and drifting:

- `EnemyDossier`, `ZoneDossier`, `SkillDossier` shared near-identical outer wrapper + header markup/styles (fixed-width surface, accent border, kind-dot/kind-label, name, optional description), differing only in the accent and a couple of header extras (Zone's status seal, Skill's rarity tag box).
- `EnemySpawnsPanel` vs. `ZoneSpawnPanel` were near-identical share-bar row lists (heading + list of name/share%/weight rows cross-linking into the other dossier), differing only in field names.
- `EnemyTable` vs. `SkillTable` shared table/column/row chrome, differing in the row mark (boss diamond + tag vs. rarity-tinted tier mark) and the selected-row accent.

## Changes

- **`DossierShell.svelte`** (new): the shared wrapper + header (kind dot/label, name, optional description, `--dossier-accent`/`borderAccent` for Skill's independent rarity-tinted border). Each dossier passes its own sub-tab-vs-stacked-section body as the shell's children — that part genuinely differs (Enemy tabs between sub-panels; Zone/Skill stack labelled sections) so it stays in each dossier file.
- **`SpawnRowList.svelte`** (new): the shared share-bar row list backing both the enemy Spawns sub-tab and the zone dossier's spawn table. `EnemySpawnsPanel`/`ZoneSpawnPanel` are now thin wrappers mapping their view-model fields onto it.
- **`_codex-table.scss`** (new mixin partial): shared table/row/column chrome for `EnemyTable`/`SkillTable`. Since Svelte scopes styles per source file, markup that genuinely differs (marks, boss tag) can't share a single component without heavy per-row snippet plumbing — a mixin partial (mirroring the existing `_decipher-stage.scss` precedent for markup-differing components) shares the CSS without forcing a rigid component contract.
- **`_codex-dossier.scss`** (new mixin partial): the stacked-body/meta-card/section-label/empty-note styles shared identically between `ZoneDossier` and `SkillDossier`, included the same way.

No behavior, data-testid, or DOM-visible change — every dossier/table/spawn-list renders identically to before.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — all 287 test files / 3350 tests pass, including `Codex.test.ts`'s full integration-style coverage of enemy/zone/skill dossiers, sub-tabs, spawn-row cross-links, and table row selection
- [x] `npm run build` — production build succeeds
- [ ] Live browser walkthrough — attempted via the sandboxed `docker-compose.yml` API+DB stack to drive a real Playwright session through signup → Codex, but the API image build stalled (no progress after 20+ minutes, likely blocked network access to pull the .NET base image) and was abandoned. Verification instead rests on the passing component test suite above, which exercises the exact same rendered markup/testids this PR touches.

Closes #1520


---
_Generated by [Claude Code](https://claude.ai/code/session_01FAXpLyvHRjmPXuFZavuVxh)_