### PR TITLE
Author the taught-by-blurb tutorial lessons (idle-loop-basics, crit-dodge-variance, cooldown-charging)

### DIFF
--- a/Game.Application.Tests/Content/ContentGraphLintTests.cs
+++ b/Game.Application.Tests/Content/ContentGraphLintTests.cs
@@ -25,16 +25,7 @@ namespace Game.Application.Tests.Content
         /// Each entry is the finding's <see cref="ContentGraphFinding.ToString"/> value; add one only with a
         /// comment saying why it is tolerated.
         /// </summary>
-        private static readonly HashSet<string> AcceptedWarnings =
-        [
-            // #1591 built the Lesson reference-data plumbing (entity, cache, Workbench CRUD, this lint rule)
-            // but deliberately left authoring the actual tutorial copy to a follow-up content-authoring issue —
-            // writing the taught-by-blurb lessons is a content-design task, not a code-infra one. Remove each
-            // entry as its lesson is authored.
-            "[Warning] Lesson -1 (LessonCoverage): content-design.md's taught-by-blurb candidate 'crit-dodge-variance' has no live lesson.",
-            "[Warning] Lesson -1 (LessonCoverage): content-design.md's taught-by-blurb candidate 'idle-loop-basics' has no live lesson.",
-            "[Warning] Lesson -1 (LessonCoverage): content-design.md's taught-by-blurb candidate 'cooldown-charging' has no live lesson.",
-        ];
+        private static readonly HashSet<string> AcceptedWarnings = [];
 
         [Fact]
         public async Task CommittedContent_HasNoReachabilityErrors()

--- a/UI/e2e-tests/helpers.ts
+++ b/UI/e2e-tests/helpers.ts
@@ -115,7 +115,32 @@ export async function createAccountAndStartGame(page: Page, prefix = 'e') {
 	// (WebKit/Firefox) under parallel load routinely takes longer than 5s and flakes. Use the same
 	// 10s budget as the other navigations in this file.
 	await expect(page).toHaveURL('/game', { timeout: 10000 });
+
+	await dismissTutorialTourIfPresent(page);
 	return username;
+}
+
+/**
+ * A fresh account's first visit to the (default) Fight screen auto-plays the screen-anchored
+ * `idle-loop-basics` tutorial tour (a full-screen coach-mark overlay), which would otherwise swallow
+ * the very next click every journey makes. Dismiss it via its Skip control if it appeared, so tests
+ * interact with the screen underneath rather than asserting anything about tutorial content — that's
+ * covered by tutorial.test.ts.
+ *
+ * The tour opens from the welcome-back gate's async `entered` transition, not synchronously with the
+ * `/game` navigation, so this waits for it rather than taking an immediate (and racy) snapshot —
+ * mirroring how {@link selectFirstCharacter} waits out the similarly-async session-takeover modal.
+ * Swallows the timeout if no tour appears (e.g. the lesson is retired later), rather than failing.
+ */
+export async function dismissTutorialTourIfPresent(page: Page) {
+	const tour = page.getByTestId('tutorial-tour');
+	try {
+		await expect(tour).toBeVisible({ timeout: 5000 });
+	} catch {
+		return;
+	}
+	await page.getByTestId('tutorial-tour-skip').click();
+	await expect(tour).not.toBeVisible();
 }
 
 /**

--- a/UI/e2e-tests/tutorial.test.ts
+++ b/UI/e2e-tests/tutorial.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+import { createAccountAndLogin } from './helpers';
+
+test.describe('Tutorial tour', () => {
+	// The one behavior every other e2e journey works around (via dismissTutorialTourIfPresent in
+	// createAccountAndStartGame): a fresh account's first visit to the default Fight screen
+	// auto-plays the screen-anchored idle-loop-basics lesson. Pin that it actually plays and can be
+	// dismissed, so the workaround stays justified rather than papering over a regression.
+	test('idle-loop-basics auto-plays on first fight-screen entry and can be dismissed', async ({ page }) => {
+		await createAccountAndLogin(page, 'tt');
+
+		const enterButton = page.getByTestId('enter-button');
+		await expect(enterButton).toBeEnabled({ timeout: 10000 });
+		await enterButton.click();
+		await expect(page).toHaveURL('/game', { timeout: 10000 });
+
+		const tour = page.getByTestId('tutorial-tour');
+		await expect(tour).toBeVisible({ timeout: 10000 });
+		await expect(tour).toContainText('Welcome to the fight screen');
+
+		await page.getByTestId('tutorial-tour-skip').click();
+		await expect(tour).not.toBeVisible();
+
+		// Dismissed, not just hidden: the screen underneath is interactive again.
+		await page.getByTestId('sidebar-item-inventory').click();
+		await expect(page.getByTestId('inventory-screen')).toBeVisible();
+	});
+});

--- a/UI/src/components/tour/TourPlayer.svelte
+++ b/UI/src/components/tour/TourPlayer.svelte
@@ -10,7 +10,7 @@
 	it can decide what each means for the lesson's read state.
 -->
 {#if open && currentStep}
-	<div class="tour-layer">
+	<div class="tour-layer" data-testid="tutorial-tour">
 		<button class="tour-backdrop" type="button" tabindex="-1" aria-label="Dismiss tour" onclick={onDismiss}></button>
 
 		{#if spotlightRect}
@@ -41,7 +41,9 @@
 				<p class="tour-callout__text">{currentStep.text}</p>
 			</div>
 			<div class="tour-callout__controls">
-				<button class="tour-callout__skip" type="button" onclick={onDismiss}>Skip</button>
+				<button class="tour-callout__skip" type="button" data-testid="tutorial-tour-skip" onclick={onDismiss}
+					>Skip</button
+				>
 				<div class="tour-callout__nav">
 					<button type="button" disabled={isFirst} onclick={goBack}>Back</button>
 					{#if isLast}

--- a/content/lessons.json
+++ b/content/lessons.json
@@ -1,1 +1,76 @@
-[]
+[
+  {
+    "id": 0,
+    "key": "idle-loop-basics",
+    "name": "The Idle Loop",
+    "triggerType": "ScreenVisit",
+    "screenKey": "fight",
+    "triggerMechanicEvent": null,
+    "ordinal": 0,
+    "designerNotes": "Screen-anchored on first Fight visit — taught-by-blurb candidate per content-design.md §2 (the core idle loop doesn't need a whole zone to teach). Fires immediately since the player is looking right at the screen it explains.",
+    "retiredAt": null,
+    "steps": [
+      {
+        "ordinal": 0,
+        "text": "Welcome to the fight screen — your build takes over from here. Skills fire on their own; there's nothing to click during battle.",
+        "anchorKey": null
+      },
+      {
+        "ordinal": 1,
+        "text": "The bars above each combatant track HP. Whoever's hits zero first loses the fight, and the next enemy loads in automatically.",
+        "anchorKey": null
+      },
+      {
+        "ordinal": 2,
+        "text": "You don't have to watch every fight — close the game and come back later. Progress continues while you're away, up to a cap, so spend your time building your character and let the idle loop do the rest.",
+        "anchorKey": null
+      }
+    ]
+  },
+  {
+    "id": 1,
+    "key": "crit-dodge-variance",
+    "name": "Crits & Dodges",
+    "triggerType": "MechanicEvent",
+    "screenKey": "fight",
+    "triggerMechanicEvent": "FirstCrit",
+    "ordinal": 1,
+    "designerNotes": "Mechanic-anchored on the player's first landed crit (EMechanicEvent.FirstCrit), per content-design.md §2's single 'crit/dodge variance' taught-by-blurb pairing — one lesson covers both crit and dodge variance rather than splitting into two, since crit and dodge are the same lesson (damage varies hit to hit) from opposite sides of the exchange. Anchored on crit rather than dodge because a crit-capable skill exists in every starter kit while dodge is opt-in gear (see content-design.md §4's Evasion path), so crit is reached first far more reliably.",
+    "retiredAt": null,
+    "steps": [
+      {
+        "ordinal": 0,
+        "text": "That hit landed harder than normal — a critical hit! Crits deal bonus damage a percentage of the time, so your damage per hit will naturally vary.",
+        "anchorKey": null
+      },
+      {
+        "ordinal": 1,
+        "text": "The same goes on defense: sometimes an incoming attack misses entirely — a dodge. Don't read too much into any single hit; it's the average over a whole fight that matters.",
+        "anchorKey": null
+      }
+    ]
+  },
+  {
+    "id": 2,
+    "key": "cooldown-charging",
+    "name": "Skill Cooldowns",
+    "triggerType": "MechanicEvent",
+    "screenKey": "fight",
+    "triggerMechanicEvent": "FirstCooldownRecharge",
+    "ordinal": 2,
+    "designerNotes": "Mechanic-anchored on the player's first observed cooldown recharge (EMechanicEvent.FirstCooldownRecharge) — taught-by-blurb candidate per content-design.md §2.",
+    "retiredAt": null,
+    "steps": [
+      {
+        "ordinal": 0,
+        "text": "See a skill icon fill back up and fire again on its own? That's its cooldown recharging. Each skill charges independently and activates the moment it's ready.",
+        "anchorKey": null
+      },
+      {
+        "ordinal": 1,
+        "text": "Reducing a skill's cooldown means more casts over the same fight, so cooldown speed compounds with your other stats instead of competing with them.",
+        "anchorKey": null
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Authors the three taught-by-blurb tutorial lessons that #1591 left as tolerated `AcceptedWarnings` gaps:

- **`idle-loop-basics`** — screen-anchored (`ScreenVisit`), hosted on the `fight` screen. Explains the core idle loop: skills fire automatically, HP bars decide the fight, and progress continues while offline.
- **`crit-dodge-variance`** — mechanic-anchored on `EMechanicEvent.FirstCrit`, hosted on `fight`. Explains why hit damage varies (crits deal bonus damage; dodges avoid it entirely).
- **`cooldown-charging`** — mechanic-anchored on `EMechanicEvent.FirstCooldownRecharge`, hosted on `fight`. Explains that each skill recharges independently and fires the moment it's ready.

Each lesson's `DesignerNotes` documents its authoring rationale in place.

## Judgment calls (flagging per the issue's open questions)

- **Single lesson for crit+dodge, anchored on `FirstCrit`.** content-design.md §2 lists `crit-dodge-variance` as one taught-by-blurb candidate (not two), and `Enums.cs`'s `EMechanicEvent` doc comment already pairs it with `FirstCrit` specifically. I kept it as one lesson covering both — a crit-capable skill exists in every class's starter kit, while dodge is opt-in gear (content-design.md §4's Evasion path), so anchoring on crit reaches far more players than anchoring on dodge would. Noted in the lesson's `DesignerNotes`.
- **All tour steps are unanchored (`anchorKey: null`).** I checked and no screen component anywhere in `UI/src` actually calls `use:tutorialAnchor` yet (#1592 built the mechanism — `TourPlayer.svelte`/`tutorial-anchor.ts` — but no real anchor is registered on any screen). Since an unregistered/missing anchor key degrades gracefully to a centered callout, I didn't invent anchor keys pointing at nothing. A follow-up wiring real anchors (e.g. onto the skill bar, HP bar) into the Fight screen would let these steps point at something concrete, but that's a frontend-anchor-wiring task, not part of this content-authoring issue.
- **Filed #1673** for the issue's optional suggestion — a frontend test asserting each lesson's `screenKey` resolves to a real `ScreenDef.key`. There's no existing pattern for a Vitest test to read committed `content/*.json`, so it's more than a one-line addition; left as its own follow-up rather than bundled here.

## How the content was authored

`content/*.json` is generated, never hand-edited (per `docs/backend-content.md`). I hand-wrote the three lesson records + steps directly into `content/lessons.json` (mirroring the existing `Contracts.Lesson`/`LessonStep` shape and the formatting of `content/skills.json`/`content/zones.json`), then ran `ContentExportDriftGuardTests` with `CONTENT_EXPORT_REGEN=1` to seed a fresh test DB from it, re-derive the export, and confirm it's already byte-canonical — the sanctioned round-trip for landing a content change without needing the Workbench UI.

Removed the three now-satisfied `LessonCoverage` entries from `ContentGraphLintTests`'s `AcceptedWarnings` allowlist.

## Test plan

- [x] `dotnet build Game.sln` — 0 warnings, 0 errors
- [x] `dotnet test Game.sln` — 2999/2999 passing (`Game.Application.Tests` incl. `ContentExportDriftGuardTests` and the now-warning-free `ContentGraphLintTests`, `Game.Api.Tests`, `Game.Core.Tests`, `Game.Infrastructure.Tests`)
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings
- [x] `npm run test:unit:ci` — 3505/3505 passing

Closes #1605


---
_Generated by [Claude Code](https://claude.ai/code/session_012NxoMQtoa9nGjgNLCwEtLt)_