### PR TITLE
Harden content-fixture tests: vacuous-pass guard, $content alias, anchorKey coverage

### DIFF
--- a/UI/src/components/tour/index.ts
+++ b/UI/src/components/tour/index.ts
@@ -1,3 +1,3 @@
 export { default as TourPlayer } from './TourPlayer.svelte';
-export { tutorialAnchor, getTutorialAnchor } from './tutorial-anchor';
+export { tutorialAnchor, getTutorialAnchor, TOUR_ANCHOR_KEY, TOUR_ANCHOR_KEYS } from './tutorial-anchor';
 export type { TourStep } from './tour-types';

--- a/UI/src/components/tour/tutorial-anchor.ts
+++ b/UI/src/components/tour/tutorial-anchor.ts
@@ -46,3 +46,26 @@ export function tutorialAnchor(node: HTMLElement, key: string) {
 		}
 	};
 }
+
+type Side = 'player' | 'enemy';
+
+/**
+ * Canonical builders for the per-side fight-screen anchor keys — the single source of truth both the
+ * `use:tutorialAnchor` call sites (`CombatFloaters`, `BattlerCard`, `Skills`) and `TOUR_ANCHOR_KEYS`
+ * below build from, so a lesson's `anchorKey` can be validated against real registrations without
+ * inspecting Svelte templates.
+ */
+export const TOUR_ANCHOR_KEY = {
+	fightCombatLog: (side: Side) => `fight-combat-log-${side}` as const,
+	fightHpBar: (side: Side) => `fight-hp-bar-${side}` as const,
+	fightSkillBar: (side: Side) => `fight-skill-bar-${side}` as const
+};
+
+const SIDES: readonly Side[] = ['player', 'enemy'];
+
+/** Every anchor key the app ever registers, across both sides. */
+export const TOUR_ANCHOR_KEYS: readonly string[] = SIDES.flatMap((side) => [
+	TOUR_ANCHOR_KEY.fightCombatLog(side),
+	TOUR_ANCHOR_KEY.fightHpBar(side),
+	TOUR_ANCHOR_KEY.fightSkillBar(side)
+]);

--- a/UI/src/components/tour/tutorial-anchor.ts
+++ b/UI/src/components/tour/tutorial-anchor.ts
@@ -63,7 +63,11 @@ export const TOUR_ANCHOR_KEY = {
 
 const SIDES: readonly Side[] = ['player', 'enemy'];
 
-/** Every anchor key the app ever registers, across both sides. */
+/**
+ * Every anchor key the app ever registers, across both sides — the *intended* single source of
+ * truth. `tutorialAnchor` itself accepts any string, so this is only complete as long as new
+ * `use:tutorialAnchor` call sites register their key here rather than inlining a fresh literal.
+ */
 export const TOUR_ANCHOR_KEYS: readonly string[] = SIDES.flatMap((side) => [
 	TOUR_ANCHOR_KEY.fightCombatLog(side),
 	TOUR_ANCHOR_KEY.fightHpBar(side),

--- a/UI/src/routes/game/screens/fight/BattlerCard.svelte
+++ b/UI/src/routes/game/screens/fight/BattlerCard.svelte
@@ -41,7 +41,7 @@
 	</div>
 
 	<!-- HP Bar -->
-	<div class="hp-bar-slot" use:tutorialAnchor={`fight-hp-bar-${side}`}>
+	<div class="hp-bar-slot" use:tutorialAnchor={TOUR_ANCHOR_KEY.fightHpBar(side)}>
 		<HpBar currentHealth={battler.currentHealth} {maxHealth} ariaLabel="{battler.name} health" />
 	</div>
 
@@ -60,7 +60,7 @@ import { EAttribute } from '$lib/api';
 import { type Battler } from '$lib/battle';
 import { formatNum, tintColor } from '$lib/common';
 import { enemyManager, playerManager } from '$lib/engine';
-import { HpBar, XpBar, tutorialAnchor } from '$components';
+import { HpBar, XpBar, tutorialAnchor, TOUR_ANCHOR_KEY } from '$components';
 import ActiveEffectChips from './ActiveEffectChips.svelte';
 import CombatFloaters from './CombatFloaters.svelte';
 import Skills from './Skills.svelte';

--- a/UI/src/routes/game/screens/fight/CombatFloaters.svelte
+++ b/UI/src/routes/game/screens/fight/CombatFloaters.svelte
@@ -10,7 +10,7 @@
 	aria-hidden="true"
 	data-testid={testId}
 	style:--float-duration="{DURATION_MS}ms"
-	use:tutorialAnchor={`fight-combat-log-${side}`}
+	use:tutorialAnchor={TOUR_ANCHOR_KEY.fightCombatLog(side)}
 >
 	{#each floaters as floater (floater.id)}
 		<div
@@ -47,7 +47,7 @@ import { onCombatFloat, type CombatFloatEvent } from '$lib/engine';
 import { EDamageType, type ISkillDamagePortion } from '$lib/api';
 import LogGlyph from '$components/log-panel/LogGlyph.svelte';
 import DamageRatioBar from '$components/DamageRatioBar.svelte';
-import { tutorialAnchor } from '$components';
+import { tutorialAnchor, TOUR_ANCHOR_KEY } from '$components';
 import type { GlyphKind } from '$components/log-panel/log-kind';
 
 type Props = {

--- a/UI/src/routes/game/screens/fight/Skills.svelte
+++ b/UI/src/routes/game/screens/fight/Skills.svelte
@@ -2,7 +2,7 @@
 	class="skills-row"
 	class:reversed={side === 'enemy'}
 	style:--ready-accent={readyAccent}
-	use:tutorialAnchor={`fight-skill-bar-${side}`}
+	use:tutorialAnchor={TOUR_ANCHOR_KEY.fightSkillBar(side)}
 >
 	{#each battler.skills as skill, index (skill?.id ?? -index - 1)}
 		<div class="skill-column">
@@ -55,7 +55,7 @@ import {
 import SkillEffectBadge from '$components/SkillEffectBadge.svelte';
 import CooldownOverlay from '$components/CooldownOverlay.svelte';
 import { describedByTooltip } from '$components/tooltip/describedby-tooltip';
-import { tutorialAnchor } from '$components';
+import { tutorialAnchor, TOUR_ANCHOR_KEY } from '$components';
 import SkillTooltip from './SkillTooltip.svelte';
 import { chargeProjection } from './skill-cooldown';
 

--- a/UI/src/tests/routes/game/screens/screen-defs.test.ts
+++ b/UI/src/tests/routes/game/screens/screen-defs.test.ts
@@ -94,6 +94,16 @@ describe('committed lesson content (content/lessons.json)', () => {
 	// anchorKey a live lesson step references must resolve to a real `use:tutorialAnchor` registration.
 	// A missing anchor degrades gracefully at runtime (centered callout), so this is a content-quality
 	// check, not a crash guard.
+	const liveAnchorKeys = liveLessons.flatMap((lesson) =>
+		lesson.steps.map((step) => step.anchorKey).filter((anchorKey) => anchorKey !== null)
+	);
+
+	// Guards against the check below passing vacuously if every live step happened to have a null
+	// anchorKey (a centered-callout step), mirroring the live-lesson guard above.
+	it('has at least one live lesson step with an anchorKey to check', () => {
+		expect(liveAnchorKeys.length).toBeGreaterThan(0);
+	});
+
 	it('gives every live lesson step an anchorKey that resolves to a registered tour anchor', () => {
 		const anchorKeys = new Set(TOUR_ANCHOR_KEYS);
 		const badAnchorKeys = liveLessons.flatMap((lesson) =>

--- a/UI/src/tests/routes/game/screens/screen-defs.test.ts
+++ b/UI/src/tests/routes/game/screens/screen-defs.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { GAME_SCREENS, visibleScreens, type ScreenDef } from '$routes/game/screens/screen-defs';
 import { ERole } from '$lib/api';
-import lessonsContent from '../../../../../../content/lessons.json';
+import { TOUR_ANCHOR_KEYS } from '$components';
+import lessonsContent from '$content/lessons.json';
 
 const screens: ScreenDef[] = [
 	{ key: 'fight', label: 'Fight', group: 'combat', built: true },
@@ -72,13 +73,35 @@ describe('GAME_SCREENS', () => {
 // backend representation, so the backend progression-graph lint deliberately leaves this check to
 // the frontend (see ProgressionGraphChecker.CheckLessons and #1673).
 describe('committed lesson content (content/lessons.json)', () => {
+	const liveLessons = lessonsContent.filter((lesson) => !lesson.retiredAt);
+
+	// Guards against the check below passing vacuously (e.g. an empty/fully-retired lessons.json)
+	// with zero real coverage.
+	it('has at least one live lesson to check', () => {
+		expect(liveLessons.length).toBeGreaterThan(0);
+	});
+
 	it('gives every live lesson a screenKey that resolves to a real ScreenDef.key', () => {
 		const screenKeys = new Set(GAME_SCREENS.map((s) => s.key));
-		const badScreenKeys = lessonsContent
-			.filter((lesson) => !lesson.retiredAt)
+		const badScreenKeys = liveLessons
 			.filter((lesson) => !screenKeys.has(lesson.screenKey))
 			.map((lesson) => `${lesson.key} -> "${lesson.screenKey}"`);
 
 		expect(badScreenKeys).toEqual([]);
+	});
+
+	// Frontend half of the coverage #1592 called for (the backend lint can't see the DOM): every
+	// anchorKey a live lesson step references must resolve to a real `use:tutorialAnchor` registration.
+	// A missing anchor degrades gracefully at runtime (centered callout), so this is a content-quality
+	// check, not a crash guard.
+	it('gives every live lesson step an anchorKey that resolves to a registered tour anchor', () => {
+		const anchorKeys = new Set(TOUR_ANCHOR_KEYS);
+		const badAnchorKeys = liveLessons.flatMap((lesson) =>
+			lesson.steps
+				.filter((step) => step.anchorKey && !anchorKeys.has(step.anchorKey))
+				.map((step) => `${lesson.key}[${step.ordinal}] -> "${step.anchorKey}"`)
+		);
+
+		expect(badAnchorKeys).toEqual([]);
 	});
 });

--- a/UI/svelte.config.js
+++ b/UI/svelte.config.js
@@ -15,7 +15,8 @@ const config = {
 			$stores: './src/stores',
 			$styles: './src/styles',
 			$components: './src/components',
-			$routes: './src/routes'
+			$routes: './src/routes',
+			$content: '../content'
 		}
 	}
 };

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -22,6 +22,8 @@ All frontend code lives in `UI`:
 
 Unit-test all UI logic (pages/components) and lib code; simple non-interactive display components don't need tests. Place tests under `tests` mirroring the source structure. Use Playwright e2e tests only for critical user flows, written from the user's perspective — they're costly to write and run.
 
+A test that reads committed content directly (e.g. asserting `content/lessons.json` only references real frontend keys) imports it via the `$content` alias (`kit.alias` in `svelte.config.js`, pointing at the repo-root `content/` folder) rather than a deep relative path out of the `UI/` package root.
+
 # Important Architectural Design Decisions
 
 ## Battle simulation & parity


### PR DESCRIPTION
## Summary

Follow-up from PR #1716 (closes #1673), addressing the two minor hardenings it flagged plus the "worth confirming" item:

1. **Vacuous-pass guard.** `screen-defs.test.ts`'s `screenKey` check now asserts at least one live lesson exists before checking them, so an empty/fully-retired `content/lessons.json` fails loudly instead of passing with zero coverage.
2. **Reusable content-import pattern.** Added a `$content` SvelteKit alias (`kit.alias` in `svelte.config.js`, pointing at the repo-root `content/` folder) and switched the deep six-level relative import to it. Documented the pattern in `docs/frontend.md`'s testing guidelines so future content-reading tests reuse it.
3. **anchorKey coverage.** Confirmed the frontend-only `anchorKey` validation referenced in #1592 ("A test asserting every anchorKey referenced by seeded lessons resolves to a registered anchor") didn't exist yet, so I added it: every live lesson step's `anchorKey` must resolve to a real `use:tutorialAnchor` registration.

   Doing that surfaced a small DRY gap: the three `use:tutorialAnchor` call sites (`CombatFloaters`, `BattlerCard`, `Skills`) each built their `fight-*-${side}` key inline, so a test would either have had to duplicate those literals (drift risk) or parse Svelte templates. Instead I added a canonical `TOUR_ANCHOR_KEY` builder registry in `tutorial-anchor.ts` that both the three call sites and the new test's `TOUR_ANCHOR_KEYS` list build from — matching the existing pattern where `GAME_SCREENS` is the single source of truth the `screenKey` check validates against.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — full suite passes, 3545/3545.
- Verified the `$content` alias resolves for both TypeScript (`svelte-kit sync` regenerates `.svelte-kit/tsconfig.json`) and Vitest.

Closes #1719


---
_Generated by [Claude Code](https://claude.ai/code/session_013ZQQsEZEppLaiAcTf8PzML)_