### PR TITLE
Suppress hidden-tab presentational side effects (combat floaters + victory toasts)

### DIFF
--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -70,11 +70,7 @@ const toastIfVisible = (message: string, options?: Parameters<typeof toastSucces
 	if (typeof document !== 'undefined' && document.hidden) {
 		return;
 	}
-	if (options) {
-		toastSuccess(message, options);
-	} else {
-		toastSuccess(message);
-	}
+	toastSuccess(message, options);
 };
 
 export const startGame = () => {

--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -58,6 +58,25 @@ let challengeCompletedUnhook: Action | undefined;
 let proficiencyXpGainedUnhook: Action | undefined;
 let serverCommandFailedUnhook: Action | undefined;
 
+/**
+ * Toasts a victory-driven success message, but skips it entirely while the tab is hidden. The tick
+ * worker (#1594) keeps resolving battles at full rate in the background, so a long hidden session can
+ * fire far more challenge/proficiency toasts than the throttled auto-dismiss timers can clear — the
+ * same pileup #1598 fixed for combat floaters. Nobody is watching for a popup on a backgrounded tab
+ * anyway; the state update and the combat log (`notifyProficiencyResult`/`notifyProficiencyOpened`)
+ * already keep the permanent record.
+ */
+const toastIfVisible = (message: string, options?: Parameters<typeof toastSuccess>[1]) => {
+	if (typeof document !== 'undefined' && document.hidden) {
+		return;
+	}
+	if (options) {
+		toastSuccess(message, options);
+	} else {
+		toastSuccess(message);
+	}
+};
+
 export const startGame = () => {
 	if (staticData.loaded) {
 		inventoryManager.initialize();
@@ -143,7 +162,7 @@ const notifyChallengeCompleted = (challengeId: number) => {
 		items: staticData.items,
 		itemMods: staticData.itemMods
 	});
-	toastSuccess(challengeCompletedMessage(challenge.name, reward), {
+	toastIfVisible(challengeCompletedMessage(challenge.name, reward), {
 		action: { label: 'View', onClick: () => navigation.requestScreen('challenges') }
 	});
 };
@@ -213,7 +232,7 @@ const notifyNewlyCreatableRecipes = (creatableBefore: ReadonlySet<number>) => {
 		if (!result) {
 			continue;
 		}
-		toastSuccess(recipeAvailableMessage(result.name), {
+		toastIfVisible(recipeAvailableMessage(result.name), {
 			action: { label: 'View', onClick: () => navigation.requestScreen('synthesis') }
 		});
 	}
@@ -248,11 +267,11 @@ const notifyProficiencyResult = (result: IProficiencyXpResultModel, previousLeve
 		const skillName = skillId != null ? staticData.skills?.[skillId]?.name : undefined;
 		const message = proficiencyMilestoneMessage(name, milestoneLevel, skillName);
 		logMessage(ELogType.Proficiency, message);
-		toastSuccess(message);
+		toastIfVisible(message);
 	}
 
 	if (leveledUp && result.milestonesCrossed.length === 0) {
-		toastSuccess(proficiencyLevelMessage(name, result.newLevel));
+		toastIfVisible(proficiencyLevelMessage(name, result.newLevel));
 	}
 };
 
@@ -266,7 +285,7 @@ const notifyProficiencyOpened = (opened: IProficiencyOpenedModel) => {
 	}
 	const message = proficiencyOpenedMessage(proficiency.name);
 	logMessage(ELogType.Proficiency, message);
-	toastSuccess(message);
+	toastIfVisible(message);
 };
 
 // Use goto() not location.href — a reload re-runs the boot gate and bounces an authenticated client back into the game.

--- a/UI/src/routes/game/screens/fight/CombatFloaters.svelte
+++ b/UI/src/routes/game/screens/fight/CombatFloaters.svelte
@@ -162,6 +162,13 @@ const spawn = (event: CombatFloatEvent) => {
 	if (event.target !== side) {
 		return;
 	}
+	// The tick worker keeps the sim running at full rate while the tab is hidden (#1594), so a long
+	// hidden battle can spawn floaters far faster than the throttled removal timer clears them.
+	// They're purely presentational (aria-hidden) and nobody is watching a hidden tab, so skip the
+	// spawn entirely rather than let the DOM accumulate for a stutter on refocus.
+	if (document.hidden) {
+		return;
+	}
 	const crit = event.kind === 'crit';
 	const id = nextId++;
 	floaters.push({

--- a/UI/src/tests/lib/engine/engine.test.ts
+++ b/UI/src/tests/lib/engine/engine.test.ts
@@ -464,7 +464,7 @@ describe('handleProficiencyXpGained', () => {
 		handleProficiencyXpGained(proficiencyXpGainedResponse([proficiencyXpResult({ proficiencyId: 0, newLevel: 2 })]));
 
 		expect(logMessage).toHaveBeenCalledWith(ELogType.Proficiency, 'Fire Magic reached level 2');
-		expect(toastSuccess).toHaveBeenCalledWith('Fire Magic reached level 2');
+		expect(toastSuccess).toHaveBeenCalledWith('Fire Magic reached level 2', undefined);
 	});
 
 	it('does not announce a level-up when the level is unchanged', () => {
@@ -483,9 +483,9 @@ describe('handleProficiencyXpGained', () => {
 		);
 
 		const milestone = 'Fire Magic milestone reached: level 5 — unlocked Fireball';
-		expect(toastSuccess).toHaveBeenCalledWith(milestone);
+		expect(toastSuccess).toHaveBeenCalledWith(milestone, undefined);
 		expect(logMessage).toHaveBeenCalledWith(ELogType.Proficiency, milestone);
-		expect(toastSuccess).not.toHaveBeenCalledWith('Fire Magic reached level 5');
+		expect(toastSuccess).not.toHaveBeenCalledWith('Fire Magic reached level 5', undefined);
 	});
 
 	it('unlocks milestone-granted skills so they are usable immediately', () => {
@@ -502,7 +502,7 @@ describe('handleProficiencyXpGained', () => {
 
 		handleProficiencyXpGained(proficiencyXpGainedResponse([], [{ proficiencyId: 3 }]));
 
-		expect(toastSuccess).toHaveBeenCalledWith('New proficiency unlocked: Inferno Magic');
+		expect(toastSuccess).toHaveBeenCalledWith('New proficiency unlocked: Inferno Magic', undefined);
 		expect(addUnlockedSkill).not.toHaveBeenCalled();
 	});
 

--- a/UI/src/tests/lib/engine/engine.test.ts
+++ b/UI/src/tests/lib/engine/engine.test.ts
@@ -178,9 +178,13 @@ const challengeCompletedResponse = (
 ): IApiSocketResponse<'ChallengeCompleted'> =>
 	({ id: '', name: 'ChallengeCompleted', data }) as IApiSocketResponse<'ChallengeCompleted'>;
 
+let hidden = false;
+
 beforeEach(() => {
 	vi.clearAllMocks();
 	clearModals();
+	hidden = false;
+	Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
 	staticDataStub.loaded = true;
 	staticDataStub.challenges = undefined;
 	staticDataStub.items = undefined;
@@ -218,6 +222,9 @@ beforeEach(() => {
 
 afterEach(() => {
 	clearModals();
+	// vi.unstubAllGlobals doesn't undo a defineProperty, so drop the own-property override of
+	// document.hidden and let it fall back to the jsdom prototype getter.
+	delete (document as unknown as Record<string, unknown>).hidden;
 });
 
 describe('handleSocketReplaced', () => {
@@ -391,6 +398,17 @@ describe('handleChallengeCompleted', () => {
 		options.action.onClick();
 		expect(navigation.requestScreen).toHaveBeenCalledWith('challenges');
 	});
+
+	it('does not toast while the tab is hidden (#1598), but still marks the challenge completed', () => {
+		staticDataStub.challenges = [];
+		staticDataStub.challenges[7] = { id: 7, name: 'First Blood' };
+		hidden = true;
+
+		handleChallengeCompleted(challengeCompletedResponse({ challengeId: 7 }));
+
+		expect(toastSuccess).not.toHaveBeenCalled();
+		expect(playerChallengesStub.markCompleted).toHaveBeenCalledWith(7);
+	});
 });
 
 /** Builds a ProficiencyXpGained push response with the given results / opened nodes. */
@@ -502,6 +520,35 @@ describe('handleProficiencyXpGained', () => {
 		expect(toastSuccess).not.toHaveBeenCalled();
 		expect(playerProficienciesStub.applyXpGained).toHaveBeenCalledWith(response.data);
 	});
+
+	it('does not toast a milestone while the tab is hidden (#1598), but still logs it and applies the grant', () => {
+		hidden = true;
+		playerProficienciesStub.levelOf.mockReturnValueOnce(4);
+		handleProficiencyXpGained(
+			proficiencyXpGainedResponse([
+				proficiencyXpResult({ proficiencyId: 0, newLevel: 5, milestonesCrossed: [5], grantedSkillIds: [12] })
+			])
+		);
+
+		expect(toastSuccess).not.toHaveBeenCalled();
+		expect(logMessage).toHaveBeenCalledWith(
+			ELogType.Proficiency,
+			'Fire Magic milestone reached: level 5 — unlocked Fireball'
+		);
+		expect(addUnlockedSkill).toHaveBeenCalledWith(12);
+	});
+
+	it('does not toast a plain level-up or a newly-opened proficiency while the tab is hidden (#1598)', () => {
+		hidden = true;
+		playerProficienciesStub.levelOf.mockReturnValueOnce(1);
+		staticDataStub.proficiencies![3] = { id: 3, name: 'Inferno Magic', levelRewards: [] };
+
+		handleProficiencyXpGained(
+			proficiencyXpGainedResponse([proficiencyXpResult({ proficiencyId: 0, newLevel: 2 })], [{ proficiencyId: 3 }])
+		);
+
+		expect(toastSuccess).not.toHaveBeenCalled();
+	});
 });
 
 describe('handleProficiencyXpGained — new-recipe-available toast', () => {
@@ -604,6 +651,20 @@ describe('handleProficiencyXpGained — new-recipe-available toast', () => {
 		const options = recipeToast?.[1] as { action: { onClick: () => void } };
 		options.action.onClick();
 		expect(navigation.requestScreen).toHaveBeenCalledWith('synthesis');
+	});
+
+	it('does not toast a newly-available recipe while the tab is hidden (#1598)', () => {
+		hidden = true;
+		staticDataStub.skillRecipes = [skillRecipe(0, 4, [0, 1])];
+		playerManagerStub.unlockedSkills = [{ skillId: 0, selected: false }];
+
+		handleProficiencyXpGained(
+			proficiencyXpGainedResponse([
+				proficiencyXpResult({ proficiencyId: 0, newLevel: 5, milestonesCrossed: [5], grantedSkillIds: [1] })
+			])
+		);
+
+		expect(toastSuccess).not.toHaveBeenCalled();
 	});
 });
 

--- a/UI/src/tests/routes/game/screens/fight/CombatFloaters.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/CombatFloaters.test.ts
@@ -256,6 +256,32 @@ describe('CombatFloaters', () => {
 		expect(getByTestId('enemy-floaters').style.getPropertyValue('--float-duration')).toBe('1500ms');
 	});
 
+	describe('hidden tab (#1598)', () => {
+		afterEach(() => {
+			delete (document as unknown as Record<string, unknown>).hidden;
+		});
+
+		it('skips spawning a floater while the tab is hidden', () => {
+			Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+			const { getByTestId } = render(CombatFloaters, { props: { side: 'enemy', testId: 'enemy-floaters' } });
+			emit({ target: 'enemy', kind: 'hit', amount: 247 });
+
+			expect(getByTestId('enemy-floaters').querySelectorAll('.floater')).toHaveLength(0);
+		});
+
+		it('resumes spawning once the tab is visible again', () => {
+			let hidden = true;
+			Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+			const { getByTestId } = render(CombatFloaters, { props: { side: 'enemy', testId: 'enemy-floaters' } });
+			emit({ target: 'enemy', kind: 'hit', amount: 247 });
+			expect(getByTestId('enemy-floaters').querySelectorAll('.floater')).toHaveLength(0);
+
+			hidden = false;
+			emit({ target: 'enemy', kind: 'hit', amount: 99 });
+			expect(getByTestId('enemy-floaters').querySelectorAll('.floater')).toHaveLength(1);
+		});
+	});
+
 	it('clears pending removal timers and unsubscribes on unmount (no write-after-destroy)', () => {
 		vi.useFakeTimers();
 		const clearSpy = vi.spyOn(globalThis, 'clearTimeout');


### PR DESCRIPTION
## Summary

Follow-up to #1594 (worker tick source), part of spike #1073. Once the sim runs at full rate while the tab is hidden, its per-tick presentational side effects run too, while `requestAnimationFrame` is suspended and page timers are throttled to ~once/minute:

- **Combat floaters** (`CombatFloaters.svelte`): `spawn()` now skips entirely while `document.hidden`. Previously each hit still pushed a floater into the DOM immediately, with only its removal `setTimeout` throttled — so a long hidden battle could accumulate a minute's worth of floater DOM before the throttled timers finally clear them, causing a stutter on refocus. They're purely presentational (`aria-hidden`), so skipping the spawn outright has no user-visible effect.
- **Victory-driven toasts** (challenge completions, proficiency milestones/level-ups/opens, newly-creatable recipes in `$lib/engine/engine.ts`): the same pileup risk applies — the tick worker can resolve far more battles per hidden minute than the throttled auto-dismiss timers can clear, so dozens of toasts could stack up over a long hidden session. A new `toastIfVisible` helper skips the toast while hidden but leaves the underlying state update and (for proficiency events) the permanent combat-log line untouched, so no information is lost — the player just doesn't see a popup for an event that happened while nobody was watching.

Audited but left unchanged, per the issue's own guidance:
- The boss-victory overlay's `delay(BOSS_VICTORY_OVERLAY_MS)` — stretching under throttling just slows hidden boss-farming slightly; acceptable.
- The combat log — already capped (`maxLogEntries`), no change needed.

No user-visible behavior change (the tab is hidden throughout); this is DOM-churn/battery hygiene so a long-hidden tab doesn't stutter on refocus.

## Test plan

- [x] New unit tests: `CombatFloaters.test.ts` (skip spawn while hidden, resume once visible) and `engine.test.ts` (challenge-completed/milestone/level-up/opened/recipe-available toasts all suppressed while hidden, underlying state updates and log lines still fire).
- [x] `npm run test:unit:ci` — full suite green (3445/3445).
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run build` — production build succeeds.

Closes #1598


---
_Generated by [Claude Code](https://claude.ai/code/session_019r24cKkXG7j59AGzbo1aEE)_