### PR TITLE
Hand back the offline pending battle with its mid-window-grown snapshot

### DIFF
--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -2341,9 +2341,9 @@ namespace Game.Application.Tests.Services
             pendingEnemy.SelectAllBattleSkills();
             var snapshot = BattleSnapshot.FromPlayer(player, []);
             var now = DateTime.UtcNow;
-            var pending = new OfflinePendingBattle(pendingEnemy, Seed: 42, ElapsedOffsetMs: 45_000);
+            var pending = new OfflinePendingBattle(pendingEnemy, Seed: 42, ElapsedOffsetMs: 45_000, Snapshot: snapshot);
 
-            var result = battleService.HandBackPendingBattle(state, pending, snapshot, zone.Id, isBossBattle: false, now);
+            var result = battleService.HandBackPendingBattle(state, pending, zone.Id, isBossBattle: false, now);
 
             Assert.Equal(enemy.Id, result.Enemy.Id);
             Assert.Equal(42u, result.Seed);
@@ -2389,9 +2389,9 @@ namespace Game.Application.Tests.Services
             pendingBoss.SelectAllBattleSkills();
             var snapshot = BattleSnapshot.FromPlayer(player, []);
             var now = DateTime.UtcNow;
-            var pending = new OfflinePendingBattle(pendingBoss, Seed: 7, ElapsedOffsetMs: 10_000);
+            var pending = new OfflinePendingBattle(pendingBoss, Seed: 7, ElapsedOffsetMs: 10_000, Snapshot: snapshot);
 
-            var result = battleService.HandBackPendingBattle(state, pending, snapshot, zone.Id, isBossBattle: true, now);
+            var result = battleService.HandBackPendingBattle(state, pending, zone.Id, isBossBattle: true, now);
 
             Assert.Equal(boss.Id, result.Enemy.Id);
             Assert.Equal(18, result.Enemy.Level);
@@ -2433,9 +2433,9 @@ namespace Game.Application.Tests.Services
             pendingEnemy.SelectAllBattleSkills();
             var snapshot = BattleSnapshot.FromPlayer(player, []);
             var now = DateTime.UtcNow;
-            var pending = new OfflinePendingBattle(pendingEnemy, Seed: 1, ElapsedOffsetMs: 0);
+            var pending = new OfflinePendingBattle(pendingEnemy, Seed: 1, ElapsedOffsetMs: 0, Snapshot: snapshot);
 
-            var result = battleService.HandBackPendingBattle(state, pending, snapshot, zone.Id, isBossBattle: false, now);
+            var result = battleService.HandBackPendingBattle(state, pending, zone.Id, isBossBattle: false, now);
 
             Assert.Equal(0, result.ElapsedOffsetMs);
             Assert.Equal(now, state.BattleStartTime);

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -389,17 +389,20 @@ namespace Game.Application.Services
         /// left it uncredited — it is not a fresh spawn, it is that same unconcluded fight. Mirrors <see
         /// cref="AbandonBattle"/>'s still-in-progress hand-back (#1595): same-shaped <see cref="BattleStartResult"/>
         /// with a non-null <see cref="BattleStartResult.ElapsedOffsetMs"/>, so the welcome-back gate resumes it
-        /// via replay-to-offset (#1597) with no extra round trip.
+        /// via replay-to-offset (#1597) with no extra round trip. The stored snapshot is <see
+        /// cref="OfflinePendingBattle.Snapshot"/> — the one the simulator actually fought this battle against,
+        /// not the window-start snapshot the caller's run started from (#1758) — so the server's later
+        /// anti-cheat replay agrees with the client, which resumes from the same post-reward state.
         /// </summary>
         internal BattleStartResult HandBackPendingBattle(
-            PlayerState state, OfflinePendingBattle pending, BattleSnapshot snapshot, int zoneId, bool isBossBattle, DateTime now)
+            PlayerState state, OfflinePendingBattle pending, int zoneId, bool isBossBattle, DateTime now)
         {
             var enemy = pending.Enemy;
             var enemySkillIds = enemy.BattleSkills.Select(skill => skill.Id).ToList();
             var startTime = now.AddMilliseconds(-pending.ElapsedOffsetMs);
 
             state.SetActiveBattle(
-                enemy.Id, enemy.Level, enemySkillIds, pending.Seed, startTime, snapshot, zoneId, isBossBattle);
+                enemy.Id, enemy.Level, enemySkillIds, pending.Seed, startTime, pending.Snapshot, zoneId, isBossBattle);
 
             return new BattleStartResult
             {

--- a/Game.Application/Services/OfflineProgressService.cs
+++ b/Game.Application/Services/OfflineProgressService.cs
@@ -153,7 +153,7 @@ namespace Game.Application.Services
             // path persists PlayerState afterward, the switch path's mutation is (like the existing ClearBattle
             // above) discarded when the switch immediately creates a fresh session for the newly selected
             // character regardless.
-            var activeBattle = ApplyTrailingRemainder(state, result.IsBossBattle, zone.Id, parameters.Snapshot, result, now);
+            var activeBattle = ApplyTrailingRemainder(state, result.IsBossBattle, zone.Id, result, now);
 
             var levelBefore = player.Level;
             var statPointsBefore = player.StatPoints.StatPointsGained;
@@ -246,18 +246,19 @@ namespace Game.Application.Services
         // The simulator already tells the two cases apart:
         // - PendingBattle: the away boundary fell inside a battle the simulator drew but could not credit (its
         //   own duration didn't fit the remaining budget) — hand it back active at its true elapsed offset
-        //   (same enemy/seed the simulator already simulated), exactly like a still-in-progress stale-battle
-        //   hand-back (#1595), so the client resumes it via replay-to-offset (#1597).
+        //   (same enemy/seed and the possibly-grown snapshot the simulator already simulated it against, #1758),
+        //   exactly like a still-in-progress stale-battle hand-back (#1595), so the client resumes it via
+        //   replay-to-offset (#1597).
         // - RemainderMs: the boundary fell inside a completed battle's post-battle cooldown — no battle is
         //   active yet even in the model, so just set the residual PlayerState cooldown; the live idle loop's
         //   first NewEnemy after the gate naturally waits it out (the existing cooldown gate).
         // Returns null when there is nothing to carry.
         private BattleStartResult? ApplyTrailingRemainder(
-            PlayerState state, bool isBossBattle, int zoneId, BattleSnapshot snapshot, OfflineProgressResult result, DateTime now)
+            PlayerState state, bool isBossBattle, int zoneId, OfflineProgressResult result, DateTime now)
         {
             if (result.PendingBattle is { } pending)
             {
-                return _battleService.HandBackPendingBattle(state, pending, snapshot, zoneId, isBossBattle, now);
+                return _battleService.HandBackPendingBattle(state, pending, zoneId, isBossBattle, now);
             }
 
             if (result.RemainderMs > 0)

--- a/Game.Core.Tests/Battle/Offline/OfflineProgressResultTests.cs
+++ b/Game.Core.Tests/Battle/Offline/OfflineProgressResultTests.cs
@@ -95,7 +95,7 @@ namespace Game.Core.Tests.Battle.Offline
         [Fact]
         public void PendingBattle_CarriesTheSuppliedValue_AndIsExcludedFromTheCreditedAggregates()
         {
-            var pending = new OfflinePendingBattle(MakeEnemy(9), Seed: 123, ElapsedOffsetMs: 500);
+            var pending = new OfflinePendingBattle(MakeEnemy(9), Seed: 123, ElapsedOffsetMs: 500, Snapshot: MakeSnapshot());
 
             var result = new OfflineProgressResult(OfflineLoopMode.Idle, zoneId: 1, battles: [], pendingBattle: pending);
 
@@ -119,6 +119,14 @@ namespace Game.Core.Tests.Battle.Offline
         private static OfflineBattleOutcome Draw(int enemyId, int totalMs) =>
             new(MakeEnemy(enemyId), new BattleResult(Victory: false, PlayerDied: false, totalMs, new BattleStats()), ExpReward: 0,
                 PlayerRating: 0, EnemyRating: 0, ProficiencyGains: ProficiencyAccrualResult.Empty);
+
+        private static BattleSnapshot MakeSnapshot() => new()
+        {
+            Level = 1,
+            StatAllocations = [],
+            EquippedItems = [],
+            SkillIds = [],
+        };
 
         private static Enemy MakeEnemy(int id) => new()
         {

--- a/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
@@ -669,6 +669,51 @@ namespace Game.Core.Tests.Battle.Offline
         }
 
         [Fact]
+        public void Simulate_PendingBattle_SnapshotReflectsMidWindowGrowth_NotTheWindowStartSnapshot()
+        {
+            // #1758: the boundary battle carried forward as PendingBattle was simulated against whatever the
+            // player had grown to by that point in the window (#1601), not the frozen window-start snapshot —
+            // the hand-back must carry that same grown state forward, since the client resumes (and the server
+            // later anti-cheat-replays) the fight from post-growth stats, not window-start ones.
+            var snapshot = ClassPlayerSnapshot(level: 1, classId: 2);
+            var scenario = new Scenario
+            {
+                Zone = MakeZone(levelMin: 1, levelMax: 1),
+                Snapshot = snapshot,
+                ResolveEnemy = FreeFarmEnemy,
+            };
+            var resolveClass = ClassResolver(2, Distribution(Endurance, baseAmount: -5m, amountPerLevel: 5m));
+
+            OfflineProgressResult Run(long awayMs) =>
+                _simulator.Simulate(IdleParameters(awayMs, scenario, capMs: TenHoursMs) with { ResolveClass = resolveClass });
+
+            // FreeFarmEnemy never draws or beats the player, and only Endurance (defense) grows here — never
+            // the player's Strength-driven offense — so every credited battle costs the same real duration
+            // regardless of how many levels the run has produced by then. PlayerRating, in contrast, only ever
+            // moves when a level-up rebuilds the rating battler (#1601): the first battle whose recorded rating
+            // differs from the opening one is the first credited after a level-up has landed.
+            var probe = Run(TenHoursMs);
+            var wins = probe.Battles.Where(b => b.Result.Victory).ToList();
+            var growthIndex = wins.FindIndex(b => b.PlayerRating != wins[0].PlayerRating);
+            Assert.True(growthIndex > 0, "The probe run produced no mid-window level-up to build on.");
+
+            var battleMs = wins[0].Result.TotalMs;
+            var stepMs = battleMs + CooldownMs;
+            // growthIndex fully credited battles — enough for the level-up to have already landed — then a
+            // sliver too small for the next battle's own duration to fit, so the boundary falls mid-fight
+            // (a PendingBattle) rather than mid-cooldown, and that next battle is drawn against grown state.
+            var awayMs = (stepMs * growthIndex) + (battleMs / 2);
+
+            var result = Run(awayMs);
+
+            Assert.Equal(growthIndex, result.BattlesSimulated);
+            Assert.NotNull(result.PendingBattle);
+            Assert.True(result.PendingBattle.Snapshot.Level > snapshot.Level,
+                "The pending battle's hand-back snapshot must reflect mid-window growth, not the window-start level.");
+            Assert.Equal(result.EndingLevel, result.PendingBattle.Snapshot.Level);
+        }
+
+        [Fact]
         public void Simulate_NonZeroStartingExp_CarriesIntoTheFirstLevelThreshold()
         {
             // StartingExp exists so a player already partway to their next level doesn't get an extra free

--- a/Game.Core/Battle/Offline/OfflinePendingBattle.cs
+++ b/Game.Core/Battle/Offline/OfflinePendingBattle.cs
@@ -11,5 +11,12 @@ namespace Game.Core.Battle.Offline
     /// leading-edge stale-battle hand-back (#1595): this is simply that same "still in progress" state, arrived
     /// at from the trailing edge of the away window instead of a mid-battle disconnect.
     /// </summary>
-    public sealed record OfflinePendingBattle(Enemy Enemy, uint Seed, int ElapsedOffsetMs);
+    /// <param name="Snapshot">
+    /// The player snapshot this battle was actually simulated against — the mid-window-grown one (#1601/#1602),
+    /// not the window-start snapshot the caller froze the run's parameters with (#1758). The hand-back must
+    /// resume the battle from this exact state: the client rebuilds its battler from the post-reward live
+    /// player, so a stale, weaker snapshot here would let the server's later anti-cheat replay disagree with a
+    /// legitimate client win.
+    /// </param>
+    public sealed record OfflinePendingBattle(Enemy Enemy, uint Seed, int ElapsedOffsetMs, BattleSnapshot Snapshot);
 }

--- a/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
+++ b/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
@@ -34,8 +34,9 @@ namespace Game.Core.Battle.Offline
         /// <c>duration + cooldown</c> from the budget. If it doesn't fit, the away-window boundary falls
         /// inside it rather than after it: it did not really conclude, so it is not credited as a win/loss/
         /// draw at all — it is carried forward as <see cref="OfflineProgressResult.PendingBattle"/> (the exact
-        /// enemy/seed just simulated, with its true elapsed-so-far offset) for the orchestration to hand back
-        /// as an already-active battle, and the loop stops (there is no away time left beyond it). This keeps
+        /// enemy/seed just simulated, with its true elapsed-so-far offset, and the snapshot — possibly grown by
+        /// prior credited victories, #1758 — it was actually simulated against) for the orchestration to hand
+        /// back as an already-active battle, and the loop stops (there is no away time left beyond it). This keeps
         /// the loop from ever double-counting the battle straddling the boundary as both a completed win and
         /// a resumed fight.
         /// </para>
@@ -91,7 +92,7 @@ namespace Game.Core.Battle.Offline
                     // ended mid-fight. Not a completed outcome: carry it forward uncredited, at the real time
                     // that had elapsed into it (exactly the budget remaining when this attempt started), and
                     // stop — there is no away time left beyond this unconcluded fight.
-                    pendingBattle = new OfflinePendingBattle(enemy, seed, (int)remainingMs);
+                    pendingBattle = new OfflinePendingBattle(enemy, seed, (int)remainingMs, workingSnapshot);
                     break;
                 }
 


### PR DESCRIPTION
## Summary

When the offline away-window boundary falls inside a battle, the offline simulator carries it forward as `PendingBattle` so the client can resume it via replay-to-offset. The snapshot stored for the eventual server-side anti-cheat replay was the **window-start** snapshot, not the mid-window-grown one (`Level`/`ProficiencyLevels`, #1601/#1602) the battle was actually simulated — and will be client-resumed — with.

## Failure scenario this fixes

A player away long enough to gain a level (or proficiency level) whose away-window boundary lands mid-battle: the client replays and wins with grown stats, but the server replayed the claim against the weaker window-start snapshot — duration divergence at best, a spurious "server replay was not a victory" / `ClaimedBeforeBattleCouldFinish` rejection at worst, logging a legitimate win as suspected cheating.

## Changes

- `OfflinePendingBattle` now carries the `BattleSnapshot` the simulator actually fought that battle against (`Game.Core/Battle/Offline/OfflinePendingBattle.cs`), rather than the caller separately supplying (and potentially mismatching) one.
- `OfflineProgressSimulator` passes its in-loop `workingSnapshot` — grown by every credited victory before the boundary battle was drawn — when constructing the pending battle.
- `BattleService.HandBackPendingBattle` now sources the snapshot from `OfflinePendingBattle.Snapshot` instead of taking a separate `snapshot` parameter — this removes the possibility of a caller (again) passing the wrong one, since there is now only one snapshot to plumb through.
- `OfflineProgressService.ApplyTrailingRemainder` no longer threads the window-start `parameters.Snapshot` through to the hand-back at all.

## Tests

- `Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs`: new `Simulate_PendingBattle_SnapshotReflectsMidWindowGrowth_NotTheWindowStartSnapshot` pins that a pending battle drawn after a mid-window level-up carries the grown snapshot (and that it agrees with `OfflineProgressResult.EndingLevel`).
- Updated the `OfflinePendingBattle` construction call sites in `Game.Core.Tests/Battle/Offline/OfflineProgressResultTests.cs` and `Game.Application.Tests/Services/BattleServiceIntegrationTests.cs` for the new required `Snapshot` field / the collapsed `HandBackPendingBattle` signature — no behavioral changes to those existing tests.

## Test plan

- [x] `dotnet build` — solution builds clean, 0 warnings.
- [x] `dotnet test` — full solution suite passes: 3037/3037 (Game.Core.Tests, Game.Application.Tests, Game.Api.Tests, Game.Infrastructure.Tests).
- [ ] Frontend unaffected (backend-only change — the client already resumes from live post-reward state; this only fixes what the server compares its anti-cheat replay against) — no frontend verification needed.

Closes #1758

---
_Generated by Claude Code_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnkZGxVHgoc8dNw65tyiLJ)_