### PR TITLE
Avoid double proficiency read in EquipItem's rating recompute

### DIFF
--- a/Game.Api/Sockets/Commands/EquipItem.cs
+++ b/Game.Api/Sockets/Commands/EquipItem.cs
@@ -29,14 +29,15 @@ namespace Game.Api.Sockets.Commands
         public override async Task<ApiSocketResponse<EquipItemResponse>> HandleExecuteAsync(SocketContext context, CancellationToken cancellationToken)
         {
             var player = context.Session.Player;
-            var success = await _playerService.EquipItem(
+            var (success, proficiencyLevels) = await _playerService.EquipItem(
                 player, Parameters.ItemId, (EEquipmentSlot)Parameters.EquipmentSlotId, cancellationToken);
 
             // Both outcomes carry the authoritative post-command rating so the client can always reconcile
-            // onto it, mirroring UpdatePlayerStats.
+            // onto it, mirroring UpdatePlayerStats. Reuses the proficiency levels the gear gate above already
+            // loaded rather than re-reading the same Redis hash (#1729).
             var result = new EquipItemResponse
             {
-                PlayerRating = await _battleService.RatePlayer(player, cancellationToken),
+                PlayerRating = _battleService.RatePlayer(player, proficiencyLevels),
             };
 
             return success ? Success(result) : ErrorWithData("Failed to equip item.", result);

--- a/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
@@ -42,7 +42,7 @@ namespace Game.Application.Tests.Services
             var player = await playerService.LoadPlayer(playerEntity.Id);
             Assert.NotNull(player);
 
-            var equipped = await playerService.EquipItem(player, item.Id, EEquipmentSlot.WeaponSlot);
+            var (equipped, _) = await playerService.EquipItem(player, item.Id, EEquipmentSlot.WeaponSlot);
 
             Assert.False(equipped);
             Assert.DoesNotContain(player.Inventory.EquipmentSlots, s => s.ItemId == item.Id);
@@ -68,10 +68,13 @@ namespace Game.Application.Tests.Services
             var player = await playerService.LoadPlayer(playerEntity.Id);
             Assert.NotNull(player);
 
-            var equipped = await playerService.EquipItem(player, item.Id, EEquipmentSlot.WeaponSlot);
+            var (equipped, proficiencyLevels) = await playerService.EquipItem(player, item.Id, EEquipmentSlot.WeaponSlot);
 
             Assert.True(equipped);
             Assert.Contains(player.Inventory.EquipmentSlots, s => s.ItemId == item.Id);
+            // The returned levels are the same read the gear gate used, so callers (e.g. EquipItem's socket
+            // command computing PlayerRating) can reuse them instead of re-reading the proficiency hash (#1729).
+            Assert.Contains(proficiencyLevels, p => p.ProficiencyId == proficiency.Id && p.Level == 5);
         }
 
         [Fact]
@@ -537,7 +540,7 @@ namespace Game.Application.Tests.Services
             var player = await playerService.LoadPlayer(playerEntity.Id);
             Assert.NotNull(player);
 
-            var success = await playerService.EquipItem(player, item.Id, EEquipmentSlot.WeaponSlot);
+            var (success, _) = await playerService.EquipItem(player, item.Id, EEquipmentSlot.WeaponSlot);
             Assert.True(success);
 
             // Drain the write-behind queue (the hosted worker is disabled in the harness) so the change
@@ -571,7 +574,7 @@ namespace Game.Application.Tests.Services
             var player = await playerService.LoadPlayer(playerEntity.Id);
             Assert.NotNull(player);
 
-            var success = await playerService.EquipItem(player, item.Id, EEquipmentSlot.WeaponSlot);
+            var (success, _) = await playerService.EquipItem(player, item.Id, EEquipmentSlot.WeaponSlot);
 
             Assert.False(success);
         }

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -547,7 +547,18 @@ namespace Game.Application.Services
         /// </summary>
         public async Task<double> RatePlayer(Player player, CancellationToken cancellationToken = default)
         {
-            var snapshot = BattleSnapshot.FromPlayer(player, await CaptureProficiencyLevels(player.Id, cancellationToken));
+            var proficiencyLevels = await _progressRepo.GetProficiencies(player.Id, cancellationToken);
+            return RatePlayer(player, proficiencyLevels);
+        }
+
+        /// <summary>
+        /// Overload for callers that already loaded the player's proficiency levels for another purpose in the
+        /// same command (e.g. <c>EquipItem</c>'s gear proficiency gate), so rating doesn't re-read the same
+        /// Redis hash a second time.
+        /// </summary>
+        public double RatePlayer(Player player, IEnumerable<PlayerProficiency> proficiencyLevels)
+        {
+            var snapshot = BattleSnapshot.FromPlayer(player, ToProficiencyLevels(proficiencyLevels));
             var battler = snapshot.ToBattler(
                 _items.GetItem, _itemMods.GetItemMod, _skills.TryGetSkill, _proficiencies.GetProficiency, ResolveClass);
             return CombatRating.Rate(battler, isPlayer: true);

--- a/Game.Application/Services/PlayerService.cs
+++ b/Game.Application/Services/PlayerService.cs
@@ -1,6 +1,7 @@
 using Game.Abstractions.DataAccess;
 using Game.Core;
 using Game.Core.Players;
+using Game.Core.Progress;
 
 namespace Game.Application.Services
 {
@@ -21,13 +22,17 @@ namespace Game.Application.Services
             return await SaveIf(player, player.TryUpdateAttributes(updates), cancellationToken);
         }
 
-        public async Task<bool> EquipItem(Player player, int itemId, EEquipmentSlot slot, CancellationToken cancellationToken = default)
+        // Returns the loaded proficiency levels alongside the outcome so callers that need them again for the
+        // same command (e.g. EquipItem's post-command PlayerRating) don't re-read the same Redis hash (#1729).
+        public async Task<(bool Success, List<PlayerProficiency> ProficiencyLevels)> EquipItem(
+            Player player, int itemId, EEquipmentSlot slot, CancellationToken cancellationToken = default)
         {
             // The proficiency gate is evaluated against the player's current levels, which live on the
             // separate PlayerProgress aggregate; the domain rule itself stays in Inventory.TryEquipItem.
             var proficiencyLevels = await _playerProgress.GetProficiencies(player.Id, cancellationToken);
             var levelsByProficiency = proficiencyLevels.ToDictionary(p => p.ProficiencyId, p => p.Level);
-            return await SaveIf(player, player.TryEquipItem(itemId, slot, levelsByProficiency), cancellationToken);
+            var success = await SaveIf(player, player.TryEquipItem(itemId, slot, levelsByProficiency), cancellationToken);
+            return (success, proficiencyLevels);
         }
 
         public async Task<bool> UnequipItem(Player player, EEquipmentSlot slot, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary

`EquipItem` read the player's proficiency progress from Redis twice per command:

1. `PlayerService.EquipItem` (`Game.Application/Services/PlayerService.cs`) — for the gear proficiency gate.
2. `BattleService.RatePlayer` → `CaptureProficiencyLevels` (`Game.Application/Services/BattleService.cs`) — the identical data again, to compute the `PlayerRating` returned in the response.

Equipping never mutates proficiency levels, so the second read was pure duplication — one wasted Redis round-trip plus deserialization per equip/unequip.

## Changes

- `PlayerService.EquipItem` now returns `(bool Success, List<PlayerProficiency> ProficiencyLevels)` instead of just `bool`, surfacing the levels it already loaded for the gear gate.
- `BattleService.RatePlayer` gains a synchronous overload, `RatePlayer(Player player, IEnumerable<PlayerProficiency> proficiencyLevels)`, for callers that already have the levels loaded. The existing `RatePlayer(player, cancellationToken)` overload (used by `UnequipItem`, `UpdatePlayerStats`, and `LoginController`, which don't have pre-loaded levels) is unchanged in behavior — it now delegates to the new overload after its own read.
- `EquipItem` socket command (`Game.Api/Sockets/Commands/EquipItem.cs`) uses the pre-loaded levels instead of triggering a second read.
- Updated the four `PlayerService.EquipItem` call sites in `PlayerServiceIntegrationTests` to destructure the new tuple, and added an assertion pinning that the returned levels match what was used for the gate check.

No behavior change — same rating computation, same data, just read once instead of twice.

## Test plan

- [x] `dotnet build` — solution builds clean, 0 warnings.
- [x] `dotnet test --no-build --no-restore` — full solution suite passes: 3035/3035, including the existing `InventorySocketTests.EquipItem_ItemWithAttributes_ReturnsPlayerRatingThatDropsOnUnequip` integration test exercising the new code path end-to-end.

Closes #1729


---
_Generated by [Claude Code](https://claude.ai/code/session_01AqpHqbiuepbTsUvC2TYrvR)_