### PR TITLE
Dedupe LoginTrackingMiddleware's DB upsert per (user, IP, device)

### DIFF
--- a/Game.Api.Tests/Unit/LoginTrackingMiddlewareTests.cs
+++ b/Game.Api.Tests/Unit/LoginTrackingMiddlewareTests.cs
@@ -1,0 +1,220 @@
+using Game.Abstractions.DataAccess;
+using Game.Api.Http;
+using Game.Api.Middleware;
+using Game.Api.Services;
+using Game.Application.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Net;
+using Xunit;
+
+namespace Game.Api.Tests.Unit
+{
+    /// <summary>
+    /// Covers <see cref="LoginTrackingMiddleware"/>'s request-skip conditions and its per-(user, IP, device)
+    /// dedupe memo (#1727): a genuinely new combination is always recorded, but repeat requests from the same
+    /// combination within the dedupe window skip the multi-query DB upsert entirely, and a failed attempt is
+    /// never memoized as done so it is retried on the next request.
+    /// </summary>
+    public class LoginTrackingMiddlewareTests
+    {
+        private const string Fingerprint = "fp-abc";
+        private const string UserAgent = "TestAgent/1.0";
+        private const string Ip = "203.0.113.7";
+
+        [Fact]
+        public async Task Unauthenticated_SkipsTrackingAndCallsNext()
+        {
+            var (middleware, userLogins, nextCalled) = CreateMiddleware();
+            var session = new SessionService(new NoOpSessionStore());
+            var context = CreateContext(Ip, Fingerprint, UserAgent);
+
+            await middleware.InvokeAsync(context, session, ScopeFactory(userLogins), new MemoryCache(new MemoryCacheOptions()));
+
+            Assert.Equal(0, userLogins.RecordConnectionCallCount);
+            Assert.True(nextCalled());
+        }
+
+        [Fact]
+        public async Task Authenticated_NoFingerprintHeader_SkipsTrackingAndCallsNext()
+        {
+            var (middleware, userLogins, nextCalled) = CreateMiddleware();
+            var session = AuthenticatedSession(userId: 5);
+            var context = CreateContext(Ip, fingerprint: null, UserAgent);
+
+            await middleware.InvokeAsync(context, session, ScopeFactory(userLogins), new MemoryCache(new MemoryCacheOptions()));
+
+            Assert.Equal(0, userLogins.RecordConnectionCallCount);
+            Assert.True(nextCalled());
+        }
+
+        [Fact]
+        public async Task Authenticated_NewDeviceIpUser_RecordsConnectionAndCallsNext()
+        {
+            var (middleware, userLogins, nextCalled) = CreateMiddleware();
+            var session = AuthenticatedSession(userId: 5);
+            var context = CreateContext(Ip, Fingerprint, UserAgent);
+
+            await middleware.InvokeAsync(context, session, ScopeFactory(userLogins), new MemoryCache(new MemoryCacheOptions()));
+
+            Assert.Equal(1, userLogins.RecordConnectionCallCount);
+            Assert.True(nextCalled());
+        }
+
+        [Fact]
+        public async Task Authenticated_RepeatRequestSameKey_SkipsTheSecondDbRoundTrip()
+        {
+            var (middleware, userLogins, _) = CreateMiddleware();
+            var session = AuthenticatedSession(userId: 5);
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var scopeFactory = ScopeFactory(userLogins);
+
+            await middleware.InvokeAsync(CreateContext(Ip, Fingerprint, UserAgent), session, scopeFactory, cache);
+            await middleware.InvokeAsync(CreateContext(Ip, Fingerprint, UserAgent), session, scopeFactory, cache);
+
+            // Same (user, IP, device) within the dedupe window: only the first request hits the DB.
+            Assert.Equal(1, userLogins.RecordConnectionCallCount);
+        }
+
+        [Theory]
+        [InlineData("203.0.113.8", Fingerprint)]
+        [InlineData(Ip, "fp-different")]
+        public async Task Authenticated_DifferentIpOrDevice_RecordsSeparately(string ip, string fingerprint)
+        {
+            var (middleware, userLogins, _) = CreateMiddleware();
+            var session = AuthenticatedSession(userId: 5);
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var scopeFactory = ScopeFactory(userLogins);
+
+            await middleware.InvokeAsync(CreateContext(Ip, Fingerprint, UserAgent), session, scopeFactory, cache);
+            await middleware.InvokeAsync(CreateContext(ip, fingerprint, UserAgent), session, scopeFactory, cache);
+
+            Assert.Equal(2, userLogins.RecordConnectionCallCount);
+        }
+
+        [Fact]
+        public async Task Authenticated_DifferentUser_RecordsSeparately()
+        {
+            var (middleware, userLogins, _) = CreateMiddleware();
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var scopeFactory = ScopeFactory(userLogins);
+
+            await middleware.InvokeAsync(CreateContext(Ip, Fingerprint, UserAgent), AuthenticatedSession(userId: 5), scopeFactory, cache);
+            await middleware.InvokeAsync(CreateContext(Ip, Fingerprint, UserAgent), AuthenticatedSession(userId: 6), scopeFactory, cache);
+
+            Assert.Equal(2, userLogins.RecordConnectionCallCount);
+        }
+
+        [Fact]
+        public async Task RecordConnectionThrows_IsSwallowedAndNotMemoized_SoTheNextRequestRetries()
+        {
+            var (middleware, userLogins, nextCalled) = CreateMiddleware();
+            userLogins.ThrowOnRecordConnection = true;
+            var session = AuthenticatedSession(userId: 5);
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var scopeFactory = ScopeFactory(userLogins);
+
+            await middleware.InvokeAsync(CreateContext(Ip, Fingerprint, UserAgent), session, scopeFactory, cache);
+            await middleware.InvokeAsync(CreateContext(Ip, Fingerprint, UserAgent), session, scopeFactory, cache);
+
+            // A failed save is never memoized as done, so both requests attempted the DB call, and neither
+            // failure broke the request itself.
+            Assert.Equal(2, userLogins.RecordConnectionCallCount);
+            Assert.True(nextCalled());
+        }
+
+        private static (LoginTrackingMiddleware Middleware, FakeUserLogins UserLogins, Func<bool> NextCalled) CreateMiddleware()
+        {
+            var nextCalled = false;
+            RequestDelegate next = _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            };
+
+            var middleware = new LoginTrackingMiddleware(next, NullLogger<LoginTrackingMiddleware>.Instance);
+            return (middleware, new FakeUserLogins(), () => nextCalled);
+        }
+
+        private static SessionService AuthenticatedSession(int userId)
+        {
+            var session = new SessionService(new NoOpSessionStore());
+            session.SetAuthenticatedUser(userId);
+            return session;
+        }
+
+        private static IServiceScopeFactory ScopeFactory(FakeUserLogins userLogins)
+        {
+            var provider = new ServiceCollection()
+                .AddScoped<IUserLogins>(_ => userLogins)
+                .AddScoped<LoginTrackingService>()
+                .BuildServiceProvider();
+            return provider.GetRequiredService<IServiceScopeFactory>();
+        }
+
+        private static DefaultHttpContext CreateContext(string ip, string? fingerprint, string userAgent)
+        {
+            var context = new DefaultHttpContext();
+            context.Connection.RemoteIpAddress = IPAddress.Parse(ip);
+            context.Request.Headers.UserAgent = userAgent;
+            if (fingerprint is not null)
+            {
+                context.Request.Headers[ClientHints.DeviceFingerprintHeader] = fingerprint;
+            }
+
+            return context;
+        }
+
+        // Records how many times RecordConnection was actually invoked, so tests can tell whether the
+        // dedupe memo skipped the DB round-trip. ThrowOnRecordConnection lets a test pin the failure path.
+        private sealed class FakeUserLogins : IUserLogins
+        {
+            public int RecordConnectionCallCount { get; private set; }
+            public bool ThrowOnRecordConnection { get; set; }
+
+            public Task RecordConnection(
+                int userId,
+                string ipAddress,
+                string deviceFingerprintHash,
+                string userAgent,
+                string? secChUa,
+                string? secChUaMobile,
+                string? secChUaPlatform,
+                CancellationToken cancellationToken = default)
+            {
+                RecordConnectionCallCount++;
+                if (ThrowOnRecordConnection)
+                {
+                    throw new InvalidOperationException("simulated tracking failure");
+                }
+
+                return Task.CompletedTask;
+            }
+
+            public Task SaveDeviceInfo(
+                string deviceFingerprintHash,
+                string userAgent,
+                string? secChUa,
+                string? secChUaMobile,
+                string? secChUaPlatform,
+                double? deviceMemory,
+                int? hardwareConcurrency,
+                CancellationToken cancellationToken = default)
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        private sealed class NoOpSessionStore : ISessionStore
+        {
+            public Task<Game.Core.Players.PlayerState?> GetSession(int userId, CancellationToken cancellationToken = default) =>
+                Task.FromResult<Game.Core.Players.PlayerState?>(null);
+
+            public void Update(Game.Core.Players.PlayerState sessionData, int userId) { }
+
+            public void Clear(int userId) { }
+        }
+    }
+}

--- a/Game.Api/Middleware/LoginTrackingMiddleware.cs
+++ b/Game.Api/Middleware/LoginTrackingMiddleware.cs
@@ -1,6 +1,7 @@
 using Game.Api.Http;
 using Game.Api.Services;
 using Game.Application.Services;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Game.Api.Middleware
 {
@@ -10,6 +11,15 @@ namespace Game.Api.Middleware
     /// request's user identity is available. Recording is keyed on the device fingerprint the frontend
     /// sends as a header, so a request without one (e.g. a WebSocket handshake, which cannot set custom
     /// headers) is skipped.
+    /// <para>
+    /// Repeat requests from the same (user, IP, device) within <see cref="DedupeWindow"/> are skipped via
+    /// an in-memory, instance-local memo — the connection row is idempotent, so re-recording it adds no
+    /// information but costs a multi-query upsert every time. This keeps a short burst of requests from
+    /// the same device (the login flow's several hops, a run of admin Workbench saves) from each paying
+    /// the DB round-trip. The memo is only set after a successful save, so a failed attempt is retried on
+    /// the next request rather than being silently memoized as done; a genuinely new device/IP is still
+    /// recorded promptly since it always misses the memo on its first request.
+    /// </para>
     /// <para>
     /// Tracking is best-effort and <b>structurally isolated</b>: it runs on its own DI scope (its own
     /// <c>GameContext</c>) and self-commits there, so a tracking save failure — which the swallow below
@@ -21,41 +31,53 @@ namespace Game.Api.Middleware
     /// </summary>
     public class LoginTrackingMiddleware(RequestDelegate next, ILogger<LoginTrackingMiddleware> logger)
     {
+        private static readonly TimeSpan DedupeWindow = TimeSpan.FromMinutes(5);
+
         private readonly RequestDelegate _next = next;
         private readonly ILogger<LoginTrackingMiddleware> _logger = logger;
 
-        public async Task InvokeAsync(HttpContext context, SessionService sessionService, IServiceScopeFactory scopeFactory)
+        public async Task InvokeAsync(HttpContext context, SessionService sessionService, IServiceScopeFactory scopeFactory, IMemoryCache cache)
         {
             var fingerprint = ClientHints.DeviceFingerprint(context.Request.Headers);
             if (sessionService.Authenticated && fingerprint is not null)
             {
-                try
+                var ipAddress = ClientIp.Resolve(context);
+                var cacheKey = new TrackingCacheKey(sessionService.UserId, ipAddress, fingerprint);
+
+                if (!cache.TryGetValue<bool>(cacheKey, out _))
                 {
-                    var hints = ClientHints.FromHeaders(context.Request.Headers);
-                    // Resolve tracking from a dedicated scope so its GameContext is independent of the
-                    // request's. RecordConnection self-commits; sharing the request context would let a
-                    // non-unique save failure leave queued inserts that the later per-request commit
-                    // re-flushes (or breaks on). The scope is disposed here whatever the outcome.
-                    await using var scope = scopeFactory.CreateAsyncScope();
-                    var trackingService = scope.ServiceProvider.GetRequiredService<LoginTrackingService>();
-                    await trackingService.RecordConnection(
-                        sessionService.UserId,
-                        ClientIp.Resolve(context),
-                        fingerprint,
-                        hints.UserAgent,
-                        hints.SecChUa,
-                        hints.SecChUaMobile,
-                        hints.SecChUaPlatform,
-                        context.RequestAborted);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Failed to record login tracking for user {UserId}.", sessionService.UserId);
+                    try
+                    {
+                        var hints = ClientHints.FromHeaders(context.Request.Headers);
+                        // Resolve tracking from a dedicated scope so its GameContext is independent of the
+                        // request's. RecordConnection self-commits; sharing the request context would let a
+                        // non-unique save failure leave queued inserts that the later per-request commit
+                        // re-flushes (or breaks on). The scope is disposed here whatever the outcome.
+                        await using var scope = scopeFactory.CreateAsyncScope();
+                        var trackingService = scope.ServiceProvider.GetRequiredService<LoginTrackingService>();
+                        await trackingService.RecordConnection(
+                            sessionService.UserId,
+                            ipAddress,
+                            fingerprint,
+                            hints.UserAgent,
+                            hints.SecChUa,
+                            hints.SecChUaMobile,
+                            hints.SecChUaPlatform,
+                            context.RequestAborted);
+
+                        cache.Set(cacheKey, true, DedupeWindow);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to record login tracking for user {UserId}.", sessionService.UserId);
+                    }
                 }
             }
 
             await _next(context);
         }
+
+        private readonly record struct TrackingCacheKey(int UserId, string IpAddress, string Fingerprint);
     }
 
     /// <summary>

--- a/Game.Api/Startup.cs
+++ b/Game.Api/Startup.cs
@@ -138,6 +138,9 @@ namespace Game.Api
             builder.Services.AddEndpointsApiExplorer()
                 .AddSwaggerGen()
                 .AddHttpContextAccessor()
+                // Backs LoginTrackingMiddleware's short-lived per-device dedupe memo (instance-local is
+                // fine — a session sticks to one instance, per the single-connection architecture).
+                .AddMemoryCache()
                 .AddDataAccess()
                 .AddDomainEventDispatcher()
                 .AddApplication()


### PR DESCRIPTION
## Summary

`LoginTrackingMiddleware` awaits `RecordConnection` (2-3 SELECTs + a `SaveChanges`, `Game.DataAccess/Repositories/UserLogins.cs:23-72`) **before** `_next(context)` on every authenticated HTTP request. Since the frontend attaches the device-fingerprint header on every authenticated request, this serially delays:

- each hop of the login flow (Login → Players → SelectPlayer → ActiveSession → Status → DeviceInfo), and
- every admin Workbench call, on top of the awaited cache reload each admin save already pays (#1708).

## Fix

The connection row is idempotent — repeat hits from the same `(user, IP, device)` add no information — so the middleware now dedupes with a short-lived in-memory memo (`IMemoryCache`, 5-minute window, instance-local):

- A cache miss runs the DB upsert as before, and only sets the memo **after** a successful save — so a failed attempt is never memoized as done and is retried on the very next request.
- A cache hit skips the DB round-trip entirely.
- A genuinely new `(user, IP, device)` combination always misses the memo on its first request, so it is still recorded promptly.

Instance-local scope is fine here: per `docs/backend.md`, a player session sticks to one server instance for its lifetime, so the memo doesn't need to be shared across instances (Redis) — worst case on an instance switch is one extra DB write, not a correctness issue.

## Changes

- `Game.Api/Middleware/LoginTrackingMiddleware.cs`: adds the `IMemoryCache`-backed dedupe memo, keyed by `(UserId, IpAddress, Fingerprint)`.
- `Game.Api/Startup.cs`: registers `IMemoryCache` via `AddMemoryCache()`.
- `Game.Api.Tests/Unit/LoginTrackingMiddlewareTests.cs` (new): covers the skip conditions (unauthenticated, no fingerprint header), that a new combination records and calls `next`, that a repeat request within the window skips the DB call, that a different IP/device/user each records separately, and that a save failure is swallowed but not memoized (so it's retried).

## Test plan

- [x] `dotnet build` — solution builds clean, 0 warnings.
- [x] `dotnet test` — full solution suite passes: 3035/3035 (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests), including the existing `LoginTrackingIsolationTests` integration test (still passes unmodified — that test uses a fresh device/IP per run, so it isn't affected by the dedupe memo) and the new middleware unit tests.

Closes #1727


---
_Generated by [Claude Code](https://claude.ai/code/session_01WniWr4qbSdrsXWubjza3Zc)_