### PR TITLE
Disable zone navigation while a dedicated-boss fight is engaged

### DIFF
--- a/UI/src/routes/game/screens/fight/ZoneNav.svelte
+++ b/UI/src/routes/game/screens/fight/ZoneNav.svelte
@@ -11,7 +11,11 @@
 			class:locked={leftLocked}
 			disabled={leftAbsent}
 			aria-disabled={leftLocked || undefined}
-			aria-label={leftLocked ? 'Previous zone locked' : 'Previous zone'}
+			aria-label={bossEngaged
+				? 'Zone navigation locked during boss fight'
+				: leftLocked
+					? 'Previous zone locked'
+					: 'Previous zone'}
 			onclick={handleClickLeft}
 			onfocus={(e) => focusLock(leftLocked, prevZone?.unlockChallengeId, e)}
 			onblur={hideLock}
@@ -40,7 +44,11 @@
 			class:locked={rightLocked}
 			disabled={rightAbsent}
 			aria-disabled={rightLocked || undefined}
-			aria-label={rightLocked ? 'Next zone locked' : 'Next zone'}
+			aria-label={bossEngaged
+				? 'Zone navigation locked during boss fight'
+				: rightLocked
+					? 'Next zone locked'
+					: 'Next zone'}
 			onclick={handleClickRight}
 			onfocus={(e) => focusLock(rightLocked, nextZone?.unlockChallengeId, e)}
 			onblur={hideLock}
@@ -123,13 +131,18 @@ const completed = (id: number) => playerChallenges.isChallengeCompleted(id);
 // simply being at the first/last zone (no neighbour at all).
 const leftLocked = $derived(prevZone != null && !isZoneUnlocked(prevZone, completed));
 const rightLocked = $derived(nextZone != null && !isZoneUnlocked(nextZone, completed));
-// An arrow is hard-`disabled` (unfocusable) only when there is no neighbour to explain at all;
-// a locked-but-existing neighbour stays focusable with `aria-disabled` so its gate is reachable.
-const leftAbsent = $derived(prevZone == null);
-const rightAbsent = $derived(nextZone == null);
+// A dedicated-boss fight is engaged, so navigation is hard-disabled: reassigning the current zone
+// mid-fight would desync the boss UI (and the eventual clear/unlock check) from the fight actually
+// in progress (#1698). Retreat is the sanctioned way out and already returns to idle before navigating.
+const bossEngaged = $derived(enemyManager.mode === 'boss');
+// An arrow is hard-`disabled` (unfocusable) when there is no neighbour to explain, or while a boss
+// fight is engaged; a locked-but-existing neighbour otherwise stays focusable with `aria-disabled` so
+// its gate is reachable.
+const leftAbsent = $derived(prevZone == null || bossEngaged);
+const rightAbsent = $derived(nextZone == null || bossEngaged);
 
 const goToZone = (zone: IZone | undefined) => {
-	if (zone != null && isZoneUnlocked(zone, completed)) {
+	if (zone != null && !bossEngaged && isZoneUnlocked(zone, completed)) {
 		enemyManager.navigateToZone(zone.id);
 	}
 };

--- a/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
@@ -13,6 +13,7 @@ const { mockPlayerManager, mockEnemyManager, staticData, playerChallenges, regis
 		// Navigation routes through enemyManager.navigateToZone (so Home can halt the loop); the mock just
 		// applies the zone the way the real method does, so the existing click assertions still hold.
 		mockEnemyManager: {
+			mode: 'idle' as 'idle' | 'boss',
 			navigateToZone: vi.fn((zoneId: number) => {
 				mockPlayerManager.currentZone = zoneId;
 			})
@@ -77,6 +78,7 @@ beforeEach(() => {
 	playerChallenges.isChallengeCompleted.mockReset();
 	playerChallenges.isChallengeCompleted.mockReturnValue(false);
 	mockEnemyManager.navigateToZone.mockClear();
+	mockEnemyManager.mode = 'idle';
 	staticData.challenges = [];
 	// Deliberately out of array order to prove the component orders by `order`, not index.
 	staticData.zones = [zone(30, 3, 'Frozen Summit'), zone(10, 1, 'Verdant Hollow'), zone(20, 2, 'Ashen Wastes')];
@@ -324,6 +326,41 @@ describe('ZoneNav', () => {
 		mockPlayerManager.currentZone = 20;
 		render(ZoneNav);
 		expect(screen.getByTestId('zone-nav').textContent).toContain('Zone · 02');
+	});
+
+	it('hard-disables both arrows while a dedicated-boss fight is engaged', () => {
+		mockEnemyManager.mode = 'boss';
+
+		render(ZoneNav);
+		const [left, right] = screen.getAllByRole('button') as HTMLButtonElement[];
+
+		expect(left.disabled).toBe(true);
+		expect(right.disabled).toBe(true);
+		expect(left.getAttribute('aria-label')).toBe('Zone navigation locked during boss fight');
+		expect(right.getAttribute('aria-label')).toBe('Zone navigation locked during boss fight');
+	});
+
+	it('does not navigate (even bypassing the disabled button) while a boss fight is engaged', async () => {
+		mockEnemyManager.mode = 'boss';
+
+		render(ZoneNav);
+		const [left, right] = screen.getAllByRole('button') as HTMLButtonElement[];
+
+		await fireEvent.click(left);
+		await fireEvent.click(right);
+
+		expect(mockEnemyManager.navigateToZone).not.toHaveBeenCalled();
+		expect(mockPlayerManager.currentZone).toBe(20);
+	});
+
+	it('leaves zone navigation enabled while idle-farming (not engaged in a boss fight)', () => {
+		mockEnemyManager.mode = 'idle';
+
+		render(ZoneNav);
+		const [left, right] = screen.getAllByRole('button') as HTMLButtonElement[];
+
+		expect(left.disabled).toBe(false);
+		expect(right.disabled).toBe(false);
 	});
 
 	it('navigates into the Home sanctuary via the left arrow', async () => {


### PR DESCRIPTION
## Problem

`Fight.svelte` renders `ZoneNav` unconditionally, and `EnemyManager.navigateToZone` had no boss-mode handling — it just reassigned `playerManager.currentZone` while `mode` stayed `'boss'` and the fight kept running. All the boss-view derivations (`bossName`/`zoneName`/`hasBoss`/`cleared` in `boss-view.svelte.ts`) read the *live* current zone, and `resolveBossVictory` snapshots `clearedZoneId` at resolution time, not challenge time. So navigating mid-fight could:

- Relabel the boss bar and Zone-Cleared overlay to the new zone's boss while the old boss was still being fought.
- Unrender `BossAffordanceSlot` entirely when navigating to a bossless zone — taking the Retreat button with it and stranding the player until the fight concluded on its own.
- Mark the wrong zone as cleared on victory after a mid-fight navigation, and evaluate the wrong "next zone unlocked" gate.
- With auto-fight on, re-challenge against a different zone's boss.

## Fix

Went with the issue's suggested "cheapest coherent fix": the zone-nav arrows now hard-disable (native `disabled`, non-focusable) whenever `enemyManager.mode === 'boss'`, mirroring the reactive pattern `BossView.engaged` already uses. Retreat remains the sanctioned way out of a boss fight — it already returns to idle before any navigation is possible. `goToZone` also short-circuits on `bossEngaged` as defense in depth, matching the existing `isZoneUnlocked` guard.

This removes the whole class of consequences described in the issue at the root — since navigation is impossible while a boss fight is engaged, the mid-fight zone-reassignment that caused them can no longer happen.

## Test plan

- [x] Added `ZoneNav.test.ts` coverage: both arrows hard-disable with a boss-specific `aria-label` while `mode === 'boss'`; clicking them (even bypassing the disabled attribute) doesn't navigate; navigation stays enabled while idle-farming.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — 3527/3527 passing.

Closes #1698


---
_Generated by [Claude Code](https://claude.ai/code/session_01KtJ9iuGabQfduhUzBcGoXa)_