### PR TITLE
Attributes screen: signal inert AGI/LUK when no matching enabler is fielded

### DIFF
--- a/UI/src/routes/game/screens/attributes/GuidedRow.svelte
+++ b/UI/src/routes/game/screens/attributes/GuidedRow.svelte
@@ -28,6 +28,9 @@
 				{/each}
 			{/if}
 		</div>
+		{#if inert}
+			<span class="dormant-note">⊘ {hint}</span>
+		{/if}
 	</div>
 
 	<Delta from={view.savedValues[i]} to={view.values[i]} />
@@ -43,7 +46,7 @@ import { tooltipHover } from '$components/tooltip/tooltip-hover';
 import { describedByTooltip } from '$components/tooltip/describedby-tooltip';
 import Delta from './Delta.svelte';
 import Stepper from './Stepper.svelte';
-import { CORE_ATTRIBUTES, DERIVED_STATS, feedsFor, type AttributesView } from './attributes-view.svelte';
+import { CORE_ATTRIBUTES, DERIVED_STATS, feedsFor, inertHint, type AttributesView } from './attributes-view.svelte';
 
 interface Props {
 	i: number;
@@ -57,6 +60,10 @@ const color = $derived(attributeColor(id));
 const code = $derived(attributeCode(id, staticData.attributes));
 const name = $derived(attributeName(id, staticData.attributes));
 const feeds = $derived(feedsFor(i));
+// Read-only "dormant, not dead" signal for the amplifier attributes (AGI/LUK, spike #1426 Decision 5) —
+// no matching enabler is fielded, so the current build gets nothing from points spent here.
+const inert = $derived(view.isInert(i));
+const hint = $derived(inertHint(id));
 
 // Hover explainer for the attribute, driven through the screen-level controller.
 const attrTip = getAttributeTooltip();
@@ -150,5 +157,17 @@ const changed = $derived(
 		color: var(--text-muted);
 		border-style: dashed;
 	}
+}
+
+// Neutral muted tone matching the Skills screen's off-weapon dormancy note (DormantNote.svelte) —
+// --warning is reserved for validation, and this is a read-only signal, not a problem to fix.
+.dormant-note {
+	display: block;
+	margin-top: 4px;
+	font-family: var(--mono);
+	font-size: 8.5px;
+	letter-spacing: 0.5px;
+	text-transform: uppercase;
+	color: var(--text-tertiary);
 }
 </style>

--- a/UI/src/routes/game/screens/attributes/TheoryRow.svelte
+++ b/UI/src/routes/game/screens/attributes/TheoryRow.svelte
@@ -30,6 +30,9 @@
 				{/each}
 			{/if}
 		</div>
+		{#if inert}
+			<span class="dormant-note">⊘ {hint}</span>
+		{/if}
 	</div>
 
 	<div class="bar">
@@ -58,7 +61,13 @@ import { getAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelt
 import { tooltipHover } from '$components/tooltip/tooltip-hover';
 import { describedByTooltip } from '$components/tooltip/describedby-tooltip';
 import Stepper from './Stepper.svelte';
-import { CORE_ATTRIBUTES, derivedShortLabel, perPointYields, type AttributesView } from './attributes-view.svelte';
+import {
+	CORE_ATTRIBUTES,
+	derivedShortLabel,
+	inertHint,
+	perPointYields,
+	type AttributesView
+} from './attributes-view.svelte';
 
 interface Props {
 	i: number;
@@ -74,6 +83,11 @@ const name = $derived(attributeName(id, staticData.attributes));
 
 // Hover explainer for the attribute, driven through the screen-level controller.
 const attrTip = getAttributeTooltip();
+
+// Read-only "dormant, not dead" signal for the amplifier attributes (AGI/LUK, spike #1426 Decision 5) —
+// no matching enabler is fielded, so the current build gets nothing from points spent here.
+const inert = $derived(view.isInert(i));
+const hint = $derived(inertHint(id));
 
 const value = $derived(view.values[i]);
 const saved = $derived(view.savedValues[i]);
@@ -146,6 +160,19 @@ const deltaWidth = $derived((Math.abs(value - saved) / view.hexMax) * 100);
 	letter-spacing: 0.8px;
 	text-transform: uppercase;
 	color: color-mix(in srgb, var(--text-primary) 30%, transparent);
+}
+
+// Neutral muted tone matching the Skills screen's off-weapon dormancy note (DormantNote.svelte) —
+// --warning is reserved for validation, and this is a read-only signal, not a problem to fix.
+.dormant-note {
+	display: block;
+	margin-top: 3px;
+	margin-left: 15px;
+	font-family: var(--mono);
+	font-size: 8px;
+	letter-spacing: 0.5px;
+	text-transform: uppercase;
+	color: var(--text-tertiary);
 }
 
 .yield {

--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -176,7 +176,10 @@ export function inertHint(id: EAttribute): string | undefined {
 /** Whether any fielded source — an equipped item/mod's static stat line, or a fielded skill's own
  *  self-targeted effect — authors a nonzero base amount of `attributeId`. Only the *authored* amount is
  *  checked (an effect's own base `amount`, not its live in-combat scaled value), matching the "committed
- *  enabler" framing the crit/dodge/parry/cadence template already uses. */
+ *  enabler" framing the crit/dodge/parry/cadence template already uses. This is exactly the source set
+ *  `StaticAttributeModifiers`' "granted by items/item-mods/skill-effects" convention documents for
+ *  DodgeChance/CooldownBonus/ParryChance — a future source authoring one of them outside that convention
+ *  (e.g. a class/proficiency payout) would need a matching scan added here. */
 function hasFieldedEnabler(
 	attributeId: EAttribute,
 	equipmentStats: readonly IBattlerAttribute[],

--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -22,11 +22,18 @@
    freely — any attribute can be decremented back to 0, refunding its points to
    the pool — so there is no respec cost or locked baseline here. */
 
-import { apiSocket, EAttribute, type IAttributeUpdate, type IBattlerAttribute } from '$lib/api';
-import { BattleAttributes } from '$lib/battle';
+import {
+	apiSocket,
+	EAttribute,
+	ESkillEffectTarget,
+	type IAttributeUpdate,
+	type IBattlerAttribute,
+	type ISkill
+} from '$lib/api';
+import { BattleAttributes, isSkillDormant } from '$lib/battle';
 import { attributeName } from '$lib/common';
 import { safeLocalStorage } from '$lib/common/local-storage';
-import { playerManager } from '$lib/engine';
+import { inventoryManager, playerManager } from '$lib/engine';
 import { staticData, toastError } from '$stores';
 
 export type AttributeMode = 'guided' | 'theory';
@@ -147,6 +154,84 @@ export function contributorsFor(derivedId: EAttribute): EAttribute[] {
 	return CONTRIBUTORS_BY_DERIVED[derivedId] ?? [];
 }
 
+/* ── amplifier inert-signal (spike #1426 Decision 5) ──────────────────────
+   AGI and LUK are pure amplifiers: their `*Multiplier` targets scale a `0`-based enabler
+   (`DodgeChance`/`CooldownBonus`/`ParryChance`/a skill's own authored `criticalChance`), so a build with no
+   matching enabler fielded gets nothing from the points invested there — dormant, not dead. This section
+   answers whether that's the case for the *current* loadout, purely as a read-only signal (no allocation
+   gating; free-pool points stay a legitimate pre-commitment). */
+
+/** Hint copy for an inert amplifier, keyed by the attribute it describes. Absent for every attribute
+ *  that always contributes (see {@link isAttributeInert}). */
+const INERT_HINT: Partial<Record<EAttribute, string>> = {
+	[EAttribute.Agility]: 'Dormant — no dodge or cadence enabler fielded',
+	[EAttribute.Luck]: 'Dormant — no crit or parry enabler fielded'
+};
+
+/** The hint text for an inert core attribute, or `undefined` if it isn't a candidate for the signal at all. */
+export function inertHint(id: EAttribute): string | undefined {
+	return INERT_HINT[id];
+}
+
+/** Whether any fielded source — an equipped item/mod's static stat line, or a fielded skill's own
+ *  self-targeted effect — authors a nonzero base amount of `attributeId`. Only the *authored* amount is
+ *  checked (an effect's own base `amount`, not its live in-combat scaled value), matching the "committed
+ *  enabler" framing the crit/dodge/parry/cadence template already uses. */
+function hasFieldedEnabler(
+	attributeId: EAttribute,
+	equipmentStats: readonly IBattlerAttribute[],
+	fieldedSkills: readonly ISkill[]
+): boolean {
+	if (equipmentStats.some((a) => a.attributeId === attributeId && a.amount > 0)) {
+		return true;
+	}
+	return fieldedSkills.some((skill) =>
+		skill.effects.some((e) => e.target === ESkillEffectTarget.Self && e.attributeId === attributeId && e.amount > 0)
+	);
+}
+
+/** Whether the core attribute at `id` is inert for the current loadout: AGI only amplifies a fielded
+ *  `DodgeChance`/`CooldownBonus` enabler, LUK only a fielded skill's own authored `criticalChance` or a
+ *  fielded `ParryChance` enabler (spike #1426 Decision 5). Every other core attribute always contributes,
+ *  so this is unconditionally `false` for them. */
+export function isAttributeInert(
+	id: EAttribute,
+	equipmentStats: readonly IBattlerAttribute[],
+	fieldedSkills: readonly ISkill[]
+): boolean {
+	if (id === EAttribute.Luck) {
+		return (
+			!fieldedSkills.some((s) => s.criticalChance > 0) &&
+			!hasFieldedEnabler(EAttribute.ParryChance, equipmentStats, fieldedSkills)
+		);
+	}
+	if (id === EAttribute.Agility) {
+		return (
+			!hasFieldedEnabler(EAttribute.DodgeChance, equipmentStats, fieldedSkills) &&
+			!hasFieldedEnabler(EAttribute.CooldownBonus, equipmentStats, fieldedSkills)
+		);
+	}
+	return false;
+}
+
+/** The player's live fielded skill set — the selected loadout plus equipped-gear grants, de-duplicated
+ *  and passed through the weapon-match gate ({@link isSkillDormant}) — mirroring `Battler.fillSkills`'s
+ *  assembly (without allocating battle `Skill` instances) so the amplifier check never disagrees with
+ *  what the battler actually fields. */
+function fieldedPlayerSkills(): ISkill[] {
+	const catalogue = staticData.skills ?? [];
+	const weaponType = inventoryManager.equippedWeaponType;
+	const ids = new Set<number>([...playerManager.selectedSkills, ...inventoryManager.grantedSkillIds]);
+	const result: ISkill[] = [];
+	for (const id of ids) {
+		const skill = catalogue[id];
+		if (skill && !isSkillDormant(skill, weaponType)) {
+			result.push(skill);
+		}
+	}
+	return result;
+}
+
 /** Maps a pointer position (in the radar's SVG user space) to the attribute
  *  value its axis vertex would represent if dragged there: projects the pointer
  *  onto the axis direction (so sideways drift is ignored and only the radial
@@ -234,6 +319,15 @@ export class AttributesView {
 	 *  a fixed value for the duration of a drag so allocating points mid-gesture
 	 *  can't rescale the radar (see {@link lockScale}). */
 	readonly hexMax = $derived(this.#lockedHexMax ?? computeHexMax(this.draft, this.committed));
+
+	/** The player's live fielded skill set (selected loadout + equipped-gear grants, weapon-gated),
+	 *  recomputed when the loadout or equipped gear changes — see {@link isInert}. */
+	readonly fieldedSkills = $derived.by<ISkill[]>(() => fieldedPlayerSkills());
+
+	/** Whether the core attribute at `i` is inert under the current loadout — see {@link isAttributeInert}. */
+	isInert(i: number): boolean {
+		return isAttributeInert(CORE_ATTRIBUTES[i], inventoryManager.equipmentStats, this.fieldedSkills);
+	}
 
 	/** Whether any attribute can still be incremented (points remain). */
 	canInc(): boolean {

--- a/UI/src/tests/routes/game/screens/attributes/Attributes.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/Attributes.test.ts
@@ -1,23 +1,29 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
-import { EAttribute, type IAttribute, type IBattlerAttribute } from '$lib/api';
+import { EAttribute, EDamageType, type IAttribute, type IBattlerAttribute, type ISkill } from '$lib/api';
 import { makeAttribute } from '../../../../fixtures/attributes';
 
-const { mockPlayerManager, sendSocketCommand, toastError, staticData } = vi.hoisted(() => ({
+const { mockPlayerManager, mockInventoryManager, sendSocketCommand, toastError, staticData } = vi.hoisted(() => ({
 	mockPlayerManager: {
 		attributes: [] as IBattlerAttribute[],
 		statPointsGained: 0,
 		statPointsUsed: 0,
 		level: 0,
 		exp: 0,
-		nextLevelThreshold: 0
+		nextLevelThreshold: 0,
+		selectedSkills: [] as number[]
+	},
+	mockInventoryManager: {
+		equipmentStats: [] as IBattlerAttribute[],
+		grantedSkillIds: [] as number[],
+		equippedWeaponType: 13 as EDamageType // EDamageType.Unarmed, a numeric literal (hoisted before the import)
 	},
 	sendSocketCommand: vi.fn(),
 	toastError: vi.fn(),
-	staticData: { attributes: [] as IAttribute[] }
+	staticData: { attributes: [] as IAttribute[], skills: [] as ISkill[] }
 }));
 
-vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager }));
+vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager, inventoryManager: mockInventoryManager }));
 vi.mock('$stores', () => ({ staticData, toastError }));
 vi.mock('$lib/api', async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, unknown>;

--- a/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
@@ -1,25 +1,40 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { EAttribute, type IBattlerAttribute } from '$lib/api';
+import {
+	EAttribute,
+	EDamageType,
+	EModifierType,
+	ERarity,
+	ESkillAcquisition,
+	ESkillEffectTarget,
+	type IBattlerAttribute,
+	type ISkill
+} from '$lib/api';
 
 // Mutable player-manager stand-in: `save()` reassigns `attributes` and adopts the
 // server's `statPointsUsed` absolutely. Declared as a class instance (not an object
 // literal) so `statify` can make its fields reactive — the view derives the
 // stat-point pool from them live, exactly like the real (statified) PlayerManager.
-const { mockPlayerManager, sendSocketCommand, toastError, staticData } = vi.hoisted(() => ({
+const { mockPlayerManager, mockInventoryManager, sendSocketCommand, toastError, staticData } = vi.hoisted(() => ({
 	mockPlayerManager: new (class MockPlayerManager {
 		attributes: IBattlerAttribute[] = [];
 		statPointsGained = 0;
 		statPointsUsed = 0;
+		selectedSkills: number[] = [];
 	})(),
+	mockInventoryManager: {
+		equipmentStats: [] as IBattlerAttribute[],
+		grantedSkillIds: [] as number[],
+		equippedWeaponType: 13 as EDamageType // EDamageType.Unarmed, a numeric literal (hoisted before the import)
+	},
 	sendSocketCommand: vi.fn(),
 	toastError: vi.fn(),
 	// Reference data is intentionally absent so the view falls back to enum names.
-	staticData: { attributes: undefined as unknown }
+	staticData: { attributes: undefined as unknown, skills: [] as ISkill[] }
 }));
 
 vi.mock('$lib/engine', async () => {
 	const { statify } = await import('$lib/common');
-	return { playerManager: statify(mockPlayerManager) };
+	return { playerManager: statify(mockPlayerManager), inventoryManager: mockInventoryManager };
 });
 vi.mock('$stores', () => ({ staticData, toastError }));
 vi.mock('$lib/api', async (importOriginal) => {
@@ -37,6 +52,8 @@ import {
 	feedsFor,
 	contributorsFor,
 	derivedShortLabel,
+	inertHint,
+	isAttributeInert,
 	radarValueAtPointer
 } from '$routes/game/screens/attributes/attributes-view.svelte';
 
@@ -53,11 +70,45 @@ const idx = {
 
 let view: AttributesView;
 
+/** Places skills at their id index — the zero-based-id catalogue convention `staticData.skills` mirrors. */
+const skillsById = (skills: ISkill[]): ISkill[] => {
+	const catalogue: ISkill[] = [];
+	for (const s of skills) {
+		catalogue[s.id] = s;
+	}
+	return catalogue;
+};
+
+/* A skill with sensible defaults so each test only states what matters. */
+const skill = (over: Partial<ISkill> & { id: number }): ISkill => ({
+	name: `Skill ${over.id}`,
+	baseDamage: 0,
+	criticalChance: 0,
+	damageMultipliers: [],
+	effects: [],
+	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
+	description: '',
+	cooldownMs: 1000,
+	iconPath: '',
+	rarityId: ERarity.Common,
+	word: '',
+	pronunciation: '',
+	translation: '',
+	acquisition: ESkillAcquisition.Player,
+	designerNotes: '',
+	...over
+});
+
 beforeEach(() => {
 	sendSocketCommand.mockReset().mockResolvedValue({ data: { attributes: allFives(), statPointsUsed: 0 } });
 	toastError.mockReset();
 	localStorage.clear();
 	mockPlayerManager.attributes = allFives();
+	mockPlayerManager.selectedSkills = [];
+	mockInventoryManager.equipmentStats = [];
+	mockInventoryManager.grantedSkillIds = [];
+	mockInventoryManager.equippedWeaponType = EDamageType.Unarmed;
+	staticData.skills = [];
 	mockPlayerManager.statPointsGained = 10;
 	mockPlayerManager.statPointsUsed = 0;
 	view = new AttributesView();
@@ -176,6 +227,162 @@ describe('contributorsFor', () => {
 		expect(contributorsFor(EAttribute.Luck)).toEqual([]);
 		// CDR keeps its base 1.0 but is no longer fed by any core attribute (#1426).
 		expect(contributorsFor(EAttribute.CooldownRecovery)).toEqual([]);
+	});
+});
+
+describe('isAttributeInert', () => {
+	it('is always false for an attribute that is not an amplifier', () => {
+		expect(isAttributeInert(EAttribute.Strength, [], [])).toBe(false);
+		expect(isAttributeInert(EAttribute.Endurance, [], [])).toBe(false);
+		expect(isAttributeInert(EAttribute.Intellect, [], [])).toBe(false);
+		expect(isAttributeInert(EAttribute.Dexterity, [], [])).toBe(false);
+	});
+
+	it('AGI is inert with no fielded skills or gear', () => {
+		expect(isAttributeInert(EAttribute.Agility, [], [])).toBe(true);
+	});
+
+	it('AGI is not inert once gear grants DodgeChance', () => {
+		const stats = [{ attributeId: EAttribute.DodgeChance, amount: 0.1 }];
+		expect(isAttributeInert(EAttribute.Agility, stats, [])).toBe(false);
+	});
+
+	it('AGI is not inert once gear grants CooldownBonus', () => {
+		const stats = [{ attributeId: EAttribute.CooldownBonus, amount: 0.05 }];
+		expect(isAttributeInert(EAttribute.Agility, stats, [])).toBe(false);
+	});
+
+	it('AGI stays inert when the granted attribute amount is zero', () => {
+		const stats = [{ attributeId: EAttribute.DodgeChance, amount: 0 }];
+		expect(isAttributeInert(EAttribute.Agility, stats, [])).toBe(true);
+	});
+
+	it('AGI stays inert when only an unrelated attribute is granted', () => {
+		const stats = [{ attributeId: EAttribute.MaxHealth, amount: 50 }];
+		expect(isAttributeInert(EAttribute.Agility, stats, [])).toBe(true);
+	});
+
+	it('AGI is not inert once a fielded skill self-effects DodgeChance', () => {
+		const fielded = [
+			skill({
+				id: 1,
+				effects: [
+					{
+						id: 1,
+						target: ESkillEffectTarget.Self,
+						attributeId: EAttribute.DodgeChance,
+						modifierTypeId: EModifierType.Additive,
+						amount: 0.2,
+						durationMs: 3000,
+						scalingAttributeId: EAttribute.Agility,
+						scalingAmount: 0
+					}
+				]
+			})
+		];
+		expect(isAttributeInert(EAttribute.Agility, [], fielded)).toBe(false);
+	});
+
+	it('AGI stays inert when the DodgeChance effect targets the opponent, not self', () => {
+		const fielded = [
+			skill({
+				id: 1,
+				effects: [
+					{
+						id: 1,
+						target: ESkillEffectTarget.Opponent,
+						attributeId: EAttribute.DodgeChance,
+						modifierTypeId: EModifierType.Additive,
+						amount: 0.2,
+						durationMs: 3000,
+						scalingAttributeId: EAttribute.Agility,
+						scalingAmount: 0
+					}
+				]
+			})
+		];
+		expect(isAttributeInert(EAttribute.Agility, [], fielded)).toBe(true);
+	});
+
+	it('LUK is inert with no fielded skills or gear', () => {
+		expect(isAttributeInert(EAttribute.Luck, [], [])).toBe(true);
+	});
+
+	it('LUK is not inert once a fielded skill authors its own CriticalChance', () => {
+		const fielded = [skill({ id: 1, criticalChance: 0.1 })];
+		expect(isAttributeInert(EAttribute.Luck, [], fielded)).toBe(false);
+	});
+
+	it('LUK is not inert once gear grants ParryChance', () => {
+		const stats = [{ attributeId: EAttribute.ParryChance, amount: 0.15 }];
+		expect(isAttributeInert(EAttribute.Luck, stats, [])).toBe(false);
+	});
+
+	it('LUK stays inert when a fielded skill has zero CriticalChance and nothing grants ParryChance', () => {
+		const fielded = [skill({ id: 1, criticalChance: 0 })];
+		expect(isAttributeInert(EAttribute.Luck, [], fielded)).toBe(true);
+	});
+});
+
+describe('inertHint', () => {
+	it('describes the AGI and LUK amplifiers', () => {
+		expect(inertHint(EAttribute.Agility)).toMatch(/dodge|cadence/i);
+		expect(inertHint(EAttribute.Luck)).toMatch(/crit|parry/i);
+	});
+
+	it('is undefined for a non-amplifier attribute', () => {
+		expect(inertHint(EAttribute.Strength)).toBeUndefined();
+	});
+});
+
+describe('AttributesView.isInert', () => {
+	it('AGI/LUK are inert by default (no equipped gear or skills grant an enabler)', () => {
+		expect(view.isInert(idx.agi)).toBe(true);
+		expect(view.isInert(idx.luk)).toBe(true);
+	});
+
+	it('every non-amplifier attribute is never inert', () => {
+		expect(view.isInert(idx.str)).toBe(false);
+		expect(view.isInert(idx.end)).toBe(false);
+		expect(view.isInert(idx.int)).toBe(false);
+		expect(view.isInert(idx.dex)).toBe(false);
+	});
+
+	it('AGI stops being inert once the equipped weapon field grants DodgeChance', () => {
+		mockInventoryManager.equipmentStats = [{ attributeId: EAttribute.DodgeChance, amount: 0.1 }];
+		view = new AttributesView();
+		expect(view.isInert(idx.agi)).toBe(false);
+	});
+
+	it('LUK stops being inert once the selected loadout includes a crit-authored skill', () => {
+		staticData.skills = skillsById([skill({ id: 7, criticalChance: 0.25 })]);
+		mockPlayerManager.selectedSkills = [7];
+		view = new AttributesView();
+		expect(view.isInert(idx.luk)).toBe(false);
+	});
+
+	it('ignores a crit-authored skill that is unlocked but not fielded (not selected/granted)', () => {
+		staticData.skills = skillsById([skill({ id: 7, criticalChance: 0.25 })]);
+		mockPlayerManager.selectedSkills = [];
+		view = new AttributesView();
+		expect(view.isInert(idx.luk)).toBe(true);
+	});
+
+	it('ignores a fielded skill dimmed by the weapon-match gate', () => {
+		staticData.skills = skillsById([
+			skill({ id: 7, criticalChance: 0.25, damagePortions: [{ type: EDamageType.Sword, weight: 1 }] })
+		]);
+		mockPlayerManager.selectedSkills = [7];
+		mockInventoryManager.equippedWeaponType = EDamageType.Bow; // Sword skill is dormant while a Bow is equipped
+		view = new AttributesView();
+		expect(view.isInert(idx.luk)).toBe(true);
+	});
+
+	it('counts a skill granted by equipped gear (e.g. a weapon signature) as fielded', () => {
+		staticData.skills = skillsById([skill({ id: 7, criticalChance: 0.25 })]);
+		mockInventoryManager.grantedSkillIds = [7];
+		view = new AttributesView();
+		expect(view.isInert(idx.luk)).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Summary

Sub-issue of #1426, unblocked now that the amplifier reworks (#1523, #1524, #1525) have landed. AGI and LUK are pure amplifiers: their `*Multiplier` targets scale a `0`-based enabler (`DodgeChance`/`CooldownBonus` for AGI; a fielded skill's own authored `criticalChance` or `ParryChance` for LUK), so a build with no matching enabler fielded gets nothing from points invested there — dormant, not dead. This adds a read-only inline hint on the Attributes screen (both Guided and Theorycraft modes) signaling that state, per #1528.

- `attributes-view.svelte.ts`: adds `isAttributeInert`/`hasFieldedEnabler` (pure, unit-tested) and `inertHint`, plus an `AttributesView.isInert(i)` / `fieldedSkills` derived that assembles the player's live fielded skill set — selected loadout + equipped-gear grants, weapon-match gated (`isSkillDormant`) — and equipped gear/mod static stat lines (`inventoryManager.equipmentStats`), mirroring what the battler actually fields so the hint can never contradict the simulation.
- `GuidedRow.svelte` / `TheoryRow.svelte`: render a `⊘ Dormant — …` note (styled like the Skills screen's existing `DormantNote.svelte` off-weapon note) when the row's attribute is currently inert.
- No allocation gating — the free-pool points stay a legitimate pre-commitment, per the spike's Decision 5.

**Scope note:** left the "inverse affordance" suggestion in the issue (showing what the multiplier currently amplifies, e.g. "×1.24 on your 5% dodge") out of scope — it was called out as a "consider," and would require surfacing the new `*Multiplier` attributes in `DERIVED_STATS`/the per-point-yield panel, which is a separate, larger change. Happy to follow up if wanted.

## Test plan

- [x] `dotnet build` — not applicable, frontend-only change
- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — full suite passes (287 files / 3376 tests), including new coverage in `attributes-view.test.ts` for `isAttributeInert` across gear-static, skill-effect, and skill-authored-crit enabler sources, the weapon-match gate, and equipped-gear-granted skills.

Closes #1528


---
_Generated by [Claude Code](https://claude.ai/code/session_01KhjEB9d89nZx55uif6embt)_