### PR TITLE
Mark PlayerData.PlayerRating as required for consistency

### DIFF
--- a/Game.Api/Models/Player/PlayerData.cs
+++ b/Game.Api/Models/Player/PlayerData.cs
@@ -42,7 +42,7 @@ namespace Game.Api.Models.Player
         /// (#1528). Recomputed fresh from current state (not a stored battle snapshot), display-only, never
         /// recomputed client-side (no parity surface).
         /// </summary>
-        public double PlayerRating { get; set; }
+        public required double PlayerRating { get; set; }
 
         public static PlayerData FromPlayer(
             CorePlayer player,


### PR DESCRIPTION
## Summary

Follow-up from PR #1617 (review nit). `PlayerData.PlayerRating` (`Game.Api/Models/Player/PlayerData.cs`) was a `double` that was not marked `required`, while every other property on `PlayerData` is. Because it's a value type it would silently default to `0` if a future construction path forgot to set it, rather than failing at compile time.

- Marked `PlayerRating` `required`.
- Verified `FromPlayer` (the only construction site solution-wide) already sets it, so this is a no-op behavior change — purely a consistency/safety improvement to bring it in line with its siblings.

## Test plan

- [x] `dotnet build Game.sln` — 0 warnings, 0 errors
- [x] `dotnet test Game.sln --no-build --no-restore` — 3000/3000 passing

No frontend changes.

Closes #1623


---
_Generated by [Claude Code](https://claude.ai/code/session_017XbsyXWPto4xFyveDd4mf4)_