### PR TITLE
Lesson state persistence: server-side PlayerLessons

### DIFF
--- a/Game.Abstractions/DataAccess/ILessons.cs
+++ b/Game.Abstractions/DataAccess/ILessons.cs
@@ -9,6 +9,9 @@ namespace Game.Abstractions.DataAccess
         /// <summary>Every lesson — the reference set the loading screen and the Help screen render from.</summary>
         List<Contracts.Lesson> AllLessons();
 
+        /// <inheritdoc cref="IItemMods.ValidateItemModId"/>
+        bool ValidateLessonId(int lessonId);
+
         /// <inheritdoc cref="IItems.VersionKey"/>
         object VersionKey { get; }
     }

--- a/Game.Api.Tests/Integration/MarkLessonReadSocketTests.cs
+++ b/Game.Api.Tests/Integration/MarkLessonReadSocketTests.cs
@@ -1,0 +1,111 @@
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    [Collection("Integration")]
+    public class MarkLessonReadSocketTests : ApiIntegrationTestBase
+    {
+        private const string Username = "marklessonreaduser";
+        private const string Password = "marklessonreadpass";
+
+        private async Task<(int UserId, int PlayerId, int LessonId)> SeedPlayerAndLessonAsync(bool unlocked)
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var lesson = await TestDataSeeder.CreateLessonAsync(context);
+            var user = await TestDataSeeder.CreateUserAsync(context, Username, Password);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+            if (unlocked)
+            {
+                await TestDataSeeder.AddPlayerLessonAsync(context, player.Id, lesson.Id);
+            }
+
+            // The caches no longer lazily refill, so reload them to resolve the seeded lesson id.
+            await ReloadReferenceCachesAsync();
+
+            return (user.Id, player.Id, lesson.Id);
+        }
+
+        public MarkLessonReadSocketTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper) : base(containers, testOutputHelper) { }
+
+        [Fact]
+        public async Task MarkLessonRead_PreviouslyUnlocked_SetsReadAt()
+        {
+            var (userId, playerId, lessonId) = await SeedPlayerAndLessonAsync(unlocked: true);
+            await LoginAsync(Username, Password);
+
+            await using var socketClient = new TestSocketClient();
+            var wsClient = Factory.Server.CreateWebSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+
+            var response = await socketClient.SendCommandRawAsync("MarkLessonRead", lessonId);
+
+            Assert.Null(response.Error);
+
+            var lessons = await WaitForReadAsync(playerId, lessonId);
+            Assert.NotNull(lessons.Single(l => l.LessonId == lessonId).ReadAt);
+        }
+
+        [Fact]
+        public async Task MarkLessonRead_NeverUnlocked_NormalizesToReadWithoutError()
+        {
+            // A screen-anchored lesson plays immediately on first visit with no prior UnlockLesson call.
+            var (userId, playerId, lessonId) = await SeedPlayerAndLessonAsync(unlocked: false);
+            await LoginAsync(Username, Password);
+
+            await using var socketClient = new TestSocketClient();
+            var wsClient = Factory.Server.CreateWebSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+
+            var response = await socketClient.SendCommandRawAsync("MarkLessonRead", lessonId);
+
+            Assert.Null(response.Error);
+
+            var lessons = await WaitForReadAsync(playerId, lessonId);
+            var persisted = lessons.Single(l => l.LessonId == lessonId);
+            Assert.NotEqual(default, persisted.UnlockedAt);
+            Assert.NotNull(persisted.ReadAt);
+        }
+
+        [Fact]
+        public async Task MarkLessonRead_UnknownLessonId_ReturnsError()
+        {
+            var (userId, _, _) = await SeedPlayerAndLessonAsync(unlocked: false);
+            await LoginAsync(Username, Password);
+
+            await using var socketClient = new TestSocketClient();
+            var wsClient = Factory.Server.CreateWebSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+
+            var response = await socketClient.SendCommandRawAsync("MarkLessonRead", 9999);
+
+            Assert.NotNull(response.Error);
+        }
+
+        /// <summary>
+        /// The command writes the cached player fire-and-forget, so poll the player snapshot until the
+        /// expected read timestamp lands (or fail after a short budget).
+        /// </summary>
+        private async Task<List<Game.Api.Models.Player.PlayerLesson>> WaitForReadAsync(int playerId, int lessonId)
+        {
+            for (var attempt = 0; attempt < 20; attempt++)
+            {
+                var lessons = (await GetPersistedPlayerAsync(playerId)).Lessons;
+                if (lessons.Any(l => l.LessonId == lessonId && l.ReadAt is not null))
+                {
+                    return lessons;
+                }
+
+                await Task.Delay(50, CancellationToken);
+            }
+
+            Assert.Fail($"Lesson {lessonId} was not marked read in time.");
+            return [];
+        }
+    }
+}

--- a/Game.Api.Tests/Integration/UnlockLessonSocketTests.cs
+++ b/Game.Api.Tests/Integration/UnlockLessonSocketTests.cs
@@ -1,0 +1,109 @@
+using Game.Infrastructure.Database;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    [Collection("Integration")]
+    public class UnlockLessonSocketTests : ApiIntegrationTestBase
+    {
+        private const string Username = "unlocklessonuser";
+        private const string Password = "unlocklessonpass";
+
+        public UnlockLessonSocketTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper) : base(containers, testOutputHelper) { }
+
+        private async Task<(int UserId, int PlayerId, int LessonId)> SeedPlayerAndLessonAsync()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var lesson = await TestDataSeeder.CreateLessonAsync(context);
+            var user = await TestDataSeeder.CreateUserAsync(context, Username, Password);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+
+            // The caches no longer lazily refill, so reload them to resolve the seeded lesson id.
+            await ReloadReferenceCachesAsync();
+
+            return (user.Id, player.Id, lesson.Id);
+        }
+
+        [Fact]
+        public async Task UnlockLesson_PersistsUnlockedAtToCachedPlayer()
+        {
+            var (userId, playerId, lessonId) = await SeedPlayerAndLessonAsync();
+            await LoginAsync(Username, Password);
+
+            await using var socketClient = new TestSocketClient();
+            var wsClient = Factory.Server.CreateWebSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+
+            var response = await socketClient.SendCommandRawAsync("UnlockLesson", lessonId);
+
+            Assert.Null(response.Error);
+
+            var lessons = await WaitForLessonAsync(playerId, lessonId);
+            var persisted = lessons.Single(l => l.LessonId == lessonId);
+            Assert.NotEqual(default, persisted.UnlockedAt);
+            Assert.Null(persisted.ReadAt);
+        }
+
+        [Fact]
+        public async Task UnlockLesson_AlreadyUnlocked_IsIdempotent()
+        {
+            var (userId, playerId, lessonId) = await SeedPlayerAndLessonAsync();
+            await LoginAsync(Username, Password);
+
+            await using var socketClient = new TestSocketClient();
+            var wsClient = Factory.Server.CreateWebSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+
+            Assert.Null((await socketClient.SendCommandRawAsync("UnlockLesson", lessonId)).Error);
+            await WaitForLessonAsync(playerId, lessonId);
+
+            // A re-fired client-side detector must not error or duplicate the row.
+            var response = await socketClient.SendCommandRawAsync("UnlockLesson", lessonId);
+
+            Assert.Null(response.Error);
+            var lessons = (await GetPersistedPlayerAsync(playerId)).Lessons;
+            Assert.Single(lessons);
+        }
+
+        [Fact]
+        public async Task UnlockLesson_UnknownLessonId_ReturnsError()
+        {
+            var (userId, _, _) = await SeedPlayerAndLessonAsync();
+            await LoginAsync(Username, Password);
+
+            await using var socketClient = new TestSocketClient();
+            var wsClient = Factory.Server.CreateWebSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+
+            var response = await socketClient.SendCommandRawAsync("UnlockLesson", 9999);
+
+            Assert.NotNull(response.Error);
+        }
+
+        /// <summary>
+        /// The command writes the cached player fire-and-forget, so poll the player snapshot until the
+        /// expected lesson row lands (or fail after a short budget).
+        /// </summary>
+        private async Task<List<Game.Api.Models.Player.PlayerLesson>> WaitForLessonAsync(int playerId, int lessonId)
+        {
+            for (var attempt = 0; attempt < 20; attempt++)
+            {
+                var lessons = (await GetPersistedPlayerAsync(playerId)).Lessons;
+                if (lessons.Any(l => l.LessonId == lessonId))
+                {
+                    return lessons;
+                }
+
+                await Task.Delay(50, CancellationToken);
+            }
+
+            Assert.Fail($"Lesson {lessonId} was not unlocked in time.");
+            return [];
+        }
+    }
+}

--- a/Game.Api/Models/Player/PlayerData.cs
+++ b/Game.Api/Models/Player/PlayerData.cs
@@ -16,6 +16,7 @@ namespace Game.Api.Models.Player
         public int StatPointsGained { get; set; }
         public int StatPointsUsed { get; set; }
         public required List<LogPreference> LogPreferences { get; set; }
+        public required List<PlayerLesson> Lessons { get; set; }
         public required InventoryData InventoryData { get; set; }
 
         /// <summary>
@@ -89,6 +90,14 @@ namespace Game.Api.Models.Player
                     {
                         Id = lp.LogType,
                         Enabled = lp.Enabled,
+                    })
+                    .ToList(),
+                Lessons = player.Lessons
+                    .Select(l => new PlayerLesson
+                    {
+                        LessonId = l.LessonId,
+                        UnlockedAt = l.UnlockedAt,
+                        ReadAt = l.ReadAt,
                     })
                     .ToList(),
                 InventoryData = new InventoryData

--- a/Game.Api/Models/Player/PlayerLesson.cs
+++ b/Game.Api/Models/Player/PlayerLesson.cs
@@ -1,0 +1,11 @@
+namespace Game.Api.Models.Player
+{
+    /// <summary>Wire model for a player's per-lesson state (spike #1392). Sent only for lessons the player has
+    /// at least unlocked — an absent entry means locked, matching the domain/entity convention.</summary>
+    public class PlayerLesson : IModel
+    {
+        public int LessonId { get; set; }
+        public DateTime UnlockedAt { get; set; }
+        public DateTime? ReadAt { get; set; }
+    }
+}

--- a/Game.Api/Sockets/Commands/MarkLessonRead.cs
+++ b/Game.Api/Sockets/Commands/MarkLessonRead.cs
@@ -1,0 +1,39 @@
+using Game.Abstractions.DataAccess;
+using Game.Api.Models.Common;
+using Game.Application.Services;
+
+namespace Game.Api.Sockets.Commands
+{
+    /// <summary>
+    /// Marks a lesson's coach-mark tour as completed (spike #1392). A screen-anchored lesson plays immediately
+    /// on first visit with no prior <see cref="UnlockLesson"/> call, so this also accepts a still-locked lesson
+    /// and normalizes it straight to read. Idempotent: re-marking an already-read lesson (a Help-screen replay)
+    /// is a no-op, not an error.
+    /// </summary>
+    public class MarkLessonRead : AbstractSocketCommandWithParams<int>
+    {
+        private readonly PlayerService _playerService;
+        private readonly ILessons _lessons;
+
+        public override string Name { get; set; } = nameof(MarkLessonRead);
+
+        public MarkLessonRead(PlayerService playerService, ILessons lessons)
+        {
+            _playerService = playerService;
+            _lessons = lessons;
+        }
+
+        public override async Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
+        {
+            if (!_lessons.ValidateLessonId(Parameters))
+            {
+                return Error("Unknown lesson.");
+            }
+
+            var player = context.Session.Player;
+            await _playerService.MarkLessonRead(player, Parameters, cancellationToken);
+
+            return Success();
+        }
+    }
+}

--- a/Game.Api/Sockets/Commands/UnlockLesson.cs
+++ b/Game.Api/Sockets/Commands/UnlockLesson.cs
@@ -1,0 +1,38 @@
+using Game.Abstractions.DataAccess;
+using Game.Api.Models.Common;
+using Game.Application.Services;
+
+namespace Game.Api.Sockets.Commands
+{
+    /// <summary>
+    /// Records that a mechanic-anchored lesson's trigger fired client-side (spike #1392). Client-detected
+    /// triggers are trusted — nothing is rewarded, so a dishonest client can only show itself tutorials early.
+    /// Idempotent: unlocking an already-unlocked (or already-read) lesson is a no-op, not an error.
+    /// </summary>
+    public class UnlockLesson : AbstractSocketCommandWithParams<int>
+    {
+        private readonly PlayerService _playerService;
+        private readonly ILessons _lessons;
+
+        public override string Name { get; set; } = nameof(UnlockLesson);
+
+        public UnlockLesson(PlayerService playerService, ILessons lessons)
+        {
+            _playerService = playerService;
+            _lessons = lessons;
+        }
+
+        public override async Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
+        {
+            if (!_lessons.ValidateLessonId(Parameters))
+            {
+                return Error("Unknown lesson.");
+            }
+
+            var player = context.Session.Player;
+            await _playerService.UnlockLesson(player, Parameters, cancellationToken);
+
+            return Success();
+        }
+    }
+}

--- a/Game.Application.Tests/Mapping/PlayerCacheMapperTests.cs
+++ b/Game.Application.Tests/Mapping/PlayerCacheMapperTests.cs
@@ -104,7 +104,8 @@ namespace Game.Application.Tests.Mapping
                     new() { Attribute = EAttribute.Agility, Amount = 3d },
                 ],
                 unlockedModIds: [100, 101],
-                logPreferences: [new() { LogType = ELogType.Damage, Enabled = false }]);
+                logPreferences: [new() { LogType = ELogType.Damage, Enabled = false }],
+                lessons: [new() { LessonId = 3, UnlockedAt = MappedLastActivity, ReadAt = null }]);
 
             var player = PlayerCacheMapper.ToCore(model, Catalog(), Catalog(), Catalog());
 
@@ -122,6 +123,10 @@ namespace Game.Application.Tests.Mapping
             var pref = Assert.Single(player.LogPreferences);
             Assert.Equal(ELogType.Damage, pref.LogType);
             Assert.False(pref.Enabled);
+            var lesson = Assert.Single(player.Lessons);
+            Assert.Equal(3, lesson.LessonId);
+            Assert.Equal(MappedLastActivity, lesson.UnlockedAt);
+            Assert.Null(lesson.ReadAt);
         }
 
         [Fact]
@@ -295,6 +300,11 @@ namespace Game.Application.Tests.Mapping
             var pref = Assert.Single(rehydrated.LogPreferences);
             Assert.Equal(ELogType.Damage, pref.LogType);
             Assert.False(pref.Enabled);
+
+            var lesson = Assert.Single(rehydrated.Lessons);
+            Assert.Equal(3, lesson.LessonId);
+            Assert.Equal(MappedLastActivity, lesson.UnlockedAt);
+            Assert.Null(lesson.ReadAt);
         }
 
         private static readonly DateTime MappedLastActivity = new(2026, 6, 20, 10, 0, 0, DateTimeKind.Utc);
@@ -306,6 +316,7 @@ namespace Game.Application.Tests.Mapping
             List<int>? unlockedModIds = null,
             List<StatAllocation>? statAllocations = null,
             List<LogPreference>? logPreferences = null,
+            List<PlayerLesson>? lessons = null,
             bool autoChallengeBoss = false) => new()
             {
                 Id = 1,
@@ -324,6 +335,7 @@ namespace Game.Application.Tests.Mapping
                 UnlockedModIds = unlockedModIds ?? [],
                 Skills = skills ?? [],
                 LogPreferences = logPreferences ?? [],
+                Lessons = lessons ?? [],
             };
 
         /// <summary>
@@ -377,6 +389,7 @@ namespace Game.Application.Tests.Mapping
                 Skills = [skill5, skill6, skill7],
                 SelectedSkills = [skill6, skill7],
                 LogPreferences = [new LogPreference { LogType = ELogType.Damage, Enabled = false }],
+                Lessons = [new PlayerLesson { LessonId = 3, UnlockedAt = MappedLastActivity, ReadAt = null }],
             };
         }
 

--- a/Game.Application/Services/PlayerService.cs
+++ b/Game.Application/Services/PlayerService.cs
@@ -55,6 +55,16 @@ namespace Game.Application.Services
             await _playerRepo.SavePlayer(player, cancellationToken);
         }
 
+        public async Task UnlockLesson(Player player, int lessonId, CancellationToken cancellationToken = default)
+        {
+            await SaveIf(player, player.UnlockLesson(lessonId, DateTime.UtcNow), cancellationToken);
+        }
+
+        public async Task MarkLessonRead(Player player, int lessonId, CancellationToken cancellationToken = default)
+        {
+            await SaveIf(player, player.MarkLessonRead(lessonId, DateTime.UtcNow), cancellationToken);
+        }
+
         public async Task<bool> ApplyMod(Player player, int itemId, int itemModId, int itemModSlotId, CancellationToken cancellationToken = default)
         {
             if (!_itemMods.ValidateItemModId(itemModId))

--- a/Game.Core.TestInfrastructure/Builders/PlayerBuilder.cs
+++ b/Game.Core.TestInfrastructure/Builders/PlayerBuilder.cs
@@ -27,6 +27,7 @@ namespace Game.Core.TestInfrastructure.Builders
         private List<Skill> _skills = [];
         private List<Skill> _selectedSkills = [];
         private List<LogPreference> _logPreferences = [];
+        private List<PlayerLesson> _lessons = [];
 
         public PlayerBuilder WithId(int id)
         {
@@ -106,6 +107,12 @@ namespace Game.Core.TestInfrastructure.Builders
             return this;
         }
 
+        public PlayerBuilder WithLessons(IEnumerable<PlayerLesson> lessons)
+        {
+            _lessons = lessons.ToList();
+            return this;
+        }
+
         public Player Build() => new()
         {
             Id = _id,
@@ -126,6 +133,7 @@ namespace Game.Core.TestInfrastructure.Builders
             SelectedSkills = _selectedSkills,
             Skills = _skills,
             LogPreferences = _logPreferences,
+            Lessons = _lessons,
         };
     }
 }

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -746,6 +746,116 @@ namespace Game.Core.Tests.Players
             Assert.True(evt.Enabled);
         }
 
+        // ── UnlockLesson ─────────────────────────────────────────────────────
+
+        [Fact]
+        public void UnlockLesson_NewLesson_AddsUnreadLessonAndRaisesEvent()
+        {
+            var player = MakePlayer();
+            var timestamp = new DateTime(2026, 7, 5, 12, 0, 0, DateTimeKind.Utc);
+
+            var result = player.UnlockLesson(3, timestamp);
+
+            Assert.True(result);
+            var lesson = Assert.Single(player.Lessons);
+            Assert.Equal(3, lesson.LessonId);
+            Assert.Equal(timestamp, lesson.UnlockedAt);
+            Assert.Null(lesson.ReadAt);
+
+            var evt = player.DomainEvents.OfType<LessonUnlockedEvent>().SingleOrDefault();
+            Assert.NotNull(evt);
+            Assert.Equal(player.Id, evt.PlayerId);
+            Assert.Equal(3, evt.LessonId);
+            Assert.Equal(timestamp, evt.UnlockedAt);
+        }
+
+        [Fact]
+        public void UnlockLesson_AlreadyUnlocked_IsNoOp()
+        {
+            var player = MakePlayer();
+            player.UnlockLesson(3, DateTime.UtcNow);
+            player.ClearEvents();
+
+            var result = player.UnlockLesson(3, DateTime.UtcNow);
+
+            Assert.False(result);
+            Assert.Single(player.Lessons);
+            Assert.Empty(player.DomainEvents.OfType<LessonUnlockedEvent>());
+        }
+
+        [Fact]
+        public void UnlockLesson_AlreadyRead_IsNoOp()
+        {
+            var player = MakePlayer();
+            player.UnlockLesson(3, DateTime.UtcNow);
+            player.MarkLessonRead(3, DateTime.UtcNow);
+            player.ClearEvents();
+
+            var result = player.UnlockLesson(3, DateTime.UtcNow);
+
+            Assert.False(result);
+            Assert.Empty(player.DomainEvents.OfType<LessonUnlockedEvent>());
+        }
+
+        // ── MarkLessonRead ────────────────────────────────────────────────────
+
+        [Fact]
+        public void MarkLessonRead_PreviouslyUnlocked_SetsReadAtAndRaisesEvent()
+        {
+            var player = MakePlayer();
+            var unlockedAt = new DateTime(2026, 7, 5, 12, 0, 0, DateTimeKind.Utc);
+            var readAt = unlockedAt.AddMinutes(5);
+            player.UnlockLesson(3, unlockedAt);
+            player.ClearEvents();
+
+            var result = player.MarkLessonRead(3, readAt);
+
+            Assert.True(result);
+            var lesson = Assert.Single(player.Lessons);
+            Assert.Equal(unlockedAt, lesson.UnlockedAt);
+            Assert.Equal(readAt, lesson.ReadAt);
+
+            var evt = player.DomainEvents.OfType<LessonReadEvent>().SingleOrDefault();
+            Assert.NotNull(evt);
+            Assert.Equal(player.Id, evt.PlayerId);
+            Assert.Equal(3, evt.LessonId);
+            Assert.Equal(unlockedAt, evt.UnlockedAt);
+            Assert.Equal(readAt, evt.ReadAt);
+        }
+
+        [Fact]
+        public void MarkLessonRead_NeverUnlocked_NormalizesToReadWithBackfilledUnlockedAt()
+        {
+            // A screen-anchored lesson plays immediately on first visit with no prior UnlockLesson call.
+            var player = MakePlayer();
+            var timestamp = new DateTime(2026, 7, 5, 12, 0, 0, DateTimeKind.Utc);
+
+            var result = player.MarkLessonRead(3, timestamp);
+
+            Assert.True(result);
+            var lesson = Assert.Single(player.Lessons);
+            Assert.Equal(timestamp, lesson.UnlockedAt);
+            Assert.Equal(timestamp, lesson.ReadAt);
+
+            var evt = player.DomainEvents.OfType<LessonReadEvent>().SingleOrDefault();
+            Assert.NotNull(evt);
+            Assert.Equal(timestamp, evt.UnlockedAt);
+            Assert.Equal(timestamp, evt.ReadAt);
+        }
+
+        [Fact]
+        public void MarkLessonRead_AlreadyRead_IsNoOp()
+        {
+            var player = MakePlayer();
+            player.MarkLessonRead(3, DateTime.UtcNow);
+            player.ClearEvents();
+
+            var result = player.MarkLessonRead(3, DateTime.UtcNow);
+
+            Assert.False(result);
+            Assert.Empty(player.DomainEvents.OfType<LessonReadEvent>());
+        }
+
         // ── RecordBattleCompleted ────────────────────────────────────────────
 
         [Fact]

--- a/Game.Core/Players/Events/LessonReadEvent.cs
+++ b/Game.Core/Players/Events/LessonReadEvent.cs
@@ -1,0 +1,16 @@
+using Game.Core.Events;
+
+namespace Game.Core.Players.Events
+{
+    /// <summary>
+    /// Raised when a lesson's coach-mark tour is completed. Carries <see cref="UnlockedAt"/> alongside
+    /// <see cref="ReadAt"/> because a screen-anchored lesson plays immediately on first visit with no prior
+    /// <see cref="LessonUnlockedEvent"/> — the handler needs both timestamps to insert the row if this is its
+    /// first write.
+    /// </summary>
+    public record LessonReadEvent(
+        int PlayerId,
+        int LessonId,
+        DateTime UnlockedAt,
+        DateTime ReadAt) : IDomainEvent;
+}

--- a/Game.Core/Players/Events/LessonUnlockedEvent.cs
+++ b/Game.Core/Players/Events/LessonUnlockedEvent.cs
@@ -1,0 +1,12 @@
+using Game.Core.Events;
+
+namespace Game.Core.Players.Events
+{
+    /// <summary>
+    /// Raised when a mechanic-anchored lesson's trigger fires (client-detected, trusted).
+    /// </summary>
+    public record LessonUnlockedEvent(
+        int PlayerId,
+        int LessonId,
+        DateTime UnlockedAt) : IDomainEvent;
+}

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -48,6 +48,7 @@ namespace Game.Core.Players
         public required List<Skill> SelectedSkills { get; set; }
         public required List<Skill> Skills { get; set; }
         public required List<LogPreference> LogPreferences { get; set; }
+        public required List<PlayerLesson> Lessons { get; set; }
 
         public void ChangeZone(int zoneId)
         {
@@ -413,6 +414,51 @@ namespace Game.Core.Players
             }
 
             RaiseEvent(new LogPreferenceChangedEvent(Id, logType, enabled));
+        }
+
+        /// <summary>
+        /// Records that a mechanic-anchored lesson's trigger fired client-side (spike #1392). Client-detected
+        /// triggers are trusted — nothing is rewarded, so a dishonest client can only show itself tutorials
+        /// early. A no-op when the lesson already has a row (already unlocked or read), mirroring
+        /// <see cref="UnlockSkill"/>'s re-grant no-op. Returns whether the lesson was newly unlocked, so the
+        /// caller can skip a redundant write-behind save.
+        /// </summary>
+        public bool UnlockLesson(int lessonId, DateTime timestamp)
+        {
+            if (Lessons.Any(l => l.LessonId == lessonId))
+            {
+                return false;
+            }
+
+            Lessons.Add(new PlayerLesson { LessonId = lessonId, UnlockedAt = timestamp });
+            RaiseEvent(new LessonUnlockedEvent(Id, lessonId, timestamp));
+            return true;
+        }
+
+        /// <summary>
+        /// Marks a lesson's coach-mark tour as completed. A screen-anchored lesson plays immediately on first
+        /// visit with no prior <see cref="UnlockLesson"/> call, so a locked lesson normalizes straight to read
+        /// (backfilling <see cref="PlayerLesson.UnlockedAt"/> with this same timestamp) rather than rejecting;
+        /// an already-read lesson (e.g. a Help-screen replay) is a no-op. Returns whether the lesson's state
+        /// actually changed.
+        /// </summary>
+        public bool MarkLessonRead(int lessonId, DateTime timestamp)
+        {
+            var lesson = Lessons.FirstOrDefault(l => l.LessonId == lessonId);
+            if (lesson is not null && lesson.ReadAt is not null)
+            {
+                return false;
+            }
+
+            if (lesson is null)
+            {
+                lesson = new PlayerLesson { LessonId = lessonId, UnlockedAt = timestamp };
+                Lessons.Add(lesson);
+            }
+
+            lesson.ReadAt = timestamp;
+            RaiseEvent(new LessonReadEvent(Id, lessonId, lesson.UnlockedAt, timestamp));
+            return true;
         }
 
         // A victory caller MUST pass the battle's real combat ratings — the effect-based accrual normalizes each

--- a/Game.Core/Players/PlayerLesson.cs
+++ b/Game.Core/Players/PlayerLesson.cs
@@ -1,0 +1,13 @@
+namespace Game.Core.Players
+{
+    /// <summary>
+    /// Per-player tutorial-lesson state (spike #1392). Absence from <see cref="Player.Lessons"/> means locked;
+    /// <see cref="UnlockedAt"/> set means unread; <see cref="ReadAt"/> also set means read.
+    /// </summary>
+    public class PlayerLesson
+    {
+        public required int LessonId { get; set; }
+        public required DateTime UnlockedAt { get; set; }
+        public DateTime? ReadAt { get; set; }
+    }
+}

--- a/Game.DataAccess/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Game.DataAccess/DependencyInjection/ServiceCollectionExtensions.cs
@@ -167,6 +167,8 @@ namespace Game.DataAccess.DependencyInjection
                 .AddPlayerUpdateHandler<SelectedSkillsChangedEvent, SelectedSkillsChangedHandler>()
                 .AddPlayerUpdateHandler<ItemFavoriteChangedEvent, ItemFavoriteChangedHandler>()
                 .AddPlayerUpdateHandler<LogPreferenceChangedEvent, LogPreferenceChangedHandler>()
+                .AddPlayerUpdateHandler<LessonUnlockedEvent, LessonUnlockedHandler>()
+                .AddPlayerUpdateHandler<LessonReadEvent, LessonReadHandler>()
                 .AddPlayerUpdateHandler<ProgressUpdatedEvent, ProgressUpdatedHandler>();
         }
 
@@ -201,6 +203,8 @@ namespace Game.DataAccess.DependencyInjection
             DomainEventDispatcher.RegisterDomainEventHandler<SelectedSkillsChangedEvent, PlayerPersistencePublisher>();
             DomainEventDispatcher.RegisterDomainEventHandler<ItemFavoriteChangedEvent, PlayerPersistencePublisher>();
             DomainEventDispatcher.RegisterDomainEventHandler<LogPreferenceChangedEvent, PlayerPersistencePublisher>();
+            DomainEventDispatcher.RegisterDomainEventHandler<LessonUnlockedEvent, PlayerPersistencePublisher>();
+            DomainEventDispatcher.RegisterDomainEventHandler<LessonReadEvent, PlayerPersistencePublisher>();
         }
 
         /// <summary>

--- a/Game.DataAccess/Mapping/PlayerCacheMapper.cs
+++ b/Game.DataAccess/Mapping/PlayerCacheMapper.cs
@@ -84,6 +84,7 @@ namespace Game.DataAccess.Mapping
                 UnlockedModIds = player.Inventory.UnlockedMods.ToList(),
                 Skills = skills,
                 LogPreferences = player.LogPreferences,
+                Lessons = player.Lessons,
             };
         }
 
@@ -179,6 +180,7 @@ namespace Game.DataAccess.Mapping
                 Skills = playerSkills,
                 SelectedSkills = selectedSkills,
                 LogPreferences = model.LogPreferences,
+                Lessons = model.Lessons,
             };
         }
 

--- a/Game.DataAccess/Mapping/PlayerCacheModel.cs
+++ b/Game.DataAccess/Mapping/PlayerCacheModel.cs
@@ -35,6 +35,7 @@ namespace Game.DataAccess.Mapping
         public required List<int> UnlockedModIds { get; init; }
         public required List<CachedPlayerSkill> Skills { get; init; }
         public required List<LogPreference> LogPreferences { get; init; }
+        public required List<PlayerLesson> Lessons { get; init; }
     }
 
     /// <summary>An unlocked item reduced to its id plus the player-specific state (equip slot, favorite).</summary>

--- a/Game.DataAccess/PlayerPersistencePublisher.cs
+++ b/Game.DataAccess/PlayerPersistencePublisher.cs
@@ -28,7 +28,9 @@ namespace Game.DataAccess
         IDomainEventHandler<SkillUnlockedEvent>,
         IDomainEventHandler<SelectedSkillsChangedEvent>,
         IDomainEventHandler<ItemFavoriteChangedEvent>,
-        IDomainEventHandler<LogPreferenceChangedEvent>
+        IDomainEventHandler<LogPreferenceChangedEvent>,
+        IDomainEventHandler<LessonUnlockedEvent>,
+        IDomainEventHandler<LessonReadEvent>
     {
         private readonly PlayerUpdateBatch _batch = batch;
 
@@ -44,6 +46,8 @@ namespace Game.DataAccess
         public Task HandleAsync(SelectedSkillsChangedEvent domainEvent, CancellationToken cancellationToken = default) => Buffer(domainEvent);
         public Task HandleAsync(ItemFavoriteChangedEvent domainEvent, CancellationToken cancellationToken = default) => Buffer(domainEvent);
         public Task HandleAsync(LogPreferenceChangedEvent domainEvent, CancellationToken cancellationToken = default) => Buffer(domainEvent);
+        public Task HandleAsync(LessonUnlockedEvent domainEvent, CancellationToken cancellationToken = default) => Buffer(domainEvent);
+        public Task HandleAsync(LessonReadEvent domainEvent, CancellationToken cancellationToken = default) => Buffer(domainEvent);
 
         private Task Buffer<T>(T domainEvent) where T : IDomainEvent
         {

--- a/Game.DataAccess/PlayerUpdates/Handlers/LessonReadHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/LessonReadHandler.cs
@@ -1,0 +1,46 @@
+using Game.Core.Players.Events;
+using Game.Infrastructure.Database;
+using Game.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Game.DataAccess.PlayerUpdates.Handlers
+{
+    internal sealed class LessonReadHandler(GameContext context) : IPlayerUpdateHandler<LessonReadEvent>
+    {
+        public async Task HandleAsync(LessonReadEvent evt)
+        {
+            // Absolute upsert (mirroring LogPreferenceChangedHandler): update first; if no row exists yet — a
+            // screen-anchored lesson goes straight from locked to read with no prior LessonUnlockedEvent, and a
+            // reordered delivery of that event behind this one is also possible — fall through to insert with
+            // both timestamps the domain already resolved.
+            Task<int> SetReadAsync() => context.PlayerLessons
+                .Where(pl => pl.PlayerId == evt.PlayerId && pl.LessonId == evt.LessonId)
+                .ExecuteUpdateAsync(s => s.SetProperty(pl => pl.ReadAt, evt.ReadAt));
+
+            if (await SetReadAsync() > 0)
+            {
+                return;
+            }
+
+            context.PlayerLessons.Add(new PlayerLesson
+            {
+                PlayerId = evt.PlayerId,
+                LessonId = evt.LessonId,
+                UnlockedAt = evt.UnlockedAt,
+                ReadAt = evt.ReadAt,
+            });
+
+            try
+            {
+                await context.SaveChangesAsync();
+            }
+            catch (DbUpdateException ex) when (ex.IsUniqueViolation())
+            {
+                // Lost the insert race to a concurrently-applied LessonUnlockedEvent; clear the failed insert
+                // and set the now-existing row's ReadAt absolutely.
+                context.ChangeTracker.Clear();
+                await SetReadAsync();
+            }
+        }
+    }
+}

--- a/Game.DataAccess/PlayerUpdates/Handlers/LessonUnlockedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/LessonUnlockedHandler.cs
@@ -1,0 +1,32 @@
+using Game.Core.Players.Events;
+using Game.Infrastructure.Database;
+using Game.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Game.DataAccess.PlayerUpdates.Handlers
+{
+    internal sealed class LessonUnlockedHandler(GameContext context) : IPlayerUpdateHandler<LessonUnlockedEvent>
+    {
+        public async Task HandleAsync(LessonUnlockedEvent evt)
+        {
+            // Unlocking an already-unlocked lesson is a domain no-op (Player.UnlockLesson), so this event only
+            // ever fires once per lesson — a plain insert, with the unique-violation catch absorbing a
+            // replayed/duplicate delivery of the same event.
+            context.PlayerLessons.Add(new PlayerLesson
+            {
+                PlayerId = evt.PlayerId,
+                LessonId = evt.LessonId,
+                UnlockedAt = evt.UnlockedAt,
+            });
+
+            try
+            {
+                await context.SaveChangesAsync();
+            }
+            catch (DbUpdateException ex) when (ex.IsUniqueViolation())
+            {
+                context.ChangeTracker.Clear();
+            }
+        }
+    }
+}

--- a/Game.DataAccess/Repositories/Lessons.cs
+++ b/Game.DataAccess/Repositories/Lessons.cs
@@ -20,6 +20,11 @@ namespace Game.DataAccess.Repositories
             return [.. Snapshot.Entities.Select(LessonMapper.ToContract)];
         }
 
+        public bool ValidateLessonId(int lessonId)
+        {
+            return LookupLesson(lessonId) is not null;
+        }
+
         public LessonEntity? LookupLesson(int lessonId)
         {
             return Snapshot.Entities.Lookup(lessonId);

--- a/Game.DataAccess/Repositories/PlayerQueryExtensions.cs
+++ b/Game.DataAccess/Repositories/PlayerQueryExtensions.cs
@@ -51,6 +51,9 @@ namespace Game.DataAccess.Repositories
                 LogPreferences = p.LogPreferences
                     .Select(lp => new LogPreference { LogType = (ELogType)lp.LogTypeId, Enabled = lp.Enabled })
                     .ToList(),
+                Lessons = p.PlayerLessons
+                    .Select(pl => new PlayerLesson { LessonId = pl.LessonId, UnlockedAt = pl.UnlockedAt, ReadAt = pl.ReadAt })
+                    .ToList(),
             }).AsSplitQuery();
         }
     }

--- a/Game.Infrastructure/Database/GameContext.cs
+++ b/Game.Infrastructure/Database/GameContext.cs
@@ -49,6 +49,7 @@ namespace Game.Infrastructure.Database
         public DbSet<Player> Players { get; set; }
         public DbSet<PlayerAttribute> PlayerAttributes { get; set; }
         public DbSet<PlayerChallenge> PlayerChallenges { get; set; }
+        public DbSet<PlayerLesson> PlayerLessons { get; set; }
         public DbSet<PlayerProficiency> PlayerProficiencies { get; set; }
         public DbSet<PlayerSkill> PlayerSkills { get; set; }
         public DbSet<PlayerStatistic> PlayerStatistics { get; set; }
@@ -393,6 +394,11 @@ namespace Game.Infrastructure.Database
 
             modelBuilder.Entity<PlayerSkill>()
                 .HasKey(ps => new { ps.PlayerId, ps.SkillId });
+
+            // The composite natural key doubles as the unique constraint the write-behind upsert relies on,
+            // mirroring PlayerProficiency — no separate index needed since neither key column is nullable.
+            modelBuilder.Entity<PlayerLesson>()
+                .HasKey(pl => new { pl.PlayerId, pl.LessonId });
 
             modelBuilder.Entity<PlayerAttribute>(entity =>
             {

--- a/Game.Infrastructure/Entities/Player.cs
+++ b/Game.Infrastructure/Entities/Player.cs
@@ -58,5 +58,6 @@ namespace Game.Infrastructure.Entities
         public virtual List<PlayerStatistic> PlayerStatistics { get => field ?? throw new NotLoadedException(nameof(PlayerStatistics)); set; }
         public virtual List<LogPreference> LogPreferences { get => field ?? throw new NotLoadedException(nameof(LogPreferences)); set; }
         public virtual List<PlayerSkill> PlayerSkills { get => field ?? throw new NotLoadedException(nameof(PlayerSkills)); set; }
+        public virtual List<PlayerLesson> PlayerLessons { get => field ?? throw new NotLoadedException(nameof(PlayerLessons)); set; }
     }
 }

--- a/Game.Infrastructure/Entities/PlayerLesson.cs
+++ b/Game.Infrastructure/Entities/PlayerLesson.cs
@@ -1,0 +1,17 @@
+namespace Game.Infrastructure.Entities
+{
+    /// <summary>
+    /// Per-player tutorial-lesson state (spike #1392). Absence of a row means locked; <see cref="ReadAt"/> null
+    /// vs. set distinguishes unread from read.
+    /// </summary>
+    public class PlayerLesson
+    {
+        public int PlayerId { get; set; }
+        public int LessonId { get; set; }
+        public DateTime UnlockedAt { get; set; }
+        public DateTime? ReadAt { get; set; }
+
+        public virtual Player Player { get => field ?? throw new NotLoadedException(nameof(Player)); set; }
+        public virtual Lesson Lesson { get => field ?? throw new NotLoadedException(nameof(Lesson)); set; }
+    }
+}

--- a/Game.Infrastructure/Migrations/20260705062532_AddPlayerLessons.Designer.cs
+++ b/Game.Infrastructure/Migrations/20260705062532_AddPlayerLessons.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Game.Infrastructure.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20260705062532_AddPlayerLessons")]
+    partial class AddPlayerLessons
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Game.Infrastructure/Migrations/20260705062532_AddPlayerLessons.cs
+++ b/Game.Infrastructure/Migrations/20260705062532_AddPlayerLessons.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Game.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlayerLessons : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PlayerLessons",
+                columns: table => new
+                {
+                    PlayerId = table.Column<int>(type: "integer", nullable: false),
+                    LessonId = table.Column<int>(type: "integer", nullable: false),
+                    UnlockedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ReadAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlayerLessons", x => new { x.PlayerId, x.LessonId });
+                    table.ForeignKey(
+                        name: "FK_PlayerLessons_Lessons_LessonId",
+                        column: x => x.LessonId,
+                        principalTable: "Lessons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PlayerLessons_Players_PlayerId",
+                        column: x => x.PlayerId,
+                        principalTable: "Players",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerLessons_LessonId",
+                table: "PlayerLessons",
+                column: "LessonId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PlayerLessons");
+        }
+    }
+}

--- a/Game.TestInfrastructure/Helpers/DatabaseCleaner.cs
+++ b/Game.TestInfrastructure/Helpers/DatabaseCleaner.cs
@@ -18,6 +18,7 @@ namespace Game.TestInfrastructure.Helpers
                     "PlayerAttributes",
                     "PlayerSkills",
                     "PlayerChallenges",
+                    "PlayerLessons",
                     "PlayerStatistics",
                     "LogPreferences",
                     "UserLogins",

--- a/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
+++ b/Game.TestInfrastructure/Helpers/TestDataSeeder.cs
@@ -629,6 +629,23 @@ namespace Game.TestInfrastructure.Helpers
             return lesson;
         }
 
+        public static async Task AddPlayerLessonAsync(
+            GameContext context,
+            int playerId,
+            int lessonId,
+            DateTime? unlockedAt = null,
+            DateTime? readAt = null)
+        {
+            context.PlayerLessons.Add(new PlayerLesson
+            {
+                PlayerId = playerId,
+                LessonId = lessonId,
+                UnlockedAt = unlockedAt ?? DateTime.UtcNow,
+                ReadAt = readAt,
+            });
+            await context.SaveChangesAsync();
+        }
+
         // A proficiency is a tier of a path. When no path is supplied, a fresh standalone single-tier path is
         // created so the proficiency is always well-formed.
         public static async Task<Proficiency> CreateProficiencyAsync(

--- a/UI/src/lib/api/types/api-socket-type-map.ts
+++ b/UI/src/lib/api/types/api-socket-type-map.ts
@@ -66,6 +66,7 @@ export type ApiSocketResponseTypes = {
 	'GetSkills': ISkill[];
 	'GetStatisticTypes': IStatisticType[];
 	'GetZones': IZone[];
+	'MarkLessonRead': undefined;
 	'NewEnemy': INewEnemyModel;
 	'ProficiencyXpGained': IProficiencyXpGainedModel;
 	'RemoveMod': undefined;
@@ -77,6 +78,7 @@ export type ApiSocketResponseTypes = {
 	'SocketReplaced': undefined;
 	'SynthesizeSkill': ISynthesisResult;
 	'UnequipItem': undefined;
+	'UnlockLesson': undefined;
 	'UpdatePlayerStats': IUpdatePlayerStatsResponse;
 };
 
@@ -85,6 +87,7 @@ export type ApiSocketRequestTypes = {
 	'ChallengeBoss': IChallengeBossRequest;
 	'DefeatEnemy': IDefeatEnemyRequest;
 	'EquipItem': IEquipRequest;
+	'MarkLessonRead': number;
 	'NewEnemy': INewEnemyRequest;
 	'RemoveMod': IRemoveModRequest;
 	'SaveLogPreferences': ILogPreference[];
@@ -93,6 +96,7 @@ export type ApiSocketRequestTypes = {
 	'SetSelectedSkills': number[];
 	'SynthesizeSkill': number;
 	'UnequipItem': IEquipRequest;
+	'UnlockLesson': number;
 	'UpdatePlayerStats': IAttributeUpdate[];
 };
 

--- a/UI/src/lib/api/types/interfaces/player.ts
+++ b/UI/src/lib/api/types/interfaces/player.ts
@@ -30,9 +30,16 @@ export interface IPlayerData {
 	statPointsGained: number;
 	statPointsUsed: number;
 	logPreferences: ILogPreference[];
+	lessons: IPlayerLesson[];
 	inventoryData: IInventoryData;
 	lockedBaseDistribution: IAttributeDistribution[];
 	signaturePassive: ISignaturePassive;
+}
+
+export interface IPlayerLesson {
+	lessonId: number;
+	unlockedAt: string;
+	readAt?: string;
 }
 
 export interface ISynthesisResult {

--- a/UI/src/lib/engine/player/player-manager.ts
+++ b/UI/src/lib/engine/player/player-manager.ts
@@ -6,10 +6,11 @@ import {
 	IInventoryData,
 	ILogPreference,
 	IPlayerData,
+	IPlayerLesson,
 	ISignaturePassive,
 	IUnlockedSkill
 } from '$lib/api';
-import { EAttribute, EModifierType } from '$lib/api';
+import { apiSocket, EAttribute, EModifierType } from '$lib/api';
 import { EXP_PER_LEVEL, STAT_POINTS_PER_LEVEL } from '$lib/api/types/game-constants';
 import { formatNum, statify } from '$lib/common';
 import { classLockedBaseModifiers, classSignaturePassiveModifier } from '$lib/battle/class-modifiers';
@@ -37,6 +38,10 @@ export class PlayerManager implements IPlayerData {
 	};
 	public unlockedSkills: IUnlockedSkill[] = [];
 	private logPreferenceList: ILogPreference[] = [];
+	/** Per-lesson tutorial state (spike #1392): absent = locked, `readAt` unset = unread, set = read. The
+	 *  trigger-evaluation/tour-playback consumer (#1587) reads this; this class only syncs it with the
+	 *  server. */
+	public lessons: IPlayerLesson[] = [];
 	public inventoryData: IInventoryData = {
 		unlockedItems: [],
 		unlockedMods: []
@@ -150,8 +155,42 @@ export class PlayerManager implements IPlayerData {
 		this.signaturePassive = data.signaturePassive;
 		this.unlockedSkills = data.unlockedSkills;
 		this.logPreferences = data.logPreferences;
+		this.lessons = data.lessons;
 		this.inventoryData = data.inventoryData;
 		this.refreshSelectedSkills();
+	}
+
+	/**
+	 * Reports that a mechanic-anchored lesson's trigger fired client-side, unlocking it (spike #1392).
+	 * Client-detected and trusted — nothing is rewarded, so a dishonest client can only show itself
+	 * tutorials early. Optimistic and idempotent: a lesson already present (unlocked or read) is a no-op,
+	 * so a re-fired detector can call this freely.
+	 */
+	public unlockLesson(lessonId: number) {
+		if (this.lessons.some((lesson) => lesson.lessonId === lessonId)) {
+			return;
+		}
+		this.lessons.push({ lessonId, unlockedAt: new Date().toISOString() });
+		void apiSocket.sendSocketCommand('UnlockLesson', lessonId);
+	}
+
+	/**
+	 * Marks a lesson's coach-mark tour as completed (spike #1392). A screen-anchored lesson plays
+	 * immediately on first visit with no prior {@link unlockLesson} call, so a lesson with no existing
+	 * entry is added rather than rejected. An already-read lesson (a Help-screen replay) is a no-op.
+	 */
+	public markLessonRead(lessonId: number) {
+		const timestamp = new Date().toISOString();
+		const lesson = this.lessons.find((l) => l.lessonId === lessonId);
+		if (lesson) {
+			if (lesson.readAt) {
+				return;
+			}
+			lesson.readAt = timestamp;
+		} else {
+			this.lessons.push({ lessonId, unlockedAt: timestamp, readAt: timestamp });
+		}
+		void apiSocket.sendSocketCommand('MarkLessonRead', lessonId);
 	}
 
 	/**

--- a/UI/src/tests/lib/engine/player/player-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/player-manager.test.ts
@@ -11,6 +11,23 @@ vi.mock('$lib/engine/log', () => ({
 	logMessage: vi.fn()
 }));
 
+// Controllable stub for the network boundary unlockLesson/markLessonRead cross (mirrors
+// inventory-manager.test.ts's socket stub); the assertions below only care that the command fires.
+const { mockSendSocketCommand } = vi.hoisted(() => {
+	const mockSendSocketCommand = vi.fn();
+	return { mockSendSocketCommand };
+});
+
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		apiSocket: {
+			sendSocketCommand: mockSendSocketCommand
+		}
+	};
+});
+
 const makePlayerData = (overrides: Partial<IPlayerData> = {}): IPlayerData => ({
 	id: 1,
 	name: 'TestPlayer',
@@ -40,6 +57,7 @@ const makePlayerData = (overrides: Partial<IPlayerData> = {}): IPlayerData => ({
 		{ id: ELogType.Damage, enabled: false },
 		{ id: ELogType.Exp, enabled: true }
 	],
+	lessons: [],
 	inventoryData: {
 		unlockedItems: [
 			{
@@ -67,6 +85,7 @@ describe('PlayerManager', () => {
 	beforeEach(() => {
 		manager = new PlayerManager();
 		vi.mocked(logMessage).mockClear();
+		mockSendSocketCommand.mockClear();
 	});
 
 	describe('initialize', () => {
@@ -83,6 +102,7 @@ describe('PlayerManager', () => {
 			expect(manager.attributes).toEqual(data.attributes);
 			expect(manager.unlockedSkills).toEqual(data.unlockedSkills);
 			expect(manager.logPreferences).toEqual(data.logPreferences);
+			expect(manager.lessons).toEqual(data.lessons);
 			expect(manager.inventoryData).toEqual(data.inventoryData);
 		});
 
@@ -309,6 +329,62 @@ describe('PlayerManager', () => {
 		});
 	});
 
+	describe('unlockLesson', () => {
+		it('adds an unread lesson entry and calls the socket command', () => {
+			manager.initialize(makePlayerData());
+
+			manager.unlockLesson(3);
+
+			const lesson = manager.lessons.find((l) => l.lessonId === 3);
+			expect(lesson).toBeDefined();
+			expect(lesson?.readAt).toBeUndefined();
+			expect(mockSendSocketCommand).toHaveBeenCalledWith('UnlockLesson', 3);
+		});
+
+		it('is idempotent — an already-unlocked lesson is not duplicated or re-sent', () => {
+			manager.initialize(makePlayerData({ lessons: [{ lessonId: 3, unlockedAt: '2026-01-01T00:00:00Z' }] }));
+
+			manager.unlockLesson(3);
+
+			expect(manager.lessons.filter((l) => l.lessonId === 3)).toHaveLength(1);
+			expect(mockSendSocketCommand).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('markLessonRead', () => {
+		it('sets readAt on a previously unlocked lesson and calls the socket command', () => {
+			manager.initialize(makePlayerData({ lessons: [{ lessonId: 3, unlockedAt: '2026-01-01T00:00:00Z' }] }));
+
+			manager.markLessonRead(3);
+
+			expect(manager.lessons.find((l) => l.lessonId === 3)?.readAt).toBeDefined();
+			expect(mockSendSocketCommand).toHaveBeenCalledWith('MarkLessonRead', 3);
+		});
+
+		it('normalizes a never-unlocked lesson straight to read (screen-anchored lessons skip unlock)', () => {
+			manager.initialize(makePlayerData());
+
+			manager.markLessonRead(3);
+
+			const lesson = manager.lessons.find((l) => l.lessonId === 3);
+			expect(lesson?.unlockedAt).toBeDefined();
+			expect(lesson?.readAt).toBeDefined();
+			expect(mockSendSocketCommand).toHaveBeenCalledWith('MarkLessonRead', 3);
+		});
+
+		it('is idempotent — an already-read lesson is not re-sent', () => {
+			manager.initialize(
+				makePlayerData({
+					lessons: [{ lessonId: 3, unlockedAt: '2026-01-01T00:00:00Z', readAt: '2026-01-01T00:05:00Z' }]
+				})
+			);
+
+			manager.markLessonRead(3);
+
+			expect(mockSendSocketCommand).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('default state', () => {
 		it('starts with empty defaults before initialization', () => {
 			expect(manager.name).toBe('');
@@ -318,6 +394,7 @@ describe('PlayerManager', () => {
 			expect(manager.unlockedSkills).toEqual([]);
 			expect(manager.selectedSkills).toEqual([]);
 			expect(manager.logPreferences).toEqual([]);
+			expect(manager.lessons).toEqual([]);
 			expect(manager.inventoryData).toEqual({
 				unlockedItems: [],
 				unlockedMods: []


### PR DESCRIPTION
## Summary

Delivers the server-side persistence leg of spike #1392 (UI tutorials): per-player tutorial-lesson state, riding the same `Player` aggregate + write-behind machinery as `LogPreferences`.

- **`PlayerLesson` EF entity + migration** — one row per player+lesson; absence = locked, `UnlockedAt` = unread, `ReadAt` also set = read. Composite PK `(PlayerId, LessonId)`, cascading FKs to `Players`/`Lessons`.
- **Domain**: `Player.Lessons`, `Player.UnlockLesson(lessonId, timestamp)` (idempotent — a re-fired mechanic-trigger detector is a no-op), `Player.MarkLessonRead(lessonId, timestamp)` (idempotent; **normalizes a never-unlocked lesson straight to read** rather than rejecting — see judgment call below).
- **Write-behind persistence**: `LessonUnlockedEvent`/`LessonReadEvent` → `PlayerPersistencePublisher` → `LessonUnlockedHandler` (insert, unique-violation-safe) / `LessonReadHandler` (absolute-upsert, mirroring `LogPreferenceChangedHandler`).
- **Socket commands**: `UnlockLesson` (client-detected trigger, trusted — nothing is rewarded) and `MarkLessonRead`, both validating the lesson id against the reference cache (`ILessons.ValidateLessonId`) and returning a plain success/error.
- **Player load payload**: `PlayerData.Lessons` carries each unlocked/read lesson's state, following the existing `LogPreferences` pattern.
- **Frontend**: a thin `PlayerManager.lessons` store + `unlockLesson`/`markLessonRead` methods that call the two new commands and update state optimistically — the "client store sync" the issue's own scope calls for. Trigger evaluation and tour playback are #1587's job, not this PR's.

## Judgment call worth flagging

The spike's trigger model has a **screen-anchored** lesson play its tour immediately on first visit with *no* prior unlock call — it goes straight from locked to read. So `MarkLessonRead` on a never-unlocked lesson **normalizes** (backfills `UnlockedAt` with the same timestamp) rather than rejecting. The issue's own test-scope line ("read-before-unlock rejected or normalized") flagged this as an open call; normalizing is the only choice consistent with the documented trigger design.

## Test plan

- [x] Backend: `dotnet build` + full `dotnet test` (`Game.Core.Tests`, `Game.Infrastructure.Tests`, `Game.Application.Tests`, `Game.Api.Tests`) — all green (2941 tests), including new unit tests for `Player.UnlockLesson`/`MarkLessonRead`, `PlayerCacheMapper` round-trip coverage, and integration tests for both socket commands (persistence, idempotency, unknown-lesson-id rejection).
- [x] Frontend: `npm run lint` (eslint + `svelte-check`) and `npm run test:unit:ci` — all green (3439 tests), including new `PlayerManager` coverage for `lessons`/`unlockLesson`/`markLessonRead`.
- [x] Regenerated the TypeScript client (`dotnet run --project Game.Api -- codegen`) — clean diff limited to the new fields/commands.
- [x] `dotnet format --verify-no-changes` — clean.

Closes #1588


---
_Generated by [Claude Code](https://claude.ai/code/session_01VLnFCfvZMs3omdKWVXX8sV)_