### PR TITLE
Refresh InventoryManager on mid-session player resync (#1639)

### DIFF
--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -1,7 +1,14 @@
 import { apiSocket, ELogType, IEnemyInstance } from '$lib/api';
 import { Action, createHook, delay, isZoneUnlocked, navigableZones, nextZoneByOrder } from '$lib/common';
 import { staticData, statistics, playerChallenges } from '$stores';
-import { battleEngine, BattleStage, onBattleStageChanged, playerManager, type PlayerBattleState } from '../';
+import {
+	battleEngine,
+	BattleStage,
+	inventoryManager,
+	onBattleStageChanged,
+	playerManager,
+	type PlayerBattleState
+} from '../';
 import { logMessage } from '../log';
 import { refreshPlayer } from '../session';
 
@@ -646,8 +653,11 @@ export class EnemyManager {
 				// The transport settles a lost/timed-out response as an error even when the command may have
 				// actually succeeded server-side (see docs/frontend.md's socket request lifecycle) — resync the
 				// authoritative player state rather than leaving exp/level silently diverged for the rest of
-				// the session.
+				// the session. refreshPlayer only re-initializes playerManager, so the inventory (an item/mod
+				// reward the lost response may have carried) is re-derived from it separately, mirroring what
+				// startGame does on the initial load.
 				await refreshPlayer();
+				inventoryManager.initialize();
 			}
 		}
 		// Guard `data` for a possible error response (absent `data`), now that this is the shared

--- a/UI/src/lib/engine/session.ts
+++ b/UI/src/lib/engine/session.ts
@@ -69,8 +69,13 @@ async function restorePlayer(): Promise<boolean> {
 /**
  * Re-pulls the authoritative player aggregate (Login/Status) and re-initializes the player manager.
  * Used by the welcome-back gate to refresh the offline-reward-updated state — level, exp, stat points,
- * unlocked skills, inventory — before the game engine builds the live battler from it. Best-effort: a
- * failed refresh leaves the existing in-memory player intact rather than stranding the player at the gate.
+ * unlocked skills, raw inventory data — before the game engine builds the live battler from it. Best-effort:
+ * a failed refresh leaves the existing in-memory player intact rather than stranding the player at the gate.
+ *
+ * This only re-initializes {@link playerManager}, not the derived `InventoryManager` — a caller that needs
+ * the player's unlocked items/mods to reflect the refresh (rather than just the raw payload) must also
+ * re-run `inventoryManager.initialize()` itself, as the mid-session resync in `EnemyManager.claimVictory`
+ * does (the welcome-back gate gets this for free from the `startGame` call that follows it).
  */
 export async function refreshPlayer(): Promise<void> {
 	await loadPlayer();

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -20,6 +20,7 @@ const h = vi.hoisted(() => ({
 	},
 	BattleStage: { Idle: 0, Active: 1, Victorious: 2, Defeated: 3, Loading: 4, Paused: 5, Drawn: 6 },
 	playerManager: { currentZone: 3, applyVictoryRewards: vi.fn() },
+	inventoryManager: { initialize: vi.fn() },
 	refreshPlayer: vi.fn(() => Promise.resolve()),
 	staticData: {
 		enemies: [{ id: 0, name: 'Catacomb Lich', isBoss: true }],
@@ -40,7 +41,8 @@ vi.mock('$lib/engine', () => ({
 		h.holder.stageCb = cb;
 		return () => {};
 	}),
-	playerManager: h.playerManager
+	playerManager: h.playerManager,
+	inventoryManager: h.inventoryManager
 }));
 vi.mock('$lib/engine/session', () => ({ refreshPlayer: h.refreshPlayer }));
 vi.mock('$stores', () => ({
@@ -137,6 +139,7 @@ describe('EnemyManager boss mode', () => {
 		h.battleEngine.playerBattleStateMatches.mockReturnValue(true);
 		h.playerManager.applyVictoryRewards.mockClear();
 		h.refreshPlayer.mockClear();
+		h.inventoryManager.initialize.mockClear();
 		h.statistics.markZoneCleared.mockClear();
 		// Default: no zones authored ⇒ no "next zone" to unlock; the unlock tests opt in.
 		h.staticData.zones = undefined;
@@ -899,6 +902,7 @@ describe('EnemyManager boss mode', () => {
 		expect(logMessage).toHaveBeenCalledWith(ELogType.EnemyDefeated, 'Catacomb Lich was defeated!');
 		// A successful claim needs no resync — the response itself carried the authoritative state.
 		expect(h.refreshPlayer).not.toHaveBeenCalled();
+		expect(h.inventoryManager.initialize).not.toHaveBeenCalled();
 	});
 
 	it('does not log the defeat when DefeatEnemy fails (no premature "defeated" line)', async () => {
@@ -920,6 +924,9 @@ describe('EnemyManager boss mode', () => {
 		// server-side, so an errored claim resyncs the authoritative player state rather than leaving the
 		// client's exp/level silently diverged.
 		expect(h.refreshPlayer).toHaveBeenCalledOnce();
+		// refreshPlayer only re-initializes playerManager; the inventory (an item/mod the outage-window
+		// victory may have unlocked) must be re-derived from it too, or it stays invisible until reload.
+		expect(h.inventoryManager.initialize).toHaveBeenCalledOnce();
 	});
 
 	it('survives a missing/retired enemy id on victory (still grants rewards, omits the name log)', async () => {


### PR DESCRIPTION
## Summary

The lost-response recovery path (`claimVictory` → `refreshPlayer()` on a `DefeatEnemy` transport error, `UI/src/lib/engine/battle/enemy-manager.ts`) re-pulls `Login/Status` and re-initializes `playerManager` (level, exp, unlocked skills), but never re-ran `inventoryManager.initialize()` — which otherwise only runs once, in `startGame`. An item/mod unlocked server-side during the outage window stayed invisible until a full page reload.

**Scenario:** the connection blips exactly as a boss kill completes a zone-gating challenge with an item reward — exp/level resync happens, but the reward item doesn't appear until reload.

## Fix

`enemy-manager.ts` now imports `inventoryManager` from the engine barrel (alongside `playerManager`, which it already pulled from there) and calls `inventoryManager.initialize()` right after `refreshPlayer()` in the resync branch — re-deriving the inventory from the freshly-loaded `playerManager.inventoryData`, mirroring what `startGame` does on the initial load.

## Test plan

- [x] Unit tests (`enemy-manager-boss.test.ts`): a successful `DefeatEnemy` claim does **not** trigger an inventory re-init (no resync needed); a failed/errored `DefeatEnemy` claim triggers both `refreshPlayer` and `inventoryManager.initialize`.
- [x] `npm run test:unit:ci` (full suite) — 3498 tests passing.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.

Closes #1639


---
_Generated by [Claude Code](https://claude.ai/code/session_01NHF2ZN22DKY8Qd38hkMSpe)_