### PR TITLE
EquipItem/UnequipItem: return PlayerRating so gear changes reflect immediately

### DIFF
--- a/Game.Api.Tests/Integration/InventorySocketTests.cs
+++ b/Game.Api.Tests/Integration/InventorySocketTests.cs
@@ -1,3 +1,4 @@
+using Game.Api.Models.InventoryItems;
 using Game.Core;
 using Game.Infrastructure.Database;
 using Game.Infrastructure.Entities;
@@ -65,6 +66,34 @@ namespace Game.Api.Tests.Integration
             var response = await socketClient.SendCommandRawAsync("UnequipItem", parameters);
 
             Assert.Null(response.Error);
+        }
+
+        [Fact]
+        public async Task EquipItem_ItemWithAttributes_ReturnsPlayerRatingThatDropsOnUnequip()
+        {
+            // The seeded weapon carries a Strength bonus (TestDataSeeder.CreateItemAsync's default), which
+            // feeds both offense and survivability (CombatRating.Classify), so equipping/unequipping it must
+            // move the reported rating immediately rather than leaving it stale until the next full
+            // player-state refresh (#1616).
+            var (userId, _, itemId) = await SeedPlayerWithInventoryAsync("equipratinguser", "equipratingpass",
+                async (context, playerId, item) =>
+                    await TestDataSeeder.LinkItemToPlayerAsync(context, playerId, item.Id));
+            await LoginAsync("equipratinguser", "equipratingpass");
+            await using var socketClient = await ConnectSocketAsync(userId);
+
+            var equipParameters = new { itemId, equipmentSlotId = (int)EEquipmentSlot.WeaponSlot };
+            var equipResponse = await socketClient.SendCommandAsync<EquipItemResponse>("EquipItem", equipParameters);
+            Assert.Null(equipResponse.Error);
+            Assert.NotNull(equipResponse.Data);
+            Assert.True(equipResponse.Data.PlayerRating > 0);
+
+            var unequipParameters = new { equipmentSlotId = (int)EEquipmentSlot.WeaponSlot };
+            var unequipResponse = await socketClient.SendCommandAsync<EquipItemResponse>("UnequipItem", unequipParameters);
+            Assert.Null(unequipResponse.Error);
+            Assert.NotNull(unequipResponse.Data);
+
+            Assert.True(unequipResponse.Data.PlayerRating < equipResponse.Data.PlayerRating,
+                $"Expected the post-unequip rating ({unequipResponse.Data.PlayerRating}) to be lower than the equipped rating ({equipResponse.Data.PlayerRating}).");
         }
 
         [Fact]

--- a/Game.Api/Models/InventoryItems/EquipItemResponse.cs
+++ b/Game.Api/Models/InventoryItems/EquipItemResponse.cs
@@ -1,0 +1,16 @@
+namespace Game.Api.Models.InventoryItems
+{
+    /// <summary>
+    /// The authoritative post-change player state for an equip/unequip mutation: the player's
+    /// post-change combat-rating (spike #1526 Decision 7), computed via
+    /// <see cref="Game.Application.Services.BattleService.RatePlayer"/>. Shared by
+    /// <see cref="Game.Api.Sockets.Commands.EquipItem"/> and
+    /// <see cref="Game.Api.Sockets.Commands.UnequipItem"/> since gear is one of the three things
+    /// Decision 7 calls out as moving the rating, mirroring the pattern
+    /// <see cref="Game.Api.Models.Attributes.UpdatePlayerStatsResponse"/> established for stat reallocation.
+    /// </summary>
+    public class EquipItemResponse : IModel
+    {
+        public required double PlayerRating { get; set; }
+    }
+}

--- a/Game.Api/Sockets/Commands/EquipItem.cs
+++ b/Game.Api/Sockets/Commands/EquipItem.cs
@@ -13,24 +13,33 @@ namespace Game.Api.Sockets.Commands
     /// safe: it is processed in the single per-player command loop alongside the idle battle commands, so
     /// it can no longer lose a concurrent read-modify-write race against a background battle save (#463).
     /// </summary>
-    public class EquipItem : AbstractSocketCommandWithParams<EquipRequest>
+    public class EquipItem : AbstractSocketCommand<EquipItemResponse, EquipRequest>
     {
         private readonly PlayerService _playerService;
+        private readonly BattleService _battleService;
 
         public override string Name { get; set; } = nameof(EquipItem);
 
-        public EquipItem(PlayerService playerService)
+        public EquipItem(PlayerService playerService, BattleService battleService)
         {
             _playerService = playerService;
+            _battleService = battleService;
         }
 
-        public override async Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
+        public override async Task<ApiSocketResponse<EquipItemResponse>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
             var player = context.Session.Player;
             var success = await _playerService.EquipItem(
                 player, Parameters.ItemId, (EEquipmentSlot)Parameters.EquipmentSlotId, cancellationToken);
 
-            return success ? Success() : Error("Failed to equip item.");
+            // Both outcomes carry the authoritative post-command rating so the client can always reconcile
+            // onto it, mirroring UpdatePlayerStats.
+            var result = new EquipItemResponse
+            {
+                PlayerRating = await _battleService.RatePlayer(player, cancellationToken),
+            };
+
+            return success ? Success(result) : ErrorWithData("Failed to equip item.", result);
         }
     }
 }

--- a/Game.Api/Sockets/Commands/UnequipItem.cs
+++ b/Game.Api/Sockets/Commands/UnequipItem.cs
@@ -13,24 +13,33 @@ namespace Game.Api.Sockets.Commands
     /// safe: it is processed in the single per-player command loop alongside the idle battle commands, so
     /// it can no longer lose a concurrent read-modify-write race against a background battle save (#463).
     /// </summary>
-    public class UnequipItem : AbstractSocketCommandWithParams<EquipRequest>
+    public class UnequipItem : AbstractSocketCommand<EquipItemResponse, EquipRequest>
     {
         private readonly PlayerService _playerService;
+        private readonly BattleService _battleService;
 
         public override string Name { get; set; } = nameof(UnequipItem);
 
-        public UnequipItem(PlayerService playerService)
+        public UnequipItem(PlayerService playerService, BattleService battleService)
         {
             _playerService = playerService;
+            _battleService = battleService;
         }
 
-        public override async Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
+        public override async Task<ApiSocketResponse<EquipItemResponse>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
             var player = context.Session.Player;
             var success = await _playerService.UnequipItem(
                 player, (EEquipmentSlot)Parameters.EquipmentSlotId, cancellationToken);
 
-            return success ? Success() : Error("Failed to unequip item.");
+            // Both outcomes carry the authoritative post-command rating so the client can always reconcile
+            // onto it, mirroring UpdatePlayerStats.
+            var result = new EquipItemResponse
+            {
+                PlayerRating = await _battleService.RatePlayer(player, cancellationToken),
+            };
+
+            return success ? Success(result) : ErrorWithData("Failed to unequip item.", result);
         }
     }
 }

--- a/UI/src/lib/api/types/api-socket-type-map.ts
+++ b/UI/src/lib/api/types/api-socket-type-map.ts
@@ -14,6 +14,7 @@ import type {
 	IDefeatEnemyRequest,
 	IDefeatEnemyResponse,
 	IEnemy,
+	IEquipItemResponse,
 	IEquipRequest,
 	IItem,
 	IItemMod,
@@ -46,7 +47,7 @@ export type ApiSocketResponseTypes = {
 	'ChallengeBoss': INewEnemyModel;
 	'ChallengeCompleted': IChallengeCompletedModel;
 	'DefeatEnemy': IDefeatEnemyResponse;
-	'EquipItem': undefined;
+	'EquipItem': IEquipItemResponse;
 	'GetAttributes': IAttribute[];
 	'GetChallenges': IChallenge[];
 	'GetChallengeTypes': IChallengeType[];
@@ -77,7 +78,7 @@ export type ApiSocketResponseTypes = {
 	'SetSelectedSkills': undefined;
 	'SocketReplaced': undefined;
 	'SynthesizeSkill': ISynthesisResult;
-	'UnequipItem': undefined;
+	'UnequipItem': IEquipItemResponse;
 	'UnlockLesson': undefined;
 	'UpdatePlayerStats': IUpdatePlayerStatsResponse;
 };

--- a/UI/src/lib/api/types/interfaces/inventory-items.ts
+++ b/UI/src/lib/api/types/interfaces/inventory-items.ts
@@ -12,6 +12,10 @@ export interface IApplyModRequest {
 	itemModSlotId: number;
 }
 
+export interface IEquipItemResponse {
+	playerRating: number;
+}
+
 export interface IEquipRequest {
 	itemId: number;
 	equipmentSlotId: number;

--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -202,6 +202,13 @@ export class InventoryManager {
 				return false;
 			}
 
+			// The response carries the authoritative post-equip rating (spike #1526 Decision 7), so
+			// adopt it absolutely rather than leaving the displayed Power stale until the next full
+			// player-state refresh (#1616).
+			if (response.data) {
+				playerManager.playerRating = response.data.playerRating;
+			}
+
 			return true;
 		});
 	}
@@ -232,6 +239,13 @@ export class InventoryManager {
 				rollback();
 				this.refreshEquipmentStats();
 				return false;
+			}
+
+			// The response carries the authoritative post-unequip rating (spike #1526 Decision 7), so
+			// adopt it absolutely rather than leaving the displayed Power stale until the next full
+			// player-state refresh (#1616).
+			if (response.data) {
+				playerManager.playerRating = response.data.playerRating;
 			}
 
 			return true;

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -12,7 +12,8 @@ vi.mock('$lib/engine', () => ({
 	playerManager: {
 		get inventoryData() {
 			return mockInventoryData;
-		}
+		},
+		playerRating: 0
 	}
 }));
 
@@ -59,6 +60,7 @@ vi.mock('$lib/engine/log', () => ({
 
 import { InventoryManager, EEquipmentSlot, getEquipmentSlotForCategory } from '$lib/engine/player/inventory-manager';
 import { logMessage } from '$lib/engine/log';
+import { playerManager } from '$lib/engine';
 import type { IInventoryItem } from '$lib/api';
 
 const makeItem = (
@@ -120,6 +122,7 @@ describe('InventoryManager', () => {
 		mockSkills.length = 0;
 		mockInventoryData.unlockedItems = [];
 		mockInventoryData.unlockedMods = [];
+		playerManager.playerRating = 0;
 	});
 
 	describe('initialize', () => {
@@ -548,6 +551,28 @@ describe('InventoryManager', () => {
 			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]).toBeUndefined();
 			expect(manager.unlockedItems.get(1)?.equipped).toBe(false);
 		});
+
+		it('adopts the post-equip player rating the response carries', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+			mockSendSocketCommand.mockResolvedValue({ data: { playerRating: 42 } });
+
+			await manager.equipItem(1, EEquipmentSlot.WeaponSlot);
+
+			expect(playerManager.playerRating).toBe(42);
+		});
+
+		it('leaves the player rating unchanged when the socket returns an error', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+			mockSendSocketCommand.mockResolvedValue({ error: 'nope' });
+
+			await manager.equipItem(1, EEquipmentSlot.WeaponSlot);
+
+			expect(playerManager.playerRating).toBe(0);
+		});
 	});
 
 	describe('overlapping mutations (serialization)', () => {
@@ -737,6 +762,32 @@ describe('InventoryManager', () => {
 
 			expect(result).toBe(false);
 			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]?.itemId).toBe(1);
+		});
+
+		it('adopts the post-unequip player rating the response carries', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({ itemId: 1, equipped: true, equipmentSlotId: EEquipmentSlot.WeaponSlot })
+			];
+			manager.initialize();
+			mockSendSocketCommand.mockResolvedValue({ data: { playerRating: 7 } });
+
+			await manager.unequipItem(EEquipmentSlot.WeaponSlot);
+
+			expect(playerManager.playerRating).toBe(7);
+		});
+
+		it('leaves the player rating unchanged when the socket returns an error', async () => {
+			mockItems[1] = makeItem(1);
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({ itemId: 1, equipped: true, equipmentSlotId: EEquipmentSlot.WeaponSlot })
+			];
+			manager.initialize();
+			mockSendSocketCommand.mockResolvedValue({ error: 'nope' });
+
+			await manager.unequipItem(EEquipmentSlot.WeaponSlot);
+
+			expect(playerManager.playerRating).toBe(0);
 		});
 	});
 


### PR DESCRIPTION
## Summary

#1534 surfaced the combat-rating "Power" display (spike #1526 Decision 7) and refreshed it on the natural existing payloads — player load/login, stat reallocation, and battle victory. Gear was explicitly left out: `EquipItem`/`UnequipItem` returned bare success/error, so equipping/unequipping an item that moves the rating left the displayed Power stale until the next full player-state refresh (a page reload / re-login), even though the equip itself took effect immediately client-side.

- Added `EquipItemResponse` (`Game.Api/Models/InventoryItems/EquipItemResponse.cs`), carrying `PlayerRating`.
- `EquipItem`/`UnequipItem` now extend `AbstractSocketCommand<EquipItemResponse, EquipRequest>` (instead of the bare `AbstractSocketCommandWithParams<EquipRequest>`) and compute the post-change rating via the existing `BattleService.RatePlayer`, mirroring the pattern `UpdatePlayerStats` already established. Both the success and error paths carry the authoritative post-command rating, same as `UpdatePlayerStats`.
- Regenerated the TypeScript client (`dotnet run --project Game.Api -- codegen`).
- `InventoryManager.equipItem`/`unequipItem` (`UI/src/lib/engine/player/inventory-manager.ts`) now reconcile `playerManager.playerRating` from the response data on success.

## Test plan

- [x] `dotnet build Game.sln` — 0 warnings, 0 errors
- [x] `dotnet test Game.sln --no-build --no-restore` — 3000/3000 passing, including a new integration test (`InventorySocketTests.EquipItem_ItemWithAttributes_ReturnsPlayerRatingThatDropsOnUnequip`) asserting the returned rating actually moves between the equipped and unequipped state, mirroring `UpdatePlayerStatsSocketTests`' rating assertions per the issue's ask.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings
- [x] `npm run test:unit:ci` — 3509/3509 passing, including 4 new unit tests covering the frontend rating reconciliation (adopts the response's rating on success, leaves it unchanged on error, for both equip and unequip)

Closes #1616


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUr6xKnYEGDDaM6izJXRvT)_