### PR TITLE
Exclude dormant skills from Skills header combined dps/burst totals (#1637)

### DIFF
--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -355,8 +355,8 @@ export class SkillsView {
 
 	/** Equipped skills the battle can actually fire — excludes a weapon-mismatched skill dormant under
 	 *  the equipped weapon (#1342), so the combined totals below never sum an output the battle can't
-	 *  produce. Innate (item-granted) skills also fire but are a selected-loadout-only readout here;
-	 *  see #1637 for the open question of whether they belong in these totals. */
+	 *  produce. Innate (item-granted) skills also fire but are deliberately excluded — the totals stay
+	 *  a selected-loadout-only readout; see #1657 for the open question of folding them in. */
 	private readonly fieldedEquipped = $derived(
 		this.equipped.filter((id) => {
 			const skill = this.metricsById[id]?.skill;

--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -353,11 +353,22 @@ export class SkillsView {
 	/** Metrics for the inspected skill, falling back to the first listed skill. */
 	readonly selected = $derived(this.metricsById[this.selectedId] ?? this.railList[0]);
 
+	/** Equipped skills the battle can actually fire — excludes a weapon-mismatched skill dormant under
+	 *  the equipped weapon (#1342), so the combined totals below never sum an output the battle can't
+	 *  produce. Innate (item-granted) skills also fire but are a selected-loadout-only readout here;
+	 *  see #1637 for the open question of whether they belong in these totals. */
+	private readonly fieldedEquipped = $derived(
+		this.equipped.filter((id) => {
+			const skill = this.metricsById[id]?.skill;
+			return skill != null && !this.dormant(skill);
+		})
+	);
+
 	/** Combined effective DPS of the equipped loadout vs the current Toughness. */
-	readonly combinedEffectiveDps = $derived(this.equipped.reduce((sum, id) => sum + this.effectiveDps(id), 0));
+	readonly combinedEffectiveDps = $derived(this.fieldedEquipped.reduce((sum, id) => sum + this.effectiveDps(id), 0));
 
 	/** Combined effective single-hit burst of the equipped loadout vs the current Toughness. */
-	readonly combinedEffectiveBurst = $derived(this.equipped.reduce((sum, id) => sum + this.effective(id), 0));
+	readonly combinedEffectiveBurst = $derived(this.fieldedEquipped.reduce((sum, id) => sum + this.effective(id), 0));
 
 	/* ── per-skill effective reads (Toughness-aware) ─────────────────────────── */
 

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -718,6 +718,44 @@ describe('SkillsView — critical hits fold into effective damage', () => {
 	});
 });
 
+/* The header's combined effective totals must never sum an output the battle can't produce (#1637):
+   a dormant (weapon-mismatched) equipped skill is excluded, mirroring the per-card suppression
+   `EquippedBand.svelte` already applies. */
+describe('SkillsView — combined effective totals exclude dormant skills (#1637)', () => {
+	const swordSkill = skill({
+		id: 6,
+		name: 'Golf',
+		baseDamage: 20,
+		cooldownMs: 1000,
+		damagePortions: [{ type: EDamageType.Sword, weight: 1 }]
+	});
+
+	beforeEach(() => {
+		staticData.skills = [...SKILLS, swordSkill];
+		mockPlayerManager.unlockedSkills = [
+			{ skillId: 0, selected: true, order: 0 },
+			{ skillId: 1, selected: true, order: 1 },
+			{ skillId: 6, selected: true, order: 2 }
+		];
+	});
+
+	it('contributes 0 to both totals while dormant under a mismatched weapon', () => {
+		mockInventoryManager.equippedWeaponType = EDamageType.Unarmed;
+		const v = new SkillsView();
+		expect(v.dormant(swordSkill)).toBe(true);
+		expect(v.combinedEffectiveBurst).toBeCloseTo(v.effective(0) + v.effective(1), 10);
+		expect(v.combinedEffectiveDps).toBeCloseTo(v.effectiveDps(0) + v.effectiveDps(1), 10);
+	});
+
+	it('restores its contribution once the matching weapon is equipped', () => {
+		mockInventoryManager.equippedWeaponType = EDamageType.Sword;
+		const v = new SkillsView();
+		expect(v.dormant(swordSkill)).toBe(false);
+		expect(v.combinedEffectiveBurst).toBeCloseTo(v.effective(0) + v.effective(1) + v.effective(6), 10);
+		expect(v.combinedEffectiveDps).toBeCloseTo(v.effectiveDps(0) + v.effectiveDps(1) + v.effectiveDps(6), 10);
+	});
+});
+
 /* The weapon-match grey-out (#1342): a weapon-leaf-typed skill is dormant unless the matching weapon is
    equipped. `dormant()` derives from the same `isFielded` rule the battle assembly applies. */
 describe('SkillsView — weapon-match grey-out', () => {


### PR DESCRIPTION
## Summary

`combinedEffectiveDps`/`combinedEffectiveBurst` (`UI/src/routes/game/screens/skills/skills-view.svelte.ts`) reduced over the raw equipped loadout with no `dormant()` gate, while the same screen already suppresses per-card stats for a dormant (weapon-mismatched) skill via `EquippedBand.svelte` (#1342). Unequipping the matching weapon left the header's "eff. dps"/"eff. burst" totals still summing damage from skills the battle can never fire.

## Fix

Added a private `fieldedEquipped` derived value that filters the equipped loadout through the existing `dormant()` predicate against `metricsById`, and reduced both totals over it instead of the raw `equipped` list.

## Design-question note (from the issue's "resolve in the same pass" ask)

The issue also raised whether fielded **innate** (item-granted) skills — which do fire in battle but are excluded from these totals today — should be folded in, versus keeping the header a selected-loadout-only readout. I kept it scoped to the selected loadout (the minimal fix for the reported bug: an unfireable output shown as fireable) rather than also changing what's counted, since that's a separate, non-trivial scope/labeling decision. Left a code comment flagging it for whoever revisits.

## Test plan

- [x] `npm run test:unit:ci` (full suite) — 295 files / 3498 tests passing, including new coverage:
  - A dormant equipped skill contributes 0 to both `combinedEffectiveDps`/`combinedEffectiveBurst`.
  - The skill's contribution is restored once the matching weapon is equipped.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.

Closes #1637


---
_Generated by [Claude Code](https://claude.ai/code/session_01JJfVmoze5j61yYABJKXDRf)_