### PR TITLE
Extract a shared "dormant note" presentational component

### DIFF
--- a/UI/src/components/DormantNote.svelte
+++ b/UI/src/components/DormantNote.svelte
@@ -1,0 +1,48 @@
+<!-- Shared "⊘ dormant" signal: a read-only, muted note that a build committed points into
+     something inert (an off-weapon skill, an unfielded amplifier attribute). Presentational
+     only — callers own the hint text and any layout spacing around it. -->
+<span
+	class="dormant-note"
+	class:block
+	{title}
+	style:font-size="{fontSize}px"
+	style:letter-spacing="{letterSpacing}px"
+	style:margin-top="{marginTop}px"
+	style:margin-left="{marginLeft}px">⊘ {text}</span
+>
+
+<script lang="ts">
+type Props = {
+	text: string;
+	title?: string;
+	fontSize?: number;
+	letterSpacing?: number;
+	/** Renders as a block below the preceding content instead of inline. */
+	block?: boolean;
+	marginTop?: number;
+	marginLeft?: number;
+};
+
+const {
+	text,
+	title,
+	fontSize = 8.5,
+	letterSpacing = 0.5,
+	block = false,
+	marginTop = 0,
+	marginLeft = 0
+}: Props = $props();
+</script>
+
+<style lang="scss">
+// Neutral muted tone — --warning is reserved for validation, and this is a read-only signal, not a problem to fix.
+.dormant-note {
+	font-family: var(--mono);
+	text-transform: uppercase;
+	color: var(--text-tertiary);
+
+	&.block {
+		display: block;
+	}
+}
+</style>

--- a/UI/src/routes/game/screens/attributes/GuidedRow.svelte
+++ b/UI/src/routes/game/screens/attributes/GuidedRow.svelte
@@ -29,7 +29,7 @@
 			{/if}
 		</div>
 		{#if inert}
-			<span class="dormant-note">⊘ {hint}</span>
+			<DormantNote text={hint ?? ''} block marginTop={4} />
 		{/if}
 	</div>
 
@@ -41,6 +41,7 @@
 import { attributeColor, attributeCode, attributeName } from '$lib/common';
 import { staticData } from '$stores';
 import AttributeIcon from '$components/AttributeIcon.svelte';
+import DormantNote from '$components/DormantNote.svelte';
 import { getAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
 import { tooltipHover } from '$components/tooltip/tooltip-hover';
 import { describedByTooltip } from '$components/tooltip/describedby-tooltip';
@@ -157,17 +158,5 @@ const changed = $derived(
 		color: var(--text-muted);
 		border-style: dashed;
 	}
-}
-
-// Neutral muted tone matching the Skills screen's off-weapon dormancy note (DormantNote.svelte) —
-// --warning is reserved for validation, and this is a read-only signal, not a problem to fix.
-.dormant-note {
-	display: block;
-	margin-top: 4px;
-	font-family: var(--mono);
-	font-size: 8.5px;
-	letter-spacing: 0.5px;
-	text-transform: uppercase;
-	color: var(--text-tertiary);
 }
 </style>

--- a/UI/src/routes/game/screens/attributes/TheoryRow.svelte
+++ b/UI/src/routes/game/screens/attributes/TheoryRow.svelte
@@ -31,7 +31,7 @@
 			{/if}
 		</div>
 		{#if inert}
-			<span class="dormant-note">⊘ {hint}</span>
+			<DormantNote text={hint ?? ''} block fontSize={8} marginTop={3} marginLeft={15} />
 		{/if}
 	</div>
 
@@ -57,6 +57,7 @@
 import { formatAttributeDelta, attributeColor, attributeCode, attributeName } from '$lib/common';
 import { staticData } from '$stores';
 import AttributeIcon from '$components/AttributeIcon.svelte';
+import DormantNote from '$components/DormantNote.svelte';
 import { getAttributeTooltip } from '$components/tooltip/attribute-tooltip.svelte';
 import { tooltipHover } from '$components/tooltip/tooltip-hover';
 import { describedByTooltip } from '$components/tooltip/describedby-tooltip';
@@ -160,19 +161,6 @@ const deltaWidth = $derived((Math.abs(value - saved) / view.hexMax) * 100);
 	letter-spacing: 0.8px;
 	text-transform: uppercase;
 	color: color-mix(in srgb, var(--text-primary) 30%, transparent);
-}
-
-// Neutral muted tone matching the Skills screen's off-weapon dormancy note (DormantNote.svelte) —
-// --warning is reserved for validation, and this is a read-only signal, not a problem to fix.
-.dormant-note {
-	display: block;
-	margin-top: 3px;
-	margin-left: 15px;
-	font-family: var(--mono);
-	font-size: 8px;
-	letter-spacing: 0.5px;
-	text-transform: uppercase;
-	color: var(--text-tertiary);
 }
 
 .yield {

--- a/UI/src/routes/game/screens/skills/DormantNote.svelte
+++ b/UI/src/routes/game/screens/skills/DormantNote.svelte
@@ -1,13 +1,16 @@
 <!-- Off-weapon dormancy note shared by the equipped + innate bands: a weapon-leaf skill the equipped
      weapon doesn't field (#1342), labelled with the weapon type it needs. -->
-<span class="dormant-note" title="Off-weapon — dormant until you equip a {required} weapon">
-	⊘ dormant · needs {required}
-</span>
+<SharedDormantNote
+	text="dormant · needs {required}"
+	title="Off-weapon — dormant until you equip a {required} weapon"
+	letterSpacing={0.8}
+/>
 
 <script lang="ts">
 import type { ISkill } from '$lib/api';
 import { primaryDamageType } from '$lib/battle';
 import { damageTypeName } from '$lib/common';
+import SharedDormantNote from '$components/DormantNote.svelte';
 
 type Props = {
 	skill: ISkill;
@@ -18,14 +21,3 @@ const { skill }: Props = $props();
 /** The weapon type the dormant skill needs equipped to field — its primary leaf type's name. */
 const required = $derived(damageTypeName(primaryDamageType(skill.damagePortions)));
 </script>
-
-<style lang="scss">
-.dormant-note {
-	font-family: var(--mono);
-	font-size: 8.5px;
-	letter-spacing: 0.8px;
-	text-transform: uppercase;
-	// Neutral muted tone (matching the innate dupe-note); --warning is reserved for validation.
-	color: var(--text-tertiary);
-}
-</style>


### PR DESCRIPTION
## Summary

Implements #1577 (follow-up from the #1576 review): the three near-identical "⊘ dormant" call sites had diverged into copy-pasted markup/CSS —

- `UI/src/routes/game/screens/skills/DormantNote.svelte` (off-weapon skill dormancy)
- `UI/src/routes/game/screens/attributes/GuidedRow.svelte` (`.dormant-note` block)
- `UI/src/routes/game/screens/attributes/TheoryRow.svelte` (`.dormant-note` block)

- **`UI/src/components/DormantNote.svelte`** — new shared presentational component (mono, uppercase, `--text-tertiary`, `⊘ {text}` prefix) per `docs/frontend.md`'s "extend a shared primitive rather than copy it" guideline. Font-size, letter-spacing, and margin are exposed as props (defaulting to the most common values) so every call site keeps its **exact** existing appearance — no visual regression, verified line-by-line against the three removed style blocks.
- The skills-screen `DormantNote.svelte` keeps its own weapon-lookup logic (`required` derived from the skill's primary damage type) and now renders the shared component internally, so `EquippedBand.svelte`/`InnateBand.svelte` needed no changes.
- `GuidedRow.svelte`/`TheoryRow.svelte` now render `<DormantNote>` directly in place of their inline `<span class="dormant-note">`, and their now-dead local `.dormant-note` style blocks are removed.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — full suite passes (3376 tests, no regressions); no existing test asserts on the removed markup/classes directly, so this is a safe presentational-only refactor
- [x] Manually diffed each call site's old vs. new rendered CSS values (font-size/letter-spacing/margin) to confirm pixel-parity

Closes #1577


---
_Generated by [Claude Code](https://claude.ai/code/session_016QTeZNgWPyHhfEaJvhdmzX)_