### PR TITLE
SocketReplaced: stop misclassifying its self-delivered push as NotDelivered (#1636)

### DIFF
--- a/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
@@ -1,4 +1,5 @@
 using Game.Abstractions.DataAccess;
+using Game.Api;
 using Game.Api.Models.Common;
 using Game.Api.Services;
 using Game.Api.Sockets;
@@ -193,6 +194,32 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
+        public async Task ExecuteServerCommand_SelfDeliveringCommand_ReturnsSucceededWithoutASecondSendOrDeliveryWarning()
+        {
+            // Mirrors SocketReplaced: the command sends its own response and closes the socket before
+            // returning. The runner must not attempt (and then misclassify as NotDelivered) a follow-up send
+            // on the now-closed socket (#1636).
+            var (socket, handler) = CreateHandler(_ => null, selfDelivering: name => name == "SelfDelivers");
+
+            var outcome = await handler.ExecuteServerCommand(new SocketCommandInfo("SelfDelivers") { Id = "c1" });
+
+            Assert.Equal(SocketCommandOutcome.Succeeded, outcome);
+            Assert.Single(socket.SentMessages, m => m.Contains("c1"));
+            Assert.DoesNotContain(_logs.Entries, e => e.Message.Contains("Failed to deliver"));
+        }
+
+        [Fact]
+        public async Task ExecuteCommand_SelfDeliveringCommand_DoesNotAttemptASecondSend()
+        {
+            var (socket, handler) = CreateHandler(_ => null, selfDelivering: name => name == "SelfDelivers");
+
+            await handler.ExecuteCommand(new SocketCommandInfo("SelfDelivers") { Id = "c1" });
+
+            Assert.Single(socket.SentMessages, m => m.Contains("c1"));
+            Assert.DoesNotContain(_logs.Entries, e => e.Message.Contains("Failed to deliver"));
+        }
+
+        [Fact]
         public async Task HandleMessage_UnparseableJson_ClosesTheSocketInsteadOfLeavingTheClientToTimeOut()
         {
             // An invalid-JSON frame carries no request id to correlate a structured rejection to, so closing
@@ -207,13 +234,13 @@ namespace Game.Api.Tests.Unit
             Assert.Contains(_logs.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("Failed to deserialize"));
         }
 
-        private (FakeWebSocket Socket, SocketHandler Handler) CreateHandler(Func<string, Exception?> throwOn, Func<string, Exception?>? throwOnCreate = null)
+        private (FakeWebSocket Socket, SocketHandler Handler) CreateHandler(Func<string, Exception?> throwOn, Func<string, Exception?>? throwOnCreate = null, Func<string, bool>? selfDelivering = null)
         {
             var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
             var session = new SessionService(new NoOpSessionStore());
             session.CreateSession(userId: 1, playerId: 1);
             var context = new SocketContext(socket, playerId: 1, session, isAdmin: false, _loggerFactory.CreateLogger<SocketContext>());
-            var handler = new SocketHandler(context, new StubCommandFactory(throwOn, throwOnCreate), _scopeFactory,
+            var handler = new SocketHandler(context, new StubCommandFactory(throwOn, throwOnCreate, selfDelivering), _scopeFactory,
                 _loggerFactory.CreateLogger<SocketHandler>(), () => { });
             return (socket, handler);
         }
@@ -229,13 +256,18 @@ namespace Game.Api.Tests.Unit
         /// throws directly from <see cref="CreateCommand"/> instead — simulating what the real factory's
         /// <c>SetParameters</c> call already throws (a classified <see cref="MalformedSocketCommandParametersException"/>)
         /// once parameter binding fails, before a command is ever fully constructed.</summary>
-        private sealed class StubCommandFactory(Func<string, Exception?> throwOn, Func<string, Exception?>? throwOnCreate = null) : SocketCommandFactory
+        private sealed class StubCommandFactory(Func<string, Exception?> throwOn, Func<string, Exception?>? throwOnCreate = null, Func<string, bool>? selfDelivering = null) : SocketCommandFactory
         {
             public override AbstractSocketCommand CreateCommand(SocketCommandInfo commandInfo, IServiceScope scope)
             {
                 if (throwOnCreate?.Invoke(commandInfo.Name) is { } creationFault)
                 {
                     throw creationFault;
+                }
+
+                if (selfDelivering?.Invoke(commandInfo.Name) is true)
+                {
+                    return new SelfDeliveringStubCommand(commandInfo.Name) { Id = commandInfo.Id };
                 }
 
                 return new StubCommand(commandInfo.Name, throwOn(commandInfo.Name)) { Id = commandInfo.Id };
@@ -258,6 +290,19 @@ namespace Game.Api.Tests.Unit
                 }
 
                 return Task.FromResult(Success());
+            }
+        }
+
+        /// <summary>Mirrors SocketReplaced's send-then-close-then-return-Success shape for #1636 coverage.</summary>
+        private sealed class SelfDeliveringStubCommand(string name) : AbstractSocketCommand, ISelfDeliveringCommand
+        {
+            public override string Name { get; set; } = name;
+
+            public override async Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
+            {
+                await context.SendData(Success());
+                await context.Close(ESocketCloseReason.SocketReplaced);
+                return Success();
             }
         }
 

--- a/Game.Api/Sockets/Commands/ISelfDeliveringCommand.cs
+++ b/Game.Api/Sockets/Commands/ISelfDeliveringCommand.cs
@@ -1,0 +1,13 @@
+namespace Game.Api.Sockets.Commands
+{
+    /// <summary>
+    /// Marks a socket command that sends its own response instead of letting the command runner send it
+    /// (<see cref="Sockets.SocketHandler"/>) — e.g. <see cref="SocketReplaced"/>, whose success frame must
+    /// reach the client strictly before the close frame it also sends. The runner skips its own unconditional
+    /// send for a self-delivering command and reports <see cref="Sockets.SocketCommandOutcome.Succeeded"/>
+    /// unconditionally, rather than reclassifying the runner's own guaranteed-to-fail follow-up send (the
+    /// socket the command just closed is no longer Open) as <see cref="Sockets.SocketCommandOutcome.NotDelivered"/>
+    /// (#1636).
+    /// </summary>
+    public interface ISelfDeliveringCommand { }
+}

--- a/Game.Api/Sockets/Commands/SocketReplaced.cs
+++ b/Game.Api/Sockets/Commands/SocketReplaced.cs
@@ -2,20 +2,21 @@
 
 namespace Game.Api.Sockets.Commands
 {
-    public class SocketReplaced : AbstractSocketCommand, IServerInitiatedCommand
+    public class SocketReplaced : AbstractSocketCommand, IServerInitiatedCommand, ISelfDeliveringCommand
     {
         public override string Name { get; set; } = nameof(SocketReplaced);
 
         public override async Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
-            // This command deliberately owns its own send-then-close rather than deferring the send to the
-            // command runner: the success frame is what the client's SocketReplaced handler reacts to, and it
-            // must reach the client BEFORE the close frame — but the runner sends only after this returns, which
-            // is too late. Close() then moves the socket out of Open, so the runner's subsequent unconditional
-            // SendData of the returned response is a no-op (SendData returns false on a non-Open socket); the
-            // returned value is never transmitted. It is returned as Success() (not an empty frame) purely
-            // defensively: were the ordering ever changed so the socket were still Open, the runner would emit a
-            // valid success frame rather than a spurious empty one.
+            // This command deliberately owns its own send-then-close (marked via ISelfDeliveringCommand)
+            // rather than deferring the send to the command runner: the success frame is what the client's
+            // SocketReplaced handler reacts to, and it must reach the client BEFORE the close frame — but the
+            // runner sends only after this returns, which is too late. Close() then moves the socket out of
+            // Open; ISelfDeliveringCommand tells the runner to skip its own follow-up send rather than attempt
+            // one that's guaranteed to fail on the now-closed socket and get misclassified as a delivery
+            // failure (#1636). It is returned as Success() (not an empty frame) purely defensively: were the
+            // ordering ever changed so the socket were still Open, the runner would emit a valid success frame
+            // rather than a spurious empty one.
             await context.SendData(Success());
             await context.Close(ESocketCloseReason.SocketReplaced);
             return Success();

--- a/Game.Api/Sockets/SocketHandler.cs
+++ b/Game.Api/Sockets/SocketHandler.cs
@@ -187,12 +187,12 @@ namespace Game.Api.Sockets
             try
             {
                 var commandTask = RunCommand(commandInfo, cts.Token);
-                ApiSocketResponse response;
+                (ApiSocketResponse Response, bool SelfDelivered) result;
                 try
                 {
                     // Bound the wait without abandoning the underlying task: WaitAsync returns the command's
                     // response when it settles, or throws once the budget elapses (the command keeps running).
-                    response = await commandTask.WaitAsync(cts.Token);
+                    result = await commandTask.WaitAsync(cts.Token);
                 }
                 catch (OperationCanceledException) when (cts.IsCancellationRequested)
                 {
@@ -211,10 +211,18 @@ namespace Game.Api.Sockets
                     return (SocketCommandOutcome.TimedOut, null);
                 }
 
+                if (result.SelfDelivered)
+                {
+                    // The command (ISelfDeliveringCommand, e.g. SocketReplaced) already sent its own response —
+                    // often after already closing the socket — so a follow-up send here would either duplicate
+                    // it or be a guaranteed-to-fail no-op misclassified as NotDelivered (#1636).
+                    return (SocketCommandOutcome.Succeeded, null);
+                }
+
                 // SendData reports whether the frame actually went out (false on a non-Open socket or send
                 // failure — e.g. the socket closed just as the command finished). That must not be reported as
                 // Succeeded: the client never saw the response, so the caller needs to know delivery failed.
-                var delivered = await _context.SendData(response);
+                var delivered = await _context.SendData(result.Response);
                 return (delivered ? SocketCommandOutcome.Succeeded : SocketCommandOutcome.NotDelivered, null);
             }
             catch (OperationCanceledException ex)
@@ -250,11 +258,12 @@ namespace Game.Api.Sockets
             }
         }
 
-        // Executes the command and commits its unit of work, returning the response for the caller to send.
-        // It deliberately does not send: ExecuteCommand owns the single send so that a command abandoned on
-        // timeout (whose task runs on here in the background) commits its write but never emits a second,
-        // late response for an id the client already saw time out.
-        private async Task<ApiSocketResponse> RunCommand(SocketCommandInfo commandInfo, CancellationToken cancellationToken)
+        // Executes the command and commits its unit of work, returning the response (and whether the command
+        // already delivered it itself — ISelfDeliveringCommand) for the caller to send. It deliberately does
+        // not send when not self-delivering: RunCommandUnderLock owns the single send so that a command
+        // abandoned on timeout (whose task runs on here in the background) commits its write but never emits a
+        // second, late response for an id the client already saw time out.
+        private async Task<(ApiSocketResponse Response, bool SelfDelivered)> RunCommand(SocketCommandInfo commandInfo, CancellationToken cancellationToken)
         {
             using var scope = _scopeFactory.CreateScope();
             // CreateCommand binds Parameters (SetParameters), which throws MalformedSocketCommandParametersException
@@ -264,7 +273,7 @@ namespace Game.Api.Sockets
             var command = _commandFactory.CreateCommand(commandInfo, scope);
             var response = await command.ExecuteAsync(_context, cancellationToken);
             await scope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
-            return response;
+            return (response, command is ISelfDeliveringCommand);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

`SocketReplaced.ExecuteAsync` (`Game.Api/Sockets/Commands/SocketReplaced.cs`) deliberately owns its own send-then-close, since the success frame must reach the client **before** the close frame. But `RunCommandUnderLock` (`Game.Api/Sockets/SocketHandler.cs`) always ran its own follow-up `SendData` afterward — which returns `false` because the socket is no longer `Open` — so every legitimate session takeover got classified `NotDelivered` and warn-logged as "Failed to deliver a server-initiated socket command", even though the push had actually succeeded.

- Added `ISelfDeliveringCommand` (`Game.Api/Sockets/Commands/ISelfDeliveringCommand.cs`), a marker interface following the existing `IServerInitiatedCommand` pattern, for a command that sends its own response instead of letting the runner send it.
- `SocketReplaced` now implements it.
- `RunCommandUnderLock`/`RunCommand` in `SocketHandler` check whether the executed command is self-delivering; if so, the runner skips its own follow-up send and reports `SocketCommandOutcome.Succeeded` directly instead of running a guaranteed-to-fail send and misclassifying the result.

## Test plan

- [x] `dotnet build` — clean, 0 warnings.
- [x] `dotnet test` (full backend suite: `Game.Core.Tests`, `Game.Infrastructure.Tests`, `Game.Api.Tests`, `Game.Application.Tests`) — all passing (2,970 tests, 0 failures).
- [x] New coverage in `SocketCommandExecutionTests`:
  - `ExecuteServerCommand_SelfDeliveringCommand_ReturnsSucceededWithoutASecondSendOrDeliveryWarning` — a self-delivering command (mirroring `SocketReplaced`'s send-then-close shape) reports `Succeeded` with no second send and no "Failed to deliver" warning.
  - `ExecuteCommand_SelfDeliveringCommand_DoesNotAttemptASecondSend` — same assertion via the client-initiated path.

Closes #1636


---
_Generated by [Claude Code](https://claude.ai/code/session_01J38oCCtE7GCu9YtmFK3Z5i)_