### PR TITLE
Guard openLesson against zero-step lessons wedging the tutorial tour (#1638)

### DIFF
--- a/UI/src/lib/engine/tutorials.ts
+++ b/UI/src/lib/engine/tutorials.ts
@@ -15,8 +15,17 @@ const isLocked = (lessonId: number): boolean => !playerManager.lessons.some((les
  * Opens `lesson`'s tour: navigates to its host screen (a no-op if already there) and plays its
  * steps. This is the single open→navigate→play flow shared by the screen-anchored auto-trigger
  * below and manually opening a queued unread lesson (e.g. from the Help nav badge, #1589).
+ *
+ * A lesson with no steps can't render `TourPlayer` (it has nothing to show as `currentStep`), so
+ * its dismiss/complete callbacks — the only path that marks a lesson read — would never fire.
+ * Rather than wedge as a permanently "active" lesson that keeps re-triggering, treat it as a no-op
+ * and mark it read immediately so bad content degrades gracefully instead of getting stuck.
  */
 export function openLesson(lesson: ILesson) {
+	if (lesson.steps.length === 0) {
+		playerManager.markLessonRead(lesson.id);
+		return;
+	}
 	navigation.requestScreen(lesson.screenKey);
 	tutorialTour.play(lesson);
 }

--- a/UI/src/tests/lib/engine/tutorials.test.ts
+++ b/UI/src/tests/lib/engine/tutorials.test.ts
@@ -45,7 +45,7 @@ const makeLesson = (overrides: Partial<ILesson> = {}): ILesson => ({
 	screenKey: 'fight',
 	ordinal: 0,
 	designerNotes: '',
-	steps: [],
+	steps: [{ ordinal: 0, text: 'Step text' }],
 	...overrides
 });
 
@@ -80,6 +80,16 @@ describe('openLesson', () => {
 		expect(navigation.requestedScreen).toBe('skills');
 		// $state wraps the assigned lesson in a reactive proxy, so compare by value, not identity.
 		expect(tutorialTour.activeLesson).toEqual(lesson);
+	});
+
+	it('marks a zero-step lesson read immediately instead of opening a stuck tour (#1638)', () => {
+		const lesson = makeLesson({ id: 8, steps: [] });
+
+		openLesson(lesson);
+
+		expect(mockMarkLessonRead).toHaveBeenCalledWith(8);
+		expect(tutorialTour.activeLesson).toBeNull();
+		expect(navigation.requestedScreen).toBeNull();
 	});
 });
 
@@ -173,6 +183,21 @@ describe('evaluateScreenTrigger', () => {
 		evaluateScreenTrigger('attributes');
 
 		expect(tutorialTour.activeLesson).toEqual(lockedLesson);
+	});
+
+	it('does not wedge on a zero-step screen-anchored lesson, and does not re-fire on a later revisit', () => {
+		const lesson = makeLesson({ id: 9, screenKey: 'attributes', steps: [] });
+		staticData.lessons = [lesson];
+
+		evaluateScreenTrigger('attributes');
+
+		expect(tutorialTour.activeLesson).toBeNull();
+		expect(mockMarkLessonRead).toHaveBeenCalledWith(9);
+
+		mockMarkLessonRead.mockClear();
+		evaluateScreenTrigger('attributes');
+
+		expect(mockMarkLessonRead).not.toHaveBeenCalled();
 	});
 });
 


### PR DESCRIPTION
## Summary

A lesson with zero steps is saveable in the Workbench (only a warning, never a blocking validation), and if such a screen-anchored lesson goes live it wedges the tutorial-tour flow:

- `TourPlayer.svelte` renders nothing when `currentStep` is `undefined` (`{#if open && currentStep}`), so its `onDismiss`/`onComplete` callbacks never fire.
- `closeTutorialTour` — the only thing that marks a lesson read — is only reachable through those callbacks.
- The lesson stays permanently "active" and, for a screen-anchored lesson, re-triggers on every activation of its host screen (`evaluateScreenTrigger` keeps finding it since it's still locked). A mechanic-anchored zero-step lesson wedges the same way once opened from the unread queue.

## Fix

`openLesson` (`UI/src/lib/engine/tutorials.ts`) now guards on `lesson.steps.length === 0`: instead of navigating and playing a tour that can never close, it calls `playerManager.markLessonRead` directly and returns — a no-op that also unlocks/marks the lesson so it stops being reconsidered by `evaluateScreenTrigger` on later visits.

Since `openLesson` is the single production call site for `tutorialTour.play` (verified via search), gating there covers both the screen-anchored auto-trigger and any manual open of a queued unread lesson (e.g. from the Help nav badge). I did not add the issue's optional secondary guard directly in `tutorialTour.play` — it isn't needed given the single call site, and `closeTutorialTour`'s own tests rely on calling `tutorialTour.play` directly with a lesson that doesn't otherwise matter for that test's purpose.

## Tests

Added to `UI/src/tests/lib/engine/tutorials.test.ts`:
- `openLesson` marks a zero-step lesson read immediately instead of opening a tour (no navigation, no active tour).
- `evaluateScreenTrigger` does not wedge on a zero-step screen-anchored lesson, and does not re-fire it on a later revisit.

`makeLesson`'s default now includes one step (previously `[]`) since most existing tests assert the tour actually opens; the two new tests explicitly override `steps: []`.

## Test plan

- [x] `npm run test:unit:ci` (full suite) — 295 files / 3498 tests passing
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings

Closes #1638


---
_Generated by [Claude Code](https://claude.ai/code/session_01EEKYo77b8oY3QYoQkPdpkj)_