### PR TITLE
Skills header: include fielded innate skills in combined dps/burst totals

### DIFF
--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -353,22 +353,24 @@ export class SkillsView {
 	/** Metrics for the inspected skill, falling back to the first listed skill. */
 	readonly selected = $derived(this.metricsById[this.selectedId] ?? this.railList[0]);
 
-	/** Equipped skills the battle can actually fire — excludes a weapon-mismatched skill dormant under
-	 *  the equipped weapon (#1342), so the combined totals below never sum an output the battle can't
-	 *  produce. Innate (item-granted) skills also fire but are deliberately excluded — the totals stay
-	 *  a selected-loadout-only readout; see #1657 for the open question of folding them in. */
-	private readonly fieldedEquipped = $derived(
-		this.equipped.filter((id) => {
+	/** Every skill id the battle will actually fire right now: equipped skills that aren't dormant under
+	 *  the current weapon (#1342), plus item-granted innate skills that are fielded — not a duplicate
+	 *  already counted via the loadout or an earlier grant, and not themselves dormant. Reuses
+	 *  {@link innateSkills}'s own duplicate/dormant rule so this can't drift from what the innate band
+	 *  already flags (#1657). */
+	private readonly fieldedSkillIds = $derived([
+		...this.equipped.filter((id) => {
 			const skill = this.metricsById[id]?.skill;
 			return skill != null && !this.dormant(skill);
-		})
-	);
+		}),
+		...this.innateSkills.filter((i) => !i.duplicate && !this.dormant(i.skill)).map((i) => i.skill.id)
+	]);
 
-	/** Combined effective DPS of the equipped loadout vs the current Toughness. */
-	readonly combinedEffectiveDps = $derived(this.fieldedEquipped.reduce((sum, id) => sum + this.effectiveDps(id), 0));
+	/** Combined effective DPS of every fielded skill (loadout + innate) vs the current Toughness. */
+	readonly combinedEffectiveDps = $derived(this.fieldedSkillIds.reduce((sum, id) => sum + this.effectiveDps(id), 0));
 
-	/** Combined effective single-hit burst of the equipped loadout vs the current Toughness. */
-	readonly combinedEffectiveBurst = $derived(this.fieldedEquipped.reduce((sum, id) => sum + this.effective(id), 0));
+	/** Combined effective single-hit burst of every fielded skill (loadout + innate) vs the current Toughness. */
+	readonly combinedEffectiveBurst = $derived(this.fieldedSkillIds.reduce((sum, id) => sum + this.effective(id), 0));
 
 	/* ── per-skill effective reads (Toughness-aware) ─────────────────────────── */
 

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -756,6 +756,50 @@ describe('SkillsView — combined effective totals exclude dormant skills (#1637
 	});
 });
 
+/* The header's combined totals reflect every skill the battle actually fields, not just the selected
+   loadout (#1657): a non-duplicate, non-dormant innate (item-granted) skill contributes too, reusing
+   innateSkills' own duplicate/dormant rule so the totals can't drift from the innate band's display. */
+describe('SkillsView — combined effective totals include fielded innate skills (#1657)', () => {
+	const grantedSwordSkill = skill({
+		id: 7,
+		name: 'Hotel',
+		baseDamage: 20,
+		cooldownMs: 1000,
+		damagePortions: [{ type: EDamageType.Sword, weight: 1 }]
+	});
+
+	it('adds a granted skill’s contribution once, alongside the selected loadout', () => {
+		mockInventoryManager.equippedSlots = [{ name: 'Staff of Embers', grantedSkillId: 4 }];
+		mockInventoryManager.grantedSkillIds = [4];
+		const v = new SkillsView();
+		expect(v.innateSkills).toEqual([{ skill: SKILLS[4], sourceItemName: 'Staff of Embers', duplicate: false }]);
+		expect(v.combinedEffectiveBurst).toBeCloseTo(v.effective(0) + v.effective(1) + v.effective(2) + v.effective(4), 10);
+		expect(v.combinedEffectiveDps).toBeCloseTo(
+			v.effectiveDps(0) + v.effectiveDps(1) + v.effectiveDps(2) + v.effectiveDps(4),
+			10
+		);
+	});
+
+	it('does not double-count a grant that duplicates an already-selected skill', () => {
+		// Skill 0 is already in the equipped loadout, so the grant is a duplicate — fielded once.
+		mockInventoryManager.equippedSlots = [{ name: 'Echo Blade', grantedSkillId: 0 }];
+		mockInventoryManager.grantedSkillIds = [0];
+		const v = new SkillsView();
+		expect(v.innateSkills[0]).toMatchObject({ duplicate: true });
+		expect(v.combinedEffectiveBurst).toBeCloseTo(v.effective(0) + v.effective(1) + v.effective(2), 10);
+	});
+
+	it('excludes a granted skill that is itself dormant under the equipped weapon', () => {
+		staticData.skills = [...SKILLS, grantedSwordSkill];
+		mockInventoryManager.equippedWeaponType = EDamageType.Unarmed;
+		mockInventoryManager.equippedSlots = [{ name: 'Runic Gauntlet', grantedSkillId: grantedSwordSkill.id }];
+		mockInventoryManager.grantedSkillIds = [grantedSwordSkill.id];
+		const v = new SkillsView();
+		expect(v.dormant(grantedSwordSkill)).toBe(true);
+		expect(v.combinedEffectiveBurst).toBeCloseTo(v.effective(0) + v.effective(1) + v.effective(2), 10);
+	});
+});
+
 /* The weapon-match grey-out (#1342): a weapon-leaf-typed skill is dormant unless the matching weapon is
    equipped. `dormant()` derives from the same `isFielded` rule the battle assembly applies. */
 describe('SkillsView — weapon-match grey-out', () => {


### PR DESCRIPTION
## Summary

#1657 asked whether the Skills header's `combinedEffectiveDps`/`combinedEffectiveBurst` totals should stay a selected-loadout-only readout, or reflect the true fielded set (loadout + fielded item-granted "innate" skills), matching what the battle actually produces.

**Decision made in this PR:** reflect the true fielded set. A player looking at "combined dps/burst" reasonably expects it to represent everything currently contributing in battle — and innate skills already fire under the same rules as the loadout (unless dormant or a duplicate). Leaving them out understated the real number rather than making the header more honest, so option 2 (fold them in) is the better default. If this reading is wrong, happy to revisit — flagging it here since #1657 framed it as an open design call rather than a defect.

## Changes

- `UI/src/routes/game/screens/skills/skills-view.svelte.ts`: renamed the private `fieldedEquipped` derivation to `fieldedSkillIds` and extended it to also include `innateSkills` entries that are fielded — i.e. not a duplicate of an already-counted skill and not themselves dormant under the equipped weapon. Reuses `innateSkills`' own `duplicate`/`dormant` logic (the same rule `InnateBand.svelte` already applies), so the two views of "what's fielded" can't drift apart.
- `combinedEffectiveDps`/`combinedEffectiveBurst` now sum over `fieldedSkillIds` instead of the loadout-only list.
- No header relabeling needed — the existing "eff. dps"/"eff. burst" labels in `Skills.svelte` were already generic enough to cover the corrected totals.

## Tests

Added to `UI/src/tests/routes/game/screens/skills/skills-view.test.ts`:
- A granted (innate) skill's contribution is added once, alongside the selected loadout.
- A grant that duplicates an already-selected skill is not double-counted.
- A granted skill that is itself dormant under the equipped weapon is excluded.

## Test plan

- [x] `npm run test:unit:ci` (full suite) — all tests passing
- [x] `npm run lint` (eslint + svelte-check) — clean

Closes #1657


---
_Generated by [Claude Code](https://claude.ai/code/session_01JwmY28bxJJ3iMBQzhGH46h)_