### PR TITLE
Fix createFirstCharacter e2e helper racing the async create-form mount

### DIFF
--- a/UI/e2e-tests/helpers.ts
+++ b/UI/e2e-tests/helpers.ts
@@ -62,9 +62,15 @@ export async function selectFirstCharacter(page: Page) {
 export async function createFirstCharacter(page: Page, name = 'Hero') {
 	await expect(page).toHaveURL('/select', { timeout: 10000 });
 
+	// The panel (and its create-form-vs-"+ New character" branch) mounts asynchronously after the URL
+	// changes, so an immediate `isVisible()` snapshot can catch neither element rendered yet and
+	// wrongly fall through to a "show-create" click that never appears (the create form ends up open
+	// instead). Wait for either to actually exist before branching on which one it is.
 	const nameInput = page.getByTestId('new-name-input');
+	const showCreateButton = page.getByTestId('show-create');
+	await nameInput.or(showCreateButton).waitFor({ timeout: 10000 });
 	if (!(await nameInput.isVisible())) {
-		await page.getByTestId('show-create').click();
+		await showCreateButton.click();
 	}
 	// A class is required to create, so wait for the picker to load (it defaults to the first class)
 	// before submitting — the Create button stays disabled until a class is selected.


### PR DESCRIPTION
## Summary

`UI/e2e-tests/helpers.ts`'s `createFirstCharacter` did an instantaneous `nameInput.isVisible()` check immediately after `toHaveURL('/select')` resolved, to decide whether to click the `show-create` button. But `PlayerSelectPanel` (and its mutually-exclusive create-form-vs-`show-create` branch) mounts asynchronously after the URL changes — `+page.svelte`'s `onMount` constructs the `PlayerSelectView` (which synchronously opens the create form for an empty account) only after a render tick. If `isVisible()` ran in the window before that mount, it saw neither element and fell through to a `show-create` click — but by the time it executed, the create form was already open and `show-create` never renders (it's the `{:else}` branch), so the click timed out.

## Failure scenario this fixes

`createAccountAndLogin` → `createFirstCharacter` right after the signup submit click, while `/select` is still finishing its client-side mount. A standing background e2e flake source (Playwright's retries were absorbing it rather than it being a hard, reliably-reproducing failure).

## Changes

- `UI/e2e-tests/helpers.ts`: `createFirstCharacter` now waits for either `new-name-input` or `show-create` to actually exist (`nameInput.or(showCreateButton).waitFor()`) before checking which one is present, instead of taking an instantaneous snapshot.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npx vitest run` (`test:unit:ci`) — 3607/3607 passing.
- [x] Ran the affected e2e spec (`select.test.ts`) against a natively-run API + the existing Postgres/Redis containers: 16/16 passes across 8 repeats under 4 parallel workers, confirming the fix holds under load.
- [ ] Backend unaffected (e2e-test-only change) — no backend logic changed.

Closes #1815


---
_Generated by [Claude Code](https://claude.ai/code/session_01NvEW94uTS2ECdCLCCxK9kP)_