### PR TITLE
Combat rating: closed-form capability rating computed from the assembled battler (#1531)

### DIFF
--- a/Game.Core.Tests/Battle/CombatRatingTests.cs
+++ b/Game.Core.Tests/Battle/CombatRatingTests.cs
@@ -1,0 +1,206 @@
+using Game.Core.Attributes;
+using Game.Core.Attributes.Modifiers;
+using Game.Core.Battle;
+using Game.Core.Skills;
+using Xunit;
+using static Game.Core.EAttribute;
+
+namespace Game.Core.Tests.Battle
+{
+    /// <summary>
+    /// Unit tests for the combat rating engine (#1531, spike #1526):
+    /// <see cref="CombatRating.Rate"/>, <see cref="CombatRating.Marginal"/>, and the
+    /// <see cref="CombatRating.Classify"/> exhaustiveness contract. Server-only domain math with no
+    /// frontend/backend parity surface, so unlike most battle-math suites this one is not mirrored on the
+    /// frontend.
+    /// </summary>
+    public class CombatRatingTests
+    {
+        // ── Classify exhaustiveness (spike #1526 Decision 9) ────────────────
+
+        [Theory]
+        [MemberData(nameof(AllAttributes))]
+        public void Classify_IsDefinedForEveryAttribute(EAttribute attribute)
+        {
+            Assert.True(Enum.IsDefined(CombatRating.Classify(attribute)));
+        }
+
+        public static IEnumerable<object[]> AllAttributes()
+        {
+            return Enum.GetValues<EAttribute>().Select(a => new object[] { a });
+        }
+
+        // ── Rate: degenerate guards ──────────────────────────────────────────
+
+        [Fact]
+        public void Rate_BattlerWithNoSkills_ReturnsFinitePositiveValue()
+        {
+            var battler = MakeBattler();
+
+            var rate = CombatRating.Rate(battler, isPlayer: true);
+
+            Assert.True(rate > 0);
+            Assert.False(double.IsNaN(rate));
+            Assert.False(double.IsInfinity(rate));
+        }
+
+        // ── Rate: survivability ──────────────────────────────────────────────
+
+        [Fact]
+        public void Rate_HigherMaxHealthAndToughness_RatesHigher()
+        {
+            var weak = MakeBattler();
+            var tough = MakeBattler((Endurance, 50));
+
+            Assert.True(CombatRating.Rate(tough, isPlayer: true) > CombatRating.Rate(weak, isPlayer: true));
+        }
+
+        // ── Rate: offense ─────────────────────────────────────────────────────
+
+        [Fact]
+        public void Rate_SkillWithDamage_RatesHigherThanNoSkills()
+        {
+            var noSkills = MakeBattler();
+            var withSkill = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+
+            Assert.True(CombatRating.Rate(withSkill, isPlayer: true) > CombatRating.Rate(noSkills, isPlayer: true));
+        }
+
+        [Fact]
+        public void Rate_DamageReflection_RaisesOffense()
+        {
+            var noReflect = MakeBattler();
+            var reflecting = MakeBattler((DamageReflection, 0.5));
+
+            Assert.True(CombatRating.Rate(reflecting, isPlayer: true) > CombatRating.Rate(noReflect, isPlayer: true));
+        }
+
+        [Fact]
+        public void Rate_DoTEffect_ContributesOffenseEvenWithZeroBaseDamage()
+        {
+            var dotEffect = new SkillEffect
+            {
+                Id = 1,
+                Target = ESkillEffectTarget.Opponent,
+                AttributeId = BleedDamagePerSecond,
+                ModifierType = EModifierType.Additive,
+                Amount = 10,
+                DurationMs = 5000,
+                ScalingAttributeId = Strength,
+                ScalingAmount = 0,
+            };
+            var noDot = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 0)]);
+            var withDot = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 0, effects: [dotEffect])]);
+
+            Assert.True(CombatRating.Rate(withDot, isPlayer: true) > CombatRating.Rate(noDot, isPlayer: true));
+        }
+
+        // ── Rate: enemy asymmetry (crit/dodge/parry/riposte gated off) ──────
+
+        [Fact]
+        public void Rate_EnemyWithAuthoredCriticalChance_IsUnaffectedByCrit()
+        {
+            var withCrit = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50, criticalChance: 1.0)]);
+            var withoutCrit = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50, criticalChance: 0.0)]);
+
+            Assert.Equal(
+                CombatRating.Rate(withoutCrit, isPlayer: false),
+                CombatRating.Rate(withCrit, isPlayer: false), 6);
+        }
+
+        [Fact]
+        public void Rate_PlayerWithAuthoredCriticalChance_RatesHigherThanEnemyEquivalent()
+        {
+            var asPlayer = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50, criticalChance: 1.0)]);
+            var asEnemy = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50, criticalChance: 1.0)]);
+
+            Assert.True(CombatRating.Rate(asPlayer, isPlayer: true) > CombatRating.Rate(asEnemy, isPlayer: false));
+        }
+
+        [Fact]
+        public void Rate_RiposteOnlyAppliesToPlayer()
+        {
+            var counter = MakeSkill(cooldownMs: 1000, baseDamage: 20);
+            var withCounter = MakeBattlerWithSkills([(ParryChance, 0.5)], [], counterSkill: counter);
+            var withoutCounter = MakeBattlerWithSkills([(ParryChance, 0.5)], []);
+
+            Assert.True(CombatRating.Rate(withCounter, isPlayer: true) > CombatRating.Rate(withoutCounter, isPlayer: true));
+            Assert.Equal(
+                CombatRating.Rate(withoutCounter, isPlayer: false),
+                CombatRating.Rate(withCounter, isPlayer: false), 6);
+        }
+
+        // ── Marginal: finite-difference dead-stat detection (#1529) ────────
+
+        [Fact]
+        public void Marginal_LuckWithNoCritOrParryEnabler_IsZero()
+        {
+            // Luck only scales CriticalChanceMultiplier/ParryChanceMultiplier — both idle at 0 × mult = 0
+            // with no fielded crit-authored skill or authored ParryChance, so more Luck rates identically.
+            var battler = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+
+            var marginal = CombatRating.Marginal(battler, isPlayer: true, Luck, delta: 100);
+
+            Assert.Equal(0, marginal, 6);
+        }
+
+        [Fact]
+        public void Marginal_AgilityRaisesRating_EvenWithNoDodgeOrCadenceEnabler()
+        {
+            // AGI always feeds CooldownRecovery (a universal tempo identity, not an enabler-gated one), so
+            // it is never fully dead the way Luck is above.
+            var battler = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+
+            var marginal = CombatRating.Marginal(battler, isPlayer: true, Agility, delta: 100);
+
+            Assert.True(marginal > 0);
+        }
+
+        [Fact]
+        public void Marginal_EnduranceRaisesRating()
+        {
+            var battler = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+
+            var marginal = CombatRating.Marginal(battler, isPlayer: true, Endurance, delta: 10);
+
+            Assert.True(marginal > 0);
+        }
+
+        // ── Helpers ───────────────────────────────────────────────────────────
+
+        private static Battler MakeBattler(params (EAttribute Attribute, double Amount)[] attributes)
+        {
+            return MakeBattlerWithSkills(attributes, []);
+        }
+
+        private static Battler MakeBattlerWithSkills(
+            (EAttribute Attribute, double Amount)[] attributes, IReadOnlyList<Skill> skills, Skill? counterSkill = null)
+        {
+            var modifiers = attributes
+                .Select(a => new AttributeModifier
+                {
+                    Attribute = a.Attribute,
+                    Amount = a.Amount,
+                    Type = EModifierType.Additive,
+                    Source = EAttributeModifierSource.AttributeDistribution,
+                })
+                .ToList();
+
+            return new Battler(new AttributeCollection(modifiers), skills, 1, counterSkill);
+        }
+
+        private static Skill MakeSkill(
+            int cooldownMs, double baseDamage, double criticalChance = 0, List<SkillEffect>? effects = null) => new()
+            {
+                Id = 1,
+                Name = "Test Skill",
+                Description = string.Empty,
+                DamagePortions = [new SkillDamagePortion { Type = EDamageType.Physical, Weight = 1.0 }],
+                CooldownMs = cooldownMs,
+                BaseDamage = baseDamage,
+                CriticalChance = criticalChance,
+                DamageMultipliers = [],
+                Effects = effects ?? [],
+            };
+    }
+}

--- a/Game.Core.Tests/Battle/CombatRatingTests.cs
+++ b/Game.Core.Tests/Battle/CombatRatingTests.cs
@@ -95,6 +95,46 @@ namespace Game.Core.Tests.Battle
             Assert.True(CombatRating.Rate(withDot, isPlayer: true) > CombatRating.Rate(noDot, isPlayer: true));
         }
 
+        [Fact]
+        public void Rate_CoreAttributeScaledDamageMultiplier_RisesWithTheScalingAttribute()
+        {
+            // Every seeded damage skill scales off a core attribute (Punch/Strike/Cleave → Strength, Focus →
+            // Intellect) via DamageMultipliers, read directly off effectiveCaster — pins that the effective
+            // caster snapshot exposes real core values rather than zeroing them.
+            var skill = MakeSkill(cooldownMs: 1000, baseDamage: 10, multipliers:
+            [
+                new DamageMultiplier { Attribute = Strength, Amount = 2.0 },
+            ]);
+            var weak = MakeBattlerWithSkills([], [skill]);
+            var strong = MakeBattlerWithSkills([(Strength, 50)], [skill]);
+
+            Assert.True(CombatRating.Rate(strong, isPlayer: true) > CombatRating.Rate(weak, isPlayer: true));
+        }
+
+        [Fact]
+        public void Rate_DoTEffectScaledByCoreAttribute_RisesWithTheScalingAttribute()
+        {
+            // A DoT effect's ScalingAttributeId is a core attribute in general (mirroring how the live engine
+            // scales an effect's magnitude off the caster) — pins that the DoT term reads it correctly rather
+            // than zeroing it.
+            var dotEffect = new SkillEffect
+            {
+                Id = 1,
+                Target = ESkillEffectTarget.Opponent,
+                AttributeId = BleedDamagePerSecond,
+                ModifierType = EModifierType.Additive,
+                Amount = 0,
+                DurationMs = 5000,
+                ScalingAttributeId = Strength,
+                ScalingAmount = 1.0,
+            };
+            var skill = MakeSkill(cooldownMs: 1000, baseDamage: 0, effects: [dotEffect]);
+            var weak = MakeBattlerWithSkills([], [skill]);
+            var strong = MakeBattlerWithSkills([(Strength, 50)], [skill]);
+
+            Assert.True(CombatRating.Rate(strong, isPlayer: true) > CombatRating.Rate(weak, isPlayer: true));
+        }
+
         // ── Rate: enemy asymmetry (crit/dodge/parry/riposte gated off) ──────
 
         [Fact]
@@ -166,6 +206,22 @@ namespace Game.Core.Tests.Battle
             Assert.True(marginal > 0);
         }
 
+        [Fact]
+        public void Marginal_StrengthOnADamageBuild_RaisesRating()
+        {
+            // A damage build's primary stat must be visible to the marginal — the exact defect a core-stripped
+            // effective-caster snapshot would hide.
+            var skill = MakeSkill(cooldownMs: 1000, baseDamage: 10, multipliers:
+            [
+                new DamageMultiplier { Attribute = Strength, Amount = 2.0 },
+            ]);
+            var battler = MakeBattlerWithSkills([(Strength, 20)], [skill]);
+
+            var marginal = CombatRating.Marginal(battler, isPlayer: true, Strength, delta: 10);
+
+            Assert.True(marginal > 0);
+        }
+
         // ── Helpers ───────────────────────────────────────────────────────────
 
         private static Battler MakeBattler(params (EAttribute Attribute, double Amount)[] attributes)
@@ -190,7 +246,8 @@ namespace Game.Core.Tests.Battle
         }
 
         private static Skill MakeSkill(
-            int cooldownMs, double baseDamage, double criticalChance = 0, List<SkillEffect>? effects = null) => new()
+            int cooldownMs, double baseDamage, double criticalChance = 0,
+            List<SkillEffect>? effects = null, List<DamageMultiplier>? multipliers = null) => new()
             {
                 Id = 1,
                 Name = "Test Skill",
@@ -199,7 +256,7 @@ namespace Game.Core.Tests.Battle
                 CooldownMs = cooldownMs,
                 BaseDamage = baseDamage,
                 CriticalChance = criticalChance,
-                DamageMultipliers = [],
+                DamageMultipliers = multipliers ?? [],
                 Effects = effects ?? [],
             };
     }

--- a/Game.Core/Battle/Battler.cs
+++ b/Game.Core/Battle/Battler.cs
@@ -164,6 +164,34 @@ namespace Game.Core.Battle
         }
 
         /// <summary>
+        /// A copy of this battler with <paramref name="delta"/> added to <paramref name="attribute"/> as a
+        /// fresh <see cref="EAttributeModifierSource.BaseValue"/> additive term — full cascade re-derivation
+        /// included, so bumping a core attribute re-derives everything <see cref="StaticAttributeModifiers"/>
+        /// hangs off it exactly like a real allocation would. Used by the combat rating's marginal helper
+        /// (<see cref="CombatRating.Marginal"/>, #1531) to price one point of investment via finite difference;
+        /// not used by the live battle simulation. Excludes any live <see cref="EAttributeModifierSource.SkillEffect"/>
+        /// modifiers (the marginal prices a permanent investment, not an in-battle timed-buff snapshot) and the
+        /// static modifiers themselves — copying those too would double them, since the fresh
+        /// <see cref="AttributeCollection"/> constructor re-adds them automatically.
+        /// </summary>
+        public Battler CloneWithAttributeDelta(EAttribute attribute, double delta)
+        {
+            var staticModifiers = new HashSet<AttributeModifier>(StaticAttributeModifiers.All);
+            var modifiers = _attributes.AllModifiers()
+                .Where(m => m.Source != EAttributeModifierSource.SkillEffect && !staticModifiers.Contains(m))
+                .ToList();
+            modifiers.Add(new AttributeModifier
+            {
+                Attribute = attribute,
+                Amount = delta,
+                Type = EModifierType.Additive,
+                Source = EAttributeModifierSource.BaseValue,
+            });
+
+            return new Battler(new AttributeCollection(modifiers), Skills.Select(s => s.Skill), Level, CounterSkill);
+        }
+
+        /// <summary>
         /// The shared overlay-tally saturation <c>φ(a) = a / (1 + a)</c>, applied to an overlay's own investment
         /// magnitude when booking its share claim (#1481): ~linear at the low end so a token investment trains
         /// proportionally little, asymptoting to <c>1</c> so even a huge investment claims at most the full booked

--- a/Game.Core/Battle/CombatRating.cs
+++ b/Game.Core/Battle/CombatRating.cs
@@ -55,14 +55,6 @@ namespace Game.Core.Battle
         // zero-survivability battler never divides a downstream consumer (e.g. a rating ratio) by zero.
         private const double Epsilon = 1e-6;
 
-        // The composed value of every attribute when built from no extra modifiers — i.e. just
-        // StaticAttributeModifiers.All with every core attribute at 0. Since every static entry is Additive
-        // (no Multiplicative terms) and no core attributes are seeded into the effective-caster snapshot below,
-        // this is exactly the amount that snapshot's automatic re-application of the static modifiers already
-        // contributes — subtracting it out lets a single explicit BaseValue term set the snapshot's attribute
-        // to the battler's real composed value with no double-counting.
-        private static readonly IReadOnlyDictionary<EAttribute, double> ZeroBaseline = BuildZeroBaseline();
-
         /// <summary>
         /// The rating for <paramref name="battler"/> as assembled — <c>√(OffenseRate × Survivability)</c>
         /// against the fixed reference profiles in <see cref="ServerGameConstants"/>. Pass
@@ -190,8 +182,10 @@ namespace Game.Core.Battle
 
                     // The exact DoT steady-state closed form (spike #1526 Decision 1): magnitude × frozen
                     // amplification × duration ÷ effective cooldown. DoT bypasses the reference Toughness
-                    // (its real property), so no mitigation term applies here.
-                    var magnitude = effect.Amount + effectiveCaster.GetAttributeValue(effect.ScalingAttributeId) * effect.ScalingAmount;
+                    // (its real property), so no mitigation term applies here. The scaling attribute is read
+                    // off the original battler, not effectiveCaster — mirroring FoldedEffectMagnitude's "the
+                    // caster's ORIGINAL attribute" rule, so the two DoT-adjacent reads agree.
+                    var magnitude = effect.Amount + battler.GetAttributeValue(effect.ScalingAttributeId) * effect.ScalingAmount;
                     var ampedMagnitude = effectiveCaster.AmplifyDamage(magnitude, dotType);
                     var durationSec = effect.DurationMs / 1000.0;
                     total += ampedMagnitude * durationSec / effectiveCooldownSec;
@@ -295,24 +289,40 @@ namespace Game.Core.Battle
 
         // A battler equal to the assembled one but with every fielded Self-targeted effect folded in at its
         // uptime-weighted average magnitude — so offense/survivability compute once from one order-free state
-        // rather than simulating the battle. Every other (non-effect) attribute is copied at its exact composed
-        // value.
+        // rather than simulating the battle. Every other attribute is copied at its exact composed value,
+        // INCLUDING the core attributes: BattleSkill.CalculateRawDamage sums DamageMultipliers over core
+        // attributes directly (not through a derived static), so a core-stripped snapshot would zero out every
+        // core-scaled skill's damage. Seeding the real cores lets a core-derived attribute (CooldownRecovery,
+        // Toughness, MaxHealth, the crit/parry/dodge multipliers) re-derive naturally from them via the fresh
+        // AttributeCollection's automatic re-application of StaticAttributeModifiers — so each non-core
+        // attribute's explicit delta below is computed against a "cores-only" baseline (the value the real
+        // cores alone would produce) rather than an all-zero one, crediting only the extra (gear/proficiency/
+        // effect) contribution on top and avoiding double-counting the core-derived share.
         private static Battler BuildEffectiveCaster(Battler battler)
         {
-            var modifiers = new List<AttributeModifier>();
+            var coreModifiers = Attributes.Attribute.CoreAttributes
+                .Select(a => new AttributeModifier
+                {
+                    Attribute = a,
+                    Amount = battler.GetAttributeValue(a),
+                    Type = EModifierType.Additive,
+                    Source = EAttributeModifierSource.BaseValue,
+                })
+                .ToList();
+            var coreOnlyBaseline = new AttributeCollection(coreModifiers);
+
+            var modifiers = new List<AttributeModifier>(coreModifiers);
             foreach (var attribute in Enum.GetValues<EAttribute>())
             {
                 if (Attributes.Attribute.IsCore(attribute))
                 {
-                    // Core attributes are never read directly by the rating — only the attributes they feed
-                    // (via StaticAttributeModifiers) are — so they are simply omitted from the copy.
-                    continue;
+                    continue; // already seeded directly above
                 }
 
                 modifiers.Add(new AttributeModifier
                 {
                     Attribute = attribute,
-                    Amount = battler.GetAttributeValue(attribute) - ZeroBaseline[attribute],
+                    Amount = battler.GetAttributeValue(attribute) - coreOnlyBaseline[attribute],
                     Type = EModifierType.Additive,
                     Source = EAttributeModifierSource.BaseValue,
                 });
@@ -411,12 +421,6 @@ namespace Game.Core.Battle
             }
 
             return (EModifierType.Additive, rawMagnitude * uptime);
-        }
-
-        private static IReadOnlyDictionary<EAttribute, double> BuildZeroBaseline()
-        {
-            var collection = new AttributeCollection([]);
-            return Enum.GetValues<EAttribute>().ToDictionary(a => a, a => collection[a]);
         }
     }
 }

--- a/Game.Core/Battle/CombatRating.cs
+++ b/Game.Core/Battle/CombatRating.cs
@@ -1,0 +1,422 @@
+using Game.Core.Attributes;
+using Game.Core.Attributes.Modifiers;
+using Game.Core.Skills;
+using static Game.Core.EAttribute;
+
+namespace Game.Core.Battle
+{
+    /// <summary>
+    /// The combat-rating classification of an <see cref="EAttribute"/> — the maintenance contract from spike
+    /// #1526 Decision 9: every attribute is assigned one via <see cref="CombatRating.Classify"/>, backed by an
+    /// exhaustiveness test, so a newly added attribute fails the build until its rating term is decided rather
+    /// than being silently unpriced.
+    /// </summary>
+    public enum ECombatRatingClassification
+    {
+        /// <summary>Feeds <see cref="CombatRating"/>'s offense rate (amplification, ExecuteBonus, …).</summary>
+        Offense,
+
+        /// <summary>Feeds <see cref="CombatRating"/>'s survivability (MaxHealth, resistances, Toughness, regen, …).</summary>
+        Survivability,
+
+        /// <summary>Feeds both sides (e.g. a core attribute that derives into both an offense and a defense term).</summary>
+        Both,
+
+        /// <summary>Deliberately unpriced — inert by design (obsolete) or read structurally rather than as a scalar term.</summary>
+        NeutralByDesign,
+
+        /// <summary>Priced only for a player battler; skipped entirely for an enemy (crit/dodge/parry).</summary>
+        AsymmetryGated,
+    }
+
+    /// <summary>
+    /// The closed-form capability rating decided in spike #1526
+    /// (<c>docs/spikes/1526-combat-rating-power-measure.md</c>): <c>Rate = √(OffenseRate × Survivability)</c>,
+    /// computed from an assembled <see cref="Battler"/> against fixed reference profiles
+    /// (<see cref="ServerGameConstants"/>). The geometric mean is exact, not aesthetic — for any matchup,
+    /// <c>(enemyRating / playerRating)²</c> <b>is</b> the time-to-kill ratio in this engine.
+    /// <para>
+    /// Server-only: this is never simulated client-side (display values are sent, not recomputed), so it
+    /// carries no frontend/backend parity surface. Reuses the exact <see cref="Battler"/>/<see cref="BattleSkill"/>
+    /// methods the engine itself uses (<see cref="BattleSkill.CalculateRawDamage"/>, <see cref="Battler.AmplifyDamage"/>,
+    /// <see cref="Battler.ComputeNetDamage"/>, <see cref="Battler.GetCooldownMultiplier"/>) — the anti-drift
+    /// mechanism that keeps the rating from silently diverging from the real damage pipeline.
+    /// </para>
+    /// <para>
+    /// Enemies do not crit, dodge, or parry in this engine, so those terms are skipped entirely for a non-player
+    /// battler (the <paramref name="isPlayer"/>-gated terms below) even when an enemy skill carries an authored
+    /// <c>CriticalChance</c> — otherwise the rating would recreate the dead-LUK defect one level up (pricing a
+    /// capability that can never fire).
+    /// </para>
+    /// </summary>
+    public static class CombatRating
+    {
+        // Degenerate-guard floor: keeps offense/survivability strictly positive so a zero-offense or
+        // zero-survivability battler never divides a downstream consumer (e.g. a rating ratio) by zero.
+        private const double Epsilon = 1e-6;
+
+        // The composed value of every attribute when built from no extra modifiers — i.e. just
+        // StaticAttributeModifiers.All with every core attribute at 0. Since every static entry is Additive
+        // (no Multiplicative terms) and no core attributes are seeded into the effective-caster snapshot below,
+        // this is exactly the amount that snapshot's automatic re-application of the static modifiers already
+        // contributes — subtracting it out lets a single explicit BaseValue term set the snapshot's attribute
+        // to the battler's real composed value with no double-counting.
+        private static readonly IReadOnlyDictionary<EAttribute, double> ZeroBaseline = BuildZeroBaseline();
+
+        /// <summary>
+        /// The rating for <paramref name="battler"/> as assembled — <c>√(OffenseRate × Survivability)</c>
+        /// against the fixed reference profiles in <see cref="ServerGameConstants"/>. Pass
+        /// <paramref name="isPlayer"/> <c>true</c> for a player battler (enables the crit/dodge/parry/riposte
+        /// terms) and <c>false</c> for an enemy (the engine's own asymmetry).
+        /// </summary>
+        public static double Rate(Battler battler, bool isPlayer)
+        {
+            var effectiveCaster = BuildEffectiveCaster(battler);
+            var referenceDefense = BuildReferenceDefense(battler);
+
+            var offense = Math.Max(OffenseRate(battler, isPlayer, effectiveCaster, referenceDefense), Epsilon);
+            var survivability = Math.Max(Survivability(isPlayer, effectiveCaster), Epsilon);
+
+            return Math.Sqrt(offense * survivability);
+        }
+
+        /// <summary>
+        /// The finite-difference marginal contribution of <paramref name="delta"/> more points of
+        /// <paramref name="attribute"/> to <paramref name="battler"/>'s rating — <c>Rate(bumped) − Rate(battler)</c>.
+        /// Doubles as the dead-stat detector the enemy content lint (#1529) needs: an attribute whose fielded
+        /// kit has no matching enabler (e.g. AGI with no dodge/cadence source) marginals to exactly <c>0</c>.
+        /// </summary>
+        public static double Marginal(Battler battler, bool isPlayer, EAttribute attribute, double delta = 1.0)
+        {
+            var baseline = Rate(battler, isPlayer);
+            var bumped = battler.CloneWithAttributeDelta(attribute, delta);
+            return Rate(bumped, isPlayer) - baseline;
+        }
+
+        /// <summary>
+        /// The combat-rating classification for every <see cref="EAttribute"/> — the exhaustiveness contract
+        /// (spike #1526 Decision 9). Throws for an unclassified member, so a newly added attribute fails the
+        /// build (via the backing test enumerating the whole enum) until its rating term is decided here.
+        /// </summary>
+        public static ECombatRatingClassification Classify(EAttribute attribute)
+        {
+#pragma warning disable CS0618 // DropBonus is obsolete but still a seeded, classifiable enum member.
+            return attribute switch
+            {
+                Strength => ECombatRatingClassification.Both,
+                Endurance => ECombatRatingClassification.Survivability,
+                Intellect => ECombatRatingClassification.Offense,
+                Agility => ECombatRatingClassification.Both,
+                Dexterity => ECombatRatingClassification.Offense,
+                Luck => ECombatRatingClassification.AsymmetryGated,
+                MaxHealth => ECombatRatingClassification.Survivability,
+                Toughness => ECombatRatingClassification.Survivability,
+                CooldownRecovery => ECombatRatingClassification.Offense,
+                DropBonus => ECombatRatingClassification.NeutralByDesign,
+                CriticalChanceMultiplier => ECombatRatingClassification.AsymmetryGated,
+                CriticalDamage => ECombatRatingClassification.AsymmetryGated,
+                DodgeChance => ECombatRatingClassification.AsymmetryGated,
+                BleedDamagePerSecond => ECombatRatingClassification.NeutralByDesign,
+                HealthRegenPerSecond => ECombatRatingClassification.Survivability,
+                PhysicalAmplification => ECombatRatingClassification.Offense,
+                PhysicalResistance => ECombatRatingClassification.Survivability,
+                FireAmplification => ECombatRatingClassification.Offense,
+                FireResistance => ECombatRatingClassification.Survivability,
+                WaterAmplification => ECombatRatingClassification.Offense,
+                WaterResistance => ECombatRatingClassification.Survivability,
+                EarthAmplification => ECombatRatingClassification.Offense,
+                EarthResistance => ECombatRatingClassification.Survivability,
+                WindAmplification => ECombatRatingClassification.Offense,
+                WindResistance => ECombatRatingClassification.Survivability,
+                BleedAmplification => ECombatRatingClassification.Offense,
+                BleedResistance => ECombatRatingClassification.Survivability,
+                PoisonAmplification => ECombatRatingClassification.Offense,
+                PoisonResistance => ECombatRatingClassification.Survivability,
+                BurnAmplification => ECombatRatingClassification.Offense,
+                BurnResistance => ECombatRatingClassification.Survivability,
+                ElementalAmplification => ECombatRatingClassification.Offense,
+                ElementalResistance => ECombatRatingClassification.Survivability,
+                DotAmplification => ECombatRatingClassification.Offense,
+                DotResistance => ECombatRatingClassification.Survivability,
+                PoisonDamagePerSecond => ECombatRatingClassification.NeutralByDesign,
+                BurnDamagePerSecond => ECombatRatingClassification.NeutralByDesign,
+                SwordAmplification => ECombatRatingClassification.Offense,
+                AxeAmplification => ECombatRatingClassification.Offense,
+                BowAmplification => ECombatRatingClassification.Offense,
+                ClubAmplification => ECombatRatingClassification.Offense,
+                DaggerAmplification => ECombatRatingClassification.Offense,
+                UnarmedAmplification => ECombatRatingClassification.Offense,
+                DamageReflection => ECombatRatingClassification.Offense,
+                ExecuteBonus => ECombatRatingClassification.Offense,
+                ParryChance => ECombatRatingClassification.AsymmetryGated,
+                ParryChanceMultiplier => ECombatRatingClassification.AsymmetryGated,
+                DodgeChanceMultiplier => ECombatRatingClassification.AsymmetryGated,
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(attribute), attribute, "No combat-rating classification defined for the given attribute."),
+            };
+#pragma warning restore CS0618
+        }
+
+        // ── Offense ──────────────────────────────────────────────────────────
+
+        private static double OffenseRate(Battler battler, bool isPlayer, Battler effectiveCaster, Battler referenceDefense)
+        {
+            var total = 0.0;
+
+            foreach (var battleSkill in battler.Skills)
+            {
+                var skill = battleSkill.Skill;
+                var effectiveCooldownSec = skill.CooldownMs / effectiveCaster.GetCooldownMultiplier() / 1000.0;
+                if (effectiveCooldownSec <= 0)
+                {
+                    // Degenerate guard: unreachable through authored content (CooldownRecovery's static base
+                    // alone is already 1), but a debuffed-to-zero-or-below multiplier must not divide by zero.
+                    continue;
+                }
+
+                total += ExpectedDirectHit(skill, isPlayer, effectiveCaster, referenceDefense) / effectiveCooldownSec;
+
+                foreach (var effect in skill.Effects)
+                {
+                    if (effect.Target != ESkillEffectTarget.Opponent)
+                    {
+                        continue;
+                    }
+
+                    if (DamageTypes.DotTypeForAccumulator(effect.AttributeId) is not EDamageType dotType)
+                    {
+                        continue;
+                    }
+
+                    // The exact DoT steady-state closed form (spike #1526 Decision 1): magnitude × frozen
+                    // amplification × duration ÷ effective cooldown. DoT bypasses the reference Toughness
+                    // (its real property), so no mitigation term applies here.
+                    var magnitude = effect.Amount + effectiveCaster.GetAttributeValue(effect.ScalingAttributeId) * effect.ScalingAmount;
+                    var ampedMagnitude = effectiveCaster.AmplifyDamage(magnitude, dotType);
+                    var durationSec = effect.DurationMs / 1000.0;
+                    total += ampedMagnitude * durationSec / effectiveCooldownSec;
+                }
+            }
+
+            // Reflect: DamageReflection × the reference incoming DPS.
+            total += effectiveCaster.GetAttributeValue(DamageReflection) * ServerGameConstants.RefDps;
+
+            // Riposte (player-side only): effectiveParryChance × reference attack rate × the counter's expected hit.
+            if (isPlayer && battler.CounterSkill is Skill counterSkill)
+            {
+                var effectiveParryChance = effectiveCaster.GetAttributeValue(ParryChance) * effectiveCaster.GetAttributeValue(ParryChanceMultiplier);
+                total += effectiveParryChance * ServerGameConstants.RefAttackRate
+                    * ExpectedDirectHit(counterSkill, isPlayer, effectiveCaster, referenceDefense);
+            }
+
+            return total;
+        }
+
+        // The expected post-mitigation damage of one fire of <paramref name="skill"/>, amplified by
+        // <paramref name="effectiveCaster"/> and mitigated by <paramref name="referenceDefense"/> — shared by
+        // a skill's own direct hit and the parry counter's phantom fire (both are "one hit of a skill").
+        private static double ExpectedDirectHit(Skill skill, bool isPlayer, Battler effectiveCaster, Battler referenceDefense)
+        {
+            var raw = BattleSkill.CalculateRawDamage(skill, effectiveCaster);
+            var portions = skill.DamagePortions;
+            var totalWeight = 0.0;
+            foreach (var portion in portions)
+            {
+                totalWeight += portion.Weight;
+            }
+
+            var afterMitigation = 0.0;
+            foreach (var portion in portions)
+            {
+                var rawPortion = raw * portion.Weight / totalWeight;
+                var amped = effectiveCaster.AmplifyDamage(rawPortion, portion.Type);
+                afterMitigation += referenceDefense.ComputeNetDamage(amped, portion.Type);
+            }
+
+            // Enemies never crit in this engine — gating this to isPlayer mirrors the same asymmetry the live
+            // damage pipeline enforces (BattleContext.DamageTarget), so an authored enemy CriticalChance is
+            // never priced as a capability that cannot fire.
+            var critExpectation = isPlayer
+                ? 1.0 + skill.CriticalChance * effectiveCaster.GetAttributeValue(CriticalChanceMultiplier)
+                      * (effectiveCaster.GetAttributeValue(CriticalDamage) - 1.0)
+                : 1.0;
+            var executeExpectation = 1.0 + effectiveCaster.GetAttributeValue(ExecuteBonus) * 0.5;
+
+            return afterMitigation * critExpectation * executeExpectation;
+        }
+
+        // ── Survivability ────────────────────────────────────────────────────
+
+        private static double Survivability(bool isPlayer, Battler effectiveCaster)
+        {
+            var maxHealth = effectiveCaster.GetAttributeValue(MaxHealth);
+            var regenRate = effectiveCaster.GetAttributeValue(HealthRegenPerSecond);
+            var effectiveHealth = maxHealth + regenRate * ServerGameConstants.RefFightDuration;
+
+            // Avoid (parry-then-dodge) is player-only — enemies never parry or dodge in this engine.
+            var avoid = 0.0;
+            if (isPlayer)
+            {
+                var parry = effectiveCaster.GetAttributeValue(ParryChance) * effectiveCaster.GetAttributeValue(ParryChanceMultiplier);
+                var dodge = effectiveCaster.GetAttributeValue(DodgeChance) * effectiveCaster.GetAttributeValue(DodgeChanceMultiplier);
+                avoid = parry + (1 - parry) * dodge;
+            }
+
+            var resist = AverageIncomingResistance(effectiveCaster);
+
+            // The Toughness curve, inlined rather than through Battler.ComputeNetDamage: survivability needs
+            // the dimensionless mitigation fraction, not a transformed damage amount, but the tunable knob
+            // (GameConstants.ToughnessMitigationConstant) is still the single shared constant.
+            var toughness = effectiveCaster.GetAttributeValue(Toughness);
+            var toughnessReduction = toughness / (toughness + GameConstants.ToughnessMitigationConstant);
+
+            var mitigationFraction = (1 - avoid) * (1 - resist) * (1 - toughnessReduction);
+            return effectiveHealth / Math.Max(mitigationFraction, Epsilon);
+        }
+
+        // The uniform average, across ServerGameConstants.RefIncomingTypeMix, of each type's own summed
+        // resistance (a type may sum more than one key, e.g. Fire = FireResistance + ElementalResistance).
+        private static double AverageIncomingResistance(Battler effectiveCaster)
+        {
+            var mix = ServerGameConstants.RefIncomingTypeMix;
+            var total = 0.0;
+            foreach (var type in mix)
+            {
+                foreach (var attribute in DamageTypes.ResistanceAttributes(type))
+                {
+                    total += effectiveCaster.GetAttributeValue(attribute);
+                }
+            }
+
+            return total / mix.Count;
+        }
+
+        // ── Steady-state effect pricing (spike #1526 Decision 2) ────────────
+
+        // A battler equal to the assembled one but with every fielded Self-targeted effect folded in at its
+        // uptime-weighted average magnitude — so offense/survivability compute once from one order-free state
+        // rather than simulating the battle. Every other (non-effect) attribute is copied at its exact composed
+        // value.
+        private static Battler BuildEffectiveCaster(Battler battler)
+        {
+            var modifiers = new List<AttributeModifier>();
+            foreach (var attribute in Enum.GetValues<EAttribute>())
+            {
+                if (Attributes.Attribute.IsCore(attribute))
+                {
+                    // Core attributes are never read directly by the rating — only the attributes they feed
+                    // (via StaticAttributeModifiers) are — so they are simply omitted from the copy.
+                    continue;
+                }
+
+                modifiers.Add(new AttributeModifier
+                {
+                    Attribute = attribute,
+                    Amount = battler.GetAttributeValue(attribute) - ZeroBaseline[attribute],
+                    Type = EModifierType.Additive,
+                    Source = EAttributeModifierSource.BaseValue,
+                });
+            }
+
+            foreach (var battleSkill in battler.Skills)
+            {
+                var skill = battleSkill.Skill;
+                foreach (var effect in skill.Effects)
+                {
+                    if (effect.Target != ESkillEffectTarget.Self)
+                    {
+                        continue;
+                    }
+
+                    var (type, amount) = FoldedEffectMagnitude(battler, skill, effect);
+                    modifiers.Add(new AttributeModifier
+                    {
+                        Attribute = effect.AttributeId,
+                        Amount = amount,
+                        Type = type,
+                        Source = EAttributeModifierSource.SkillEffect,
+                    });
+                }
+            }
+
+            return new Battler(new AttributeCollection(modifiers), [], battler.Level);
+        }
+
+        // A fresh reference-defense profile (Toughness = RefToughness, everything else at its static default)
+        // with every fielded Opponent-targeted, non-DoT-accumulator effect (a Hex resistance debuff, a Sunder
+        // Toughness debuff, …) folded in at its uptime-weighted average magnitude — so a debuff-authored skill
+        // is priced as raising the offense rate against a softened reference target. Opponent-targeted DoT
+        // effects are excluded here; they are priced as their own exact closed-form term in OffenseRate instead.
+        private static Battler BuildReferenceDefense(Battler battler)
+        {
+            var modifiers = new List<AttributeModifier>
+            {
+                new()
+                {
+                    Attribute = Toughness,
+                    Amount = ServerGameConstants.RefToughness,
+                    Type = EModifierType.Additive,
+                    Source = EAttributeModifierSource.BaseValue,
+                },
+            };
+
+            foreach (var battleSkill in battler.Skills)
+            {
+                var skill = battleSkill.Skill;
+                foreach (var effect in skill.Effects)
+                {
+                    if (effect.Target != ESkillEffectTarget.Opponent)
+                    {
+                        continue;
+                    }
+
+                    if (DamageTypes.DotTypeForAccumulator(effect.AttributeId) is not null)
+                    {
+                        continue;
+                    }
+
+                    var (type, amount) = FoldedEffectMagnitude(battler, skill, effect);
+                    modifiers.Add(new AttributeModifier
+                    {
+                        Attribute = effect.AttributeId,
+                        Amount = amount,
+                        Type = type,
+                        Source = EAttributeModifierSource.SkillEffect,
+                    });
+                }
+            }
+
+            return new Battler(new AttributeCollection(modifiers), [], battler.Level);
+        }
+
+        // The uptime-weighted average magnitude of one fielded effect (spike #1526 Decision 2):
+        // (Amount + casterAttribute × ScalingAmount) × min(DurationMs, RefFightDuration/2) ÷ effectiveCooldownMs
+        // — one closed form covering both the non-ramp uptime case (d ≤ cd → d/cd) and the shared-expiry ramp
+        // case (d > cd), whose average alive magnitude over a reference fight is RefFightDuration/(2·cd).
+        // Scaling always reads the caster's ORIGINAL (unfolded) attribute — mirroring how the live engine
+        // always scales an effect off the caster at apply time — so folding stays order-free.
+        private static (EModifierType Type, double Amount) FoldedEffectMagnitude(Battler battler, Skill skill, SkillEffect effect)
+        {
+            var effectiveCooldownMs = skill.CooldownMs / battler.GetCooldownMultiplier();
+            var cappedDurationMs = Math.Min(effect.DurationMs, ServerGameConstants.RefFightDuration * 1000.0 / 2.0);
+            var uptime = effectiveCooldownMs > 0 ? cappedDurationMs / effectiveCooldownMs : 0.0;
+            var rawMagnitude = effect.Amount + battler.GetAttributeValue(effect.ScalingAttributeId) * effect.ScalingAmount;
+
+            if (effect.ModifierType == EModifierType.Multiplicative)
+            {
+                // A multiplicative factor is centered on 1 (a no-op); interpolate toward neutral by uptime
+                // rather than scaling the factor itself, so a partial-uptime buff is a partial buff rather than
+                // a nonsensical sub-1 multiply.
+                return (EModifierType.Multiplicative, 1.0 + (rawMagnitude - 1.0) * uptime);
+            }
+
+            return (EModifierType.Additive, rawMagnitude * uptime);
+        }
+
+        private static IReadOnlyDictionary<EAttribute, double> BuildZeroBaseline()
+        {
+            var collection = new AttributeCollection([]);
+            return Enum.GetValues<EAttribute>().ToDictionary(a => a, a => collection[a]);
+        }
+    }
+}

--- a/Game.Core/ServerGameConstants.cs
+++ b/Game.Core/ServerGameConstants.cs
@@ -55,5 +55,46 @@ namespace Game.Core
         /// represents.
         /// </summary>
         public const double ResistMitigatedTrainingRate = 1.0;
+
+        /// <summary>
+        /// The reference Toughness the combat rating (<see cref="Battle.CombatRating"/>, #1531) prices offense
+        /// against — nonzero so a Sunder debuff and DoT's real Toughness-bypass premium both price meaningfully
+        /// (a 0 reference would make both inert). A strawman value pending the calibration report (#1533).
+        /// </summary>
+        public const double RefToughness = 50.0;
+
+        /// <summary>
+        /// The reference incoming damage-type mix the combat rating prices survivability's resistance term
+        /// against — the eight resistance-bearing leaf types (the weapon leaves carry no resistance of their
+        /// own; see <see cref="Attributes.DamageTypes"/>), weighted uniformly. Matchup tech (the right resist
+        /// against a specific enemy) is deliberately not priced per-fight — the rating stays intrinsic (spike
+        /// #1526, Decision 3).
+        /// </summary>
+        public static readonly IReadOnlyList<EDamageType> RefIncomingTypeMix =
+        [
+            EDamageType.Physical, EDamageType.Fire, EDamageType.Water, EDamageType.Earth,
+            EDamageType.Wind, EDamageType.Bleed, EDamageType.Poison, EDamageType.Burn,
+        ];
+
+        /// <summary>
+        /// The reference attacks/sec the combat rating assumes for a matched opponent — the incoming attack
+        /// frequency the riposte term prices against (each parry's proc opportunity rate). A strawman value
+        /// pending the calibration report (#1533).
+        /// </summary>
+        public const double RefAttackRate = 1.0;
+
+        /// <summary>
+        /// The reference incoming damage/sec the combat rating assumes for a matched opponent — prices the
+        /// reflect term (<c>DamageReflection × RefDps</c>). A strawman value pending the calibration report
+        /// (#1533).
+        /// </summary>
+        public const double RefDps = 10.0;
+
+        /// <summary>
+        /// The reference fight duration in seconds the combat rating uses for the regen credit
+        /// (<c>regenRate × RefFightDuration</c>) and the effect-uptime ramp horizon
+        /// (<c>min(duration, RefFightDuration / 2)</c>). ~30s per the spike (#1526).
+        /// </summary>
+        public const double RefFightDuration = 30.0;
     }
 }


### PR DESCRIPTION
Closes #1531 (implements the rating decided in spike #1526 — full reasoning in `docs/spikes/1526-combat-rating-power-measure.md`).

## What

A pure, server-only `CombatRating` in `Game.Core.Battle`: `Rate(Battler, bool isPlayer)` computed from the assembled battler (attributes + fielded `BattleSkills` + `CounterSkill`) against fixed reference profiles in `ServerGameConstants` (`RefToughness`, `RefIncomingTypeMix`, `RefAttackRate`, `RefDps`, `RefFightDuration` — all strawman values pending the calibration report, #1533).

```
Rating = √(OffenseRate × Survivability)
```

- **Offense rate**: for each fielded skill, `expectedHit ÷ effectiveCooldownSeconds` — per-portion weighted split, amplification, the Toughness curve (against a reference defense), crit expectation (player-only), execute expectation — plus DoT effects (exact steady-state closed form: `magnitude × frozen amp × duration ÷ cooldown`), a reflect term (`DamageReflection × RefDps`), and a riposte term (player-only, `effectiveParryChance × RefAttackRate × expectedHit(counterSkill)`).
- **Survivability**: `(MaxHealth + regenRate × RefFightDuration) ÷ mitigated-and-avoided fraction`, where avoid (`parry + (1-parry)×dodge`) is player-only.
- **Steady-state effect pricing**: every fielded skill effect (buffs/debuffs) is folded into an ephemeral snapshot at its uptime-weighted average magnitude (`(Amount + casterAttr×ScalingAmount) × min(duration, RefFightDuration/2) ÷ effectiveCooldown`) — self-targeted effects fold into a caster snapshot, opponent-targeted non-DoT effects (Hex/Sunder-style debuffs) fold into a reference-defense snapshot — so offense/survivability compute once, order-free, with no per-tick simulation.
- **Engine-asymmetry mirroring**: enemies never crit/dodge/parry in this engine, so those terms (and riposte) are skipped entirely for `isPlayer: false`, even when an enemy skill carries an authored `CriticalChance` — the same asymmetry the live damage pipeline enforces.
- **Maintenance contract**: `CombatRating.Classify(EAttribute)` is an exhaustive classification (Offense / Survivability / Both / NeutralByDesign / AsymmetryGated) over every attribute, backed by a test enumerating the whole enum — a new attribute fails the build until its rating term is decided.
- **Marginal helper**: `CombatRating.Marginal(Battler, bool, EAttribute, delta)` — a finite-difference per-attribute contribution, backed by a new `Battler.CloneWithAttributeDelta` (full cascade re-derivation, so bumping a core attribute re-derives everything that hangs off it). Doubles as the dead-stat detector the enemy content lint (#1529) will need.

## Anti-drift

Raw damage, amplification, mitigation, and cooldown multipliers are read through the exact same methods the live engine uses — `BattleSkill.CalculateRawDamage`, `Battler.AmplifyDamage`, `Battler.ComputeNetDamage`, `Battler.GetCooldownMultiplier` — rather than reimplementing the formulas, so the rating cannot silently diverge from the real damage pipeline.

## Out of scope

- Swapping `DefeatRewards`/proficiency onto the rating and the reward-curve reshape (#1532).
- The calibration report that picks final constant values (#1533).
- UI surfacing (#1534).
- Documentation updates (`game-design.md`, `content-design.md`, `backend-attributes.md`) — these ride #1532 per the spike doc, not this issue.

## Testing

- New `Game.Core.Tests/Battle/CombatRatingTests.cs`: the `Classify` exhaustiveness contract, degenerate guards (a skill-less battler rates a finite positive value), survivability (MaxHealth/Toughness raise the rating), offense (a damaging skill, `DamageReflection`, and a zero-BaseDamage DoT effect all raise the rating), the enemy asymmetry gate (an authored `CriticalChance`/riposte is priced for a player but not an enemy), and `Marginal` (Luck marginals to exactly 0 with no fielded crit/parry enabler; Agility and Endurance always marginal positive).
- Full backend suite: `Game.Core.Tests` (1295), `Game.Infrastructure.Tests` (59), `Game.Application.Tests` (824), `Game.Api.Tests` (677) — all pass.
- No frontend changes: this is explicitly server-only with no client-side simulation (display values will be sent, not recomputed — #1534), so there is no parity surface and no codegen impact (`ServerGameConstants` is deliberately not `[ClientMirrored]`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01831iuoTxRFoNW75ySfx6vQ)_