### PR TITLE
Escape ILIKE wildcards in admin user search

### DIFF
--- a/Game.Api.Tests/Integration/AdminUsersControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminUsersControllerTests.cs
@@ -172,6 +172,23 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task GetUsers_SearchTermWithLiteralBackslash_MatchesOnlyThatUser()
+        {
+            using var authClient = await SetupAdminClientAsync();
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                await TestDataSeeder.CreateUserAsync(context, @"back\slash", "pw");
+                await TestDataSeeder.CreateUserAsync(context, "someoneelse", "pw");
+            }
+
+            // The escape character itself must be escaped first, or a literal "\" in the search term
+            // would corrupt the pattern's own escaping of "%"/"_" (or fail the query outright).
+            var results = await GetUsersAsync(authClient, "?search=back%5Cslash");
+            Assert.Equal(new[] { @"back\slash" }, results.Users.Select(u => u.Username));
+        }
+
+        [Fact]
         public async Task GetUsers_FilterByRole_ReturnsOnlyUsersInRole()
         {
             using var authClient = await SetupAdminClientAsync();

--- a/Game.Api.Tests/Integration/AdminUsersControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminUsersControllerTests.cs
@@ -139,6 +139,39 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task GetUsers_SearchTermWithLiteralPercent_MatchesOnlyThatUserAndDoesNotMatchEveryone()
+        {
+            using var authClient = await SetupAdminClientAsync();
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                await TestDataSeeder.CreateUserAsync(context, "100%legit", "pw");
+                await TestDataSeeder.CreateUserAsync(context, "someoneelse", "pw");
+            }
+
+            // A literal "%" in the search term must not act as an ILIKE wildcard: it should find only
+            // the user whose name actually contains it, not every user (as an unescaped "%...%" would).
+            var results = await GetUsersAsync(authClient, "?search=100%25legit");
+            Assert.Equal(new[] { "100%legit" }, results.Users.Select(u => u.Username));
+        }
+
+        [Fact]
+        public async Task GetUsers_SearchTermWithLiteralUnderscore_MatchesOnlyThatUser()
+        {
+            using var authClient = await SetupAdminClientAsync();
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                await TestDataSeeder.CreateUserAsync(context, "under_score", "pw");
+                await TestDataSeeder.CreateUserAsync(context, "underxscore", "pw");
+            }
+
+            // An unescaped "_" would match any single character, so "underxscore" would also match.
+            var results = await GetUsersAsync(authClient, "?search=under_score");
+            Assert.Equal(new[] { "under_score" }, results.Users.Select(u => u.Username));
+        }
+
+        [Fact]
         public async Task GetUsers_FilterByRole_ReturnsOnlyUsersInRole()
         {
             using var authClient = await SetupAdminClientAsync();

--- a/Game.DataAccess/Repositories/Users.cs
+++ b/Game.DataAccess/Repositories/Users.cs
@@ -388,16 +388,26 @@ namespace Game.DataAccess.Repositories
                 && u.Roles.Any(r => r.Id == adminRoleId), cancellationToken);
         }
 
+        private const string LikeEscapeCharacter = "\\";
+
+        // Escapes ILIKE's own wildcard characters so a search term is matched literally, e.g. a
+        // username containing "%" or "_" is only findable by that literal text, not as a wildcard.
+        private static string EscapeLikePattern(string search) =>
+            search
+                .Replace(LikeEscapeCharacter, LikeEscapeCharacter + LikeEscapeCharacter)
+                .Replace("%", LikeEscapeCharacter + "%")
+                .Replace("_", LikeEscapeCharacter + "_");
+
         private IQueryable<UserEntity> FilteredUsers(string? search, int? roleId, bool? archived)
         {
             var query = _context.Users.AsQueryable();
 
             if (!string.IsNullOrWhiteSpace(search))
             {
-                var pattern = $"%{search}%";
+                var pattern = $"%{EscapeLikePattern(search)}%";
                 query = query.Where(u =>
-                    EF.Functions.ILike(u.Username, pattern)
-                    || u.Players.Any(p => EF.Functions.ILike(p.Name, pattern)));
+                    EF.Functions.ILike(u.Username, pattern, LikeEscapeCharacter)
+                    || u.Players.Any(p => EF.Functions.ILike(p.Name, pattern, LikeEscapeCharacter)));
             }
 
             if (roleId is not null)


### PR DESCRIPTION
## Summary

`FilteredUsers` (`Game.DataAccess/Repositories/Users.cs`) built its `ILIKE` search pattern directly from raw admin input (`$"%{search}%"`), so `%` and `_` in the search term were interpreted as `ILIKE` wildcards rather than matched literally: a bare `%` search matched every user, and a username/player name containing a literal `%`, `_`, or `\` couldn't be searched for. Parameterized (no injection risk), admin-only surface — but the results were wrong.

## Fix

- Added `EscapeLikePattern`, which escapes `\`, `%`, and `_` in the raw search term (backslash first, so it doesn't double-escape the characters it introduces).
- Passed the escape character through to `EF.Functions.ILike(matchExpression, pattern, escapeCharacter)` for both the username and player-name predicates, so the escaped sequences are honored by Postgres.

## Tests

Added two integration tests to `AdminUsersControllerTests`:
- A username containing a literal `%` is found by that exact term and doesn't cause every user to match.
- A username containing a literal `_` is found by that exact term, without matching a similarly-named user that merely has some other character in that position.

## Test plan

- [x] `dotnet build` (whole solution) — 0 warnings, 0 errors
- [x] `dotnet test` (whole solution, against the containerized Postgres/Redis) — 2980 tests passing
- [x] New tests specifically verified passing (`Game.Api.Tests -- --filter-class "*AdminUsersControllerTests"`)

Closes #1643


---
_Generated by [Claude Code](https://claude.ai/code/session_016E17wLuMc1kxnbDbaQkqJ8)_