### PR TITLE
Drive the logical engine from a Web Worker tick source (#1594)

### DIFF
--- a/UI/src/lib/engine/logical-engine.ts
+++ b/UI/src/lib/engine/logical-engine.ts
@@ -1,11 +1,11 @@
 import { createHook, getEventCounter } from '$lib/common';
 import { MS_PER_TICK } from '$lib/api/types/game-constants';
+import { createTickSource, type TickSource } from './tick-source';
 
 // The logical tick size in ms — generated from the backend GameConstants so it can never drift
 // from the simulation the server replays (battle parity depends on it).
 export const tickSize = MS_PER_TICK;
 const tickSizeX5 = tickSize * 5;
-const pollingIntervalMs = 10;
 
 const logicalUpdateHook = createHook<[number]>();
 const notifyLogicalUpdate = logicalUpdateHook.notify;
@@ -24,26 +24,26 @@ export class LogicalEngine {
 	private lastTime = 0;
 	private timeBank = 0;
 	private countTick = getEventCounter((t) => (this.tickRate = Math.round(t)));
-	private tickHandle = 0;
+	private tickSource?: TickSource;
 
 	public start() {
-		if (this.tickHandle) {
+		if (this.tickSource) {
 			return;
 		}
 
 		this.lastTime = performance.now();
 		this.time = this.lastTime;
 
-		this.tickHandle = window.setInterval(() => this.logicLoop(), pollingIntervalMs);
+		this.tickSource = createTickSource(() => this.logicLoop());
 	}
 
 	public stop() {
-		if (!this.tickHandle) {
+		if (!this.tickSource) {
 			return;
 		}
 
-		window.clearInterval(this.tickHandle);
-		this.tickHandle = 0;
+		this.tickSource.stop();
+		this.tickSource = undefined;
 		this.lastTime = 0;
 		this.timeBank = 0;
 		this.time = 0;

--- a/UI/src/lib/engine/tick-source.ts
+++ b/UI/src/lib/engine/tick-source.ts
@@ -13,6 +13,7 @@ export function createTickSource(onTick: () => void): TickSource {
 	if (typeof Worker !== 'undefined') {
 		const worker = new Worker(new URL('./tick-worker.ts', import.meta.url), { type: 'module' });
 		worker.onmessage = () => onTick();
+		worker.onerror = (ev) => console.error('The logical engine tick worker failed', ev);
 		return {
 			stop: () => worker.terminate()
 		};

--- a/UI/src/lib/engine/tick-source.ts
+++ b/UI/src/lib/engine/tick-source.ts
@@ -1,0 +1,25 @@
+// Dedicated-worker timers are not throttled when the tab is hidden (unlike page timers), so
+// driving the logical engine's polling loop from a worker is what keeps a backgrounded character's
+// simulation ticking at full rate instead of falling behind wall-clock. Environments without
+// `Worker` (SSR, jsdom unit tests) fall back to `window.setInterval` — that fallback also doubles
+// as the unit-test seam, since `LogicalEngine` itself has no environment branching.
+export const pollingIntervalMs = 10;
+
+export interface TickSource {
+	stop(): void;
+}
+
+export function createTickSource(onTick: () => void): TickSource {
+	if (typeof Worker !== 'undefined') {
+		const worker = new Worker(new URL('./tick-worker.ts', import.meta.url), { type: 'module' });
+		worker.onmessage = () => onTick();
+		return {
+			stop: () => worker.terminate()
+		};
+	}
+
+	const handle = window.setInterval(onTick, pollingIntervalMs);
+	return {
+		stop: () => window.clearInterval(handle)
+	};
+}

--- a/UI/src/lib/engine/tick-worker.ts
+++ b/UI/src/lib/engine/tick-worker.ts
@@ -1,0 +1,6 @@
+// Dedicated module worker driving `LogicalEngine`'s tick source (see `tick-source.ts`). A worker's
+// own timers keep running at full rate while the page is hidden, and posting a message to a hidden
+// page is not throttled either — so this is the whole fix for background-tab throttling.
+import { pollingIntervalMs } from './tick-source';
+
+setInterval(() => postMessage(null), pollingIntervalMs);

--- a/UI/src/tests/lib/engine/tick-source.test.ts
+++ b/UI/src/tests/lib/engine/tick-source.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { createTickSource, pollingIntervalMs } from '$lib/engine/tick-source';
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+describe('createTickSource', () => {
+	it('falls back to window.setInterval when Worker is unavailable (the jsdom/SSR case)', () => {
+		vi.stubGlobal('Worker', undefined);
+		vi.useFakeTimers();
+
+		const onTick = vi.fn();
+		const source = createTickSource(onTick);
+
+		vi.advanceTimersByTime(pollingIntervalMs * 3);
+		expect(onTick.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+		const callCount = onTick.mock.calls.length;
+		source.stop();
+		vi.advanceTimersByTime(pollingIntervalMs * 5);
+		expect(onTick).toHaveBeenCalledTimes(callCount);
+	});
+
+	it('drives ticks from a Worker and terminates it on stop when Worker is available', () => {
+		class MockWorker {
+			static instances: MockWorker[] = [];
+			public onmessage: (() => void) | null = null;
+			public terminate = vi.fn();
+
+			constructor(
+				public url: URL,
+				public options: unknown
+			) {
+				MockWorker.instances.push(this);
+			}
+		}
+		vi.stubGlobal('Worker', MockWorker);
+
+		const onTick = vi.fn();
+		const source = createTickSource(onTick);
+
+		expect(MockWorker.instances).toHaveLength(1);
+		const worker = MockWorker.instances[0];
+		expect(worker.options).toEqual({ type: 'module' });
+		expect(worker.url.pathname).toContain('tick-worker');
+
+		worker.onmessage?.();
+		worker.onmessage?.();
+		expect(onTick).toHaveBeenCalledTimes(2);
+
+		source.stop();
+		expect(worker.terminate).toHaveBeenCalledTimes(1);
+	});
+});

--- a/UI/src/tests/lib/engine/tick-source.test.ts
+++ b/UI/src/tests/lib/engine/tick-source.test.ts
@@ -24,19 +24,25 @@ describe('createTickSource', () => {
 		expect(onTick).toHaveBeenCalledTimes(callCount);
 	});
 
-	it('drives ticks from a Worker and terminates it on stop when Worker is available', () => {
-		class MockWorker {
-			static instances: MockWorker[] = [];
-			public onmessage: (() => void) | null = null;
-			public terminate = vi.fn();
+	class MockWorker {
+		static instances: MockWorker[] = [];
+		public onmessage: (() => void) | null = null;
+		public onerror: ((ev: unknown) => void) | null = null;
+		public terminate = vi.fn();
 
-			constructor(
-				public url: URL,
-				public options: unknown
-			) {
-				MockWorker.instances.push(this);
-			}
+		constructor(
+			public url: URL,
+			public options: unknown
+		) {
+			MockWorker.instances.push(this);
 		}
+	}
+
+	afterEach(() => {
+		MockWorker.instances = [];
+	});
+
+	it('drives ticks from a Worker and terminates it on stop when Worker is available', () => {
 		vi.stubGlobal('Worker', MockWorker);
 
 		const onTick = vi.fn();
@@ -53,5 +59,17 @@ describe('createTickSource', () => {
 
 		source.stop();
 		expect(worker.terminate).toHaveBeenCalledTimes(1);
+	});
+
+	it('logs a diagnosable error instead of silently stalling if the worker fails', () => {
+		vi.stubGlobal('Worker', MockWorker);
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		createTickSource(vi.fn());
+		const worker = MockWorker.instances[0];
+		worker.onerror?.(new ErrorEvent('error', { message: 'boom' }));
+
+		expect(errorSpy).toHaveBeenCalledTimes(1);
+		errorSpy.mockRestore();
 	});
 });


### PR DESCRIPTION
## Summary

Implements #1594 (spike #1073, Decision 1): replaces `LogicalEngine`'s `window.setInterval` tick source with a dedicated module worker.

- **`tick-source.ts`** (new): `createTickSource(onTick)` returns a `{ stop() }` handle. When `Worker` is available it spins up `tick-worker.ts` as a module worker and drives `onTick` from `worker.onmessage`; when it isn't (SSR, jsdom unit tests) it falls back to `window.setInterval` — the fallback is also the unit-test seam the issue asked for.
- **`tick-worker.ts`** (new): the worker entry point — `setInterval(() => postMessage(null), pollingIntervalMs)`. Dedicated-worker timers aren't throttled in Chromium/Firefox, and `postMessage` delivery to a hidden page isn't throttled either, so the engine keeps ticking at full rate while the tab is backgrounded instead of falling behind and hitting the `tickSizeX5` catch-up clamp.
- **`logical-engine.ts`**: `start()`/`stop()` now delegate to a `TickSource` instead of managing a raw interval handle directly. `logicLoop`/`update` are unchanged — deltas are still measured via `performance.now()`, and the catch-up clamp + `onIdleTimeLost` remain as the safety valve/instrumentation for what a worker can't cover (page freeze/discard, Safari tab suspension), per the spike's Decision 1.
- `BackgroundThrottleMonitor` (#1074) needs no change — it self-gates on `onIdleTimeLost`, which naturally stops firing while hidden wherever the worker trick works.

## Test plan

- [x] New `tick-source.test.ts`: covers both branches — Worker unavailable (fallback to `window.setInterval`, verified via `vi.useFakeTimers`) and Worker available (mocked `Worker` class asserting construction args, tick delivery via `onmessage`, and `terminate()` on stop).
- [x] Existing `logical-engine.test.ts` passes unchanged — jsdom has no global `Worker`, so it continues to exercise the fallback path.
- [x] `npm run lint` (ESLint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — full suite passes, coverage thresholds met.
- [x] `npm run build` — confirms Vite's worker plugin picks up `new Worker(new URL('./tick-worker.ts', import.meta.url))` and emits a dedicated worker chunk (`_app/immutable/workers/tick-worker-*.js`).

Closes #1594


---
_Generated by [Claude Code](https://claude.ai/code/session_01TNkTVtHjz7kqRtZR16J2Wc)_