### PR TITLE
Workbench: extract guardedSave helper to collapse repeated ChildSaver shape (#1654)

### DIFF
--- a/UI/src/routes/admin/workbench/entities/class.ts
+++ b/UI/src/routes/admin/workbench/entities/class.ts
@@ -2,7 +2,7 @@ import { ApiRequest, EAttribute, EModifierType, ESkillAcquisition, fetchSocketDa
 import { hasFlag } from '$lib/common';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
-import { childChanged, persistEntity } from '../save-helpers';
+import { childChanged, guardedSave, persistEntity } from '../save-helpers';
 import { firstFree } from './helpers';
 import { chipsSection, type EntityConfig } from './types';
 
@@ -243,36 +243,27 @@ export const classEntity: EntityConfig<WorkbenchClass> = {
 			postPrimary: (changes) => ApiRequest.post('AdminTools/AddEditClasses', changes),
 			refresh,
 			childSavers: [
-				async (id, record, baseline) => {
-					if (!childChanged(record.starterSkillIds, baseline?.starterSkillIds)) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetClassStarterSkills', {
-						classId: id,
-						skillIds: record.starterSkillIds
-					});
-					return true;
-				},
-				async (id, record, baseline) => {
-					if (!childChanged(record.starterEquipment, baseline?.starterEquipment)) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetClassStarterEquipment', {
-						classId: id,
-						equipment: record.starterEquipment
-					});
-					return true;
-				},
-				async (id, record, baseline) => {
-					if (!childChanged(record.attributeDistributions, baseline?.attributeDistributions)) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetClassAttributeDistributions', {
-						classId: id,
-						attributeDistributions: record.attributeDistributions
-					});
-					return true;
-				}
+				async (id, record, baseline) =>
+					guardedSave(childChanged(record.starterSkillIds, baseline?.starterSkillIds), () =>
+						ApiRequest.post('AdminTools/SetClassStarterSkills', {
+							classId: id,
+							skillIds: record.starterSkillIds
+						})
+					),
+				async (id, record, baseline) =>
+					guardedSave(childChanged(record.starterEquipment, baseline?.starterEquipment), () =>
+						ApiRequest.post('AdminTools/SetClassStarterEquipment', {
+							classId: id,
+							equipment: record.starterEquipment
+						})
+					),
+				async (id, record, baseline) =>
+					guardedSave(childChanged(record.attributeDistributions, baseline?.attributeDistributions), () =>
+						ApiRequest.post('AdminTools/SetClassAttributeDistributions', {
+							classId: id,
+							attributeDistributions: record.attributeDistributions
+						})
+					)
 			]
 		})
 };

--- a/UI/src/routes/admin/workbench/entities/enemy.ts
+++ b/UI/src/routes/admin/workbench/entities/enemy.ts
@@ -2,7 +2,7 @@ import { ApiRequest, ESkillAcquisition, fetchSocketData, type IEnemy } from '$li
 import { hasFlag } from '$lib/common';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
-import { childChanged, persistEntity } from '../save-helpers';
+import { childChanged, guardedSave, persistEntity } from '../save-helpers';
 import { firstFree } from './helpers';
 import { chipsSection, type EntityConfig } from './types';
 
@@ -195,30 +195,21 @@ export const enemyEntity: EntityConfig<WorkbenchEnemy> = {
 			postPrimary: (changes) => ApiRequest.post('AdminTools/AddEditEnemies', changes),
 			refresh,
 			childSavers: [
-				async (id, record, baseline) => {
-					if (!childChanged(record.attributeDistribution, baseline?.attributeDistribution)) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetEnemyAttributeDistributions', {
-						enemyId: id,
-						attributeDistributions: record.attributeDistribution
-					});
-					return true;
-				},
-				async (id, record, baseline) => {
-					if (!childChanged(record.skillPool, baseline?.skillPool)) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetEnemySkills', { enemyId: id, skillIds: record.skillPool });
-					return true;
-				},
-				async (id, record, baseline) => {
-					if (!childChanged(record.spawns, baseline?.spawns)) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetEnemySpawns', { enemyId: id, spawns: record.spawns });
-					return true;
-				}
+				async (id, record, baseline) =>
+					guardedSave(childChanged(record.attributeDistribution, baseline?.attributeDistribution), () =>
+						ApiRequest.post('AdminTools/SetEnemyAttributeDistributions', {
+							enemyId: id,
+							attributeDistributions: record.attributeDistribution
+						})
+					),
+				async (id, record, baseline) =>
+					guardedSave(childChanged(record.skillPool, baseline?.skillPool), () =>
+						ApiRequest.post('AdminTools/SetEnemySkills', { enemyId: id, skillIds: record.skillPool })
+					),
+				async (id, record, baseline) =>
+					guardedSave(childChanged(record.spawns, baseline?.spawns), () =>
+						ApiRequest.post('AdminTools/SetEnemySpawns', { enemyId: id, spawns: record.spawns })
+					)
 			]
 		})
 };

--- a/UI/src/routes/admin/workbench/entities/item-mod.ts
+++ b/UI/src/routes/admin/workbench/entities/item-mod.ts
@@ -1,7 +1,7 @@
 import { ApiRequest, EItemModType, ERarity, fetchSocketData, type IItemMod } from '$lib/api';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
-import { attributeChanges, childChanged, persistEntity } from '../save-helpers';
+import { attributeChanges, childChanged, guardedSave, persistEntity } from '../save-helpers';
 import { firstFree } from './helpers';
 import { tagsSection } from './tags-section';
 import type { EntityConfig } from './types';
@@ -118,19 +118,14 @@ export const itemModEntity: EntityConfig<IItemMod> = {
 			childSavers: [
 				async (id, record, baseline) => {
 					const changes = attributeChanges(record.attributes, baseline?.attributes, 'amount');
-					if (!changes.length) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/AddEditItemModAttributes', { id, changes });
-					return true;
+					return guardedSave(changes.length > 0, () =>
+						ApiRequest.post('AdminTools/AddEditItemModAttributes', { id, changes })
+					);
 				},
-				async (id, record, baseline) => {
-					if (!childChanged(record.tags, baseline?.tags)) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetTagsForItemMod', { id, tagIds: record.tags });
-					return true;
-				}
+				async (id, record, baseline) =>
+					guardedSave(childChanged(record.tags, baseline?.tags), () =>
+						ApiRequest.post('AdminTools/SetTagsForItemMod', { id, tagIds: record.tags })
+					)
 			]
 		})
 };

--- a/UI/src/routes/admin/workbench/entities/item.ts
+++ b/UI/src/routes/admin/workbench/entities/item.ts
@@ -1,7 +1,7 @@
 import { ApiRequest, EItemCategory, ERarity, fetchSocketData, type IItem } from '$lib/api';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
-import { attributeChanges, childChanged, modSlotChanges, persistEntity } from '../save-helpers';
+import { attributeChanges, childChanged, guardedSave, modSlotChanges, persistEntity } from '../save-helpers';
 import { firstFree } from './helpers';
 import { tagsSection } from './tags-section';
 import type { EntityConfig } from './types';
@@ -212,27 +212,18 @@ export const itemEntity: EntityConfig<WorkbenchItem> = {
 			childSavers: [
 				async (id, record, baseline) => {
 					const changes = attributeChanges(record.attributes, baseline?.attributes, 'amount');
-					if (!changes.length) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/AddEditItemAttributes', { id, changes });
-					return true;
+					return guardedSave(changes.length > 0, () =>
+						ApiRequest.post('AdminTools/AddEditItemAttributes', { id, changes })
+					);
 				},
 				async (id, record, baseline) => {
 					const changes = modSlotChanges(record.modSlots, baseline?.modSlots, id);
-					if (!changes.length) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/AddEditItemModSlots', changes);
-					return true;
+					return guardedSave(changes.length > 0, () => ApiRequest.post('AdminTools/AddEditItemModSlots', changes));
 				},
-				async (id, record, baseline) => {
-					if (!childChanged(record.tags, baseline?.tags)) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetTagsForItem', { id, tagIds: record.tags });
-					return true;
-				}
+				async (id, record, baseline) =>
+					guardedSave(childChanged(record.tags, baseline?.tags), () =>
+						ApiRequest.post('AdminTools/SetTagsForItem', { id, tagIds: record.tags })
+					)
 			]
 		})
 };

--- a/UI/src/routes/admin/workbench/entities/lesson.ts
+++ b/UI/src/routes/admin/workbench/entities/lesson.ts
@@ -1,7 +1,7 @@
 import { ApiRequest, ELessonTriggerType, fetchSocketData, type ILesson } from '$lib/api';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
-import { childChanged, persistEntity } from '../save-helpers';
+import { childChanged, guardedSave, persistEntity } from '../save-helpers';
 import type { EntityConfig } from './types';
 
 /** A lesson, normalising the optional mechanic-event trigger to the select's "None" sentinel (-1) so the
@@ -192,23 +192,20 @@ export const lessonEntity: EntityConfig<WorkbenchLesson> = {
 			postPrimary: (changes) => ApiRequest.post('AdminTools/AddEditLessons', changes),
 			refresh,
 			childSavers: [
-				async (id, record, baseline) => {
-					if (!childChanged(record.steps, baseline?.steps)) {
-						return false;
-					}
+				async (id, record, baseline) =>
 					// SetLessonSteps reconciles against the full desired set (keyed by ordinal), not a diff —
 					// mirroring SetZoneEnemies rather than the Add/Edit/Delete-changes shape SetSkillPortions
 					// takes, since the backend's ChildCollectionReconciler wants the whole set every time.
-					await ApiRequest.post('AdminTools/SetLessonSteps', {
-						id,
-						steps: record.steps.map(({ ordinal, text, anchorKey }) => ({
-							ordinal,
-							text,
-							anchorKey: anchorKey || undefined
-						}))
-					});
-					return true;
-				}
+					guardedSave(childChanged(record.steps, baseline?.steps), () =>
+						ApiRequest.post('AdminTools/SetLessonSteps', {
+							id,
+							steps: record.steps.map(({ ordinal, text, anchorKey }) => ({
+								ordinal,
+								text,
+								anchorKey: anchorKey || undefined
+							}))
+						})
+					)
 			]
 		})
 };

--- a/UI/src/routes/admin/workbench/entities/skill-recipe.ts
+++ b/UI/src/routes/admin/workbench/entities/skill-recipe.ts
@@ -1,7 +1,7 @@
 import { ApiRequest, fetchSocketData, type ISkillRecipe } from '$lib/api';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
-import { childChanged, persistEntity } from '../save-helpers';
+import { childChanged, guardedSave, persistEntity } from '../save-helpers';
 import { firstFree } from './helpers';
 import { chipsSection, type EntityConfig } from './types';
 
@@ -157,20 +157,14 @@ export const skillRecipeEntity: EntityConfig<ISkillRecipe> = {
 			postPrimary: (changes) => ApiRequest.post('AdminTools/AddEditSkillRecipes', changes),
 			refresh,
 			childSavers: [
-				async (id, record, baseline) => {
-					if (!childChanged(record.inputSkillIds, baseline?.inputSkillIds)) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetSkillRecipeInputs', { id, skillIds: record.inputSkillIds });
-					return true;
-				},
-				async (id, record, baseline) => {
-					if (!childChanged(record.conditions, baseline?.conditions)) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetSkillRecipeConditions', { id, conditions: record.conditions });
-					return true;
-				}
+				async (id, record, baseline) =>
+					guardedSave(childChanged(record.inputSkillIds, baseline?.inputSkillIds), () =>
+						ApiRequest.post('AdminTools/SetSkillRecipeInputs', { id, skillIds: record.inputSkillIds })
+					),
+				async (id, record, baseline) =>
+					guardedSave(childChanged(record.conditions, baseline?.conditions), () =>
+						ApiRequest.post('AdminTools/SetSkillRecipeConditions', { id, conditions: record.conditions })
+					)
 			]
 		})
 };

--- a/UI/src/routes/admin/workbench/entities/skill.ts
+++ b/UI/src/routes/admin/workbench/entities/skill.ts
@@ -11,7 +11,13 @@ import {
 } from '$lib/api';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
-import { attributeChanges, damagePortionChanges, persistEntity, skillEffectChanges } from '../save-helpers';
+import {
+	attributeChanges,
+	damagePortionChanges,
+	guardedSave,
+	persistEntity,
+	skillEffectChanges
+} from '../save-helpers';
 import { firstFree } from './helpers';
 import type { EntityConfig } from './types';
 
@@ -259,27 +265,17 @@ export const skillEntity: EntityConfig<ISkill> = {
 			childSavers: [
 				async (id, record, baseline) => {
 					const changes = damagePortionChanges(record.damagePortions, baseline?.damagePortions);
-					if (!changes.length) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetSkillPortions', { id, changes });
-					return true;
+					return guardedSave(changes.length > 0, () => ApiRequest.post('AdminTools/SetSkillPortions', { id, changes }));
 				},
 				async (id, record, baseline) => {
 					const changes = attributeChanges(record.damageMultipliers, baseline?.damageMultipliers, 'multiplier');
-					if (!changes.length) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetSkillMultipliers', { id, changes });
-					return true;
+					return guardedSave(changes.length > 0, () =>
+						ApiRequest.post('AdminTools/SetSkillMultipliers', { id, changes })
+					);
 				},
 				async (id, record, baseline) => {
 					const changes = skillEffectChanges(record.effects, baseline?.effects);
-					if (!changes.length) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetSkillEffects', { id, changes });
-					return true;
+					return guardedSave(changes.length > 0, () => ApiRequest.post('AdminTools/SetSkillEffects', { id, changes }));
 				}
 			]
 		})

--- a/UI/src/routes/admin/workbench/entities/zone.ts
+++ b/UI/src/routes/admin/workbench/entities/zone.ts
@@ -1,7 +1,7 @@
 import { ApiRequest, fetchSocketData, type IZone, type IZoneEnemy } from '$lib/api';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
-import { childChanged, persistEntity } from '../save-helpers';
+import { childChanged, guardedSave, persistEntity } from '../save-helpers';
 import { firstFree } from './helpers';
 import type { EntityConfig } from './types';
 
@@ -183,13 +183,10 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 			postPrimary: (changes) => ApiRequest.post('AdminTools/AddEditZones', changes),
 			refresh,
 			childSavers: [
-				async (id, record, baseline) => {
-					if (!childChanged(record.zoneEnemies, baseline?.zoneEnemies)) {
-						return false;
-					}
-					await ApiRequest.post('AdminTools/SetZoneEnemies', { zoneId: id, zoneEnemies: record.zoneEnemies });
-					return true;
-				}
+				async (id, record, baseline) =>
+					guardedSave(childChanged(record.zoneEnemies, baseline?.zoneEnemies), () =>
+						ApiRequest.post('AdminTools/SetZoneEnemies', { zoneId: id, zoneEnemies: record.zoneEnemies })
+					)
 			]
 		})
 };

--- a/UI/src/routes/admin/workbench/save-helpers.ts
+++ b/UI/src/routes/admin/workbench/save-helpers.ts
@@ -64,6 +64,15 @@ export const resolveId = (id: number, idMap: Map<number, number>): number => idM
 /** Returns whether it actually wrote — a no-op (unchanged collection) must report `false`. */
 type ChildSaver<T> = (id: number, record: T, baseline: T | undefined) => Promise<boolean>;
 
+/** Collapses a child saver's no-op/write branch: skip (and report `false`) when unchanged, else post and report `true`. */
+export const guardedSave = async (changed: boolean, post: () => Promise<unknown>): Promise<boolean> => {
+	if (!changed) {
+		return false;
+	}
+	await post();
+	return true;
+};
+
 interface PersistOptions<T extends Identified, D> {
 	diff: SaveDiff<T>;
 	/** Maps a record to the DTO sent through the primary Add/Edit/Delete endpoint. */


### PR DESCRIPTION
## Summary

Follow-up from PR #1653 (issue #1634) review. `ChildSaver`s across the Workbench entity configs repeated the same no-op/write shape:

```ts
if (!changed) {
  return false;
}
await ApiRequest.post(...);
return true;
```

- Added `guardedSave(changed, post)` to `UI/src/routes/admin/workbench/save-helpers.ts`, collapsing that shape to `if (!changed) return false; await post(); return true;` in one place.
- Collapsed all ~18 `ChildSaver`s across the 8 entity files this pattern appeared in — `class.ts`, `enemy.ts`, `item-mod.ts`, `item.ts`, `lesson.ts`, `skill-recipe.ts`, `skill.ts`, `zone.ts` — to `return guardedSave(cond, () => ApiRequest.post(...))` (or an equivalent single-expression arrow where the saver had no other local statements).
- Purely mechanical: every guard condition (`childChanged(...)` or `changes.length > 0`) and every `ApiRequest.post` call/payload is unchanged.

## Test plan

- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` (full suite) — passing, no behavior change (no existing tests cover this admin/Workbench glue code, consistent with it being infra plumbing rather than domain logic).

Closes #1654


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ng9tz9ArzfH2qQvQNcXVGB)_