### PR TITLE
Key dead-letter rows by refresh generation, not queue position

### DIFF
--- a/UI/src/routes/admin/ops/DeadLetterConsole.svelte
+++ b/UI/src/routes/admin/ops/DeadLetterConsole.svelte
@@ -111,7 +111,7 @@
 					</tr>
 				</thead>
 				<tbody>
-					{#each queue.entries as entry (entry.index)}
+					{#each queue.entries as entry (`${queue.generation}-${entry.index}`)}
 						<DeadLetterRow
 							{entry}
 							selected={queue.isSelected(entry.index)}

--- a/UI/src/routes/admin/ops/dead-letters.svelte.ts
+++ b/UI/src/routes/admin/ops/dead-letters.svelte.ts
@@ -91,6 +91,13 @@ export class DeadLetterConsoleState {
 	error = $state<string | null>(null);
 	readonly selected = new SvelteSet<number>();
 
+	/**
+	 * Bumped on every successful {@link load}. `entry.index` is only a queue position, reused by whatever
+	 * entry now sits there, so the console keys rows by `generation` + `index` rather than `index` alone —
+	 * otherwise a row's local expanded-payload state would leak onto a different entry after a refresh.
+	 */
+	generation = $state(0);
+
 	private readonly routes: QueueRoutes;
 
 	constructor(variant: DeadLetterQueueVariant = 'player-update') {
@@ -160,6 +167,7 @@ export class DeadLetterConsoleState {
 			});
 			this.totalCount = inspection.totalCount;
 			this.entries = inspection.entries;
+			this.generation++;
 			this.clearSelection();
 			this.loaded = true;
 			return true;

--- a/UI/src/tests/routes/admin/ops/DeadLetterConsole.test.ts
+++ b/UI/src/tests/routes/admin/ops/DeadLetterConsole.test.ts
@@ -76,6 +76,22 @@ describe('DeadLetterConsole', () => {
 		expect(screen.queryByTestId('dl-empty')).toBeNull();
 	});
 
+	it('collapses an expanded row on refresh instead of leaking it onto whatever entry now sits at that position', async () => {
+		getMock.mockResolvedValueOnce(inspection([entry({ index: 0, rawPayload: 'old-payload' })], 1));
+		render(DeadLetterConsole);
+
+		await waitFor(() => expect(screen.getByTestId('dl-table')).toBeTruthy());
+		await fireEvent.click(screen.getByTestId('dl-row-expand'));
+		expect(screen.getByTestId('dl-row-payload').textContent).toContain('old-payload');
+
+		// A different entry now occupies queue position 0 after the refresh.
+		getMock.mockResolvedValueOnce(inspection([entry({ index: 0, rawPayload: 'new-payload' })], 1));
+		await fireEvent.click(screen.getByTestId('dl-refresh'));
+
+		await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+		expect(screen.queryByTestId('dl-row-payload')).toBeNull();
+	});
+
 	it('disables replay-selected until entries are selected', async () => {
 		getMock.mockResolvedValue(inspection([entry({ index: 0 })]));
 		render(DeadLetterConsole);

--- a/UI/src/tests/routes/admin/ops/dead-letters.test.ts
+++ b/UI/src/tests/routes/admin/ops/dead-letters.test.ts
@@ -112,6 +112,22 @@ describe('DeadLetterConsoleState.load', () => {
 
 		expect(state.selectedCount).toBe(0);
 	});
+
+	it('bumps generation on every successful load, but not on a failed one', async () => {
+		getMock.mockResolvedValue(inspection([entry({ index: 0 })]));
+		const state = new DeadLetterConsoleState();
+		expect(state.generation).toBe(0);
+
+		await state.load();
+		expect(state.generation).toBe(1);
+
+		getMock.mockRejectedValueOnce(new Error('boom'));
+		await state.load();
+		expect(state.generation).toBe(1);
+
+		await state.load();
+		expect(state.generation).toBe(2);
+	});
 });
 
 describe('DeadLetterConsoleState selection', () => {


### PR DESCRIPTION
## Summary

`UI/src/routes/admin/ops/DeadLetterConsole.svelte:114` keyed each row's `DeadLetterRow` component by `entry.index` — the queue *position*, not an entry identity — while `DeadLetterRow.svelte:62` holds `expanded` as local component state. After a replay/refresh shifts the queue, the row component at position `k` is reused for whatever entry now sits there, so a payload panel an operator had expanded stayed open showing a **different** entry's payload.

## Failure scenario this fixes

An operator expands the payload for the entry at position 0, then clicks Refresh (or replays some entries and the queue re-shuffles). A different entry now occupies position 0, but its row reuses the previous row's component state — the payload panel stays expanded, silently showing the wrong entry's payload to an operator who is specifically trying to inspect dead letters carefully.

## Changes

- `dead-letters.svelte.ts`: `DeadLetterConsoleState` gains a `generation` counter, bumped on every successful `load()`.
- `DeadLetterConsole.svelte`: the keyed `{#each}` now keys rows by `` `${queue.generation}-${entry.index}` `` instead of `entry.index` alone, so every refresh mounts fresh row components (collapsing any stale expansion) — consistent with how the console already clears the operator's selection on every `load()`.

I went with "collapse expansion on refresh" over the issue's alternative ("key by payload hash + occurrence") because the codebase already established that pattern for selection (see the comment on `DeadLetterConsoleState`'s selected set docblock, which deliberately avoids payload-based keying since duplicate payloads exist and complicate identity). Keying by payload + occurrence would also need special-casing duplicate payloads to stay unique per Svelte's keyed-each requirement, for comparatively little benefit — a plain "Refresh" is cheap enough that remounting up to 200 rows is a non-issue.

## Tests

- `dead-letters.test.ts`: new case pins that `generation` increments only on a successful `load()`, not a failed one.
- `DeadLetterConsole.test.ts`: new case expands a row, refreshes with a different entry at the same queue position, and asserts the payload panel is no longer shown (i.e., it collapsed rather than leaking).

## Test plan

- [x] `npm run lint` — clean.
- [x] `npx vitest run` (scoped: dead-letter suites) — 33/33 passing.
- [x] `npm run test:unit:ci` (full suite) — 3566/3566 passing.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1780


---
_Generated by [Claude Code](https://claude.ai/code/session_01TP8U98R4ZXcnEER7gGXn7i)_