### PR TITLE
Remove dead frontend exports kept alive only by their own tests

### DIFF
--- a/UI/src/lib/battle/battle-attributes.ts
+++ b/UI/src/lib/battle/battle-attributes.ts
@@ -43,8 +43,8 @@ export interface AttributeEntry {
  *   deep-proxy its elements, so the stored modifier would no longer be `===` the reference the caller
  *   holds). Only the reactive `attributeValues` — what combat reads — is reassigned on each recompute.
  *
- * The named display projections ({@link getAttributeMap}/{@link getAttributeCount}) are nothing the
- * combat loop consumes — they back the inventory/breakdown/tooltip surfaces only — so they are built
+ * The named display projection ({@link getAttributeMap}) is nothing the
+ * combat loop consumes — it backs the inventory/breakdown/tooltip surfaces only — so it is built
  * **lazily on first read** and memoised, then invalidated on the next recompute. This keeps the
  * per-modifier hot path (every effect application/expiry, for both battlers, up to each tick) off the
  * per-attribute `.map` + `attributeName` reference scans; the projections rebuild once, the next time
@@ -172,9 +172,6 @@ export class BattleAttributes {
 		const { all, nonZero } = this.#ensureProjections();
 		return includeZeroes ? all : nonZero;
 	};
-
-	/** The count of non-zero attributes, for consumers that only need the size. */
-	public getAttributeCount = (): number => this.#ensureProjections().nonZero.length;
 
 	/** Builds and memoises the named display projections on demand. A read of the reactive
 	 *  `attributeValues` keeps `$derived` consumers tracking changes; the projections themselves cache

--- a/UI/src/lib/common/functions.ts
+++ b/UI/src/lib/common/functions.ts
@@ -78,16 +78,3 @@ export function plural(str: string) {
 export function tintColor(color: string, alpha: number): string {
 	return `color-mix(in srgb, ${color} ${+(alpha * 100).toFixed(3)}%, transparent)`;
 }
-
-export function groupBy<T>(arr: T[], groupFn: (item: T) => string) {
-	const ret: { [key: string]: T[] } = {};
-	for (const t of arr) {
-		const key = groupFn(t);
-		if (ret[key]) {
-			ret[key].push(t);
-		} else {
-			ret[key] = [t];
-		}
-	}
-	return ret;
-}

--- a/UI/src/routes/admin/workbench/progression/MilestonesEditor.svelte
+++ b/UI/src/routes/admin/workbench/progression/MilestonesEditor.svelte
@@ -101,7 +101,7 @@
 import WorkbenchIcon from '../WorkbenchIcon.svelte';
 import { reference } from '../reference.svelte';
 import type { ProgressionStore } from './progression-store.svelte';
-import { cumulativeXp, modifiersAtLevel, rewardAtLevel } from './progression-helpers';
+import { cumulativeXp, isMilestoneLevel, modifiersAtLevel, rewardAtLevel } from './progression-helpers';
 import { NO_SKILL, type WorkbenchProficiency } from './types';
 import ProgSelect from './ProgSelect.svelte';
 import ProgNumber from './ProgNumber.svelte';
@@ -137,7 +137,7 @@ const attrOptionsFor = (current: number) =>
 const levelNodes = $derived.by(() => {
 	const nodes: { level: number; kind: 'empty' | 'bonus' | 'milestone' }[] = [];
 	for (let level = 1; level <= maxLevel; level++) {
-		const hasReward = rewardAtLevel(tier, level) !== undefined;
+		const hasReward = isMilestoneLevel(tier, level);
 		const hasMod = modifiersAtLevel(tier, level).length > 0;
 		nodes.push({ level, kind: hasReward ? 'milestone' : hasMod ? 'bonus' : 'empty' });
 	}

--- a/UI/src/tests/common/functions.test.ts
+++ b/UI/src/tests/common/functions.test.ts
@@ -5,7 +5,6 @@ import {
 	normalizeText,
 	plural,
 	keys,
-	groupBy,
 	enumPairs,
 	hasFlag,
 	toggleFlag,
@@ -105,23 +104,6 @@ describe('keys', () => {
 
 	it('returns empty array for undefined', () => {
 		expect(keys(undefined)).toEqual([]);
-	});
-});
-
-describe('groupBy', () => {
-	it('groups items by the given function', () => {
-		const items = [
-			{ type: 'a', value: 1 },
-			{ type: 'b', value: 2 },
-			{ type: 'a', value: 3 }
-		];
-		const result = groupBy(items, (i) => i.type);
-		expect(result['a']).toHaveLength(2);
-		expect(result['b']).toHaveLength(1);
-	});
-
-	it('returns empty object for empty array', () => {
-		expect(groupBy([], () => 'x')).toEqual({});
 	});
 });
 

--- a/UI/src/tests/lib/battle/battle-attributes.test.ts
+++ b/UI/src/tests/lib/battle/battle-attributes.test.ts
@@ -311,22 +311,6 @@ describe('BattleAttributes', () => {
 		});
 	});
 
-	describe('getAttributeCount', () => {
-		it('returns the non-zero attribute count without building the full map', () => {
-			const ba = new BattleAttributes(makeAttrs([EAttribute.Strength, 10], [EAttribute.Agility, 4]), false);
-			expect(ba.getAttributeCount()).toBe(ba.getAttributeMap().length);
-			expect(ba.getAttributeCount()).toBe(2);
-		});
-
-		it('reflects a modifier change', () => {
-			const ba = new BattleAttributes([], false);
-			expect(ba.getAttributeCount()).toBe(0);
-
-			ba.addModifier(additive(EAttribute.Strength, 5));
-			expect(ba.getAttributeCount()).toBe(1);
-		});
-	});
-
 	// Mirrors Game.Core.Tests AttributeCollectionTests.RemoveModifier_* so the two attribute
 	// implementations stay aligned on add/remove and the derived-cascade behaviour.
 	describe('addModifier / removeModifier', () => {


### PR DESCRIPTION
## Summary

Three exported members had no production consumers — only their own unit tests kept them referenced:

- `groupBy` (`UI/src/lib/common/functions.ts`) — removed, along with its `describe` block in `functions.test.ts`.
- `BattleAttributes.getAttributeCount` (`UI/src/lib/battle/battle-attributes.ts`) — removed, along with its tests and the `@link getAttributeCount` reference in the class doc comment (now singular, referring only to `getAttributeMap`).
- `isMilestoneLevel` (`progression-helpers.ts`) — kept, per the issue's alternative option: wired it into `MilestonesEditor.svelte`'s `levelNodes` derivation, which previously inlined the identical `rewardAtLevel(tier, level) !== undefined` check. This reads more clearly at the call site and the function already had a useful doc comment explaining the "milestone" concept.

No behavior change other than the `isMilestoneLevel` call-site swap, which is logically identical to what it replaced.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — 295 files / 3506 tests passing

Closes #1644


---
_Generated by [Claude Code](https://claude.ai/code/session_01Af5tWu5zxdwx98avQbasuC)_