### PR TITLE
ProgressionGraphChecker: cover the boss-level branch of ResolveRatingLevel

### DIFF
--- a/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
+++ b/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
@@ -392,6 +392,24 @@ namespace Game.Application.Tests.Content
             Assert.DoesNotContain(_checker.Check(graph), f => f.Check == "EnemyInertAttribute");
         }
 
+        [Fact]
+        public void Enemy_PlacedOnlyAsZoneBoss_IsRatedAtZoneBossLevel()
+        {
+            // Enemy 9 carries no spawn-table entry at all — its only live placement is zone 1's dedicated boss
+            // slot — so a representative level can only come from ResolveRatingLevel's boss-level branch
+            // (zone.BossLevel). Its kit (skill 2, same as the sibling AGI-dead-stat tests above) doesn't consume
+            // Agility, so a live rating (i.e. the branch actually firing rather than being skipped as unplaced)
+            // must still surface the dead-stat warning.
+            var graph = HealthyGraph() with
+            {
+                Zones = [Zone(0), Zone(1, unlockChallengeId: 0, bossEnemyId: 9, bossLevel: 5), Zone(2, isHome: true)],
+                Enemies = HealthyGraph().Enemies
+                    .Append(Enemy(9, isBoss: true, skillPool: [2], spawns: [], attributeDistribution: [(EAttribute.Agility, 5, 1)]))
+                    .ToList(),
+            };
+            AssertHasFinding(graph, "EnemyInertAttribute", ContentGraphSeverity.Warning, "Enemy", 9);
+        }
+
         // --- Classes ----------------------------------------------------------------------------------
 
         [Fact]
@@ -1075,6 +1093,7 @@ namespace Game.Application.Tests.Content
             int id,
             bool isHome = false,
             int? bossEnemyId = null,
+            int bossLevel = 1,
             int? unlockChallengeId = null,
             DateTime? retiredAt = null) => new()
             {
@@ -1085,7 +1104,7 @@ namespace Game.Application.Tests.Content
                 LevelMin = 1,
                 LevelMax = 10,
                 BossEnemyId = bossEnemyId,
-                BossLevel = 1,
+                BossLevel = bossLevel,
                 UnlockChallengeId = unlockChallengeId,
                 IsHome = isHome,
                 DesignerNotes = "",

--- a/Game.Application/Content/ProgressionGraphChecker.cs
+++ b/Game.Application/Content/ProgressionGraphChecker.cs
@@ -270,6 +270,9 @@ namespace Game.Application.Content
             {
                 foreach (var zone in Live(_graph.Zones, z => z.RetiredAt))
                 {
+                    // Deliberate precedence: a zone's spawn-table placement is checked before its boss slot, so
+                    // an enemy that is both spawn-tabled and the dedicated boss of the same zone rates at the
+                    // zone's level range midpoint, not BossLevel.
                     if (enemy.Spawns.Any(s => s.ZoneId == zone.Id))
                     {
                         return (zone.LevelMin + zone.LevelMax) / 2;


### PR DESCRIPTION
## Summary

Follow-up from PR #1607 (issue #1581), which migrated `CheckEnemyAttributeConsumption` onto `CombatRating.Marginal` and added `ResolveRatingLevel`. `ResolveRatingLevel` returns `zone.BossLevel` when an enemy is placed only via a zone's dedicated `BossEnemyId` (not a spawn table), but no test in the existing graph exercised that branch — no zone set `BossEnemyId` on an enemy with a nonzero core attribute distribution.

- Added `Enemy_PlacedOnlyAsZoneBoss_IsRatedAtZoneBossLevel`: places an enemy exclusively via a zone's `BossEnemyId` (no spawn-table entry) with a dead (unconsumed) Agility distribution, and asserts the `EnemyInertAttribute` warning still fires — proving the boss-level branch actually supplies a representative level rather than the enemy being skipped as unplaced.
- Extended the test file's `Zone` fixture helper with an optional `bossLevel` parameter so the test can pin a distinct `BossLevel`.
- Added a one-line comment on `ResolveRatingLevel` documenting the (already-implemented, now more discoverable) precedence: a zone's spawn-table placement is checked before its boss slot, so an enemy that's both spawn-tabled and the dedicated boss of the same zone rates at the zone's level-range midpoint, not `BossLevel`.

Per the issue, item 2 (memoizing `CombatRating.Marginal`'s baseline `Rate`) was left out — it's explicitly called out as optional/negligible for this offline lint and out of scope for a test-coverage fix.

## Test plan

- [x] `dotnet build Game.sln` — 0 warnings, 0 errors
- [x] `dotnet test Game.sln --no-build --no-restore` — 3000/3000 passing (`Game.Core.Tests`, `Game.Infrastructure.Tests`, `Game.Application.Tests` incl. the new test, `Game.Api.Tests`)

No frontend changes.

Closes #1614


---
_Generated by [Claude Code](https://claude.ai/code/session_01XLPXmHiqQcKaubLxtAxF96)_