### PR TITLE
Thread a boss flag through the battle hand-back payload (#1647)

### DIFF
--- a/Game.Api.Tests/Unit/EnemyInstanceMappingTests.cs
+++ b/Game.Api.Tests/Unit/EnemyInstanceMappingTests.cs
@@ -27,6 +27,20 @@ namespace Game.Api.Tests.Unit
             Assert.Equal([20, 10], model.SelectedSkills);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void FromSource_ProjectsIsBossBattle(bool isBossBattle)
+        {
+            var enemy = MakeEnemy();
+            enemy.SetBattleSkills([]);
+            var result = new BattleStartResult { Enemy = enemy, Seed = 1u, IsBossBattle = isBossBattle };
+
+            var model = EnemyInstanceModel.FromSource(result);
+
+            Assert.Equal(isBossBattle, model.IsBossBattle);
+        }
+
         [Fact]
         public void FromSource_ProjectsEnemyRating_FromTheFieldedBattleSkills()
         {

--- a/Game.Api/Models/Enemies/EnemyInstance.cs
+++ b/Game.Api/Models/Enemies/EnemyInstance.cs
@@ -27,6 +27,13 @@ namespace Game.Api.Models.Enemies
         public double EnemyRating { get; set; }
 
         /// <summary>
+        /// Whether this is (or, for a hand-back, was) a dedicated-boss fight rather than an idle-zone spawn
+        /// (#1647) — lets the client route a resumed hand-back into the boss loop instead of always
+        /// defaulting to idle.
+        /// </summary>
+        public bool IsBossBattle { get; set; }
+
+        /// <summary>
         /// Projects a battle-start result onto the wire model. The single source of truth for the
         /// enemy-instance projection shared by the <c>NewEnemy</c> and <c>ChallengeBoss</c> socket commands,
         /// keeping the two from drifting (#492).
@@ -44,6 +51,7 @@ namespace Game.Api.Models.Enemies
                     .Select(modifier => BattlerAttribute.From(modifier.Attribute, modifier.Amount)),
                 ElapsedOffsetMs = source.ElapsedOffsetMs,
                 EnemyRating = CombatRating.Rate(enemy.ToBattler(), isPlayer: false),
+                IsBossBattle = source.IsBossBattle,
             };
         }
     }

--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -625,6 +625,7 @@ namespace Game.Application.Tests.Services
             Assert.NotNull(next.Enemy);
             Assert.True(state.HasActiveBattle);
             Assert.False(state.IsBossBattle);
+            Assert.False(next.IsBossBattle);
             // The prefetched battle's start is anchored to the scheduled cooldown expiry — NOT to now — so the
             // next victory's elapsed-time check passes (latency only delays the claim) and the FOLLOWING
             // cooldown stays correctly sized (anchoring to now would back-date the start and shrink it).
@@ -1218,6 +1219,8 @@ namespace Game.Application.Tests.Services
             Assert.NotNull(result.ElapsedOffsetMs);
             Assert.True(result.ElapsedOffsetMs >= 900, $"Expected roughly a 1-second offset, got {result.ElapsedOffsetMs}ms.");
             Assert.True(result.ElapsedOffsetMs < GameConstants.DefaultMaxBattleMs);
+            // Idle-loop battle, so the hand-back must not mislabel it as a boss fight (#1647).
+            Assert.False(result.IsBossBattle);
 
             // PlayerState is left completely untouched: same enemy, same seed, same (unbackdated-further)
             // BattleStartTime.
@@ -1241,6 +1244,57 @@ namespace Game.Application.Tests.Services
             Assert.Equal(0m, StatValue(EStatisticType.BattlesWon, null));
             Assert.Equal(0m, StatValue(EStatisticType.PlayerDeaths, null));
             Assert.Equal(expBefore, player.Exp);
+        }
+
+        [Fact]
+        public async Task StartBattle_AbandoningAStillInProgressBossBattle_HandsItBackWithBossFlagSet()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // Mirrors the idle-battle sibling above, but starting from a boss fight (#1647): both combatants
+            // wield a skill with an effectively infinite cooldown so the abandon re-simulation resolves as
+            // neither a win nor a death, and the still-in-progress hand-back must carry IsBossBattle so the
+            // client can stay routed into the boss loop instead of defaulting to idle.
+            var boss = await TestDataSeeder.CreateEnemyAsync(context, "Zone Boss", isBoss: true);
+            var bossSkill = await TestDataSeeder.CreateSkillAsync(context, "SlowBossSwipe", baseDamage: 1m, cooldownMs: 100_000_000);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, boss.Id, bossSkill.Id);
+            var zone = await TestDataSeeder.CreateZoneAsync(context, levelMin: 1, levelMax: 1, bossEnemyId: boss.Id, bossLevel: 1);
+
+            var playerSkill = await TestDataSeeder.CreateSkillAsync(context, "SlowPoke", baseDamage: 1m, cooldownMs: 100_000_000);
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, playerSkill.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+
+            var started = await battleService.StartBossBattle(player, state, zone.Id);
+            Assert.NotNull(started);
+            Assert.True(state.HasActiveBattle);
+            Assert.True(state.IsBossBattle);
+
+            // Let a little wall-clock time elapse for the abandon, but far less than the skills' cooldowns
+            // (and the 2-minute cap), so the re-simulation completes no actions and resolves as neither a win
+            // nor a death — the boss fight is genuinely still in progress.
+            state.BattleStartTime = DateTime.UtcNow.AddSeconds(-1);
+
+            // An ordinary NewEnemy request (StartBattle) while the boss fight is still active abandons it —
+            // but since it hasn't concluded, it must be handed back unchanged, still flagged as a boss battle
+            // (the quick-reconnect path #1647 is about).
+            var result = await battleService.StartBattle(player, state, zoneId: zone.Id);
+
+            Assert.Equal(boss.Id, result.Enemy.Id);
+            Assert.NotNull(result.ElapsedOffsetMs);
+            Assert.True(result.IsBossBattle);
+            Assert.True(state.HasActiveBattle);
+            Assert.True(state.IsBossBattle);
         }
 
         [Fact]
@@ -1734,6 +1788,7 @@ namespace Game.Application.Tests.Services
             Assert.Equal(boss.Id, result.Enemy.Id);
             Assert.True(state.HasActiveBattle);
             Assert.True(state.IsBossBattle);
+            Assert.True(result.IsBossBattle);
         }
 
         [Fact]
@@ -2241,6 +2296,7 @@ namespace Game.Application.Tests.Services
             Assert.Equal(enemy.Id, result.Enemy.Id);
             Assert.Equal(42u, result.Seed);
             Assert.Equal(45_000, result.ElapsedOffsetMs);
+            Assert.False(result.IsBossBattle);
             Assert.True(state.HasActiveBattle);
             Assert.False(state.IsBossBattle);
             Assert.Equal(zone.Id, state.BattleZoneId);
@@ -2289,6 +2345,7 @@ namespace Game.Application.Tests.Services
             Assert.Equal(18, result.Enemy.Level);
             Assert.True(state.HasActiveBattle);
             Assert.True(state.IsBossBattle);
+            Assert.True(result.IsBossBattle);
             Assert.Equal(10_000, result.ElapsedOffsetMs);
             Assert.Equal(now.AddMilliseconds(-10_000), state.BattleStartTime);
         }

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -113,6 +113,7 @@ namespace Game.Application.Services
             {
                 Enemy = enemy,
                 Seed = seed,
+                IsBossBattle = false,
             };
         }
 
@@ -212,6 +213,7 @@ namespace Game.Application.Services
             {
                 Enemy = enemy,
                 Seed = seed,
+                IsBossBattle = true,
             };
         }
 
@@ -400,6 +402,7 @@ namespace Game.Application.Services
                 Enemy = enemy,
                 Seed = pending.Seed,
                 ElapsedOffsetMs = pending.ElapsedOffsetMs,
+                IsBossBattle = isBossBattle,
             };
         }
 
@@ -460,6 +463,7 @@ namespace Game.Application.Services
                     Enemy = enemy,
                     Seed = state.BattleSeed ?? 0,
                     ElapsedOffsetMs = wallClockMs,
+                    IsBossBattle = state.IsBossBattle,
                 };
             }
             else
@@ -640,6 +644,13 @@ namespace Game.Application.Services
         /// #1597 — before continuing live. Null for a freshly started battle.
         /// </summary>
         public int? ElapsedOffsetMs { get; set; }
+
+        /// <summary>
+        /// Whether this is (or, for a hand-back, was) a dedicated-boss fight rather than an idle-zone
+        /// spawn — mirrors the authoritative <see cref="PlayerState.IsBossBattle"/> so a resumed hand-back
+        /// (#1595/#1596) lets the client route into the boss loop instead of always defaulting to idle (#1647).
+        /// </summary>
+        public bool IsBossBattle { get; set; }
     }
 
 }

--- a/UI/src/lib/api/types/interfaces/enemies.ts
+++ b/UI/src/lib/api/types/interfaces/enemies.ts
@@ -42,6 +42,7 @@ export interface IEnemyInstance {
 	selectedSkills: number[];
 	elapsedOffsetMs?: number;
 	enemyRating: number;
+	isBossBattle: boolean;
 }
 
 export interface INewEnemyModel {

--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -112,12 +112,17 @@ export class EnemyManager {
 	 * remainder) — presented directly rather than through the normal fetch, since the idle loop's first
 	 * `NewEnemy` would otherwise report 0ms fought and abandon it with no outcome (#1597). Absent, the loop
 	 * starts exactly as before: the initial stage (`Idle`) drives a fresh fetch.
+	 *
+	 * A handed-back battle's `isBossBattle` (the authoritative `PlayerState.IsBossBattle`) routes the mode
+	 * accordingly (#1647), so a resumed boss fight is presented through the boss loop instead of always
+	 * defaulting to idle.
 	 */
 	public start(activeBattle?: IEnemyInstance) {
 		if (!this.started) {
 			this.started = true;
 			this.battleStageUnhook = onBattleStageChanged((stage) => this.watchBattleStage(stage));
 			if (activeBattle) {
+				this.mode = activeBattle.isBossBattle ? 'boss' : 'idle';
 				this.currentEnemy = activeBattle;
 				notifyNewEnemyLoaded(activeBattle);
 			} else {
@@ -266,6 +271,11 @@ export class EnemyManager {
 					if (result.data.zoneId != null && result.data.zoneId !== playerManager.currentZone) {
 						playerManager.currentZone = result.data.zoneId;
 					}
+					// A still-in-progress battle handed back on this NewEnemy (e.g. a sub-5-minute reconnect
+					// the welcome-back gate didn't resume directly) may be a boss fight the authoritative
+					// PlayerState never actually abandoned — trust its isBossBattle flag over this fetch
+					// loop's own idle-only assumption so the client routes into the boss loop (#1647).
+					this.mode = result.data.enemyInstance.isBossBattle ? 'boss' : 'idle';
 					this.currentEnemy = result.data.enemyInstance;
 					notifyNewEnemyLoaded(this.currentEnemy);
 					return;

--- a/UI/src/tests/lib/engine/battle/battle-engine-parity.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine-parity.test.ts
@@ -248,7 +248,8 @@ describe('BattleEngine parity with the headless BattleSimulator', () => {
 				seed: PARITY_SEED,
 				selectedSkills: enemySkillIds,
 				attributes: toBattlerAttributes(scenario.enemyAttrs),
-				enemyRating: 100
+				enemyRating: 100,
+				isBossBattle: false
 			});
 
 			expect(runEngine(engine)).toEqual(simResult);

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -268,7 +268,15 @@ describe('BattleEngine', () => {
 		it('transitions to Active when enemy is loaded', () => {
 			engine.start();
 
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			expect(engine.stage).toBe(BattleStage.Active);
@@ -277,7 +285,15 @@ describe('BattleEngine', () => {
 		it('transitions to Victorious when enemy dies', () => {
 			engine.start();
 
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			// Simulate enough logical updates to kill the enemy
@@ -293,7 +309,15 @@ describe('BattleEngine', () => {
 
 		it('pause sets stage to Paused', () => {
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			engine.pause();
@@ -302,7 +326,15 @@ describe('BattleEngine', () => {
 
 		it('resume returns to Active when both alive', () => {
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			engine.pause();
@@ -312,7 +344,15 @@ describe('BattleEngine', () => {
 
 		it('resume falls back to Idle when a battler is already dead', () => {
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			engine.enemy.takeDamage(1e9, EDamageType.Physical);
@@ -323,7 +363,15 @@ describe('BattleEngine', () => {
 
 		it('transitions to Defeated and logs when the player dies', () => {
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			// Kill the player, then run a sub-cooldown tick so no skill fires and the enemy survives —
@@ -339,7 +387,15 @@ describe('BattleEngine', () => {
 			// A true stalemate: neither side deals damage, so nobody can ever land the killing blow.
 			mockSkills[0].baseDamage = 0;
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			// Just short of the 2-minute cap: the battle is still in progress.
@@ -354,7 +410,15 @@ describe('BattleEngine', () => {
 
 		it('does not draw when the enemy dies on the same tick the cap is reached (death wins)', () => {
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			// Pre-kill the enemy, then cross the cap in one tick: the death branch is checked before the
@@ -373,7 +437,15 @@ describe('BattleEngine', () => {
 			// Engine A fights the battle live, tick by tick, up to 600ms.
 			const engineA = new BattleEngine();
 			engineA.start();
-			const enemyInstance = { id: 1, level: 1, seed: 7, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 7,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 			for (let elapsed = 0; elapsed < 600; elapsed += 40) {
 				logicalUpdateCallbacks[0](40);
@@ -401,6 +473,7 @@ describe('BattleEngine', () => {
 				level: 1,
 				seed: 0,
 				enemyRating: 100,
+				isBossBattle: false,
 				selectedSkills: [0],
 				attributes: [{ attributeId: EAttribute.Endurance, amount: 200 }],
 				elapsedOffsetMs: 600
@@ -422,6 +495,7 @@ describe('BattleEngine', () => {
 				level: 1,
 				seed: 0,
 				enemyRating: 100,
+				isBossBattle: false,
 				selectedSkills: [0],
 				attributes: [],
 				elapsedOffsetMs: 90
@@ -441,6 +515,7 @@ describe('BattleEngine', () => {
 				level: 1,
 				seed: 0,
 				enemyRating: 100,
+				isBossBattle: false,
 				selectedSkills: [0],
 				attributes: [],
 				elapsedOffsetMs: 2000
@@ -459,6 +534,7 @@ describe('BattleEngine', () => {
 				level: 1,
 				seed: 0,
 				enemyRating: 100,
+				isBossBattle: false,
 				selectedSkills: [1],
 				attributes: [],
 				elapsedOffsetMs: 2000
@@ -475,6 +551,7 @@ describe('BattleEngine', () => {
 				level: 1,
 				seed: 0,
 				enemyRating: 100,
+				isBossBattle: false,
 				selectedSkills: [0],
 				attributes: [],
 				elapsedOffsetMs: 10
@@ -495,6 +572,7 @@ describe('BattleEngine', () => {
 				level: 1,
 				seed: 0,
 				enemyRating: 100,
+				isBossBattle: false,
 				selectedSkills: [0],
 				attributes: [],
 				elapsedOffsetMs: DEFAULT_MAX_BATTLE_MS
@@ -553,7 +631,15 @@ describe('BattleEngine', () => {
 			const promise = engine.startLoading(1000);
 			expect(logicalUpdateCallbacks).toHaveLength(2);
 
-			engine.reset({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+			engine.reset({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
 
 			// Reset cancels the in-flight cooldown (releasing the awaiter) but leaves the engine's own
 			// logical hook in place for the re-armed battle.
@@ -582,7 +668,15 @@ describe('BattleEngine', () => {
 	describe('renderUpdate', () => {
 		it('advances both battlers render cooldowns while Active', () => {
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			const playerSpy = vi.spyOn(engine.player, 'updateRenderCooldowns');
@@ -608,7 +702,15 @@ describe('BattleEngine', () => {
 	describe('logicalUpdate', () => {
 		it('logs damage messages', () => {
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			logicalUpdateCallbacks[0](500);
@@ -631,6 +733,7 @@ describe('BattleEngine', () => {
 				level: 1,
 				seed: 0,
 				enemyRating: 100,
+				isBossBattle: false,
 				selectedSkills: [0],
 				attributes: [{ attributeId: EAttribute.FireResistance, amount: 0.5 }]
 			});
@@ -647,7 +750,15 @@ describe('BattleEngine', () => {
 
 		it('wires the tick activations into evaluateMechanicTriggers when a skill fires (#1587)', () => {
 			engine.start();
-			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
 
 			logicalUpdateCallbacks[0](500);
 
@@ -658,7 +769,15 @@ describe('BattleEngine', () => {
 
 		it('does not call evaluateMechanicTriggers on a tick with no activations (nothing off cooldown yet)', () => {
 			engine.start();
-			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
 
 			logicalUpdateCallbacks[0](40);
 
@@ -678,7 +797,15 @@ describe('BattleEngine', () => {
 			// The battle clock advances only while a battle is live, so load an enemy to enter the Active
 			// stage. Slash charges for 500ms, so within these 300ms it never fires — the enemy stays alive
 			// and the engine stays Active.
-			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
 			logicalUpdateCallbacks[0](100);
 			logicalUpdateCallbacks[0](200);
 
@@ -698,7 +825,15 @@ describe('BattleEngine', () => {
 
 		it('rest() stops the live battle: drops to Idle and clears the battle clock', () => {
 			engine.start();
-			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
 			logicalUpdateCallbacks[0](100);
 			expect(engine.timeElapsed).toBe(100);
 
@@ -723,7 +858,15 @@ describe('BattleEngine', () => {
 				}
 			];
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			logicalUpdateCallbacks[0](500); // the 500ms-cooldown skill fires, applying its self buff
@@ -739,6 +882,7 @@ describe('BattleEngine', () => {
 				level: 1,
 				seed: 0,
 				enemyRating: 100,
+				isBossBattle: false,
 				selectedSkills: [0],
 				attributes: [
 					{ attributeId: EAttribute.Endurance, amount: 200 }, // survive the full second
@@ -762,7 +906,15 @@ describe('BattleEngine', () => {
 		it('aggregates heal-over-time on the player into a single per-second summary line', () => {
 			mockSkills[0].baseDamage = 0; // no kill, so the full second of regen accumulates
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			engine.player.currentHealth = 10; // leave room so the regen is not capped away
@@ -796,6 +948,7 @@ describe('BattleEngine', () => {
 				level: 1,
 				seed: 0,
 				enemyRating: 100,
+				isBossBattle: false,
 				selectedSkills: [],
 				attributes: [
 					{ attributeId: EAttribute.Endurance, amount: 200 },
@@ -844,6 +997,7 @@ describe('BattleEngine', () => {
 				level: 1,
 				seed: 0,
 				enemyRating: 100,
+				isBossBattle: false,
 				selectedSkills: [0],
 				attributes: [{ attributeId: EAttribute.Endurance, amount: 200 }]
 			};
@@ -852,7 +1006,15 @@ describe('BattleEngine', () => {
 				// The enabler is now the skill's own base chance (#1453); 1 guarantees every [0,1) draw crits.
 				mockSkills[0].criticalChance = 1;
 				engine.start();
-				enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+				enemyLoadedCallbacks[0]({
+					id: 1,
+					level: 1,
+					seed: 0,
+					enemyRating: 100,
+					selectedSkills: [0],
+					attributes: [],
+					isBossBattle: false
+				});
 
 				logicalUpdateCallbacks[0](500); // the player's 500ms skill fires and crits
 
@@ -888,6 +1050,7 @@ describe('BattleEngine', () => {
 					level: 1,
 					seed: 0,
 					enemyRating: 100,
+					isBossBattle: false,
 					selectedSkills: [0],
 					attributes: [
 						{ attributeId: EAttribute.Endurance, amount: 200 },
@@ -949,13 +1112,22 @@ describe('BattleEngine', () => {
 				level: 1,
 				seed: 0,
 				enemyRating: 100,
+				isBossBattle: false,
 				selectedSkills: [0],
 				attributes: [{ attributeId: EAttribute.Endurance, amount: 200 }]
 			};
 
 			it("emits an enemy-targeted hit carrying the skill's damage on a player hit", () => {
 				engine.start();
-				enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+				enemyLoadedCallbacks[0]({
+					id: 1,
+					level: 1,
+					seed: 0,
+					enemyRating: 100,
+					selectedSkills: [0],
+					attributes: [],
+					isBossBattle: false
+				});
 
 				logicalUpdateCallbacks[0](500);
 
@@ -967,7 +1139,15 @@ describe('BattleEngine', () => {
 			it("carries the skill's damage type on a typed hit float (#1320)", () => {
 				mockSkills[0].damagePortions = [{ type: EDamageType.Fire, weight: 1 }];
 				engine.start();
-				enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+				enemyLoadedCallbacks[0]({
+					id: 1,
+					level: 1,
+					seed: 0,
+					enemyRating: 100,
+					selectedSkills: [0],
+					attributes: [],
+					isBossBattle: false
+				});
 
 				logicalUpdateCallbacks[0](500);
 
@@ -981,7 +1161,15 @@ describe('BattleEngine', () => {
 					{ type: EDamageType.Fire, weight: 40 }
 				];
 				engine.start();
-				enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+				enemyLoadedCallbacks[0]({
+					id: 1,
+					level: 1,
+					seed: 0,
+					enemyRating: 100,
+					selectedSkills: [0],
+					attributes: [],
+					isBossBattle: false
+				});
 
 				logicalUpdateCallbacks[0](500);
 
@@ -998,7 +1186,15 @@ describe('BattleEngine', () => {
 				// The enabler is now the skill's own base chance (#1453); 1 guarantees every [0,1) draw crits.
 				mockSkills[0].criticalChance = 1;
 				engine.start();
-				enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+				enemyLoadedCallbacks[0]({
+					id: 1,
+					level: 1,
+					seed: 0,
+					enemyRating: 100,
+					selectedSkills: [0],
+					attributes: [],
+					isBossBattle: false
+				});
 
 				logicalUpdateCallbacks[0](500);
 
@@ -1024,6 +1220,7 @@ describe('BattleEngine', () => {
 					level: 1,
 					seed: 0,
 					enemyRating: 100,
+					isBossBattle: false,
 					selectedSkills: [0],
 					attributes: [
 						{ attributeId: EAttribute.Endurance, amount: 200 },
@@ -1061,7 +1258,15 @@ describe('BattleEngine', () => {
 	describe('renderUpdate', () => {
 		it('interpolates skill cooldowns and active-effect countdowns while Active', () => {
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 
 			engine.player.applyEffect({
@@ -1085,7 +1290,15 @@ describe('BattleEngine', () => {
 
 		it('leaves render state untouched when not Active', () => {
 			engine.start();
-			const enemyInstance = { id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] };
+			const enemyInstance = {
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
 			enemyLoadedCallbacks[0](enemyInstance);
 			engine.player.applyEffect({
 				id: 1,
@@ -1140,7 +1353,15 @@ describe('BattleEngine', () => {
 			engine.start(); // the first reset fully derives the player and caches its inputs
 			const resetSpy = vi.spyOn(engine.player, 'reset');
 
-			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
 
 			// A data-less re-arm (no args) — the expensive attribute graph + skill rebuild is skipped.
 			expect(resetSpy).toHaveBeenCalledTimes(1);
@@ -1153,7 +1374,15 @@ describe('BattleEngine', () => {
 
 			const newStats = [{ attributeId: EAttribute.Strength, amount: 5 }];
 			mockInventoryManager.equipmentStats = newStats;
-			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
 
 			expect(resetSpy).toHaveBeenCalledWith(
 				mockPlayerManager,
@@ -1170,7 +1399,15 @@ describe('BattleEngine', () => {
 			const resetSpy = vi.spyOn(engine.player, 'reset');
 
 			mockPlayerManager.level = 6;
-			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
 
 			expect(resetSpy).toHaveBeenCalledWith(
 				mockPlayerManager,
@@ -1191,7 +1428,15 @@ describe('BattleEngine', () => {
 
 			const newModifiers = [{ attribute: EAttribute.Strength, amount: 3, type: EModifierType.Additive, source: 4 }];
 			mockPlayerProficiencies.battleModifiers = newModifiers;
-			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
 
 			expect(resetSpy).toHaveBeenCalledWith(
 				mockPlayerManager,
@@ -1208,7 +1453,15 @@ describe('BattleEngine', () => {
 			const resetSpy = vi.spyOn(engine.player, 'reset');
 
 			// Same equipment/attributes/loadout/level and the same proficiency-modifiers reference.
-			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
 
 			expect(resetSpy).toHaveBeenCalledWith();
 		});
@@ -1221,7 +1474,15 @@ describe('BattleEngine', () => {
 
 			const newLockedBase = [{ attribute: EAttribute.Endurance, amount: 8, type: EModifierType.Additive, source: 3 }];
 			mockPlayerManager.battleLockedBaseModifiers = newLockedBase;
-			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
 
 			expect(resetSpy).toHaveBeenCalledWith(
 				mockPlayerManager,
@@ -1252,7 +1513,15 @@ describe('BattleEngine', () => {
 
 			// A data-less re-arm (unchanged inputs) skips setData, so the already-composed passive persists — it is
 			// neither lost (→ 50) nor re-applied (→ 64).
-			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
 			expect(engine.player.attributes.getValue(EAttribute.Strength)).toBe(57);
 		});
 
@@ -1267,7 +1536,15 @@ describe('BattleEngine', () => {
 			const proficiency = [{ attribute: EAttribute.Strength, amount: 2, type: EModifierType.Additive, source: 8 }];
 			mockPlayerManager.battleLockedBaseModifiers = lockedBase;
 			mockPlayerProficiencies.battleModifiers = proficiency;
-			enemyLoadedCallbacks[0]({ id: 1, level: 1, seed: 0, enemyRating: 100, selectedSkills: [0], attributes: [] });
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
 
 			expect(resetSpy).toHaveBeenCalledWith(
 				mockPlayerManager,

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -62,7 +62,8 @@ const bossInstance: IEnemyInstance = {
 	seed: 1,
 	selectedSkills: [],
 	attributes: [],
-	enemyRating: 100
+	enemyRating: 100,
+	isBossBattle: true
 };
 const normalInstance: IEnemyInstance = {
 	id: 0,
@@ -70,7 +71,8 @@ const normalInstance: IEnemyInstance = {
 	seed: 2,
 	selectedSkills: [],
 	attributes: [],
-	enemyRating: 100
+	enemyRating: 100,
+	isBossBattle: false
 };
 // The next idle enemy the server bundles with a victory / boss-loss response so the client can begin it
 // without a separate NewEnemy round-trip (distinct from the fetched normalInstance so the two are told apart).
@@ -80,7 +82,8 @@ const preparedInstance: IEnemyInstance = {
 	seed: 7,
 	selectedSkills: [],
 	attributes: [],
-	enemyRating: 100
+	enemyRating: 100,
+	isBossBattle: false
 };
 
 const resp = <T extends 'ChallengeBoss' | 'DefeatEnemy' | 'BattleLost' | 'NewEnemy'>(

--- a/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
@@ -36,7 +36,8 @@ const makeEnemy = (id = 0): IEnemyInstance => ({
 	seed: 123,
 	selectedSkills: [0],
 	attributes: [],
-	enemyRating: 100
+	enemyRating: 100,
+	isBossBattle: false
 });
 
 const enemyResponse = (enemy: IEnemyInstance): IApiSocketResponse<'NewEnemy'> => ({
@@ -97,6 +98,19 @@ describe('EnemyManager.getNewEnemy', () => {
 		expect(loaded).toEqual([enemy]);
 		expect(delay).not.toHaveBeenCalled();
 		expect(logMessage).not.toHaveBeenCalled();
+	});
+
+	// #1647: a sub-5-minute reconnect resumes via this ordinary NewEnemy fetch rather than a welcome-back
+	// activeBattle hand-back — if the still-in-progress battle it hands back was actually a boss fight, the
+	// mode must follow the authoritative flag instead of staying idle.
+	it('adopts boss mode when NewEnemy hands back a still-in-progress boss battle', async () => {
+		const bossHandback = { ...makeEnemy(2), elapsedOffsetMs: 12000, isBossBattle: true };
+		sendSocketCommand.mockResolvedValue(enemyResponse(bossHandback));
+
+		await manager.getNewEnemy();
+
+		expect(manager.currentEnemy).toEqual(bossHandback);
+		expect(manager.mode).toBe('boss');
 	});
 
 	it('adopts the server-reported zone when the player was relocated out of an unplayable zone', async () => {
@@ -293,6 +307,18 @@ describe('EnemyManager.start', () => {
 		expect(sendSocketCommand).not.toHaveBeenCalled();
 		expect(manager.currentEnemy).toEqual(activeBattle);
 		expect(loaded).toEqual([activeBattle]);
+		expect(manager.mode).toBe('idle');
+	});
+
+	// #1647: a resumed battle handed back as still-active must route into the boss loop when it actually
+	// was a boss fight, or the Zone-Cleared overlay/BattleLost/auto-rechallenge bookkeeping never runs.
+	it('routes a resumed boss battle into the boss loop', () => {
+		const activeBossBattle = { ...makeEnemy(6), elapsedOffsetMs: 45000, isBossBattle: true };
+
+		manager.start(activeBossBattle);
+
+		expect(manager.mode).toBe('boss');
+		expect(manager.currentEnemy).toEqual(activeBossBattle);
 	});
 });
 

--- a/UI/src/tests/lib/engine/engine.test.ts
+++ b/UI/src/tests/lib/engine/engine.test.ts
@@ -327,7 +327,8 @@ describe('startGame', () => {
 			enemyRating: 100,
 			selectedSkills: [],
 			attributes: [],
-			elapsedOffsetMs: 12000
+			elapsedOffsetMs: 12000,
+			isBossBattle: false
 		};
 
 		startGame(activeBattle);

--- a/UI/src/tests/routes/game/welcome-back/welcome-back-view.test.ts
+++ b/UI/src/tests/routes/game/welcome-back/welcome-back-view.test.ts
@@ -100,7 +100,8 @@ describe('WelcomeBackView', () => {
 			enemyRating: 100,
 			selectedSkills: [0],
 			attributes: [],
-			elapsedOffsetMs: 30000
+			elapsedOffsetMs: 30000,
+			isBossBattle: false
 		};
 		const view = makeView(progress({ activeBattle }));
 		await view.run();


### PR DESCRIPTION
## Summary

`BattleStartResult`/`EnemyInstance` (the payload shared by `NewEnemy`, `ChallengeBoss`, and the `GetOfflineProgress` welcome-back summary) carried no field indicating whether a handed-back battle was a dedicated-boss fight. `PlayerState.IsBossBattle` is the authoritative server-side truth, but the client had no way to see it, so `EnemyManager` always defaulted a resumed/reconnected battle to `mode = 'idle'` — even when it was genuinely a boss fight still in progress. That skipped:
- The Zone-Cleared overlay / "next zone unlocked" flow on a resumed boss victory
- Sending `BattleLost` on a resumed boss loss
- Auto-rechallenge for an `autoChallengeBoss` farmer whose fight resumed this way

Server-side crediting was already correct (it keys off `PlayerState.IsBossBattle`, not which command the client called) — this was purely a client-side presentation/loop-control gap.

## Changes

- **Backend**: added `IsBossBattle` to `BattleStartResult` (`Game.Application/Services/BattleService.cs`), set at all four construction sites (fresh idle spawn, fresh boss spawn, the offline-progress hand-back `HandBackPendingBattle`, and the still-in-progress `AbandonBattle` hand-back — the exact path this issue is about). Threaded it into `EnemyInstance`'s `FromSource` projection, the single source shared by every consumer.
- **Codegen**: regenerated `UI/src/lib/api/types/interfaces/enemies.ts` (`dotnet run --project Game.Api -- codegen`) to add `isBossBattle: boolean` to `IEnemyInstance`.
- **Frontend**: `EnemyManager` now sets `this.mode` from `isBossBattle` wherever a server-handed-back battle is presented — both the session-start `start(activeBattle)` path (#1595/#1596 welcome-back hand-back) and the ordinary `NewEnemy` fetch-loop response (the sub-5-minute quick-reconnect case named in the issue, where the still-in-progress battle comes back through a normal fetch rather than the welcome-back summary).

## Test plan

- [x] Backend: new/extended unit + integration tests — `EnemyInstanceMappingTests.FromSource_ProjectsIsBossBattle`, a new `StartBattle_AbandoningAStillInProgressBossBattle_HandsItBackWithBossFlagSet` integration test, and assertions added to the existing idle/boss hand-back and prefetch tests.
- [x] Frontend: new/extended vitest tests in `enemy-manager.test.ts` covering both the session-start resume and the ordinary-`NewEnemy` reconnect path adopting boss mode.
- [x] `dotnet build` + full backend test suite (3007 tests) pass.
- [x] `npm run lint` (ESLint + svelte-check) and full frontend test suite (3522 tests) pass.
- [x] `dotnet format --verify-no-changes` passes.

Closes #1647


---
_Generated by [Claude Code](https://claude.ai/code/session_01BL3ovSP3Vd4tfPzNbw6Zk6)_