### PR TITLE
Resync inventory on a dead-lettered ChallengeCompleted push

### DIFF
--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -21,6 +21,7 @@ import { InventoryManager } from './player/inventory-manager';
 import { playerManager } from './player/player-manager';
 import { logMessage } from './log';
 import { EnemyManager } from './battle/enemy-manager';
+import { refreshPlayer } from './session';
 import {
 	staticData,
 	statistics,
@@ -102,16 +103,18 @@ export const startGame = () => {
 /**
  * Reacts to a ServerCommandFailed notice: the server dead-lettered a server-pushed command that threw and
  * is telling us to re-sync rather than silently diverge from the authoritative state. Two pushes leave
- * divergent client state: ChallengeCompleted (its completion gates zone navigation) and ProficiencyXpGained
- * (its levels feed the live battler's attribute bonuses), so a failed one force-reloads the matching
- * authoritative progress; any reward/skill it carried still surfaces on the next natural load of the
- * inventory/skills stores.
+ * divergent client state: ChallengeCompleted (its completion gates zone navigation, and may carry an
+ * item/mod reward) and ProficiencyXpGained (its levels feed the live battler's attribute bonuses), so a
+ * failed one force-reloads the matching authoritative progress. A dead-lettered ChallengeCompleted also
+ * re-pulls the player aggregate and re-derives the inventory from it (mirroring `claimVictory`'s resync),
+ * so a reward item the failed push carried appears immediately rather than only after a page reload.
  */
 export const handleServerCommandFailed = (response: IApiSocketResponse<'ServerCommandFailed'>) => {
 	const failedCommand = response.data?.commandName;
 	console.warn(`A server-pushed command failed on the server and was dead-lettered: ${failedCommand ?? 'unknown'}.`);
 	if (failedCommand === 'ChallengeCompleted') {
 		void playerChallenges.load(true);
+		void refreshPlayer().then(() => inventoryManager.initialize());
 	} else if (failedCommand === 'ProficiencyXpGained') {
 		void playerProficiencies.load(true);
 	}

--- a/UI/src/tests/lib/engine/engine.test.ts
+++ b/UI/src/tests/lib/engine/engine.test.ts
@@ -146,6 +146,8 @@ vi.mock('$lib/engine/player/inventory-manager', () => ({
 }));
 vi.mock('$lib/engine/player/player-manager', () => ({ playerManager: playerManagerStub }));
 vi.mock('$lib/engine/log', () => ({ logMessage }));
+const { refreshPlayer } = vi.hoisted(() => ({ refreshPlayer: vi.fn(() => Promise.resolve()) }));
+vi.mock('$lib/engine/session', () => ({ refreshPlayer }));
 
 import {
 	startGame,
@@ -714,15 +716,31 @@ describe('handleServerCommandFailed', () => {
 		expect(playerChallengesStub.load).toHaveBeenCalledWith(true);
 	});
 
+	it('resyncs the player and re-derives inventory when a ChallengeCompleted push was dead-lettered, so a reward item it carried appears immediately', async () => {
+		handleServerCommandFailed(serverCommandFailedResponse('ChallengeCompleted'));
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(refreshPlayer).toHaveBeenCalledTimes(1);
+		expect(inventoryManager.initialize).toHaveBeenCalledTimes(1);
+	});
+
 	it('force-reloads proficiency progress when a ProficiencyXpGained push was dead-lettered', () => {
 		handleServerCommandFailed(serverCommandFailedResponse('ProficiencyXpGained'));
 
 		expect(playerProficienciesStub.load).toHaveBeenCalledWith(true);
 	});
 
+	it('does not resync the player for a dead-lettered ProficiencyXpGained push', () => {
+		handleServerCommandFailed(serverCommandFailedResponse('ProficiencyXpGained'));
+
+		expect(refreshPlayer).not.toHaveBeenCalled();
+	});
+
 	it('does not reload challenges for an unrelated failed command', () => {
 		handleServerCommandFailed(serverCommandFailedResponse('SocketReplaced'));
 
 		expect(playerChallengesStub.load).not.toHaveBeenCalled();
+		expect(refreshPlayer).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

Follow-up from review of #1659 (which fixed the analogous gap on the `claimVictory` → `refreshPlayer()` resync path for #1639).

`handleServerCommandFailed`'s dead-letter path for a `ChallengeCompleted` push (`UI/src/lib/engine/engine.ts`) only reloaded `playerChallenges`, never the inventory stores. If the dead-lettered challenge completion carried an item/mod reward, that reward stayed invisible mid-session until a full page reload — the same class of bug #1639/#1659 fixed, just on a different path. The existing code comment even claimed the reward "surfaces on the next natural load of the inventory stores," which #1639 established is false for a mid-session player who never triggers such a load.

## Fix

Mirrors the #1659 fix in `EnemyManager.claimVictory`: on a dead-lettered `ChallengeCompleted`, in addition to force-reloading `playerChallenges`, re-pull the authoritative player aggregate via `refreshPlayer()` and re-run `inventoryManager.initialize()` (idempotent — clears and re-derives from `playerManager.inventoryData`) so a reward item unlocked by the challenge appears immediately. Updated the stale doc comment on `handleServerCommandFailed` accordingly.

## Tests

Added to `UI/src/tests/lib/engine/engine.test.ts`:
- A dead-lettered `ChallengeCompleted` push resyncs the player and re-derives inventory.
- A dead-lettered `ProficiencyXpGained` push does *not* trigger a player resync (scoped correctly to `ChallengeCompleted`).
- The existing "unrelated failed command" test now also asserts no resync happens.

## Test plan

- [x] `npm run test:unit:ci` (full suite) — 295 files / 3503 tests passing
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings

Closes #1661


---
_Generated by [Claude Code](https://claude.ai/code/session_017YvK4godPrmQkwWbaxeAUm)_