### PR TITLE
Add missed paths to CI detect-changes filters

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,10 +58,14 @@ jobs:
             - 'content/**'
             - 'e2e-admin-provision.sql'
             - '.dockerignore'
+            - '.editorconfig'
+            - 'global.json'
+            - '.config/dotnet-tools.json'
             - '.github/workflows/**'
             - 'UI/src/lib/api/types/**'
           frontend:
             - 'UI/**'
+            - 'content/**'
             - '.github/workflows/**'
 
   # Non-test backend verifications (codegen drift + formatter), split out of test-backend so that


### PR DESCRIPTION
## Summary

The `detect-changes` path filters in `.github/workflows/run-tests.yml` didn't cover everything the gated jobs actually consume:

1. **The `frontend` filter lacked `content/**`**, but the frontend unit suite imports repo content directly (`$content` aliases `../content` in `UI/svelte.config.js`, and `UI/src/tests/routes/game/screens/screen-defs.test.ts` asserts invariants over `content/lessons.json`). A PR editing only `lessons.json` ran the backend + e2e jobs (the backend filter already has `content/**`) but skipped `test-frontend` — so a lesson edit that breaks those assertions could merge green and fail on the next push to `main`.
2. **The `backend` filter lacked `.editorconfig`** (drives `dotnet format --verify-no-changes` in `verify-backend`), **`global.json`** (SDK pin), and **`.config/dotnet-tools.json`** (pins `dotnet-coverage`/`ReportGenerator`, used by `build/coverage.ps1`). A PR touching only these files skipped every job that consumes them — same break-lands-on-main failure mode.

## Changes

- Added `content/**` to the `frontend` filter.
- Added `.editorconfig`, `global.json`, and `.config/dotnet-tools.json` to the `backend` filter.

I also audited the jobs for any other unfiltered inputs per the issue's suggestion (MSBuild `Directory.*.props`, `NuGet.config`, etc.) — none exist in this repo, so no further gaps found.

## Test plan

- [x] Validated the workflow YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] Confirmed `.editorconfig`, `global.json`, and `.config/dotnet-tools.json` exist at the paths added.
- [ ] No application build/test surface — this is a CI configuration-only change (path filter lists), so `dotnet build`/`npm run lint` are not applicable.

Closes #1810

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_015W8DccbfijGW38yR2wgfvH)_