### PR TITLE
Reuse equippedRail's equipped→metrics association in fieldedSkillIds (#1662)

### DIFF
--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -357,12 +357,10 @@ export class SkillsView {
 	 *  the current weapon (#1342), plus item-granted innate skills that are fielded — not a duplicate
 	 *  already counted via the loadout or an earlier grant, and not themselves dormant. Reuses
 	 *  {@link innateSkills}'s own duplicate/dormant rule so this can't drift from what the innate band
-	 *  already flags (#1657). */
+	 *  already flags (#1657), and {@link equippedRail}'s equipped→metrics association rather than
+	 *  re-walking `equipped` against `metricsById` a second time (#1662). */
 	private readonly fieldedSkillIds = $derived([
-		...this.equipped.filter((id) => {
-			const skill = this.metricsById[id]?.skill;
-			return skill != null && !this.dormant(skill);
-		}),
+		...this.equippedRail.filter((m) => !this.dormant(m.skill)).map((m) => m.skill.id),
 		...this.innateSkills.filter((i) => !i.duplicate && !this.dormant(i.skill)).map((i) => i.skill.id)
 	]);
 


### PR DESCRIPTION
## Summary

Minor DRY cleanup flagged during review of #1656/#1657.

`fieldedSkillIds` (`UI/src/routes/game/screens/skills/skills-view.svelte.ts`) re-walked the equipped loadout and re-indexed into `metricsById` just to check dormancy — an equipped→metrics association `equippedRail` already builds for the per-card rendering. `fieldedSkillIds` now filters `equippedRail` directly instead of re-deriving the pairing from `this.equipped` + `metricsById`.

Note: the code has moved on somewhat since #1662 was filed (the #1657 fix reshaped `fieldedSkillIds` from the described `fieldedEquipped` shape into a plain id list), so the redundancy is smaller than originally described, but the core ask — factor the equipped→metrics pairing into a single derived value both `equippedRail` and the combined totals consume — still applied and is now done.

No behavior change: `equippedRail` already filters out ids with no `metricsById` entry the same way the old inline check did, so the resulting `fieldedSkillIds` set is identical.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.
- [x] `npm run test:unit:ci` (full suite) — 3509/3509 tests passing, including the existing `skills-view.test.ts` coverage of `fieldedSkillIds`/combined-totals behavior.

Closes #1662


---
_Generated by [Claude Code](https://claude.ai/code/session_01EXLbepnBAK1GsUEfkXwxJg)_