### PR TITLE
Make statify's idempotency marker non-enumerable

### DIFF
--- a/UI/src/lib/common/statify.svelte.ts
+++ b/UI/src/lib/common/statify.svelte.ts
@@ -26,13 +26,9 @@ export const statify = <T>(state: T) => {
 		return state;
 	}
 
-	statified.__statifyPerformed = true;
+	Object.defineProperty(statified, '__statifyPerformed', { value: true, enumerable: false });
 
 	for (const property in state) {
-		if (property === '__statifyPerformed') {
-			continue;
-		}
-
 		const data = statified[property];
 		const dataType = typeof data;
 		if (dataType === 'function') {

--- a/UI/src/tests/lib/common/statify.svelte.test.ts
+++ b/UI/src/tests/lib/common/statify.svelte.test.ts
@@ -39,6 +39,13 @@ describe('statify', () => {
 		expect(statify(outer)).toBe(outer);
 	});
 
+	it('stamps the idempotency guard as non-enumerable', () => {
+		const outer = statify(new Outer());
+
+		expect(Object.keys(outer)).not.toContain('__statifyPerformed');
+		expect(JSON.stringify(outer)).not.toContain('__statifyPerformed');
+	});
+
 	it('recursively statifies nested class instances and array elements', () => {
 		const outer = statify(new Outer());
 


### PR DESCRIPTION
## Summary

`statify`'s idempotency flag was set as a plain enumerable property (`UI/src/lib/common/statify.svelte.ts:29`), so `__statifyPerformed` showed up in `Object.keys`/spread/`JSON.stringify` of any statified object — every manager, battler, and inventory `Item`. No current call site serializes a statified object onto the wire, but a statified instance accidentally passed into a command payload would have leaked the marker.

## Changes

- `Object.defineProperty(statified, '__statifyPerformed', { value: true, enumerable: false })` instead of a plain assignment.
- Removed the now-unreachable `if (property === '__statifyPerformed') continue;` guard in the `for...in` loop — a non-enumerable property never appears there, so the check was dead code.
- Added a test asserting the marker doesn't appear in `Object.keys` or `JSON.stringify` of a statified instance.

## Test plan

- [x] `npm run lint` — clean, 0 errors/warnings.
- [x] `npm run test:unit:ci` — full suite passes: 3543/3543 tests across 296 files, including the new assertion.

Closes #1710


---
_Generated by [Claude Code](https://claude.ai/code/session_01QBzddcUESL78FxvaYAriyy)_