### PR TITLE
Fail the coverage gate when a branch floor is configured but the report has no branch data

### DIFF
--- a/build/coverage-gate.ps1
+++ b/build/coverage-gate.ps1
@@ -59,11 +59,16 @@ foreach ($name in $gatedNames) {
   }
   $lineOk = $a.coverage -ge $floor.line
   $branchOk = $true
-  if ($null -ne $floor.branch -and $null -ne $a.branchcoverage) {
-    $branchOk = $a.branchcoverage -ge $floor.branch
+  if ($null -ne $floor.branch) {
+    if ($null -eq $a.branchcoverage) {
+      $branchOk = $false
+      $failures.Add("$name branch floor configured ($($floor.branch)%) but no branch data in report")
+    } elseif ($a.branchcoverage -lt $floor.branch) {
+      $branchOk = $false
+      $failures.Add("$name branch $($a.branchcoverage)% < floor $($floor.branch)%")
+    }
   }
   if (-not $lineOk) { $failures.Add("$name line $($a.coverage)% < floor $($floor.line)%") }
-  if (-not $branchOk) { $failures.Add("$name branch $($a.branchcoverage)% < floor $($floor.branch)%") }
   $status = 'PASS'
   if (-not ($lineOk -and $branchOk)) { $status = 'FAIL' }
   $floorText = "L$($floor.line)"
@@ -91,11 +96,16 @@ foreach ($name in $gatedNsNames) {
   }
   $lineOk = $ns.LinePct -ge $entry.line
   $branchOk = $true
-  if ($null -ne $entry.branch -and $null -ne $ns.BranchPct) {
-    $branchOk = $ns.BranchPct -ge $entry.branch
+  if ($null -ne $entry.branch) {
+    if ($null -eq $ns.BranchPct) {
+      $branchOk = $false
+      $failures.Add("$name branch floor configured ($($entry.branch)%) but no branch data in report")
+    } elseif ($ns.BranchPct -lt $entry.branch) {
+      $branchOk = $false
+      $failures.Add("$name branch $($ns.BranchPct)% < floor $($entry.branch)%")
+    }
   }
   if (-not $lineOk) { $failures.Add("$name line $($ns.LinePct)% < floor $($entry.line)%") }
-  if (-not $branchOk) { $failures.Add("$name branch $($ns.BranchPct)% < floor $($entry.branch)%") }
   $status = 'PASS'
   if (-not ($lineOk -and $branchOk)) { $status = 'FAIL' }
   $floorText = "L$($entry.line)"


### PR DESCRIPTION
## Summary

In `build/coverage-gate.ps1`, `$branchOk` defaulted to `$true` whenever `branchcoverage`/`BranchPct` was `$null` — for gated assemblies (lines 61-64) and for gated namespaces (lines 93-96, where `Get-NamespaceCoverage` in `build/coverage-lib.ps1` returns a `$null` `BranchPct` when `totalBranches` is 0). So if the collector/report ever stopped emitting branch data — a tool behavior change, a filter change — every configured branch ratchet would pass silently instead of enforcing.

This was asymmetric with the gate's own design principle: a missing gated assembly or an emptied namespace bucket fails loudly (lines 55-58, 87-90), but a missing gated *dimension* did not.

## Failure scenario this fixes

`dotnet-coverage`/ReportGenerator stops including branch data in a report (upstream behavior change, a filter tweak, etc.) — every assembly/namespace with a configured `branch` floor silently stops being gated on branches, and a real branch-coverage regression could ship undetected.

## Changes

- `build/coverage-gate.ps1`: when a branch floor is configured (`$floor.branch`/`$entry.branch` non-null) and the report has no branch figure, the gate now adds a failure ("branch floor configured but no branch data in report") instead of passing. Applies to both the gated-assembly loop and the gated-namespace loop.

## Test plan

`pwsh` isn't available in the CI test-runner sense here beyond running the script itself, so I verified behaviorally with `dotnet tool install --global PowerShell` and synthetic `Summary.json`/`coverage-floors.json` fixtures covering:
- [x] Branch floor configured, no branch data (`null`) → gate now **fails** with the new message (previously passed silently) — both assembly-level and namespace-level.
- [x] Branch floor configured, branch data present and above floor → **passes** (unaffected).
- [x] Branch floor configured, branch data present and below floor → **fails** with the original message (unaffected).
- [x] No branch floor configured at all, branch data `null` → **passes** (unaffected — the dimension simply isn't gated).
- [x] `dotnet build` — solution builds clean, 0 warnings.
- [x] `dotnet test` — full solution suite passes: 3049/3049 (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests).
- [x] `./build/coverage.ps1 -NoBuild` (the real script, with the fix in place) run end-to-end against the actual test suite — gate still passes cleanly against real coverage data, confirming the fix has no effect on the normal (branch-data-present) path.

Closes #1811


---
_Generated by [Claude Code](https://claude.ai/code/session_01SXqSwc2V1QoxscC7Aoum7q)_