### PR TITLE
Split Player.RecordBattleCompleted into a mandatory-rating victory overload

### DIFF
--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -524,7 +524,7 @@ namespace Game.Application.Services
             // Thread both combat ratings onto the battle-completed event so the progress handler can normalize
             // each path's activity by max(playerRating, enemyRating) for the effect-based proficiency accrual
             // (spike #1526 Decision 5) — the same snapshot-measured ratings the exp reward above used.
-            player.RecordBattleCompleted(
+            player.RecordBattleVictory(
                 enemy, result, state.IsBossBattle, state.BattleZoneId ?? player.CurrentZoneId, timestamp,
                 rewards.PlayerRating, rewards.EnemyRating);
 

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -896,6 +896,56 @@ namespace Game.Core.Tests.Players
             Assert.Equal(timestamp, coreUpdated.LastActivity);
         }
 
+        [Fact]
+        public void RecordBattleCompleted_CarriesZeroRatingsOntoEvent()
+        {
+            // No rating parameters exist on this overload at all — a loss/draw never claims proficiency XP.
+            var player = MakePlayer();
+            var result = new BattleResult(Victory: false, PlayerDied: true, TotalMs: 1000, Stats: new BattleStats());
+
+            player.RecordBattleCompleted(MakeEnemy(), result, isBossBattle: false, zoneId: 3, timestamp: DateTime.UtcNow);
+
+            var evt = Assert.Single(player.DomainEvents.OfType<BattleCompletedEvent>());
+            Assert.Equal(0, evt.PlayerRating);
+            Assert.Equal(0, evt.EnemyRating);
+        }
+
+        // ── RecordBattleVictory ──────────────────────────────────────────────
+
+        [Fact]
+        public void RecordBattleVictory_ThreadsCombatRatingsOntoEvent()
+        {
+            var player = MakePlayer();
+            var enemy = MakeEnemy(id: 5);
+            var result = new BattleResult(Victory: true, PlayerDied: false, TotalMs: 3200, Stats: new BattleStats());
+
+            player.RecordBattleVictory(
+                enemy, result, isBossBattle: true, zoneId: 7, timestamp: DateTime.UtcNow,
+                playerRating: 12.5, enemyRating: 8.25);
+
+            var evt = Assert.Single(player.DomainEvents.OfType<BattleCompletedEvent>());
+            Assert.Equal(12.5, evt.PlayerRating);
+            Assert.Equal(8.25, evt.EnemyRating);
+        }
+
+        [Fact]
+        public void RecordBattleVictory_StampsLastActivityAndRaisesCoreUpdated()
+        {
+            var player = MakePlayer();
+            var enemy = MakeEnemy(id: 5);
+            var result = new BattleResult(Victory: true, PlayerDied: false, TotalMs: 1000, Stats: new BattleStats());
+            var timestamp = new DateTime(2026, 6, 20, 12, 0, 0, DateTimeKind.Utc);
+
+            player.RecordBattleVictory(
+                enemy, result, isBossBattle: false, zoneId: 3, timestamp: timestamp,
+                playerRating: 1, enemyRating: 1);
+
+            Assert.Equal(timestamp, player.LastActivity);
+            var coreUpdated = player.DomainEvents.OfType<PlayerCoreUpdatedEvent>().SingleOrDefault();
+            Assert.NotNull(coreUpdated);
+            Assert.Equal(timestamp, coreUpdated.LastActivity);
+        }
+
         // ── StampActivity ────────────────────────────────────────────────────
 
         [Fact]

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -463,15 +463,28 @@ namespace Game.Core.Players
             return true;
         }
 
-        // A victory caller MUST pass the battle's real combat ratings — the effect-based accrual normalizes each
-        // path's activity by max(playerRating, enemyRating), so the default 0/0 disables the accrual entirely
-        // (the normalization guard treats a non-positive denominator as no claim). Defaulting to 0 is correct
-        // only for the loss/abandon paths (no XP on a non-victory); a future victory path that forgets to thread
-        // them would silently accrue zero XP. Today both victory paths route through RecordVictory, which passes
-        // them.
-        public void RecordBattleCompleted(
+        // Records a non-victory (loss/draw) battle outcome. No combat ratings are threaded onto the event —
+        // XP only accrues on a win — so a victory MUST go through RecordBattleVictory instead, which requires
+        // them; that split (rather than a defaultable parameter) makes a victory caller forgetting the ratings
+        // a compile error instead of a silent zero-XP accrual.
+        public void RecordBattleCompleted(Enemy enemy, BattleResult result, bool isBossBattle, int zoneId, DateTime timestamp)
+        {
+            RecordBattleOutcome(enemy, result, isBossBattle, zoneId, timestamp, playerRating: 0, enemyRating: 0);
+        }
+
+        // Records a victorious battle outcome, threading the combat ratings the win was rated against so the
+        // progress handler can normalize proficiency accrual by max(playerRating, enemyRating) (spike #1526
+        // Decision 5). Both current victory paths route through BattleService.RecordVictory, which supplies them.
+        public void RecordBattleVictory(
             Enemy enemy, BattleResult result, bool isBossBattle, int zoneId, DateTime timestamp,
-            double playerRating = 0, double enemyRating = 0)
+            double playerRating, double enemyRating)
+        {
+            RecordBattleOutcome(enemy, result, isBossBattle, zoneId, timestamp, playerRating, enemyRating);
+        }
+
+        private void RecordBattleOutcome(
+            Enemy enemy, BattleResult result, bool isBossBattle, int zoneId, DateTime timestamp,
+            double playerRating, double enemyRating)
         {
             RaiseEvent(new BattleCompletedEvent(
                 this, enemy, result.Victory, result.PlayerDied, result.TotalMs, result.Stats, isBossBattle, zoneId,


### PR DESCRIPTION
## Summary

`Player.RecordBattleCompleted`'s `playerRating`/`enemyRating` parameters defaulted to `0` (`Game.Core/Players/Player.cs:466-478`). The method's own comment already flagged the hazard: a victory caller that forgot to pass them would accrue **zero proficiency XP with no error** (`ProficiencyXpCalculator.cs` treats a non-positive denominator as no claim). Both current victory paths threaded the ratings correctly, so this was a commented footgun rather than a live bug — but a compile-time guarantee was available and wasn't used.

## Changes

- `Game.Core/Players/Player.cs`: split the single defaultable-parameter method into two, both delegating to a shared private `RecordBattleOutcome`:
  - `RecordBattleCompleted(enemy, result, isBossBattle, zoneId, timestamp)` — for loss/draw outcomes. No rating parameters exist on this overload at all (not just defaulted), so there's nothing to forget.
  - `RecordBattleVictory(enemy, result, isBossBattle, zoneId, timestamp, playerRating, enemyRating)` — for victories. The ratings are required parameters, so a future victory caller that forgets them fails to compile instead of silently zeroing out proficiency accrual.
- `Game.Application/Services/BattleService.cs`: `RecordVictory` (the sole path that always has real ratings — both the explicit win and the won-abandon path route through it) now calls `player.RecordBattleVictory(...)` instead of the old combined method.
- `Game.Core.Tests/Players/PlayerTests.cs`: added coverage that was previously missing at the `Player` level — `RecordBattleCompleted` carries zero ratings onto the event, and `RecordBattleVictory` threads the given ratings onto the event and still stamps activity/raises `PlayerCoreUpdatedEvent` the same way.

No behavior change for either existing call path — the loss/abandon call sites (`BattleService.cs:358,475`) were never reachable for a `Victory` result (both are gated on `!result.Victory` upstream), so they simply drop the two rating arguments they never passed.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] `dotnet test --no-build --no-restore` — full solution suite passes: 3027/3027 (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests).

Closes #1706


---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY1kKWURWzEy4mGfkALxJ)_