### PR TITLE
Fix /socket block to use dynamic-DNS re-resolution

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -27,8 +27,11 @@ server {
 
 		# 2. Dedicated WebSocket rerouting path
     location /socket {
-        proxy_pass "http://gameserver.railway.internal:8080";
-        
+        # Use a variable for the hostname to prevent Nginx from crashing if a service is restarting
+        set $dotnet_backend "http://gameserver.railway.internal:8080";
+
+        proxy_pass $dotnet_backend;
+
         proxy_http_version 1.1;
 				proxy_set_header Host $host;
 				proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Problem

The `/api/` and `/` blocks in `nginx.conf` set their upstream in a **variable** specifically so nginx re-resolves it through the `resolver … valid=10s` directive and survives a backend restart. The `/socket` block instead used a literal `proxy_pass "http://gameserver.railway.internal:8080"`.

With a literal upstream, nginx resolves the name once at config load and never re-resolves — so after a backend redeploy changes the internal IP, all WebSocket traffic (the primary game transport) would stay pinned to the stale IP until nginx itself restarted, while REST recovered within 10s.

## Fix

Applied the same variable-indirection pattern already used by the `/api/` block: `set $dotnet_backend "…"; proxy_pass $dotnet_backend;` in the `/socket` location.

## Test plan

- [x] Validated the resulting config with a real `nginx:alpine` container: mounted `nginx.conf` as the config template, ran `envsubst` + `nginx -t` — syntax OK, config test successful.
- [x] No application code paths affected; this is an infra config-only change with no unit/integration test surface.

Closes #1700


---
_Generated by [Claude Code](https://claude.ai/code/session_01DWJZZbgpnQ7GSoF26xNDVU)_