### PR TITLE
Set reload marker when an abandoned command's late flush fails

### DIFF
--- a/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
@@ -271,6 +271,49 @@ namespace Game.Api.Tests.Unit
             Assert.Same(reloadedPlayer, session.Player);
         }
 
+        [Fact]
+        public async Task ExecuteCommand_AbandonedCommandsFlushFailsAfterTheTimeoutResponse_ReloadsPlayerBeforeTheNextCommand()
+        {
+            // A command abandoned on the per-command timeout budget whose flush later fails for a
+            // non-cancellation reason faults inside ReleaseCommandLockWhenSettled's continuation, not
+            // RunCommandUnderLock's synchronous fault path — it must still mark the session for reload so the
+            // #1632 divergence window doesn't reopen on this path too (#1663).
+            var reloadedPlayer = new PlayerBuilder().WithId(1).Build();
+            var playerRepo = new FakePlayerRepository(reloadedPlayer);
+            using var provider = new ServiceCollection()
+                .AddScoped<IUnitOfWork, NoOpUnitOfWork>()
+                .AddScoped<IPlayerRepository>(_ => playerRepo)
+                .BuildServiceProvider();
+
+            var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
+            var session = new SessionService(new NoOpSessionStore());
+            session.CreateSession(userId: 1, playerId: 1);
+            var context = new SocketContext(socket, playerId: 1, session, isAdmin: false, _loggerFactory.CreateLogger<SocketContext>());
+            var release = new TaskCompletionSource();
+            var handler = new SocketHandler(
+                context,
+                new WedgedThenStubCommandFactory(release.Task, new PlayerPersistenceFlushFailedException(new InvalidOperationException("late blip"))),
+                provider.GetRequiredService<IServiceScopeFactory>(),
+                _loggerFactory.CreateLogger<SocketHandler>(),
+                () => { },
+                commandTimeout: TimeSpan.FromMilliseconds(10));
+
+            await handler.ExecuteCommand(new SocketCommandInfo("Wedged") { Id = "c1" });
+            Assert.Contains(socket.SentMessages, m => m.Contains("Command timed out.") && m.Contains("c1"));
+            Assert.False(session.PlayerNeedsReload);
+
+            // Let the abandoned command's flush fail now. Acquiring the lock for the next command blocks until
+            // ReleaseCommandLockWhenSettled's continuation has released it, so by the time this call proceeds
+            // the marker (if set) is already visible.
+            release.SetResult();
+            await handler.ExecuteCommand(new SocketCommandInfo("Ok") { Id = "c2" });
+
+            Assert.Equal(1, playerRepo.GetPlayerCallCount);
+            Assert.False(session.PlayerNeedsReload);
+            Assert.Same(reloadedPlayer, session.Player);
+            Assert.Contains(_logs.Entries, e => e.Level == LogLevel.Error && e.Message.Contains("Abandoned socket command faulted"));
+        }
+
         private (FakeWebSocket Socket, SocketHandler Handler) CreateHandler(Func<string, Exception?> throwOn, Func<string, Exception?>? throwOnCreate = null, Func<string, bool>? selfDelivering = null)
         {
             var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
@@ -313,6 +356,33 @@ namespace Game.Api.Tests.Unit
             // Every name is treated as registered except the explicit "Unknown" sentinel, so the
             // HandleMessage unknown-command guard can be exercised without populating the static registry.
             public override bool IsKnownCommand(string commandName) => commandName != "Unknown";
+        }
+
+        /// <summary>Ignores the timeout's cancellation token like a genuinely wedged command, then throws once
+        /// <paramref name="waitFor"/> completes — for "Wedged" only; any other command name behaves as a
+        /// normal succeeding <see cref="StubCommand"/>, so a follow-up command can be run afterward.</summary>
+        private sealed class WedgedThenStubCommandFactory(Task waitFor, Exception toThrowAfter) : SocketCommandFactory
+        {
+            public override AbstractSocketCommand CreateCommand(SocketCommandInfo commandInfo, IServiceScope scope)
+            {
+                return commandInfo.Name == "Wedged"
+                    ? new WedgedStubCommand(commandInfo.Name, waitFor, toThrowAfter) { Id = commandInfo.Id }
+                    : new StubCommand(commandInfo.Name, null) { Id = commandInfo.Id };
+            }
+
+            public override bool IsKnownCommand(string commandName) => true;
+        }
+
+        private sealed class WedgedStubCommand(string name, Task waitFor, Exception toThrowAfter) : AbstractSocketCommand
+        {
+            public override string Name { get; set; } = name;
+
+            public override async Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
+            {
+                // Deliberately ignores cancellationToken to simulate a command wedged past the timeout budget.
+                await waitFor;
+                throw toThrowAfter;
+            }
         }
 
         private sealed class StubCommand(string name, Exception? toThrow) : AbstractSocketCommand

--- a/Game.Api/Sockets/SocketHandler.cs
+++ b/Game.Api/Sockets/SocketHandler.cs
@@ -310,11 +310,23 @@ namespace Game.Api.Sockets
         {
             _ = commandTask.ContinueWith(task =>
             {
-                // The client already received a timeout response; a cooperative cancellation surfaces here as
-                // the expected OperationCanceledException, while any other fault is genuine and worth logging.
-                if (task.Exception is { } fault && fault.InnerExceptions.Any(e => e is not OperationCanceledException))
+                if (task.Exception is { } fault)
                 {
-                    _logger.LogError(fault, "Abandoned socket command faulted after its timeout response was sent: {CommandInfo} on socket: {Id}.", commandInfo, Id);
+                    // The abandoned flush faulted for a non-cancellation reason after the command's timeout
+                    // already ran: the in-memory Player may hold mutations that never reached the write-behind
+                    // queue, so mark it for reload before the next command runs, same as the synchronous fault
+                    // path in RunCommandUnderLock (#1663).
+                    if (fault.InnerExceptions.Any(e => e is PlayerPersistenceFlushFailedException))
+                    {
+                        _context.Session.MarkPlayerNeedsReload();
+                    }
+
+                    // The client already received a timeout response; a cooperative cancellation surfaces here as
+                    // the expected OperationCanceledException, while any other fault is genuine and worth logging.
+                    if (fault.InnerExceptions.Any(e => e is not OperationCanceledException))
+                    {
+                        _logger.LogError(fault, "Abandoned socket command faulted after its timeout response was sent: {CommandInfo} on socket: {Id}.", commandInfo, Id);
+                    }
                 }
 
                 cts.Dispose();


### PR DESCRIPTION
## Summary

#1651 set the `PlayerNeedsReload` marker in `RunCommandUnderLock`'s synchronous fault path when a command's `SavePlayer` flush fails with `PlayerPersistenceFlushFailedException`. It missed a second fault path: a command abandoned on the 25s per-command timeout, whose flush *later* fails for a non-cancellation reason, faults inside `ReleaseCommandLockWhenSettled`'s continuation instead — which only logged the fault and never marked the session for reload. In theory this reopened the #1632 divergence window (Redis/Postgres diverging silently) on that specific path.

This was flagged as low-priority/near-impossible in practice (a timeout cancels the command's token, so the abandoned flush normally fails with `OperationCanceledException`, which is deliberately left unwrapped — it would take a non-cancellation flush failure racing a just-timed-out command to hit this), but the fix is small and closes the gap for good rather than leaving it undocumented.

## Changes

- **`Game.Api/Sockets/SocketHandler.cs`**: `ReleaseCommandLockWhenSettled`'s continuation now also marks the session for reload (`_context.Session.MarkPlayerNeedsReload()`) when the abandoned command's fault is/contains a `PlayerPersistenceFlushFailedException`, mirroring the existing synchronous fault-path behavior in `RunCommandUnderLock`. The existing "log a genuine (non-cancellation) fault" behavior is unchanged.

## Test plan

- [x] New test: `ExecuteCommand_AbandonedCommandsFlushFailsAfterTheTimeoutResponse_ReloadsPlayerBeforeTheNextCommand` (`Game.Api.Tests/Unit/SocketCommandExecutionTests.cs`) — a command wedged past the timeout (ignoring the cancellation token) whose flush fails after the timeout response was already sent still causes the next command to reload the player from the repository, mirroring the existing synchronous-path test's shape.
- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] `dotnet test --no-build --no-restore` — full backend suite (3005 tests) passes.
- [x] `dotnet format --verify-no-changes` — clean.

Closes #1663


---
_Generated by [Claude Code](https://claude.ai/code/session_0177hYHxk8rkX3f1U7ZonUAD)_