### PR TITLE
Guard resolveBossLoss against a superseding transition after its awaits

### DIFF
--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -487,6 +487,14 @@ export class EnemyManager {
 		return this.started && this.mode === 'boss' && !this.transitioning;
 	}
 
+	/** Whether `generation` (a {@link transitionGeneration} snapshot) is still current — false once a stop
+	 *  or a superseding challenge/retreat (which bumps the generation via {@link beginTransition}) has moved
+	 *  on. Unlike {@link bossLoopActive}, this doesn't require `mode === 'boss'`: boss-loss resolution leaves
+	 *  boss mode itself partway through (via returnToIdle), so it re-checks this after each await instead. */
+	private transitionCurrent(generation: number): boolean {
+		return this.started && generation === this.transitionGeneration;
+	}
+
 	private async watchBattleStage(stage: BattleStage) {
 		// While swapping the active battle, ignore the outgoing battle's resolving stage changes.
 		if (this.transitioning) {
@@ -619,9 +627,19 @@ export class EnemyManager {
 	}
 
 	private async resolveBossLoss() {
+		// Snapshot the transition generation up front: a challenge/retreat pressed during either await below
+		// bumps it (via beginTransition), and its result can resolve the parked startLoading below early
+		// (finishLoading) — so this resolution must not then hand a stale prepared idle battle to a fresh
+		// getNewEnemy call and clobber the fight the supersession already started (#1696).
+		const generation = this.transitionGeneration;
 		// Record the loss explicitly (turning auto-fight off) and drop back to the boss-available
 		// state — the normal idle farm loop — honoring the post-loss cooldown.
 		const lostResponse = await apiSocket.sendSocketCommand('BattleLost');
+		// A retreat/challenge superseded this resolution while BattleLost was in flight; the superseding
+		// transition already owns the loop's state, so abandon rather than clobber it below.
+		if (!this.transitionCurrent(generation)) {
+			return;
+		}
 		if (lostResponse.error) {
 			logMessage(ELogType.Debug, 'There was an error recording the boss loss: ' + lostResponse.error);
 		}
@@ -634,6 +652,11 @@ export class EnemyManager {
 		const cooldown = lostResponse.data?.cooldown ?? 0;
 		if (cooldown > 0) {
 			await battleEngine.startLoading(cooldown);
+			// Re-check after the cooldown: a challenge pressed during it can resolve this parked startLoading
+			// early, so a fresh getNewEnemy below must not present the stale prepared battle over the new fight.
+			if (!this.transitionCurrent(generation)) {
+				return;
+			}
 		}
 		await this.getNewEnemy(prepared);
 	}

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -516,6 +516,57 @@ describe('EnemyManager boss mode', () => {
 		expect(send).toHaveBeenCalledWith('NewEnemy', expect.objectContaining({ newZoneId: 3 }));
 	});
 
+	it('abandons boss-loss resolution when a retreat lands while BattleLost is in flight', async () => {
+		// #1696: a retreat pressed while the loss is still being recorded must win — the resolution's own
+		// (stale) BattleLost response must not clobber the idle fight the retreat already moved to.
+		await manager.challengeBoss();
+		let releaseLost!: (r: IApiSocketResponse<'BattleLost'>) => void;
+		const lostGate = new Promise<IApiSocketResponse<'BattleLost'>>((resolve) => (releaseLost = resolve));
+		send.mockImplementation((name: string) => (name === 'BattleLost' ? lostGate : Promise.resolve(newEnemyResponse)));
+
+		const handled = fireStage(h.BattleStage.Defeated);
+		await flush(); // park the loss resolution on the in-flight BattleLost
+
+		const retreated = manager.retreatFromBoss(); // supersedes: bumps the transition generation
+		await flush();
+		releaseLost(lostResponse); // the stale BattleLost now resolves
+		await Promise.all([handled, retreated]);
+
+		// The retreat's own idle enemy stands; the loss resolution bailed rather than re-fetching over it.
+		expect(manager.mode).toBe('idle');
+		expect(manager.currentEnemy).toEqual(normalInstance);
+		expect(send.mock.calls.filter((c: unknown[]) => c[0] === 'NewEnemy').length).toBe(1);
+	});
+
+	it('does not spawn the stale prepared idle enemy when a challenge lands during the post-loss cooldown', async () => {
+		// #1696's exact failure scenario: BattleLost bundles a prefetched idle enemy and a cooldown; a
+		// challenge pressed during that cooldown resolves the parked startLoading early (finishLoading) and
+		// takes over the boss loop. The loss resolution's continuation must not then present the stale
+		// prepared idle enemy over the fight the challenge started.
+		await manager.challengeBoss();
+		let releaseCooldown!: () => void;
+		const cooldownGate = new Promise<void>((resolve) => (releaseCooldown = resolve));
+		h.battleEngine.startLoading.mockReturnValueOnce(cooldownGate);
+		send.mockImplementation((name: string) =>
+			name === 'BattleLost' ? Promise.resolve(bundledLostResponse(5000)) : Promise.resolve(challengeResponse)
+		);
+
+		const handled = fireStage(h.BattleStage.Defeated);
+		await flush(); // loss recorded; parked on the gated post-loss cooldown
+		expect(h.battleEngine.startLoading).toHaveBeenCalledWith(5000);
+
+		// The player re-challenges during the cooldown — this bumps the transition generation and engages
+		// the boss, mirroring the engine reset that resolves the parked startLoading early in production.
+		const challenge = manager.challengeBoss();
+		releaseCooldown();
+		await Promise.all([handled, challenge]);
+
+		// The boss fight the challenge started stands; the stale prepared idle enemy was never presented.
+		expect(manager.mode).toBe('boss');
+		expect(manager.currentEnemy).toEqual(bossInstance);
+		expect(manager.currentEnemy).not.toEqual(preparedInstance);
+	});
+
 	it('on a boss draw (timeout): retreats to the idle loop with auto-fight off, recording no loss', async () => {
 		await manager.challengeBoss();
 		manager.setAutoFight(true);


### PR DESCRIPTION
## Summary

`enemy-manager.ts`'s three boss resolutions handled mid-resolution supersession inconsistently. `resolveBossVictory` re-checks `bossLoopActive` after every await, but `resolveBossLoss` had no equivalent guard — it awaited `BattleLost`, then `battleEngine.startLoading(cooldown)`, then unconditionally called `getNewEnemy(prepared)`.

**Failure scenario:** a player loses to the boss and `resolveBossLoss` parks on the post-loss cooldown. If the player presses **Challenge** again during that cooldown, the challenge transitions into boss mode and its engine reset resolves the parked `startLoading` early. `resolveBossLoss`'s continuation then ran `getNewEnemy(prepared)` with a *fresh* generation capture, so the existing fetch-generation guard didn't catch the supersession — the stale prepared idle enemy replaced the boss fight the challenge had just started. The same hole applied to a Retreat pressed while `BattleLost` was still in flight.

## Fix

`resolveBossLoss` couldn't reuse `bossLoopActive` (which requires `mode === 'boss'`) because it deliberately leaves boss mode partway through, via `returnToIdle()`. Instead:

- Snapshot `transitionGeneration` at the top of `resolveBossLoss`, before any awaits.
- Added a `transitionCurrent(generation)` guard (parallel to `bossLoopActive`, but generation-based) that re-checks after the `BattleLost` await and again after `startLoading`, before calling `getNewEnemy`.
- If a challenge/retreat bumped the generation in the meantime, the resolution abandons rather than clobbering the transition that took over.

## Test plan

- [x] Added a test pinning that a retreat landing while `BattleLost` is in flight wins — the loss resolution's own (stale) response no longer re-fetches over the idle fight the retreat already started.
- [x] Added a test reproducing the exact traced scenario: a challenge landing during the post-loss cooldown takes over the boss loop, and the stale prepared idle enemy from the bundled `BattleLost` response is never presented.
- [x] `npx vitest run src/tests/lib/engine/battle/enemy-manager-boss.test.ts` — 51/51 passed
- [x] `npm run test:unit:ci` — 295 files / 3524 tests passed
- [x] `npm run lint` — clean (eslint + svelte-check, 0 errors/warnings)

No backend changes — this is a purely frontend client-side race in the transition/generation bookkeeping; the backend's authoritative state and anti-cheat replay are unaffected.

Closes #1696


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9RxkTLdD7L2igYQDQXxqW)_