### PR TITLE
Fix game route lifecycle: socket listener leak on remount and welcome-back gate race

### DIFF
--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -108,9 +108,13 @@ export const startGame = (activeBattle?: IEnemyInstance) => {
 		startLogicEngine();
 		startRenderEngine();
 		startBattleEngine(activeBattle);
+		// Unhook any listeners a prior startGame left behind (defensive against a missed stopEngines)
+		// before registering this call's own — otherwise a second startGame without an intervening
+		// unhook would leak the first set and double-fire every handler.
+		unhookSocketListeners();
 		// cleanupOnDestroy must stay off: startGame runs outside component init (from welcome.run()'s
 		// async continuation or the WelcomeBackGate click handler), where Svelte's onDestroy throws.
-		// Teardown instead relies on the unhooks captured here, invoked unconditionally by stopGame.
+		// Teardown instead relies on the unhooks captured here, invoked unconditionally by stopEngines.
 		socketReplacedUnhook = apiSocket.listenCommand('SocketReplaced', handleSocketReplaced);
 		challengeCompletedUnhook = apiSocket.listenCommand('ChallengeCompleted', handleChallengeCompleted);
 		proficiencyXpGainedUnhook = apiSocket.listenCommand('ProficiencyXpGained', handleProficiencyXpGained);
@@ -320,11 +324,28 @@ export const handleSocketReplaced = async () => {
 };
 
 /**
- * Stops the live game loops (logical, render, battle) and the background-throttle monitor. Shared by the
- * full {@link stopGame} teardown and the game route's own unmount cleanup, so navigating away from the
- * game stops the loops without tearing down the socket/stores a session-replacement must clear. Every
- * stop is idempotent, so this is safe to call even when the loops never started (e.g. the player left
- * during the welcome-back gate, before {@link startGame} ran).
+ * Unhooks the four `startGame`-registered socket listeners, if any are currently registered.
+ * Idempotent (each unhook no-ops once already removed) and safe to call when `startGame` never ran.
+ */
+const unhookSocketListeners = () => {
+	socketReplacedUnhook?.();
+	challengeCompletedUnhook?.();
+	proficiencyXpGainedUnhook?.();
+	serverCommandFailedUnhook?.();
+	socketReplacedUnhook = undefined;
+	challengeCompletedUnhook = undefined;
+	proficiencyXpGainedUnhook = undefined;
+	serverCommandFailedUnhook = undefined;
+};
+
+/**
+ * Stops the live game loops (logical, render, battle), the background-throttle monitor, and the four
+ * `startGame`-registered socket listeners. Shared by the full {@link stopGame} teardown and the game
+ * route's own unmount cleanup, so navigating away from the game fully tears down this run of the engines
+ * — including its listeners — without tearing down the socket/stores a session-replacement must clear.
+ * Every stop is idempotent, so this is safe to call even when the loops never started (e.g. the player
+ * left during the welcome-back gate, before {@link startGame} ran), and safe to call again on a route
+ * that never re-entered the game.
  */
 export const stopEngines = () => {
 	logicEngine.stop();
@@ -332,6 +353,7 @@ export const stopEngines = () => {
 	renderEngine.stop();
 	enemyManager.stop();
 	battleEngine.stop();
+	unhookSocketListeners();
 };
 
 const stopGame = () => {
@@ -340,10 +362,6 @@ const stopGame = () => {
 	playerChallenges.reset();
 	playerProficiencies.reset();
 	resetLogs();
-	socketReplacedUnhook?.();
-	challengeCompletedUnhook?.();
-	proficiencyXpGainedUnhook?.();
-	serverCommandFailedUnhook?.();
 	// SocketReplaced routes back to login client-side (no reload), so the socket singleton survives. Tear
 	// it down explicitly, otherwise the keepalive ping would silently reconnect and fight the session that
 	// just took over.

--- a/UI/src/routes/game/+page.svelte
+++ b/UI/src/routes/game/+page.svelte
@@ -76,7 +76,12 @@ const welcome = new WelcomeBackView({
 if (browser) {
 	// Cleanup is registered once at init (the gate may start the loops later, after an await, where
 	// onDestroy can't be called); stopEngines is idempotent, so it's safe even if the loops never ran.
-	onDestroy(stopEngines);
+	// welcome.cancel() guards against welcome.run()'s async continuation (still in flight on a slow
+	// GetOfflineProgress) starting the engines after this page has already unmounted.
+	onDestroy(() => {
+		stopEngines();
+		welcome.cancel();
+	});
 	onMount(() => {
 		void welcome.run();
 	});

--- a/UI/src/routes/game/welcome-back/welcome-back-view.svelte.ts
+++ b/UI/src/routes/game/welcome-back/welcome-back-view.svelte.ts
@@ -28,6 +28,7 @@ export interface WelcomeBackDeps {
 export class WelcomeBackView {
 	phase = $state<WelcomePhase>('checking');
 	summary = $state<IOfflineProgressModel | null>(null);
+	private cancelled = false;
 
 	constructor(private readonly deps: WelcomeBackDeps) {}
 
@@ -38,6 +39,9 @@ export class WelcomeBackView {
 	 */
 	async run(): Promise<void> {
 		const progress = await this.deps.fetchProgress();
+		if (this.cancelled) {
+			return;
+		}
 
 		if (progress) {
 			this.deps.reconcileMode(progress.autoChallengeBoss);
@@ -51,16 +55,31 @@ export class WelcomeBackView {
 
 		// Pull the reward-updated player aggregate before the engine builds the live battler from it.
 		await this.deps.resyncPlayer();
+		if (this.cancelled) {
+			return;
+		}
 		this.summary = progress;
 		this.phase = 'summary';
 	}
 
-	/** Dismisses the gate (or the no-gate pass-through) and starts the game exactly once. */
+	/** Dismisses the gate (or the no-gate pass-through) and starts the game exactly once. Also a no-op
+	 *  once {@link cancel} has been called (the page unmounted before this ran). */
 	enter(): void {
-		if (this.phase === 'entered') {
+		if (this.phase === 'entered' || this.cancelled) {
 			return;
 		}
 		this.phase = 'entered';
 		this.deps.enterGame(this.summary?.activeBattle);
+	}
+
+	/**
+	 * Marks the gate cancelled so a `run()` continuation that resolves after the game page has already
+	 * unmounted (e.g. the `GetOfflineProgress` round-trip lands after the player navigated away) can't
+	 * start the engines behind a screen that no longer owns them — {@link enter} becomes a no-op, and
+	 * a still-in-flight `run()` bails out at its next await rather than reconciling mode or entering.
+	 * Call from the page's `onDestroy`.
+	 */
+	cancel(): void {
+		this.cancelled = true;
 	}
 }

--- a/UI/src/tests/lib/engine/engine.test.ts
+++ b/UI/src/tests/lib/engine/engine.test.ts
@@ -151,6 +151,7 @@ vi.mock('$lib/engine/session', () => ({ refreshPlayer }));
 
 import {
 	startGame,
+	stopEngines,
 	handleSocketReplaced,
 	handleChallengeCompleted,
 	handleProficiencyXpGained,
@@ -370,6 +371,55 @@ describe('startGame', () => {
 		void handleSocketReplaced();
 
 		expect(disconnect).toHaveBeenCalledTimes(1);
+	});
+
+	it("unhooks the previous call's listeners before re-registering, so a remount cannot leak them (#1807)", () => {
+		startGame();
+		startGame();
+
+		expect(unlistenSocketReplaced).toHaveBeenCalledTimes(1);
+		expect(unlistenChallengeCompleted).toHaveBeenCalledTimes(1);
+		expect(unlistenProficiencyXpGained).toHaveBeenCalledTimes(1);
+		expect(unlistenServerCommandFailed).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('stopEngines', () => {
+	it('stops every loop and the background-throttle monitor', () => {
+		stopEngines();
+
+		expect(logicEngine.stop).toHaveBeenCalledTimes(1);
+		expect(renderEngine.stop).toHaveBeenCalledTimes(1);
+		expect(enemyManager.stop).toHaveBeenCalledTimes(1);
+		expect(battleEngine.stop).toHaveBeenCalledTimes(1);
+	});
+
+	it('unhooks the four startGame-registered socket listeners (the game route unmount cleanup, #1807)', () => {
+		startGame();
+		stopEngines();
+
+		expect(unlistenSocketReplaced).toHaveBeenCalledTimes(1);
+		expect(unlistenChallengeCompleted).toHaveBeenCalledTimes(1);
+		expect(unlistenProficiencyXpGained).toHaveBeenCalledTimes(1);
+		expect(unlistenServerCommandFailed).toHaveBeenCalledTimes(1);
+	});
+
+	it('is idempotent and safe to call when startGame never ran', () => {
+		expect(() => {
+			stopEngines();
+			stopEngines();
+		}).not.toThrow();
+	});
+
+	it('lets a later startGame register fresh listeners without leaking the previous set', () => {
+		startGame();
+		stopEngines();
+		vi.clearAllMocks();
+
+		startGame();
+
+		expect(unlistenSocketReplaced).not.toHaveBeenCalled();
+		expect(listenCommand).toHaveBeenCalledWith('SocketReplaced', handleSocketReplaced);
 	});
 });
 

--- a/UI/src/tests/routes/game/page.test.ts
+++ b/UI/src/tests/routes/game/page.test.ts
@@ -230,4 +230,22 @@ describe('game +page.svelte shell', () => {
 		await waitFor(() => expect(screen.getByTestId('tour-player').getAttribute('data-open')).toBe('false'));
 		expect(playerManager.lessons.some((l) => l.lessonId === 7 && l.readAt)).toBe(true);
 	});
+
+	it('stops the engines and cancels the welcome-back gate on unmount, so a GetOfflineProgress that resolves afterwards cannot start the game (#1807)', async () => {
+		let resolveProgress: (value: { data: { hasProgress: boolean } }) => void = () => {};
+		sendSocketCommand.mockImplementation(() => new Promise((resolve) => (resolveProgress = resolve)));
+
+		const { unmount } = render(GamePage);
+		await waitFor(() => expect(sendSocketCommand).toHaveBeenCalled());
+
+		unmount();
+		expect(stopEngines).toHaveBeenCalledTimes(1);
+
+		// The GetOfflineProgress round-trip lands only now, after the page is gone.
+		resolveProgress({ data: { hasProgress: false } });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(startGame).not.toHaveBeenCalled();
+	});
 });

--- a/UI/src/tests/routes/game/welcome-back/welcome-back-view.test.ts
+++ b/UI/src/tests/routes/game/welcome-back/welcome-back-view.test.ts
@@ -119,4 +119,75 @@ describe('WelcomeBackView', () => {
 
 		expect(deps.enterGame).toHaveBeenCalledWith(undefined);
 	});
+
+	// #1807: the game page's onDestroy cancels the gate so a run() continuation that resolves after
+	// unmount (e.g. a slow GetOfflineProgress round-trip) can't start the engines behind an already-left
+	// screen, and enter() can't be invoked afterwards either.
+	describe('cancellation (#1807)', () => {
+		it('does not reconcile mode or enter the game when cancelled before fetchProgress resolves', async () => {
+			let resolveFetch: (value: IOfflineProgressModel | null) => void = () => {};
+			deps = {
+				fetchProgress: vi.fn(() => new Promise<IOfflineProgressModel | null>((resolve) => (resolveFetch = resolve))),
+				resyncPlayer: vi.fn(() => Promise.resolve()),
+				reconcileMode: vi.fn(),
+				enterGame: vi.fn()
+			};
+			const view = new WelcomeBackView(deps as unknown as WelcomeBackDeps);
+
+			const runPromise = view.run();
+			view.cancel();
+			resolveFetch(progress({ hasProgress: false }));
+			await runPromise;
+
+			expect(deps.reconcileMode).not.toHaveBeenCalled();
+			expect(deps.enterGame).not.toHaveBeenCalled();
+			expect(view.phase).toBe('checking');
+		});
+
+		it('does not show the summary gate when cancelled during the post-progress resync', async () => {
+			let resolveResync: () => void = () => {};
+			deps = {
+				fetchProgress: vi.fn(() => Promise.resolve(progress())),
+				resyncPlayer: vi.fn(() => new Promise<void>((resolve) => (resolveResync = resolve))),
+				reconcileMode: vi.fn(),
+				enterGame: vi.fn()
+			};
+			const view = new WelcomeBackView(deps as unknown as WelcomeBackDeps);
+
+			const runPromise = view.run();
+			// Flush the microtask queue until run() is parked at the resyncPlayer await (reconcileMode
+			// already ran by then), then cancel before letting the resync settle.
+			await Promise.resolve();
+			await Promise.resolve();
+			view.cancel();
+			resolveResync();
+			await runPromise;
+
+			expect(deps.reconcileMode).toHaveBeenCalledTimes(1);
+			expect(view.phase).toBe('checking');
+			expect(view.summary).toBeNull();
+		});
+
+		it('enter() is a no-op once cancelled, even from the "no reward window" fast path', async () => {
+			const view = makeView(progress({ hasProgress: false }));
+			view.cancel();
+
+			await view.run();
+
+			expect(deps.enterGame).not.toHaveBeenCalled();
+			expect(view.phase).toBe('checking');
+		});
+
+		it('enter() is a no-op once cancelled after the summary gate is already showing', async () => {
+			const view = makeView(progress());
+			await view.run();
+			expect(view.phase).toBe('summary');
+
+			view.cancel();
+			view.enter();
+
+			expect(deps.enterGame).not.toHaveBeenCalled();
+			expect(view.phase).toBe('summary');
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Two related defects in the `/game` route lifecycle seam (`UI/src/lib/engine/engine.ts` + `UI/src/routes/game/+page.svelte`), per #1807.

**1. `stopEngines` never unhooked the socket listeners `startGame` registers.** The game route's unmount cleanup calls `stopEngines` directly (not `stopGame`, which is only invoked via a `SocketReplaced` push). Only `stopGame` unhooked the four listeners (`SocketReplaced`, `ChallengeCompleted`, `ProficiencyXpGained`, `ServerCommandFailed`), so a client-side round-trip like `/game` → `/admin` → `/game` re-ran `startGame` and registered a second set of listeners on top of the first — permanently orphaning the original set and causing every handler to fire once per stacked registration (duplicated combat-log lines, duplicated resync round-trips, N stacked modals on a session takeover).

**2. The welcome-back gate had no cancellation.** `welcome.run()`'s async continuation (waiting on `GetOfflineProgress`, up to a 30s socket timeout) calls `enterGame` → `startGame()` unconditionally, with no check for whether the game page is still mounted. Navigating away mid-check let the full game — logical/render loops, enemy-fetch loop, live battles — start running headless behind another screen, and a later return to `/game` would then run the gate again against an already-running live loop.

## Changes

- `engine.ts`: `stopEngines` now unhooks the four `startGame`-registered listeners (via a new `unhookSocketListeners` helper), since it's the route's actual unmount cleanup. `stopGame` no longer duplicates the unhook calls — it already calls `stopEngines`. `startGame` also defensively unhooks any listeners left behind by a prior call before registering its own, as extra insurance against a missed `stopEngines`.
- `welcome-back-view.svelte.ts`: `WelcomeBackView` gains a `cancelled` flag and a `cancel()` method. `run()` bails out after each `await` once cancelled (before reconciling mode / before showing the summary gate), and `enter()` is a no-op once cancelled.
- `+page.svelte`: the route's `onDestroy` now calls both `stopEngines()` and `welcome.cancel()`.

## Tests

- `engine.test.ts`: new cases pinning that `stopEngines` unhooks the four listeners, that it's idempotent/safe when `startGame` never ran, that a later `startGame` re-registers cleanly after `stopEngines`, and that a second `startGame` call (without an intervening stop) unhooks the first set before re-registering.
- `welcome-back-view.test.ts`: new cases covering cancellation before `fetchProgress` resolves, cancellation during the post-progress resync, and `enter()` as a no-op once cancelled (both from the fast-path and after the summary gate is already showing).

## Test plan

- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings.
- [x] `npm run lint` — clean.
- [x] `npm run test:unit:ci` — full suite passes: 3595/3595 (including the new/updated cases above), coverage floors intact.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1807


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHSpi5H7kUEP6jwtCsVTUk)_