### PR TITLE
Thread an injected timestamp through challenge completion instead of DateTime.UtcNow

### DIFF
--- a/Game.Application.Tests/Services/OfflineProgressServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/OfflineProgressServiceIntegrationTests.cs
@@ -134,6 +134,42 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task SimulateOfflineProgress_AwayLongerThanSimulationCap_StampsChallengeCompletedAtWithinCappedWindow()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var setup = await SeedWinningScenarioAsync(scope, reload: false);
+            var item = await TestDataSeeder.CreateItemAsync(context);
+            var challenge = await TestDataSeeder.CreateChallengeAsync(
+                context, challengeTypeId: EChallengeType.EnemiesKilled, progressGoal: 3m, rewardItemId: item.Id);
+            await ReloadReferenceCachesAsync();
+
+            var (player, state) = await LoadAsync(scope, setup.PlayerId);
+            var offlineProgressService = scope.ServiceProvider.GetRequiredService<OfflineProgressService>();
+            var progressRepo = scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>();
+
+            // Well beyond MaximumOfflineSimulation (10h): the simulated window is clamped to the cap, so a
+            // challenge completed within it must be stamped at the capped window's end, not at this claim
+            // (which is ~10h later than the window it was actually simulated within).
+            var lastActivity = DateTime.UtcNow.AddHours(-20);
+            player.LastActivity = lastActivity;
+
+            var summary = await offlineProgressService.SimulateOfflineProgress(player, state, CancellationToken);
+
+            Assert.Single(summary.CompletedChallenges, c => c.ChallengeId == challenge.Id);
+            var challenges = await progressRepo.GetChallenges(setup.PlayerId);
+            var playerChallenge = Assert.Single(challenges, c => c.Challenge.Id == challenge.Id);
+            Assert.NotNull(playerChallenge.CompletedAt);
+
+            var expectedWindowEnd = lastActivity + OfflineProgressService.MaximumOfflineSimulation;
+            Assert.True(
+                Math.Abs((playerChallenge.CompletedAt!.Value - expectedWindowEnd).TotalSeconds) < 5,
+                $"Expected CompletedAt near the capped window end {expectedWindowEnd:O}, got {playerChallenge.CompletedAt:O}.");
+            Assert.True(DateTime.UtcNow - playerChallenge.CompletedAt!.Value > TimeSpan.FromHours(9));
+        }
+
+        [Fact]
         public async Task SimulateOfflineProgress_MixedWinLossWindow_CompletesAWinTrackingChallengeCrossedByEarlyWins()
         {
             using var scope = CreateScope();

--- a/Game.Application/Events/BattleStatisticsEventHandler.cs
+++ b/Game.Application/Events/BattleStatisticsEventHandler.cs
@@ -29,7 +29,8 @@ namespace Game.Application.Events
             // Evaluate only the challenges whose tracked statistic this battle actually moved (plus the
             // statistic-independent ones) and apply their rewards, raising the live per-challenge push. The
             // offline-rewards batch runs this same step with the push suppressed.
-            _challengeRewards.EvaluateAndApply(progress, touchedStatistics, domainEvent.Player, notify: true);
+            _challengeRewards.EvaluateAndApply(
+                progress, touchedStatistics, domainEvent.Player, DateTime.UtcNow, notify: true);
 
             // Accrue proficiency XP on a victory: each path claims pie × activity ÷ max(playerRating,
             // enemyRating), routed to its frontier tier (the effect-based model, spike #1318, max-normalized per

--- a/Game.Application/Services/ChallengeRewardService.cs
+++ b/Game.Application/Services/ChallengeRewardService.cs
@@ -28,16 +28,19 @@ namespace Game.Application.Services
         /// <paramref name="progress"/> (plus the statistic-independent ones), applies each completion's rewards
         /// to <paramref name="player"/>, and returns the completions so the caller can surface them. Pass
         /// <paramref name="notify"/> <c>true</c> on the live path to raise the per-challenge client push, or
-        /// <c>false</c> for the offline batch to suppress it.
+        /// <c>false</c> for the offline batch to suppress it. <paramref name="timestamp"/> stamps any completion's
+        /// <see cref="PlayerChallenge.CompletedAt"/> — the live "now" or, for the offline batch, the simulated
+        /// away-window time rather than the moment the rewards are claimed.
         /// </summary>
         public IReadOnlyList<CompletedChallenge> EvaluateAndApply(
             PlayerProgress progress,
             IReadOnlyCollection<(EStatisticType Type, int? EntityId)> touchedStatistics,
             Player player,
+            DateTime timestamp,
             bool notify)
         {
             var relevantChallenges = _challenges.Index().RelevantTo(touchedStatistics);
-            var completed = progress.EvaluateChallenges(relevantChallenges);
+            var completed = progress.EvaluateChallenges(relevantChallenges, timestamp);
 
             foreach (var c in completed)
             {

--- a/Game.Application/Services/OfflineProgressService.cs
+++ b/Game.Application/Services/OfflineProgressService.cs
@@ -105,6 +105,12 @@ namespace Game.Application.Services
             var awayMs = (long)(now - player.LastActivity).TotalMilliseconds;
             var cappedAwayMs = Math.Min(awayMs, (long)MaximumOfflineSimulation.TotalMilliseconds);
 
+            // The simulated window's end — captured from LastActivity before anything below can re-anchor it.
+            // Challenge completions during this pass are stamped here rather than at "now": when a long absence
+            // is clamped to MaximumOfflineSimulation, "now" could be hours past the point the window's replay
+            // actually simulated the completion.
+            var awayWindowEnd = player.LastActivity + TimeSpan.FromMilliseconds(cappedAwayMs);
+
             // Below the threshold there are no offline rewards. Re-anchor LastActivity (so the next away period
             // starts fresh and an immediate re-claim is a no-op) and return an empty summary. Any stale
             // in-flight battle is left for the idle loop's first StartBattle to abandon, exactly as on a normal
@@ -151,7 +157,7 @@ namespace Game.Application.Services
 
             var levelBefore = player.Level;
             var statPointsBefore = player.StatPoints.StatPointsGained;
-            var rewards = await ApplyOfflineRewards(player, progress, result, cancellationToken);
+            var rewards = await ApplyOfflineRewards(player, progress, result, awayWindowEnd, cancellationToken);
 
             // Re-anchor the away clock and persist the player (exp/levels/unlocks) in one save. The exp batch
             // already raised its own single core update in ApplyOfflineRewards; this re-anchor raises one more.
@@ -269,7 +275,8 @@ namespace Game.Application.Services
         // (the summary is the notification). Returns the completed challenges and the folded proficiency gains
         // (spike #982 decision 9 — the offline accrual's notification rides the summary, not a per-battle push).
         private async Task<OfflineRewards> ApplyOfflineRewards(
-            Player player, PlayerProgress progress, OfflineProgressResult result, CancellationToken cancellationToken)
+            Player player, PlayerProgress progress, OfflineProgressResult result, DateTime timestamp,
+            CancellationToken cancellationToken)
         {
             if (result.BattlesSimulated == 0)
             {
@@ -328,7 +335,7 @@ namespace Game.Application.Services
             }
             _proficiencyRewards.GrantRewardSkills(proficiencyResult, player);
 
-            var completed = _challengeRewards.EvaluateAndApply(progress, touchedStatistics, player, notify: false);
+            var completed = _challengeRewards.EvaluateAndApply(progress, touchedStatistics, player, timestamp, notify: false);
 
             await _progressRepo.Save(progress, cancellationToken);
             return new OfflineRewards(completed, proficiencyResult);

--- a/Game.Core.Tests/Progress/ChallengeTests.cs
+++ b/Game.Core.Tests/Progress/ChallengeTests.cs
@@ -7,6 +7,8 @@ namespace Game.Core.Tests.Progress
 {
     public class ChallengeTests
     {
+        private static readonly DateTime Timestamp = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
         [Fact]
         public void UpdateChallengeProgress_StatisticType_UsesMatchingStatisticValue()
         {
@@ -17,7 +19,7 @@ namespace Game.Core.Tests.Progress
                 new PlayerStatistic { Type = EStatisticType.EnemiesKilled, EntityId = null, Value = 7m },
             ]);
 
-            challenge.UpdateChallengeProgress(playerChallenge, progress);
+            challenge.UpdateChallengeProgress(playerChallenge, progress, Timestamp);
 
             Assert.Equal(7m, playerChallenge.Progress);
             Assert.False(playerChallenge.Completed);
@@ -34,10 +36,11 @@ namespace Game.Core.Tests.Progress
                 new PlayerStatistic { Type = EStatisticType.EnemiesKilled, EntityId = 4, Value = 5m },
             ]);
 
-            challenge.UpdateChallengeProgress(playerChallenge, progress);
+            challenge.UpdateChallengeProgress(playerChallenge, progress, Timestamp);
 
             Assert.Equal(5m, playerChallenge.Progress);
             Assert.True(playerChallenge.Completed);
+            Assert.Equal(Timestamp, playerChallenge.CompletedAt);
         }
 
         [Fact]
@@ -47,7 +50,7 @@ namespace Game.Core.Tests.Progress
             var playerChallenge = new PlayerChallenge(challenge, progress: 0m, completed: false);
             var progress = MakeProgress(player: new PlayerBuilder().WithLevel(8).Build());
 
-            challenge.UpdateChallengeProgress(playerChallenge, progress);
+            challenge.UpdateChallengeProgress(playerChallenge, progress, Timestamp);
 
             Assert.Equal(8m, playerChallenge.Progress);
             Assert.True(playerChallenge.Completed);
@@ -60,7 +63,7 @@ namespace Game.Core.Tests.Progress
             var playerChallenge = new PlayerChallenge(challenge, progress: 0m, completed: false);
             var progress = MakeProgress();
 
-            challenge.UpdateChallengeProgress(playerChallenge, progress);
+            challenge.UpdateChallengeProgress(playerChallenge, progress, Timestamp);
 
             Assert.Equal(0m, playerChallenge.Progress);
             Assert.False(playerChallenge.Completed);
@@ -85,7 +88,7 @@ namespace Game.Core.Tests.Progress
                     : [];
                 var progress = MakeProgress(player, statistics);
 
-                challenge.UpdateChallengeProgress(playerChallenge, progress);
+                challenge.UpdateChallengeProgress(playerChallenge, progress, Timestamp);
 
                 Assert.True(playerChallenge.Completed, $"Challenge type {type} did not progress.");
             }

--- a/Game.Core.Tests/Progress/PlayerChallengeTests.cs
+++ b/Game.Core.Tests/Progress/PlayerChallengeTests.cs
@@ -6,12 +6,14 @@ namespace Game.Core.Tests.Progress
 {
     public class PlayerChallengeTests
     {
+        private static readonly DateTime Timestamp = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
         [Fact]
         public void UpdateProgress_BelowGoal_StoresProgressAndStaysIncomplete()
         {
             var playerChallenge = MakePlayerChallenge(goal: 10);
 
-            playerChallenge.UpdateProgress(4m, hasData: true);
+            playerChallenge.UpdateProgress(4m, hasData: true, Timestamp);
 
             Assert.Equal(4m, playerChallenge.Progress);
             Assert.False(playerChallenge.Completed);
@@ -23,11 +25,11 @@ namespace Game.Core.Tests.Progress
         {
             var playerChallenge = MakePlayerChallenge(goal: 10);
 
-            playerChallenge.UpdateProgress(10m, hasData: true);
+            playerChallenge.UpdateProgress(10m, hasData: true, Timestamp);
 
             Assert.Equal(10m, playerChallenge.Progress);
             Assert.True(playerChallenge.Completed);
-            Assert.NotNull(playerChallenge.CompletedAt);
+            Assert.Equal(Timestamp, playerChallenge.CompletedAt);
         }
 
         [Fact]
@@ -35,7 +37,7 @@ namespace Game.Core.Tests.Progress
         {
             var playerChallenge = MakePlayerChallenge(goal: 10);
 
-            playerChallenge.UpdateProgress(15m, hasData: true);
+            playerChallenge.UpdateProgress(15m, hasData: true, Timestamp);
 
             Assert.Equal(10m, playerChallenge.Progress);
             Assert.True(playerChallenge.Completed);
@@ -46,13 +48,11 @@ namespace Game.Core.Tests.Progress
         {
             var playerChallenge = MakePlayerChallenge(goal: 10);
 
-            playerChallenge.UpdateProgress(10m, hasData: true);
-            var firstCompletedAt = playerChallenge.CompletedAt;
-
-            playerChallenge.UpdateProgress(20m, hasData: true);
+            playerChallenge.UpdateProgress(10m, hasData: true, Timestamp);
+            playerChallenge.UpdateProgress(20m, hasData: true, Timestamp.AddDays(1));
 
             Assert.True(playerChallenge.Completed);
-            Assert.Equal(firstCompletedAt, playerChallenge.CompletedAt);
+            Assert.Equal(Timestamp, playerChallenge.CompletedAt);
         }
 
         // ── "At most" goals (e.g. time trials) ───────────────────────────────
@@ -62,11 +62,11 @@ namespace Game.Core.Tests.Progress
         {
             var playerChallenge = MakePlayerChallenge(goal: 10, type: EChallengeType.TimeTrial);
 
-            playerChallenge.UpdateProgress(7m, hasData: true);
+            playerChallenge.UpdateProgress(7m, hasData: true, Timestamp);
 
             Assert.Equal(7m, playerChallenge.Progress);
             Assert.True(playerChallenge.Completed);
-            Assert.NotNull(playerChallenge.CompletedAt);
+            Assert.Equal(Timestamp, playerChallenge.CompletedAt);
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace Game.Core.Tests.Progress
         {
             var playerChallenge = MakePlayerChallenge(goal: 10, type: EChallengeType.TimeTrial);
 
-            playerChallenge.UpdateProgress(10m, hasData: true);
+            playerChallenge.UpdateProgress(10m, hasData: true, Timestamp);
 
             Assert.True(playerChallenge.Completed);
         }
@@ -84,7 +84,7 @@ namespace Game.Core.Tests.Progress
         {
             var playerChallenge = MakePlayerChallenge(goal: 10, type: EChallengeType.TimeTrial);
 
-            playerChallenge.UpdateProgress(15m, hasData: true);
+            playerChallenge.UpdateProgress(15m, hasData: true, Timestamp);
 
             Assert.Equal(15m, playerChallenge.Progress);
             Assert.False(playerChallenge.Completed);
@@ -98,7 +98,7 @@ namespace Game.Core.Tests.Progress
             // 0 is at or below the goal — the absence of data, not the value, is what blocks completion.
             var playerChallenge = MakePlayerChallenge(goal: 10, type: EChallengeType.TimeTrial);
 
-            playerChallenge.UpdateProgress(0m, hasData: false);
+            playerChallenge.UpdateProgress(0m, hasData: false, Timestamp);
 
             Assert.False(playerChallenge.Completed);
             Assert.Null(playerChallenge.CompletedAt);
@@ -111,7 +111,7 @@ namespace Game.Core.Tests.Progress
             // reads as the best possible progress, so writing it would surface a misleading 0 best.
             var playerChallenge = MakePlayerChallenge(goal: 10, type: EChallengeType.TimeTrial, initialProgress: 42m);
 
-            playerChallenge.UpdateProgress(0m, hasData: false);
+            playerChallenge.UpdateProgress(0m, hasData: false, Timestamp);
 
             Assert.Equal(42m, playerChallenge.Progress);
         }
@@ -123,10 +123,10 @@ namespace Game.Core.Tests.Progress
             // must complete — the old "0 means no data" sentinel made this case unwinnable.
             var playerChallenge = MakePlayerChallenge(goal: 10, type: EChallengeType.TimeTrial);
 
-            playerChallenge.UpdateProgress(0m, hasData: true);
+            playerChallenge.UpdateProgress(0m, hasData: true, Timestamp);
 
             Assert.True(playerChallenge.Completed);
-            Assert.NotNull(playerChallenge.CompletedAt);
+            Assert.Equal(Timestamp, playerChallenge.CompletedAt);
         }
 
         private static PlayerChallenge MakePlayerChallenge(decimal goal, EChallengeType type = EChallengeType.EnemiesKilled, decimal initialProgress = 0m)

--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -10,6 +10,8 @@ namespace Game.Core.Tests.Progress
 {
     public class PlayerProgressTests
     {
+        private static readonly DateTime Timestamp = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
         // ── RecordBattleCompleted: global statistics ─────────────────────────
 
         [Fact]
@@ -584,7 +586,7 @@ namespace Game.Core.Tests.Progress
                 Stat(EStatisticType.EnemiesKilled, null, 5m),
             ]);
 
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             var result = Assert.Single(completed);
             Assert.Equal(0, result.ChallengeId);
@@ -593,7 +595,7 @@ namespace Game.Core.Tests.Progress
 
             var playerChallenge = Assert.Single(progress.ChallengeProgress);
             Assert.True(playerChallenge.Completed);
-            Assert.NotNull(playerChallenge.CompletedAt);
+            Assert.Equal(Timestamp, playerChallenge.CompletedAt);
             Assert.Equal(5m, playerChallenge.Progress);
         }
 
@@ -606,7 +608,7 @@ namespace Game.Core.Tests.Progress
                 Stat(EStatisticType.EnemiesKilled, null, 3m),
             ]);
 
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             Assert.Empty(completed);
             var playerChallenge = Assert.Single(progress.ChallengeProgress);
@@ -624,7 +626,7 @@ namespace Game.Core.Tests.Progress
                 Stat(EStatisticType.EnemiesKilled, null, 12m),
             ]);
 
-            progress.EvaluateChallenges([challenge]);
+            progress.EvaluateChallenges([challenge], Timestamp);
 
             var playerChallenge = Assert.Single(progress.ChallengeProgress);
             Assert.True(playerChallenge.Completed);
@@ -640,7 +642,7 @@ namespace Game.Core.Tests.Progress
                 statistics: [Stat(EStatisticType.EnemiesKilled, null, 12m)],
                 challenges: [alreadyCompleted]);
 
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             Assert.Empty(completed);
         }
@@ -653,7 +655,7 @@ namespace Game.Core.Tests.Progress
             var challenge = MakeChallenge(id: 0, EChallengeType.EnemiesKilled, goal: 5, retiredAt: DateTime.UtcNow);
             var progress = MakeProgress(statistics: [Stat(EStatisticType.EnemiesKilled, null, 12m)]);
 
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             Assert.Empty(completed);
             Assert.Empty(progress.ChallengeProgress);
@@ -671,7 +673,7 @@ namespace Game.Core.Tests.Progress
                 statistics: [Stat(EStatisticType.EnemiesKilled, null, 12m)],
                 challenges: [alreadyCompleted]);
 
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             Assert.Empty(completed);
             Assert.True(Assert.Single(progress.ChallengeProgress).Completed);
@@ -687,7 +689,7 @@ namespace Game.Core.Tests.Progress
                 Stat(EStatisticType.EnemiesKilled, 2, 3m),
             ]);
 
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             Assert.Single(completed);
         }
@@ -703,7 +705,7 @@ namespace Game.Core.Tests.Progress
 
             progress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000, new BattleStats(),
                 isBossBattle: true, zoneId: 3);
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             Assert.Single(completed);
             Assert.True(Assert.Single(progress.ChallengeProgress).Completed);
@@ -715,7 +717,7 @@ namespace Game.Core.Tests.Progress
             var challenge = MakeChallenge(id: 0, EChallengeType.LevelReached, goal: 5);
             var progress = MakeProgress(player: new PlayerBuilder().WithLevel(5).Build());
 
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             Assert.Single(completed);
         }
@@ -726,7 +728,7 @@ namespace Game.Core.Tests.Progress
             var challenge = MakeChallenge(id: 0, EChallengeType.LevelReached, goal: 10);
             var progress = MakeProgress(player: new PlayerBuilder().WithLevel(5).Build());
 
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             Assert.Empty(completed);
             Assert.Equal(5m, Assert.Single(progress.ChallengeProgress).Progress);
@@ -741,7 +743,7 @@ namespace Game.Core.Tests.Progress
                 Stat(EStatisticType.FastestVictory, null, 8m), // best victory in 8s, goal is "within 10s"
             ]);
 
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             Assert.Single(completed);
             Assert.True(Assert.Single(progress.ChallengeProgress).Completed);
@@ -756,7 +758,7 @@ namespace Game.Core.Tests.Progress
                 Stat(EStatisticType.FastestVictory, null, 14m),
             ]);
 
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             Assert.Empty(completed);
         }
@@ -767,7 +769,7 @@ namespace Game.Core.Tests.Progress
             var challenge = MakeChallenge(id: 0, EChallengeType.TimeTrial, goal: 10);
             var progress = MakeProgress(); // no FastestVictory statistic recorded yet
 
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             Assert.Empty(completed);
         }
@@ -783,7 +785,7 @@ namespace Game.Core.Tests.Progress
                 Stat(EStatisticType.FastestVictory, null, 0m),
             ]);
 
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             Assert.Single(completed);
             Assert.True(Assert.Single(progress.ChallengeProgress).Completed);
@@ -798,7 +800,7 @@ namespace Game.Core.Tests.Progress
             var challenge = MakeChallenge(id: 0, EChallengeType.EnemiesKilled, goal: 5);
             var progress = MakeProgress(); // no EnemiesKilled statistic recorded yet
 
-            var completed = progress.EvaluateChallenges([challenge]);
+            var completed = progress.EvaluateChallenges([challenge], Timestamp);
 
             Assert.Empty(completed);
             Assert.Empty(progress.DirtyChallenges);
@@ -816,7 +818,7 @@ namespace Game.Core.Tests.Progress
                 Stat(EStatisticType.BattlesWon, null, 2m),
             ]);
 
-            var completed = progress.EvaluateChallenges([met, unmet]);
+            var completed = progress.EvaluateChallenges([met, unmet], Timestamp);
 
             Assert.Equal(0, Assert.Single(completed).ChallengeId);
         }
@@ -850,7 +852,7 @@ namespace Game.Core.Tests.Progress
             var progress = MakeProgress();
             progress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000,
                 new BattleStats { PlayerDamageDealt = 10.0 }, isBossBattle: false, zoneId: 0);
-            progress.EvaluateChallenges([MakeChallenge(id: 0, EChallengeType.EnemiesKilled, goal: 5)]);
+            progress.EvaluateChallenges([MakeChallenge(id: 0, EChallengeType.EnemiesKilled, goal: 5)], Timestamp);
             progress.SetProficiencyProgress(proficiencyId: 3, level: 1, xp: 40m);
 
             progress.AcceptChanges();
@@ -1023,7 +1025,7 @@ namespace Game.Core.Tests.Progress
                 statistics: [Stat(EStatisticType.EnemiesKilled, null, 5m)],
                 challenges: [doneRow]);
 
-            progress.EvaluateChallenges([progressed, alreadyDone]);
+            progress.EvaluateChallenges([progressed, alreadyDone], Timestamp);
 
             // The challenge that advanced this evaluation is dirty; the already-completed one is skipped untouched.
             Assert.Contains(0, progress.DirtyChallenges.Select(c => c.Challenge.Id));

--- a/Game.Core/Progress/Challenge.cs
+++ b/Game.Core/Progress/Challenge.cs
@@ -25,17 +25,17 @@ namespace Game.Core.Progress
         /// resolvable by id so existing references (and completions) stay valid. Null while active.</summary>
         public DateTime? RetiredAt { get; init; }
 
-        public void UpdateChallengeProgress(PlayerChallenge playerChallenge, PlayerProgress playerProgress)
+        public void UpdateChallengeProgress(PlayerChallenge playerChallenge, PlayerProgress playerProgress, DateTime timestamp)
         {
             if (Type.StatisticType is not null)
             {
                 var hasData = playerProgress.TryGetStatisticValue(Type.StatisticType.Id, TargetEntityId, out var value);
-                playerChallenge.UpdateProgress(value, hasData);
+                playerChallenge.UpdateProgress(value, hasData, timestamp);
             }
             else if (Type.Id is EChallengeType.LevelReached)
             {
                 // The player's level is always present, so the progress value is always real data.
-                playerChallenge.UpdateProgress(playerProgress.Player.Level, hasData: true);
+                playerChallenge.UpdateProgress(playerProgress.Player.Level, hasData: true, timestamp);
             }
             else
             {

--- a/Game.Core/Progress/PlayerChallenge.cs
+++ b/Game.Core/Progress/PlayerChallenge.cs
@@ -24,7 +24,7 @@ namespace Game.Core.Progress
         /// <paramref name="value"/> is not a real best), while a genuine 0 (<paramref name="hasData"/> true)
         /// can satisfy the goal.
         /// </param>
-        public void UpdateProgress(decimal value, bool hasData)
+        public void UpdateProgress(decimal value, bool hasData, DateTime timestamp)
         {
             if (Completed)
             {
@@ -42,7 +42,7 @@ namespace Game.Core.Progress
                     if (value <= Challenge.ProgressGoal)
                     {
                         Completed = true;
-                        CompletedAt = DateTime.UtcNow;
+                        CompletedAt = timestamp;
                     }
                 }
             }
@@ -52,7 +52,7 @@ namespace Game.Core.Progress
                 if (value >= Challenge.ProgressGoal)
                 {
                     Completed = true;
-                    CompletedAt = DateTime.UtcNow;
+                    CompletedAt = timestamp;
                 }
             }
         }

--- a/Game.Core/Progress/PlayerProgress.cs
+++ b/Game.Core/Progress/PlayerProgress.cs
@@ -139,7 +139,7 @@ namespace Game.Core.Progress
             return [.. _dirtyStatistics];
         }
 
-        public List<CompletedChallenge> EvaluateChallenges(IEnumerable<Challenge> challenges)
+        public List<CompletedChallenge> EvaluateChallenges(IEnumerable<Challenge> challenges, DateTime timestamp)
         {
             var completed = new List<CompletedChallenge>();
 
@@ -169,7 +169,7 @@ namespace Game.Core.Progress
                 var beforeProgress = playerChallenge.Progress;
                 var beforeCompleted = playerChallenge.Completed;
 
-                challenge.UpdateChallengeProgress(playerChallenge, this);
+                challenge.UpdateChallengeProgress(playerChallenge, this, timestamp);
 
                 if (playerChallenge.Progress != beforeProgress || playerChallenge.Completed != beforeCompleted)
                 {


### PR DESCRIPTION
## Summary

`PlayerChallenge.UpdateProgress` stamped `CompletedAt` from the ambient `DateTime.UtcNow` (`Game.Core/Progress/PlayerChallenge.cs:44,58`), unlike every other domain write path, which injects its timestamp (`Player.StampActivity(timestamp)`, `UnlockLesson(lessonId, timestamp)`, `RecordBattleCompleted(..., timestamp)`).

This meant:
- Offline-window challenge completions were stamped at **claim** time rather than the simulated time within the away window — most visibly wrong when a long absence is clamped by `OfflineProgressService.MaximumOfflineSimulation` (10h), where "now" can be hours later than the window the completion was actually simulated within.
- The completion timestamp was untestable/non-deterministic.

## Changes

Threaded a `DateTime timestamp` parameter through the whole chain:

- `PlayerChallenge.UpdateProgress(value, hasData, timestamp)` — stamps `CompletedAt` from the injected value.
- `Challenge.UpdateChallengeProgress(playerChallenge, playerProgress, timestamp)`
- `PlayerProgress.EvaluateChallenges(challenges, timestamp)`
- `ChallengeRewardService.EvaluateAndApply(progress, touchedStatistics, player, timestamp, notify)`

Callers:
- **Live path** (`BattleStatisticsEventHandler`): passes `DateTime.UtcNow` — no behavior change, just now an explicit value instead of an ambient read.
- **Offline path** (`OfflineProgressService.SimulateProgress`): passes the simulated window's end (`player.LastActivity + cappedAwayMs`, captured before anything can re-anchor `LastActivity`) instead of the claim-time `now` — a real behavior fix whenever the away duration exceeds the simulation cap.

## Test plan

- [x] `dotnet build` — solution builds clean, 0 warnings.
- [x] `dotnet test` — full solution suite passes (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests): 3025/3025 passing.
- Updated `PlayerChallengeTests` / `ChallengeTests` / `PlayerProgressTests` to pin an injected timestamp and assert `CompletedAt` equals it (previously only asserted `NotNull`).
- Added `OfflineProgressServiceIntegrationTests.SimulateOfflineProgress_AwayLongerThanSimulationCap_StampsChallengeCompletedAtWithinCappedWindow`, which sets `LastActivity` 20h in the past (beyond the 10h cap) and asserts the completed challenge's `CompletedAt` lands at the capped window's end rather than near "now".

Closes #1704


---
_Generated by [Claude Code](https://claude.ai/code/session_01SG2ifraFVy9xT5Ye9ucDuV)_