### PR TITLE
Extract shared resyncPlayerAndInventory() helper

### DIFF
--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -4,13 +4,12 @@ import { staticData, statistics, playerChallenges } from '$stores';
 import {
 	battleEngine,
 	BattleStage,
-	inventoryManager,
 	onBattleStageChanged,
 	playerManager,
+	resyncPlayerAndInventory,
 	type PlayerBattleState
 } from '../';
 import { logMessage } from '../log';
-import { refreshPlayer } from '../session';
 
 const newEnemyLoadedHook = createHook<[IEnemyInstance]>();
 const notifyNewEnemyLoaded = newEnemyLoadedHook.notify;
@@ -674,12 +673,10 @@ export class EnemyManager {
 			if (defeatResponse.error) {
 				// The transport settles a lost/timed-out response as an error even when the command may have
 				// actually succeeded server-side (see docs/frontend.md's socket request lifecycle) — resync the
-				// authoritative player state rather than leaving exp/level silently diverged for the rest of
-				// the session. refreshPlayer only re-initializes playerManager, so the inventory (an item/mod
-				// reward the lost response may have carried) is re-derived from it separately, mirroring what
-				// startGame does on the initial load.
-				await refreshPlayer();
-				inventoryManager.initialize();
+				// authoritative player state (and the inventory derived from it, in case the lost response
+				// carried an item/mod reward) rather than leaving exp/level silently diverged for the rest of
+				// the session.
+				await resyncPlayerAndInventory();
 			}
 		}
 		// Guard `data` for a possible error response (absent `data`), now that this is the shared

--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -44,6 +44,18 @@ import {
 export const inventoryManager = statify(new InventoryManager());
 export const enemyManager = statify(new EnemyManager());
 
+/**
+ * Re-pulls the authoritative player aggregate and re-derives the inventory from it — the shared resync
+ * used whenever a lost/dead-lettered command may have actually succeeded server-side and left exp/level/
+ * inventory silently diverged. See {@link refreshPlayer}'s doc comment for why the two steps don't happen
+ * together automatically. Lives here (rather than alongside `refreshPlayer` in `session.ts`) because it
+ * needs the `inventoryManager` instance owned by this module.
+ */
+export async function resyncPlayerAndInventory(): Promise<void> {
+	await refreshPlayer();
+	inventoryManager.initialize();
+}
+
 export const logicEngine = statify(new LogicalEngine());
 export const renderEngine = statify(new RenderEngine());
 export const battleEngine = statify(new BattleEngine());
@@ -120,7 +132,7 @@ export const handleServerCommandFailed = (response: IApiSocketResponse<'ServerCo
 	console.warn(`A server-pushed command failed on the server and was dead-lettered: ${failedCommand ?? 'unknown'}.`);
 	if (failedCommand === 'ChallengeCompleted') {
 		void playerChallenges.load(true);
-		void refreshPlayer().then(() => inventoryManager.initialize());
+		void resyncPlayerAndInventory();
 	} else if (failedCommand === 'ProficiencyXpGained') {
 		void playerProficiencies.load(true);
 	}

--- a/UI/src/lib/engine/session.ts
+++ b/UI/src/lib/engine/session.ts
@@ -72,10 +72,10 @@ async function restorePlayer(): Promise<boolean> {
  * unlocked skills, raw inventory data — before the game engine builds the live battler from it. Best-effort:
  * a failed refresh leaves the existing in-memory player intact rather than stranding the player at the gate.
  *
- * This only re-initializes {@link playerManager}, not the derived `InventoryManager` — a caller that needs
- * the player's unlocked items/mods to reflect the refresh (rather than just the raw payload) must also
- * re-run `inventoryManager.initialize()` itself, as the mid-session resync in `EnemyManager.claimVictory`
- * does (the welcome-back gate gets this for free from the `startGame` call that follows it).
+ * This only re-initializes {@link playerManager}, not the derived `InventoryManager` — a mid-session caller
+ * that needs the player's unlocked items/mods to reflect the refresh (rather than just the raw payload)
+ * should use `resyncPlayerAndInventory()` (in `engine.ts`) instead, which does both steps. The welcome-back
+ * gate gets the inventory step for free from the `startGame` call that follows it.
  */
 export async function refreshPlayer(): Promise<void> {
 	await loadPlayer();

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -20,8 +20,7 @@ const h = vi.hoisted(() => ({
 	},
 	BattleStage: { Idle: 0, Active: 1, Victorious: 2, Defeated: 3, Loading: 4, Paused: 5, Drawn: 6 },
 	playerManager: { currentZone: 3, applyVictoryRewards: vi.fn() },
-	inventoryManager: { initialize: vi.fn() },
-	refreshPlayer: vi.fn(() => Promise.resolve()),
+	resyncPlayerAndInventory: vi.fn(() => Promise.resolve()),
 	staticData: {
 		enemies: [{ id: 0, name: 'Catacomb Lich', isBoss: true }],
 		zones: undefined as IZone[] | undefined
@@ -42,9 +41,8 @@ vi.mock('$lib/engine', () => ({
 		return () => {};
 	}),
 	playerManager: h.playerManager,
-	inventoryManager: h.inventoryManager
+	resyncPlayerAndInventory: h.resyncPlayerAndInventory
 }));
-vi.mock('$lib/engine/session', () => ({ refreshPlayer: h.refreshPlayer }));
 vi.mock('$stores', () => ({
 	staticData: h.staticData,
 	statistics: h.statistics,
@@ -141,8 +139,7 @@ describe('EnemyManager boss mode', () => {
 		h.battleEngine.playerBattleStateMatches.mockReset();
 		h.battleEngine.playerBattleStateMatches.mockReturnValue(true);
 		h.playerManager.applyVictoryRewards.mockClear();
-		h.refreshPlayer.mockClear();
-		h.inventoryManager.initialize.mockClear();
+		h.resyncPlayerAndInventory.mockClear();
 		h.statistics.markZoneCleared.mockClear();
 		// Default: no zones authored ⇒ no "next zone" to unlock; the unlock tests opt in.
 		h.staticData.zones = undefined;
@@ -904,8 +901,7 @@ describe('EnemyManager boss mode', () => {
 		// The "X was defeated!" line is logged with the resolved enemy name once rewards are granted.
 		expect(logMessage).toHaveBeenCalledWith(ELogType.EnemyDefeated, 'Catacomb Lich was defeated!');
 		// A successful claim needs no resync — the response itself carried the authoritative state.
-		expect(h.refreshPlayer).not.toHaveBeenCalled();
-		expect(h.inventoryManager.initialize).not.toHaveBeenCalled();
+		expect(h.resyncPlayerAndInventory).not.toHaveBeenCalled();
 	});
 
 	it('does not log the defeat when DefeatEnemy fails (no premature "defeated" line)', async () => {
@@ -924,12 +920,10 @@ describe('EnemyManager boss mode', () => {
 		expect(logMessage).toHaveBeenCalledWith(ELogType.Debug, 'There was an error defeating the enemy: boom');
 		expect(h.playerManager.applyVictoryRewards).not.toHaveBeenCalled();
 		// The transport can settle a lost/timed-out DefeatEnemy as an error even when it actually succeeded
-		// server-side, so an errored claim resyncs the authoritative player state rather than leaving the
-		// client's exp/level silently diverged.
-		expect(h.refreshPlayer).toHaveBeenCalledOnce();
-		// refreshPlayer only re-initializes playerManager; the inventory (an item/mod the outage-window
-		// victory may have unlocked) must be re-derived from it too, or it stays invisible until reload.
-		expect(h.inventoryManager.initialize).toHaveBeenCalledOnce();
+		// server-side, so an errored claim resyncs the authoritative player state (and the inventory derived
+		// from it, in case the outage-window victory unlocked an item/mod) rather than leaving the client's
+		// exp/level silently diverged.
+		expect(h.resyncPlayerAndInventory).toHaveBeenCalledOnce();
 	});
 
 	it('survives a missing/retired enemy id on victory (still grants rewards, omits the name log)', async () => {


### PR DESCRIPTION
## Summary

`refreshPlayer()` followed by `inventoryManager.initialize()` was the "resync the authoritative player state and re-derive the inventory" pattern used at two call sites:

- `EnemyManager.claimVictory` (`UI/src/lib/engine/battle/enemy-manager.ts`) — resyncs after a lost/timed-out `DefeatEnemy` response that may have actually succeeded server-side.
- `handleServerCommandFailed`'s `ChallengeCompleted` path (`UI/src/lib/engine/engine.ts`)

`refreshPlayer`'s own doc comment already flagged that a caller needing the derived inventory to reflect the refresh must remember the second step — exactly the footgun #1661 anticipated and #1669/#1670 both surfaced once it spread to a second site.

This PR extracts a shared `resyncPlayerAndInventory()` helper and routes both call sites through it, so a future third caller can't silently forget the inventory step. No user-facing behavior change.

## Note on the two linked issues

#1669 and #1670 are near-duplicate follow-ups filed 14 seconds apart requesting the same fix. This PR resolves both; I'll close #1670 as a duplicate of #1669 once this merges.

## Design note

The issue suggested putting the helper in `session.ts` alongside `refreshPlayer`. I put it in `engine.ts` instead: `refreshPlayer` lives in `session.ts`, but the `inventoryManager` singleton instance is constructed and owned by `engine.ts`, which already imports `refreshPlayer` from `session.ts`. Putting the helper in `session.ts` would have required `session.ts` to import back from `engine.ts`, creating a circular module dependency. `engine.ts` avoids that while keeping both call sites just as simple (they already import from the `$lib/engine` barrel, which re-exports `engine.ts`). Updated `refreshPlayer`'s doc comment to point at the new helper instead of describing the manual two-step.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — passes
- [x] `npm run test:unit:ci` — 295 test files / 3522 tests pass
- [x] Updated `enemy-manager-boss.test.ts` mocks/assertions to match the new single-call shape

Closes #1669
Closes #1670


---
_Generated by [Claude Code](https://claude.ai/code/session_01MzqdugyeLYf7Udkz1VBVYH)_