### PR TITLE
Fix TourPlayer stealing keyboard focus to Skip on step change

### DIFF
--- a/UI/src/components/tour/TourPlayer.svelte
+++ b/UI/src/components/tour/TourPlayer.svelte
@@ -45,9 +45,9 @@
 				<div class="tour-callout__nav">
 					<button type="button" disabled={isFirst} onclick={goBack}>Back</button>
 					{#if isLast}
-						<button type="button" onclick={onComplete}>Done</button>
+						<button type="button" bind:this={primaryButton} onclick={onComplete}>Done</button>
 					{:else}
-						<button type="button" onclick={goNext}>Next</button>
+						<button type="button" bind:this={primaryButton} onclick={goNext}>Next</button>
 					{/if}
 				</div>
 			</div>
@@ -56,7 +56,7 @@
 {/if}
 
 <script lang="ts">
-import { focusTrap, FOCUSABLE_SELECTOR } from '../focus-trap';
+import { focusTrap } from '../focus-trap';
 import { getTutorialAnchor } from './tutorial-anchor';
 import type { TourStep } from './tour-types';
 
@@ -77,6 +77,7 @@ const { open, steps, label, onDismiss, onComplete }: Props = $props();
 
 let stepIndex = $state(0);
 let shell = $state<HTMLElement | null>(null);
+let primaryButton = $state<HTMLButtonElement | null>(null);
 let calloutPos = $state<{ top: number; left: number } | null>(null);
 let spotlightRect = $state<{ top: number; left: number; width: number; height: number } | null>(null);
 
@@ -156,14 +157,14 @@ $effect(() => {
 	calloutPos = { top, left };
 });
 
-// On open (and per step, since Back/Next can remount focusable controls), move focus onto the first
-// focusable inside the callout, or the shell itself if it somehow has none. Trap/Escape/scroll-lock/
-// restore are owned by focusTrap.
+// Initial focus lands on the primary action (Next/Done) rather than the first focusable control
+// (Skip), so a keyboard user driving the tour via Enter is never bounced onto Skip. `primaryButton`
+// is a fresh DOM node only when Next/Done swap (isLast flips) — not on every step within the same
+// Next/Back pair — so this naturally leaves focus wherever the user already put it (e.g. clicked
+// Back) undisturbed. Trap/Escape/scroll-lock/restore are owned by focusTrap.
 $effect(() => {
-	void stepIndex;
-	if (open && shell) {
-		const target = shell.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
-		(target ?? shell).focus();
+	if (open) {
+		(primaryButton ?? shell)?.focus();
 	}
 });
 </script>

--- a/UI/src/tests/components/tour/TourPlayer.test.ts
+++ b/UI/src/tests/components/tour/TourPlayer.test.ts
@@ -119,6 +119,34 @@ describe('TourPlayer', () => {
 		outside.remove();
 	});
 
+	it('focuses the primary action (Next) on open, not Skip', async () => {
+		const { getByRole } = setup(threeSteps);
+		await tick();
+		expect(document.activeElement).toBe(getByRole('button', { name: 'Next' }));
+	});
+
+	it('does not steal focus back to Skip when advancing steps', async () => {
+		const { getByRole } = setup(threeSteps);
+		await tick();
+
+		const next = getByRole('button', { name: 'Next' }) as HTMLButtonElement;
+		next.focus();
+		await fireEvent.click(next);
+		await tick();
+
+		expect(document.activeElement).toBe(next);
+	});
+
+	it('moves focus onto Done when the last step swaps Next for Done', async () => {
+		const { getByRole } = setup(threeSteps);
+
+		await fireEvent.click(getByRole('button', { name: 'Next' }));
+		await fireEvent.click(getByRole('button', { name: 'Next' }));
+		await tick();
+
+		expect(document.activeElement).toBe(getByRole('button', { name: 'Done' }));
+	});
+
 	it('resets to the first step each time it reopens', async () => {
 		const { getByText, getByRole, rerender } = setup(threeSteps);
 


### PR DESCRIPTION
## Summary

`TourPlayer.svelte`'s per-step focus `$effect` re-ran on every `stepIndex` change and moved focus to the **first** focusable element in the callout, which is the **Skip** button. A keyboard user advancing the tour by pressing Enter on **Next** was bounced back to **Skip** on every step transition — a poor and slightly hazardous keyboard flow.

## Fix

- Bound a `primaryButton` ref to whichever of **Next**/**Done** is currently rendered and retarget the focus effect at it instead of "first focusable via `FOCUSABLE_SELECTOR`".
- Because the same `Next` button DOM node persists across `Next` → `Next` transitions (Svelte only creates a new node when the `{#if isLast}` branch flips to `Done`), the effect no longer needlessly re-fires on every step — focus naturally stays wherever the user last put it (e.g. on `Next`, or on `Back` if they clicked it).
- The effect still re-anchors focus when `Next` swaps for `Done` (a genuinely new DOM node that would otherwise lose focus), and still sets initial focus on open — now onto the primary action rather than Skip.
- Removed the now-unused `FOCUSABLE_SELECTOR` import.
- Capture/restore of focus on open/close (owned by the shared `focusTrap`) is unchanged.

## Test plan

- [x] Added unit tests: focuses `Next` on open (not `Skip`), does not steal focus back on step advance, and moves focus onto `Done` when it swaps in for `Next`.
- [x] `npx vitest run src/tests/components/tour/TourPlayer.test.ts` — 13/13 passing
- [x] `npm run lint` — clean
- [x] `npm run test:unit:ci` — full suite, 3434/3434 passing

Closes #1613


---
_Generated by [Claude Code](https://claude.ai/code/session_01XePrcm1mua9jfX3YyfzoRP)_