### PR TITLE
Docs: fix two stale frontend.md claims that survived the later docs passes

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -6,7 +6,7 @@ All frontend code lives in `UI`:
   - **`components`** — shared components. Several reusable primitives are worth composing over re-implementing — the collapsible side rails (`components/sidebar`), the tooltip chrome (`components/tooltip`, incl. `AttributeTooltip`), and the progress/fill `Bar` (with specialised variants like `HpBar`). **Extend an existing primitive rather than copying it**, and check here before hand-rolling a new one; each primitive's own API lives in its code/props.
   - **`lib`** — non-UI logic: `api` (HTTP/WebSocket client + generated client types), `battle` (battle-sim domain objects + the shared domain mirrors backing the breakdown/inventory screens), `card-game` (pure "Initiative Loom" mechanics, DOM-free), `common` (shared utilities), `engine` (render/logical engines, battle engine, player/enemy managers).
   - **`routes`** — pages and route-specific components. In-game screens under `routes/game/screens` use a config-driven **screen registry** (`screen-defs.ts`); adding a screen means registering it there. Per-screen detail lives in [frontend-screens.md](./frontend-screens.md).
-  - **`stores`** — Svelte stores. NOTE: most stateful data is moving to reactive classes in `lib` made reactive via `statify`; prefer a reactive class over a new store.
+  - **`stores`** — rune-based (`$state`) UI state modules (no classic `svelte/store` stores remain). NOTE: most stateful data is moving to reactive classes in `lib` made reactive via `statify`; prefer a reactive class over a new store module.
   - **`styles`** — global styles and theming.
   - **`tests`** — unit tests for lib/pages/components.
 - **`static`** — assets. Item/skill icons live in `static/img` — see [icon-art.md](./icon-art.md) before creating or regenerating any.
@@ -14,7 +14,7 @@ All frontend code lives in `UI`:
 
 # General Frontend Guidelines
 
-- There is ongoing work both to reach feature parity with the old frontend and to redesign the UI/UX; not all new UI/UX decisions are final.
+- The UI/UX is being redesigned incrementally; not all UI/UX decisions are final.
 - Keep components small. If a component grows large or you find yourself commenting each section, break it into subcomponents (in their own folder if there are several), even if only the parent uses them.
 - Use [statify](../UI/src/lib/common/statify.svelte.ts) to make a logic class reactive in Svelte — it keeps complex state/logic (e.g. battle simulation) in object-oriented classes while staying reactive, rather than pushing it into stores or components.
 


### PR DESCRIPTION
## Summary

This began as a full docs health pass (stale-claim fixes across four docs plus a combat split into `docs/game-design-combat.md`). Every other edit it carried has since landed on `main` through the later docs passes (#1787, #1826, #1838/#1848) and #1689, which also created a differently-scoped `game-design-combat.md` — so the branch was rebased onto current `main` and pared down to its only surviving unique contribution, per the review recommendation.

## What remains (both re-verified against current `main`)

- **`docs/frontend.md` `stores` folder description** — still read "Svelte stores"; every module under `UI/src/stores` is a rune-based `$state` `.svelte.ts` module and zero `svelte/store` imports remain in `UI/src`.
- **`docs/frontend.md` old-frontend parity clause** — "ongoing work … to reach feature parity with the old frontend" no longer has a referent; the guideline now just notes the incremental UI/UX redesign.

## Dropped as superseded

- `game-design.md`/`game-design-combat.md` combat split (superseded by #1787's split, add/add conflict)
- `backend-battle.md` replay-to-offset/boss-flag updates (landed via #1689, and `main` now also carries #1882 on those lines)
- `backend.md` HTTP-that-remains list (landed more thoroughly via later passes)
- `content-design.md` anchor retarget (main's `game-design.md` kept the section with the corrected anchor)
- `frontend.md` tick-source fallback wording (landed via #1676's own docs touch)

Docs-only — no code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019UqDmJv27wLDasrnqZdUtm)_