### PR TITLE
Add eager cancellation check to RedisCommandBudget.Write

### DIFF
--- a/Game.Infrastructure.Tests/RedisCommandBudgetTests.cs
+++ b/Game.Infrastructure.Tests/RedisCommandBudgetTests.cs
@@ -50,6 +50,34 @@ namespace Game.Infrastructure.Tests
         }
 
         [Fact]
+        public async Task Write_WhenBudgetAlreadyCancelled_ThrowsWithoutAwaitingTheCommand()
+        {
+            // A command that never completes on its own: if Write awaited it the test would hang, so completing
+            // promptly proves the already-cancelled budget is honoured up front (the racy-WaitAsync guard).
+            var command = new TaskCompletionSource<int>();
+            using var cts = new CancellationTokenSource();
+            var logger = new CapturingLogger();
+            await cts.CancelAsync();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => RedisCommandBudget.Write(command.Task, cts.Token, logger, "ignored"));
+            Assert.False(command.Task.IsCompleted);
+            Assert.Empty(logger.Entries);
+        }
+
+        [Fact]
+        public async Task Write_Void_WhenBudgetAlreadyCancelled_ThrowsWithoutAwaitingTheCommand()
+        {
+            var command = new TaskCompletionSource();
+            using var cts = new CancellationTokenSource();
+            var logger = new CapturingLogger();
+            await cts.CancelAsync();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => RedisCommandBudget.Write(command.Task, cts.Token, logger, "ignored"));
+            Assert.False(command.Task.IsCompleted);
+            Assert.Empty(logger.Entries);
+        }
+
+        [Fact]
         public async Task Write_AwaitCancelledThenCommandFaults_LogsTheAbandonedFault()
         {
             var command = new TaskCompletionSource<int>();

--- a/Game.Infrastructure/Redis/RedisCommandBudget.cs
+++ b/Game.Infrastructure/Redis/RedisCommandBudget.cs
@@ -41,6 +41,9 @@ namespace Game.Infrastructure.Redis
 
         public static async Task<T> Write<T>(Task<T> command, CancellationToken cancellationToken, ILogger logger, string faultMessage)
         {
+            // Same racy-WaitAsync guard as Read: honour an already-cancelled budget before awaiting, so a command
+            // that finished first can't silently swallow the cancellation.
+            cancellationToken.ThrowIfCancellationRequested();
             try
             {
                 return await command.WaitAsync(cancellationToken);
@@ -54,6 +57,9 @@ namespace Game.Infrastructure.Redis
 
         public static async Task Write(Task command, CancellationToken cancellationToken, ILogger logger, string faultMessage)
         {
+            // Same racy-WaitAsync guard as Read: honour an already-cancelled budget before awaiting, so a command
+            // that finished first can't silently swallow the cancellation.
+            cancellationToken.ThrowIfCancellationRequested();
             try
             {
                 await command.WaitAsync(cancellationToken);


### PR DESCRIPTION
## Summary

`RedisCommandBudget.Read` was fixed in #854 to check `cancellationToken.ThrowIfCancellationRequested()` eagerly before awaiting the underlying Redis command, because `Task.WaitAsync` is racy: it returns the inner task unchanged when that task is already complete (checking `IsCompleted` before the token), so a command that finishes first can silently swallow an already-cancelled budget.

`RedisCommandBudget.Write<T>` and `Write` (void) never got the same fix, leaving every write path that routes through them (`RedisQueue.AddToQueueAsync`, `AcknowledgeAsync`, `RemoveAsync`, `GetNextAsync`, and `RedisService`'s `ObserveWrite`-backed methods) exposed to the same race. This was surfaced by `PlayerWriteBehindTests.SavePlayer_PublishFails_PreservesTheEventForTheNextFlush` failing intermittently on CI (hosted-runner Redis round-trip timing apparently wins the race consistently there) while passing reliably locally.

## Changes

- Added the same eager `cancellationToken.ThrowIfCancellationRequested()` to both `RedisCommandBudget.Write<T>` and `Write` (void), mirroring `Read`.
- Added two unit tests (`Write_WhenBudgetAlreadyCancelled_ThrowsWithoutAwaitingTheCommand` and the void-overload equivalent) that pin the fix the same way the existing `Read_WhenBudgetAlreadyCancelled_ThrowsWithoutAwaitingTheCommand` test does — using a never-completing `TaskCompletionSource` to prove the already-cancelled budget is honored without awaiting the command.

Left the redundant inline `ThrowIfCancellationRequested()` checks in `RedisQueue.ReserveNextAsync`/`ReclaimProcessingAsync` in place — they're harmless now that the shared helper covers it, and removing them wasn't necessary to fix the bug.

## Test plan

- [x] `dotnet build Game.sln` — succeeds
- [x] `dotnet test Game.sln --no-build` — all 3010 backend tests pass (`Game.Core.Tests` 1341, `Game.Infrastructure.Tests` 61, `Game.Application.Tests` 894 including the previously-flaky `PlayerWriteBehindTests`, `Game.Api.Tests` 714)
- [x] New tests specifically cover the fixed race for both `Write` overloads

Closes #1691

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRRR1yXPNbzFeDJDMfoauG)_