### PR TITLE
FE test: assert each Lesson's screenKey resolves to a real ScreenDef.key

### DIFF
--- a/UI/src/tests/routes/game/screens/screen-defs.test.ts
+++ b/UI/src/tests/routes/game/screens/screen-defs.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { GAME_SCREENS, visibleScreens, type ScreenDef } from '$routes/game/screens/screen-defs';
 import { ERole } from '$lib/api';
+import lessonsContent from '../../../../../../content/lessons.json';
 
 const screens: ScreenDef[] = [
 	{ key: 'fight', label: 'Fight', group: 'combat', built: true },
@@ -64,5 +65,20 @@ describe('GAME_SCREENS', () => {
 		const wipWithComponent = GAME_SCREENS.filter((s) => !s.built && s.component).map((s) => s.key);
 
 		expect(wipWithComponent).toEqual([]);
+	});
+});
+
+// `Lesson.screenKey` is a plain string, not an FK — screens are a frontend-only registry with no
+// backend representation, so the backend progression-graph lint deliberately leaves this check to
+// the frontend (see ProgressionGraphChecker.CheckLessons and #1673).
+describe('committed lesson content (content/lessons.json)', () => {
+	it('gives every live lesson a screenKey that resolves to a real ScreenDef.key', () => {
+		const screenKeys = new Set(GAME_SCREENS.map((s) => s.key));
+		const badScreenKeys = lessonsContent
+			.filter((lesson) => !lesson.retiredAt)
+			.filter((lesson) => !screenKeys.has(lesson.screenKey))
+			.map((lesson) => `${lesson.key} -> "${lesson.screenKey}"`);
+
+		expect(badScreenKeys).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary

`Lesson.ScreenKey` is a plain string, not an FK — screens are a frontend-only registry (`GAME_SCREENS` in `UI/src/routes/game/screens/screen-defs.ts`) with no backend representation. The backend's `ProgressionGraphChecker.CheckLessons` deliberately skips validating `screenKey` against real screens, leaving that check to the frontend — but no such frontend test existed yet, so a typo'd or stale `screenKey` (e.g. after a screen rename/removal) would silently degrade at runtime with nothing catching it in CI.

## Change

Added a test in `UI/src/tests/routes/game/screens/screen-defs.test.ts` (the existing home for `GAME_SCREENS` invariant tests) that:

- Imports the committed `content/lessons.json` export directly (`resolveJsonModule` is already enabled in `tsconfig.json`).
- Filters to live (non-retired) lessons.
- Asserts every live lesson's `screenKey` matches a `key` in `GAME_SCREENS`.

This is new (small) test infrastructure — no frontend test previously read `content/*.json` directly — since the issue flagged there wasn't yet an established pattern for it.

I verified the test actually catches a regression: temporarily corrupting `content/lessons.json` with a bogus `screenKey` made the new test fail with a clear message, then reverted.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — 3525/3525 passing (295/295 test files).
- [x] Manually verified the assertion fails on a corrupted `screenKey`, then restored the original content file.

Closes #1673

---
_Generated by Claude Code_


---
_Generated by [Claude Code](https://claude.ai/code/session_011xvRaLUmmJc9SrxbvUUG4t)_