### PR TITLE
Await ensureValidAccessToken before reading the refresh token in CharacterSwitcher

### DIFF
--- a/UI/src/routes/game/CharacterSwitcher.svelte
+++ b/UI/src/routes/game/CharacterSwitcher.svelte
@@ -39,7 +39,7 @@
 </Popover>
 
 <script lang="ts">
-import { ApiRequest, apiSocket, getRefreshToken, setTokens } from '$lib/api';
+import { ApiRequest, apiSocket, ensureValidAccessToken, getRefreshToken, setTokens } from '$lib/api';
 import { playerManager, stopEngines } from '$lib/engine';
 import Popover from '$components/Popover.svelte';
 import { confirmSessionTakeover } from '../login/session-takeover';
@@ -65,6 +65,10 @@ let view = $state<PlayerSelectView | null>(null);
 // credit + rebind through SwitchPlayer. Every terminal outcome ends in a full-page navigation, so the
 // brief window with a torn-down game is never interactive.
 const switchPlayer: PlayerSelectDeps['selectPlayer'] = async (playerId) => {
+	// SwitchPlayer is authenticated, so posting it would otherwise let ApiRequest.execute's own
+	// pre-emptive ensureValidAccessToken() rotate the refresh token *after* it had already been read
+	// below — settling that refresh here first means the token we read is the one that's actually sent.
+	await ensureValidAccessToken();
 	const refreshToken = getRefreshToken();
 	if (!refreshToken) {
 		reloadToBoot();

--- a/UI/src/tests/routes/game/character-switcher.test.ts
+++ b/UI/src/tests/routes/game/character-switcher.test.ts
@@ -5,16 +5,25 @@ import { render, fireEvent, cleanup, screen, waitFor } from '@testing-library/sv
 // switch/create), and the socket teardown, engine stop, token storage, and takeover are mocked so the
 // overlay can be driven without real I/O. window.location is replaced so the commit/recovery reloads are
 // observable instead of throwing in jsdom.
-const { getMock, postMock, disconnectMock, stopEnginesMock, getRefreshTokenMock, setTokensMock, confirmTakeoverMock } =
-	vi.hoisted(() => ({
-		getMock: vi.fn(),
-		postMock: vi.fn(),
-		disconnectMock: vi.fn(),
-		stopEnginesMock: vi.fn(),
-		getRefreshTokenMock: vi.fn(),
-		setTokensMock: vi.fn(),
-		confirmTakeoverMock: vi.fn()
-	}));
+const {
+	getMock,
+	postMock,
+	disconnectMock,
+	stopEnginesMock,
+	ensureValidAccessTokenMock,
+	getRefreshTokenMock,
+	setTokensMock,
+	confirmTakeoverMock
+} = vi.hoisted(() => ({
+	getMock: vi.fn(),
+	postMock: vi.fn(),
+	disconnectMock: vi.fn(),
+	stopEnginesMock: vi.fn(),
+	ensureValidAccessTokenMock: vi.fn(),
+	getRefreshTokenMock: vi.fn(),
+	setTokensMock: vi.fn(),
+	confirmTakeoverMock: vi.fn()
+}));
 
 // Spread the real module so the enums/values the class picker's display helpers read at import stay
 // intact; only the I/O entry points are replaced with spies.
@@ -26,6 +35,7 @@ vi.mock('$lib/api', async (importOriginal) => ({
 		post = (body: unknown) => postMock(this.route, body);
 	},
 	apiSocket: { disconnect: disconnectMock },
+	ensureValidAccessToken: ensureValidAccessTokenMock,
 	getRefreshToken: getRefreshTokenMock,
 	setTokens: setTokensMock
 }));
@@ -71,6 +81,7 @@ beforeEach(() => {
 	postMock.mockReset();
 	disconnectMock.mockReset();
 	stopEnginesMock.mockReset();
+	ensureValidAccessTokenMock.mockReset().mockResolvedValue('a');
 	getRefreshTokenMock.mockReset().mockReturnValue('r');
 	setTokensMock.mockReset();
 	confirmTakeoverMock.mockReset().mockResolvedValue(true);
@@ -116,6 +127,27 @@ describe('CharacterSwitcher', () => {
 		expect(setTokensMock).toHaveBeenCalledWith({ accessToken: 'a2', refreshToken: 'r2' });
 		await waitFor(() => expect(confirmTakeoverMock).toHaveBeenCalled());
 		await waitFor(() => expect(window.location.href).toBe('/'));
+	});
+
+	it('reads the refresh token after settling any pre-emptive refresh, not before', async () => {
+		// Simulate ApiRequest's own pre-emptive refresh rotating the token pair while it settles, the
+		// exact race #1767 fixed: reading the token first would capture the now-stale 'r'.
+		ensureValidAccessTokenMock.mockImplementation(async () => {
+			getRefreshTokenMock.mockReturnValue('rotated');
+			return 'a2';
+		});
+		postMock.mockResolvedValue({
+			status: 200,
+			data: { tokens: { accessToken: 'a2', refreshToken: 'r2' }, player: { id: 2, name: 'Rogue' } }
+		});
+		render(CharacterSwitcher, { open: true, onClose: vi.fn() });
+
+		await waitFor(() => expect(screen.getAllByTestId('player-card')).toHaveLength(1));
+		await fireEvent.click(screen.getAllByTestId('player-card')[0]);
+
+		await waitFor(() =>
+			expect(postMock).toHaveBeenCalledWith('Login/SwitchPlayer', { playerId: 2, refreshToken: 'rotated' })
+		);
 	});
 
 	it('recovers with a reload when the switch fails after teardown', async () => {


### PR DESCRIPTION
## Summary

`UI/src/routes/game/CharacterSwitcher.svelte`'s `switchPlayer` captured `getRefreshToken()` and then posted `Login/SwitchPlayer` with it — but `SwitchPlayer` is not anonymous, so `ApiRequest.execute` runs `ensureValidAccessToken()` first (`api-request.ts`), which can pre-emptively rotate the token pair when the access token is inside the 30s expiry leeway. The refresh token captured before that call could already be consumed by the time the request actually went out.

## Failure scenario this fixes

Switch pressed while the access token is within the leeway window → the pre-emptive refresh inside `ApiRequest.execute` rotates the token pair → the backend rejects `SwitchPlayer` with the now-stale refresh token → `reloadToBoot()` fires on what should have been a clean character switch. Narrow, purely timing-dependent window from the player's perspective (distinct from #1518's takeover-ordering problem).

## Changes

- `CharacterSwitcher.svelte`: `switchPlayer` now `await`s `ensureValidAccessToken()` before reading the refresh token, so any pre-emptive refresh settles first and the token read is the one that's actually sent. (Went with the issue's first suggested fix shape rather than moving the refresh token server-side for `SwitchPlayer` — that's a bigger backend contract change for a narrow client-side race.)

## Tests

- `character-switcher.test.ts`: new case that simulates `ensureValidAccessToken` rotating the stored refresh token while it resolves (mirroring `ApiRequest`'s real pre-emptive-refresh behavior), and asserts `SwitchPlayer` is posted with the rotated token rather than the stale one captured before the await.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` (`vitest run`) — full suite passes, including the new case above.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1767

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1FcKXjKigD1XCpAAMwoLe)_