### PR TITLE
Fix multi-byte UTF-8 characters corrupting on 4KB receive boundary

### DIFF
--- a/Game.Api.Tests/Unit/SocketContextTests.cs
+++ b/Game.Api.Tests/Unit/SocketContextTests.cs
@@ -166,6 +166,26 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
+        public async Task ReadMessage_MultiByteCharacterSplitAcrossFrames_DecodesCorrectly()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var socket = new ScriptedWebSocket();
+            var context = CreateContext(socket);
+
+            // "hel😀lo" — the emoji's 4-byte UTF-8 sequence (F0 9F 98 80) is split mid-character across two
+            // receive fills, reproducing a code point straddling the 4KB buffer boundary (#1699).
+            var fullBytes = Encoding.UTF8.GetBytes("hel😀lo");
+            var firstChunk = fullBytes[..5];
+            var secondChunk = fullBytes[5..];
+            socket.QueueBytes(firstChunk, endOfMessage: false);
+            socket.QueueBytes(secondChunk, endOfMessage: true);
+
+            var message = await context.ReadMessage(cancellationToken).WaitAsync(WaitTimeout, cancellationToken);
+
+            Assert.Equal("hel😀lo", message);
+        }
+
+        [Fact]
         public async Task ReadMessage_CloseFrame_StopsReadingAndReturnsEmpty()
         {
             var cancellationToken = TestContext.Current.CancellationToken;
@@ -230,6 +250,9 @@ namespace Game.Api.Tests.Unit
 
             public void QueueData(string text, bool endOfMessage)
                 => _receives.Enqueue(new ReceiveStep(Encoding.UTF8.GetBytes(text), WebSocketMessageType.Text, endOfMessage));
+
+            public void QueueBytes(byte[] payload, bool endOfMessage)
+                => _receives.Enqueue(new ReceiveStep(payload, WebSocketMessageType.Text, endOfMessage));
 
             public void QueueClose()
                 => _receives.Enqueue(new ReceiveStep([], WebSocketMessageType.Close, EndOfMessage: true));

--- a/Game.Api/Sockets/SocketContext.cs
+++ b/Game.Api/Sockets/SocketContext.cs
@@ -18,6 +18,11 @@ namespace Game.Api.Sockets
 
         private readonly byte[] _buffer = new byte[MAX_MESSAGE_SIZE];
 
+        // Sized for the worst case (every byte a standalone char, plus a possible carried-over decoder char)
+        // so a single ReceiveAsync fill can never overflow it, regardless of how the UTF-8 sequences in that
+        // fill are split.
+        private readonly char[] _charBuffer = new char[Encoding.UTF8.GetMaxCharCount(MAX_MESSAGE_SIZE)];
+
         private readonly TaskCompletionSource<ESocketCloseReason> _socketClosedSource = new();
         private readonly ILogger<SocketContext> _logger;
         private readonly WebSocket _socket;
@@ -115,6 +120,12 @@ namespace Game.Api.Sockets
         public async Task<string> ReadMessage(CancellationToken cancellationToken = default)
         {
             var message = new StringBuilder();
+
+            // ReceiveAsync fills at most MAX_MESSAGE_SIZE bytes per call regardless of the sender's UTF-8
+            // framing, so a multi-byte code point can land split across two fills. A stateful decoder carries
+            // an incomplete trailing sequence over to the next GetChars call instead of decoding each fill in
+            // isolation, which would otherwise turn each half into a replacement character (U+FFFD).
+            var decoder = Encoding.UTF8.GetDecoder();
             WebSocketReceiveResult result;
             var framesRead = 0;
             do
@@ -131,7 +142,8 @@ namespace Game.Api.Sockets
                 framesRead++;
                 if (result.Count > 0)
                 {
-                    message.Append(Encoding.UTF8.GetString(_buffer, 0, result.Count));
+                    var charCount = decoder.GetChars(_buffer, 0, result.Count, _charBuffer, 0);
+                    message.Append(_charBuffer, 0, charCount);
                 }
             }
             while (!result.EndOfMessage && framesRead < MAX_FRAMES_PER_MESSAGE);


### PR DESCRIPTION
## Problem

`SocketContext.ReadMessage` decoded each `ReceiveAsync` fill independently via `Encoding.UTF8.GetString(_buffer, 0, result.Count)`. `ReceiveAsync` returns at most 4096 bytes per call regardless of client framing, so a multi-byte UTF-8 code point could be split across two fills — each half then decoded to U+FFFD (replacement character), corrupting the reassembled JSON and causing the socket to close as `MalformedFrame`.

The read path deliberately supports multi-chunk messages up to ~4 MB (`MAX_FRAMES_PER_MESSAGE = 1024`), so this large-message support was deterministically broken for any non-ASCII payload over 4096 bytes.

## Fix

`ReadMessage` now holds a stateful `System.Text.Decoder` (`Encoding.UTF8.GetDecoder()`) across all the fills of a single message, instead of calling `GetString` per fill. The decoder carries an incomplete trailing byte sequence over to the next fill, so a code point split by the buffer boundary decodes correctly. A fixed `_charBuffer` (sized via `Encoding.UTF8.GetMaxCharCount(MAX_MESSAGE_SIZE)`) avoids a per-fill allocation, mirroring the existing `_buffer` field.

The decoder is created fresh per `ReadMessage` call (i.e. per message), so no state leaks between messages.

## Test plan

- [x] Added `ReadMessage_MultiByteCharacterSplitAcrossFrames_DecodesCorrectly` to `SocketContextTests`, which splits a 4-byte emoji's UTF-8 sequence mid-character across two receive fills and asserts correct reassembly. Required adding a `QueueBytes` helper to the `ScriptedWebSocket` test double so a test can queue exact byte-boundary splits instead of always splitting on a string boundary.
- [x] `dotnet build` — clean.
- [x] `dotnet test` (full solution) — 3012/3012 passing.

Closes #1699


---
_Generated by [Claude Code](https://claude.ai/code/session_01GqEpptQTi5oDi9ydyDokA6)_