### PR TITLE
Workbench: only commit persistEntity after a child saver actually writes (#1634)

### DIFF
--- a/UI/src/routes/admin/workbench/entities/class.ts
+++ b/UI/src/routes/admin/workbench/entities/class.ts
@@ -244,28 +244,34 @@ export const classEntity: EntityConfig<WorkbenchClass> = {
 			refresh,
 			childSavers: [
 				async (id, record, baseline) => {
-					if (childChanged(record.starterSkillIds, baseline?.starterSkillIds)) {
-						await ApiRequest.post('AdminTools/SetClassStarterSkills', {
-							classId: id,
-							skillIds: record.starterSkillIds
-						});
+					if (!childChanged(record.starterSkillIds, baseline?.starterSkillIds)) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetClassStarterSkills', {
+						classId: id,
+						skillIds: record.starterSkillIds
+					});
+					return true;
 				},
 				async (id, record, baseline) => {
-					if (childChanged(record.starterEquipment, baseline?.starterEquipment)) {
-						await ApiRequest.post('AdminTools/SetClassStarterEquipment', {
-							classId: id,
-							equipment: record.starterEquipment
-						});
+					if (!childChanged(record.starterEquipment, baseline?.starterEquipment)) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetClassStarterEquipment', {
+						classId: id,
+						equipment: record.starterEquipment
+					});
+					return true;
 				},
 				async (id, record, baseline) => {
-					if (childChanged(record.attributeDistributions, baseline?.attributeDistributions)) {
-						await ApiRequest.post('AdminTools/SetClassAttributeDistributions', {
-							classId: id,
-							attributeDistributions: record.attributeDistributions
-						});
+					if (!childChanged(record.attributeDistributions, baseline?.attributeDistributions)) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetClassAttributeDistributions', {
+						classId: id,
+						attributeDistributions: record.attributeDistributions
+					});
+					return true;
 				}
 			]
 		})

--- a/UI/src/routes/admin/workbench/entities/enemy.ts
+++ b/UI/src/routes/admin/workbench/entities/enemy.ts
@@ -196,22 +196,28 @@ export const enemyEntity: EntityConfig<WorkbenchEnemy> = {
 			refresh,
 			childSavers: [
 				async (id, record, baseline) => {
-					if (childChanged(record.attributeDistribution, baseline?.attributeDistribution)) {
-						await ApiRequest.post('AdminTools/SetEnemyAttributeDistributions', {
-							enemyId: id,
-							attributeDistributions: record.attributeDistribution
-						});
+					if (!childChanged(record.attributeDistribution, baseline?.attributeDistribution)) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetEnemyAttributeDistributions', {
+						enemyId: id,
+						attributeDistributions: record.attributeDistribution
+					});
+					return true;
 				},
 				async (id, record, baseline) => {
-					if (childChanged(record.skillPool, baseline?.skillPool)) {
-						await ApiRequest.post('AdminTools/SetEnemySkills', { enemyId: id, skillIds: record.skillPool });
+					if (!childChanged(record.skillPool, baseline?.skillPool)) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetEnemySkills', { enemyId: id, skillIds: record.skillPool });
+					return true;
 				},
 				async (id, record, baseline) => {
-					if (childChanged(record.spawns, baseline?.spawns)) {
-						await ApiRequest.post('AdminTools/SetEnemySpawns', { enemyId: id, spawns: record.spawns });
+					if (!childChanged(record.spawns, baseline?.spawns)) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetEnemySpawns', { enemyId: id, spawns: record.spawns });
+					return true;
 				}
 			]
 		})

--- a/UI/src/routes/admin/workbench/entities/item-mod.ts
+++ b/UI/src/routes/admin/workbench/entities/item-mod.ts
@@ -118,14 +118,18 @@ export const itemModEntity: EntityConfig<IItemMod> = {
 			childSavers: [
 				async (id, record, baseline) => {
 					const changes = attributeChanges(record.attributes, baseline?.attributes, 'amount');
-					if (changes.length) {
-						await ApiRequest.post('AdminTools/AddEditItemModAttributes', { id, changes });
+					if (!changes.length) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/AddEditItemModAttributes', { id, changes });
+					return true;
 				},
 				async (id, record, baseline) => {
-					if (childChanged(record.tags, baseline?.tags)) {
-						await ApiRequest.post('AdminTools/SetTagsForItemMod', { id, tagIds: record.tags });
+					if (!childChanged(record.tags, baseline?.tags)) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetTagsForItemMod', { id, tagIds: record.tags });
+					return true;
 				}
 			]
 		})

--- a/UI/src/routes/admin/workbench/entities/item.ts
+++ b/UI/src/routes/admin/workbench/entities/item.ts
@@ -212,20 +212,26 @@ export const itemEntity: EntityConfig<WorkbenchItem> = {
 			childSavers: [
 				async (id, record, baseline) => {
 					const changes = attributeChanges(record.attributes, baseline?.attributes, 'amount');
-					if (changes.length) {
-						await ApiRequest.post('AdminTools/AddEditItemAttributes', { id, changes });
+					if (!changes.length) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/AddEditItemAttributes', { id, changes });
+					return true;
 				},
 				async (id, record, baseline) => {
 					const changes = modSlotChanges(record.modSlots, baseline?.modSlots, id);
-					if (changes.length) {
-						await ApiRequest.post('AdminTools/AddEditItemModSlots', changes);
+					if (!changes.length) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/AddEditItemModSlots', changes);
+					return true;
 				},
 				async (id, record, baseline) => {
-					if (childChanged(record.tags, baseline?.tags)) {
-						await ApiRequest.post('AdminTools/SetTagsForItem', { id, tagIds: record.tags });
+					if (!childChanged(record.tags, baseline?.tags)) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetTagsForItem', { id, tagIds: record.tags });
+					return true;
 				}
 			]
 		})

--- a/UI/src/routes/admin/workbench/entities/lesson.ts
+++ b/UI/src/routes/admin/workbench/entities/lesson.ts
@@ -193,19 +193,21 @@ export const lessonEntity: EntityConfig<WorkbenchLesson> = {
 			refresh,
 			childSavers: [
 				async (id, record, baseline) => {
-					if (childChanged(record.steps, baseline?.steps)) {
-						// SetLessonSteps reconciles against the full desired set (keyed by ordinal), not a diff —
-						// mirroring SetZoneEnemies rather than the Add/Edit/Delete-changes shape SetSkillPortions
-						// takes, since the backend's ChildCollectionReconciler wants the whole set every time.
-						await ApiRequest.post('AdminTools/SetLessonSteps', {
-							id,
-							steps: record.steps.map(({ ordinal, text, anchorKey }) => ({
-								ordinal,
-								text,
-								anchorKey: anchorKey || undefined
-							}))
-						});
+					if (!childChanged(record.steps, baseline?.steps)) {
+						return false;
 					}
+					// SetLessonSteps reconciles against the full desired set (keyed by ordinal), not a diff —
+					// mirroring SetZoneEnemies rather than the Add/Edit/Delete-changes shape SetSkillPortions
+					// takes, since the backend's ChildCollectionReconciler wants the whole set every time.
+					await ApiRequest.post('AdminTools/SetLessonSteps', {
+						id,
+						steps: record.steps.map(({ ordinal, text, anchorKey }) => ({
+							ordinal,
+							text,
+							anchorKey: anchorKey || undefined
+						}))
+					});
+					return true;
 				}
 			]
 		})

--- a/UI/src/routes/admin/workbench/entities/skill-recipe.ts
+++ b/UI/src/routes/admin/workbench/entities/skill-recipe.ts
@@ -158,14 +158,18 @@ export const skillRecipeEntity: EntityConfig<ISkillRecipe> = {
 			refresh,
 			childSavers: [
 				async (id, record, baseline) => {
-					if (childChanged(record.inputSkillIds, baseline?.inputSkillIds)) {
-						await ApiRequest.post('AdminTools/SetSkillRecipeInputs', { id, skillIds: record.inputSkillIds });
+					if (!childChanged(record.inputSkillIds, baseline?.inputSkillIds)) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetSkillRecipeInputs', { id, skillIds: record.inputSkillIds });
+					return true;
 				},
 				async (id, record, baseline) => {
-					if (childChanged(record.conditions, baseline?.conditions)) {
-						await ApiRequest.post('AdminTools/SetSkillRecipeConditions', { id, conditions: record.conditions });
+					if (!childChanged(record.conditions, baseline?.conditions)) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetSkillRecipeConditions', { id, conditions: record.conditions });
+					return true;
 				}
 			]
 		})

--- a/UI/src/routes/admin/workbench/entities/skill.ts
+++ b/UI/src/routes/admin/workbench/entities/skill.ts
@@ -259,21 +259,27 @@ export const skillEntity: EntityConfig<ISkill> = {
 			childSavers: [
 				async (id, record, baseline) => {
 					const changes = damagePortionChanges(record.damagePortions, baseline?.damagePortions);
-					if (changes.length) {
-						await ApiRequest.post('AdminTools/SetSkillPortions', { id, changes });
+					if (!changes.length) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetSkillPortions', { id, changes });
+					return true;
 				},
 				async (id, record, baseline) => {
 					const changes = attributeChanges(record.damageMultipliers, baseline?.damageMultipliers, 'multiplier');
-					if (changes.length) {
-						await ApiRequest.post('AdminTools/SetSkillMultipliers', { id, changes });
+					if (!changes.length) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetSkillMultipliers', { id, changes });
+					return true;
 				},
 				async (id, record, baseline) => {
 					const changes = skillEffectChanges(record.effects, baseline?.effects);
-					if (changes.length) {
-						await ApiRequest.post('AdminTools/SetSkillEffects', { id, changes });
+					if (!changes.length) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetSkillEffects', { id, changes });
+					return true;
 				}
 			]
 		})

--- a/UI/src/routes/admin/workbench/entities/zone.ts
+++ b/UI/src/routes/admin/workbench/entities/zone.ts
@@ -184,9 +184,11 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 			refresh,
 			childSavers: [
 				async (id, record, baseline) => {
-					if (childChanged(record.zoneEnemies, baseline?.zoneEnemies)) {
-						await ApiRequest.post('AdminTools/SetZoneEnemies', { zoneId: id, zoneEnemies: record.zoneEnemies });
+					if (!childChanged(record.zoneEnemies, baseline?.zoneEnemies)) {
+						return false;
 					}
+					await ApiRequest.post('AdminTools/SetZoneEnemies', { zoneId: id, zoneEnemies: record.zoneEnemies });
+					return true;
 				}
 			]
 		})

--- a/UI/src/routes/admin/workbench/save-helpers.ts
+++ b/UI/src/routes/admin/workbench/save-helpers.ts
@@ -61,7 +61,8 @@ export const resolveNewIds = (
 /** Resolve a possibly-local id through the new-id map (returns the input when already persisted). */
 export const resolveId = (id: number, idMap: Map<number, number>): number => idMap.get(id) ?? id;
 
-type ChildSaver<T> = (id: number, record: T, baseline: T | undefined) => Promise<void>;
+/** Returns whether it actually wrote — a no-op (unchanged collection) must report `false`. */
+type ChildSaver<T> = (id: number, record: T, baseline: T | undefined) => Promise<boolean>;
 
 interface PersistOptions<T extends Identified, D> {
 	diff: SaveDiff<T>;
@@ -139,8 +140,8 @@ export async function persistEntity<T extends Identified, D>(opts: PersistOption
 		if (childSavers.length && childTargets.length) {
 			for (const target of childTargets) {
 				for (const saver of childSavers) {
-					await saver(target.id, target.record, target.baseline);
-					committed = true;
+					const wrote = await saver(target.id, target.record, target.baseline);
+					committed ||= wrote;
 				}
 			}
 			return await refresh();

--- a/UI/src/tests/routes/admin/workbench/save-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/save-helpers.test.ts
@@ -197,6 +197,7 @@ describe('persistEntity', () => {
 			childSavers: [
 				async (id, record, baseline) => {
 					childCalls.push({ id, name: record.name, hasBaseline: baseline !== undefined });
+					return true;
 				}
 			]
 		});
@@ -261,6 +262,7 @@ describe('persistEntity', () => {
 			childSavers: [
 				async (id) => {
 					childIds.push(id);
+					return true;
 				}
 			]
 		});
@@ -299,6 +301,39 @@ describe('persistEntity', () => {
 				]
 			})
 		).rejects.toBeInstanceOf(PersistFailedError);
+	});
+
+	it('propagates a child-saver failure raw when every saver ahead of it no-op’d (nothing actually written)', async () => {
+		interface ChildRow extends Identified {
+			id: number;
+			name: string;
+			kids: number[];
+		}
+		// Identity and the first child collection are unchanged; only a second, unrelated child
+		// collection differs. The saver for that second collection fails before writing anything.
+		// Since neither the primary call nor the first (no-op) saver wrote, nothing has committed —
+		// the caller must be able to keep the user's edit for a clean retry.
+		const diff: SaveDiff<ChildRow> = {
+			added: [],
+			modified: [{ record: { id: 0, name: 'X', kids: [1, 2] }, baseline: { id: 0, name: 'X', kids: [1] } }],
+			deleted: [],
+			existingIds: [0]
+		};
+		const cause = new Error('child saver 500');
+		await expect(
+			persistEntity<ChildRow, { id: number; name: string }>({
+				diff,
+				toPrimaryDto: (r) => ({ id: r.id, name: r.name }),
+				postPrimary: async () => undefined,
+				refresh: async () => [{ id: 0, name: 'X', kids: [1, 2] }],
+				childSavers: [
+					async () => false,
+					async () => {
+						throw cause;
+					}
+				]
+			})
+		).rejects.toBe(cause);
 	});
 
 	it('wraps a post-commit refresh failure as PersistFailedError', async () => {


### PR DESCRIPTION
## Summary

`persistEntity` (`UI/src/routes/admin/workbench/save-helpers.ts`) flipped `committed = true` unconditionally after **every** child saver ran, even when the saver no-op'd because its collection was unchanged. `committed` gates whether a later failure is treated as recoverable (keep the user's pending edit for retry) or post-commit (re-seed from server truth, discarding the edit). A record whose only real change lives in a *later* child collection — with earlier no-op savers running first — would get its edit silently discarded on a pre-commit failure, because the no-ops had already (incorrectly) marked the record committed.

- `ChildSaver<T>` now returns `Promise<boolean>` — whether it actually wrote — instead of `Promise<void>`.
- `persistEntity` only ORs `committed` with a saver's return value, so a run of no-op savers no longer marks the record committed.
- Updated every `childSavers` definition (`class.ts`, `enemy.ts`, `item-mod.ts`, `item.ts`, `lesson.ts`, `skill-recipe.ts`, `skill.ts`, `zone.ts`) to return `true`/`false` based on whether it actually posted a change, matching their existing no-op guards (`changes.length` / `childChanged(...)`).

## Test plan

- [x] Added a unit test (`save-helpers.test.ts`): a record with only a child-collection edit, where an earlier no-op saver runs before a saver that fails *before* writing — the failure now propagates raw (not wrapped as `PersistFailedError`), so the caller keeps the pending edit.
- [x] Updated the existing `persistEntity` tests' inline child savers to return a boolean per the new `ChildSaver` contract.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.
- [x] `npm run test:unit:ci` (full suite) — 295 files / 3496 tests passing.

Closes #1634


---
_Generated by [Claude Code](https://claude.ai/code/session_013L6Nw9Jo7eexkoFpc7CVN7)_