### PR TITLE
Fix KillsByDamageType challenge defaulting to a backend-rejected Global scope

### DIFF
--- a/UI/src/routes/admin/workbench/entities/challenge-helpers.ts
+++ b/UI/src/routes/admin/workbench/entities/challenge-helpers.ts
@@ -1,6 +1,7 @@
 import {
 	EChallengeGoalComparison,
 	EChallengeType,
+	EDamageTypeKey,
 	EEntityType,
 	EStatisticType,
 	type IChallenge,
@@ -164,5 +165,8 @@ export function deriveFromType(c: IChallenge, types: IChallengeType[], typeId: E
 	c.challengeTypeId = typeId;
 	c.statisticType = stat?.id;
 	c.entityType = stat?.entityType ?? EEntityType.None;
-	c.targetEntityId = undefined;
+	// A DamageType-scoped statistic writes only per-damage-type-key rows (no global row), so
+	// Global is never a valid target for it — default to the first key rather than landing on
+	// the state the backend hard-rejects. Every other dimension defaults to Global as before.
+	c.targetEntityId = c.entityType === EEntityType.DamageType ? EDamageTypeKey.Physical : undefined;
 }

--- a/UI/src/routes/admin/workbench/entities/challenge.ts
+++ b/UI/src/routes/admin/workbench/entities/challenge.ts
@@ -86,9 +86,18 @@ export const challengeEntity: EntityConfig<IChallenge> = {
 			desc: 'What the player must do to complete it',
 			kind: 'challenge-condition',
 			// Statistic & entity are fully determined by the type, so they can't be
-			// inconsistent — the only condition-level slip is a non-positive goal.
+			// inconsistent — the remaining condition-level slips are a non-positive goal and a
+			// DamageType-scoped statistic left Global (it has no global row; the backend hard-rejects it).
 			dirtyKeys: ['challengeTypeId', 'statisticType', 'entityType', 'targetEntityId', 'progressGoal'],
-			warn: (c) => (!c.progressGoal || c.progressGoal <= 0 ? 'Goal must be greater than zero' : null)
+			warn: (c) => {
+				if (!c.progressGoal || c.progressGoal <= 0) {
+					return 'Goal must be greater than zero';
+				}
+				if (c.entityType === EEntityType.DamageType && c.targetEntityId == null) {
+					return 'Must target a damage type — this statistic has no global total';
+				}
+				return null;
+			}
 		},
 		{
 			key: 'reward',

--- a/UI/src/tests/routes/admin/workbench/challenge-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge-helpers.test.ts
@@ -264,6 +264,15 @@ describe('deriveFromType', () => {
 		expect(c.statisticType).toBeUndefined();
 		expect(c.entityType).toBe(EEntityType.None);
 	});
+
+	it('defaults a DamageType-scoped type to the first damage-type key instead of Global (#1781)', () => {
+		// KillsByDamageType has no global row on the backend, so leaving the default Global
+		// target would land on a state the backend hard-rejects on save.
+		const c = make({ challengeTypeId: EChallengeType.EnemiesKilled });
+		deriveFromType(c, TYPES, EChallengeType.KillsByDamageType);
+		expect(c.entityType).toBe(EEntityType.DamageType);
+		expect(c.targetEntityId).toBe(0);
+	});
 });
 
 describe('number formatting', () => {

--- a/UI/src/tests/routes/admin/workbench/entities/challenge.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/challenge.test.ts
@@ -114,4 +114,28 @@ describe('challengeEntity', () => {
 
 		expect(postBodyTo('AdminTools/AddEditChallenges')[0].item).toEqual(record);
 	});
+
+	describe('condition section warn (#1781)', () => {
+		const conditionWarn = challengeEntity.sections.find((s) => s.key === 'condition')?.warn;
+
+		it('flags a non-positive goal', () => {
+			const c = { ...challengeEntity.newItem(1), progressGoal: 0 };
+			expect(conditionWarn?.(c)).toBe('Goal must be greater than zero');
+		});
+
+		it('flags a DamageType-scoped statistic left Global — the backend has no global row for it', () => {
+			const c = { ...challengeEntity.newItem(1), entityType: EEntityType.DamageType, targetEntityId: undefined };
+			expect(conditionWarn?.(c)).toBe('Must target a damage type — this statistic has no global total');
+		});
+
+		it('passes once a DamageType-scoped statistic is targeted', () => {
+			const c = { ...challengeEntity.newItem(1), entityType: EEntityType.DamageType, targetEntityId: 0 };
+			expect(conditionWarn?.(c)).toBeNull();
+		});
+
+		it('does not require a target for a non-DamageType statistic', () => {
+			const c = { ...challengeEntity.newItem(1), entityType: EEntityType.Enemy, targetEntityId: undefined };
+			expect(conditionWarn?.(c)).toBeNull();
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Switching a Workbench challenge's objective type to "Kills By Damage Type" ran `deriveFromType`, which clears `targetEntityId` (`UI/src/routes/admin/workbench/entities/challenge-helpers.ts`), and `ScopeField.svelte` lands on **Global** whenever a target is unset — so the *default* state right after picking that type was exactly what the backend hard-rejects (`Game.DataAccess/Repositories/Admin/AdminChallenges.cs:165-170`, "must target a damage-type key"), failing the entire `AddEditChallenges` batch (including any sibling adds/edits) with only a toast and no warning triangle.

## Changes

- `challenge-helpers.ts`: `deriveFromType` now defaults the target to the first `EDamageTypeKey` (`Physical`) instead of `undefined` whenever the newly-selected type's statistic is `DamageType`-scoped, since that dimension has no global row (mirrors the backend's own reasoning: "the statistic writes only per-damage-type-key rows, no global row"). Every other entity dimension keeps defaulting to Global as before — this is metadata-driven off `entityType`, not hardcoded to `KillsByDamageType`, so it stays correct if another `DamageType`-scoped statistic is ever added.
- `challenge.ts`: the condition section's `warn` gains a matching check (`entityType === EEntityType.DamageType && targetEntityId == null`) as a backstop — an admin can still manually click "Global" in `ScopeField` after picking the type, and this closes that path with the same amber-triangle pattern the codebase already uses for every other cheap, local authoring rule (see `docs/frontend-admin.md` → "Validation lives where it occurs").

## Tests

- `challenge-helpers.test.ts`: new case pinning that `deriveFromType` defaults a `KillsByDamageType` switch to damage-type key `0` instead of clearing the target.
- `entities/challenge.test.ts`: new cases for the condition section's `warn` — non-positive goal, an untargeted `DamageType` statistic, a targeted one, and a non-`DamageType` statistic left untargeted (which is fine).

## Test plan

- [x] `npm run lint` — clean (eslint + svelte-check, 0 errors/warnings).
- [x] `npx vitest run` (full suite) — 296 files / 3571 tests passing.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1781


---
_Generated by [Claude Code](https://claude.ai/code/session_01XZ9ZgY1rWmESeEqztrnYfy)_