### PR TITLE
Mark PlayerData's always-set value-type properties as required

### DIFF
--- a/Game.Api/Models/Player/PlayerData.cs
+++ b/Game.Api/Models/Player/PlayerData.cs
@@ -6,15 +6,15 @@ namespace Game.Api.Models.Player
 {
     public class PlayerData : IModel
     {
-        public int Id { get; set; }
+        public required int Id { get; set; }
         public required string Name { get; set; }
-        public int Level { get; set; }
-        public int Exp { get; set; }
+        public required int Level { get; set; }
+        public required int Exp { get; set; }
         public required List<BattlerAttribute> Attributes { get; set; }
         public required List<UnlockedSkill> UnlockedSkills { get; set; }
-        public int CurrentZone { get; set; }
-        public int StatPointsGained { get; set; }
-        public int StatPointsUsed { get; set; }
+        public required int CurrentZone { get; set; }
+        public required int StatPointsGained { get; set; }
+        public required int StatPointsUsed { get; set; }
         public required List<LogPreference> LogPreferences { get; set; }
         public required List<PlayerLesson> Lessons { get; set; }
         public required InventoryData InventoryData { get; set; }


### PR DESCRIPTION
## Summary

Follow-up from review of #1679. That PR marked `PlayerData.PlayerRating` `required` on the premise that every other property on `PlayerData` was already `required`, but that premise didn't fully hold: `Id`, `Level`, `Exp`, `CurrentZone`, `StatPointsGained`, and `StatPointsUsed` were left unmarked despite sharing the exact same footgun (a value type silently defaulting to `0` if a future construction path forgets to set it).

## Decision

The issue asked to pick a rule intentionally: mark all always-set value-type properties `required` for consistency, or explicitly adopt a convention that value types stay unmarked.

I went with **marking them all `required`**. The rest of the codebase already establishes this as the standing convention — `required` on always-set value types (not just reference types) appears across 46 files (`Game.Core`, `Game.Api`, `Game.DataAccess`, etc.), and `PlayerRating` itself (#1679) is a direct precedent on this same model. Carving out a value-type exception here would be inconsistent with the rest of the domain, not a real simplification.

## Changes

- `Game.Api/Models/Player/PlayerData.cs`: marked `Id`, `Level`, `Exp`, `CurrentZone`, `StatPointsGained`, `StatPointsUsed` as `required`.
- Verified `PlayerData.FromPlayer` — the sole construction site solution-wide (confirmed via `grep -rn "new PlayerData"`) — already sets all six unconditionally, so this is a no-op behavior change.

## Test plan

- [x] `dotnet build Game.sln` — 0 warnings, 0 errors
- [x] `dotnet test Game.sln --no-build --no-restore` — 3012/3012 passing

No frontend changes.

Closes #1680


---
_Generated by [Claude Code](https://claude.ai/code/session_01F5jAg1irJJoGviFwfTtkow)_