### PR TITLE
Route server-push socket commands through the shared DeserializeParameters helper

### DIFF
--- a/Game.Api.Tests/CodeGen/SocketCommandMetadataTests.cs
+++ b/Game.Api.Tests/CodeGen/SocketCommandMetadataTests.cs
@@ -75,6 +75,18 @@ namespace Game.Api.Tests.CodeGen
             Assert.Null(metadata.ResponseDescriptor);
             Assert.Null(metadata.ParameterDescriptor);
         }
+
+        [Fact]
+        public void Constructor_ServerInitiatedCommand_OmitsParameterDescriptor()
+        {
+            // A server-initiated command may still bind Parameters from a typed base (to reuse
+            // DeserializeParameters<T>'s malformed-payload classification), but the client only ever listens
+            // for it and can never send it, so it must not surface in ApiSocketRequestTypes.
+            var metadata = new SocketCommandMetadata(typeof(TestSocketCommandServerInitiatedFull));
+
+            Assert.NotNull(metadata.ResponseDescriptor);
+            Assert.Null(metadata.ParameterDescriptor);
+        }
     }
 
     public class SocketParamModel
@@ -147,6 +159,16 @@ namespace Game.Api.Tests.CodeGen
         public override Task<ApiSocketResponse> ExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
             return Task.FromResult(Success());
+        }
+    }
+
+    public class TestSocketCommandServerInitiatedFull : AbstractSocketCommand<SimpleModel, SocketParamModel>, IServerInitiatedCommand
+    {
+        public override string Name { get; set; } = "TestServerInitiatedFull";
+
+        public override Task<ApiSocketResponse<SimpleModel>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Success(new SimpleModel()));
         }
     }
 }

--- a/Game.Api.Tests/Unit/ProficiencyXpGainedCommandTests.cs
+++ b/Game.Api.Tests/Unit/ProficiencyXpGainedCommandTests.cs
@@ -6,12 +6,18 @@ namespace Game.Api.Tests.Unit
 {
     /// <summary>
     /// Unit coverage for the server-initiated <see cref="ProficiencyXpGained"/> push command: it echoes the
-    /// emitted payload straight back as its response data (the client listens for it), and rejects a missing
-    /// payload on both the set-parameters and execute paths. The handler ignores the socket context, so these
-    /// run as plain unit tests without a live socket — mirroring the other echo push commands.
+    /// emitted payload straight back as its response data (the client listens for it), and classifies a missing
+    /// payload as <see cref="MalformedSocketCommandParametersException"/> like every other command's
+    /// <c>SetParameters</c>. The handler ignores the socket context, so these run as plain unit tests without a
+    /// live socket — mirroring the other echo push commands.
     /// </summary>
     public class ProficiencyXpGainedCommandTests
     {
+        private static ProficiencyXpGained NewCommand()
+        {
+            return new ProficiencyXpGained { Parameters = new ProficiencyXpGainedModel { Proficiencies = [], Opened = [] } };
+        }
+
         [Fact]
         public async Task SetParameters_ThenExecute_EchoesThePayloadBack()
         {
@@ -32,7 +38,7 @@ namespace Game.Api.Tests.Unit
                 Opened = [new ProficiencyOpenedModel { ProficiencyId = 4 }],
             };
 
-            var command = new ProficiencyXpGained();
+            var command = NewCommand();
             // The emitted info carries the serialized payload exactly as the notifier would send it.
             command.SetParameters(new ProficiencyXpGainedInfo(model).Parameters);
 
@@ -51,18 +57,13 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
-        public void SetParameters_NullPayload_Throws()
+        public void SetParameters_NullPayload_ThrowsMalformedSocketCommandParametersException()
         {
-            var command = new ProficiencyXpGained();
-            Assert.Throws<ArgumentNullException>(() => command.SetParameters(null));
-        }
+            var command = NewCommand();
 
-        [Fact]
-        public async Task Execute_WithoutParameters_Throws()
-        {
-            var command = new ProficiencyXpGained();
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                () => command.HandleExecuteAsync(context: null!, CancellationToken.None));
+            var ex = Assert.Throws<MalformedSocketCommandParametersException>(() => command.SetParameters(null));
+
+            Assert.IsType<ArgumentNullException>(ex.InnerException);
         }
     }
 }

--- a/Game.Api/CodeGen/Data/SocketCommandMetadata.cs
+++ b/Game.Api/CodeGen/Data/SocketCommandMetadata.cs
@@ -30,8 +30,14 @@ namespace Game.Api.CodeGen.Data
                 }
             }
 
-            if (socketCommand.GetClosedGenericBase(typeof(AbstractSocketCommandWithParams<>)) is not null
-                || socketCommand.GetClosedGenericBase(typeof(AbstractSocketCommand<,>)) is not null)
+            // A server-initiated command (IServerInitiatedCommand) may bind its Parameters from a typed base
+            // purely to reuse DeserializeParameters<T>'s malformed-payload classification, but the client only
+            // ever listens for it and can never send it (SocketCommandFactory.IsServerInitiatedOnly rejects an
+            // inbound attempt). It must never surface in ApiSocketRequestTypes/ApiSocketCommandWithRequest,
+            // which the frontend uses to type its client->server sends.
+            if (!socketCommand.IsAssignableTo(typeof(IServerInitiatedCommand))
+                && (socketCommand.GetClosedGenericBase(typeof(AbstractSocketCommandWithParams<>)) is not null
+                    || socketCommand.GetClosedGenericBase(typeof(AbstractSocketCommand<,>)) is not null))
             {
                 var property = socketCommand.GetProperty(nameof(AbstractSocketCommandWithParams<>.Parameters));
                 if (property is not null)

--- a/Game.Api/Sockets/Commands/ChallengeCompleted.cs
+++ b/Game.Api/Sockets/Commands/ChallengeCompleted.cs
@@ -8,30 +8,15 @@ namespace Game.Api.Sockets.Commands
     /// A server-initiated push (never sent by the client): the instance holding the player's socket
     /// receives the emitted <see cref="ChallengeCompletedInfo"/> and forwards its payload to the client.
     /// The payload arrives as the command parameters and is echoed straight back as the response data, so
-    /// the client's <c>ChallengeCompleted</c> listener can unlock the rewards locally. It carries no
-    /// request type (the parameters are not a typed <c>Parameters</c> property) since the client only
-    /// listens for it.
+    /// the client's <c>ChallengeCompleted</c> listener can unlock the rewards locally.
     /// </summary>
-    public class ChallengeCompleted : AbstractSocketCommandWithResponseData<ChallengeCompletedModel>, IServerInitiatedCommand
+    public class ChallengeCompleted : AbstractSocketCommand<ChallengeCompletedModel, ChallengeCompletedModel>, IServerInitiatedCommand
     {
-        private ChallengeCompletedModel? _model;
-
         public override string Name { get; set; } = nameof(ChallengeCompleted);
-
-        public override void SetParameters(string? parameters)
-        {
-            _model = parameters.Deserialize<ChallengeCompletedModel>()
-                ?? throw new ArgumentNullException(nameof(parameters));
-        }
 
         public override Task<ApiSocketResponse<ChallengeCompletedModel>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
-            if (_model is null)
-            {
-                throw new InvalidOperationException("ChallengeCompleted executed without parameters.");
-            }
-
-            return Task.FromResult(Success(_model));
+            return Task.FromResult(Success(Parameters));
         }
     }
 

--- a/Game.Api/Sockets/Commands/ProficiencyXpGained.cs
+++ b/Game.Api/Sockets/Commands/ProficiencyXpGained.cs
@@ -8,30 +8,16 @@ namespace Game.Api.Sockets.Commands
     /// A server-initiated push (never sent by the client): the instance holding the player's socket receives
     /// the emitted <see cref="ProficiencyXpGainedInfo"/> and forwards its payload to the client. The payload
     /// arrives as the command parameters and is echoed straight back as the response data, so the client's
-    /// <c>ProficiencyXpGained</c> listener can update its proficiency store and surface level-ups/milestones.
-    /// It carries no request type (the parameters are not a typed <c>Parameters</c> property) since the client
-    /// only listens for it — mirroring <see cref="ChallengeCompleted"/>.
+    /// <c>ProficiencyXpGained</c> listener can update its proficiency store and surface level-ups/milestones
+    /// — mirroring <see cref="ChallengeCompleted"/>.
     /// </summary>
-    public class ProficiencyXpGained : AbstractSocketCommandWithResponseData<ProficiencyXpGainedModel>, IServerInitiatedCommand
+    public class ProficiencyXpGained : AbstractSocketCommand<ProficiencyXpGainedModel, ProficiencyXpGainedModel>, IServerInitiatedCommand
     {
-        private ProficiencyXpGainedModel? _model;
-
         public override string Name { get; set; } = nameof(ProficiencyXpGained);
-
-        public override void SetParameters(string? parameters)
-        {
-            _model = parameters.Deserialize<ProficiencyXpGainedModel>()
-                ?? throw new ArgumentNullException(nameof(parameters));
-        }
 
         public override Task<ApiSocketResponse<ProficiencyXpGainedModel>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
-            if (_model is null)
-            {
-                throw new InvalidOperationException("ProficiencyXpGained executed without parameters.");
-            }
-
-            return Task.FromResult(Success(_model));
+            return Task.FromResult(Success(Parameters));
         }
     }
 

--- a/Game.Api/Sockets/Commands/ServerCommandFailed.cs
+++ b/Game.Api/Sockets/Commands/ServerCommandFailed.cs
@@ -7,29 +7,15 @@ namespace Game.Api.Sockets.Commands
     /// A server-initiated push (never sent by the client) telling the client that a different server-pushed
     /// command failed on the server and was dead-lettered, so the client can re-sync the authoritative state
     /// that push would have updated rather than silently diverging. It carries the failed command's name as
-    /// the payload and echoes it back as the response data, mirroring <see cref="ChallengeCompleted"/>; the
-    /// client only listens for it, so it carries no client request type.
+    /// the payload and echoes it back as the response data, mirroring <see cref="ChallengeCompleted"/>.
     /// </summary>
-    public class ServerCommandFailed : AbstractSocketCommandWithResponseData<ServerCommandFailedModel>, IServerInitiatedCommand
+    public class ServerCommandFailed : AbstractSocketCommand<ServerCommandFailedModel, ServerCommandFailedModel>, IServerInitiatedCommand
     {
-        private ServerCommandFailedModel? _model;
-
         public override string Name { get; set; } = nameof(ServerCommandFailed);
-
-        public override void SetParameters(string? parameters)
-        {
-            _model = parameters.Deserialize<ServerCommandFailedModel>()
-                ?? throw new ArgumentNullException(nameof(parameters));
-        }
 
         public override Task<ApiSocketResponse<ServerCommandFailedModel>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
-            if (_model is null)
-            {
-                throw new InvalidOperationException("ServerCommandFailed executed without parameters.");
-            }
-
-            return Task.FromResult(Success(_model));
+            return Task.FromResult(Success(Parameters));
         }
     }
 


### PR DESCRIPTION
## Summary

`ChallengeCompleted`, `ProficiencyXpGained`, and `ServerCommandFailed` each overrode `SetParameters` with a raw `Deserialize<T>` call plus a manual `ArgumentNullException`, instead of going through the shared `DeserializeParameters<T>` helper on `AbstractSocketCommand` (`Game.Api/Sockets/Commands/AbstractSocketCommand.cs:25`). That meant a malformed payload on these three commands classified as `Faulted` rather than `MalformedParameters`, contradicting the `SocketHandler` comment claiming every `SetParameters` implementation throws `MalformedSocketCommandParametersException` — plus each command carried its own null-recheck in `HandleExecuteAsync` that the helper already makes unnecessary.

## Changes

All three server-push commands echo their payload straight back as response data (same model in and out), so they're a natural fit for the existing `AbstractSocketCommand<TReturn, TParams>` base (used elsewhere for typed request/response commands) with `TReturn == TParams`:

- `ChallengeCompleted`, `ProficiencyXpGained`, `ServerCommandFailed`: now extend `AbstractSocketCommand<TModel, TModel>` instead of `AbstractSocketCommandWithResponseData<TModel>`. This drops the bespoke `SetParameters` override, the backing nullable field, and the `HandleExecuteAsync` null-recheck in each — `Parameters` is guaranteed bound before `ExecuteAsync` runs (`SocketCommandFactory.CreateCommand` always calls `SetParameters` right after construction).
- A malformed/missing payload on any of the three now throws `MalformedSocketCommandParametersException` (wrapping the original `JsonException`/`ArgumentNullException`) like every other command, so the `SocketHandler` comment is accurate again.

## Tests

- `Game.Api.Tests/Unit/ProficiencyXpGainedCommandTests.cs`: updated the null-payload test to assert `MalformedSocketCommandParametersException` (wrapping `ArgumentNullException`) instead of a bare `ArgumentNullException`. Removed `Execute_WithoutParameters_Throws` since the scenario it covered (executing before parameters are bound) no longer exists once the null-recheck is removed — no other command in the codebase tests that path either, since the factory always binds parameters first.
- No behavior change for the happy path or for existing integration tests (`ChallengeCompletedSocketTests`, `ServerInitiatedCommandRejectionTests`) — both still pass unchanged.

## Test plan

- [x] `dotnet build` — solution builds clean, 0 warnings.
- [x] `dotnet test --no-build --no-restore` — full solution suite passes: 3034/3034.

Closes #1728


---
_Generated by [Claude Code](https://claude.ai/code/session_017L5P7BEMmS9JA6XuErsbMf)_