### PR TITLE
Re-seed Attributes/Options screen baselines on a mid-session resync

### DIFF
--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -461,8 +461,14 @@ export class AttributesView {
 		this.saving = false;
 
 		// Snapshot the current effective deltas (any mid-flight edit included) before the
-		// reassignment below moves the resync marker out from under them.
+		// reassignment below moves the resync marker out from under them. Reference equality
+		// with `#pendingDeltas` tells whether they were still valid at this exact moment —
+		// `effectiveDeltas()` falls back to a *new* zero array (never `#pendingDeltas` itself)
+		// the instant an external resync lands mid-flight and invalidates them; in that case
+		// they're already gone and must not be "consumed" a second time below (which would
+		// otherwise subtract `sentDeltas` from zero and manufacture a phantom negative delta).
 		const currentDeltas = this.effectiveDeltas();
+		const deltasStillValid = currentDeltas === this.#pendingDeltas;
 
 		// Any returned payload is the server's authoritative post-command state (the
 		// rejection path returns it unchanged), so adopt the allocations and the spent
@@ -483,8 +489,11 @@ export class AttributesView {
 		}
 
 		// Consume exactly the deltas that were sent, preserving any edit made while the save was
-		// in flight instead of wiping it (#1506).
-		this.#pendingDeltas = this.#pendingDeltas.map((d, i) => d - sentDeltas[i]);
+		// in flight instead of wiping it (#1506) — unless an external resync already discarded
+		// the pending set mid-flight, in which case there's nothing left to consume.
+		if (deltasStillValid) {
+			this.#pendingDeltas = this.#pendingDeltas.map((d, i) => d - sentDeltas[i]);
+		}
 		this.flashSaved();
 	}
 

--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -268,17 +268,34 @@ export function derivedShortLabel(id: EAttribute): string {
 }
 
 /* ── reactive view-model ──────────────────────────────────────────────────
-   Owns the working allocation (`draft`) and the persisted baseline
-   (`committed`), derives the dirty set and the live/preview derived stats, and
+   Owns the persisted baseline (`committed`) and the working allocation
+   (`draft`), derives the dirty set and the live/preview derived stats, and
    persists only the per-attribute deltas (mirroring the backend's update
-   contract). */
+   contract).
+
+   `committed` is read live off the player manager rather than snapshotted once
+   at construction: a mid-session resync (`playerManager.initialize()`, #1809)
+   reassigns `attributes` wholesale, and the baseline must track it or the
+   screen computes `remaining`/deltas against a server state that no longer
+   exists. `draft` layers unsaved per-attribute deltas (`#pendingDeltas`) over
+   `committed`, but only while `#pendingDeltasAttrs` — the manager `attributes`
+   reference those deltas were computed against — still matches the live one;
+   {@link effectiveDeltas} treats them as zero the moment it doesn't. A
+   not-yet-saved edit can't be trusted to still apply cleanly against a
+   baseline it was never computed against, and an **external** resync (not this
+   view's own `save`, which keeps the marker in lockstep) is by definition the
+   fresher truth — so it silently drops the edit rather than layering it onto
+   the new baseline. `save` instead consumes exactly the deltas it sent,
+   preserving any edit made while that request was in flight (#1506). */
 export class AttributesView {
 	/** Active density mode; persisted to local storage per player. */
 	mode = $state<AttributeMode>('guided');
-	/** Working allocation per core attribute (index matches CORE_ATTRIBUTES). */
-	draft = $state<number[]>([]);
-	/** Last-saved allocation; the dirty set is `draft` minus this. */
-	committed = $state<number[]>([]);
+	/** Unsaved per-attribute deltas (index matches CORE_ATTRIBUTES), valid only against
+	 *  {@link #pendingDeltasAttrs} — see {@link effectiveDeltas}. */
+	#pendingDeltas = $state<number[]>(CORE_ATTRIBUTES.map(() => 0));
+	/** The `playerManager.attributes` reference {@link #pendingDeltas} was computed against; `null`
+	 *  never matches, so deltas read as zero until the first edit stamps it. */
+	#pendingDeltasAttrs = $state<IBattlerAttribute[] | null>(null);
 	/** Brief "Attributes saved" confirmation flash. */
 	saved = $state(false);
 	/** True while a save request is in flight (guards against double-submit). */
@@ -291,14 +308,26 @@ export class AttributesView {
 
 	constructor() {
 		this.mode = readStoredMode();
-		const committed = CORE_ATTRIBUTES.map((id) => readAllocation(id));
-		this.committed = committed;
-		this.draft = [...committed];
 	}
 
 	/** Unspent pool (statPointsGained − statPointsUsed), derived live from the reactive
 	 *  player manager so points granted by a background level-up appear without a remount. */
 	readonly savedAvailable = $derived(playerManager.statPointsGained - playerManager.statPointsUsed);
+
+	/** Last-saved allocation per core attribute, read live off the player manager (see the class doc). */
+	readonly committed = $derived(CORE_ATTRIBUTES.map((id) => readAllocation(id)));
+
+	/** {@link #pendingDeltas} if they're still valid against the live manager state, otherwise all
+	 *  zero — a pure read (no mutation), so it's safe to call from a `$derived` (see the class doc). */
+	private effectiveDeltas(): number[] {
+		return this.#pendingDeltasAttrs === playerManager.attributes ? this.#pendingDeltas : CORE_ATTRIBUTES.map(() => 0);
+	}
+
+	/** Working allocation per core attribute: {@link committed} plus the {@link effectiveDeltas}. */
+	readonly draft = $derived.by(() => {
+		const deltas = this.effectiveDeltas();
+		return this.committed.map((v, i) => v + deltas[i]);
+	});
 
 	/** Current (pending) value per core attribute. */
 	readonly values = $derived(this.draft);
@@ -347,9 +376,10 @@ export class AttributesView {
 		if (add <= 0) {
 			return;
 		}
-		const next = [...this.draft];
+		const next = [...this.effectiveDeltas()];
 		next[i] += add;
-		this.draft = next;
+		this.#pendingDeltas = next;
+		this.#pendingDeltasAttrs = playerManager.attributes;
 		this.saved = false;
 	}
 
@@ -358,9 +388,10 @@ export class AttributesView {
 		if (sub <= 0) {
 			return;
 		}
-		const next = [...this.draft];
+		const next = [...this.effectiveDeltas()];
 		next[i] -= sub;
-		this.draft = next;
+		this.#pendingDeltas = next;
+		this.#pendingDeltasAttrs = playerManager.attributes;
 		this.saved = false;
 	}
 
@@ -396,7 +427,8 @@ export class AttributesView {
 	}
 
 	discard(): void {
-		this.draft = [...this.committed];
+		this.#pendingDeltas = CORE_ATTRIBUTES.map(() => 0);
+		this.#pendingDeltasAttrs = playerManager.attributes;
 		this.saved = false;
 	}
 
@@ -405,10 +437,10 @@ export class AttributesView {
 	 *  non-reactive call sites like {@link save}. */
 	get changedUpdates(): IAttributeUpdate[] {
 		const updates: IAttributeUpdate[] = [];
+		const deltas = this.effectiveDeltas();
 		for (let i = 0; i < CORE_ATTRIBUTES.length; i++) {
-			const delta = this.draft[i] - this.committed[i];
-			if (delta !== 0) {
-				updates.push({ attributeId: CORE_ATTRIBUTES[i], amount: delta });
+			if (deltas[i] !== 0) {
+				updates.push({ attributeId: CORE_ATTRIBUTES[i], amount: deltas[i] });
 			}
 		}
 		return updates;
@@ -420,17 +452,29 @@ export class AttributesView {
 			return;
 		}
 
+		// The exact deltas being sent, so they can be subtracted back out below regardless of
+		// what happens to the rest of the pending set while the request is in flight.
+		const sentDeltas = [...this.effectiveDeltas()];
+
 		this.saving = true;
 		const response = await apiSocket.sendSocketCommand('UpdatePlayerStats', updates);
 		this.saving = false;
 
+		// Snapshot the current effective deltas (any mid-flight edit included) before the
+		// reassignment below moves the resync marker out from under them.
+		const currentDeltas = this.effectiveDeltas();
+
 		// Any returned payload is the server's authoritative post-command state (the
 		// rejection path returns it unchanged), so adopt the allocations and the spent
-		// total absolutely rather than re-deriving the spend locally (#1548).
+		// total absolutely rather than re-deriving the spend locally (#1548). `committed`
+		// picks this up live (see the class doc); this view's own reassignment isn't an
+		// external resync, so re-pin the (still-unconsumed, on an error) deltas against it.
 		if (response.data) {
 			playerManager.attributes = response.data.attributes;
 			playerManager.statPointsUsed = response.data.statPointsUsed;
 			playerManager.playerRating = response.data.playerRating;
+			this.#pendingDeltas = currentDeltas;
+			this.#pendingDeltasAttrs = playerManager.attributes;
 		}
 
 		if (response.error || !response.data) {
@@ -438,11 +482,9 @@ export class AttributesView {
 			return;
 		}
 
-		// Advance the baseline by exactly the deltas that were sent, preserving any
-		// draft edits made while the save was in flight instead of wiping them (#1506).
-		this.committed = this.committed.map(
-			(value, i) => value + (updates.find((u) => u.attributeId === CORE_ATTRIBUTES[i])?.amount ?? 0)
-		);
+		// Consume exactly the deltas that were sent, preserving any edit made while the save was
+		// in flight instead of wiping it (#1506).
+		this.#pendingDeltas = this.#pendingDeltas.map((d, i) => d - sentDeltas[i]);
 		this.flashSaved();
 	}
 

--- a/UI/src/routes/game/screens/options/options-view.svelte.ts
+++ b/UI/src/routes/game/screens/options/options-view.svelte.ts
@@ -127,15 +127,33 @@ export const SETTINGS_CATS: SettingsCatDef[] = [
 export type LogPrefMap = Record<number, boolean>;
 
 /* ── reactive view-model ─────────────────────────────────────────────────
-   Owns the working copy (`draft`) and the persisted baseline (`baseline`),
+   Owns the persisted baseline (`baseline`) and the working copy (`draft`),
    derives the dirty set by comparison, and — mirroring the original
-   `LogManager.saveSettingChanges` — persists only the actual diff. */
+   `LogManager.saveSettingChanges` — persists only the actual diff.
+
+   `baseline` is read live off the player manager rather than snapshotted once
+   at construction: a mid-session resync (`playerManager.initialize()`, #1809)
+   reassigns `logPreferences` wholesale, and the baseline must track it or the
+   screen keeps showing pre-resync values and diffs against a server state that
+   no longer exists. `draft` layers explicitly-touched overrides
+   (`#draftOverrides`) over `baseline`, but only while `#draftOverridesPrefs` —
+   the manager `logPreferences` reference those overrides were computed against
+   — still matches the live one; {@link effectiveOverrides} treats them as
+   empty the moment it doesn't. A not-yet-saved toggle can't be trusted to
+   still apply cleanly against a baseline it was never computed against, and an
+   **external** resync (not this view's own `save`, which keeps the marker in
+   lockstep) is by definition the fresher truth — so it silently drops the
+   toggle rather than layering it onto the new baseline. `save` instead
+   consumes exactly the overrides it sent, preserving any toggle made while
+   that request was in flight (#1506). */
 export class OptionsView {
 	category = $state<string>('logging');
-	/** Working copy edited by the toggles. */
-	draft = $state<LogPrefMap>({});
-	/** Last-persisted state; the dirty set is `draft` minus this. */
-	baseline = $state<LogPrefMap>({});
+	/** Log types toggled since the last save/discard, valid only against
+	 *  {@link #draftOverridesPrefs} — see {@link effectiveOverrides}. */
+	#draftOverrides = $state<Partial<Record<ELogType, boolean>>>({});
+	/** The `playerManager.logPreferences` reference {@link #draftOverrides} was computed against;
+	 *  `null` never matches, so overrides read as empty until the first toggle stamps it. */
+	#draftOverridesPrefs = $state<ILogPreference[] | null>(null);
 	/** Brief "Preferences saved" confirmation flash. */
 	saved = $state(false);
 	/** True while a save request is in flight (guards against double-submit). */
@@ -143,11 +161,27 @@ export class OptionsView {
 
 	#flashTimer: ReturnType<typeof setTimeout> | undefined;
 
-	constructor() {
-		const initial = readPlayerPrefs();
-		this.draft = { ...initial };
-		this.baseline = { ...initial };
+	/** Last-persisted preferences, read live off the player manager (see the class doc). */
+	readonly baseline = $derived(readPlayerPrefs());
+
+	/** {@link #draftOverrides} if they're still valid against the live manager state, otherwise
+	 *  empty — a pure read (no mutation), so it's safe to call from a `$derived` (see the class doc). */
+	private effectiveOverrides(): Partial<Record<ELogType, boolean>> {
+		return this.#draftOverridesPrefs === playerManager.logPreferences ? this.#draftOverrides : {};
 	}
+
+	/** Working preferences: {@link baseline} with the {@link effectiveOverrides} layered on top. */
+	readonly draft = $derived.by<LogPrefMap>(() => {
+		const map: LogPrefMap = { ...this.baseline };
+		const overrides = this.effectiveOverrides();
+		for (const lt of LOG_TYPES) {
+			const override = overrides[lt.id];
+			if (override !== undefined) {
+				map[lt.id] = override;
+			}
+		}
+		return map;
+	});
 
 	/** Log types whose draft value differs from the persisted baseline. */
 	readonly dirtyIds = $derived(LOG_TYPES.filter((lt) => this.isDirtyId(lt.id)).map((lt) => lt.id));
@@ -170,21 +204,24 @@ export class OptionsView {
 	}
 
 	setOne(id: ELogType, enabled: boolean): void {
-		this.draft = { ...this.draft, [id]: enabled };
+		this.#draftOverrides = { ...this.effectiveOverrides(), [id]: enabled };
+		this.#draftOverridesPrefs = playerManager.logPreferences;
 		this.saved = false;
 	}
 
 	setMany(ids: ELogType[], enabled: boolean): void {
-		const next = { ...this.draft };
+		const next = { ...this.effectiveOverrides() };
 		for (const id of ids) {
 			next[id] = enabled;
 		}
-		this.draft = next;
+		this.#draftOverrides = next;
+		this.#draftOverridesPrefs = playerManager.logPreferences;
 		this.saved = false;
 	}
 
 	discard(): void {
-		this.draft = { ...this.baseline };
+		this.#draftOverrides = {};
+		this.#draftOverridesPrefs = playerManager.logPreferences;
 		this.saved = false;
 	}
 
@@ -204,6 +241,11 @@ export class OptionsView {
 			return;
 		}
 
+		// The exact values being sent, so an override can be told apart below from one that was
+		// re-touched while the request was in flight. A transient local (not reactive state).
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const sentValues = new Map(changed.map((pref) => [pref.id, pref.enabled]));
+
 		this.saving = true;
 		const response = await apiSocket.sendSocketCommand('SaveLogPreferences', changed);
 		this.saving = false;
@@ -215,15 +257,24 @@ export class OptionsView {
 			return;
 		}
 
-		// Mirror only the entries actually sent onto the player manager and baseline —
-		// a toggle flipped while the save was in flight stays dirty (and unapplied)
-		// instead of being baselined as clean without ever reaching the server (#1506).
+		// Snapshot the current effective overrides (any mid-flight toggle included) before
+		// applyToPlayer's reassignment below moves the resync marker out from under them.
+		const currentOverrides = this.effectiveOverrides();
+
+		// Applying to the player manager advances the live baseline (see the class doc); this
+		// view's own reassignment isn't an external resync, so re-pin the overrides against it.
 		applyToPlayer(changed);
-		const baseline = { ...this.baseline };
-		for (const pref of changed) {
-			baseline[pref.id] = pref.enabled;
+		this.#draftOverridesPrefs = playerManager.logPreferences;
+
+		// Drop an override only if it still holds exactly the value that was sent — one re-touched
+		// while the request was in flight stays pending instead of being silently cleared (#1506).
+		const remaining = { ...currentOverrides };
+		for (const [id, sentValue] of sentValues) {
+			if (remaining[id] === sentValue) {
+				delete remaining[id];
+			}
 		}
-		this.baseline = baseline;
+		this.#draftOverrides = remaining;
 		this.flashSaved();
 	}
 

--- a/UI/src/tests/routes/game/screens/attributes/Attributes.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/Attributes.test.ts
@@ -3,17 +3,20 @@ import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
 import { EAttribute, EDamageType, type IAttribute, type IBattlerAttribute, type ISkill } from '$lib/api';
 import { makeAttribute } from '../../../../fixtures/attributes';
 
+// Declared as a class instance (not an object literal) so `statify` can make its fields
+// reactive — the view reads it live (not just at construction, #1809), exactly like the real
+// (statified) PlayerManager.
 const { mockPlayerManager, mockInventoryManager, sendSocketCommand, toastError, staticData } = vi.hoisted(() => ({
-	mockPlayerManager: {
-		attributes: [] as IBattlerAttribute[],
-		statPointsGained: 0,
-		statPointsUsed: 0,
-		level: 0,
-		exp: 0,
-		nextLevelThreshold: 0,
-		playerRating: 0,
-		selectedSkills: [] as number[]
-	},
+	mockPlayerManager: new (class MockPlayerManager {
+		attributes: IBattlerAttribute[] = [];
+		statPointsGained = 0;
+		statPointsUsed = 0;
+		level = 0;
+		exp = 0;
+		nextLevelThreshold = 0;
+		playerRating = 0;
+		selectedSkills: number[] = [];
+	})(),
 	mockInventoryManager: {
 		equipmentStats: [] as IBattlerAttribute[],
 		grantedSkillIds: [] as number[],
@@ -24,7 +27,10 @@ const { mockPlayerManager, mockInventoryManager, sendSocketCommand, toastError, 
 	staticData: { attributes: [] as IAttribute[], skills: [] as ISkill[] }
 }));
 
-vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager, inventoryManager: mockInventoryManager }));
+vi.mock('$lib/engine', async () => {
+	const { statify } = await import('$lib/common');
+	return { playerManager: statify(mockPlayerManager), inventoryManager: mockInventoryManager };
+});
 vi.mock('$stores', () => ({ staticData, toastError }));
 vi.mock('$lib/api', async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, unknown>;

--- a/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
@@ -687,6 +687,36 @@ describe('AttributesView.save', () => {
 		expect(sendSocketCommand).not.toHaveBeenCalled();
 		expect(toastError).not.toHaveBeenCalled();
 	});
+
+	it('does not manufacture a phantom negative delta when an external resync lands mid-flight during a successful save', async () => {
+		const serverResult: IBattlerAttribute[] = CORE_ATTRIBUTES.map((id) => ({
+			attributeId: id,
+			amount: id === EAttribute.Strength ? 6 : 5
+		}));
+		let resolveSend: (value: unknown) => void = () => {};
+		sendSocketCommand.mockReturnValue(new Promise((resolve) => (resolveSend = resolve)));
+
+		view.inc(idx.str);
+		const saving = view.save();
+
+		// An external resync (unrelated to this save, e.g. a background ChallengeCompleted
+		// reconcile) reassigns attributes while the request is still in flight — this already
+		// discards the pending edit per the class's external-resync policy.
+		mockPlayerManager.attributes = CORE_ATTRIBUTES.map((id) => ({
+			attributeId: id,
+			amount: id === EAttribute.Endurance ? 7 : 5
+		}));
+
+		resolveSend({ data: { attributes: serverResult, statPointsUsed: 1 } });
+		await saving;
+
+		// The save still succeeds and its own result is adopted, but the already-discarded edit
+		// must not be "consumed" a second time into a spurious -1 Strength refund.
+		expect(view.committed[idx.str]).toBe(6);
+		expect(view.dirty).toBe(false);
+		expect(view.changedUpdates).toEqual([]);
+		expect(view.values).toEqual(view.committed);
+	});
 });
 
 describe('AttributesView live stat-point pool', () => {

--- a/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
@@ -702,3 +702,58 @@ describe('AttributesView live stat-point pool', () => {
 		expect(view.budget).toBe(15);
 	});
 });
+
+describe('AttributesView mid-session resync (#1809)', () => {
+	it('follows a resync of the underlying attributes while idle instead of going stale', () => {
+		expect(view.committed).toEqual([5, 5, 5, 5, 5, 5]);
+		expect(view.values).toEqual([5, 5, 5, 5, 5, 5]);
+
+		// A background resync (e.g. playerManager.initialize() after a dead-lettered event)
+		// reassigns attributes wholesale, with no interaction from this screen.
+		mockPlayerManager.attributes = CORE_ATTRIBUTES.map((id) => ({
+			attributeId: id,
+			amount: id === EAttribute.Strength ? 8 : 5
+		}));
+
+		expect(view.committed[idx.str]).toBe(8);
+		expect(view.values[idx.str]).toBe(8);
+		expect(view.dirty).toBe(false);
+	});
+
+	it('clears a stale dirty state when a resync reveals a lost save actually applied', () => {
+		// The player allocates a point; the save's response is lost (never sent here at all —
+		// the failure scenario is that the client never even learns the attempt succeeded).
+		view.inc(idx.str);
+		expect(view.values[idx.str]).toBe(6);
+		expect(view.dirty).toBe(true);
+
+		// A later background resync reveals the server actually holds the incremented value.
+		mockPlayerManager.attributes = CORE_ATTRIBUTES.map((id) => ({
+			attributeId: id,
+			amount: id === EAttribute.Strength ? 6 : 5
+		}));
+
+		expect(view.committed[idx.str]).toBe(6);
+		expect(view.values[idx.str]).toBe(6);
+		expect(view.dirty).toBe(false);
+	});
+
+	it('discards an in-progress unsaved edit when an external resync arrives, so a stale delta is never sent', () => {
+		view.inc(idx.str); // unsaved local edit
+		expect(view.dirty).toBe(true);
+
+		// An external resync (unrelated to this edit, and not this view's own save) reassigns
+		// attributes wholesale. The now-unreliable pending edit can't be trusted to still apply
+		// cleanly against a baseline it was never computed against, so it is discarded outright
+		// rather than layered onto the fresh baseline (#1809).
+		mockPlayerManager.attributes = CORE_ATTRIBUTES.map((id) => ({
+			attributeId: id,
+			amount: id === EAttribute.Endurance ? 6 : 5
+		}));
+
+		expect(view.committed[idx.end]).toBe(6);
+		expect(view.values).toEqual(view.committed);
+		expect(view.dirty).toBe(false);
+		expect(view.changedUpdates).toEqual([]);
+	});
+});

--- a/UI/src/tests/routes/game/screens/options/options-view.test.ts
+++ b/UI/src/tests/routes/game/screens/options/options-view.test.ts
@@ -1,16 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ELogType, type ILogPreference } from '$lib/api';
 
-// Mutable player-manager stand-in: `save()` reassigns `logPreferences`, so it is
-// a plain writable property (not a getter). `vi.hoisted` keeps it initialised
-// before the hoisted vi.mock factory runs.
+// Mutable player-manager stand-in: `save()` reassigns `logPreferences`, and the view reads it
+// live (not just at construction, #1809), so it must be reactive like the real (statified)
+// PlayerManager — declared as a class instance (not an object literal) so `statify` applies.
+// `vi.hoisted` keeps it initialised before the hoisted vi.mock factory runs.
 const { mockPlayerManager, mockSendSocketCommand, toastError } = vi.hoisted(() => ({
-	mockPlayerManager: { logPreferences: [] as ILogPreference[] },
+	mockPlayerManager: new (class MockPlayerManager {
+		logPreferences: ILogPreference[] = [];
+	})(),
 	mockSendSocketCommand: vi.fn(),
 	toastError: vi.fn()
 }));
 
-vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager }));
+vi.mock('$lib/engine', async () => {
+	const { statify } = await import('$lib/common');
+	return { playerManager: statify(mockPlayerManager) };
+});
 vi.mock('$stores', () => ({ toastError }));
 vi.mock('$components', () => ({
 	logColors: {
@@ -237,5 +243,45 @@ describe('OptionsView.save', () => {
 
 		view.setOne(ELogType.Damage, true);
 		expect(view.saved).toBe(false);
+	});
+});
+
+describe('OptionsView mid-session resync (#1809)', () => {
+	it('follows a resync of the underlying preferences while idle instead of going stale', () => {
+		expect(view.isOn(ELogType.Damage)).toBe(true);
+
+		// A background resync (e.g. playerManager.initialize() after a dead-lettered event)
+		// reassigns logPreferences wholesale, with no interaction from this screen.
+		mockPlayerManager.logPreferences = [{ id: ELogType.Damage, enabled: false }];
+
+		expect(view.isOn(ELogType.Damage)).toBe(false);
+		expect(view.isDirty).toBe(false);
+	});
+
+	it('clears a stale dirty state when a resync reveals a lost save actually applied', () => {
+		view.setOne(ELogType.Damage, false);
+		expect(view.isDirty).toBe(true);
+
+		// A later background resync reveals the server actually holds the toggled-off value.
+		mockPlayerManager.logPreferences = [{ id: ELogType.Damage, enabled: false }];
+
+		expect(view.isOn(ELogType.Damage)).toBe(false);
+		expect(view.isDirty).toBe(false);
+	});
+
+	it('discards an in-progress unsaved toggle when an external resync arrives, so a stale diff is never sent', () => {
+		view.setOne(ELogType.Damage, false); // unsaved local edit
+		expect(view.isDirty).toBe(true);
+
+		// An external resync (unrelated to this toggle, and not this view's own save) reassigns
+		// logPreferences wholesale. The now-unreliable pending toggle can't be trusted to still
+		// apply cleanly against a baseline it was never computed against, so it is discarded
+		// outright rather than layered onto the fresh baseline (#1809).
+		mockPlayerManager.logPreferences = [{ id: ELogType.Exp, enabled: false }];
+
+		expect(view.isOn(ELogType.Exp)).toBe(false);
+		expect(view.isOn(ELogType.Damage)).toBe(true); // back to the (defaulted-enabled) baseline
+		expect(view.isDirty).toBe(false);
+		expect(view.changedPreferences).toEqual([]);
 	});
 });

--- a/UI/src/tests/routes/game/screens/options/options-view.test.ts
+++ b/UI/src/tests/routes/game/screens/options/options-view.test.ts
@@ -236,6 +236,28 @@ describe('OptionsView.save', () => {
 		expect(toastError).not.toHaveBeenCalled();
 	});
 
+	it('does not resurrect an already-discarded toggle when an external resync lands mid-flight during a successful save', async () => {
+		let resolveSend: (value: unknown) => void = () => {};
+		mockSendSocketCommand.mockReturnValue(new Promise((resolve) => (resolveSend = resolve)));
+
+		view.setOne(ELogType.Damage, false);
+		const saving = view.save();
+
+		// An external resync (unrelated to this save) reassigns logPreferences while the request
+		// is still in flight — this already discards the pending toggle per the class's
+		// external-resync policy.
+		mockPlayerManager.logPreferences = [{ id: ELogType.Exp, enabled: false }];
+
+		resolveSend({});
+		await saving;
+
+		// The save still succeeds and its own result is adopted, but the already-discarded
+		// toggle must not reappear as a pending change.
+		expect(mockPlayerManager.logPreferences.find((p) => p.id === ELogType.Damage)?.enabled).toBe(false);
+		expect(view.isDirty).toBe(false);
+		expect(view.changedPreferences).toEqual([]);
+	});
+
 	it('toggling after a save clears the saved flash', async () => {
 		view.setOne(ELogType.Damage, false);
 		await view.save();


### PR DESCRIPTION
## Summary

`AttributesView` (`committed`/`draft`) and `OptionsView` (`baseline`/`draft`) snapshotted the player manager's state once at construction and never observed a mid-session `playerManager.initialize()` — the resync path that runs after a lost `DefeatEnemy`/`UpdatePlayerStats` response or a dead-lettered `ChallengeCompleted`.

## Failure scenario this fixes

Player parks on the Attributes (or Options) screen. An earlier save's response was lost (the save toasts an error, the baseline isn't advanced), and a later background resync pulls the server state where that save actually applied. Previously the screen kept showing the pre-resync allocations, `remaining`/dirty was computed against a baseline the server no longer held, and the next save would have sent deltas relative to a stale baseline.

## Changes

- `attributes-view.svelte.ts`: `committed` is now a live `$derived` read off `playerManager.attributes` instead of a `$state` field seeded once in the constructor. Unsaved edits are tracked as per-attribute deltas (`#pendingDeltas`) that stay valid only while `#pendingDeltasAttrs` (the manager `attributes` reference they were computed against) still matches the live one — `effectiveDeltas()` treats them as zero the instant it doesn't. An **external** resync (not this view's own `save`) is therefore silently dropped rather than layered onto a baseline it was never computed against; `save()` keeps the marker in lockstep with its own reassignment so it correctly preserves an edit made while the request was in flight (#1506).
- `options-view.svelte.ts`: the identical pattern for `baseline`/`draft`, using a sparse per-log-type override map (`#draftOverrides`) instead of numeric deltas.
- Test mocks for `playerManager` in `Attributes.test.ts` and `options-view.test.ts` now use a `statify`'d class instance (matching `attributes-view.test.ts`'s existing pattern) so the mock is reactive like the real (statified) `PlayerManager` — required for the live-baseline behavior to be exercised at all.
- New tests pin: following an idle resync, clearing a stale dirty state when a resync reveals a lost save actually applied, and discarding an in-progress unsaved edit on an unrelated external resync so a stale delta/diff is never sent.

## Note for reviewer

I considered a design where an edit unrelated to what a resync touched would survive the resync (only the touched attribute/log-type resets), but that reopens a double-counting risk: if the resync is itself the arrival of a previously-lost save, any surviving delta would be re-applied on top of a baseline that already includes it. I went with the simpler, safer rule instead: **any** external resync discards **all** unsaved edits outright, matching the issue's suggested fix ("re-seed baseline + draft"). This is a rare recovery-path edge case, so losing an in-progress unsaved allocation/toggle on a resync is an acceptable trade for correctness.

## Test plan

- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings.
- [x] `npm run lint` — clean.
- [x] `npx vitest run` — full suite passes: 3595/3595.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1809


---
_Generated by [Claude Code](https://claude.ai/code/session_019fj4HMEo4bvGd4BM4duNab)_