### PR TITLE
Game.Core: prune/reclassify test-only public members and fix two misleading doc comments

### DIFF
--- a/Game.Application.Tests/DataAccess/ZonesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/ZonesIntegrationTests.cs
@@ -40,7 +40,6 @@ namespace Game.Application.Tests.DataAccess
             Assert.Equal(11, result.LevelMax);
             Assert.Equal(boss.Id, result.BossEnemyId);
             Assert.Equal(18, result.BossLevel);
-            Assert.True(result.HasBoss);
         }
 
         [Fact]
@@ -57,7 +56,6 @@ namespace Game.Application.Tests.DataAccess
             var result = zones.GetDomainZone(zone.Id);
 
             Assert.Null(result.BossEnemyId);
-            Assert.False(result.HasBoss);
         }
 
         [Fact]

--- a/Game.Core.TestInfrastructure/Builders/PlayerAttributeTestExtensions.cs
+++ b/Game.Core.TestInfrastructure/Builders/PlayerAttributeTestExtensions.cs
@@ -18,7 +18,7 @@ namespace Game.Core.TestInfrastructure.Builders
     {
         public static IEnumerable<AttributeModifier> GetAllModifiers(this Player player)
         {
-            return player.StatPoints.ToAttributeModifiers()
+            return player.StatPoints.StatAllocations.Select(allocation => allocation.ToModifier())
                 .Concat(player.Inventory.GetEquippedAttributeModifiers());
         }
 

--- a/Game.Core.Tests/Players/StatAllocationTests.cs
+++ b/Game.Core.Tests/Players/StatAllocationTests.cs
@@ -18,28 +18,5 @@ namespace Game.Core.Tests.Players
             Assert.Equal(EModifierType.Additive, modifier.Type);
             Assert.Equal(EAttributeModifierSource.PlayerStatPoints, modifier.Source);
         }
-
-        [Fact]
-        public void ToModifier_MatchesPlayerStatPointsToAttributeModifiers()
-        {
-            var allocations = new List<StatAllocation>
-            {
-                new() { Attribute = EAttribute.Strength, Amount = 4 },
-                new() { Attribute = EAttribute.Agility, Amount = 6 },
-            };
-            var statPoints = new PlayerStatPoints { StatAllocations = allocations, StatPointsGained = 10, StatPointsUsed = 10 };
-
-            var fromAllocations = allocations.Select(a => a.ToModifier()).ToList();
-            var fromStatPoints = statPoints.ToAttributeModifiers().ToList();
-
-            Assert.Equal(fromStatPoints.Count, fromAllocations.Count);
-            for (var i = 0; i < fromStatPoints.Count; i++)
-            {
-                Assert.Equal(fromStatPoints[i].Attribute, fromAllocations[i].Attribute);
-                Assert.Equal(fromStatPoints[i].Amount, fromAllocations[i].Amount);
-                Assert.Equal(fromStatPoints[i].Type, fromAllocations[i].Type);
-                Assert.Equal(fromStatPoints[i].Source, fromAllocations[i].Source);
-            }
-        }
     }
 }

--- a/Game.Core.Tests/Zones/ZoneTests.cs
+++ b/Game.Core.Tests/Zones/ZoneTests.cs
@@ -29,22 +29,6 @@ namespace Game.Core.Tests.Zones
         }
 
         [Fact]
-        public void HasBoss_WithBossEnemyId_IsTrue()
-        {
-            var zone = MakeZone(bossEnemyId: 9);
-
-            Assert.True(zone.HasBoss);
-        }
-
-        [Fact]
-        public void HasBoss_WithoutBossEnemyId_IsFalse()
-        {
-            var zone = MakeZone(bossEnemyId: null);
-
-            Assert.False(zone.HasBoss);
-        }
-
-        [Fact]
         public void IsUnlocked_UngatedZone_IsAlwaysUnlocked()
         {
             var zone = MakeZone(unlockChallengeId: null);

--- a/Game.Core/Attributes/AttributeCollection.cs
+++ b/Game.Core/Attributes/AttributeCollection.cs
@@ -99,9 +99,10 @@ namespace Game.Core.Attributes
         }
 
         /// <summary>
-        /// Retrieves all the <see cref="AttributeModifier"/> instances contained in the collection.
-        /// Test-only today (no production caller) — kept as an instance member rather than moved out since
-        /// it needs the private per-attribute node storage.
+        /// Retrieves all the <see cref="AttributeModifier"/> instances contained in the collection. Used by
+        /// <see cref="Battle.Battler.CloneWithAttributeDelta"/> to rebuild a battler's modifier set minus its
+        /// static and skill-effect modifiers (the combat rating's marginal-value helper). Kept as an instance
+        /// member rather than moved out since it needs the private per-attribute node storage.
         /// </summary>
         /// <returns></returns>
         public IEnumerable<AttributeModifier> AllModifiers()

--- a/Game.Core/Attributes/DamageTypes.cs
+++ b/Game.Core/Attributes/DamageTypes.cs
@@ -169,7 +169,9 @@ namespace Game.Core.Attributes
 
         /// <summary>The martial weapon-leaf damage types (Sword / Axe / Bow / Club / Dagger / Unarmed), in enum
         /// order — the types the weapon-match gate treats as gated. A weapon's <see cref="Items.Item.WeaponType"/>
-        /// is not constrained to this set (any leaf is valid, e.g. a caster weapon's element).</summary>
+        /// is not constrained to this set (any leaf is valid, e.g. a caster weapon's element). No production
+        /// caller today — <see cref="IsWeaponLeaf"/> is the production gate — but kept public deliberately as the
+        /// taxonomy-invariant contract <c>DamageTypesTests</c> pins <see cref="IsWeaponLeaf"/> against.</summary>
         public static IReadOnlyList<EDamageType> WeaponLeaves { get; } = LeafTypes.Where(WeaponLeafSet.Contains).ToList();
 
         /// <summary>Whether <paramref name="type"/> is a weapon-type leaf — a leaf under the Physical category key,
@@ -199,7 +201,10 @@ namespace Game.Core.Attributes
 
         /// <summary>
         /// The amplification / resistance attribute pair a <paramref name="key"/> backs. The resistance is
-        /// <c>null</c> for an amplification-only weapon key (#1340).
+        /// <c>null</c> for an amplification-only weapon key (#1340). No production caller today — the damage
+        /// pipeline reads the precomputed <see cref="AmplificationAttributes"/>/<see cref="ResistanceAttributes"/>
+        /// lists instead — but kept public deliberately as the taxonomy-invariant contract
+        /// <c>DamageTypesTests</c> pins those precomputed lists against.
         /// </summary>
         public static (EAttribute Amplification, EAttribute? Resistance) AttributesFor(EDamageTypeKey key)
         {

--- a/Game.Core/Players/PlayerStatPoints.cs
+++ b/Game.Core/Players/PlayerStatPoints.cs
@@ -1,6 +1,4 @@
-﻿using Game.Core.Attributes.Modifiers;
-
-namespace Game.Core.Players
+﻿namespace Game.Core.Players
 {
     /// <summary>
     /// Represents the stat points a player can and has allocated to core attributes.
@@ -68,14 +66,6 @@ namespace Game.Core.Players
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// Converts the stat allocations to a list of <see cref="AttributeModifier"/>.
-        /// </summary>
-        public IEnumerable<AttributeModifier> ToAttributeModifiers()
-        {
-            return StatAllocations.Select(allocation => allocation.ToModifier());
         }
     }
 }

--- a/Game.Core/Players/StatAllocation.cs
+++ b/Game.Core/Players/StatAllocation.cs
@@ -13,9 +13,9 @@ namespace Game.Core.Players
 
         /// <summary>
         /// Converts this allocation into the additive <see cref="AttributeModifier"/> it contributes to a
-        /// player's battle attributes. Single source of truth for the allocation → modifier rule, shared by
-        /// the live <see cref="PlayerStatPoints.ToAttributeModifiers"/> path and the battle-snapshot
-        /// reconstruction (<see cref="Battle.BattleSnapshot.ToBattler"/>).
+        /// player's battle attributes. Single source of truth for the allocation → modifier rule, used by the
+        /// battle-snapshot reconstruction (<see cref="Battle.BattleSnapshot.ToBattler"/>) and the
+        /// <c>Game.Core.TestInfrastructure</c> attribute-composition shortcut.
         /// </summary>
         public AttributeModifier ToModifier()
         {

--- a/Game.Core/Progress/PlayerProgress.cs
+++ b/Game.Core/Progress/PlayerProgress.cs
@@ -204,6 +204,12 @@ namespace Game.Core.Progress
         public HashSet<int> CompletedChallengeIds() =>
             [.. _challenges.Values.Where(c => c.Completed).Select(c => c.Challenge.Id)];
 
+        /// <summary>
+        /// Looks up a recorded statistic value, collapsing "no row" and "recorded 0" to the same <c>0m</c>.
+        /// Production code must always distinguish the two (see <see cref="TryGetStatisticValue"/>'s remarks) and
+        /// so never calls this; it is kept as a deliberate test-only convenience — most test assertions only
+        /// care about the value, not row presence — rather than removed.
+        /// </summary>
         public decimal GetStatisticValue(EStatisticType type, int? entityId)
         {
             TryGetStatisticValue(type, entityId, out var value);

--- a/Game.Core/Zones/Zone.cs
+++ b/Game.Core/Zones/Zone.cs
@@ -79,9 +79,6 @@ namespace Game.Core.Zones
         /// chain) keeps progression authorable and decoupled from zone ordering.</summary>
         public required int? UnlockChallengeId { get; init; }
 
-        /// <summary>Whether this zone has a dedicated boss that can be challenged.</summary>
-        public bool HasBoss => BossEnemyId.HasValue;
-
         /// <summary>
         /// Whether this zone is unlocked for a player given the set of challenge ids they have completed.
         /// An ungated zone (<see cref="UnlockChallengeId"/> is <c>null</c>) is always unlocked; a gated zone


### PR DESCRIPTION
## Summary

Follow-through on a codebase health review (#1645): a handful of public `Game.Core` members had no production caller, and two doc comments misstated reality.

**Removed (no production caller, thin test-only wrappers):**
- `PlayerStatPoints.ToAttributeModifiers` — a one-line `StatAllocations.Select(a => a.ToModifier())` wrapper only used by `Game.Core.TestInfrastructure` and one unit test that existed solely to pin it against `StatAllocation.ToModifier`. Inlined the equivalent LINQ at the one call site (`PlayerAttributeTestExtensions.GetAllModifiers`) and removed the now-pointless parity test.
- `Zone.HasBoss` — a one-line `BossEnemyId.HasValue` wrapper used only by 4 test assertions that were redundant with the `BossEnemyId` assertions already alongside them. Removed the property and the two dedicated `ZoneTests` cases; trimmed the two now-redundant integration-test assertions.

**Kept, with the "why" made explicit instead of leaving it ambiguous:**
- `PlayerProgress.GetStatisticValue` — heavily used (~80 call sites) as a test convenience that collapses "no row" vs. "recorded 0" to a single return value; production code must always distinguish the two via `TryGetStatisticValue`, so this deliberately stays test-only. Added a doc comment saying so.
- `DamageTypes.AttributesFor` / `DamageTypes.WeaponLeaves` — no production caller (the damage pipeline reads the precomputed `AmplificationAttributes`/`ResistanceAttributes` lists and `IsWeaponLeaf` instead), but they back the taxonomy-invariant tests in `DamageTypesTests` that pin those precomputed structures against the base table. Kept public and documented as a deliberate invariant-pinning contract.

**Misleading doc comments fixed:**
- `StatAllocation.ToModifier` no longer references the removed `PlayerStatPoints.ToAttributeModifiers`.
- `AttributeCollection.AllModifiers` claimed "no production caller" — false: `Battler.CloneWithAttributeDelta` calls it on the `CombatRating.Marginal` path. Doc comment now says so.

The legacy `DefeatRewards.GetDifficultyMultiplier`/`SumCoreAttributes` and `BattleSnapshot.GetModifiersWithSignaturePassive` mentioned in the issue as **not** dead (the #1533 calibrator still consumes them) were left untouched, as instructed.

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test --no-build --no-restore` — full solution, 2004/2004 passing (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests)
- [x] Grepped the whole solution for the two removed members post-change — no stray references

Closes #1645


---
_Generated by [Claude Code](https://claude.ai/code/session_01MqUxYhtSiH4fe9ffHLQKPr)_