### PR TITLE
Extract shared CapHealToRoom helper across battle absorption channels

### DIFF
--- a/Game.Core/Battle/Battler.cs
+++ b/Game.Core/Battle/Battler.cs
@@ -359,17 +359,29 @@ namespace Game.Core.Battle
             var net = ComputeNetDamage(dealt, damageType);
             if (net < 0)
             {
-                // Absorption: cap the heal at the remaining room to MaxHealth (consistent with ApplyHealOverTime),
-                // and report the actual healed amount so the per-skill / global stats stay reconciled.
-                var room = _attributes[MaxHealth] - CurrentHealth;
-                var heal = -net < room ? -net : room;
-                heal = heal > 0 ? heal : 0;
+                // Absorption: cap the heal at the remaining room to MaxHealth, and report the actual healed
+                // amount so the per-skill / global stats stay reconciled.
+                var heal = CapHealToRoom(-net);
                 CurrentHealth += heal;
-                return -heal;
+                return heal == 0 ? 0 : -heal;
             }
 
             CurrentHealth -= net;
             return net;
+        }
+
+        /// <summary>
+        /// Caps <paramref name="heal"/> to this battler's remaining room to <see cref="MaxHealth"/>, floored at
+        /// <c>0</c> — never negative, and never a negative zero when the room is fully exhausted. Shared by the
+        /// three channels whose net effect can be a heal — <see cref="TakeDamage"/>'s direct-hit absorption,
+        /// <see cref="ApplyDamageOverTime"/>'s aggregate DoT-absorption, and <see cref="ApplyHealOverTime"/> —
+        /// since the game has no overheal/shield concept regardless of the heal's source.
+        /// </summary>
+        private double CapHealToRoom(double heal)
+        {
+            var room = _attributes[MaxHealth] - CurrentHealth;
+            var capped = heal < room ? heal : room;
+            return capped > 0 ? capped : 0;
         }
 
         /// <summary>
@@ -515,9 +527,7 @@ namespace Game.Core.Battle
                 // the remaining room to MaxHealth, consistent with TakeDamage's absorption cap and
                 // ApplyHealOverTime — the game has no overheal/shield concept. Per-type booking above already
                 // recorded the uncapped tick.
-                var room = _attributes[MaxHealth] - CurrentHealth;
-                var heal = -dot < room ? -dot : room;
-                heal = heal > 0 ? heal : 0;
+                var heal = CapHealToRoom(-dot);
                 dot = heal == 0 ? 0 : -heal; // avoid -0.0, matching the frontend mirror bit-for-bit
             }
 
@@ -533,7 +543,7 @@ namespace Game.Core.Battle
         public double ApplyHealOverTime(int ms)
         {
             var heal = _attributes[HealthRegenPerSecond] * ms / 1000.0;
-            var healed = Math.Min(heal, _attributes[MaxHealth] - CurrentHealth);
+            var healed = CapHealToRoom(heal);
             if (healed > 0)
             {
                 CurrentHealth += healed;

--- a/UI/src/lib/battle/battler.ts
+++ b/UI/src/lib/battle/battler.ts
@@ -178,13 +178,23 @@ export class Battler {
 		const net = mitigateDamage(dealt, damageType, this.attributes);
 		if (net < 0) {
 			// Absorption: cap the heal at the remaining room to MaxHealth, and report the actual healed amount.
-			const room = this.attributes.getValue(EAttribute.MaxHealth) - this.currentHealth;
-			const heal = Math.max(Math.min(-net, room), 0);
+			const heal = this.capHealToRoom(-net);
 			this.currentHealth += heal;
-			return -heal;
+			return heal === 0 ? 0 : -heal;
 		}
 		this.currentHealth -= net;
 		return net;
+	}
+
+	/** Caps `heal` to this battler's remaining room to MaxHealth, floored at 0 — never negative, and never a
+	 *  negative zero when the room is fully exhausted. Shared by the three channels whose net effect can be a
+	 *  heal — {@link takeDamage}'s direct-hit absorption, {@link applyDamageOverTime}'s aggregate DoT-absorption,
+	 *  and {@link applyHealOverTime} — since the game has no overheal/shield concept regardless of source.
+	 *  Mirrors the backend `Battler.CapHealToRoom`. */
+	private capHealToRoom(heal: number): number {
+		const room = this.attributes.getValue(EAttribute.MaxHealth) - this.currentHealth;
+		const capped = Math.min(heal, room);
+		return capped > 0 ? capped : 0;
 	}
 
 	/** Subtracts `amount` of reflected damage directly from this (attacking) battler's health, BYPASSING all of
@@ -222,8 +232,7 @@ export class Battler {
 		if (dot < 0) {
 			// Aggregate absorption (net heal): cap the realized health change at the remaining room to
 			// MaxHealth, consistent with takeDamage's absorption cap and applyHealOverTime.
-			const room = this.attributes.getValue(EAttribute.MaxHealth) - this.currentHealth;
-			const heal = Math.max(Math.min(-dot, room), 0);
+			const heal = this.capHealToRoom(-dot);
 			dot = heal === 0 ? 0 : -heal; // avoid returning -0 when the room is fully exhausted
 		}
 		this.currentHealth -= dot;
@@ -234,7 +243,7 @@ export class Battler {
 	 *  `timeDelta`), capped at MaxHealth. Returns the actual (post-cap) health restored. */
 	public applyHealOverTime(timeDelta: number) {
 		const heal = (this.attributes.getValue(EAttribute.HealthRegenPerSecond) * timeDelta) / 1000;
-		const healed = Math.min(heal, this.attributes.getValue(EAttribute.MaxHealth) - this.currentHealth);
+		const healed = this.capHealToRoom(heal);
 		if (healed > 0) {
 			this.currentHealth += healed;
 			return healed;


### PR DESCRIPTION
## Summary

Follow-up from #1666. Three battle channels each independently implemented the same "cap a net heal at the battler's remaining room to `MaxHealth`, avoiding `-0`" logic, mirrored across the C# and TS battler implementations:

- `Battler.TakeDamage` / `battler.ts` `takeDamage` — direct-hit absorption
- `Battler.ApplyDamageOverTime` / `battler.ts` `applyDamageOverTime` — DoT-absorption aggregate
- `Battler.ApplyHealOverTime` / `battler.ts` `applyHealOverTime`

This extracts a shared private helper — `CapHealToRoom` in `Game.Core/Battle/Battler.cs` and its mirror `capHealToRoom` in `UI/src/lib/battle/battler.ts` — that computes `room = MaxHealth - CurrentHealth` and returns the heal clamped to `[0, room]`. All three call sites now go through it.

## Behavior change

None. This is a pure refactor:
- `ApplyDamageOverTime`/`applyDamageOverTime`'s existing `-0` avoidance is preserved unchanged.
- `TakeDamage`/`takeDamage` previously could return a `-0.0` result when the heal was fully capped to `0`; it now explicitly avoids that (`heal == 0 ? 0 : -heal`), matching the DoT channel's existing convention. Since `-0.0 == 0.0` under IEEE-754/JS numeric equality, this is not an observable behavior change — every existing test still passes.
- `ApplyHealOverTime`/`applyHealOverTime` is functionally identical (`Math.Min(heal, room)` guarded by `> 0` ⇔ `CapHealToRoom` clamped to `[0, room]` guarded by `> 0`).
- Per-type stat booking in `ApplyDamageOverTime` (the #1482 overkill behavior) is untouched — only the aggregate health-change cap was consolidated.

The issue's "optional, related" ask (adding a DoT-absorption-above-max row to the mirrored parity matrix) was flagged as low priority and left out, since #1666's mirrored unit tests already pin that divergence risk.

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test --no-build --no-restore` — Game.Core.Tests (1341), Game.Infrastructure.Tests (61), Game.Application.Tests (894), Game.Api.Tests (715) all passing
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run test:unit:ci` — 295 files / 3522 tests passing

Closes #1671


---
_Generated by [Claude Code](https://claude.ai/code/session_01CyZ4X9NkAHEfJyJRAGKtPW)_