### PR TITLE
Guard Workbench/progression store mutators against an in-flight save

### DIFF
--- a/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
+++ b/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
@@ -77,7 +77,7 @@
 		</div>
 
 		<div class="detail-body">
-			<div class="body-inner" class:locked={status === 'deleted'}>
+			<div class="body-inner" class:locked={status === 'deleted' || store.saving}>
 				<div class="sec-title">
 					{curSection.label}{#if curSection.desc}<span class="sub">— {curSection.desc}</span>{/if}<span class="ln"
 					></span>

--- a/UI/src/routes/admin/workbench/entity-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/entity-store.svelte.ts
@@ -109,7 +109,15 @@ export class EntityStore<T extends Identified> {
 		return { added, modified, deleted, total: added + modified + deleted };
 	});
 
+	/**
+	 * Edits made while a save is in flight would either be silently overwritten by that save's
+	 * post-persist baseline replacement or would land as a "clean" record whose dirty indicator
+	 * never fires — so every mutator no-ops while {@link saving} is true rather than risk either.
+	 */
 	patch(id: number, mutate: (draft: T) => void) {
+		if (this.saving) {
+			return;
+		}
 		this.items = this.items.map((record) => {
 			if (record.id !== id) {
 				return record;
@@ -122,6 +130,9 @@ export class EntityStore<T extends Identified> {
 	}
 
 	addItem(): number {
+		if (this.saving) {
+			return this.items[0]?.id ?? 0;
+		}
 		const id = this.nextId--;
 		this.items = [this.config.newItem(id), ...this.items];
 		this.saved = false;
@@ -129,6 +140,9 @@ export class EntityStore<T extends Identified> {
 	}
 
 	removeItem(id: number) {
+		if (this.saving) {
+			return;
+		}
 		if (this.baseMap[id] === undefined) {
 			// Never-saved record: just drop it.
 			this.items = this.items.filter((record) => record.id !== id);
@@ -139,6 +153,9 @@ export class EntityStore<T extends Identified> {
 	}
 
 	restoreItem(id: number) {
+		if (this.saving) {
+			return;
+		}
 		this.deleted.delete(id);
 		this.saved = false;
 	}
@@ -163,6 +180,9 @@ export class EntityStore<T extends Identified> {
 	}
 
 	resetItem(id: number) {
+		if (this.saving) {
+			return;
+		}
 		const baseline = this.baseMap[id];
 		if (baseline) {
 			this.items = this.items.map((record) => (record.id === id ? clone(baseline) : record));

--- a/UI/src/routes/admin/workbench/progression/PathDetail.svelte
+++ b/UI/src/routes/admin/workbench/progression/PathDetail.svelte
@@ -19,7 +19,7 @@
 		onRemove={() => store.removePath(path.id)}
 	/>
 
-	<div class="detail-body" class:locked={store.isRetired(path)}>
+	<div class="detail-body" class:locked={store.isRetired(path) || store.saving}>
 		<div class="body-inner">
 			{#if store.pathTab === 'identity'}
 				<div class="sec-title">Identity<span class="sub">— the path-level record</span><span class="ln"></span></div>

--- a/UI/src/routes/admin/workbench/progression/TierDetail.svelte
+++ b/UI/src/routes/admin/workbench/progression/TierDetail.svelte
@@ -30,7 +30,7 @@
 		{/snippet}
 	</DetailHeader>
 
-	<div class="detail-body" class:locked={store.isRetired(tier)}>
+	<div class="detail-body" class:locked={store.isRetired(tier) || store.saving}>
 		<div class="body-inner">
 			{#if store.tierTab === 'identity'}
 				<div class="sec-title">

--- a/UI/src/routes/admin/workbench/progression/progression-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/progression/progression-store.svelte.ts
@@ -180,7 +180,15 @@ export class ProgressionStore {
 
 	// ── Record patches ──
 
+	/**
+	 * Edits made while a save is in flight would either be silently overwritten by the post-save
+	 * reseed from server truth or land as a "clean" record whose dirty indicator never fires — so
+	 * every mutator no-ops while {@link saving} is true rather than risk either.
+	 */
 	patchPath(id: number, mutate: (draft: WorkbenchPath) => void) {
+		if (this.saving) {
+			return;
+		}
 		this.paths = this.paths.map((path) => {
 			if (path.id !== id) {
 				return path;
@@ -193,6 +201,9 @@ export class ProgressionStore {
 	}
 
 	patchProf(id: number, mutate: (draft: WorkbenchProficiency) => void) {
+		if (this.saving) {
+			return;
+		}
 		this.profs = this.profs.map((prof) => {
 			if (prof.id !== id) {
 				return prof;
@@ -207,6 +218,9 @@ export class ProgressionStore {
 	// ── Add / reorder / retire ──
 
 	addPath() {
+		if (this.saving) {
+			return;
+		}
 		const pathId = this.nextId--;
 		const tierId = this.nextId--;
 		this.paths = [newPath(pathId), ...this.paths];
@@ -218,6 +232,9 @@ export class ProgressionStore {
 	}
 
 	addTier(pathId: number): number {
+		if (this.saving) {
+			return tiersOfPath(this.profs, pathId)[0]?.id ?? 0;
+		}
 		const tiers = tiersOfPath(this.profs, pathId);
 		const ordinal = tiers.length ? Math.max(...tiers.map((t) => t.pathOrdinal)) + 1 : 0;
 		const id = this.nextId--;
@@ -227,6 +244,9 @@ export class ProgressionStore {
 	}
 
 	reorderTiers(pathId: number, fromIndex: number, toIndex: number) {
+		if (this.saving) {
+			return;
+		}
 		const tiers = tiersOfPath(this.profs, pathId);
 		if (fromIndex < 0 || toIndex < 0 || fromIndex >= tiers.length || toIndex >= tiers.length || fromIndex === toIndex) {
 			return;
@@ -256,6 +276,9 @@ export class ProgressionStore {
 
 	/** Remove a never-saved path (and its never-saved tiers) locally; reconcile the selection. */
 	removePath(id: number) {
+		if (this.saving) {
+			return;
+		}
 		this.paths = this.paths.filter((path) => path.id !== id);
 		this.profs = this.profs.filter((prof) => prof.pathId !== id);
 		if (this.selectedPathId === id) {
@@ -267,6 +290,9 @@ export class ProgressionStore {
 
 	/** Remove a never-saved tier locally; leave the drill view if it was open. */
 	removeTier(id: number) {
+		if (this.saving) {
+			return;
+		}
 		this.profs = this.profs.filter((prof) => prof.id !== id);
 		if (this.drilledTierId === id) {
 			this.drilledTierId = null;

--- a/UI/src/tests/routes/admin/workbench/entity-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entity-store.test.ts
@@ -345,6 +345,40 @@ describe('EntityStore', () => {
 		});
 	});
 
+	describe('mutators guard against an in-flight save', () => {
+		it('patch no-ops while saving so a keystroke landing mid-save cannot be silently discarded', () => {
+			const store = new EntityStore(makeConfig(), seed);
+			store.saving = true;
+			store.patch(0, (draft) => (draft.name = 'raced'));
+			expect(store.items.find((r) => r.id === 0)!.name).toBe('Alpha');
+		});
+
+		it('addItem, removeItem, restoreItem and resetItem all no-op while saving', () => {
+			const store = new EntityStore(makeConfig(), seed);
+			store.saving = true;
+
+			expect(store.addItem()).toBe(0);
+			expect(store.items).toHaveLength(2);
+
+			store.removeItem(0);
+			expect(store.status(store.items.find((r) => r.id === 0)!)).toBe('clean');
+
+			store.saving = false;
+			store.patch(1, (draft) => (draft.value = 7));
+			store.saving = true;
+
+			store.resetItem(1);
+			expect(store.items.find((r) => r.id === 1)!.value).toBe(7);
+
+			store.removeItem(1);
+			store.saving = false;
+			store.removeItem(1);
+			store.saving = true;
+			store.restoreItem(1);
+			expect(store.status(store.items.find((r) => r.id === 1)!)).toBe('deleted');
+		});
+	});
+
 	describe('recordStates memo', () => {
 		// A config with a required-name field so warnings are exercised alongside status.
 		const requiredNameConfig = (): EntityConfig<Row> => ({

--- a/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
@@ -429,4 +429,31 @@ describe('navigation & detail mutations', () => {
 
 		store.dispose();
 	});
+
+	it('mutators no-op while a save is in flight so a keystroke landing mid-save cannot be silently discarded', async () => {
+		seedServer();
+		const store = new ProgressionStore();
+		await store.load();
+
+		store.saving = true;
+
+		store.patchPath(0, (d) => (d.name = 'raced'));
+		expect(reqPath(store, 0).name).toBe('Fire');
+
+		store.patchProf(0, (d) => (d.name = 'raced'));
+		expect(reqProf(store, 0).name).toBe('Fire T0');
+
+		store.addPath();
+		expect(store.paths).toHaveLength(1);
+
+		const beforeTierCount = store.profs.length;
+		expect(store.addTier(0)).toBe(0);
+		expect(store.profs).toHaveLength(beforeTierCount);
+
+		store.reorderTiers(0, 0, 0);
+		store.removePath(0);
+		expect(store.paths).toHaveLength(1);
+		store.removeTier(0);
+		expect(store.profs).toHaveLength(beforeTierCount);
+	});
 });


### PR DESCRIPTION
## Summary

`EntityStore.patch()` (`UI/src/routes/admin/workbench/entity-store.svelte.ts`) had no `saving` guard, and `save()` wholesale-replaces both `items` and `base` from the server response after the persist completes. The detail pane's inputs stayed live during a save — only the Save/Discard buttons disabled — so an admin who kept editing while a save was in flight would have those edits silently overwritten by the post-save baseline replacement, with no dirty indicator hinting anything was lost. The progression editor (`workbench/progression/progression-store.svelte.ts`) has the identical pattern via `patchPath`/`patchProf`.

## Failure scenario this fixes

Admin hits Save and keeps typing (or clicks Reset/Remove/Retire/Add on the same record); the save lands; the keystrokes/action vanish because the store's baseline is replaced from the server response, so the record reads "clean" with no trace anything was lost.

## Changes

- `entity-store.svelte.ts`: every mutator that touches `items`/`deleted` (`patch`, `addItem`, `removeItem`, `restoreItem`, `resetItem`) now no-ops while `this.saving` is true. `setRetired` is covered transitively since it routes through `patch`.
- `progression-store.svelte.ts`: same treatment for `patchPath`, `patchProf`, `addPath`, `addTier`, `reorderTiers`, `removePath`, `removeTier`. Every other mutator (`resetPath`/`resetProf`/`retirePath`/`retireProf`/the milestone-modifier, reward, and prerequisite editors) routes through `patchPath`/`patchProf`, so they're covered transitively too.
- `WorkbenchDetail.svelte`, `PathDetail.svelte`, `TierDetail.svelte`: the existing "locked" dim/pointer-events-none treatment (previously only for a deleted/retired record) now also applies while `store.saving` is true, so the pane visibly communicates it's locked during a save rather than just silently rejecting input.

I went with guarding the store mutators directly (one of the two fix shapes the issue proposed) rather than only relying on the CSS lock, since the header action buttons (Reset/Retire/Remove/Restore) sit outside the locked pane region in both `WorkbenchDetail` and the progression editor's `DetailHeader` — a CSS-only lock wouldn't have stopped those from racing a save. Guarding at the store level closes that gap without needing to thread a `saving` prop through every button.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors/warnings.
- [x] `npx vitest run` (`npm run test:unit:ci`) — full suite passes: 3550/3550, including new cases pinning that every mutator no-ops while `saving` is true, for both `EntityStore` and `ProgressionStore`.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1768


---
_Generated by [Claude Code](https://claude.ai/code/session_01CktKeMigSXpZwzDXqb4wP7)_