### PR TITLE
Filter class starter-equipment item picker by slot category

### DIFF
--- a/UI/src/routes/admin/workbench/components/TableCell.svelte
+++ b/UI/src/routes/admin/workbench/components/TableCell.svelte
@@ -2,7 +2,7 @@
 	<td style:min-width="{col.min ?? 160}px">
 		<div class="fld">
 			<select class="sel" class:dirty value={row[col.key] as number} onchange={(e) => onChange(+e.currentTarget.value)}>
-				{#each col.options?.(row[col.key] as number) ?? [] as option (option.value)}
+				{#each col.options?.(row[col.key] as number, row) ?? [] as option (option.value)}
 					<option value={option.value} disabled={taken.has(option.value) && option.value !== row[col.key]}>
 						{option.text}
 					</option>
@@ -16,7 +16,7 @@
 	<td style:min-width="{col.min ?? 160}px">
 		<AttributePicker
 			value={row[col.key] as number}
-			options={col.options?.(row[col.key] as number) ?? []}
+			options={col.options?.(row[col.key] as number, row) ?? []}
 			onChange={(v) => onChange(v)}
 			ariaLabel={col.label}
 			disabledValues={col.unique ? taken : undefined}

--- a/UI/src/routes/admin/workbench/entities/class.ts
+++ b/UI/src/routes/admin/workbench/entities/class.ts
@@ -1,4 +1,12 @@
-import { ApiRequest, EAttribute, EModifierType, ESkillAcquisition, fetchSocketData, type IClass } from '$lib/api';
+import {
+	ApiRequest,
+	EAttribute,
+	type EEquipmentSlot,
+	EModifierType,
+	ESkillAcquisition,
+	fetchSocketData,
+	type IClass
+} from '$lib/api';
 import { hasFlag } from '$lib/common';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
@@ -155,6 +163,12 @@ export const classEntity: EntityConfig<WorkbenchClass> = {
 			glyph: 'box',
 			desc: 'Items equipped at character creation',
 			count: (c) => c.starterEquipment.length,
+			warn: (c) => {
+				const mismatch = c.starterEquipment.find(
+					(e) => reference.itemCategoryOf(e.itemId) !== reference.equipmentSlotCategory(e.equipmentSlot)
+				);
+				return mismatch ? `Item doesn't match its equipment slot's category` : null;
+			},
 			kind: 'table',
 			itemsKey: 'starterEquipment',
 			rowKey: 'equipmentSlot',
@@ -162,13 +176,16 @@ export const classEntity: EntityConfig<WorkbenchClass> = {
 			emptyIcon: 'box',
 			emptyTitle: 'No starter equipment',
 			emptySub: 'This class starts with nothing equipped.',
-			newRow: (c) => ({
-				equipmentSlot: firstFree(
+			newRow: (c) => {
+				const equipmentSlot = firstFree(
 					c.starterEquipment.map((e) => e.equipmentSlot),
 					reference.equipmentSlotOptions()
-				),
-				itemId: reference.itemOptions()[0]?.value ?? 0
-			}),
+				);
+				return {
+					equipmentSlot,
+					itemId: reference.itemOptionsForSlot(equipmentSlot)[0]?.value ?? 0
+				};
+			},
 			columns: [
 				{
 					key: 'equipmentSlot',
@@ -178,7 +195,13 @@ export const classEntity: EntityConfig<WorkbenchClass> = {
 					min: 160,
 					unique: true
 				},
-				{ key: 'itemId', label: 'Item', type: 'select', options: reference.itemOptions, min: 220 }
+				{
+					key: 'itemId',
+					label: 'Item',
+					type: 'select',
+					options: (current, row) => reference.itemOptionsForSlot((row?.equipmentSlot as EEquipmentSlot) ?? 0, current),
+					min: 220
+				}
 			]
 		},
 		{

--- a/UI/src/routes/admin/workbench/entities/types.ts
+++ b/UI/src/routes/admin/workbench/entities/types.ts
@@ -74,8 +74,12 @@ export interface ColumnConfig {
 	/** `attribute` renders the searchable, group-by-type AttributePicker (#1327); `text` a free-form
 	 *  string input (e.g. tutorial tour step copy); otherwise as `select`. */
 	type: 'select' | 'attribute' | 'number' | 'share' | 'text';
-	/** Select option provider; receives the row's current value so a retired reference stays visible. */
-	options?: (current?: number) => SelectOption[];
+	/**
+	 * Select option provider; receives the row's current value (so a retired reference stays visible)
+	 * and the full row (so options can be filtered by a sibling column, e.g. an item picker narrowed to
+	 * the row's equipment-slot category).
+	 */
+	options?: (current?: number, row?: Record<string, number | string>) => SelectOption[];
 	align?: 'r';
 	width?: number;
 	min?: number;

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -34,6 +34,16 @@ type RetireableRef = { id: number; name: string; retiredAt?: string | null };
  *  dimension has no DB reference table to load, so its "records" are just the enum itself. */
 const damageTypeKeyRefs: RetireableRef[] = enumPairs(EDamageTypeKey);
 
+/** Mirrors the backend's `EquipmentSlot.ItemCategory` mapping (`Game.Core/Players/Inventories/EquipmentSlot.cs`). */
+const equipmentSlotCategories: Record<EEquipmentSlot, EItemCategory> = {
+	[EEquipmentSlot.HelmSlot]: EItemCategory.Helm,
+	[EEquipmentSlot.ChestSlot]: EItemCategory.Chest,
+	[EEquipmentSlot.LegSlot]: EItemCategory.Leg,
+	[EEquipmentSlot.BootSlot]: EItemCategory.Boot,
+	[EEquipmentSlot.WeaponSlot]: EItemCategory.Weapon,
+	[EEquipmentSlot.AccessorySlot]: EItemCategory.Accessory
+};
+
 /**
  * Loads and exposes the reference data the workbench's select options, tag UI,
  * and derived spawn-share math read from. Catalogues that the workbench also
@@ -176,6 +186,22 @@ class WorkbenchReference {
 	];
 	/** Item picker options (active items, plus the current value even if retired). */
 	itemOptions = (keep?: number): SelectOption[] => this.retireableOptions(staticData.items ?? [], keep);
+	/** The item category an equipment slot accepts, mirroring the backend's `EquipmentSlot.ItemCategory`. */
+	equipmentSlotCategory = (slot: EEquipmentSlot): EItemCategory => equipmentSlotCategories[slot];
+	/**
+	 * Item picker options narrowed to the category a given equipment slot accepts (plus the current
+	 * value even if it's since become a category mismatch — the class starter-equipment table's
+	 * section `warn` is the backstop for that case, mirroring the retired-`keep` convention above).
+	 */
+	itemOptionsForSlot = (slot: EEquipmentSlot, keep?: number): SelectOption[] => {
+		const category = this.equipmentSlotCategory(slot);
+		return this.retireableOptions(
+			(staticData.items ?? []).filter((i) => i.itemCategoryId === category || i.id === keep),
+			keep
+		);
+	};
+	/** An item's category, for validating it against the equipment slot it's assigned to. */
+	itemCategoryOf = (id: number): EItemCategory | undefined => staticData.items?.[id]?.itemCategoryId;
 	skillCatalogue = () =>
 		(staticData.skills ?? []).map((s) => ({
 			id: s.id,

--- a/UI/src/tests/routes/admin/workbench/TableCell.test.ts
+++ b/UI/src/tests/routes/admin/workbench/TableCell.test.ts
@@ -106,6 +106,22 @@ describe('TableCell — select type', () => {
 		expect(zone1?.disabled).toBe(false);
 	});
 
+	it('passes the full row to the options provider, alongside the current value', () => {
+		const options = vi.fn(() => [{ value: 1, text: 'Zone A' }]);
+		render(TableCell, {
+			props: {
+				col: makeSelectCol({ options }),
+				row: { zoneId: 1, kind: 2 },
+				idx: 0,
+				rows: [{ zoneId: 1, kind: 2 }],
+				record: {},
+				dirty: false,
+				onChange: vi.fn()
+			}
+		});
+		expect(options).toHaveBeenCalledWith(1, { zoneId: 1, kind: 2 });
+	});
+
 	it('adds the "dirty" class to the select when dirty=true', () => {
 		const { container } = render(TableCell, {
 			props: {

--- a/UI/src/tests/routes/admin/workbench/entities/class.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/class.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
-import { EAttribute, EModifierType } from '$lib/api';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EAttribute, EEquipmentSlot, EItemCategory, EModifierType } from '$lib/api';
+import type { TableSectionConfig } from '$routes/admin/workbench/entities/types';
 
 /* Only the refresh() write-through added for #1633 — classEntity's field/table configs aren't touched here.
    `fetchSocketData` is stubbed; the write-through into staticData.classes is what retire-confirm's reference
@@ -25,7 +26,16 @@ vi.mock('$lib/api', async (importOriginal) => {
 	return { ...actual, ApiRequest, fetchSocketData: mockFetch };
 });
 
-import { classEntity } from '$routes/admin/workbench/entities/class';
+import { classEntity, type WorkbenchClass } from '$routes/admin/workbench/entities/class';
+
+/** The starter-equipment table section, for exercising its `newRow`/column-options/`warn` (#1782). */
+const starterEquipmentSection = () =>
+	classEntity.sections.find((s) => s.key === 'starterEquipment') as TableSectionConfig<WorkbenchClass>;
+
+const blankClass = (starterEquipment: WorkbenchClass['starterEquipment'] = []): WorkbenchClass => ({
+	...classEntity.newItem(0),
+	starterEquipment
+});
 
 describe('classEntity.refresh', () => {
 	it('writes the fetched classes through to staticData.classes (#1633 — needed for retire-confirm)', async () => {
@@ -73,5 +83,51 @@ describe('classEntity.refresh', () => {
 		await classEntity.refresh();
 
 		expect(staticData.classes[0].passiveScalingAttributeId).toBe(-1);
+	});
+});
+
+describe('starterEquipment section (#1782)', () => {
+	beforeEach(() => {
+		staticData.items = [
+			{ id: 0, name: 'Iron Helm', itemCategoryId: EItemCategory.Helm },
+			{ id: 1, name: 'Dragon Blade', itemCategoryId: EItemCategory.Weapon }
+		];
+	});
+
+	it('newRow picks the first item matching the auto-picked slot, not just the first catalogue item', () => {
+		// The first item option overall is Iron Helm (Helm); a Weapon-slot row must not default to it.
+		const row = starterEquipmentSection().newRow(blankClass());
+		expect(row.equipmentSlot).toBe(EEquipmentSlot.HelmSlot);
+		expect(row.itemId).toBe(0);
+	});
+
+	it("newRow skips to the next free slot and picks that slot's matching item", () => {
+		const row = starterEquipmentSection().newRow(blankClass([{ equipmentSlot: EEquipmentSlot.HelmSlot, itemId: 0 }]));
+		expect(row.equipmentSlot).toBe(EEquipmentSlot.ChestSlot);
+		// No Chest item in the catalogue, so newRow falls back to 0 (no valid option).
+		expect(row.itemId).toBe(0);
+	});
+
+	it("the Item column's options are filtered to the row's slot category", () => {
+		const itemColumn = starterEquipmentSection().columns.find((c) => c.key === 'itemId')!;
+		expect(itemColumn.options?.(undefined, { equipmentSlot: EEquipmentSlot.HelmSlot })).toEqual([
+			{ value: 0, text: 'Iron Helm' }
+		]);
+		expect(itemColumn.options?.(undefined, { equipmentSlot: EEquipmentSlot.WeaponSlot })).toEqual([
+			{ value: 1, text: 'Dragon Blade' }
+		]);
+	});
+
+	it('warn is null when every entry matches its slot category', () => {
+		const cls = blankClass([
+			{ equipmentSlot: EEquipmentSlot.HelmSlot, itemId: 0 },
+			{ equipmentSlot: EEquipmentSlot.WeaponSlot, itemId: 1 }
+		]);
+		expect(starterEquipmentSection().warn?.(cls)).toBeNull();
+	});
+
+	it('warn flags a slot/category mismatch as a backstop', () => {
+		const cls = blankClass([{ equipmentSlot: EEquipmentSlot.HelmSlot, itemId: 1 }]);
+		expect(starterEquipmentSection().warn?.(cls)).toBe("Item doesn't match its equipment slot's category");
 	});
 });

--- a/UI/src/tests/routes/admin/workbench/reference.test.ts
+++ b/UI/src/tests/routes/admin/workbench/reference.test.ts
@@ -4,6 +4,7 @@ import {
 	EChallengeGoalComparison,
 	EDamageTypeKey,
 	EEntityType,
+	EEquipmentSlot,
 	EItemCategory,
 	EItemModType,
 	ELessonTriggerType,
@@ -276,6 +277,39 @@ describe('granted-skill picker options', () => {
 		expect(reference.grantedSkillOptions(2)).toContainEqual({ value: 2, text: 'Smite · retired' });
 		// …and a Player-only skill that was somehow already authored stays selectable rather than vanishing.
 		expect(reference.grantedSkillOptions(1)).toContainEqual({ value: 1, text: 'Fireball' });
+	});
+});
+
+describe('equipment slot / item category', () => {
+	it('maps each equipment slot to the item category it accepts', () => {
+		expect(reference.equipmentSlotCategory(EEquipmentSlot.HelmSlot)).toBe(EItemCategory.Helm);
+		expect(reference.equipmentSlotCategory(EEquipmentSlot.ChestSlot)).toBe(EItemCategory.Chest);
+		expect(reference.equipmentSlotCategory(EEquipmentSlot.LegSlot)).toBe(EItemCategory.Leg);
+		expect(reference.equipmentSlotCategory(EEquipmentSlot.BootSlot)).toBe(EItemCategory.Boot);
+		expect(reference.equipmentSlotCategory(EEquipmentSlot.WeaponSlot)).toBe(EItemCategory.Weapon);
+		expect(reference.equipmentSlotCategory(EEquipmentSlot.AccessorySlot)).toBe(EItemCategory.Accessory);
+	});
+
+	it('narrows the item picker to only items matching the slot category', () => {
+		// staticData.items: Iron Helm (Helm) and Dragon Blade (Weapon).
+		expect(reference.itemOptionsForSlot(EEquipmentSlot.HelmSlot)).toEqual([{ value: 0, text: 'Iron Helm' }]);
+		expect(reference.itemOptionsForSlot(EEquipmentSlot.WeaponSlot)).toEqual([{ value: 1, text: 'Dragon Blade' }]);
+		expect(reference.itemOptionsForSlot(EEquipmentSlot.ChestSlot)).toEqual([]);
+	});
+
+	it('keeps a category-mismatched current value visible in the narrowed picker', () => {
+		// Dragon Blade (Weapon) kept as the current value on a Helm-slot row, as a backstop for
+		// already-authored bad data — the section warn is what actually flags it.
+		expect(reference.itemOptionsForSlot(EEquipmentSlot.HelmSlot, 1)).toEqual([
+			{ value: 0, text: 'Iron Helm' },
+			{ value: 1, text: 'Dragon Blade' }
+		]);
+	});
+
+	it('resolves an item id to its category', () => {
+		expect(reference.itemCategoryOf(0)).toBe(EItemCategory.Helm);
+		expect(reference.itemCategoryOf(1)).toBe(EItemCategory.Weapon);
+		expect(reference.itemCategoryOf(99)).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
## Summary

`UI/src/routes/admin/workbench/entities/class.ts`'s starter-equipment row picker let an admin assign any item to any equipment slot, regardless of category. The backend's `FindStarterEquipmentViolation` (`Game.DataAccess/Repositories/Admin/AdminClasses.cs:229-248`) only rejects a slot/category mismatch when the `SetClassStarterEquipment` **child saver** runs — which is *after* the identity save has already committed. That turns the rejection into a `PersistFailedError`, and `EntityStore.save()`'s post-commit re-seed then discards every other unsaved edit in the store.

## Failure scenario this fixes

Admin renames a class, clicks "Add equipment" for the Helm slot (the first catalogue item happens to be a weapon), saves → the rename commits, the starter-equipment call 400s, and the re-seed silently wipes the admin's other pending edits.

## Changes

- `ColumnConfig.options` (`entities/types.ts`) now also receives the full row, not just the column's current value — mirroring the `shareTotal` column callback's existing `(row, rows, record)` shape. `TableCell.svelte` passes the row through at both call sites (`select` and `attribute`). This is additive/backward-compatible: existing zero/one-arg `options` callbacks are unaffected.
- `reference.svelte.ts`: adds `equipmentSlotCategory` (mirrors the backend's `EquipmentSlot.ItemCategory` switch), `itemOptionsForSlot` (an item picker narrowed to the category a slot accepts, keeping an already-assigned mismatched item visible the same way retired references stay visible elsewhere), and `itemCategoryOf`.
- `class.ts`: the starter-equipment table's Item column now filters its options by the row's `equipmentSlot`; `newRow` picks the first *category-matching* item for the auto-picked slot instead of the first catalogue item overall; the section gets a `warn` that flags any already-authored slot/category mismatch as a backstop.

## Not included

The general "a post-commit child-saver failure re-seeds the whole store, discarding unrelated unsaved edits" behavior is a store-wide design tradeoff, not specific to this entity — the issue itself scoped that out, and a related persistEntity commit-classification bug was already fixed separately in #1634. This PR removes the *trigger* for that path in the starter-equipment case rather than changing the store's re-seed behavior itself.

## Tests

- `reference.test.ts`: `equipmentSlotCategory` covers all six slots; `itemOptionsForSlot` narrows by category and keeps a mismatched current value visible; `itemCategoryOf` resolves an item's category.
- `class.test.ts`: `newRow` picks a category-matching item for the auto-picked slot (including the case where the first catalogue item is the wrong category); the Item column's `options` is filtered per row; the section `warn` is null when consistent and flags a mismatch otherwise.
- `TableCell.test.ts`: the select cell's `options` provider is called with both the current value and the full row.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings.
- [x] `npx vitest run` (`test:unit:ci`) — full suite passes: 3581/3581.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1782


---
_Generated by [Claude Code](https://claude.ai/code/session_011ZGYPBuhYFo5zAFKSKSAxQ)_