### PR TITLE
Migrate the enemy dead-stat lint onto CombatRating.Marginal (#1581)

### DIFF
--- a/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
+++ b/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
@@ -291,6 +291,24 @@ namespace Game.Application.Tests.Content
         }
 
         [Fact]
+        public void Enemy_DistributesAgilityWithCoAuthoredCooldownBonus_ProducesNoFinding()
+        {
+            // Agility has no direct kit consumer here, but co-authoring CooldownBonus makes its derived
+            // CooldownBonusMultiplier live (CooldownBonus × CooldownBonusMultiplier feeds the cooldown rate),
+            // so Agility is no longer dead weight — the exact case #1581 moved off the heuristic for.
+            var graph = HealthyGraph() with
+            {
+                Enemies =
+                [
+                    Enemy(0, skillPool: [2], spawns: [(0, 1), (1, 1)],
+                        attributeDistribution: [(EAttribute.Agility, 5, 1), (EAttribute.CooldownBonus, 5, 1)]),
+                    Enemy(1, isBoss: true),
+                ],
+            };
+            Assert.DoesNotContain(_checker.Check(graph), f => f.Check == "EnemyInertAttribute");
+        }
+
+        [Fact]
         public void Enemy_DistributesLuckConsumedByPooledEffectScaling_ProducesNoFinding()
         {
             var graph = HealthyGraph() with

--- a/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
+++ b/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
@@ -360,6 +360,20 @@ namespace Game.Application.Tests.Content
             Assert.DoesNotContain(_checker.Check(graph), f => f.Check == "EnemyInertAttribute");
         }
 
+        [Fact]
+        public void Enemy_NotPlacedInAnyLiveZone_ProducesNoFinding()
+        {
+            // No spawn table entry and no dedicated-boss slot means no representative level to rate at, so the
+            // check is skipped rather than rating at a made-up level.
+            var graph = HealthyGraph() with
+            {
+                Enemies = HealthyGraph().Enemies
+                    .Append(Enemy(9, skillPool: [2], spawns: [], attributeDistribution: [(EAttribute.Luck, 5, 1)]))
+                    .ToList(),
+            };
+            Assert.DoesNotContain(_checker.Check(graph), f => f.Check == "EnemyInertAttribute");
+        }
+
         // --- Classes ----------------------------------------------------------------------------------
 
         [Fact]
@@ -927,7 +941,14 @@ namespace Game.Application.Tests.Content
                 .Select(m => new Contracts.AttributeMultiplier { AttributeId = m.attributeId, Multiplier = m.multiplier })
                 .ToList(),
                 Effects = (effectScaling ?? [])
-                .Select(e => new Contracts.SkillEffect { AttributeId = EAttribute.MaxHealth, ScalingAttributeId = e.attributeId, ScalingAmount = e.scalingAmount })
+                .Select(e => new Contracts.SkillEffect
+                {
+                    Target = ESkillEffectTarget.Self,
+                    AttributeId = EAttribute.MaxHealth,
+                    DurationMs = 1000,
+                    ScalingAttributeId = e.attributeId,
+                    ScalingAmount = e.scalingAmount,
+                })
                 .ToList(),
                 DamagePortions = [new Contracts.SkillDamagePortion { Type = primaryType, Weight = 1 }],
                 Description = "",

--- a/Game.Application/Content/ProgressionGraphChecker.cs
+++ b/Game.Application/Content/ProgressionGraphChecker.cs
@@ -1,6 +1,7 @@
 using Game.Core;
 using Game.Core.Attributes;
 using Game.Core.Attributes.Modifiers;
+using Game.Core.Battle;
 using Game.Core.Progress;
 using Game.Core.Skills;
 using Contracts = Game.Abstractions.Contracts;
@@ -197,17 +198,29 @@ namespace Game.Application.Content
                 }
             }
 
+            // Below this finite-difference magnitude, CombatRating.Marginal is treated as "no matching enabler
+            // fielded" rather than genuine (if tiny) capability — matching the tolerance CombatRatingTests uses
+            // to assert an exactly-dead marginal (Assert.Equal(0, marginal, 6)).
+            private const double DeadStatMarginalEpsilon = 1e-6;
+
             /// <summary>
             /// Flags a live enemy's core-attribute distribution points that nothing in its kit consumes (#1529):
             /// dead weight that still counts into <c>DefeatRewards.SumCoreAttributes</c>, inflating XP payout
-            /// without adding threat. A v1 heuristic map, not the exact per-attribute marginal spike #1526's
-            /// <see cref="Game.Core.Battle.CombatRating.Marginal"/> now computes — see the follow-up filed
-            /// alongside this check to migrate onto that once the calibration work (#1533) lands.
+            /// without adding threat. Exact, via spike #1526's <see cref="CombatRating.Marginal"/> (#1581) rather
+            /// than a heuristic — an attribute whose fielded kit has no matching enabler marginals to ~0.
             /// </summary>
             private void CheckEnemyAttributeConsumption()
             {
                 foreach (var enemy in Live(_graph.Enemies, e => e.RetiredAt))
                 {
+                    // No live placement (spawn table or dedicated boss slot) means no representative encounter
+                    // level to rate the enemy at — mirrors the combat-rating calibration report's own omission
+                    // of unplaced enemies from its pricing pass.
+                    if (ResolveRatingLevel(enemy) is not int level)
+                    {
+                        continue;
+                    }
+
                     var kit = new List<Contracts.Skill>();
                     foreach (var skillId in enemy.SkillPool)
                     {
@@ -216,6 +229,8 @@ namespace Game.Application.Content
                             kit.Add(skill);
                         }
                     }
+
+                    var battler = BuildRatingBattler(enemy, kit, level);
 
                     foreach (var distribution in enemy.AttributeDistribution)
                     {
@@ -227,7 +242,13 @@ namespace Game.Application.Content
                         // Only the six core (directly-allocatable) attributes feed SumCoreAttributes; a
                         // directly-authored secondary (e.g. a fast enemy's own CooldownBonus) is its own
                         // enabler, not a distribution point this check polices.
-                        if (!GameAttribute.CoreAttributes.Contains(distribution.AttributeId) || IsConsumedByKit(distribution.AttributeId, kit))
+                        if (!GameAttribute.CoreAttributes.Contains(distribution.AttributeId))
+                        {
+                            continue;
+                        }
+
+                        var marginal = CombatRating.Marginal(battler, isPlayer: false, distribution.AttributeId);
+                        if (Math.Abs(marginal) >= DeadStatMarginalEpsilon)
                         {
                             continue;
                         }
@@ -239,29 +260,78 @@ namespace Game.Application.Content
             }
 
             /// <summary>
-            /// Consumed = a static derivation targets it (Endurance/Strength feed the always-live
-            /// Toughness/MaxHealth), a pooled skill's <c>DamageMultipliers</c> scales off it, or a pooled skill
-            /// effect's <c>ScalingAttributeId</c> does. Luck and Agility are excepted from the static-derivation
-            /// half, for different reasons: Luck's derivations (the crit/parry-multiplier family) gate behind
-            /// mechanics the engine never rolls for an enemy (<c>BattleContext.DamageTarget</c>'s crit/parry/dodge
-            /// draws are player-only); Agility's <c>DodgeChanceMultiplier</c> is equally never-rolled, but its
-            /// <c>CooldownBonusMultiplier</c> is symmetric (enemies cycle too) and only bites when the enemy
-            /// co-authors a <c>CooldownBonus</c> distribution point (0 × mult = 0) — dead for Agility alone. So
-            /// until an enemy fields such a kit, both are consumed only by a direct kit hit.
+            /// The representative level to rate a live enemy at for <see cref="CheckEnemyAttributeConsumption"/>:
+            /// the arc midpoint of the first live zone it spawns in, or that zone's fixed <c>BossLevel</c> if
+            /// it's the dedicated boss there — the same placement precedent the combat-rating calibration report
+            /// (#1533) uses. <c>Contracts.Enemy</c> carries no level of its own; one only exists at an encounter.
             /// </summary>
-            private static bool IsConsumedByKit(EAttribute attribute, IReadOnlyList<Contracts.Skill> kit)
+            private int? ResolveRatingLevel(Contracts.Enemy enemy)
             {
-                if (attribute != EAttribute.Agility && attribute != EAttribute.Luck && HasStaticDerivation(attribute))
+                foreach (var zone in Live(_graph.Zones, z => z.RetiredAt))
                 {
-                    return true;
+                    if (enemy.Spawns.Any(s => s.ZoneId == zone.Id))
+                    {
+                        return (zone.LevelMin + zone.LevelMax) / 2;
+                    }
+
+                    if (zone.BossEnemyId == enemy.Id)
+                    {
+                        return zone.BossLevel;
+                    }
                 }
 
-                return kit.Any(skill => skill.DamageMultipliers.Any(m => m.AttributeId == attribute && m.Multiplier != 0)
-                    || skill.Effects.Any(e => e.ScalingAttributeId == attribute && e.ScalingAmount != 0));
+                return null;
             }
 
-            private static bool HasStaticDerivation(EAttribute attribute)
-                => StaticAttributeModifiers.All.Any(m => m.Source == EAttributeModifierSource.Derived && m.DerivedSource == attribute);
+            /// <summary>
+            /// Assembles a rating <see cref="Battler"/> for a live enemy's full authored kit (every live skill in
+            /// <see cref="Contracts.Enemy.SkillPool"/>, not a random per-encounter draw — the check asks whether
+            /// anything in the <em>kit</em> consumes the attribute) at <paramref name="level"/>. Mirrors
+            /// <see cref="Enemies.Enemy.ToBattler"/>, but built directly from the source-agnostic
+            /// <c>Contracts</c> DTOs this lint works from: <c>Game.Application</c> has no reach into the data
+            /// tier's entity↔domain mapping (<c>Game.DataAccess.Mapping.SkillMapper</c>), and <c>Game.Core</c>
+            /// itself has no dependency on <c>Game.Abstractions.Contracts</c> to host this mapping instead.
+            /// </summary>
+            private static Battler BuildRatingBattler(Contracts.Enemy enemy, IReadOnlyList<Contracts.Skill> kit, int level)
+            {
+                var modifiers = enemy.AttributeDistribution.Select(d => new AttributeModifier
+                {
+                    Attribute = d.AttributeId,
+                    Amount = (double)d.BaseAmount + (double)d.AmountPerLevel * level,
+                    Type = EModifierType.Additive,
+                    Source = EAttributeModifierSource.AttributeDistribution,
+                });
+
+                return new Battler(new AttributeCollection(modifiers), kit.Select(ToRatingSkill), level);
+            }
+
+            private static Skill ToRatingSkill(Contracts.Skill skill) => new()
+            {
+                Id = skill.Id,
+                Name = skill.Name,
+                BaseDamage = (double)skill.BaseDamage,
+                Description = skill.Description,
+                CooldownMs = skill.CooldownMs,
+                CriticalChance = (double)skill.CriticalChance,
+                DamagePortions = skill.DamagePortions
+                    .Select(p => new SkillDamagePortion { Type = p.Type, Weight = (double)p.Weight })
+                    .ToList(),
+                DamageMultipliers = skill.DamageMultipliers
+                    .Select(m => new DamageMultiplier { Attribute = m.AttributeId, Amount = (double)m.Multiplier })
+                    .ToList(),
+                Effects = skill.Effects
+                    .Select(e => new SkillEffect
+                    {
+                        Id = e.Id,
+                        Target = e.Target,
+                        AttributeId = e.AttributeId,
+                        ModifierType = e.ModifierTypeId,
+                        Amount = (double)e.Amount,
+                        DurationMs = e.DurationMs,
+                        ScalingAttributeId = e.ScalingAttributeId,
+                        ScalingAmount = (double)e.ScalingAmount,
+                    }).ToList(),
+            };
 
             // --- Classes ----------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements #1581: replaces the v1 heuristic in `ProgressionGraphChecker.CheckEnemyAttributeConsumption` (static-derivation check + pooled `DamageMultiplier`/effect-scaling check, from #1580) with an exact per-attribute check via spike #1526's `CombatRating.Marginal` (`Game.Core/Battle/CombatRating.cs`), now that the calibration report (#1533, merged as PR #1579) established the pattern for assembling a representative `Battler` from reference data at a chosen level outside of live battle.

- **Level resolution**: `Contracts.Enemy` carries no level of its own, so `ResolveRatingLevel` rates a live enemy at the arc midpoint of the first live zone it spawns in, or that zone's fixed `BossLevel` if it's the dedicated boss there — the same placement precedent `CombatRatingCalibrationIntegrationTests.BuildPricedEnemyList` uses. An enemy with no live placement has no representative encounter to rate and is skipped (mirroring the calibration report's own omission of unplaced enemies), rather than being checked at a made-up level.
- **Battler assembly**: `BuildRatingBattler`/`ToRatingSkill` build a `Battler` directly from `Contracts.Enemy`/`Contracts.Skill` (every live skill in the enemy's `SkillPool` — the check asks whether anything in the *kit* consumes the attribute, not a random per-encounter draw, matching the prior heuristic's kit). This mirrors `Enemy.ToBattler()`, but can't reuse it or `Game.DataAccess.Mapping.SkillMapper`: `Game.Application` has no reach into the data tier's entity↔domain mapping, and `Game.Core` itself has no dependency on `Game.Abstractions.Contracts` to host a shared mapping instead. So this is a small, local Contracts→Core mapping inside `ProgressionGraphChecker`, scoped to what this check needs.
- **Dead-stat threshold**: attributes whose finite-difference `Marginal` is under `1e-6` are flagged as inert — matching the tolerance `CombatRatingTests` already uses to assert an exactly-dead marginal (`Assert.Equal(0, marginal, 6)`).
- The old `IsConsumedByKit`/`HasStaticDerivation` heuristic helpers are removed — no remaining callers.

## Judgment calls (flagged per this project's convention)

1. **Where the Contracts→Core.Skills.Skill mapping lives.** Since `Game.Core` has zero project references and `Game.Application` can't reach `Game.DataAccess`, this mapping has no natural shared home — I kept it as a private, `ProgressionGraphChecker`-local helper rather than introducing a new shared abstraction for a single caller. Worth revisiting if a second consumer of "Battler from Contracts" ever appears outside the data tier.
2. **Test fixture fix required for real math.** `Enemy_DistributesLuckConsumedByPooledEffectScaling_ProducesNoFinding`'s skill effect never set `Target`/`DurationMs`, which the old structural heuristic didn't care about but which made the effect invisible to `CombatRating` (no target ⇒ folded into neither the effective-caster nor reference-defense pass; zero duration ⇒ zero uptime). Fixed the fixture to set `Target = Self` and a nonzero `DurationMs` so it's a genuine self-buff, per the project's convention of only changing test fixtures when the change reflects reality — the old assertion (not flagged) still holds, now for the right reason.
3. Added one new test (`Enemy_NotPlacedInAnyLiveZone_ProducesNoFinding`) covering the new "no live placement → skip" branch, since it's new domain logic without a prior heuristic equivalent.

## Test plan

- [x] `dotnet build` — whole solution builds clean
- [x] `dotnet test --no-build --no-restore` — full suite passes (2916 tests: Core 1317, Infrastructure 59, Application 851, Api 689), including the updated `ProgressionGraphCheckerTests` (all prior `EnemyInertAttribute` cases still pass under the real rating math) and `ContentGraphLintTests` (the committed `content/*.json` stays lint-clean under the exact check)
- [x] `dotnet format --verify-no-changes` — clean

Closes #1581


---
_Generated by [Claude Code](https://claude.ai/code/session_01S4jY9p8PH1sVo7PpWJAMkV)_