### PR TITLE
Extract shared PollingHelper for integration-test polling loops

### DIFF
--- a/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
@@ -416,22 +416,9 @@ namespace Game.Application.Tests.DataAccess
         // HashSetAndForget dispatches its HSET with CommandFlags.FireAndForget (RedisService.cs), so it can
         // return before the write lands on the server — a read on a separate connection right after a Save can
         // race it. Poll until the expected field count shows up rather than asserting on a single read (#1718).
-        private static async Task<HashEntry[]> WaitForHashFieldCountAsync(IDatabase redis, string hashKey, int minCount, int timeoutMs = 5000)
+        private static Task<HashEntry[]> WaitForHashFieldCountAsync(IDatabase redis, string hashKey, int minCount, int timeoutMs = 5000)
         {
-            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
-            HashEntry[] fields;
-            do
-            {
-                fields = await redis.HashGetAllAsync(hashKey);
-                if (fields.Length >= minCount)
-                {
-                    return fields;
-                }
-
-                await Task.Delay(25);
-            } while (DateTime.UtcNow < deadline);
-
-            return fields;
+            return PollingHelper.PollUntilAsync(() => redis.HashGetAllAsync(hashKey), fields => fields.Length >= minCount, timeoutMs);
         }
 
         private static async Task<ProgressUpdatedEvent> DequeueProgressEvent(IDatabase redis)

--- a/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
@@ -1,6 +1,7 @@
 using Game.Abstractions.Infrastructure;
 using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using StackExchange.Redis;
 using Xunit;
@@ -136,18 +137,7 @@ namespace Game.Application.Tests.DataAccess
 
             cache.ReclaimAndForget(key, "owner-a", TimeSpan.FromSeconds(30));
 
-            var deadline = DateTime.UtcNow.AddSeconds(5);
-            TimeSpan? ttl = null;
-            while (DateTime.UtcNow < deadline)
-            {
-                ttl = await ReadTtlAsync(key);
-                if (ttl > TimeSpan.FromSeconds(10))
-                {
-                    break;
-                }
-
-                await Task.Delay(25);
-            }
+            var ttl = await PollingHelper.PollUntilAsync(() => ReadTtlAsync(key), t => t > TimeSpan.FromSeconds(10));
 
             Assert.True(ttl > TimeSpan.FromSeconds(10), $"Expected the TTL to be extended past its 2s seed but was {ttl}.");
             Assert.Equal("owner-a", await cache.Get(key));
@@ -188,18 +178,7 @@ namespace Game.Application.Tests.DataAccess
 
             cache.HashSetAndForget(key, new Dictionary<string, string> { ["a"] = "1", ["b"] = "2" }, TimeSpan.FromSeconds(30));
 
-            Dictionary<string, string>? fields = null;
-            var deadline = DateTime.UtcNow.AddSeconds(5);
-            while (DateTime.UtcNow < deadline)
-            {
-                fields = await cache.HashGetAllIfExists(key);
-                if (fields is not null)
-                {
-                    break;
-                }
-
-                await Task.Delay(25);
-            }
+            var fields = await PollingHelper.PollUntilAsync(() => cache.HashGetAllIfExists(key), f => f is not null);
 
             Assert.NotNull(fields);
             Assert.Equal(2, fields.Count);
@@ -225,18 +204,7 @@ namespace Game.Application.Tests.DataAccess
             // past the 2s seed ceiling.
             cache.HashSetAndForget(key, new Dictionary<string, string> { ["a"] = "9" }, TimeSpan.FromSeconds(30));
 
-            Dictionary<string, string>? fields = null;
-            var deadline = DateTime.UtcNow.AddSeconds(5);
-            while (DateTime.UtcNow < deadline)
-            {
-                fields = await cache.HashGetAllIfExists(key);
-                if (fields?.GetValueOrDefault("a") == "9")
-                {
-                    break;
-                }
-
-                await Task.Delay(25);
-            }
+            var fields = await PollingHelper.PollUntilAsync(() => cache.HashGetAllIfExists(key), f => f?.GetValueOrDefault("a") == "9");
 
             Assert.NotNull(fields);
             Assert.Equal("9", fields["a"]);
@@ -277,34 +245,17 @@ namespace Game.Application.Tests.DataAccess
 
         private static async Task WaitForHashFieldCountAsync(ICacheService cache, string key, int count, int timeoutMs = 5000)
         {
-            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
-            while (DateTime.UtcNow < deadline)
+            var fields = await PollingHelper.PollUntilAsync(() => cache.HashGetAllIfExists(key), f => f?.Count == count, timeoutMs);
+            if (fields?.Count != count)
             {
-                if ((await cache.HashGetAllIfExists(key))?.Count == count)
-                {
-                    return;
-                }
-
-                await Task.Delay(25);
+                Assert.Fail($"Expected hash '{key}' to have {count} fields within the timeout.");
             }
-
-            Assert.Fail($"Expected hash '{key}' to have {count} fields within the timeout.");
         }
 
         private static async Task<bool> WaitUntilValueEqualsAsync(ICacheService cache, string key, string expected, int timeoutMs = 5000)
         {
-            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
-            while (DateTime.UtcNow < deadline)
-            {
-                if (await cache.Get(key) == expected)
-                {
-                    return true;
-                }
-
-                await Task.Delay(25);
-            }
-
-            return await cache.Get(key) == expected;
+            var value = await PollingHelper.PollUntilAsync(() => cache.Get(key), v => v == expected, timeoutMs);
+            return value == expected;
         }
 
         private async Task<TimeSpan?> ReadTtlAsync(string key)

--- a/Game.TestInfrastructure/Helpers/PollingHelper.cs
+++ b/Game.TestInfrastructure/Helpers/PollingHelper.cs
@@ -1,0 +1,33 @@
+namespace Game.TestInfrastructure.Helpers
+{
+    /// <summary>
+    /// Shared polling loop for integration tests reading a fire-and-forget write (e.g. Redis
+    /// <c>HashSetAndForget</c>/<c>ReclaimAndForget</c>) that can complete before the write lands
+    /// on the server, so a read taken immediately after can race it (#1718).
+    /// </summary>
+    public static class PollingHelper
+    {
+        /// <summary>
+        /// Polls <paramref name="read"/> every 25ms, returning as soon as <paramref name="satisfied"/> holds
+        /// on the read value. Returns the last read value even if <paramref name="satisfied"/> never holds
+        /// before <paramref name="timeoutMs"/> elapses, leaving the pass/fail decision to the caller.
+        /// </summary>
+        public static async Task<T> PollUntilAsync<T>(Func<Task<T>> read, Func<T, bool> satisfied, int timeoutMs = 5000)
+        {
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            T value;
+            do
+            {
+                value = await read();
+                if (satisfied(value))
+                {
+                    return value;
+                }
+
+                await Task.Delay(25);
+            } while (DateTime.UtcNow < deadline);
+
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The backend integration test suite had accumulated several near-identical "poll a Redis read until a condition holds, or fail on a timeout" loops, driven by `HashSetAndForget`/`ReclaimAndForget`'s fire-and-forget writes racing a read taken on a separate connection right after (#1718). Per the issue, they differed in the abstraction polled and in timeout behavior (assert-and-fail vs. return-last-read), but the underlying loop — poll every 25ms until a predicate holds or a deadline passes — was identical everywhere.

## Changes

- **`Game.TestInfrastructure/Helpers/PollingHelper.cs`** (new): a single generic `PollUntilAsync<T>(Func<Task<T>> read, Func<T, bool> satisfied, int timeoutMs = 5000)`. It always returns the last read value — even on timeout — so each call site keeps its own pass/fail decision (`Assert.Fail`, `Assert.NotNull`, or just returning the value), matching the issue's suggested shape.
- **`RedisServiceIntegrationTests.cs`**: expressed both named waiters (`WaitForHashFieldCountAsync` on `ICacheService`, `WaitUntilValueEqualsAsync`) in terms of the helper, and additionally converted three inline ad-hoc polling loops in the same file (TTL-refresh wait, two hash-field waits) that had the identical pattern but weren't separately named — the issue's own notes call out that the pattern is "the same everywhere," and these were a mechanical fit for the same fix.
- **`PlayerProgressRepositoryIntegrationTests.cs`**: expressed its `WaitForHashFieldCountAsync` (on raw `IDatabase`, `>= minCount`, returns last read on timeout) in terms of the helper.

No behavior change — purely test-suite maintainability, as called out in the issue.

## Test plan

- [x] `dotnet build` — solution builds clean, 0 warnings.
- [x] `dotnet test --no-build --no-restore` — full solution suite passes: 3027/3027 (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests), including both modified integration test classes.

Closes #1723


---
_Generated by [Claude Code](https://claude.ai/code/session_012TRToBYehkQe2fjbvPFujA)_