### PR TITLE
Let retreatFromBoss force-abandon a still-in-progress boss battle

### DIFF
--- a/Game.Api/Models/Enemies/NewEnemyRequest.cs
+++ b/Game.Api/Models/Enemies/NewEnemyRequest.cs
@@ -9,5 +9,10 @@
         /// server-prefetched next battle discarded by a zone/build change during the cooldown — reports 0,
         /// so the abandon records no outcome. Null when not reported (the server falls back to wall-clock).</summary>
         public int? ClientBattleMs { get; set; }
+
+        /// <summary>When true, a still-in-progress battle is discarded rather than handed back unchanged —
+        /// the same override <c>ChallengeBoss</c> always applies. Lets a retreat leave a still-active boss
+        /// fight immediately instead of waiting for it to reach a real conclusion (#1690).</summary>
+        public bool ForceAbandon { get; set; }
     }
 }

--- a/Game.Api/Sockets/Commands/NewEnemy.cs
+++ b/Game.Api/Sockets/Commands/NewEnemy.cs
@@ -32,7 +32,7 @@ namespace Game.Api.Sockets.Commands
 
             var player = context.Session.Player;
 
-            var result = await _battleService.StartBattle(player, state, player.CurrentZoneId, Parameters.NewZoneId, clientBattleMs: Parameters.ClientBattleMs, cancellationToken: cancellationToken);
+            var result = await _battleService.StartBattle(player, state, player.CurrentZoneId, Parameters.NewZoneId, clientBattleMs: Parameters.ClientBattleMs, forceAbandon: Parameters.ForceAbandon, cancellationToken: cancellationToken);
 
             context.Session.SavePlayerState();
 

--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -1298,6 +1298,58 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task StartBattle_ForceAbandonAStillInProgressBossBattle_DiscardsItAndStartsAFreshIdleBattle()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // Mirrors StartBattle_AbandoningAStillInProgressBossBattle_HandsItBackWithBossFlagSet, but this
+            // NewEnemy request sets forceAbandon (retreat, #1690): the still-in-progress boss fight must be
+            // discarded instead of handed back, and a fresh idle battle started in its place — the same
+            // override StartBossBattle already applies unconditionally for ChallengeBoss.
+            var boss = await TestDataSeeder.CreateEnemyAsync(context, "Zone Boss", isBoss: true);
+            var bossSkill = await TestDataSeeder.CreateSkillAsync(context, "SlowBossSwipe", baseDamage: 1m, cooldownMs: 100_000_000);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, boss.Id, bossSkill.Id);
+            var idleEnemy = await TestDataSeeder.CreateEnemyAsync(context, "Idle Critter");
+            var idleSkill = await TestDataSeeder.CreateSkillAsync(context, "Nibble");
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, idleEnemy.Id, idleSkill.Id);
+            var zone = await TestDataSeeder.CreateZoneAsync(context, levelMin: 1, levelMax: 1, bossEnemyId: boss.Id, bossLevel: 1);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, idleEnemy.Id);
+
+            var playerSkill = await TestDataSeeder.CreateSkillAsync(context, "SlowPoke", baseDamage: 1m, cooldownMs: 100_000_000);
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, playerSkill.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+
+            var started = await battleService.StartBossBattle(player, state, zone.Id);
+            Assert.NotNull(started);
+            Assert.True(state.HasActiveBattle);
+            Assert.True(state.IsBossBattle);
+
+            // Still genuinely in progress (far under the 2-minute cap) — without forceAbandon this would be
+            // handed back unchanged, per the sibling test above.
+            state.BattleStartTime = DateTime.UtcNow.AddSeconds(-1);
+
+            var result = await battleService.StartBattle(player, state, zoneId: zone.Id, forceAbandon: true);
+
+            Assert.Equal(idleEnemy.Id, result.Enemy.Id);
+            Assert.Null(result.ElapsedOffsetMs);
+            Assert.False(result.IsBossBattle);
+            Assert.True(state.HasActiveBattle);
+            Assert.False(state.IsBossBattle);
+            Assert.Equal(idleEnemy.Id, state.ActiveEnemyId);
+        }
+
+        [Fact]
         public async Task ResolveStaleBattle_Concludes_ReturnsNullAndCreditsTheWin()
         {
             using var scope = CreateScope();

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -54,14 +54,18 @@ namespace Game.Application.Services
         // offline pass paces the same as the live idle loop.
         internal static readonly TimeSpan PostBattleCooldown = TimeSpan.FromSeconds(5);
 
-        public async Task<BattleStartResult> StartBattle(Player player, PlayerState state, int zoneId, int? newZoneId = null, DateTime? scheduledStartTime = null, int? clientBattleMs = null, CancellationToken cancellationToken = default)
+        public async Task<BattleStartResult> StartBattle(Player player, PlayerState state, int zoneId, int? newZoneId = null, DateTime? scheduledStartTime = null, int? clientBattleMs = null, bool forceAbandon = false, CancellationToken cancellationToken = default)
         {
             if (state.HasActiveBattle)
             {
-                // A still-in-progress handoff (#1595) means the existing battle hasn't concluded yet — hand
-                // it back instead of abandoning it for a fresh spawn.
-                if (await AbandonBattle(player, state, clientBattleMs, cancellationToken) is { } handoff)
+                var handoff = await AbandonBattle(player, state, clientBattleMs, cancellationToken);
+                if (handoff is not null && !forceAbandon)
                 {
+                    // A still-in-progress handoff (#1595) means the existing battle hasn't concluded yet —
+                    // hand it back instead of abandoning it for a fresh spawn, unless the caller explicitly
+                    // asked to force-discard it (forceAbandon) — the same override StartBossBattle always
+                    // applies for ChallengeBoss (#1690). Nothing was cleared or persisted for a
+                    // still-in-progress abandon, so proceeding to overwrite it below is safe either way.
                     return handoff;
                 }
             }

--- a/UI/src/lib/api/types/interfaces/enemies.ts
+++ b/UI/src/lib/api/types/interfaces/enemies.ts
@@ -54,4 +54,5 @@ export interface INewEnemyModel {
 export interface INewEnemyRequest {
 	newZoneId?: number;
 	clientBattleMs?: number;
+	forceAbandon: boolean;
 }

--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -191,8 +191,12 @@ export class EnemyManager {
 	 * *inside* this method's re-entrancy/supersession guard (rather than from the stage handler directly), so
 	 * a prefetched enemy can never double-spawn with a concurrent fetch nor clobber a fight a transition moved
 	 * on to — the same guarantees the fetch path relies on.
+	 *
+	 * `forceAbandon` discards a still-in-progress battle instead of the default hand-back — used by
+	 * {@link retreatFromBoss} so leaving a boss fight is immediate rather than waiting for it to conclude
+	 * (#1690), mirroring the unconditional discard `ChallengeBoss` already applies server-side.
 	 */
-	public async getNewEnemy(prepared?: PreparedBattle): Promise<void> {
+	public async getNewEnemy(prepared?: PreparedBattle, forceAbandon = false): Promise<void> {
 		const generation = this.fetchGeneration;
 		if (this.fetchingEnemy) {
 			// A fetch is already running. If it captured this same generation it's a genuine re-entrant
@@ -211,12 +215,12 @@ export class EnemyManager {
 				return;
 			}
 		}
-		const run = this.runFetchLoop(generation, prepared);
+		const run = this.runFetchLoop(generation, prepared, forceAbandon);
 		this.inFlightFetch = run;
 		await run;
 	}
 
-	private async runFetchLoop(generation: number, prepared?: PreparedBattle): Promise<void> {
+	private async runFetchLoop(generation: number, prepared?: PreparedBattle, forceAbandon = false): Promise<void> {
 		this.fetchingEnemy = true;
 		this.fetchingGeneration = generation;
 		try {
@@ -254,7 +258,8 @@ export class EnemyManager {
 			while (this.started && generation === this.fetchGeneration) {
 				const result = await apiSocket.sendSocketCommand('NewEnemy', {
 					newZoneId: playerManager.currentZone,
-					clientBattleMs
+					clientBattleMs,
+					forceAbandon
 				});
 				// The loop condition only gates the top of each iteration, so a stop / superseding
 				// transition that lands while parked on the await above (not on the cancellable backoff)
@@ -399,7 +404,11 @@ export class EnemyManager {
 		}
 	}
 
-	/** Retreat from an in-progress boss fight back to the normal idle farm loop. */
+	/**
+	 * Retreat from an in-progress boss fight back to the normal idle farm loop. Force-abandons the boss
+	 * battle server-side (#1690) — mirroring the unconditional discard `challengeBoss()` gets for free —
+	 * so a still-active fight ends immediately instead of being handed back and resumed under boss mode.
+	 */
 	public async retreatFromBoss() {
 		if (this.transitioning) {
 			if (this.mode === 'idle') {
@@ -418,7 +427,7 @@ export class EnemyManager {
 		try {
 			// getNewEnemy self-guards via the fetch generation, so a press superseding this retreat is
 			// abandoned there; endTransition then leaves the guard for whichever transition is current.
-			await this.getNewEnemy();
+			await this.getNewEnemy(undefined, true);
 		} finally {
 			this.endTransition(generation);
 		}

--- a/UI/src/tests/lib/api/api-socket.test.ts
+++ b/UI/src/tests/lib/api/api-socket.test.ts
@@ -193,7 +193,7 @@ describe('ApiSocket', () => {
 
 		it('assigns incrementing command IDs', async () => {
 			const p1 = apiSocket.sendSocketCommand('DefeatEnemy', { clientTotalMs: 1 });
-			const p2 = apiSocket.sendSocketCommand('NewEnemy', { newZoneId: 1 });
+			const p2 = apiSocket.sendSocketCommand('NewEnemy', { newZoneId: 1, forceAbandon: false });
 			await flushMicrotasks();
 			const ws = lastWs();
 

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -596,6 +596,19 @@ describe('EnemyManager boss mode', () => {
 		expect(manager.currentEnemy).toEqual(normalInstance);
 	});
 
+	it('retreat force-abandons a still-in-progress boss fight instead of asking the backend to hand it back', async () => {
+		// #1690: retreat must not resume the same boss fight even if the server would otherwise hand a
+		// still-active battle back unchanged (as an ordinary NewEnemy does). The frontend signals the
+		// discard via forceAbandon; the backend-side discard itself is pinned by
+		// BattleServiceIntegrationTests.StartBattle_ForceAbandonAStillInProgressBossBattle_DiscardsItAndStartsAFreshIdleBattle.
+		await manager.challengeBoss();
+		expect(manager.mode).toBe('boss');
+
+		await manager.retreatFromBoss();
+
+		expect(send).toHaveBeenCalledWith('NewEnemy', expect.objectContaining({ forceAbandon: true }));
+	});
+
 	it('ignores retreat when not engaged in a boss fight', async () => {
 		await manager.retreatFromBoss();
 		expect(send).not.toHaveBeenCalledWith('NewEnemy', expect.anything());
@@ -940,7 +953,7 @@ describe('EnemyManager boss mode', () => {
 		expect(send).not.toHaveBeenCalledWith('BattleLost');
 		// The drawn battle was fought to the cap, so the fetch reports the elapsed time the client simulated
 		// (battleEngine.timeElapsed) — the backend abandon re-simulates that window and records the draw.
-		expect(send).toHaveBeenCalledWith('NewEnemy', { newZoneId: 3, clientBattleMs: 8880 });
+		expect(send).toHaveBeenCalledWith('NewEnemy', { newZoneId: 3, clientBattleMs: 8880, forceAbandon: false });
 		expect(manager.mode).toBe('idle');
 	});
 
@@ -1032,7 +1045,7 @@ describe('EnemyManager boss mode', () => {
 		// The bundled enemy was for zone 3; the player is now in zone 7, so it is discarded and a fresh enemy
 		// is fetched for (and the server told about) the new zone. The discarded prefetch was never fought, so
 		// the fetch reports clientBattleMs 0 — the backend records no phantom abandon for it.
-		expect(send).toHaveBeenCalledWith('NewEnemy', { newZoneId: 7, clientBattleMs: 0 });
+		expect(send).toHaveBeenCalledWith('NewEnemy', { newZoneId: 7, clientBattleMs: 0, forceAbandon: false });
 		expect(manager.currentEnemy).toEqual(normalInstance);
 	});
 
@@ -1056,7 +1069,7 @@ describe('EnemyManager boss mode', () => {
 		await handled;
 
 		// The never-fought prefetch reports clientBattleMs 0, so the backend records no phantom abandon for it.
-		expect(send).toHaveBeenCalledWith('NewEnemy', { newZoneId: 3, clientBattleMs: 0 });
+		expect(send).toHaveBeenCalledWith('NewEnemy', { newZoneId: 3, clientBattleMs: 0, forceAbandon: false });
 		expect(manager.currentEnemy).toEqual(normalInstance);
 	});
 

--- a/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
@@ -81,7 +81,11 @@ describe('EnemyManager.getNewEnemy', () => {
 
 		await manager.getNewEnemy();
 
-		expect(sendSocketCommand).toHaveBeenCalledWith('NewEnemy', { newZoneId: 3 });
+		expect(sendSocketCommand).toHaveBeenCalledWith('NewEnemy', {
+			newZoneId: 3,
+			clientBattleMs: undefined,
+			forceAbandon: false
+		});
 	});
 
 	it('stores the enemy and notifies listeners on success', async () => {
@@ -291,7 +295,13 @@ describe('EnemyManager.start', () => {
 
 		manager.start();
 
-		await vi.waitFor(() => expect(sendSocketCommand).toHaveBeenCalledWith('NewEnemy', { newZoneId: 3 }));
+		await vi.waitFor(() =>
+			expect(sendSocketCommand).toHaveBeenCalledWith('NewEnemy', {
+				newZoneId: 3,
+				clientBattleMs: undefined,
+				forceAbandon: false
+			})
+		);
 		expect(manager.currentEnemy).toEqual(makeEnemy(5));
 	});
 
@@ -372,6 +382,12 @@ describe('EnemyManager Home zone', () => {
 		manager.navigateToZone(COMBAT_ZONE);
 
 		expect(playerManager.currentZone).toBe(COMBAT_ZONE);
-		await vi.waitFor(() => expect(sendSocketCommand).toHaveBeenCalledWith('NewEnemy', { newZoneId: COMBAT_ZONE }));
+		await vi.waitFor(() =>
+			expect(sendSocketCommand).toHaveBeenCalledWith('NewEnemy', {
+				newZoneId: COMBAT_ZONE,
+				clientBattleMs: undefined,
+				forceAbandon: false
+			})
+		);
 	});
 });


### PR DESCRIPTION
## Summary

Closes #1690.

`retreatFromBoss()` couldn't instantly leave a still-in-progress boss fight, unlike `challengeBoss()`:

- `challengeBoss()` → `ChallengeBoss` → `BattleService.StartBossBattle` unconditionally discards any in-progress battle (even a genuinely-ongoing one) and proceeds — a deliberate override.
- `retreatFromBoss()` → `NewEnemy` → `BattleService.StartBattle` only discards a battle that's actually *concluded*; a still-active fight (boss or idle) is handed back **unchanged**, `IsBossBattle` included — so post-#1689, pressing retreat while the boss fight is still going flips the client's `mode` right back to `'boss'` and the same fight resumes.

## Decision

The issue asked to decide between force-abandon symmetry with `ChallengeBoss`, or keeping the current wait-it-out behavior (bounded by the 2-minute battle cap anyway). I went with **symmetry**: a player choosing to retreat should be able to leave immediately, the same way choosing to challenge the boss already discards whatever's running. `game-design.md`'s Battle Outcomes section already frames "retreating from a boss" as a walk-away action, which reads as the intended UX.

## Changes

- **Backend**: `BattleService.StartBattle` gains an opt-in `forceAbandon` parameter — when the existing handoff is still in progress, `forceAbandon: true` discards it and starts fresh instead of handing it back, mirroring exactly what `StartBossBattle` already does unconditionally for `ChallengeBoss`. Threaded through a new `NewEnemyRequest.ForceAbandon` field (codegen'd to the frontend). Ordinary `NewEnemy` calls (idle loop, zone-switch, reconnect) default to `false` and keep the existing hand-back behavior — this closes the "retreat" gap specifically, not the general hand-back invariant `#1595` relies on.
- **Frontend**: `enemy-manager.ts`'s `getNewEnemy`/`runFetchLoop` thread an optional `forceAbandon` flag into the `NewEnemy` socket call; `retreatFromBoss()` passes `true`.

Nothing was cleared or persisted for a still-in-progress abandon either way, so proceeding to overwrite it in `StartBattle` is safe — same reasoning `StartBossBattle`'s existing comment already documents.

## Note on scope

This closes the gap only for `retreatFromBoss`. It intentionally does **not** touch the general `NewEnemy` zone-switch-mid-battle hand-back (which still waits out an in-progress fight) — that's the `#1595` stale-battle-recovery invariant, out of scope here.

## Test plan

- [x] Backend: new `BattleServiceIntegrationTests.StartBattle_ForceAbandonAStillInProgressBossBattle_DiscardsItAndStartsAFreshIdleBattle`, mirroring the existing hand-back-pinning sibling test but asserting the force-discard instead.
- [x] Frontend: new `enemy-manager-boss.test.ts` case asserting `retreatFromBoss()` sends `forceAbandon: true`; updated exact-object `NewEnemy` call assertions across the existing suites for the new required field.
- [x] `dotnet build` + full backend test suite (`Game.Core.Tests`, `Game.Infrastructure.Tests`, `Game.Application.Tests`, `Game.Api.Tests`) — all passing.
- [x] `dotnet format --verify-no-changes` — clean.
- [x] Frontend `npm run lint` (ESLint + svelte-check) and `npm run test:unit:ci` (3532 tests) — all passing.
- [x] Codegen re-run confirms no drift beyond the intended `INewEnemyRequest.forceAbandon` addition.


---
_Generated by [Claude Code](https://claude.ai/code/session_012m43zqNvRRnpmbV6Fgp2p1)_