### PR TITLE
Fix OverflowException in PlayerStatPoints.TryUpdateAttributes (#1641)

### DIFF
--- a/Game.Core.Tests/Players/PlayerStatPointsTests.cs
+++ b/Game.Core.Tests/Players/PlayerStatPointsTests.cs
@@ -126,6 +126,24 @@ namespace Game.Core.Tests.Players
         }
 
         [Fact]
+        public void TryUpdateAttributes_NearIntMaxValueUpdates_RejectsWithoutOverflowing()
+        {
+            // Two updates whose sum overflows int (checked LINQ Sum would throw OverflowException)
+            // must still be rejected via the normal all-or-nothing contract, not crash.
+            var stats = MakeStats(gained: 10, used: 0);
+
+            var result = stats.TryUpdateAttributes([
+                new Update(EAttribute.Strength, 1_500_000_000),
+                new Update(EAttribute.Endurance, 1_500_000_000),
+            ]);
+
+            Assert.False(result);
+            Assert.Equal(0, stats.StatPointsUsed);
+            Assert.Equal(0, stats.StatAllocations.First(a => a.Attribute == EAttribute.Strength).Amount);
+            Assert.Equal(0, stats.StatAllocations.First(a => a.Attribute == EAttribute.Endurance).Amount);
+        }
+
+        [Fact]
         public void TryUpdateAttributes_UnknownAttribute_RejectsWithoutMutating()
         {
             // An update targeting an attribute the player has no allocation row for is rejected rather

--- a/Game.Core/Players/PlayerStatPoints.cs
+++ b/Game.Core/Players/PlayerStatPoints.cs
@@ -50,12 +50,15 @@ namespace Game.Core.Players
                 }
             }
 
-            var changedPoints = matchedUpdates.Values.Sum(match => match.Update.Amount);
-            var availablePoints = StatPointsGained - StatPointsUsed;
+            // long accumulator: matchedUpdates.Values.Sum for int uses checked arithmetic and would
+            // throw OverflowException on a crafted payload (e.g. two near-int.MaxValue updates)
+            // instead of honoring the all-or-nothing reject contract.
+            var changedPoints = matchedUpdates.Values.Sum(match => (long)match.Update.Amount);
+            var availablePoints = (long)StatPointsGained - StatPointsUsed;
             if (availablePoints - changedPoints >= 0
-                && matchedUpdates.Values.All(match => match.Allocation.Amount + match.Update.Amount >= 0))
+                && matchedUpdates.Values.All(match => match.Allocation.Amount + (long)match.Update.Amount >= 0))
             {
-                StatPointsUsed += changedPoints;
+                StatPointsUsed += (int)changedPoints;
                 foreach (var (allocation, update) in matchedUpdates.Values)
                 {
                     allocation.Amount += update.Amount;


### PR DESCRIPTION
## Summary

- `PlayerStatPoints.TryUpdateAttributes` (`Game.Core/Players/PlayerStatPoints.cs`) summed the batch of stat-point updates with `Enumerable.Sum` over `int`, which uses **checked** arithmetic. A crafted payload with two updates of ~1.5 billion each — each individually valid enough to pass the earlier attribute-matching checks — overflowed the sum and threw `OverflowException` instead of being rejected via the documented all-or-nothing anti-cheat contract.
- Switched the aggregation (`changedPoints`) and the available-points comparison to `long`, so the sum can't overflow and an out-of-range payload is rejected the normal way (`return false`, no mutation). The per-item `Allocation.Amount + Update.Amount >= 0` check was also widened to `long` for consistency, though that check was not the one throwing (plain `+` doesn't use checked arithmetic).
- `StatPointsUsed += (int)changedPoints` stays safe: by that point the code has already verified `changedPoints <= availablePoints`, and `availablePoints` is derived from existing `int` fields, so the cast back can't lose information.

## Test plan

- Added `TryUpdateAttributes_NearIntMaxValueUpdates_RejectsWithoutOverflowing`: two updates of 1.5 billion each → `false`, no mutation, no throw.
- `dotnet build` — 0 warnings, 0 errors.
- `dotnet test --no-build --no-restore` — full backend suite green (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests all passed).

Closes #1641

## Note

While picking up work in this backlog sweep, I also found #1625 (`verify-frontend red on main`) was already fixed by a prior, unrelated merge (#1624) — verified against current `main` and closed it as completed; no PR needed there.


---
_Generated by [Claude Code](https://claude.ai/code/session_015naWqXZpi1vfwtSY5jr2RW)_