### PR TITLE
Progression editor shell: fix infinite spinner on load failure and hidden save bar in Map view

### DIFF
--- a/UI/src/routes/admin/workbench/progression/Progression.svelte
+++ b/UI/src/routes/admin/workbench/progression/Progression.svelte
@@ -34,30 +34,37 @@
 		</div>
 	</div>
 
-	{#if !store.loaded}
-		<div class="prog-loading"><Loading loading={true} delay={120} /></div>
-	{:else if view === 'map'}
-		<ProgressionMap {store} onNavigate={() => (view = 'list')} />
-	{:else}
-		<div class="prog-body">
-			<ProgressionList {store} />
-
-			<div class="detail-col">
-				{#if store.drilledTier}
-					<TierDetail {store} />
-				{:else if store.selectedPath}
-					<PathDetail {store} />
-				{:else}
-					<div class="empty-detail" data-testid="progression-empty">
-						<div class="glyph"><WorkbenchIcon kind="rune" size={22} /></div>
-						<div class="et">No path selected</div>
-						<button type="button" class="btn primary sm" onclick={() => store.addPath()}>
-							<WorkbenchIcon kind="plus" size={12} />New path
-						</button>
-					</div>
-				{/if}
-			</div>
+	{#if store.error}
+		<div class="prog-error" role="alert" data-testid="progression-error">
+			<p>{store.error}</p>
+			<button type="button" class="btn" onclick={() => store.load()}>Refresh</button>
 		</div>
+	{:else if !store.loaded}
+		<div class="prog-loading"><Loading loading={true} delay={120} /></div>
+	{:else}
+		{#if view === 'map'}
+			<ProgressionMap {store} onNavigate={() => (view = 'list')} />
+		{:else}
+			<div class="prog-body">
+				<ProgressionList {store} />
+
+				<div class="detail-col">
+					{#if store.drilledTier}
+						<TierDetail {store} />
+					{:else if store.selectedPath}
+						<PathDetail {store} />
+					{:else}
+						<div class="empty-detail" data-testid="progression-empty">
+							<div class="glyph"><WorkbenchIcon kind="rune" size={22} /></div>
+							<div class="et">No path selected</div>
+							<button type="button" class="btn primary sm" onclick={() => store.addPath()}>
+								<WorkbenchIcon kind="plus" size={12} />New path
+							</button>
+						</div>
+					{/if}
+				</div>
+			</div>
+		{/if}
 
 		<div class="save-bar">
 			<div class="save-summary">
@@ -207,6 +214,23 @@ $effect(() => {
 .prog-loading {
 	flex: 1;
 	min-height: 0;
+}
+.prog-error {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 14px;
+	padding: 20px;
+	text-align: center;
+
+	p {
+		max-width: 480px;
+		color: var(--error);
+		font-size: 13px;
+	}
 }
 .prog-body {
 	display: flex;

--- a/UI/src/routes/admin/workbench/progression/progression-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/progression/progression-store.svelte.ts
@@ -47,6 +47,7 @@ export class ProgressionStore {
 	loaded = $state(false);
 	saving = $state(false);
 	saved = $state(false);
+	error = $state<string | null>(null);
 
 	// Selection / navigation.
 	selectedPathId = $state<number | null>(null);
@@ -61,6 +62,7 @@ export class ProgressionStore {
 	// ── Loading / seeding ──
 
 	async load() {
+		this.error = null;
 		try {
 			const [paths, profs] = await Promise.all([fetchSocketData('GetPaths'), fetchSocketData('GetProficiencies')]);
 			this.setData(paths, profs);
@@ -69,7 +71,9 @@ export class ProgressionStore {
 			this.pathTab = 'tiers';
 			this.loaded = true;
 		} catch (ex) {
-			toastError(ex instanceof Error ? ex.message : 'Failed to load progression data.');
+			const message = ex instanceof Error ? ex.message : 'Failed to load progression data.';
+			this.error = message;
+			toastError(message);
 		}
 	}
 

--- a/UI/src/tests/routes/admin/workbench/progression/Progression.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/Progression.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, waitFor, fireEvent } from '@testing-library/svelte';
+
+// jsdom has no ResizeObserver; ProgressionMap observes its container on mount.
+class ResizeObserverStub {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+
+beforeAll(() => {
+	(globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver = ResizeObserverStub;
+});
 
 // Mirrors progression-store.test.ts's fake in-memory backend — Progression.svelte owns its own
 // ProgressionStore instance (no store prop to inject), so the socket-read layer is mocked the same
@@ -51,5 +62,37 @@ describe('Progression — unsaved-change reporting', () => {
 
 		unmount();
 		expect(workbenchDirty.total).toBe(0);
+	});
+});
+
+describe('Progression — load-failure recovery', () => {
+	it('shows a persistent error panel with a retry affordance instead of spinning forever, and recovers on retry', async () => {
+		fetchMock.mockRejectedValueOnce(new Error('network down'));
+		fetchMock.mockResolvedValue([]);
+		render(Progression);
+
+		await waitFor(() => expect(screen.getByTestId('progression-error')).toBeTruthy());
+		expect(screen.getByTestId('progression-error').textContent).toContain('network down');
+		expect(screen.queryByTestId('progression-new-path')).toBeNull();
+
+		await fireEvent.click(screen.getByText('Refresh'));
+
+		await waitFor(() => expect(screen.getByTestId('progression-new-path')).toBeTruthy());
+		expect(screen.queryByTestId('progression-error')).toBeNull();
+	});
+});
+
+describe('Progression — Map view save bar', () => {
+	it('keeps the save bar (and its unsaved-change count) visible after switching to Map view', async () => {
+		render(Progression);
+		await waitFor(() => expect(screen.getByTestId('progression-new-path')).toBeTruthy());
+
+		await fireEvent.click(screen.getByTestId('progression-new-path'));
+		await waitFor(() => expect(workbenchDirty.total).toBeGreaterThan(0));
+
+		await fireEvent.click(screen.getByTestId('progression-map-toggle'));
+		await waitFor(() => expect(screen.getByTestId('progression-map')).toBeTruthy());
+
+		expect(screen.getByTestId('progression-save')).toBeTruthy();
 	});
 });

--- a/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
@@ -150,6 +150,29 @@ describe('load & normalization', () => {
 		expect(store.selectedPathId).toBe(0);
 		expect(store.totalChanges).toBe(0);
 	});
+
+	it('surfaces a persistent error and stays unloaded when the initial load fails', async () => {
+		fetchMock.mockRejectedValue(new Error('network down'));
+		const store = new ProgressionStore();
+		await store.load();
+
+		expect(store.loaded).toBe(false);
+		expect(store.error).toBe('network down');
+		expect(toastErrorMock).toHaveBeenCalledWith('network down');
+	});
+
+	it('clears the error and loads once a retry succeeds', async () => {
+		fetchMock.mockRejectedValueOnce(new Error('network down'));
+		const store = new ProgressionStore();
+		await store.load();
+		expect(store.error).toBe('network down');
+
+		seedServer();
+		await store.load();
+
+		expect(store.error).toBeNull();
+		expect(store.loaded).toBe(true);
+	});
 });
 
 describe('local editing', () => {


### PR DESCRIPTION
## Summary

Two small shell defects in the progression editor (`UI/src/routes/admin/workbench/progression/`):

1. **Infinite spinner on load failure.** `progression-store.svelte.ts`'s `load()` caught a failed fetch into a transient toast and left `loaded = false` forever — `Progression.svelte` then rendered the loading spinner with no retry affordance. The Ops consoles (`DeadLetterConsole.svelte`) already handle this correctly with a persistent error panel plus a Refresh button; this PR mirrors that pattern.
2. **Save bar only existed in List view.** The Save/Discard bar rendered only in the `list` branch of `Progression.svelte`; in Map view the header still counted "N unsaved" but there was no way to save or discard without toggling back to List view.

## Changes

- `progression-store.svelte.ts`: added an `error` state field. `load()` now clears it on each attempt and sets it (alongside the existing toast) on failure, instead of only toasting.
- `Progression.svelte`:
  - Template now checks `store.error` first and renders a persistent error panel (`role="alert"`, `data-testid="progression-error"`) with the error message and a Refresh button that re-invokes `store.load()`, before falling back to the spinner (only shown while genuinely still loading) or the loaded content.
  - The save bar moved outside the `view === 'map'` / list branch so it renders once loaded regardless of which view is active — Map view's `.map` element already has `flex: 1; min-height: 0`, so it sits correctly above the save bar in the existing flex-column shell.
  - Added `.prog-error` styling mirroring the Ops console's `.dl-error` treatment.

## Tests

- `progression-store.test.ts`: new cases — a failed initial load sets `store.error` (and still leaves `loaded` false), and a subsequent successful retry clears `store.error` and completes the load.
- `Progression.test.ts`: new cases — a failed load shows the persistent error panel (not the spinner) and recovers once "Refresh" is clicked; switching to Map view with a pending change keeps the save bar (and its save button) visible.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` (`vitest run`) — full suite passes: 3557/3557 (including the 4 new cases above).
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1779


---
_Generated by [Claude Code](https://claude.ai/code/session_0176tckGs4mxeJGSKPq2jidp)_