### PR TITLE
Fix stale countdown ring on cross-type shared-expiry reset

### DIFF
--- a/UI/src/lib/battle/battler.ts
+++ b/UI/src/lib/battle/battler.ts
@@ -311,6 +311,7 @@ export class Battler {
 		// on the same tick (see advanceEffects).
 		for (const v of this.activeEffects) {
 			if (v.attribute === effect.attributeId) {
+				v.durationMs = effect.durationMs;
 				v.remainingMs = effect.durationMs;
 				v.renderRemainingMs = effect.durationMs;
 			}

--- a/UI/src/lib/battle/battler.ts
+++ b/UI/src/lib/battle/battler.ts
@@ -289,7 +289,6 @@ export class Battler {
 		if (view) {
 			view.totalAmount = combinedAmount;
 			view.count++;
-			view.durationMs = effect.durationMs;
 			foldSourceContribution(view.sources, effect.id, amount, isMultiplicative);
 		} else {
 			view = {

--- a/UI/src/tests/lib/battle/battler-effects.test.ts
+++ b/UI/src/tests/lib/battle/battler-effects.test.ts
@@ -310,6 +310,23 @@ describe('Battler skill-effect bookkeeping', () => {
 		expect(battler.activeEffects[0].sources).toEqual([{ sourceId: 1, amount: 10, count: 2 }]);
 	});
 
+	it('adopts the new duration on a sibling view when a shared-expiry reset crosses modifier types', () => {
+		const battler = makeBattler();
+
+		battler.applyEffect(effect(1, EAttribute.Strength, EModifierType.Additive, 5, 5000));
+		battler.applyEffect(effect(2, EAttribute.Strength, EModifierType.Multiplicative, 2, 5000));
+		expect(battler.activeEffects).toHaveLength(2);
+
+		// Re-applying the multiplicative effect at a shorter duration resets the shared remaining for
+		// both views; the additive sibling's durationMs must move with it, not stay pinned at 5000, or
+		// its countdown ring renders against the wrong denominator.
+		battler.applyEffect(effect(2, EAttribute.Strength, EModifierType.Multiplicative, 2, 2000));
+
+		const additiveView = battler.activeEffects.find((v) => v.modifierType === EModifierType.Additive);
+		expect(additiveView?.durationMs).toBe(2000);
+		expect(additiveView?.remainingMs).toBe(2000);
+	});
+
 	it('folds different source effects on one attribute+type into one view with a per-source breakdown', () => {
 		const battler = makeBattler();
 


### PR DESCRIPTION
## Summary

Closes #1731.

In `UI/src/lib/battle/battler.ts`'s `applyEffect`, the shared-expiry reset loop (the block that resets every effect view on an attribute to the newest application's remaining time) updated `remainingMs`/`renderRemainingMs` on every sibling view, but only updated `durationMs` on the one view matching the applied effect's `(attribute, modifierType)`.

Scenario: an additive buff (5000ms) and a multiplicative effect (2000ms) are both active on the same attribute. Re-applying the 2000ms multiplicative effect resets the additive view's `remainingMs` to 2000 while its `durationMs` stays pinned at 5000 — so `ActiveEffectChips.svelte`'s countdown ring (`renderRemainingMs / durationMs`) renders against the wrong denominator (40% full immediately, or pinned near 100% depending on direction).

This is display-only — the parity-relevant expiry bookkeeping (which effects actually expire when) was already correct; only the ring fraction was wrong.

## Fix

One line: the reset loop now also updates `durationMs` on every sibling view, matching what it already does for `remainingMs`/`renderRemainingMs`.

## Tests

Added a case to `UI/src/tests/lib/battle/battler-effects.test.ts` pinning that a shared-expiry reset crossing modifier types updates the sibling view's `durationMs` (not just `remainingMs`), reproducing the additive/multiplicative scenario from the issue.

## Test plan

- [x] `npm run test:unit:ci` — full frontend suite passes (295 files, 3533 tests).
- [x] `npm run lint` — eslint + svelte-check clean, 0 errors/warnings.
- [ ] Backend unaffected (frontend-only display bug) — no backend verification needed.

Closes #1731


---
_Generated by [Claude Code](https://claude.ai/code/session_011kCQgnRxcQDky5FGRZcGiy)_