### PR TITLE
Fix skills loadout rollback clobbering an externally-resynced loadout

### DIFF
--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -150,22 +150,23 @@ export class SkillsView {
 	dragIndex = $state<number | null>(null);
 
 	constructor() {
-		this.syncFromPlayer();
-	}
-
-	/** (Re)seed the committed baseline + inspector selection from the player manager. */
-	syncFromPlayer(): void {
-		this.committed = [...playerManager.selectedSkills];
-		this.pendingLoadout = null;
-		if (this.selectedId < 0) {
-			this.selectedId = this.equipped[0] ?? staticData.skills?.[0]?.id ?? -1;
-		}
+		// Reading `equipped` seeds `committed` via its idle branch below.
+		this.selectedId = this.equipped[0] ?? staticData.skills?.[0]?.id ?? -1;
 	}
 
 	/** Working equipped loadout, ordered by priority: the pending optimistic edit while a commit is in
 	 *  flight, otherwise the player manager's committed loadout — so an external loadout change (e.g. a
-	 *  challenge skill unlock or server reconciliation) is reflected once no edit is pending. */
-	readonly equipped = $derived(this.pendingLoadout ?? [...playerManager.selectedSkills]);
+	 *  challenge skill unlock or server reconciliation) is reflected once no edit is pending. While idle
+	 *  (no edit pending), this also re-seeds {@link committed} from the manager, so an external resync
+	 *  becomes the rollback target for the next edit rather than a stale pre-resync baseline — every edit
+	 *  path reads {@link equipped} before calling {@link commit}, so `committed` is always current by then. */
+	readonly equipped = $derived.by(() => {
+		if (this.pendingLoadout !== null) {
+			return this.pendingLoadout;
+		}
+		this.committed = [...playerManager.selectedSkills];
+		return this.committed;
+	});
 
 	/** The loadout cap (number of equip slots) — the single generated game constant. */
 	readonly cap = MAX_SELECTED_SKILLS;

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -587,6 +587,23 @@ describe('SkillsView — persistence failure', () => {
 		mockPlayerManager.setSelectedSkills([3]); // external write
 		await vi.waitFor(() => expect(view.equipped).toEqual([3]));
 	});
+
+	it('rolls back a later failed edit to a settled external resync, not the pre-resync baseline', async () => {
+		// A resync (e.g. a dead-lettered-command resync replacing the authoritative loadout) lands while a
+		// commit is in flight and is still in effect once that commit settles. A further edit that fails
+		// must roll back to the resynced loadout — not the stale pre-resync baseline `committed` was seeded
+		// with at construction (the bug: nothing ever re-seeded `committed` from an idle external change).
+		view.toggle(0); // [0, 1, 2] → [1, 2], in flight, succeeds
+		mockPlayerManager.setSelectedSkills([3]); // external resync lands mid-flight
+		await vi.waitFor(() => expect(view.equipped).toEqual([3])); // settles once the commit resolves
+
+		sendSocketCommand.mockResolvedValueOnce({ error: 'nope' });
+		view.toggle(0); // edit from the resynced loadout → [3, 0], fails
+		expect(view.equipped).toEqual([3, 0]); // optimistic
+		await vi.waitFor(() => expect(toastError).toHaveBeenCalled());
+		expect(view.equipped).toEqual([3]); // rolls back to the resynced loadout, not [1, 2]
+		expect(mockPlayerManager.selectedSkills).toEqual([3]);
+	});
 });
 
 describe('SkillsView — compare-vs toughness', () => {


### PR DESCRIPTION
## Summary

Closes #1735.

In `UI/src/routes/game/screens/skills/skills-view.svelte.ts`, the rollback baseline `committed` was only ever seeded once at construction (via `syncFromPlayer`) and advanced only by this view's own successful commits. But the authoritative loadout can be replaced mid-session by an external resync (e.g. `resyncPlayerAndInventory` fired off a `ServerCommandFailed` push) — and nothing ever folded that external change into `committed`.

Scenario: screen mounts with loadout A → a dead-lettered-command resync sets the manager to authoritative loadout B while no edit is pending → player edits → the commit fails → rollback writes `committed` (still A, or a stale intermediate value) over B, clobbering the resynced state and silently diverging client and server until reload.

## Fix

`equipped` now re-seeds `committed` from `playerManager.selectedSkills` whenever no edit is pending (the idle branch), instead of only at construction:

```ts
readonly equipped = $derived.by(() => {
	if (this.pendingLoadout !== null) {
		return this.pendingLoadout;
	}
	this.committed = [...playerManager.selectedSkills];
	return this.committed;
});
```

Every edit path (`toggle`, `swapInto`, `reorder`) already reads `this.equipped` before calling `commit`, so `committed` is guaranteed current at the moment a new edit starts. This also let the now-redundant `syncFromPlayer` method be folded away — it was only ever called from the constructor and its `committed` seeding is now handled by `equipped` itself.

## Tests

Added a case to `UI/src/tests/routes/game/screens/skills/skills-view.test.ts` reproducing the scenario: a commit succeeds, an external resync lands and settles, then a *further* edit fails — asserting the rollback lands on the resynced loadout rather than the pre-resync baseline. Verified this test fails against the pre-fix code (rolls back to the stale baseline) and passes with the fix.

## Test plan

- [x] `npm run test:unit:ci` — full frontend suite passes (295 files, 3534 tests).
- [x] `npm run lint` — eslint + svelte-check clean, 0 errors/warnings.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZLpYVSQ3pKd71G9FTj6P4)_