### PR TITLE
Anchored tutorial tour component (coach-marks) (#1592)

### DIFF
--- a/UI/src/components/index.ts
+++ b/UI/src/components/index.ts
@@ -16,3 +16,4 @@ export { default as WordOfPower } from './WordOfPower.svelte';
 export { default as XpBar } from './XpBar.svelte';
 export * from './log-panel';
 export * from './nav-menu';
+export * from './tour';

--- a/UI/src/components/tour/TourPlayer.svelte
+++ b/UI/src/components/tour/TourPlayer.svelte
@@ -1,0 +1,252 @@
+<!--
+	Anchored tutorial tour ("coach-marks"): highlights a registered {@link tutorialAnchor} target and
+	positions a callout beside it with the current step's text and next/back/done controls. Distinct
+	from `Popover` (a container overlay with no target anchoring) — this positions relative to a real
+	on-screen control, and degrades to a centered, unanchored callout when the step names no anchor or
+	the anchor isn't (yet) registered, rather than failing.
+
+	A controlled component: the caller owns `open`/`steps` and is told about early dismissal
+	(`onDismiss` — Escape, backdrop, Skip) versus finishing the last step (`onComplete`) separately, so
+	it can decide what each means for the lesson's read state.
+-->
+{#if open && currentStep}
+	<div class="tour-layer">
+		<button class="tour-backdrop" type="button" tabindex="-1" aria-label="Dismiss tour" onclick={onDismiss}></button>
+
+		{#if spotlightRect}
+			<div
+				class="tour-spotlight"
+				style:top="{spotlightRect.top}px"
+				style:left="{spotlightRect.left}px"
+				style:width="{spotlightRect.width}px"
+				style:height="{spotlightRect.height}px"
+			></div>
+		{/if}
+
+		<div
+			class="tour-callout"
+			class:tour-callout--centered={!calloutPos}
+			role="dialog"
+			aria-modal="true"
+			aria-label={label}
+			data-tour-position={calloutPos ? 'anchored' : 'centered'}
+			tabindex="-1"
+			bind:this={shell}
+			style:top={calloutPos ? `${calloutPos.top}px` : undefined}
+			style:left={calloutPos ? `${calloutPos.left}px` : undefined}
+			use:focusTrap={{ onEscape: onDismiss, scrollLockClass: 'tour-open' }}
+		>
+			<div class="tour-callout__body" bind:this={calloutEl} aria-live="polite">
+				<p class="tour-callout__step">{stepIndex + 1} of {steps.length}</p>
+				<p class="tour-callout__text">{currentStep.text}</p>
+			</div>
+			<div class="tour-callout__controls">
+				<button class="tour-callout__skip" type="button" onclick={onDismiss}>Skip</button>
+				<div class="tour-callout__nav">
+					<button type="button" disabled={isFirst} onclick={goBack}>Back</button>
+					{#if isLast}
+						<button type="button" onclick={onComplete}>Done</button>
+					{:else}
+						<button type="button" onclick={goNext}>Next</button>
+					{/if}
+				</div>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<script lang="ts">
+import { focusTrap, FOCUSABLE_SELECTOR } from '../focus-trap';
+import { getTutorialAnchor } from './tutorial-anchor';
+import type { TourStep } from './tour-types';
+
+interface Props {
+	/** Whether the tour is shown. */
+	open: boolean;
+	/** The tour's ordered steps. Resets to the first step whenever `open` transitions to `true`. */
+	steps: TourStep[];
+	/** Accessible name for the dialog (e.g. the lesson's display name). */
+	label: string;
+	/** Called on early dismissal — Escape, backdrop click, or the Skip control. */
+	onDismiss: () => void;
+	/** Called when the player finishes the tour via Done on the last step. */
+	onComplete: () => void;
+}
+
+const { open, steps, label, onDismiss, onComplete }: Props = $props();
+
+let stepIndex = $state(0);
+let shell = $state<HTMLElement | null>(null);
+let calloutEl = $state<HTMLElement | null>(null);
+let calloutPos = $state<{ top: number; left: number } | null>(null);
+let spotlightRect = $state<{ top: number; left: number; width: number; height: number } | null>(null);
+
+// A fresh open always starts from the first step; steps changing while already open (not a supported
+// use — reopen per lesson instead) deliberately leaves the current position alone.
+$effect(() => {
+	if (open) {
+		stepIndex = 0;
+	}
+});
+
+const currentStep = $derived(steps[stepIndex] as TourStep | undefined);
+const isFirst = $derived(stepIndex === 0);
+const isLast = $derived(stepIndex === steps.length - 1);
+const anchorEl = $derived(currentStep?.anchorKey ? getTutorialAnchor(currentStep.anchorKey) : undefined);
+
+const goBack = () => {
+	if (!isFirst) {
+		stepIndex -= 1;
+	}
+};
+const goNext = () => {
+	if (!isLast) {
+		stepIndex += 1;
+	}
+};
+
+// Recomputed on resize so a viewport change while the tour is open doesn't leave it pointing at a
+// stale rect (getBoundingClientRect is a snapshot, not itself reactive).
+let resizeTick = $state(0);
+$effect(() => {
+	if (!open) {
+		return;
+	}
+	const onResize = () => (resizeTick += 1);
+	window.addEventListener('resize', onResize);
+	return () => window.removeEventListener('resize', onResize);
+});
+
+const GAP = 12;
+const EDGE_PADDING = 8;
+const SPOTLIGHT_PADDING = 6;
+
+$effect(() => {
+	void resizeTick;
+	if (!open || !anchorEl) {
+		spotlightRect = null;
+		calloutPos = null;
+		return;
+	}
+
+	const rect = anchorEl.getBoundingClientRect();
+	spotlightRect = {
+		top: rect.top - SPOTLIGHT_PADDING,
+		left: rect.left - SPOTLIGHT_PADDING,
+		width: rect.width + SPOTLIGHT_PADDING * 2,
+		height: rect.height + SPOTLIGHT_PADDING * 2
+	};
+
+	if (!calloutEl) {
+		return;
+	}
+	const calloutWidth = calloutEl.offsetWidth;
+	const calloutHeight = calloutEl.offsetHeight;
+
+	let top = rect.bottom + GAP;
+	if (top + calloutHeight + EDGE_PADDING > window.innerHeight) {
+		top = rect.top - calloutHeight - GAP;
+	}
+	top = Math.max(EDGE_PADDING, Math.min(top, window.innerHeight - calloutHeight - EDGE_PADDING));
+
+	let left = rect.left + rect.width / 2 - calloutWidth / 2;
+	left = Math.max(EDGE_PADDING, Math.min(left, window.innerWidth - calloutWidth - EDGE_PADDING));
+
+	calloutPos = { top, left };
+});
+
+// On open (and per step, since Back/Next can remount focusable controls), move focus onto the first
+// focusable inside the callout, or the shell itself if it somehow has none. Trap/Escape/scroll-lock/
+// restore are owned by focusTrap.
+$effect(() => {
+	void stepIndex;
+	if (open && shell) {
+		const target = shell.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+		(target ?? shell).focus();
+	}
+});
+</script>
+
+<style lang="scss">
+:global(body.tour-open) {
+	overflow: hidden;
+}
+
+.tour-layer {
+	position: fixed;
+	inset: 0;
+	z-index: 60;
+}
+
+.tour-backdrop {
+	position: absolute;
+	inset: 0;
+	padding: 0;
+	border: none;
+	cursor: pointer;
+	background: color-mix(in srgb, var(--black) 40%, transparent);
+}
+
+.tour-spotlight {
+	position: fixed;
+	border-radius: var(--border-radius);
+	// The oversized box-shadow paints the dimmed backdrop everywhere *except* this box, giving the
+	// highlighted control a cutout without needing an actual clip-path mask.
+	box-shadow:
+		0 0 0 9999px color-mix(in srgb, var(--black) 40%, transparent),
+		0 0 0 2px var(--accent);
+	pointer-events: none;
+}
+
+.tour-callout {
+	position: fixed;
+	max-width: 320px;
+	background: var(--tooltip-bg);
+	border: 1px solid var(--border-light);
+	border-radius: var(--border-radius);
+	box-shadow:
+		0 12px 28px color-mix(in srgb, var(--black) 55%, transparent),
+		0 0 0 1px color-mix(in srgb, var(--black) 40%, transparent);
+	backdrop-filter: blur(6px);
+	color: var(--text-primary);
+	outline: none;
+	padding: 16px;
+
+	&--centered {
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+	}
+}
+
+.tour-callout__step {
+	margin: 0 0 4px;
+	font-size: 0.75rem;
+	color: var(--text-tertiary);
+}
+
+.tour-callout__text {
+	margin: 0 0 12px;
+	line-height: 1.4;
+}
+
+.tour-callout__controls {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+}
+
+.tour-callout__skip {
+	background: none;
+	border: none;
+	color: var(--text-secondary);
+	cursor: pointer;
+	padding: 0;
+}
+
+.tour-callout__nav {
+	display: flex;
+	gap: 8px;
+}
+</style>

--- a/UI/src/components/tour/TourPlayer.svelte
+++ b/UI/src/components/tour/TourPlayer.svelte
@@ -36,7 +36,7 @@
 			style:left={calloutPos ? `${calloutPos.left}px` : undefined}
 			use:focusTrap={{ onEscape: onDismiss, scrollLockClass: 'tour-open' }}
 		>
-			<div class="tour-callout__body" bind:this={calloutEl} aria-live="polite">
+			<div class="tour-callout__body" aria-live="polite">
 				<p class="tour-callout__step">{stepIndex + 1} of {steps.length}</p>
 				<p class="tour-callout__text">{currentStep.text}</p>
 			</div>
@@ -77,7 +77,6 @@ const { open, steps, label, onDismiss, onComplete }: Props = $props();
 
 let stepIndex = $state(0);
 let shell = $state<HTMLElement | null>(null);
-let calloutEl = $state<HTMLElement | null>(null);
 let calloutPos = $state<{ top: number; left: number } | null>(null);
 let spotlightRect = $state<{ top: number; left: number; width: number; height: number } | null>(null);
 
@@ -137,11 +136,13 @@ $effect(() => {
 		height: rect.height + SPOTLIGHT_PADDING * 2
 	};
 
-	if (!calloutEl) {
+	if (!shell) {
 		return;
 	}
-	const calloutWidth = calloutEl.offsetWidth;
-	const calloutHeight = calloutEl.offsetHeight;
+	// Measure the positioned shell itself (padding + border included), not the inner text body —
+	// otherwise the box is under-reported by the shell's own padding/border on every side.
+	const calloutWidth = shell.offsetWidth;
+	const calloutHeight = shell.offsetHeight;
 
 	let top = rect.bottom + GAP;
 	if (top + calloutHeight + EDGE_PADDING > window.innerHeight) {

--- a/UI/src/components/tour/index.ts
+++ b/UI/src/components/tour/index.ts
@@ -1,0 +1,3 @@
+export { default as TourPlayer } from './TourPlayer.svelte';
+export { tutorialAnchor, getTutorialAnchor } from './tutorial-anchor';
+export type { TourStep } from './tour-types';

--- a/UI/src/components/tour/tour-types.ts
+++ b/UI/src/components/tour/tour-types.ts
@@ -1,0 +1,12 @@
+/**
+ * A single step of an anchored tutorial tour ({@link TourPlayer}). Mirrors the shape `LessonStep`
+ * (#1591, backend reference data) will carry — `text` plus an optional `anchorKey` — so the player
+ * can be built and tested ahead of that entity landing; a real `LessonStep` maps onto this directly
+ * (its `ordinal` is just this array's position).
+ */
+export interface TourStep {
+	/** The step's callout copy. */
+	text: string;
+	/** Key registered via {@link tutorialAnchor}. Omitted (or unregistered) degrades to a centered callout. */
+	anchorKey?: string;
+}

--- a/UI/src/components/tour/tutorial-anchor.ts
+++ b/UI/src/components/tour/tutorial-anchor.ts
@@ -1,0 +1,48 @@
+import { SvelteMap } from 'svelte/reactivity';
+
+/**
+ * Registry of tour anchor targets, keyed by a stable string (`anchorKey`) rather than a DOM selector —
+ * lesson steps reference the key, so the target markup can move/restyle without breaking a tour.
+ * Registration goes through the {@link tutorialAnchor} action; {@link TourPlayer} reads it reactively
+ * via {@link getTutorialAnchor} to resolve (or fail to resolve) the current step's target.
+ *
+ * Keyed by string rather than a per-registration id (mirroring `tooltipsData`'s id-keyed map): unlike
+ * the tooltip case, only one element should ever claim a given anchor key at a time, so the destroy
+ * guard below (only unregister if this node is still the one on file) is the simpler analogue of that
+ * same overlapping-mount/unmount hazard.
+ */
+const anchors = new SvelteMap<string, HTMLElement>();
+
+/** The registered element for `key`, or `undefined` if nothing (yet) claims it. Reactive. */
+export const getTutorialAnchor = (key: string): HTMLElement | undefined => anchors.get(key);
+
+/**
+ * Registers `node` as the tour anchor target for `key` for as long as the element using the action
+ * stays mounted. Attach with `use:tutorialAnchor={'skill-bar'}` on any real UI control a tour step
+ * should point at.
+ */
+export function tutorialAnchor(node: HTMLElement, key: string) {
+	let currentKey = key;
+	anchors.set(currentKey, node);
+
+	return {
+		update(nextKey: string) {
+			if (nextKey === currentKey) {
+				return;
+			}
+			if (anchors.get(currentKey) === node) {
+				anchors.delete(currentKey);
+			}
+			currentKey = nextKey;
+			anchors.set(currentKey, node);
+		},
+		destroy() {
+			// Only clear the slot if it's still this element — a second mount for the same key (e.g. an
+			// overlapping screen transition) may have already replaced it, and that registration owns the
+			// slot now.
+			if (anchors.get(currentKey) === node) {
+				anchors.delete(currentKey);
+			}
+		}
+	};
+}

--- a/UI/src/tests/components/tour/TourPlayer.test.ts
+++ b/UI/src/tests/components/tour/TourPlayer.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import TourPlayer from '$components/tour/TourPlayer.svelte';
+import { tutorialAnchor } from '$components/tour/tutorial-anchor';
+import type { TourStep } from '$components/tour/tour-types';
+
+afterEach(() => {
+	cleanup();
+	document.body.classList.remove('tour-open');
+});
+
+const threeSteps: TourStep[] = [{ text: 'Step one' }, { text: 'Step two' }, { text: 'Step three' }];
+
+const setup = (steps: TourStep[], overrides: Partial<{ open: boolean }> = {}) => {
+	const onDismiss = vi.fn();
+	const onComplete = vi.fn();
+	const result = render(TourPlayer, {
+		props: { open: overrides.open ?? true, steps, label: 'Test tour', onDismiss, onComplete }
+	});
+	return { ...result, onDismiss, onComplete };
+};
+
+describe('TourPlayer', () => {
+	it('renders nothing while closed', () => {
+		const { container } = setup(threeSteps, { open: false });
+		expect(container.querySelector('.tour-callout')).toBeNull();
+	});
+
+	it('shows the first step with a 1-based step counter', () => {
+		const { getByText } = setup(threeSteps);
+		expect(getByText('1 of 3')).toBeTruthy();
+		expect(getByText('Step one')).toBeTruthy();
+	});
+
+	it('degrades to a centered callout when the step has no anchorKey', async () => {
+		const { container } = setup(threeSteps);
+		await tick();
+		const callout = container.querySelector('.tour-callout') as HTMLElement;
+		expect(callout.getAttribute('data-tour-position')).toBe('centered');
+	});
+
+	it('degrades to a centered callout when the anchorKey is not registered', async () => {
+		const { container } = setup([{ text: 'Dangling anchor', anchorKey: 'never-registered' }]);
+		await tick();
+		const callout = container.querySelector('.tour-callout') as HTMLElement;
+		expect(callout.getAttribute('data-tour-position')).toBe('centered');
+	});
+
+	it('positions as anchored when the step names a registered anchor', async () => {
+		const anchorEl = document.createElement('button');
+		document.body.appendChild(anchorEl);
+		const action = tutorialAnchor(anchorEl, 'skill-bar');
+
+		const { container } = setup([{ text: 'Look here', anchorKey: 'skill-bar' }]);
+		await tick();
+		const callout = container.querySelector('.tour-callout') as HTMLElement;
+		expect(callout.getAttribute('data-tour-position')).toBe('anchored');
+		expect(container.querySelector('.tour-spotlight')).not.toBeNull();
+
+		action.destroy();
+		anchorEl.remove();
+	});
+
+	it('navigates forward and back, disabling Back on the first step', async () => {
+		const { getByText, getByRole } = setup(threeSteps);
+
+		const back = getByRole('button', { name: 'Back' }) as HTMLButtonElement;
+		expect(back.disabled).toBe(true);
+
+		await fireEvent.click(getByRole('button', { name: 'Next' }));
+		expect(getByText('2 of 3')).toBeTruthy();
+		expect(back.disabled).toBe(false);
+
+		await fireEvent.click(back);
+		expect(getByText('1 of 3')).toBeTruthy();
+	});
+
+	it('shows Done instead of Next on the last step and calls onComplete', async () => {
+		const { getByText, getByRole, onComplete } = setup(threeSteps);
+
+		await fireEvent.click(getByRole('button', { name: 'Next' }));
+		await fireEvent.click(getByRole('button', { name: 'Next' }));
+		expect(getByText('3 of 3')).toBeTruthy();
+		expect(() => getByRole('button', { name: 'Next' })).toThrow();
+
+		await fireEvent.click(getByRole('button', { name: 'Done' }));
+		expect(onComplete).toHaveBeenCalledTimes(1);
+	});
+
+	it('calls onDismiss on Escape, backdrop click, and Skip', async () => {
+		const { container, getByRole, onDismiss } = setup(threeSteps);
+
+		await fireEvent.keyDown(window, { key: 'Escape' });
+		expect(onDismiss).toHaveBeenCalledTimes(1);
+
+		await fireEvent.click(container.querySelector('.tour-backdrop')!);
+		expect(onDismiss).toHaveBeenCalledTimes(2);
+
+		await fireEvent.click(getByRole('button', { name: 'Skip' }));
+		expect(onDismiss).toHaveBeenCalledTimes(3);
+	});
+
+	it('restores focus to the prior element once dismissed', async () => {
+		const outside = document.createElement('button');
+		document.body.appendChild(outside);
+		outside.focus();
+		expect(document.activeElement).toBe(outside);
+
+		const { rerender } = setup(threeSteps, { open: false });
+		await rerender({ open: true, steps: threeSteps, label: 'Test tour', onDismiss: vi.fn(), onComplete: vi.fn() });
+		await tick();
+		expect(document.activeElement).not.toBe(outside);
+
+		await rerender({ open: false, steps: threeSteps, label: 'Test tour', onDismiss: vi.fn(), onComplete: vi.fn() });
+		await tick();
+		expect(document.activeElement).toBe(outside);
+		outside.remove();
+	});
+
+	it('resets to the first step each time it reopens', async () => {
+		const { getByText, getByRole, rerender } = setup(threeSteps);
+
+		await fireEvent.click(getByRole('button', { name: 'Next' }));
+		expect(getByText('2 of 3')).toBeTruthy();
+
+		await rerender({ open: false, steps: threeSteps, label: 'Test tour', onDismiss: vi.fn(), onComplete: vi.fn() });
+		await rerender({ open: true, steps: threeSteps, label: 'Test tour', onDismiss: vi.fn(), onComplete: vi.fn() });
+		await tick();
+		expect(getByText('1 of 3')).toBeTruthy();
+	});
+});

--- a/UI/src/tests/components/tour/tutorial-anchor.test.ts
+++ b/UI/src/tests/components/tour/tutorial-anchor.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { tutorialAnchor, getTutorialAnchor } from '$components/tour/tutorial-anchor';
+
+const makeNode = () => document.createElement('div');
+
+describe('tutorialAnchor', () => {
+	it('registers a node under its key and resolves it via getTutorialAnchor', () => {
+		const node = makeNode();
+		const action = tutorialAnchor(node, 'skill-bar');
+		expect(getTutorialAnchor('skill-bar')).toBe(node);
+		action.destroy();
+	});
+
+	it('returns undefined for an unregistered key', () => {
+		expect(getTutorialAnchor('never-registered')).toBeUndefined();
+	});
+
+	it('unregisters on destroy', () => {
+		const node = makeNode();
+		const action = tutorialAnchor(node, 'help-button');
+		action.destroy();
+		expect(getTutorialAnchor('help-button')).toBeUndefined();
+	});
+
+	it('moves registration to the new key on update', () => {
+		const node = makeNode();
+		const action = tutorialAnchor(node, 'old-key');
+		action.update('new-key');
+		expect(getTutorialAnchor('old-key')).toBeUndefined();
+		expect(getTutorialAnchor('new-key')).toBe(node);
+		action.destroy();
+	});
+
+	it('update is a no-op when the key is unchanged', () => {
+		const node = makeNode();
+		const action = tutorialAnchor(node, 'same-key');
+		action.update('same-key');
+		expect(getTutorialAnchor('same-key')).toBe(node);
+		action.destroy();
+	});
+
+	it('does not clobber a second element that already claimed the key on destroy of the first', () => {
+		const first = makeNode();
+		const second = makeNode();
+		const firstAction = tutorialAnchor(first, 'shared-key');
+		// Simulates an overlapping screen transition: a second mount claims the key before the first's
+		// destroy runs.
+		const secondAction = tutorialAnchor(second, 'shared-key');
+		expect(getTutorialAnchor('shared-key')).toBe(second);
+
+		firstAction.destroy();
+		// The first mount's destroy must not delete the second mount's registration.
+		expect(getTutorialAnchor('shared-key')).toBe(second);
+
+		secondAction.destroy();
+		expect(getTutorialAnchor('shared-key')).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Implements #1592 (spike #1392, revised direction): the anchored popover "coach-marks" tour player, built ahead of #1591 (the `Lesson`/`LessonStep` reference-data entity) landing — the issue explicitly calls this out as buildable against a typed shape before that entity exists.

- **`TourPlayer.svelte`** (`UI/src/components/tour/`): highlights a registered anchor target with a spotlight cutout (an oversized `box-shadow` trick — no `clip-path` mask needed) and positions a callout beside it with the step's text, a 1-based step counter, and Back/Next/Done controls. Edge-aware positioning (flips above the anchor if there's no room below, clamps to the viewport) recomputes on window resize. Degrades to a centered, unanchored callout when the current step has no `anchorKey` or the key isn't (yet) registered.
- **`tutorial-anchor.ts`**: the `tutorialAnchor` Svelte action (`use:tutorialAnchor={'skill-bar'}`) registers a DOM element under a stable string key in a reactive `SvelteMap`; `getTutorialAnchor(key)` resolves it. The destroy guard only clears a key's slot if the destroying element still owns it — the same overlapping-mount/unmount hazard the existing tooltip registry's id-keyed map documents, here guarded by identity instead since only one element should claim a given anchor key at a time.
- **`tour-types.ts`**: a local `TourStep` (`{ text, anchorKey? }`) shape mirroring the future `LessonStep`, so lesson steps map onto it directly (`ordinal` is just array position) once #1591 lands.
- Reuses the shared `focusTrap` action (Escape, Tab-trap, scroll-lock, focus capture/restore) from the `Popover`/`ModalHost` overlay family, per `docs/frontend-overlays.md`.

## Scope notes / judgment calls

- **Not wired up anywhere yet.** This issue is scoped to the component + anchor action only; the trigger-evaluation/open-flow layer that will actually invoke it with real lesson content is #1587 (blocked on #1591, which is still open as of this PR), and the Help screen consumer is #1589. `TourPlayer` is a fully controlled component (`open`/`steps`/`onDismiss`/`onComplete`) so either can drive it once they land.
- **`onDismiss` vs `onComplete` are separate callbacks**, mirroring `Modal`'s `onConfirm`/`onCancel` split rather than a single dismissal callback — early exit (Escape/backdrop/Skip) and finishing the last step via Done are different signals for the lesson's read state (#1588), and that distinction belongs to the caller, not this component.
- **The anchor-resolution test is fixture-based, not seeded-lesson-based**, since `content/lessons.json` doesn't exist yet (#1591 unmerged). `TourPlayer.test.ts` registers a plain `tutorialAnchor` fixture and asserts the anchored/centered branches; the real "every anchorKey referenced by seeded lessons resolves to a registered anchor" lint test the issue asks for needs actual lesson content and is left for whichever of #1587/#1589/#1605 first has real seeded steps to test against.
- No global store/host (à la `modal.svelte.ts`/`ModalHost`) is added — how tours queue and get triggered is a design decision that belongs to #1587 ("trigger evaluation"), not this issue.

## Test plan

- [x] New unit tests: `TourPlayer.test.ts` (rendering, step navigation, Back-disabled-on-first-step, Done-replaces-Next-on-last-step, anchored vs. centered positioning, Escape/backdrop/Skip dismissal, focus restore, reset-to-first-step on reopen) and `tutorial-anchor.test.ts` (register/resolve, unregister, key-change via `update`, no-op on unchanged key, destroy-guard against a second claimant)
- [x] `npm run lint` (ESLint + svelte-check) — clean
- [x] `npm run test:unit:ci` — full suite passes (290 files / 3416 tests); `components/tour` coverage (97.32% lines / 79.62% branches / 96% functions / 96.29% statements) clears the `src/components/**` floor

Closes #1592


---
_Generated by [Claude Code](https://claude.ai/code/session_01SfUnvKTqDuGLRGuP4usgj3)_