### PR TITLE
Clear PlayerProgress dirty tracking after a successful save

### DIFF
--- a/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
@@ -85,6 +85,29 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task Save_SavingTheSameAggregateAgainWithoutFurtherMutation_EnqueuesNothing()
+        {
+            var playerId = await SeedPlayerAsync();
+            using var multiplexer = await ConnectRedisAsync();
+            var redis = multiplexer.GetDatabase();
+
+            using var scope = CreateScope();
+            var repo = scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>();
+            var progress = new PlayerProgress(MakeDomainPlayer(playerId), [], [], []);
+            progress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000,
+                new BattleStats(), isBossBattle: false, zoneId: 0);
+
+            await repo.Save(progress);
+            Assert.Equal(1, await redis.ListLengthAsync(Constants.PUBSUB_PLAYER_QUEUE));
+
+            // Saving the exact same aggregate a second time, with no new mutation, must not re-enqueue the
+            // rows the first save already persisted — Save clears the dirty tracking once its own envelope
+            // is buffered (the double-publish sharp edge a future multi-step caller could otherwise hit).
+            await repo.Save(progress);
+            Assert.Equal(1, await redis.ListLengthAsync(Constants.PUBSUB_PLAYER_QUEUE));
+        }
+
+        [Fact]
         public async Task Save_WritesCache_SoASubsequentReadIsServedWithoutTheDatabase()
         {
             var playerId = await SeedPlayerAsync();

--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -845,6 +845,38 @@ namespace Game.Core.Tests.Progress
         }
 
         [Fact]
+        public void AcceptChanges_ClearsAllThreeDirtySets()
+        {
+            var progress = MakeProgress();
+            progress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000,
+                new BattleStats { PlayerDamageDealt = 10.0 }, isBossBattle: false, zoneId: 0);
+            progress.EvaluateChallenges([MakeChallenge(id: 0, EChallengeType.EnemiesKilled, goal: 5)]);
+            progress.SetProficiencyProgress(proficiencyId: 3, level: 1, xp: 40m);
+
+            progress.AcceptChanges();
+
+            Assert.Empty(progress.DirtyStatistics);
+            Assert.Empty(progress.DirtyChallenges);
+            Assert.Empty(progress.DirtyProficiencies);
+        }
+
+        [Fact]
+        public void AcceptChanges_ThenMutatingAgain_DirtiesOnlyTheNewMutation()
+        {
+            // Simulates a saved aggregate reused for a second mutation: the first save's rows must not
+            // resurface in the persist set once a new, unrelated statistic is touched.
+            var progress = MakeProgress();
+            progress.RecordBattleCompleted(MakeEnemy(id: 1), victory: true, playerDied: false, totalMs: 1000,
+                new BattleStats { PlayerDamageDealt = 10.0 }, isBossBattle: false, zoneId: 0);
+            progress.AcceptChanges();
+
+            progress.SetProficiencyProgress(proficiencyId: 3, level: 1, xp: 40m);
+
+            Assert.Empty(progress.DirtyStatistics);
+            Assert.Equal(3, Assert.Single(progress.DirtyProficiencies).ProficiencyId);
+        }
+
+        [Fact]
         public void RecordBattleCompleted_MarksOnlyTheTouchedStatisticsDirty()
         {
             var progress = MakeProgress();

--- a/Game.Core/Progress/PlayerProgress.cs
+++ b/Game.Core/Progress/PlayerProgress.cs
@@ -244,6 +244,18 @@ namespace Game.Core.Progress
             _proficiencies.TryGetValue(proficiencyId, out proficiency);
 
         /// <summary>
+        /// Clears the dirty-row tracking, so a subsequent save of this same aggregate re-enqueues and
+        /// re-persists only rows mutated since <em>this</em> point rather than every row dirtied since load.
+        /// Called by the repository once a save's envelope has been buffered.
+        /// </summary>
+        public void AcceptChanges()
+        {
+            _dirtyStatistics.Clear();
+            _dirtyChallenges.Clear();
+            _dirtyProficiencies.Clear();
+        }
+
+        /// <summary>
         /// Sets a proficiency's absolute level and accumulated XP, creating the row on first training, and
         /// marks it dirty for the write-behind persist. The XP → level computation against the authored curve
         /// belongs to the XP-accrual sub-issue (#1116); this is the persistence seam it writes its result

--- a/Game.DataAccess/Repositories/PlayerProgressRepository.cs
+++ b/Game.DataAccess/Repositories/PlayerProgressRepository.cs
@@ -98,6 +98,10 @@ namespace Game.DataAccess.Repositories
             };
             _updateBatch.Add(envelope);
 
+            // The envelope above already captured this save's changed rows, so clearing the dirty tracking
+            // now is safe: a second save of this same aggregate (without further mutation) enqueues nothing.
+            progress.AcceptChanges();
+
             // The cache is the source of truth, but it is stored as a Redis hash keyed by row identity, so
             // advancing it only needs to HSET the rows this save actually touched (changed, captured now off
             // the live aggregate so a deferred advance still reflects this save's state) rather than


### PR DESCRIPTION
## Summary

Closes #1703.

`PlayerProgressRepository.Save` reads `DirtyStatistics`/`DirtyChallenges`/`DirtyProficiencies` off the aggregate to build the write-behind event and cache HSET, but nothing ever cleared those dirty sets. Every current caller loads-mutates-saves an aggregate exactly once, so this was harmless in practice — but it was an invisible contract: a future caller that saved the same aggregate twice (e.g. a multi-step command) would silently re-enqueue and re-persist every row dirtied since load, double-publishing the `ProgressUpdated` event.

## Changes

- `Game.Core/Progress/PlayerProgress.cs`: added `AcceptChanges()`, which clears all three dirty sets (statistics, challenges, proficiencies).
- `Game.DataAccess/Repositories/PlayerProgressRepository.cs`: `Save` now calls `progress.AcceptChanges()` right after the write-behind envelope is buffered. This is safe even in the deferred-cache-advance path, since `Save` already snapshots the changed rows (`changed`/`fields`) before touching the dirty sets.
- Tests:
  - `Game.Core.Tests/Progress/PlayerProgressTests.cs`: two new unit tests — `AcceptChanges` clears all three dirty sets, and a subsequent mutation after `AcceptChanges` dirties only the new change (the prior save's rows don't resurface).
  - `Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs`: new integration test pinning that saving the same aggregate a second time (no further mutation) enqueues nothing onto the write-behind queue.

## Test plan

- [x] `dotnet build` — solution builds clean, 0 warnings.
- [x] `dotnet test` — full solution suite passes (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests): 3024/3024 passing, including the new tests above.
- [ ] Frontend unaffected (backend-only change) — no frontend verification needed.

Closes #1703


---
_Generated by [Claude Code](https://claude.ai/code/session_01NoQsGMscnAvtjcAi7AoPCH)_