### PR TITLE
Fix lesson-step table ordinal collision and false-dirty Anchor Key

### DIFF
--- a/UI/src/routes/admin/workbench/components/SectionTable.svelte
+++ b/UI/src/routes/admin/workbench/components/SectionTable.svelte
@@ -79,7 +79,7 @@
 import WorkbenchIcon from '../WorkbenchIcon.svelte';
 import type { EntityStore } from '../entity-store.svelte';
 import { recordsEqual } from '../entity-store.svelte';
-import { fieldsOf, type Identified, type TableSectionConfig } from '../entities/types';
+import { fieldsOf, type Identified, type TableRow, type TableSectionConfig } from '../entities/types';
 import EmptySection from './EmptySection.svelte';
 import TableCell from './TableCell.svelte';
 
@@ -94,13 +94,13 @@ const { section, record, baseline, store }: Props = $props();
 
 const itemsKey = $derived(section.itemsKey as string);
 const rowKey = $derived(section.rowKey);
-const rows = $derived((fieldsOf(record)[itemsKey] as Record<string, number | string>[]) ?? []);
-const baseRows = $derived(baseline ? (fieldsOf(baseline)[itemsKey] as Record<string, number | string>[]) : null);
+const rows = $derived((fieldsOf(record)[itemsKey] as TableRow[]) ?? []);
+const baseRows = $derived(baseline ? (fieldsOf(baseline)[itemsKey] as TableRow[]) : null);
 
 // Match each row to its baseline by stable identity (not array position), so a mid-list delete
 // shifting indices can no longer compare a row against the wrong baseline.
 const baseByKey = $derived.by(() => {
-	const map: Record<number, Record<string, number | string>> = {};
+	const map: Record<number, TableRow> = {};
 	for (const baseRow of baseRows ?? []) {
 		map[baseRow[rowKey] as number] = baseRow;
 	}
@@ -113,15 +113,15 @@ const noFree = $derived(
 	uniqueCol ? (uniqueCol.options?.() ?? []).every((o) => rows.some((r) => r[uniqueCol.key] === o.value)) : false
 );
 
-const mutateRows = (mutate: (list: Record<string, number | string>[]) => void) => {
+const mutateRows = (mutate: (list: TableRow[]) => void) => {
 	store.patch(record.id, (draft) => {
-		mutate(fieldsOf(draft)[itemsKey] as Record<string, number | string>[]);
+		mutate(fieldsOf(draft)[itemsKey] as TableRow[]);
 	});
 };
 
 const add = () =>
 	store.patch(record.id, (draft) => {
-		const list = fieldsOf(draft)[itemsKey] as Record<string, number | string>[];
+		const list = fieldsOf(draft)[itemsKey] as TableRow[];
 		const row = section.newRow(draft);
 		// Surrogate-id collections mark new rows with id 0; give each a unique negative id so its
 		// identity (and the {#each} key) stays stable and collision-free across several unsaved rows.
@@ -132,7 +132,19 @@ const add = () =>
 		list.push(row);
 	});
 const removeRow = (i: number) => mutateRows((list) => list.splice(i, 1));
-const setCell = (i: number, key: string, value: number | string) => mutateRows((list) => (list[i][key] = value));
+const setCell = (i: number, key: string, value: number | string | undefined) =>
+	mutateRows((list) => {
+		// Editing a row's identity column (e.g. a tour step's author-editable `ordinal`) into another
+		// row's value would duplicate the {#each} key — crashing dev builds and mis-reconciling prod
+		// ones. Swap the two rows' identities instead, so the edit still lands and both keys stay unique.
+		if (key === rowKey) {
+			const collision = list.find((r, ri) => ri !== i && r[rowKey] === value);
+			if (collision) {
+				collision[rowKey] = list[i][rowKey];
+			}
+		}
+		list[i][key] = value;
+	});
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/admin/workbench/components/TableCell.svelte
+++ b/UI/src/routes/admin/workbench/components/TableCell.svelte
@@ -44,7 +44,7 @@
 				aria-label={col.label}
 				placeholder={col.placeholder}
 				value={(row[col.key] as string) ?? ''}
-				oninput={(e) => onChange(e.currentTarget.value)}
+				oninput={(e) => onChange(col.optional ? e.currentTarget.value || undefined : e.currentTarget.value)}
 			/>
 			{#if dirty}<DirtyDot />{/if}
 		</div>
@@ -59,7 +59,7 @@
 {/if}
 
 <script lang="ts">
-import type { ColumnConfig } from '../entities/types';
+import type { ColumnConfig, TableRow } from '../entities/types';
 import Bar from '$components/Bar.svelte';
 import NumInput from './NumInput.svelte';
 import SelectCaret from './SelectCaret.svelte';
@@ -68,12 +68,12 @@ import AttributePicker from './AttributePicker.svelte';
 
 interface Props {
 	col: ColumnConfig;
-	row: Record<string, number | string>;
+	row: TableRow;
 	idx: number;
-	rows: Record<string, number | string>[];
+	rows: TableRow[];
 	record: unknown;
 	dirty: boolean;
-	onChange: (value: number | string) => void;
+	onChange: (value: number | string | undefined) => void;
 }
 
 const { col, row, idx, rows, record, dirty, onChange }: Props = $props();

--- a/UI/src/routes/admin/workbench/entities/lesson.ts
+++ b/UI/src/routes/admin/workbench/entities/lesson.ts
@@ -157,7 +157,8 @@ export const lessonEntity: EntityConfig<WorkbenchLesson> = {
 					label: 'Anchor Key',
 					type: 'text',
 					width: 200,
-					placeholder: 'Optional — centered if blank'
+					placeholder: 'Optional — centered if blank',
+					optional: true
 				}
 			]
 		}

--- a/UI/src/routes/admin/workbench/entities/lesson.ts
+++ b/UI/src/routes/admin/workbench/entities/lesson.ts
@@ -141,7 +141,7 @@ export const lessonEntity: EntityConfig<WorkbenchLesson> = {
 			newRow: (l) => ({
 				ordinal: l.steps.length ? Math.max(...l.steps.map((s) => s.ordinal)) + 1 : 0,
 				text: '',
-				anchorKey: ''
+				anchorKey: undefined
 			}),
 			columns: [
 				{ key: 'ordinal', label: 'Step', type: 'number', align: 'r', width: 90 },

--- a/UI/src/routes/admin/workbench/entities/types.ts
+++ b/UI/src/routes/admin/workbench/entities/types.ts
@@ -68,6 +68,10 @@ export interface FieldConfig<T> {
 	reqMsg?: string;
 }
 
+/** A table row's cell values; `undefined` marks an optional field explicitly cleared (vs. `''`), so
+ *  it canonicalizes the same as a baseline that omits the field entirely. */
+export type TableRow = Record<string, number | string | undefined>;
+
 export interface ColumnConfig {
 	key: string;
 	label: string;
@@ -79,7 +83,7 @@ export interface ColumnConfig {
 	 * and the full row (so options can be filtered by a sibling column, e.g. an item picker narrowed to
 	 * the row's equipment-slot category).
 	 */
-	options?: (current?: number, row?: Record<string, number | string>) => SelectOption[];
+	options?: (current?: number, row?: TableRow) => SelectOption[];
 	align?: 'r';
 	width?: number;
 	min?: number;
@@ -87,17 +91,16 @@ export interface ColumnConfig {
 	/** Select columns: disable options already chosen in sibling rows. */
 	unique?: boolean;
 	allowNegative?: boolean;
+	/** Text columns: a cleared input stores as `undefined` rather than `''`, so an optional field reads
+	 *  as unmodified against a baseline that omits it (e.g. a tour step's Anchor Key). */
+	optional?: boolean;
 	/** Share columns: which numeric field drives the bar (default "weight"). */
 	weightKey?: string;
 	/**
 	 * Share columns: override the denominator. Defaults to the sum across sibling
 	 * rows; an enemy's spawn share instead competes against all enemies in the zone.
 	 */
-	shareTotal?: (
-		row: Record<string, number | string>,
-		rows: Record<string, number | string>[],
-		record: unknown
-	) => number;
+	shareTotal?: (row: TableRow, rows: TableRow[], record: unknown) => number;
 }
 
 interface BaseSection<T> {
@@ -128,7 +131,7 @@ export interface FieldsSectionConfig<T> extends BaseSection<T> {
 export interface TableActionConfig {
 	label: string;
 	glyph?: WorkbenchIconKind;
-	apply: (rows: Record<string, number | string>[]) => void;
+	apply: (rows: TableRow[]) => void;
 }
 
 export interface TableSectionConfig<T> extends BaseSection<T> {
@@ -148,7 +151,7 @@ export interface TableSectionConfig<T> extends BaseSection<T> {
 	emptyIcon: WorkbenchIconKind;
 	emptyTitle: string;
 	emptySub: string;
-	newRow: (rec: T) => Record<string, number | string>;
+	newRow: (rec: T) => TableRow;
 	columns: ColumnConfig[];
 }
 

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -22,7 +22,7 @@ import {
 } from '$lib/api';
 import { enumPairs, hasFlag, rarityColor as rarityVar, rarityLabel, tagColor } from '$lib/common';
 import { staticData } from '$stores';
-import type { SelectOption } from './entities/types';
+import type { SelectOption, TableRow } from './entities/types';
 
 const toOptions = (pairs: { id: number; name: string }[]): SelectOption[] =>
 	pairs.map((p) => ({ value: p.id, text: p.name }));
@@ -335,11 +335,7 @@ class WorkbenchReference {
 	 * enemy's weight in the same zone (so an enemy's share reflects zone competition,
 	 * not its own zone list).
 	 */
-	enemySpawnShareTotal = (
-		row: Record<string, number | string>,
-		_rows: Record<string, number | string>[],
-		record: unknown
-	): number => {
+	enemySpawnShareTotal = (row: TableRow, _rows: TableRow[], record: unknown): number => {
 		const enemyId = (record as { id: number }).id;
 		let sum = Number(row.weight) || 0;
 		for (const enemy of staticData.enemies ?? []) {

--- a/UI/src/tests/routes/admin/workbench/SectionTable.test.ts
+++ b/UI/src/tests/routes/admin/workbench/SectionTable.test.ts
@@ -212,6 +212,7 @@ describe('SectionTable — surrogate-id collections', () => {
 interface Step {
 	ordinal: number;
 	text: string;
+	anchorKey?: string;
 }
 interface StepRow extends Identified {
 	steps: Step[];
@@ -219,7 +220,8 @@ interface StepRow extends Identified {
 
 // Mirrors the lesson entity's "Tour Steps" section: `ordinal` is both the row identity (rowKey) and
 // an author-editable number column, unlike every other table's rowKey (a surrogate id or a `unique`
-// select/attribute the UI itself keeps collision-free).
+// select/attribute the UI itself keeps collision-free). `anchorKey` mirrors the optional Anchor Key
+// column (blank stores as unset rather than "").
 const stepSection: TableSectionConfig<StepRow> = {
 	key: 'steps',
 	label: 'Steps',
@@ -231,10 +233,11 @@ const stepSection: TableSectionConfig<StepRow> = {
 	emptyIcon: 'map',
 	emptyTitle: 'No steps',
 	emptySub: '',
-	newRow: (rec) => ({ ordinal: rec.steps.length, text: '' }),
+	newRow: (rec) => ({ ordinal: rec.steps.length, text: '', anchorKey: undefined }),
 	columns: [
 		{ key: 'ordinal', label: 'Step', type: 'number', align: 'r' },
-		{ key: 'text', label: 'Text', type: 'text' }
+		{ key: 'text', label: 'Text', type: 'text' },
+		{ key: 'anchorKey', label: 'Anchor Key', type: 'text', optional: true }
 	]
 };
 
@@ -283,5 +286,28 @@ describe('SectionTable — editable-identity (rowKey) collections', () => {
 		// The edited row took the new ordinal; its former sibling was swapped to the vacated one.
 		expect(store.items[0].steps.find((s) => s.text === 'First')?.ordinal).toBe(1);
 		expect(store.items[0].steps.find((s) => s.text === 'Second')?.ordinal).toBe(0);
+	});
+
+	it('typing into then erasing an optional cell returns the row to baseline-equal (not dirty)', async () => {
+		// Baseline (and the initial draft) omit anchorKey entirely — the "centered callout" state. A
+		// typed-then-erased edit must land back on that same unset state, not a stray "".
+		const store = new EntityStore(config(), [{ id: 1, steps: [{ ordinal: 0, text: 'Welcome' }] }]);
+		const { container } = render(SectionTable, {
+			props: {
+				section: stepSection as unknown as TableSectionConfig<Identified>,
+				record: store.items[0] as Identified,
+				baseline: store.baselineOf(1),
+				store: store as unknown as EntityStore<Identified>
+			}
+		});
+
+		const anchorInput = screen.getByLabelText('Anchor Key') as HTMLInputElement;
+		await fireEvent.input(anchorInput, { target: { value: 'nav-fight' } });
+		await fireEvent.input(anchorInput, { target: { value: '' } });
+
+		expect(store.items[0].steps[0].anchorKey).toBeUndefined();
+		const edge = container.querySelector('.row-edge') as HTMLElement;
+		expect(edge.getAttribute('style')).toContain('box-shadow: none');
+		expect(edge.getAttribute('style')).not.toContain('var(--change-modified)');
 	});
 });

--- a/UI/src/tests/routes/admin/workbench/SectionTable.test.ts
+++ b/UI/src/tests/routes/admin/workbench/SectionTable.test.ts
@@ -208,3 +208,80 @@ describe('SectionTable — surrogate-id collections', () => {
 		expect(new Set(ids).size).toBe(ids.length);
 	});
 });
+
+interface Step {
+	ordinal: number;
+	text: string;
+}
+interface StepRow extends Identified {
+	steps: Step[];
+}
+
+// Mirrors the lesson entity's "Tour Steps" section: `ordinal` is both the row identity (rowKey) and
+// an author-editable number column, unlike every other table's rowKey (a surrogate id or a `unique`
+// select/attribute the UI itself keeps collision-free).
+const stepSection: TableSectionConfig<StepRow> = {
+	key: 'steps',
+	label: 'Steps',
+	glyph: 'map',
+	kind: 'table',
+	itemsKey: 'steps',
+	rowKey: 'ordinal',
+	addLabel: 'Add step',
+	emptyIcon: 'map',
+	emptyTitle: 'No steps',
+	emptySub: '',
+	newRow: (rec) => ({ ordinal: rec.steps.length, text: '' }),
+	columns: [
+		{ key: 'ordinal', label: 'Step', type: 'number', align: 'r' },
+		{ key: 'text', label: 'Text', type: 'text' }
+	]
+};
+
+describe('SectionTable — editable-identity (rowKey) collections', () => {
+	const config = (): EntityConfig<StepRow> =>
+		({
+			key: 'rows',
+			label: 'Rows',
+			singular: 'Row',
+			glyph: 'box',
+			blankName: 'Unnamed',
+			newItem: (id: number) => ({ id, steps: [] }),
+			meta: () => [],
+			sections: [stepSection],
+			refresh: async () => [],
+			persist: async () => []
+		}) as unknown as EntityConfig<StepRow>;
+
+	it('swaps identities instead of duplicating them when an edit collides with a sibling row', async () => {
+		const store = new EntityStore(config(), [
+			{
+				id: 1,
+				steps: [
+					{ ordinal: 0, text: 'First' },
+					{ ordinal: 1, text: 'Second' }
+				]
+			}
+		]);
+		const { container } = render(SectionTable, {
+			props: {
+				section: stepSection as unknown as TableSectionConfig<Identified>,
+				record: store.items[0] as Identified,
+				baseline: store.baselineOf(1),
+				store: store as unknown as EntityStore<Identified>
+			}
+		});
+
+		// Editing the first row's ordinal (0) to the second row's ordinal (1) must not leave two
+		// rows sharing ordinal 1 — that duplicate key crashes Svelte's keyed {#each}.
+		const ordinalInputs = container.querySelectorAll('input.num');
+		await fireEvent.input(ordinalInputs[0], { target: { value: '1' } });
+
+		const ordinals = store.items[0].steps.map((s) => s.ordinal).sort();
+		expect(ordinals).toEqual([0, 1]);
+		expect(new Set(ordinals).size).toBe(2);
+		// The edited row took the new ordinal; its former sibling was swapped to the vacated one.
+		expect(store.items[0].steps.find((s) => s.text === 'First')?.ordinal).toBe(1);
+		expect(store.items[0].steps.find((s) => s.text === 'Second')?.ordinal).toBe(0);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/TableCell.test.ts
+++ b/UI/src/tests/routes/admin/workbench/TableCell.test.ts
@@ -240,6 +240,42 @@ describe('TableCell — text type', () => {
 		});
 		expect(container.querySelector('input')!.classList.contains('dirty')).toBe(true);
 	});
+
+	it('calls onChange with undefined (not "") when an optional column is cleared to blank', async () => {
+		const onChange = vi.fn();
+		const { container } = render(TableCell, {
+			props: {
+				col: makeTextCol({ optional: true }),
+				row: { text: 'nav-fight' },
+				idx: 0,
+				rows: [{ text: 'nav-fight' }],
+				record: {},
+				dirty: false,
+				onChange
+			}
+		});
+		const input = container.querySelector('input') as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: '' } });
+		expect(onChange).toHaveBeenCalledWith(undefined);
+	});
+
+	it('calls onChange with "" (not undefined) when a non-optional column is cleared to blank', async () => {
+		const onChange = vi.fn();
+		const { container } = render(TableCell, {
+			props: {
+				col: makeTextCol(),
+				row: { text: 'a' },
+				idx: 0,
+				rows: [{ text: 'a' }],
+				record: {},
+				dirty: false,
+				onChange
+			}
+		});
+		const input = container.querySelector('input') as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: '' } });
+		expect(onChange).toHaveBeenCalledWith('');
+	});
 });
 
 describe('TableCell — share type', () => {

--- a/UI/src/tests/routes/admin/workbench/entities/lesson.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/lesson.test.ts
@@ -210,7 +210,7 @@ describe('lessonEntity', () => {
 			expect(section && 'newRow' in section ? section.newRow(l) : null).toEqual({
 				ordinal: 3,
 				text: '',
-				anchorKey: ''
+				anchorKey: undefined
 			});
 		});
 
@@ -227,7 +227,7 @@ describe('lessonEntity', () => {
 			expect(section && 'newRow' in section ? section.newRow(l) : null).toEqual({
 				ordinal: 0,
 				text: '',
-				anchorKey: ''
+				anchorKey: undefined
 			});
 		});
 	});

--- a/UI/src/tests/routes/admin/workbench/entities/lesson.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/lesson.test.ts
@@ -214,6 +214,13 @@ describe('lessonEntity', () => {
 			});
 		});
 
+		it('marks the Anchor Key column optional, so a cleared cell reads as unset rather than ""', () => {
+			const section = stepsSection();
+			const anchorCol =
+				section && 'columns' in section ? section.columns.find((c) => c.key === 'anchorKey') : undefined;
+			expect(anchorCol?.optional).toBe(true);
+		});
+
 		it('newRow starts at ordinal 0 for a lesson with no steps yet', () => {
 			const section = stepsSection();
 			const l = { ...lessonEntity.newItem(0), steps: [] };


### PR DESCRIPTION
## Summary

Two small defects in the Workbench lesson-step editing table (`UI/src/routes/admin/workbench/entities/lesson.ts`'s "Tour Steps" section):

1. **Ordinal collision broke the keyed `{#each}`.** `SectionTable.svelte` keys rows by `row[rowKey]`, and the lesson steps table's `rowKey` is the author-editable `ordinal` — the only table in the Workbench where the identity column is also a freely-editable number (every other table's `rowKey` is either a surrogate id or a `unique` select/attribute the UI already keeps collision-free). The moment `setCell` committed a duplicate ordinal, dev builds threw `each_key_duplicate` and prod builds could mis-reconcile rows.
2. **A cleared optional Anchor Key stuck the row false-dirty.** Text cells wrote back `''`, the server omits the optional `anchorKey` when unset, and `canonicalize` (`save-helpers.ts`) collapses `null`/absent but not `''` — so clearing an existing step's Anchor Key left a phantom dirty state and triggered a redundant `SetLessonSteps` post.

## Changes

- `SectionTable.svelte`: `setCell` now detects when an edit to the row's identity column (`rowKey`) would collide with a sibling row, and swaps the sibling onto the vacated identity instead of allowing the duplicate. This is implemented generically (keyed on `key === rowKey`), not lesson-specific — it's a no-op for every other table today since their `rowKey` columns are already collision-proof by construction, but it protects any future editable-identity column the same way.
- `entities/types.ts`: new `ColumnConfig.optional` flag for text columns, and a `TableRow` type alias (`Record<string, number | string | undefined>`) replacing the repeated inline type across the table components — needed since an optional column's cleared value is now `undefined` rather than `''`.
- `TableCell.svelte`: a text column's `oninput` now stores `undefined` instead of `''` when `col.optional` is set and the field is cleared.
- `lesson.ts`: marks the Anchor Key column `optional: true`.
- `reference.svelte.ts`: `enemySpawnShareTotal`'s signature updated to the new shared `TableRow` type (mechanical, no behavior change).

## Tests

- `SectionTable.test.ts`: new `describe('SectionTable — editable-identity (rowKey) collections')` pinning that editing a row's ordinal into a sibling's swaps identities rather than duplicating the key.
- `TableCell.test.ts`: new cases confirming an `optional` text column's cleared input calls `onChange(undefined)`, while a non-optional column still calls `onChange('')`.
- `lesson.test.ts`: new case asserting the Anchor Key column carries `optional: true`.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.
- [x] `npx vitest run` (targeted + full suite) — 3585/3585 passing, including the new cases above.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1784


---
_Generated by [Claude Code](https://claude.ai/code/session_019vifMzWzFn6PSKhnq1FYoA)_