### PR TITLE
Guard InventoryManager rollback against a resync that superseded it

### DIFF
--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -80,7 +80,18 @@ export class InventoryManager {
 	/** Serializes the optimistic mutations so rollback baselines never interleave (see {@link serialize}). */
 	private queue = new SerializedQueue();
 
+	/**
+	 * Bumped on every {@link initialize}. `initialize()` runs outside the {@link queue} (a mid-session
+	 * resync can't wait behind an in-flight mutation's persist), so a mutation that started optimistically
+	 * applying before a resync — then has its persist fail afterward — must not roll back: its snapshot
+	 * predates the resync's fresh item instances, and restoring it would splice orphaned pre-resync objects
+	 * back into live state (#1808). Each mutation captures the generation at snapshot time and checks it
+	 * via {@link rollbackIfCurrent} before invoking its rollback.
+	 */
+	private generation = 0;
+
 	public initialize() {
+		this.generation++;
 		this.unlockedItems.clear();
 		this.unlockedMods.clear();
 		this.equippedSlots = new Array(6).fill(undefined);
@@ -185,6 +196,7 @@ export class InventoryManager {
 
 			// Apply optimistically (instant UI), then persist; a failed persist rolls the change back so
 			// the authoritative state can never diverge from what was actually saved.
+			const startGeneration = this.generation;
 			const affected = [item, this.equippedSlots[slotId]].filter((it): it is Item => it != null);
 			const rollback = combineSnapshots(
 				snapshotFields(this, 'equippedSlots'),
@@ -197,8 +209,7 @@ export class InventoryManager {
 				equipmentSlotId: slotId
 			});
 			if (response.error) {
-				rollback();
-				this.refreshEquipmentStats();
+				this.rollbackIfCurrent(startGeneration, rollback, () => this.refreshEquipmentStats());
 				return false;
 			}
 
@@ -220,6 +231,7 @@ export class InventoryManager {
 				return false;
 			}
 
+			const startGeneration = this.generation;
 			const rollback = combineSnapshots(
 				snapshotFields(this, 'equippedSlots'),
 				snapshotFields(item, 'equipped', 'equipmentSlotId')
@@ -236,8 +248,7 @@ export class InventoryManager {
 				equipmentSlotId: slotId
 			});
 			if (response.error) {
-				rollback();
-				this.refreshEquipmentStats();
+				this.rollbackIfCurrent(startGeneration, rollback, () => this.refreshEquipmentStats());
 				return false;
 			}
 
@@ -261,6 +272,7 @@ export class InventoryManager {
 				return false;
 			}
 
+			const startGeneration = this.generation;
 			const rollback = snapshotFields(item, 'appliedMods', 'totalAttributes');
 			item.appliedMods = [...item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId), mod];
 			this.refreshItemAttributes(item);
@@ -272,8 +284,7 @@ export class InventoryManager {
 				itemModSlotId
 			});
 			if (response.error) {
-				rollback();
-				this.refreshEquipmentStatsIfEquipped(item);
+				this.rollbackIfCurrent(startGeneration, rollback, () => this.refreshEquipmentStatsIfEquipped(item));
 				return false;
 			}
 
@@ -289,6 +300,7 @@ export class InventoryManager {
 				return false;
 			}
 
+			const startGeneration = this.generation;
 			const rollback = snapshotFields(item, 'appliedMods', 'totalAttributes');
 			item.appliedMods = item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId);
 			this.refreshItemAttributes(item);
@@ -299,8 +311,7 @@ export class InventoryManager {
 				itemModSlotId
 			});
 			if (response.error) {
-				rollback();
-				this.refreshEquipmentStatsIfEquipped(item);
+				this.rollbackIfCurrent(startGeneration, rollback, () => this.refreshEquipmentStatsIfEquipped(item));
 				return false;
 			}
 
@@ -374,6 +385,21 @@ export class InventoryManager {
 	 */
 	private serialize<T>(operation: () => Promise<T>): Promise<T> {
 		return this.queue.run(operation);
+	}
+
+	/**
+	 * Invokes `rollback` only if no {@link initialize} resync has happened since `startGeneration` was
+	 * captured. `initialize()` runs outside the {@link queue}, so a mid-flight mutation's persist can fail
+	 * after a resync has already rebuilt `unlockedItems`/`equippedSlots` with fresh objects; rolling back at
+	 * that point would restore the stale pre-resync snapshot — reintroducing orphaned item references the
+	 * resync just replaced (#1808). When the generation has moved on, the resync's own state is left as-is.
+	 */
+	private rollbackIfCurrent(startGeneration: number, rollback: RestoreSnapshot, after: () => void) {
+		if (this.generation !== startGeneration) {
+			return;
+		}
+		rollback();
+		after();
 	}
 
 	/** The equip mutation, reassigning a fresh slot array so a captured snapshot stays a valid baseline. */

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -720,6 +720,86 @@ describe('InventoryManager', () => {
 		});
 	});
 
+	describe('resync during an in-flight mutation (#1808)', () => {
+		beforeEach(() => {
+			mockItems[1] = makeItem(1, EItemCategory.Weapon);
+			mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+			manager.initialize();
+		});
+
+		it('does not roll back a mid-flight equip whose persist fails after a resync superseded it', async () => {
+			let resolveSend: (value: { error?: string }) => void = () => {};
+			mockSendSocketCommand.mockReturnValueOnce(new Promise((resolve) => (resolveSend = resolve)));
+
+			const pending = manager.equipItem(1, EEquipmentSlot.WeaponSlot);
+			await flush();
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]?.itemId).toBe(1);
+
+			// A mid-session resync (e.g. resyncPlayerAndInventory after a lost DefeatEnemy response) rebuilds
+			// the inventory with fresh item instances while the equip's persist is still in flight. The
+			// authoritative state shows the equip actually landed server-side — only the ack was lost.
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({ itemId: 1, equipped: true, equipmentSlotId: EEquipmentSlot.WeaponSlot })
+			];
+			manager.initialize();
+			const postResyncItem = manager.unlockedItems.get(1);
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]?.itemId).toBe(1);
+
+			resolveSend({ error: 'nope' });
+			await pending;
+
+			// The rollback must be skipped: firing it would restore the pre-optimistic-apply snapshot (empty
+			// slot), clobbering the resync's authoritative "actually equipped" state with stale data and
+			// splicing the orphaned pre-resync item back into live state.
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]).toBe(postResyncItem);
+		});
+
+		it('rolls back a mid-flight equip normally when no resync happened since it started', async () => {
+			let resolveSend: (value: { error?: string }) => void = () => {};
+			mockSendSocketCommand.mockReturnValueOnce(new Promise((resolve) => (resolveSend = resolve)));
+
+			const pending = manager.equipItem(1, EEquipmentSlot.WeaponSlot);
+			await flush();
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]?.itemId).toBe(1);
+
+			resolveSend({ error: 'nope' });
+			await pending;
+
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]).toBeUndefined();
+			expect(manager.unlockedItems.get(1)?.equipped).toBe(false);
+		});
+
+		it('does not roll back a mid-flight unequip whose persist fails after a resync superseded it', async () => {
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({ itemId: 1, equipped: true, equipmentSlotId: EEquipmentSlot.WeaponSlot })
+			];
+			manager.initialize();
+
+			let resolveSend: (value: { error?: string }) => void = () => {};
+			mockSendSocketCommand.mockReturnValueOnce(new Promise((resolve) => (resolveSend = resolve)));
+
+			const pending = manager.unequipItem(EEquipmentSlot.WeaponSlot);
+			await flush();
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]).toBeUndefined();
+
+			// The resync's authoritative state has the item still equipped (the unequip never reached the
+			// server before the resync fired).
+			mockInventoryData.unlockedItems = [
+				makeInventoryItem({ itemId: 1, equipped: true, equipmentSlotId: EEquipmentSlot.WeaponSlot })
+			];
+			manager.initialize();
+			const postResyncItem = manager.unlockedItems.get(1);
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]?.itemId).toBe(1);
+
+			resolveSend({ error: 'nope' });
+			await pending;
+
+			// A stale rollback would splice the pre-resync (now-orphaned) item object back into
+			// equippedSlots instead of leaving the resync's fresh, still-equipped item in place.
+			expect(manager.equippedSlots[EEquipmentSlot.WeaponSlot]).toBe(postResyncItem);
+		});
+	});
+
 	describe('unequipItem', () => {
 		it('unequips the item in a slot and sends the socket command', async () => {
 			mockItems[1] = makeItem(1);


### PR DESCRIPTION
## Summary

`InventoryManager`'s optimistic mutations (equip/unequip/applyMod/removeMod) are single-flight-serialized through `SerializedQueue` precisely so rollback baselines can't interleave. But `initialize()` (`UI/src/lib/engine/player/inventory-manager.ts`) rebuilds `unlockedItems`/`equippedSlots` with fresh `Item` instances **outside** that queue, since a mid-session resync (`resyncPlayerAndInventory`) can't wait behind an in-flight mutation's persist.

## Failure scenario this fixes

An `EquipItem` is in flight when a `DefeatEnemy` response times out (both ride the same flaky socket):

1. `resyncPlayerAndInventory` calls `inventoryManager.initialize()`, rebuilding the inventory with fresh `Item` objects — the authoritative state may even show the equip already landed server-side (only the ack was lost).
2. The in-flight equip's response later resolves with `error` (the transport settles a lost/timed-out response as an error even when the command may have actually succeeded server-side).
3. Its rollback fires unconditionally, restoring the **pre-resync** `equippedSlots` array and mutating pre-resync `Item` objects that are no longer in `unlockedItems` — clobbering the resync's fresh, authoritative state with a stale snapshot and splicing orphaned objects back into live state.

The equipped rail and `equipmentStats` then diverge from the item grid until the next full reload.

## Changes

- `inventory-manager.ts`: added a `generation` counter bumped on every `initialize()`. Each of the four rollback-capable mutations (`equipItem`, `unequipItem`, `applyMod`, `removeMod`) now captures `this.generation` at snapshot time and routes its error-path rollback through a new `rollbackIfCurrent` helper, which skips the rollback (and the post-rollback stats refresh) entirely if a resync has superseded it since — leaving the resync's authoritative state untouched.

I kept `initialize()` itself synchronous rather than routing it through the queue (the issue's other suggested fix shape) — the existing test suite calls it synchronously and asserts immediately after in ~60 places, and queuing it would force those onto an async `await` for no behavioral benefit over the generation-counter guard.

## Tests

- `inventory-manager.test.ts`: new `resync during an in-flight mutation (#1808)` describe block:
  - a mid-flight equip whose persist fails after a resync superseded it does **not** roll back (verified this fails without the fix — a stale rollback would clobber the resync's "actually equipped" state).
  - a mid-flight equip still rolls back normally when no resync happened (regression guard on the existing behavior).
  - a mid-flight unequip whose persist fails after a resync superseded it does **not** roll back (verified this fails without the fix too — the same corruption class in the opposite direction).

## Test plan

- [x] `npm run lint` — clean (eslint + svelte-check, 0 errors/warnings).
- [x] `npm run test:unit:ci` — full suite passes: 3589/3589, coverage floors intact.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1808


---
_Generated by [Claude Code](https://claude.ai/code/session_01HXJEREDtmBVTKz2X4RGpZj)_