### PR TITLE
Guard absorbed-heal combat floater against the attack's icon/ratio bar

### DIFF
--- a/UI/src/routes/game/screens/fight/CombatFloaters.svelte
+++ b/UI/src/routes/game/screens/fight/CombatFloaters.svelte
@@ -118,8 +118,12 @@ const colorOf = (event: CombatFloatEvent): string => {
 };
 
 /** The floater's icon: a crit/dodge's per-outcome art, otherwise a typed (non-physical) plain hit's
- *  damage-type icon so basic/physical attacks stay clean. Physical is the untyped baseline. */
+ *  damage-type icon so basic/physical attacks stay clean. Physical is the untyped baseline. An absorbed
+ *  heal shows no icon — it's not the incoming attack's damage type, it's a heal. */
 const iconOf = (event: CombatFloatEvent): string => {
+	if (isHeal(event)) {
+		return '';
+	}
 	const outcome = FLOAT_ICON[event.kind];
 	if (outcome) {
 		return outcome;
@@ -181,7 +185,7 @@ const spawn = (event: CombatFloatEvent) => {
 		glyph: glyphOf(event),
 		amount: amountOf(event),
 		label: labelFor(event.kind),
-		portions: event.portions ?? []
+		portions: isHeal(event) ? [] : (event.portions ?? [])
 	});
 	const timer = setTimeout(() => {
 		removalTimers.delete(timer);

--- a/UI/src/tests/routes/game/screens/fight/CombatFloaters.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/CombatFloaters.test.ts
@@ -144,13 +144,33 @@ describe('CombatFloaters', () => {
 			expect(floater.querySelector('img.floater-icon')?.getAttribute('src')).toContain('Critical Damage.png');
 		});
 
-		it('shows an absorbed hit as a positive heal in the regen hue', () => {
+		it('shows an absorbed hit as a positive heal in the regen hue with no damage-type icon', () => {
 			const { getByTestId } = render(CombatFloaters, { props: { side: 'enemy', testId: 'enemy-floaters' } });
 			emit({ target: 'enemy', kind: 'hit', amount: -20, damageType: EDamageType.Fire });
 
 			const floater = getByTestId('enemy-floaters').querySelector('.floater') as HTMLElement;
 			expect(floater.textContent).toContain('+20');
 			expect(floater.getAttribute('style')).toContain('var(--health-remaining-color)');
+			expect(floater.querySelector('img.floater-icon')).toBeNull();
+		});
+
+		it('omits the typed ratio bar for a multi-typed absorbed hit', () => {
+			const { getByTestId } = render(CombatFloaters, { props: { side: 'enemy', testId: 'enemy-floaters' } });
+			emit({
+				target: 'enemy',
+				kind: 'hit',
+				amount: -30,
+				damageType: EDamageType.Fire,
+				portions: [
+					{ type: EDamageType.Fire, weight: 60 },
+					{ type: EDamageType.Water, weight: 40 }
+				]
+			});
+
+			const floater = getByTestId('enemy-floaters').querySelector('.floater') as HTMLElement;
+			expect(floater.textContent).toContain('+30');
+			expect(floater.querySelector('img.floater-icon')).toBeNull();
+			expect(floater.querySelector('.floater-ratio')).toBeNull();
 		});
 	});
 


### PR DESCRIPTION
## Summary

A hit absorbed into a net heal (negative amount, reachable at type resistance ≥ 1) is special-cased by `colorOf`/`amountOf` in `CombatFloaters.svelte` (`isHeal` → green `+N`), but `iconOf` had no `isHeal` guard — the heal floated wearing the incoming attack's damage-type icon, and a multi-typed absorbed hit also rendered the typed damage-ratio bar under the heal number.

## Fix

- `iconOf` now returns `''` when `isHeal(event)` is true, so an absorbed heal shows no icon (consistent with `colorOf`/`amountOf`, which already special-case it).
- The floater's stored `portions` are now `[]` for a heal event, so the typed ratio bar never renders under an absorbed-heal number.

## Test plan

- [x] Updated `CombatFloaters.test.ts`'s existing absorbed-hit test to also assert no damage-type icon, and added a new test asserting a multi-typed absorbed hit renders no ratio bar.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.
- [x] `npm run test:unit:ci` (full suite) — 295 files / 3499 tests passing.

Closes #1640


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gb2dzfqLNYHkQvojKvEKgQ)_