### PR TITLE
Wire real tutorialAnchor targets into the Fight screen

### DIFF
--- a/UI/src/routes/game/screens/fight/BattlerCard.svelte
+++ b/UI/src/routes/game/screens/fight/BattlerCard.svelte
@@ -41,7 +41,7 @@
 	</div>
 
 	<!-- HP Bar -->
-	<div class="hp-bar-slot">
+	<div class="hp-bar-slot" use:tutorialAnchor={`fight-hp-bar-${side}`}>
 		<HpBar currentHealth={battler.currentHealth} {maxHealth} ariaLabel="{battler.name} health" />
 	</div>
 
@@ -60,7 +60,7 @@ import { EAttribute } from '$lib/api';
 import { type Battler } from '$lib/battle';
 import { formatNum, tintColor } from '$lib/common';
 import { enemyManager, playerManager } from '$lib/engine';
-import { HpBar, XpBar } from '$components';
+import { HpBar, XpBar, tutorialAnchor } from '$components';
 import ActiveEffectChips from './ActiveEffectChips.svelte';
 import CombatFloaters from './CombatFloaters.svelte';
 import Skills from './Skills.svelte';

--- a/UI/src/routes/game/screens/fight/CombatFloaters.svelte
+++ b/UI/src/routes/game/screens/fight/CombatFloaters.svelte
@@ -5,7 +5,13 @@
      its net heal in the regen hue (#1320, Area F). A reflect (#1330) floats over the original attacker
      with the shared combat-log reflect glyph and the side's hue — raw/untyped, never tinted by type.
      Purely presentational (aria-hidden) — the combat log is the accessible record of the same events. -->
-<div class="floaters" aria-hidden="true" data-testid={testId} style:--float-duration="{DURATION_MS}ms">
+<div
+	class="floaters"
+	aria-hidden="true"
+	data-testid={testId}
+	style:--float-duration="{DURATION_MS}ms"
+	use:tutorialAnchor={`fight-combat-log-${side}`}
+>
 	{#each floaters as floater (floater.id)}
 		<div
 			class="floater"
@@ -41,6 +47,7 @@ import { onCombatFloat, type CombatFloatEvent } from '$lib/engine';
 import { EDamageType, type ISkillDamagePortion } from '$lib/api';
 import LogGlyph from '$components/log-panel/LogGlyph.svelte';
 import DamageRatioBar from '$components/DamageRatioBar.svelte';
+import { tutorialAnchor } from '$components';
 import type { GlyphKind } from '$components/log-panel/log-kind';
 
 type Props = {

--- a/UI/src/routes/game/screens/fight/Skills.svelte
+++ b/UI/src/routes/game/screens/fight/Skills.svelte
@@ -1,4 +1,9 @@
-<div class="skills-row" class:reversed={side === 'enemy'} style:--ready-accent={readyAccent}>
+<div
+	class="skills-row"
+	class:reversed={side === 'enemy'}
+	style:--ready-accent={readyAccent}
+	use:tutorialAnchor={`fight-skill-bar-${side}`}
+>
 	{#each battler.skills as skill, index (skill?.id ?? -index - 1)}
 		<div class="skill-column">
 			{#if skill}
@@ -50,6 +55,7 @@ import {
 import SkillEffectBadge from '$components/SkillEffectBadge.svelte';
 import CooldownOverlay from '$components/CooldownOverlay.svelte';
 import { describedByTooltip } from '$components/tooltip/describedby-tooltip';
+import { tutorialAnchor } from '$components';
 import SkillTooltip from './SkillTooltip.svelte';
 import { chargeProjection } from './skill-cooldown';
 

--- a/UI/src/tests/routes/game/screens/fight/BattlerCard.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/BattlerCard.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
 import { EAttribute, type IAttribute } from '$lib/api';
+import { getTutorialAnchor } from '$components';
 
 // The card renders a Skills -> SkillTooltip subtree, which imports the battle engine and the
 // reference-data store at module load; both are mocked even though no hover happens here. The player
@@ -160,5 +161,16 @@ describe('BattlerCard', () => {
 			props: { battler: makeBattler({ name: 'Dire Wolf' }), side: 'enemy' }
 		});
 		expect(queryByTestId('enemy-power')).toBeNull();
+	});
+
+	it('registers its HP bar as a tutorial-tour anchor keyed by side', () => {
+		const player = render(BattlerCard, { props: { battler: makeBattler(), side: 'player' } });
+		expect(getTutorialAnchor('fight-hp-bar-player')).toBe(
+			player.getByTestId('player-card').querySelector('.hp-bar-slot')
+		);
+		player.unmount();
+
+		const enemy = render(BattlerCard, { props: { battler: makeBattler({ name: 'Dire Wolf' }), side: 'enemy' } });
+		expect(getTutorialAnchor('fight-hp-bar-enemy')).toBe(enemy.getByTestId('enemy-card').querySelector('.hp-bar-slot'));
 	});
 });

--- a/UI/src/tests/routes/game/screens/fight/CombatFloaters.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/CombatFloaters.test.ts
@@ -3,6 +3,7 @@ import { render, cleanup } from '@testing-library/svelte';
 import { flushSync } from 'svelte';
 import { EDamageType } from '$lib/api';
 import type { CombatFloatEvent } from '$lib/engine';
+import { getTutorialAnchor } from '$components';
 
 // CombatFloaters subscribes to the engine's combat-float hook at init. Capture the registered
 // callback so the test can drive events directly; the real `$lib/common` formatNum is used.
@@ -268,6 +269,15 @@ describe('CombatFloaters', () => {
 		vi.advanceTimersByTime(1600);
 		flushSync();
 		expect(getByTestId('enemy-floaters').querySelectorAll('.floater')).toHaveLength(0);
+	});
+
+	it('registers itself as a tutorial-tour anchor keyed by side', () => {
+		const enemy = render(CombatFloaters, { props: { side: 'enemy', testId: 'enemy-floaters' } });
+		expect(getTutorialAnchor('fight-combat-log-enemy')).toBe(enemy.getByTestId('enemy-floaters'));
+		enemy.unmount();
+
+		const player = render(CombatFloaters, { props: { side: 'player', testId: 'player-floaters' } });
+		expect(getTutorialAnchor('fight-combat-log-player')).toBe(player.getByTestId('player-floaters'));
 	});
 
 	it('drives the CSS animation duration from the JS constant via a custom property', () => {

--- a/UI/src/tests/routes/game/screens/fight/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/Skills.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, fireEvent } from '@testing-library/svelte';
 import { EAttribute, EModifierType, ESkillEffectTarget, type IAttribute } from '$lib/api';
+import { getTutorialAnchor } from '$components';
 
 // Skills renders a SkillTooltip child, which resolves the opponent through the battle engine
 // and attribute names through the reference-data store; both are mocked.
@@ -140,6 +141,15 @@ describe('Skills', () => {
 		// The misleading grid semantics are gone — no grid roles remain.
 		expect(container.querySelector('[role="grid"]')).toBeNull();
 		expect(container.querySelector('[role="gridcell"]')).toBeNull();
+	});
+
+	it('registers itself as a tutorial-tour anchor keyed by side', () => {
+		const player = render(Skills, { props: { battler, side: 'player' } });
+		expect(getTutorialAnchor('fight-skill-bar-player')).toBe(player.container.querySelector('.skills-row'));
+		player.unmount();
+
+		const enemy = render(Skills, { props: { battler, side: 'enemy' } });
+		expect(getTutorialAnchor('fight-skill-bar-enemy')).toBe(enemy.container.querySelector('.skills-row'));
 	});
 
 	it('associates every skill slot with the shared tooltip via aria-describedby', () => {

--- a/content/lessons.json
+++ b/content/lessons.json
@@ -18,7 +18,7 @@
       {
         "ordinal": 1,
         "text": "The bars above each combatant track HP. Whoever's hits zero first loses the fight, and the next enemy loads in automatically.",
-        "anchorKey": null
+        "anchorKey": "fight-hp-bar-player"
       },
       {
         "ordinal": 2,
@@ -41,12 +41,12 @@
       {
         "ordinal": 0,
         "text": "That hit landed harder than normal — a critical hit! Crits deal bonus damage a percentage of the time, so your damage per hit will naturally vary.",
-        "anchorKey": null
+        "anchorKey": "fight-combat-log-enemy"
       },
       {
         "ordinal": 1,
         "text": "The same goes on defense: sometimes an incoming attack misses entirely — a dodge. Don't read too much into any single hit; it's the average over a whole fight that matters.",
-        "anchorKey": null
+        "anchorKey": "fight-combat-log-player"
       }
     ]
   },
@@ -64,7 +64,7 @@
       {
         "ordinal": 0,
         "text": "See a skill icon fill back up and fire again on its own? That's its cooldown recharging. Each skill charges independently and activates the moment it's ready.",
-        "anchorKey": null
+        "anchorKey": "fight-skill-bar-player"
       },
       {
         "ordinal": 1,


### PR DESCRIPTION
## Summary

#1592 built the coach-mark tour mechanism (`TourPlayer.svelte`, the `use:tutorialAnchor` action and its anchor registry), but no screen component anywhere in `UI/src` registered an anchor. As a result, every step in the three lessons authored in #1605 used `anchorKey: null` and degraded to a centered, unanchored callout instead of pointing at the concrete UI it describes.

## Change

Registered `use:tutorialAnchor` on the three Fight-screen elements the issue calls out, keyed per side (`{key}-player` / `{key}-enemy`) so both the player and enemy `BattlerCard`/`Skills` instances can register safely without one clobbering the other's slot:

- `BattlerCard.svelte` — the `.hp-bar-slot` div → `fight-hp-bar-player` / `fight-hp-bar-enemy`
- `Skills.svelte` — the `.skills-row` div → `fight-skill-bar-player` / `fight-skill-bar-enemy`
- `CombatFloaters.svelte` — the `.floaters` overlay div → `fight-combat-log-player` / `fight-combat-log-enemy`

Then pointed the relevant lesson steps in `content/lessons.json` at these keys:

- `idle-loop-basics` step 2 ("the bars above each combatant track HP") → `fight-hp-bar-player`
- `crit-dodge-variance` step 1 (the crit) → `fight-combat-log-enemy` — a crit-capable skill exists in every starter kit, so the player's own hit landing the crit is the reliable path (per the lesson's own design notes), and that lands on the enemy card.
- `crit-dodge-variance` step 2 (the dodge) → `fight-combat-log-player` — "the same goes on defense" refers to an incoming attack against the player missing.
- `cooldown-charging` step 1 → `fight-skill-bar-player`

A few steps stay `anchorKey: null` on purpose — they're general/scene-setting statements (the intro welcome, "you don't have to watch every fight", "cooldown speed compounds with your other stats") that don't point at one specific control, so the centered-callout fallback is the right treatment for them.

**Judgment call worth flagging:** picking *which* side's element (player vs. enemy) each step anchors on isn't spelled out in the issue — I inferred it from the lesson text and design notes as described above. If that reads wrong once seen in the actual tour, it's a one-line `anchorKey` change in `content/lessons.json`, not a structural one.

Boss-mode components (`BossBattlerCard`, `BossHpBar`, etc.) are untouched — these lessons trigger very early (first Fight visit, first crit, first cooldown recharge), well before a player would reach a boss fight, so wiring boss anchors is out of scope here per the issue's "add anchors for other screens' lessons as they are authored" note.

## Test plan

- [x] Added a "registers itself as a tutorial-tour anchor keyed by side" test to `BattlerCard.test.ts`, `Skills.test.ts`, and `CombatFloaters.test.ts`, asserting `getTutorialAnchor` resolves to the right element for both `player` and `enemy`.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — 3527/3527 passing.
- [x] `dotnet build` — clean; confirmed `AnchorKey` validation is deliberately frontend-only (`ProgressionGraphChecker.cs`), so no backend change is needed for the content edit.
- [x] `dotnet test --filter "FullyQualifiedName~Content|FullyQualifiedName~Lesson"` — all passing (content/lesson graph-check tests unaffected).

Closes #1675


---
_Generated by [Claude Code](https://claude.ai/code/session_01DYnxrrQRxu5pLV1hCnASSA)_