### PR TITLE
Keep the Gateways tab reachable for a non-root tier that still has prerequisites

### DIFF
--- a/UI/src/routes/admin/workbench/progression/TierDetail.svelte
+++ b/UI/src/routes/admin/workbench/progression/TierDetail.svelte
@@ -11,7 +11,12 @@
 			{ key: 'identity', label: 'Identity · Conlang', warn: identityWarn },
 			{ key: 'xp', label: 'XP Curve', warn: xpWarn },
 			{ key: 'milestones', label: 'Milestones', count: payoutCount, dirty: milestonesDirty, warn: milestoneWarn },
-			{ key: 'gateways', label: 'Gateways', count: tier.prerequisiteIds.length, disabled: !isRoot }
+			{
+				key: 'gateways',
+				label: 'Gateways',
+				count: tier.prerequisiteIds.length,
+				disabled: !isRoot && tier.prerequisiteIds.length === 0
+			}
 		]}
 		activeTab={store.tierTab}
 		onTab={(k) => store.setTierTab(k as TierTab)}

--- a/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
@@ -207,6 +207,25 @@ describe('TierDetail — tab bodies', () => {
 		expect(screen.getByText(/Starter tier/)).toBeTruthy();
 	});
 
+	it('disables the Gateways tab for a non-root tier with no prerequisites', () => {
+		const store = makeStore(tier({ pathOrdinal: 1, prerequisiteIds: [] }), { tierTab: 'milestones' });
+		render(TierDetail, { props: { store } });
+
+		const tab = screen.getByText('Gateways').closest('button');
+		expect(tab?.hasAttribute('disabled')).toBe(true);
+	});
+
+	it('keeps the Gateways tab enabled for a non-root tier that still carries prerequisites (e.g. reordered off root)', async () => {
+		const store = makeStore(tier({ pathOrdinal: 1, prerequisiteIds: [3] }), { tierTab: 'milestones' });
+		render(TierDetail, { props: { store } });
+
+		const tab = screen.getByText('Gateways').closest('button');
+		expect(tab?.hasAttribute('disabled')).toBe(false);
+
+		await fireEvent.click(tab!);
+		expect(store.setTierTab).toHaveBeenCalledWith('gateways');
+	});
+
 	it('lists an existing prerequisite chip, removes it, and adds a new one', async () => {
 		// staticData.proficiencies is index-addressed (the zero-based-id/index invariant), so each
 		// entry must sit at its own id as the array index.


### PR DESCRIPTION
## Summary

Gateways are only editable on ordinal-0 (root) tiers — `TierDetail.svelte`'s Gateways tab was `disabled: !isRoot` — but `reorderTiers` (`progression-store.svelte.ts`) freely renumbers a gated root tier to a non-root ordinal. Its `prerequisiteIds` remain — still saved, still drawn on the Map, still counted on the tab's badge — but could no longer be viewed or removed except by reordering the tier back to root. The backend has no root-only restriction on which tier can carry cross-path prerequisites (`AdminProficiencies.SetPrerequisites` validates existence/cycles only, never ordinal); this was purely a UI lockout of live data.

## Failure scenario this fixes

A root tier (ordinal 0) is gated behind another path's tiers. An operator drags a different tier above it in the same path, pushing the gated tier to ordinal 1+. The Gateways tab becomes disabled (`isRoot` is now false), so the operator can no longer see or edit the tier's existing prerequisites short of reordering it back to root.

## Changes

- `TierDetail.svelte`: the Gateways tab's `disabled` check now also allows access whenever the tier already carries prerequisites (`!isRoot && tier.prerequisiteIds.length === 0`), not just on root tiers. Authoring the tier's **first** prerequisite is still root-only, preserving the existing authoring convention; once a non-root tier carries any prerequisite (e.g. from being reordered off root), its Gateways tab stays fully editable — including adding further prerequisites — since the backend allows cross-path gateways on any ordinal.

## Note for reviewers

The issue's fix shape offered two options ("Enable the tab whenever `prerequisiteIds.length > 0`… or block/warn when reordering a gated tier off ordinal 0"). I went with enabling the tab: the backend model doesn't actually restrict gateways to root tiers (per `game-design.md`, a "gateway tier" is a general concept, not root-specific), and `GatewaysEditor.svelte` already works generically off `tier.prerequisiteIds` with no root check of its own — it renders "opens `{tier.name}` · Tier `{pathOrdinal}`" regardless of ordinal. Blocking the reorder instead would add friction to a normal admin operation (inserting/reordering tiers) for a restriction that's UI-only in the first place.

## Tests

- `TierDetail.test.ts`: two new cases — the Gateways tab stays disabled for a non-root tier with no prerequisites (preserving current behavior), and it's enabled (and navigable via `setTierTab`) for a non-root tier that still carries prerequisites, i.e. the reordered-off-root scenario the issue describes.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` (`vitest run`) — full suite passes: 3553/3553 (including the 2 new cases above).
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1778
