### PR TITLE
Fix flaky PlayerProgressRepository cache-hash integration test (#1718)

### DIFF
--- a/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
@@ -332,7 +332,10 @@ namespace Game.Application.Tests.DataAccess
                 await repo.Save(progress); // first save: creates the hash with several statistic fields
             }
 
-            var fieldsAfterFirstSave = await redis.HashGetAllAsync(hashKey);
+            // The cache advance is a fire-and-forget HSET (Save returns once the write is dispatched, not once
+            // it lands), so poll rather than reading immediately — otherwise this races the write and sees a
+            // partial (or empty) hash (#1718).
+            var fieldsAfterFirstSave = await WaitForHashFieldCountAsync(redis, hashKey, minCount: 2);
             Assert.True(fieldsAfterFirstSave.Length > 1, "Expected the battle-completion save to touch more than one statistic row.");
 
             using (var scope = CreateScope())
@@ -346,7 +349,7 @@ namespace Game.Application.Tests.DataAccess
             // The second save's HSET only wrote the one new proficiency field — every field the first save
             // wrote is still present, proving a save's cache write is scoped to its own dirty rows rather than
             // re-serializing (and re-sending) the whole cached snapshot (#1635).
-            var fieldsAfterSecondSave = await redis.HashGetAllAsync(hashKey);
+            var fieldsAfterSecondSave = await WaitForHashFieldCountAsync(redis, hashKey, minCount: fieldsAfterFirstSave.Length + 1);
             Assert.Equal(fieldsAfterFirstSave.Length + 1, fieldsAfterSecondSave.Length);
             foreach (var field in fieldsAfterFirstSave)
             {
@@ -385,6 +388,27 @@ namespace Game.Application.Tests.DataAccess
         {
             var options = ConfigurationOptions.Parse(Containers.PubSubConnectionString);
             return await ConnectionMultiplexer.ConnectAsync(options);
+        }
+
+        // HashSetAndForget dispatches its HSET with CommandFlags.FireAndForget (RedisService.cs), so it can
+        // return before the write lands on the server — a read on a separate connection right after a Save can
+        // race it. Poll until the expected field count shows up rather than asserting on a single read (#1718).
+        private static async Task<HashEntry[]> WaitForHashFieldCountAsync(IDatabase redis, string hashKey, int minCount, int timeoutMs = 5000)
+        {
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            HashEntry[] fields;
+            do
+            {
+                fields = await redis.HashGetAllAsync(hashKey);
+                if (fields.Length >= minCount)
+                {
+                    return fields;
+                }
+
+                await Task.Delay(25);
+            } while (DateTime.UtcNow < deadline);
+
+            return fields;
         }
 
         private static async Task<ProgressUpdatedEvent> DequeueProgressEvent(IDatabase redis)


### PR DESCRIPTION
## Summary

`PlayerProgressRepositoryIntegrationTests.Save_OnlyWritesTheRowsThatChanged_LeavingEarlierCachedRowsInTheHashUntouched` failed intermittently, turning `test-backend` red on unrelated PRs (observed on #1717).

## Root cause

`PlayerProgressRepository.Save` advances the Redis cache via `ICacheService.HashSetAndForget`, which (`Game.Infrastructure/Cache/Redis/RedisService.cs:167-189`) dispatches its HSET Lua script with `CommandFlags.FireAndForget` — a deliberate perf choice to keep it off the hot inbound-message path. That means `Save` can return before the write has actually landed on the Redis server.

The test read the `Progress_{playerId}` hash on a **separate** Redis connection immediately after `Save` returned. Most of the time the fire-and-forget write had already landed by then, but occasionally the test's read raced it and observed a partial (≤1 field) hash, failing the `> 1` assertion.

The issue's own hypothesis pointed at the write-behind batch flush; that's not quite it (this test's `Save` calls take the "standalone" branch, which already awaits the batch flush before calling `AdvanceCache()`) — the race is specifically in the fire-and-forget `HSET` itself, not the batch/event-queue mechanism.

This isn't a new problem class: `RedisServiceIntegrationTests.cs` already has a `WaitForHashFieldCountAsync` polling helper for exercising `HashSetAndForget`, for exactly this reason. This PR applies the same pattern here instead of reinventing it.

## Fix

- Added a `WaitForHashFieldCountAsync` helper (mirroring the existing one in `RedisServiceIntegrationTests.cs`, adapted to the raw `IDatabase` this test file uses) that polls the hash until the expected field count appears, with a 5s timeout.
- Replaced both immediate `redis.HashGetAllAsync(hashKey)` reads in the flaky test with calls to the new helper.

No production code changed — `HashSetAndForget`'s fire-and-forget behavior is intentional and correct; the test just needs to account for it, like its sibling tests already do.

## Note on the issue

I noticed issue #1718 has a comment from an unaffiliated external account linking to a `.zip` "fix" — I did not download or use that file. This fix was derived independently from reading the actual repository/cache code.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test Game.Application.Tests` (full suite, 894 tests) — ran 3x back-to-back, 0 failures each run (previously ~50% flake rate per the issue's own repro)

Closes #1718


---
_Generated by [Claude Code](https://claude.ai/code/session_01DB1DF6BedWwqGggh7t6iNi)_