### PR TITLE
Untrack lesson-state reads in the screen-activation effect (#1709)

### DIFF
--- a/UI/src/routes/game/+page.svelte
+++ b/UI/src/routes/game/+page.svelte
@@ -47,7 +47,7 @@ import { apiSocket, getRoles } from '$lib/api';
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
-import { onDestroy, onMount } from 'svelte';
+import { onDestroy, onMount, untrack } from 'svelte';
 import { confirmQuit } from './game-actions';
 import { WelcomeBackView } from './welcome-back/welcome-back-view.svelte';
 import WelcomeBackGate from './welcome-back/WelcomeBackGate.svelte';
@@ -140,10 +140,16 @@ $effect(() => {
 
 // Screen-anchored tutorial trigger (#1587): the single screen-activation point cross-screen
 // navigation uses. Gated on `entered` so a lesson can't fire against the default screen before the
-// welcome-back gate passes (the player hasn't "navigated" anywhere yet at that point).
+// welcome-back gate passes (the player hasn't "navigated" anywhere yet at that point). Only
+// `welcome.phase` and `currentScreen` should drive a re-evaluation — `evaluateScreenTrigger` also
+// reads `staticData.lessons`/`playerManager.lessons` (#1709), and those must NOT be tracked here or
+// any lesson-state mutation (e.g. a mechanic-anchored unlock, or marking a lesson read) would re-run
+// this effect and re-open/re-queue a lesson mid-tour instead of only on an actual screen change.
 $effect(() => {
-	if (welcome.phase === 'entered') {
-		evaluateScreenTrigger(currentScreen);
+	const phase = welcome.phase;
+	const screenKey = currentScreen;
+	if (phase === 'entered') {
+		untrack(() => evaluateScreenTrigger(screenKey));
 	}
 });
 

--- a/UI/src/tests/routes/game/page.test.ts
+++ b/UI/src/tests/routes/game/page.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { ELessonTriggerType } from '$lib/api';
+import type { ILesson } from '$lib/api';
+import { staticData } from '$stores/static-data.svelte';
+import { navigation, requiresRemount } from '$stores/navigation.svelte';
+import { tutorialTour } from '$stores/tutorial-tour.svelte';
+import { playerManager } from '$lib/engine/player/player-manager';
+import { mountTracker } from './page/screen-mount-tracker';
+import FightScreenStub from './page/FightScreenStub.svelte';
+import StatsScreenStub from './page/StatsScreenStub.svelte';
+import NavSidebarStub from './page/NavSidebarStub.svelte';
+import LogPanelStub from './page/LogPanelStub.svelte';
+import TourPlayerStub from './page/TourPlayerStub.svelte';
+import CharacterSwitcherStub from './page/CharacterSwitcherStub.svelte';
+import BootSplashStub from './page/BootSplashStub.svelte';
+import WelcomeBackGateStub from './page/WelcomeBackGateStub.svelte';
+import PlaceholderScreenStub from './page/PlaceholderScreenStub.svelte';
+
+// `+page.svelte` pulls in the live engine, socket, and every screen component; all of that is
+// mocked/stubbed so the test exercises only the shell wiring: the welcome-gate phase transition,
+// the screen-anchored tutorial trigger's `entered` gating (and its #1709 untrack fix), the
+// navigation-intent same-screen remount, and `handleNavigate`'s action keys.
+const {
+	sendSocketCommand,
+	getRoles,
+	refreshPlayer,
+	reconcilePersistedMode,
+	startGame,
+	stopEngines,
+	confirmQuit,
+	goto
+} = vi.hoisted(() => ({
+	sendSocketCommand: vi.fn(),
+	getRoles: vi.fn<() => string[]>(() => []),
+	refreshPlayer: vi.fn(async () => {}),
+	reconcilePersistedMode: vi.fn(),
+	startGame: vi.fn(),
+	stopEngines: vi.fn(),
+	confirmQuit: vi.fn(),
+	goto: vi.fn()
+}));
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('$app/navigation', () => ({ goto }));
+vi.mock('$app/paths', () => ({ resolve: (path: string) => path }));
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return { ...actual, apiSocket: { sendSocketCommand }, getRoles };
+});
+vi.mock('$lib/engine', () => ({
+	startGame,
+	stopEngines,
+	enemyManager: { reconcilePersistedMode }
+}));
+vi.mock('$lib/engine/session', () => ({ refreshPlayer }));
+// The real `evaluateScreenTrigger` is kept (wrapped as a spy) rather than mocked away: the #1709 bug
+// and fix live entirely in whether the shell's `$effect` re-runs when this function's *internal*
+// reads (`staticData.lessons`, `playerManager.lessons`) change, which a full mock would hide.
+vi.mock('$lib/engine/tutorials', async (importOriginal) => {
+	const actual = (await importOriginal()) as { evaluateScreenTrigger: (screenKey: string) => void };
+	return { ...actual, evaluateScreenTrigger: vi.fn(actual.evaluateScreenTrigger) };
+});
+vi.mock('$stores', () => ({ navigation, staticData, tutorialTour, requiresRemount }));
+vi.mock('$routes/game/game-actions', () => ({ confirmQuit }));
+vi.mock('$routes/game/screens/screen-defs', () => ({
+	GAME_SCREENS: [
+		{ key: 'fight', label: 'Fight', group: 'combat', built: true, component: FightScreenStub },
+		{ key: 'stats', label: 'Stats', group: 'character', built: true, component: StatsScreenStub },
+		{ key: 'help', label: 'Help', group: 'settings', built: false },
+		{ key: 'switch', label: 'Switch Character', group: 'settings', built: true },
+		{ key: 'quit', label: 'Quit', group: 'settings', built: true },
+		{ key: 'admin', label: 'Admin', group: 'admin', built: true, requiresRole: 'Admin' }
+	],
+	visibleScreens: (screens: { requiresRole?: string }[], roles: readonly string[]) =>
+		screens.filter((s) => !s.requiresRole || roles.includes(s.requiresRole))
+}));
+vi.mock('$routes/game/screens/PlaceholderScreen.svelte', () => ({ default: PlaceholderScreenStub }));
+vi.mock('$routes/game/welcome-back/WelcomeBackGate.svelte', () => ({ default: WelcomeBackGateStub }));
+vi.mock('$routes/game/CharacterSwitcher.svelte', () => ({ default: CharacterSwitcherStub }));
+vi.mock('$routes/BootSplash.svelte', () => ({ default: BootSplashStub }));
+vi.mock('$components', () => ({ NavSidebar: NavSidebarStub, LogPanel: LogPanelStub, TourPlayer: TourPlayerStub }));
+
+import GamePage from '../../../routes/game/+page.svelte';
+import { evaluateScreenTrigger } from '$lib/engine/tutorials';
+
+const screenVisitLesson = (overrides: Partial<ILesson> = {}): ILesson => ({
+	id: 0,
+	key: 'fight-intro',
+	name: 'Fight Intro',
+	triggerType: ELessonTriggerType.ScreenVisit,
+	screenKey: 'fight',
+	ordinal: 0,
+	designerNotes: '',
+	steps: [],
+	...overrides
+});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	getRoles.mockReturnValue([]);
+	sendSocketCommand.mockResolvedValue({ data: { hasProgress: false } });
+	staticData.lessons = undefined;
+	playerManager.lessons = [];
+	navigation.clear();
+	tutorialTour.clear();
+	mountTracker.fight = 0;
+});
+
+afterEach(cleanup);
+
+describe('game +page.svelte shell', () => {
+	it('gates the screen-anchored tutorial trigger on welcome.phase === "entered" and does not re-run it on unrelated lesson-state writes (#1709)', async () => {
+		sendSocketCommand.mockResolvedValue({ data: { hasProgress: true } });
+		staticData.lessons = [screenVisitLesson()];
+
+		render(GamePage);
+
+		await screen.findByTestId('welcome-gate-enter');
+		expect(evaluateScreenTrigger).not.toHaveBeenCalled();
+
+		// A lesson-state write while still gated (not yet 'entered') must not evaluate the trigger either.
+		playerManager.unlockLesson(999);
+		expect(evaluateScreenTrigger).not.toHaveBeenCalled();
+
+		await fireEvent.click(screen.getByTestId('welcome-gate-enter'));
+
+		await waitFor(() => expect(evaluateScreenTrigger).toHaveBeenCalledTimes(1));
+		expect(evaluateScreenTrigger).toHaveBeenCalledWith('fight');
+
+		// The lesson has 0 steps, so `openLesson` marks it read immediately — a write to
+		// `playerManager.lessons` triggered from *inside* `evaluateScreenTrigger` itself. Before the
+		// #1709 fix this write re-ran the effect (the exact bug the issue describes); it must not now.
+		await waitFor(() => expect(playerManager.lessons.some((l) => l.lessonId === 0 && l.readAt)).toBe(true));
+		expect(evaluateScreenTrigger).toHaveBeenCalledTimes(1);
+
+		// A further, unrelated lesson-state write (e.g. a mechanic-anchored unlock elsewhere) must also
+		// not re-trigger screen evaluation absent an actual screen change.
+		playerManager.unlockLesson(1);
+		expect(evaluateScreenTrigger).toHaveBeenCalledTimes(1);
+	});
+
+	it('forces a remount of the active screen on a same-screen deep-link request so its one-shot payload is consumed', async () => {
+		render(GamePage);
+
+		await waitFor(() => expect(mountTracker.fight).toBe(1));
+
+		navigation.requestScreen('fight', { some: 'payload' });
+
+		await waitFor(() => expect(mountTracker.fight).toBe(2));
+		expect(navigation.requestedScreen).toBeNull();
+	});
+
+	it('switches screens (without a forced remount) on a cross-screen deep-link request', async () => {
+		render(GamePage);
+		await waitFor(() => expect(screen.getByTestId('fight-screen')).toBeTruthy());
+
+		navigation.requestScreen('stats');
+
+		await waitFor(() => expect(screen.queryByTestId('stats-screen')).toBeTruthy());
+		expect(screen.queryByTestId('fight-screen')).toBeNull();
+		expect(navigation.requestedScreen).toBeNull();
+	});
+
+	it("routes handleNavigate's action keys: admin navigates, quit confirms, switch opens (and closes) the character switcher", async () => {
+		getRoles.mockReturnValue(['Admin']);
+
+		render(GamePage);
+		await waitFor(() => expect(screen.getByTestId('nav-admin')).toBeTruthy());
+
+		await fireEvent.click(screen.getByTestId('nav-admin'));
+		expect(goto).toHaveBeenCalledWith('/admin');
+
+		await fireEvent.click(screen.getByTestId('nav-quit'));
+		expect(confirmQuit).toHaveBeenCalledTimes(1);
+
+		expect(screen.getByTestId('character-switcher').getAttribute('data-open')).toBe('false');
+		await fireEvent.click(screen.getByTestId('nav-switch'));
+		await waitFor(() => expect(screen.getByTestId('character-switcher').getAttribute('data-open')).toBe('true'));
+
+		await fireEvent.click(screen.getByTestId('character-switcher-close'));
+		await waitFor(() => expect(screen.getByTestId('character-switcher').getAttribute('data-open')).toBe('false'));
+	});
+
+	it('binds the sidebar pinned state two-way to the .sidebar-spacer class', async () => {
+		const { container } = render(GamePage);
+		await waitFor(() => expect(screen.getByTestId('nav-toggle-pinned')).toBeTruthy());
+
+		const spacer = () => container.querySelector('.sidebar-spacer');
+		expect(spacer()?.classList.contains('pinned')).toBe(false);
+
+		await fireEvent.click(screen.getByTestId('nav-toggle-pinned'));
+		await waitFor(() => expect(spacer()?.classList.contains('pinned')).toBe(true));
+	});
+
+	it('falls back to PlaceholderScreen (with the registry label) for a screen with no component', async () => {
+		render(GamePage);
+		await waitFor(() => expect(screen.getByTestId('fight-screen')).toBeTruthy());
+
+		navigation.requestScreen('help');
+
+		await waitFor(() => expect(screen.getByTestId('placeholder-screen').textContent).toBe('Help'));
+	});
+
+	it('wires TourPlayer to tutorialTour and closeTutorialTour marks the lesson read on dismiss/complete', async () => {
+		const tourLesson: ILesson = {
+			id: 7,
+			key: 'gear-intro',
+			name: 'Gear Basics',
+			triggerType: ELessonTriggerType.ScreenVisit,
+			screenKey: 'stats',
+			ordinal: 0,
+			designerNotes: '',
+			steps: [{ ordinal: 0, text: 'Equip your first item.' }]
+		};
+		staticData.lessons = [tourLesson];
+
+		render(GamePage);
+		await waitFor(() => expect(screen.getByTestId('fight-screen')).toBeTruthy());
+		expect(screen.getByTestId('tour-player').getAttribute('data-open')).toBe('false');
+
+		navigation.requestScreen('stats');
+
+		await waitFor(() => expect(screen.getByTestId('tour-player').getAttribute('data-open')).toBe('true'));
+		expect(screen.getByTestId('tour-player').getAttribute('data-step-count')).toBe('1');
+		expect(screen.getByTestId('tour-player').textContent).toContain('Gear Basics');
+
+		await fireEvent.click(screen.getByTestId('tour-player-complete'));
+
+		await waitFor(() => expect(screen.getByTestId('tour-player').getAttribute('data-open')).toBe('false'));
+		expect(playerManager.lessons.some((l) => l.lessonId === 7 && l.readAt)).toBe(true);
+	});
+});

--- a/UI/src/tests/routes/game/page/BootSplashStub.svelte
+++ b/UI/src/tests/routes/game/page/BootSplashStub.svelte
@@ -1,0 +1,2 @@
+<!-- Test stub for BootSplash: a bare marker shown while the welcome-back gate is still 'checking'. -->
+<div data-testid="boot-splash"></div>

--- a/UI/src/tests/routes/game/page/CharacterSwitcherStub.svelte
+++ b/UI/src/tests/routes/game/page/CharacterSwitcherStub.svelte
@@ -1,0 +1,10 @@
+<!-- Test stub for CharacterSwitcher: exposes `open` as a data attribute and a close button wired to
+     the real `onClose` callback, so the page test can assert the 'switch' nav action both opens and
+     closes it, without the real overlay/session-takeover machinery. -->
+<div data-testid="character-switcher" data-open={open}>
+	<button data-testid="character-switcher-close" onclick={onClose}>Close</button>
+</div>
+
+<script lang="ts">
+const { open, onClose }: { open: boolean; onClose: () => void } = $props();
+</script>

--- a/UI/src/tests/routes/game/page/FightScreenStub.svelte
+++ b/UI/src/tests/routes/game/page/FightScreenStub.svelte
@@ -1,0 +1,12 @@
+<!-- Test stub for the 'fight' screen: records a mount in the shared tracker so the page test can
+     assert whether `{#key screenNonce}` remounted it (same-screen deep-link handling). -->
+<div data-testid="fight-screen"></div>
+
+<script lang="ts">
+import { onMount } from 'svelte';
+import { mountTracker } from './screen-mount-tracker';
+
+onMount(() => {
+	mountTracker.fight++;
+});
+</script>

--- a/UI/src/tests/routes/game/page/LogPanelStub.svelte
+++ b/UI/src/tests/routes/game/page/LogPanelStub.svelte
@@ -1,0 +1,2 @@
+<!-- Test stub for LogPanel: a bare marker, no props. -->
+<div data-testid="log-panel"></div>

--- a/UI/src/tests/routes/game/page/NavSidebarStub.svelte
+++ b/UI/src/tests/routes/game/page/NavSidebarStub.svelte
@@ -1,0 +1,25 @@
+<!-- Test stub for NavSidebar: renders one button per visible screen (driving `handleNavigate`) plus a
+     pinned-toggle button that exercises the real `bind:pinned` two-way binding, and surfaces `active`
+     as a data attribute — all without the real sidebar's chrome/animation. -->
+<div data-testid="nav-sidebar" data-active={active}>
+	<button data-testid="nav-toggle-pinned" onclick={() => (pinned = !pinned)}>Toggle pinned</button>
+	{#each screens as screenDef (screenDef.key)}
+		<button data-testid={`nav-${screenDef.key}`} onclick={() => onNavigate(screenDef.key)}>
+			{screenDef.label}
+		</button>
+	{/each}
+</div>
+
+<script lang="ts">
+interface ScreenDef {
+	key: string;
+	label: string;
+}
+
+let {
+	screens,
+	active,
+	onNavigate,
+	pinned = $bindable(false)
+}: { screens: ScreenDef[]; active: string; onNavigate: (key: string) => void; pinned?: boolean } = $props();
+</script>

--- a/UI/src/tests/routes/game/page/PlaceholderScreenStub.svelte
+++ b/UI/src/tests/routes/game/page/PlaceholderScreenStub.svelte
@@ -1,0 +1,7 @@
+<!-- Test stub for PlaceholderScreen: renders the `label` prop so the page test can assert the
+     registry's label reaches an unbuilt/action-only screen entry's fallback. -->
+<div data-testid="placeholder-screen">{label}</div>
+
+<script lang="ts">
+const { label }: { label: string } = $props();
+</script>

--- a/UI/src/tests/routes/game/page/StatsScreenStub.svelte
+++ b/UI/src/tests/routes/game/page/StatsScreenStub.svelte
@@ -1,0 +1,2 @@
+<!-- Test stub for the 'stats' screen: a bare marker so cross-screen navigation is observable. -->
+<div data-testid="stats-screen"></div>

--- a/UI/src/tests/routes/game/page/TourPlayerStub.svelte
+++ b/UI/src/tests/routes/game/page/TourPlayerStub.svelte
@@ -1,0 +1,29 @@
+<!-- Test stub for TourPlayer: surfaces `open`/`label`/`steps` as data/text so the page test can assert
+     the shell wired them from `tutorialTour`, and exposes dismiss/complete buttons wired to the real
+     callbacks, without the real coach-mark overlay. -->
+<div data-testid="tour-player" data-open={open} data-step-count={steps.length}>
+	{label}
+	<button data-testid="tour-player-dismiss" onclick={onDismiss}>Dismiss</button>
+	<button data-testid="tour-player-complete" onclick={onComplete}>Complete</button>
+</div>
+
+<script lang="ts">
+interface Step {
+	text: string;
+	anchorKey?: string;
+}
+
+const {
+	open,
+	steps,
+	label,
+	onDismiss,
+	onComplete
+}: {
+	open: boolean;
+	steps: Step[];
+	label: string;
+	onDismiss: () => void;
+	onComplete: () => void;
+} = $props();
+</script>

--- a/UI/src/tests/routes/game/page/WelcomeBackGateStub.svelte
+++ b/UI/src/tests/routes/game/page/WelcomeBackGateStub.svelte
@@ -1,0 +1,7 @@
+<!-- Test stub for WelcomeBackGate: a single button that invokes the real `onEnter` callback the shell
+     wires to `welcome.enter()`, so the page test can drive the 'summary' -> 'entered' transition. -->
+<button data-testid="welcome-gate-enter" onclick={onEnter}>Enter</button>
+
+<script lang="ts">
+const { onEnter }: { summary: unknown; onEnter: () => void } = $props();
+</script>

--- a/UI/src/tests/routes/game/page/screen-mount-tracker.ts
+++ b/UI/src/tests/routes/game/page/screen-mount-tracker.ts
@@ -1,0 +1,3 @@
+// Shared across the page test and FightScreenStub: counts how many times the stubbed 'fight' screen
+// has mounted, so the test can assert whether `{#key screenNonce}` actually remounted it.
+export const mountTracker = { fight: 0 };


### PR DESCRIPTION
## Summary

The screen-activation `$effect` in the game shell (`UI/src/routes/game/+page.svelte`) called `evaluateScreenTrigger` directly inside its body, so the effect tracked *everything that function reads* — including `staticData.lessons` and `playerManager.lessons` (via `isLocked`), not just the screen key. Any lesson-state mutation elsewhere — a mechanic-anchored `unlockLesson` push from the battle tick, or `markLessonRead` on tour close — re-ran the effect and re-evaluated the screen trigger, even though nothing about "which screen is active" had changed.

Today the worst-case outcome was masked because `tutorialTour.play(sameLessonRef)` is a same-reference `$state` write (no signal), but the effect was still silently re-invoking `openLesson`/`requestScreen` mid-tour on every unrelated lesson-state write, and the issue calls out that the moment two `ScreenVisit` lessons target the same screen this becomes visibly wrong (the second would auto-play the instant the first is marked read).

## Fix

`UI/src/routes/game/+page.svelte`: the effect now reads `welcome.phase` and `currentScreen` normally (so those two still drive re-evaluation), then calls `evaluateScreenTrigger` inside Svelte's `untrack()` so the function's *internal* reads of `staticData.lessons`/`playerManager.lessons` are no longer tracked by this effect.

## Tests

`routes/game/+page.svelte` had no component test at all before this PR. Added `UI/src/tests/routes/game/page.test.ts` (with stub components under `UI/src/tests/routes/game/page/`) covering:

- The `welcome.phase === 'entered'` gating of the screen trigger, **and the fix itself** — a 0-step lesson causes `openLesson` to call `playerManager.markLessonRead` from *inside* `evaluateScreenTrigger`, a self-triggered `playerManager.lessons` write that is exactly the regression this issue describes; the test asserts `evaluateScreenTrigger` stays at a call count of 1 across that write and a further unrelated lesson-state write.
- The navigation-intent effect's same-screen `screenNonce` remount (so a deep-link payload is consumed) vs. an ordinary cross-screen switch (no forced remount).
- `handleNavigate`'s action keys (`admin` navigates, `quit` confirms, `switch` opens/closes the character switcher).
- The sidebar `bind:pinned` two-way binding, the `PlaceholderScreen` fallback for an unbuilt screen, and the shared `TourPlayer`/`closeTutorialTour` wiring.

This intentionally uses the **real** `evaluateScreenTrigger` (wrapped as a spy via `importOriginal`), not a mock — a fully-mocked version would hide the exact bug/fix, since the bug lives in which reads the effect tracks.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — 296 files / 3542 tests pass, coverage gate (`src/routes/**` ratchet floor) passes

## Note on scope

The issue's linked `+page.svelte:144-148` line numbers reflect the file as originally reported; the fix targets the same block (now at a slightly different offset from unrelated changes since). No other unclear points — this was a well-scoped, unambiguous fix.

Closes #1709


---
_Generated by [Claude Code](https://claude.ai/code/session_012iGQuexYYFeJybWrRTTd3w)_