### PR TITLE
TickSource: fall back to setInterval when the worker fails to start

### DIFF
--- a/UI/src/lib/engine/tick-source.ts
+++ b/UI/src/lib/engine/tick-source.ts
@@ -11,11 +11,26 @@ export interface TickSource {
 
 export function createTickSource(onTick: () => void): TickSource {
 	if (typeof Worker !== 'undefined') {
-		const worker = new Worker(new URL('./tick-worker.ts', import.meta.url), { type: 'module' });
+		let worker: Worker | null = new Worker(new URL('./tick-worker.ts', import.meta.url), {
+			type: 'module'
+		});
+		let fallbackHandle: number | null = null;
+
 		worker.onmessage = () => onTick();
-		worker.onerror = (ev) => console.error('The logical engine tick worker failed', ev);
+		worker.onerror = (ev) => {
+			console.error('The logical engine tick worker failed, falling back to setInterval', ev);
+			worker?.terminate();
+			worker = null;
+			fallbackHandle = window.setInterval(onTick, pollingIntervalMs);
+		};
+
 		return {
-			stop: () => worker.terminate()
+			stop: () => {
+				worker?.terminate();
+				if (fallbackHandle !== null) {
+					window.clearInterval(fallbackHandle);
+				}
+			}
 		};
 	}
 

--- a/UI/src/lib/engine/tick-source.ts
+++ b/UI/src/lib/engine/tick-source.ts
@@ -18,8 +18,11 @@ export function createTickSource(onTick: () => void): TickSource {
 
 		worker.onmessage = () => onTick();
 		worker.onerror = (ev) => {
+			if (worker === null) {
+				return;
+			}
 			console.error('The logical engine tick worker failed, falling back to setInterval', ev);
-			worker?.terminate();
+			worker.terminate();
 			worker = null;
 			fallbackHandle = window.setInterval(onTick, pollingIntervalMs);
 		};
@@ -27,6 +30,7 @@ export function createTickSource(onTick: () => void): TickSource {
 		return {
 			stop: () => {
 				worker?.terminate();
+				worker = null;
 				if (fallbackHandle !== null) {
 					window.clearInterval(fallbackHandle);
 				}

--- a/UI/src/tests/lib/engine/tick-source.test.ts
+++ b/UI/src/tests/lib/engine/tick-source.test.ts
@@ -72,4 +72,25 @@ describe('createTickSource', () => {
 		expect(errorSpy).toHaveBeenCalledTimes(1);
 		errorSpy.mockRestore();
 	});
+
+	it('falls back to window.setInterval when the worker fails to start', () => {
+		vi.stubGlobal('Worker', MockWorker);
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.useFakeTimers();
+
+		const onTick = vi.fn();
+		const source = createTickSource(onTick);
+		const worker = MockWorker.instances[0];
+
+		worker.onerror?.(new ErrorEvent('error', { message: 'boom' }));
+		expect(worker.terminate).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(pollingIntervalMs * 3);
+		expect(onTick.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+		const callCount = onTick.mock.calls.length;
+		source.stop();
+		vi.advanceTimersByTime(pollingIntervalMs * 5);
+		expect(onTick).toHaveBeenCalledTimes(callCount);
+	});
 });


### PR DESCRIPTION
## Summary

- `createTickSource`'s worker `onerror` handler (`UI/src/lib/engine/tick-source.ts`) previously only logged the failure — if the dedicated tick worker ever failed to construct or load, the logical engine's tick loop would stall silently and permanently, even in a foregrounded tab.
- `onerror` now tears down the failed worker (`terminate()`) and transparently starts the existing `window.setInterval` fallback, so a worker failure degrades gracefully instead of halting ticks. `stop()` cleans up whichever of the two (worker or fallback interval) ended up active.

## Test plan

- [x] Added a unit test (`UI/src/tests/lib/engine/tick-source.test.ts`) that fires the mocked worker's `onerror`, asserts the failed worker is torn down, and asserts ticks continue via the `setInterval` fallback (and stop cleanly on `source.stop()`).
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run test:unit:ci` — 3506/3506 passing

Closes #1612


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgmaa7k8xbneY3nU8h36yd)_