### PR TITLE
Content-events derivation layer (shared before/after-diff for mechanic occurrence)

### DIFF
--- a/UI/src/lib/common/content-events.ts
+++ b/UI/src/lib/common/content-events.ts
@@ -1,0 +1,70 @@
+/* Shared before/after-diff derivation for "did this just become true" (content-events, spike #1392 area
+   A). Consolidates the pattern already duplicated across challenge-unlocks/synthesis-feedback/
+   proficiency-feedback call sites (a snapshot taken before a change, compared against the same
+   derivation after) into reusable primitives, so the tutorial mechanic-anchored triggers (#1587) and any
+   future consumer (e.g. #1395's badges) have one place to detect "newly true" instead of a fourth
+   bespoke diff. Pure, no UI, no persistence — callers own snapshotting and any one-shot/ever-seen state. */
+
+import type { SkillActivation } from '$lib/battle/battle-step';
+
+/** The base flip primitive every mechanic-anchored trigger reduces to: false→true, and only that
+ *  direction (already-true stays uninteresting, true→false is not "newly" anything). */
+export function newlyTrue(wasTrueBefore: boolean, isTrueNow: boolean): boolean {
+	return isTrueNow && !wasTrueBefore;
+}
+
+/** Ids present in `after` but absent from `before` — the shared set-diff behind "what newly unlocked"
+ *  (skills, items, creatable recipes, or any other zero-based/reference id set). */
+export function newlyInSet<T>(before: ReadonlySet<T>, after: ReadonlySet<T>): T[] {
+	const added: T[] = [];
+	for (const id of after) {
+		if (!before.has(id)) {
+			added.push(id);
+		}
+	}
+	return added;
+}
+
+/** Whether a numeric progress value (e.g. a proficiency level) crossed `threshold` going from `before`
+ *  to `after` — the shared "crossed a level/milestone" check. */
+export function crossedThreshold(before: number, after: number, threshold: number): boolean {
+	return after >= threshold && before < threshold;
+}
+
+/** Whether this tick's activations include the player's first-ever landed critical hit (enemies never
+ *  crit in this engine, so only player-side activations are relevant). */
+export function isFirstCrit(
+	hasCritBefore: boolean,
+	activations: readonly Pick<SkillActivation, 'byPlayer' | 'crit'>[]
+): boolean {
+	return newlyTrue(
+		hasCritBefore,
+		activations.some((a) => a.byPlayer && a.crit)
+	);
+}
+
+/** Whether this tick's activations include the player's first-ever dodged incoming hit (only enemy-fired
+ *  activations carry a dodge roll). */
+export function isFirstDodge(
+	hasDodgedBefore: boolean,
+	activations: readonly Pick<SkillActivation, 'dodged'>[]
+): boolean {
+	return newlyTrue(
+		hasDodgedBefore,
+		activations.some((a) => a.dodged)
+	);
+}
+
+/** Whether this tick's activations include the first time one of the player's own skills has fully
+ *  recharged and fired (a skill's cooldown resets to 0 the same tick it reaches its cap and fires, so a
+ *  player-fired, non-counter activation IS that recharge). The riposte counter fires off a parry, not a
+ *  cooldown, so it's excluded. */
+export function isFirstCooldownRecharge(
+	hasFiredBefore: boolean,
+	activations: readonly Pick<SkillActivation, 'byPlayer' | 'counter'>[]
+): boolean {
+	return newlyTrue(
+		hasFiredBefore,
+		activations.some((a) => a.byPlayer && !a.counter)
+	);
+}

--- a/UI/src/lib/common/index.ts
+++ b/UI/src/lib/common/index.ts
@@ -5,6 +5,7 @@ export * from './tag-color';
 export * from './challenge-unlocks';
 export * from './proficiency-feedback';
 export * from './synthesis-feedback';
+export * from './content-events';
 export * from './zone-progression';
 export * from './enemy-attributes';
 export * from './attribute-display';

--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -11,7 +11,8 @@ import {
 	proficiencyMilestoneMessage,
 	proficiencyOpenedMessage,
 	creatableRecipeIds,
-	recipeAvailableMessage
+	recipeAvailableMessage,
+	newlyInSet
 } from '$lib/common';
 import { RenderEngine } from './render-engine';
 import { LogicalEngine } from './logical-engine';
@@ -192,19 +193,20 @@ const currentCreatableRecipeIds = (): Set<number> =>
 
 /**
  * Toasts each recipe that became creatable as a result of the just-applied proficiency gain, comparing the
- * current creatable set against the pre-push snapshot. Mirrors the milestone/challenge feedback — a success
- * toast with a "View" action into the Synthesis screen — so the player learns a new recipe opened up even
- * while idling on another screen. Synthesizing is player-driven and stays un-toasted (spike #1125 area F);
- * this only fires for an availability change driven by background progress. Unknown reference ids are skipped.
+ * current creatable set against the pre-push snapshot (the shared content-events set-diff, #1586). Mirrors
+ * the milestone/challenge feedback — a success toast with a "View" action into the Synthesis screen — so
+ * the player learns a new recipe opened up even while idling on another screen. Synthesizing is
+ * player-driven and stays un-toasted (spike #1125 area F); this only fires for an availability change
+ * driven by background progress. Unknown reference ids are skipped.
  */
 const notifyNewlyCreatableRecipes = (creatableBefore: ReadonlySet<number>) => {
 	const recipes = staticData.skillRecipes;
 	if (!recipes) {
 		return;
 	}
-	const creatableNow = currentCreatableRecipeIds();
+	const newlyCreatable = new Set(newlyInSet(creatableBefore, currentCreatableRecipeIds()));
 	for (const recipe of recipes) {
-		if (!creatableNow.has(recipe.id) || creatableBefore.has(recipe.id)) {
+		if (!newlyCreatable.has(recipe.id)) {
 			continue;
 		}
 		const result = staticData.skills?.[recipe.resultSkillId];

--- a/UI/src/tests/lib/common/content-events.test.ts
+++ b/UI/src/tests/lib/common/content-events.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+	newlyTrue,
+	newlyInSet,
+	crossedThreshold,
+	isFirstCrit,
+	isFirstDodge,
+	isFirstCooldownRecharge
+} from '$lib/common';
+
+describe('newlyTrue', () => {
+	it('is true only on a false-to-true flip', () => {
+		expect(newlyTrue(false, true)).toBe(true);
+	});
+
+	it('is false when already true before', () => {
+		expect(newlyTrue(true, true)).toBe(false);
+	});
+
+	it('is false when still false', () => {
+		expect(newlyTrue(false, false)).toBe(false);
+	});
+
+	it('is false on a true-to-false flip', () => {
+		expect(newlyTrue(true, false)).toBe(false);
+	});
+});
+
+describe('newlyInSet', () => {
+	it('collects ids present in after but absent from before', () => {
+		expect(newlyInSet(new Set([1, 2]), new Set([1, 2, 3]))).toEqual([3]);
+	});
+
+	it('is empty when nothing new was added', () => {
+		expect(newlyInSet(new Set([1, 2]), new Set([1, 2]))).toEqual([]);
+	});
+
+	it('does not report an id that disappeared', () => {
+		expect(newlyInSet(new Set([1, 2]), new Set([1]))).toEqual([]);
+	});
+});
+
+describe('crossedThreshold', () => {
+	it('is true when before is under the threshold and after meets it', () => {
+		expect(crossedThreshold(4, 5, 5)).toBe(true);
+	});
+
+	it('is false when before already met the threshold', () => {
+		expect(crossedThreshold(5, 6, 5)).toBe(false);
+	});
+
+	it('is false when after still falls short', () => {
+		expect(crossedThreshold(3, 4, 5)).toBe(false);
+	});
+});
+
+const activation = (over: Partial<{ byPlayer: boolean; crit: boolean; dodged: boolean; counter: boolean }>) => ({
+	byPlayer: false,
+	crit: false,
+	dodged: false,
+	counter: false,
+	...over
+});
+
+describe('isFirstCrit', () => {
+	it('fires the first time a player activation lands a crit', () => {
+		expect(isFirstCrit(false, [activation({ byPlayer: true, crit: true })])).toBe(true);
+	});
+
+	it('does not fire again once a crit has already landed', () => {
+		expect(isFirstCrit(true, [activation({ byPlayer: true, crit: true })])).toBe(false);
+	});
+
+	it('ignores a crit flag on a non-player activation', () => {
+		expect(isFirstCrit(false, [activation({ byPlayer: false, crit: true })])).toBe(false);
+	});
+
+	it('does not fire when no activation crit', () => {
+		expect(isFirstCrit(false, [activation({ byPlayer: true, crit: false })])).toBe(false);
+	});
+});
+
+describe('isFirstDodge', () => {
+	it('fires the first time an activation is dodged', () => {
+		expect(isFirstDodge(false, [activation({ dodged: true })])).toBe(true);
+	});
+
+	it('does not fire again once a dodge has already occurred', () => {
+		expect(isFirstDodge(true, [activation({ dodged: true })])).toBe(false);
+	});
+
+	it('does not fire when nothing was dodged', () => {
+		expect(isFirstDodge(false, [activation({ dodged: false })])).toBe(false);
+	});
+});
+
+describe('isFirstCooldownRecharge', () => {
+	it('fires the first time a non-counter player activation fires', () => {
+		expect(isFirstCooldownRecharge(false, [activation({ byPlayer: true, counter: false })])).toBe(true);
+	});
+
+	it('does not fire again once a skill has already recharged and fired', () => {
+		expect(isFirstCooldownRecharge(true, [activation({ byPlayer: true, counter: false })])).toBe(false);
+	});
+
+	it('ignores the riposte counter fire', () => {
+		expect(isFirstCooldownRecharge(false, [activation({ byPlayer: true, counter: true })])).toBe(false);
+	});
+
+	it('ignores enemy activations', () => {
+		expect(isFirstCooldownRecharge(false, [activation({ byPlayer: false })])).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Implements #1586 (part of spike #1392, area A — design in `docs/spikes/1392-ui-tutorials.md`): a shared, pure before/after-diff module (`UI/src/lib/common/content-events.ts`) for detecting "a mechanic just occurred for the first time" and "something newly became true," so the upcoming tutorial mechanic-anchored triggers (#1587) and any future consumer (e.g. #1395's badges) have one shared diff layer instead of re-deriving it a fourth time.

- **`newlyTrue(before, after)`** — the base false→true flip primitive every mechanic-anchored trigger reduces to.
- **`newlyInSet(before, after)`** — the shared set-diff behind "what newly unlocked" (skills, items, creatable recipes, or any other id set).
- **`crossedThreshold(before, after, threshold)`** — the shared "crossed a level/milestone" numeric check.
- **`isFirstCrit` / `isFirstDodge` / `isFirstCooldownRecharge`** — battle-mechanic detectors built on `newlyTrue`, operating on `SkillActivation[]` from `battleStep` (a skill's cooldown resets to 0 the same tick it fires, so a player-fired, non-counter activation *is* the "cooldown recharged" event).

## On migrating existing call sites

I audited the three files the issue named as the duplicated pattern:

- **`synthesis-feedback.ts`**'s `creatableRecipeIds`, diffed manually in `engine.ts`'s `notifyNewlyCreatableRecipes` — this *is* a genuine before/after diff, so I migrated it onto `newlyInSet` (see `engine.ts`).
- **`challenge-unlocks.ts`** and **`proficiency-feedback.ts`** are pure derivation/formatting helpers, not diff functions themselves — challenge completion and proficiency level-ups/milestones already arrive as precomputed deltas from the server (`data.proficiencies[].newLevel`/`milestonesCrossed`, the challenge-completed push), so there's no client-side before/after state to diff for those. Nothing to migrate there; noting it here so it's not mistaken for an oversight.

## Test plan

- [x] New unit tests (`UI/src/tests/lib/common/content-events.test.ts`) cover each primitive and detector: the flip-only-on-false-to-true semantics, set-diff add/no-change/removed cases, threshold-crossing edges, and each battle detector's first-occurrence / already-occurred / wrong-side / excluded-counter cases.
- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — full suite passes (3397 tests, no regressions)
- [x] No backend files touched — `dotnet build`/`dotnet test` not needed for this change.

Closes #1586


---
_Generated by [Claude Code](https://claude.ai/code/session_014V3iNwuVQseGoZN7wT91G2)_