### PR TITLE
Load classes/skillRecipes into staticData so retire-confirm sees them (#1633)

### DIFF
--- a/UI/src/routes/admin/workbench/entities/class.ts
+++ b/UI/src/routes/admin/workbench/entities/class.ts
@@ -1,5 +1,6 @@
 import { ApiRequest, EAttribute, EModifierType, ESkillAcquisition, fetchSocketData, type IClass } from '$lib/api';
 import { hasFlag } from '$lib/common';
+import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import { childChanged, persistEntity } from '../save-helpers';
 import { firstFree } from './helpers';
@@ -15,10 +16,13 @@ export interface WorkbenchClass extends Omit<IClass, 'passiveScalingAttributeId'
 
 // Classes load over the socket; the admin filter invalidates this cache on every write server-side, so a
 // plain refetch returns the freshly-saved list. The optional scaling attribute is normalised to the select's
-// "None" sentinel (-1) for the editable copy.
+// "None" sentinel (-1) for the editable copy. Written through to staticData.classes so retire-confirm's
+// reference computation (starter-skill/starter-equipment groups) sees post-save edits (#1633).
 const refresh = async (): Promise<WorkbenchClass[]> => {
 	const classes = await fetchSocketData('GetClasses');
-	return classes.map((c) => ({ ...c, passiveScalingAttributeId: c.passiveScalingAttributeId ?? -1 }));
+	const workbenchClasses = classes.map((c) => ({ ...c, passiveScalingAttributeId: c.passiveScalingAttributeId ?? -1 }));
+	staticData.classes = workbenchClasses;
+	return workbenchClasses;
 };
 
 export const classEntity: EntityConfig<WorkbenchClass> = {

--- a/UI/src/routes/admin/workbench/entities/skill-recipe.ts
+++ b/UI/src/routes/admin/workbench/entities/skill-recipe.ts
@@ -1,4 +1,5 @@
 import { ApiRequest, fetchSocketData, type ISkillRecipe } from '$lib/api';
+import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import { childChanged, persistEntity } from '../save-helpers';
 import { firstFree } from './helpers';
@@ -16,7 +17,13 @@ import { chipsSection, type EntityConfig } from './types';
  * (acyclicity/reachability, an input equal to the result, the proficiency-level range) live on the backend and
  * surface as a save-failure toast; the cheap, local rules are flagged as warnings here.
  */
-const refresh = (): Promise<ISkillRecipe[]> => fetchSocketData('GetSkillRecipes');
+// Written through to staticData.skillRecipes so retire-confirm's reference computation (recipe-result/
+// recipe-input/recipe-condition groups) sees post-save edits, mirroring how entities/skill.ts writes through (#1633).
+const refresh = async (): Promise<ISkillRecipe[]> => {
+	const recipes = await fetchSocketData('GetSkillRecipes');
+	staticData.skillRecipes = recipes;
+	return recipes;
+};
 
 /** The result skill's name, the recipe's identity in the list/detail title and the referenced-by dialog. */
 const resultName = (recipe: ISkillRecipe): string => reference.skillName(recipe.resultSkillId) ?? '';

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -64,7 +64,9 @@ class WorkbenchReference {
 			challenges,
 			paths,
 			proficiencies,
-			lessons
+			lessons,
+			classes,
+			skillRecipes
 		] = await Promise.all([
 			fetchSocketData('GetEnemies'),
 			fetchSocketData('GetSkills'),
@@ -80,7 +82,11 @@ class WorkbenchReference {
 			fetchSocketData('GetChallenges'),
 			fetchSocketData('GetPaths'),
 			fetchSocketData('GetProficiencies'),
-			fetchSocketData('GetLessons')
+			fetchSocketData('GetLessons'),
+			// Referenced (not authored) via this loader too — retire-confirm's reference computation
+			// reads staticData.classes/skillRecipes, and the admin can be entered directly (#1633).
+			fetchSocketData('GetClasses'),
+			fetchSocketData('GetSkillRecipes')
 		]);
 		staticData.enemies = enemies;
 		staticData.skills = skills;
@@ -92,6 +98,8 @@ class WorkbenchReference {
 		staticData.paths = paths;
 		staticData.proficiencies = proficiencies;
 		staticData.lessons = lessons;
+		staticData.classes = classes;
+		staticData.skillRecipes = skillRecipes;
 		this.tags = tags;
 		this.tagCategories = tagCategories;
 		this.challengeTypes = challengeTypes;

--- a/UI/src/tests/routes/admin/workbench/entities/class.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/class.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EAttribute, EModifierType } from '$lib/api';
+
+/* Only the refresh() write-through added for #1633 — classEntity's field/table configs aren't touched here.
+   `fetchSocketData` is stubbed; the write-through into staticData.classes is what retire-confirm's reference
+   computation (starter-skill/starter-equipment groups) reads. */
+
+const { staticData, socket, mockFetch } = vi.hoisted(() => {
+	const socket = { classes: [] as unknown[] };
+	return {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		staticData: {} as any,
+		socket,
+		mockFetch: vi.fn(async (command: string) => (command === 'GetClasses' ? socket.classes : []))
+	};
+});
+
+vi.mock('$stores', () => ({ staticData }));
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	class ApiRequest {
+		static post = vi.fn();
+		static get = vi.fn();
+	}
+	return { ...actual, ApiRequest, fetchSocketData: mockFetch };
+});
+
+import { classEntity } from '$routes/admin/workbench/entities/class';
+
+describe('classEntity.refresh', () => {
+	it('writes the fetched classes through to staticData.classes (#1633 — needed for retire-confirm)', async () => {
+		socket.classes = [
+			{
+				id: 0,
+				name: 'Warrior',
+				description: '',
+				word: '',
+				passiveAttributeId: EAttribute.Strength,
+				passiveAmount: 1,
+				passiveScalingAmount: 0,
+				passiveModifierType: EModifierType.Additive,
+				designerNotes: '',
+				starterSkillIds: [3],
+				starterEquipment: [],
+				attributeDistributions: []
+			}
+		];
+
+		const result = await classEntity.refresh();
+
+		expect(staticData.classes).toBe(result);
+		expect(staticData.classes[0]).toMatchObject({ name: 'Warrior', starterSkillIds: [3] });
+	});
+
+	it('normalises a missing scaling attribute to the -1 sentinel in the written-through copy', async () => {
+		socket.classes = [
+			{
+				id: 0,
+				name: 'Mage',
+				description: '',
+				word: '',
+				passiveAttributeId: EAttribute.Intellect,
+				passiveAmount: 1,
+				passiveScalingAmount: 0,
+				passiveModifierType: EModifierType.Additive,
+				designerNotes: '',
+				starterSkillIds: [],
+				starterEquipment: [],
+				attributeDistributions: []
+			}
+		];
+
+		await classEntity.refresh();
+
+		expect(staticData.classes[0].passiveScalingAttributeId).toBe(-1);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/entities/skill-recipe.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/skill-recipe.test.ts
@@ -85,6 +85,16 @@ beforeEach(() => {
 });
 
 describe('skillRecipeEntity', () => {
+	it('refresh writes the fetched recipes through to staticData.skillRecipes (#1633 — needed for retire-confirm)', async () => {
+		const fetched = [recipe({ id: 0 }), recipe({ id: 1, resultSkillId: 4 })];
+		socket.recipes = fetched;
+
+		const result = await skillRecipeEntity.refresh();
+
+		expect(result).toBe(fetched);
+		expect(staticData.skillRecipes).toBe(fetched);
+	});
+
 	it('newItem defaults to the first Synthesis result with empty input/condition collections', () => {
 		expect(skillRecipeEntity.newItem(7)).toEqual({
 			id: 7,

--- a/UI/src/tests/routes/admin/workbench/reference-load.test.ts
+++ b/UI/src/tests/routes/admin/workbench/reference-load.test.ts
@@ -39,7 +39,9 @@ const SOCKET_SETS: Record<string, { id: number; name: string }[]> = {
 	GetChallenges: [{ id: 0, name: 'First Blood' }],
 	GetPaths: [{ id: 0, name: 'Fire Magic' }],
 	GetProficiencies: [{ id: 0, name: 'Fire' }],
-	GetLessons: [{ id: 0, name: 'Idle Combat' }]
+	GetLessons: [{ id: 0, name: 'Idle Combat' }],
+	GetClasses: [{ id: 0, name: 'Warrior' }],
+	GetSkillRecipes: [{ id: 0, name: 'Recipe' }]
 };
 const TAGS = [{ id: 10, name: 'Fire', tagCategoryId: 100 }];
 const TAG_CATEGORIES = [{ id: 100, name: 'Element' }];
@@ -62,7 +64,8 @@ describe('WorkbenchReference.load', () => {
 
 		await reference.load();
 
-		// The zero-based-id catalogues plus challenge types, paths and proficiencies load over the socket.
+		// The zero-based-id catalogues plus challenge types, paths, proficiencies, classes and skill
+		// recipes load over the socket.
 		for (const command of [
 			'GetEnemies',
 			'GetSkills',
@@ -74,12 +77,14 @@ describe('WorkbenchReference.load', () => {
 			'GetChallenges',
 			'GetPaths',
 			'GetProficiencies',
-			'GetLessons'
+			'GetLessons',
+			'GetClasses',
+			'GetSkillRecipes'
 		]) {
 			expect(mockFetchSocket).toHaveBeenCalledWith(command);
 		}
-		// Only tags + categories use HTTP — the transport split is exactly 11 socket / 2 HTTP.
-		expect(mockFetchSocket).toHaveBeenCalledTimes(11);
+		// Only tags + categories use HTTP — the transport split is exactly 13 socket / 2 HTTP.
+		expect(mockFetchSocket).toHaveBeenCalledTimes(13);
 		expect(mockGet).toHaveBeenCalledTimes(2);
 		expect(mockGet).toHaveBeenCalledWith('Tags');
 		expect(mockGet).toHaveBeenCalledWith('Tags/TagCategories');
@@ -95,6 +100,8 @@ describe('WorkbenchReference.load', () => {
 		expect(staticData.paths).toBe(SOCKET_SETS.GetPaths);
 		expect(staticData.proficiencies).toBe(SOCKET_SETS.GetProficiencies);
 		expect(staticData.lessons).toBe(SOCKET_SETS.GetLessons);
+		expect(staticData.classes).toBe(SOCKET_SETS.GetClasses);
+		expect(staticData.skillRecipes).toBe(SOCKET_SETS.GetSkillRecipes);
 		// …and the tags/categories/challenge-types the singleton owns onto its own fields
 		// (these are $state-wrapped reactive proxies, so compare by value, not identity).
 		expect(reference.tags).toEqual(TAGS);

--- a/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
+++ b/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
@@ -130,4 +130,25 @@ describe('retireWithConfirm', () => {
 		expect(body).toContain('Advanced Blades');
 		expect(onConfirmed).toHaveBeenCalledOnce();
 	});
+
+	it('surfaces a class starter-skill reference from a bare admin load (#1633 — classes must land in staticData)', async () => {
+		dangerModal.mockResolvedValue(true);
+		const onConfirmed = vi.fn();
+		// Simulates reference.load() populating staticData.classes on a direct /admin entry (no game load).
+		staticData.classes = [{ id: 0, name: 'Warrior', starterSkillIds: [3], starterEquipment: [] }];
+
+		await retireWithConfirm({
+			entityKey: 'skills',
+			id: 3,
+			name: 'Cleave',
+			title: 'Retire Skill?',
+			sources: referenceSourcesFromStatic(),
+			onConfirmed
+		});
+
+		expect(dangerModal).toHaveBeenCalledOnce();
+		const body = dangerModal.mock.calls[0][0].body as string;
+		expect(body).toContain('Warrior');
+		expect(onConfirmed).toHaveBeenCalledOnce();
+	});
 });


### PR DESCRIPTION
## Summary

`referenceSourcesFromStatic()` (`retire-confirm.ts`) reads `staticData.classes`/`staticData.skillRecipes` for the retire-confirm dialog's starter-skill / starter-equipment / recipe-result / recipe-input / recipe-condition reference groups. But `reference.load()` never fetched `GetClasses`/`GetSkillRecipes`, and the class/skill-recipe entity `refresh()` functions didn't write those catalogues into `staticData` either (unlike `entities/skill.ts`, which does write through). So entering `/admin` directly — a path the loader's own comment says must be supported — left both sets empty: retiring a class's starter skill, a recipe's result/input skill, a class's starter-equipment item, or a recipe-condition proficiency computed **zero references** and showed no confirm dialog at all. In-admin class/recipe edits also left the snapshot stale until a full reload.

## Fix

- `reference.svelte.ts`: `load()` now fetches `GetClasses`/`GetSkillRecipes` alongside the other catalogues and writes them into `staticData.classes`/`staticData.skillRecipes`.
- `entities/class.ts` / `entities/skill-recipe.ts`: their `refresh()` functions now write through to `staticData.classes`/`staticData.skillRecipes` on every refresh (including the post-save refresh `persistEntity` runs), mirroring the write-through `entities/skill.ts` already does. This keeps the snapshot fresh after in-admin class/recipe edits too, not just on a bare load.

## Tests

- `reference-load.test.ts`: asserts `GetClasses`/`GetSkillRecipes` are fetched over the socket and land in `staticData` (transport split now 13 socket / 2 HTTP).
- `retire-confirm.test.ts`: new test confirming a class's starter skill surfaces its "referenced by" group after a bare admin load (i.e. `staticData.classes` populated the way `reference.load()` now populates it).
- New `entities/class.test.ts` and an addition to `entities/skill-recipe.test.ts`: `refresh()` writes the fetched records through to `staticData` (no prior test file existed for the class entity).

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.
- [x] `npm run test:unit:ci` — 295 files / 3495 tests passing.

Closes #1633


---
_Generated by [Claude Code](https://claude.ai/code/session_01DJNvKFAgR9jdyZiuznGHEL)_