### PR TITLE
Settle queued commands before routing to auth failure on pre-emptive refresh failure

### DIFF
--- a/UI/src/lib/api/api-socket.ts
+++ b/UI/src/lib/api/api-socket.ts
@@ -128,6 +128,9 @@ export class ApiSocket {
 		// (no prior refresh token) still opens an unauthenticated socket below.
 		if (!accessToken && hadRefreshToken) {
 			this.stopPingInterval();
+			// Terminal: nothing will reconnect and re-flush the queue, so settle it here too (mirroring every
+			// other terminal branch in handleClose) rather than stranding a caller mid-connect.
+			this.settleQueuedRequests(CONNECTION_LOST_ERROR);
 			handleAuthFailure();
 			return;
 		}

--- a/UI/src/tests/lib/api/api-socket.test.ts
+++ b/UI/src/tests/lib/api/api-socket.test.ts
@@ -164,13 +164,16 @@ describe('ApiSocket', () => {
 			// Refresh token spent/revoked: no usable token can be obtained.
 			vi.mocked(ensureValidAccessToken).mockResolvedValue(null);
 
-			apiSocket.sendSocketCommand('DefeatEnemy', { clientTotalMs: 1 });
+			const promise = apiSocket.sendSocketCommand('DefeatEnemy', { clientTotalMs: 1 });
 			await flushMicrotasks();
 
 			expect(handleAuthFailure).toHaveBeenCalledTimes(1);
 			// No doomed unauthenticated handshake is opened, and the keepalive is not left running.
 			expect(webSocketMock).not.toHaveBeenCalled();
 			expect(internals(apiSocket).pingIntervalId).toBeNull();
+			// The queued command was never sent (no socket ever opened) and nothing will reconnect to
+			// re-flush it, so it must settle with an error rather than await a response forever.
+			await expect(promise).resolves.toMatchObject({ error: expect.any(String) });
 		});
 	});
 


### PR DESCRIPTION
## Summary

`UI/src/lib/api/api-socket.ts` — `openSocket`'s pre-emptive-refresh-failure branch stopped the ping loop and called `handleAuthFailure()` but never settled the request queue. `docs/frontend.md` promises queued commands "can't await a response forever," and every other terminal branch of `handleClose` honors it (normal closure, auth-retry budget exhausted, no refresh token, failed reconnect refresh) — this branch was the one exception.

## Failure scenario this fixes

A command queued while a socket connect is in flight, where the pre-connect token refresh then fails (refresh token spent/revoked), would await a response forever. This was masked in practice by `handleAuthFailure`'s full-page redirect, except when already on `/`.

## Changes

- `UI/src/lib/api/api-socket.ts`: `openSocket` now calls `this.settleQueuedRequests(CONNECTION_LOST_ERROR)` before `handleAuthFailure()` in the pre-emptive-refresh-failure branch, mirroring every other terminal branch in `handleClose`.

## Tests

- `UI/src/tests/lib/api/api-socket.test.ts`: the existing test driving this exact path (`routes to auth failure (without opening) when the pre-emptive refresh fails for a logged-in session`) now also asserts the queued command's promise settles with an error, per the issue's suggested fix.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` (`vitest run`) — full suite passes: 3546/3546 (including the updated case above).
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1766


---
_Generated by [Claude Code](https://claude.ai/code/session_01VVWTGusX39sVw9E9wxC5qL)_