### PR TITLE
Fix synchronous Worker construction throw bypassing the setInterval fallback

### DIFF
--- a/UI/src/lib/engine/tick-source.ts
+++ b/UI/src/lib/engine/tick-source.ts
@@ -10,19 +10,31 @@ export interface TickSource {
 }
 
 export function createTickSource(onTick: () => void): TickSource {
+	let worker: Worker | null = null;
+
 	if (typeof Worker !== 'undefined') {
-		let worker: Worker | null = new Worker(new URL('./tick-worker.ts', import.meta.url), {
-			type: 'module'
-		});
+		try {
+			worker = new Worker(new URL('./tick-worker.ts', import.meta.url), {
+				type: 'module'
+			});
+		} catch (err) {
+			// A CSP worker-src restriction throws synchronously from the constructor itself,
+			// unlike a worker script failure, which only ever surfaces via the async onerror below.
+			console.error('The logical engine tick worker failed to start, falling back to setInterval', err);
+		}
+	}
+
+	if (worker !== null) {
+		const activeWorker = worker;
 		let fallbackHandle: number | null = null;
 
-		worker.onmessage = () => onTick();
-		worker.onerror = (ev) => {
+		activeWorker.onmessage = () => onTick();
+		activeWorker.onerror = (ev) => {
 			if (worker === null) {
 				return;
 			}
 			console.error('The logical engine tick worker failed, falling back to setInterval', ev);
-			worker.terminate();
+			activeWorker.terminate();
 			worker = null;
 			fallbackHandle = window.setInterval(onTick, pollingIntervalMs);
 		};

--- a/UI/src/tests/lib/engine/tick-source.test.ts
+++ b/UI/src/tests/lib/engine/tick-source.test.ts
@@ -75,7 +75,7 @@ describe('createTickSource', () => {
 
 	it('falls back to window.setInterval when the worker fails to start', () => {
 		vi.stubGlobal('Worker', MockWorker);
-		vi.spyOn(console, 'error').mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		vi.useFakeTimers();
 
 		const onTick = vi.fn();
@@ -92,5 +92,31 @@ describe('createTickSource', () => {
 		source.stop();
 		vi.advanceTimersByTime(pollingIntervalMs * 5);
 		expect(onTick).toHaveBeenCalledTimes(callCount);
+		errorSpy.mockRestore();
+	});
+
+	it('falls back to window.setInterval when the Worker constructor throws synchronously', () => {
+		class ThrowingWorker {
+			constructor() {
+				throw new DOMException('Refused to construct a worker', 'SecurityError');
+			}
+		}
+		vi.stubGlobal('Worker', ThrowingWorker);
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.useFakeTimers();
+
+		const onTick = vi.fn();
+		const source = createTickSource(onTick);
+
+		expect(errorSpy).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(pollingIntervalMs * 3);
+		expect(onTick.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+		const callCount = onTick.mock.calls.length;
+		source.stop();
+		vi.advanceTimersByTime(pollingIntervalMs * 5);
+		expect(onTick).toHaveBeenCalledTimes(callCount);
+		errorSpy.mockRestore();
 	});
 });


### PR DESCRIPTION
## Summary

Closes #1732.

#1676 added a `setInterval` fallback for when the logical engine's tick worker fails — but only via the async `onerror` event (`UI/src/lib/engine/tick-source.ts`). A `new Worker(...)` blocked by a CSP `worker-src` restriction throws **synchronously** in Chromium, which would propagate out of `createTickSource` → `LogicalEngine.start()` → `startGame` and leave the whole game loop dead with no fallback — exactly the failure #1676 set out to survive.

## Fix

`createTickSource` now wraps the `new Worker(...)` construction in a try/catch. On a synchronous construction failure, it logs the error and falls through to the same `window.setInterval` branch used both for environments without `Worker` and for the existing async `onerror` fallback — no new code path, just reusing what's already there.

## Incidental test fix

While adding a test for the new path, I found the existing `'falls back to window.setInterval when the worker fails to start'` test never restored its `console.error` spy (`errorSpy.mockRestore()` was missing). Because Vitest's `spyOn` on an already-spied method reuses the same mock, that stale spy's call history leaked into later tests in the file and caused a flaky assertion in my new test. Restored it there, matching the pattern already used by the sibling `'logs a diagnosable error...'` test.

## Tests

- `UI/src/tests/lib/engine/tick-source.test.ts`: added a case where the `Worker` constructor itself throws (a `DOMException`, mirroring a CSP rejection), asserting the error is logged once and the source falls back to ticking via `setInterval`.
- Fixed the pre-existing spy leak noted above.

## Test plan

- [x] `npm run lint` — eslint + svelte-check clean, 0 errors/warnings.
- [x] `npm run test:unit:ci` — full frontend suite passes (295 files, 3533 tests).
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_019YDguG6Xy52pKsqS36fejb)_