### PR TITLE
Preserve the cached in-flight battle when re-entering the same character

### DIFF
--- a/Game.Api.Tests/Integration/AdminCacheReloadBroadcastTests.cs
+++ b/Game.Api.Tests/Integration/AdminCacheReloadBroadcastTests.cs
@@ -34,7 +34,7 @@ namespace Game.Api.Tests.Integration
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
             var user = await TestDataSeeder.CreateUserAsync(context, "adminuser", "adminpass");
             var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            using var authClient = CreateAuthenticatedClient(user.Id, player.Id, nameof(ERole.Admin));
+            using var authClient = await CreateAuthenticatedClient(user.Id, player.Id, nameof(ERole.Admin));
 
             var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
             var received = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
@@ -30,7 +30,7 @@ namespace Game.Api.Tests.Integration
             await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
 
             var roles = admin ? new[] { nameof(ERole.Admin) } : [];
-            var client = CreateAuthenticatedClient(user.Id, player.Id, roles);
+            var client = await CreateAuthenticatedClient(user.Id, player.Id, roles);
 
             // Tests seed their reference data directly before calling this, so reload the caches to mirror
             // the production invariant that they are warm before any admin action. The admin write path

--- a/Game.Api.Tests/Integration/AdminUsersControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminUsersControllerTests.cs
@@ -49,7 +49,7 @@ namespace Game.Api.Tests.Integration
                 await TestDataSeeder.AssignRoleToUserAsync(context, user.Id, ERole.Admin);
             }
 
-            return (CreateAuthenticatedClient(user.Id, player.Id, roles), user.Id);
+            return (await CreateAuthenticatedClient(user.Id, player.Id, roles), user.Id);
         }
 
         private static async Task<AdminUserSearchResults> GetUsersAsync(HttpClient client, string query = "")

--- a/Game.Api.Tests/Integration/ApiIntegrationTestBase.cs
+++ b/Game.Api.Tests/Integration/ApiIntegrationTestBase.cs
@@ -57,13 +57,13 @@ namespace Game.Api.Tests.Integration
         /// set to <paramref name="playerId"/>) for the given user ID and any granted roles, with a player
         /// session pre-created in the cache.
         /// </summary>
-        protected HttpClient CreateAuthenticatedClient(int userId, int playerId, params string[] roles)
+        protected async Task<HttpClient> CreateAuthenticatedClient(int userId, int playerId, params string[] roles)
         {
             var client = Factory.CreateClient();
             TestAuthHelper.AddAuthHeader(client, userId, playerId, roles);
             using var scope = Factory.Services.CreateScope();
             var sessionService = scope.ServiceProvider.GetRequiredService<SessionService>();
-            sessionService.CreateSession(userId, playerId);
+            await sessionService.CreateSession(userId, playerId);
             return client;
         }
 

--- a/Game.Api.Tests/Integration/LoginControllerTests.cs
+++ b/Game.Api.Tests/Integration/LoginControllerTests.cs
@@ -196,6 +196,43 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task SelectPlayer_ReEntersSameCharacterWithCachedInFlightBattle_PreservesTheBattle()
+        {
+            // A credential re-login (rather than a plain socket reconnect) must not discard the same
+            // character's cache-only in-flight battle snapshot (#1818) — it exists nowhere else, and the
+            // battle already resumes fine across a plain reconnect, so behavior shouldn't hinge on how the
+            // client re-entered.
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context, "relogin", "reloginpass");
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+            await ReloadReferenceCachesAsync();
+
+            var firstLogin = await LoginAsync("relogin", "reloginpass");
+            await SelectPlayerAsync(firstLogin.Tokens, player.Id);
+
+            // Simulate quitting mid-battle: the session cache holds an in-flight battle snapshot that exists
+            // nowhere else (the write-behind path is what would normally populate this via the game socket).
+            var sessionStore = scope.ServiceProvider.GetRequiredService<ISessionStore>();
+            var inFlight = new Game.Core.Players.PlayerState { PlayerId = player.Id };
+            inFlight.SetActiveBattle(
+                enemyId: 1, level: 1, enemySkillIds: [1], seed: 1,
+                startTime: DateTime.UtcNow, snapshot: new Game.Core.Battle.BattleSnapshot { Level = 1, StatAllocations = [], EquippedItems = [], SkillIds = [] },
+                zoneId: 1, isBossBattle: false);
+            sessionStore.Update(inFlight, user.Id);
+
+            // Log back in with credentials (a new pre-selection token, not a plain socket reconnect) and
+            // re-select the same character.
+            var secondLogin = await LoginAsync("relogin", "reloginpass");
+            await SelectPlayerAsync(secondLogin.Tokens, player.Id);
+
+            var session = await sessionStore.GetSession(user.Id);
+            Assert.NotNull(session);
+            Assert.True(session.HasActiveBattle);
+            Assert.Equal(inFlight.ActiveEnemyId, session.ActiveEnemyId);
+        }
+
+        [Fact]
         public async Task SelectPlayer_DeliversClassLockedBaseAndSignaturePassive()
         {
             // The logged-in player payload (LoginController.BuildPlayerData) projects the character's class

--- a/Game.Api.Tests/Integration/NewEnemySocketTests.cs
+++ b/Game.Api.Tests/Integration/NewEnemySocketTests.cs
@@ -87,7 +87,7 @@ namespace Game.Api.Tests.Integration
 
             using var scope = CreateScope();
             var sessionService = scope.ServiceProvider.GetRequiredService<SessionService>();
-            sessionService.CreateSession(userId, playerId);
+            await sessionService.CreateSession(userId, playerId);
             sessionService.PlayerState.SetCooldown(DateTime.UtcNow.AddMinutes(5)); // Set cooldown for 5 minutes
             sessionService.SavePlayerState();
 

--- a/Game.Api.Tests/Integration/SocketConnectionTests.cs
+++ b/Game.Api.Tests/Integration/SocketConnectionTests.cs
@@ -114,7 +114,7 @@ namespace Game.Api.Tests.Integration
             // An authenticated but non-upgrade request to /socket short-circuits to 400 before any upgrade, so
             // the body carries the { errorMessage } envelope rather than being empty.
             var (userId, playerId) = await SeedAsync();
-            var authedClient = CreateAuthenticatedClient(userId, playerId);
+            var authedClient = await CreateAuthenticatedClient(userId, playerId);
 
             var response = await authedClient.GetAsync("/socket", CancellationToken);
 

--- a/Game.Api.Tests/Integration/SocketDrainTests.cs
+++ b/Game.Api.Tests/Integration/SocketDrainTests.cs
@@ -114,7 +114,7 @@ namespace Game.Api.Tests.Integration
             // surface this behaviour deterministically.
             using var scope = CreateScope();
             var session = scope.ServiceProvider.GetRequiredService<SessionService>();
-            session.CreateSession(userId: 4242, playerId: 4242);
+            await session.CreateSession(userId: 4242, playerId: 4242);
             var socketManager = scope.ServiceProvider.GetRequiredService<SocketManagerService>();
             var registry = Factory.Services.GetRequiredService<SocketConnectionRegistry>();
 

--- a/Game.Api.Tests/Integration/TagsControllerTests.cs
+++ b/Game.Api.Tests/Integration/TagsControllerTests.cs
@@ -102,7 +102,7 @@ namespace Game.Api.Tests.Integration
             }
 
             // Non-admin token: the endpoints are gated by AdminRoleAuthorizationFilter (#690).
-            using var client = CreateAuthenticatedClient(userId, playerId);
+            using var client = await CreateAuthenticatedClient(userId, playerId);
 
             var response = await client.GetAsync(url, CancellationToken);
 

--- a/Game.Api.Tests/Unit/SessionServiceTests.cs
+++ b/Game.Api.Tests/Unit/SessionServiceTests.cs
@@ -1,5 +1,6 @@
 using Game.Abstractions.DataAccess;
 using Game.Api.Services;
+using Game.Core.Battle;
 using Game.Core.Players;
 using Game.Core.TestInfrastructure.Builders;
 using Xunit;
@@ -90,20 +91,58 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
-        public void CreateSession_PrimesTheCache()
+        public async Task CreateSession_NoExistingCachedSession_PrimesTheCacheWithFreshState()
         {
             // Login establishes the binding before any socket exists, so it does prime the cache (the one HTTP
             // path that legitimately writes the session, at the start of the session lifecycle).
             var store = new FakeSessionStore();
             var session = new SessionService(store);
 
-            session.CreateSession(userId: 5, playerId: 7);
+            await session.CreateSession(userId: 5, playerId: 7);
 
             Assert.True(session.HasPlayerSession);
             Assert.Equal(7, session.SelectedPlayerId);
             var update = Assert.Single(store.Updates);
             Assert.Equal(5, update.UserId);
             Assert.Equal(7, update.State.PlayerId);
+        }
+
+        [Fact]
+        public async Task CreateSession_CachedSessionForSamePlayer_PreservesTheExistingInFlightBattleSnapshot()
+        {
+            // A credential re-login (or a switch back onto the character already bound) for a player whose
+            // cache-only in-flight battle is still live must not clobber it with a fresh, battle-less state
+            // (#1818) — the same battle already resumes fine across a plain socket reconnect.
+            var existing = new PlayerState { PlayerId = 7 };
+            existing.SetActiveBattle(
+                enemyId: 42, level: 3, enemySkillIds: [1, 2], seed: 99,
+                startTime: DateTime.UtcNow, snapshot: new BattleSnapshot { Level = 3, StatAllocations = [], EquippedItems = [], SkillIds = [] }, zoneId: 1, isBossBattle: false);
+            var store = new FakeSessionStore { Session = existing };
+            var session = new SessionService(store);
+
+            await session.CreateSession(userId: 5, playerId: 7);
+
+            Assert.Same(existing, session.PlayerState);
+            Assert.True(session.PlayerState.HasActiveBattle);
+        }
+
+        [Fact]
+        public async Task CreateSession_CachedSessionForADifferentPlayer_ResetsToFreshState()
+        {
+            // Switching to a genuinely different character has nothing to preserve in this cache slot (it only
+            // ever holds one player's state per account), so it must still reset rather than carry the departed
+            // character's battle forward onto the new one.
+            var departed = new PlayerState { PlayerId = 3 };
+            departed.SetActiveBattle(
+                enemyId: 42, level: 3, enemySkillIds: [1, 2], seed: 99,
+                startTime: DateTime.UtcNow, snapshot: new BattleSnapshot { Level = 3, StatAllocations = [], EquippedItems = [], SkillIds = [] }, zoneId: 1, isBossBattle: false);
+            var store = new FakeSessionStore { Session = departed };
+            var session = new SessionService(store);
+
+            await session.CreateSession(userId: 5, playerId: 7);
+
+            Assert.Equal(7, session.PlayerState.PlayerId);
+            Assert.False(session.PlayerState.HasActiveBattle);
         }
 
         [Fact]

--- a/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
@@ -190,7 +190,7 @@ namespace Game.Api.Tests.Unit
             // stay pinned until process shutdown (#1760).
             var socket = new FakeWebSocket(new TaskCompletionSource().Task);
             var session = new SessionService(new NoOpSessionStore());
-            session.CreateSession(userId: 1, playerId: 1);
+            await session.CreateSession(userId: 1, playerId: 1);
             var context = new SocketContext(socket, playerId: 1, session, isAdmin: false, _loggerFactory.CreateLogger<SocketContext>(),
                 sendAbortTimeout: TimeSpan.FromMilliseconds(50));
             var handler = new SocketHandler(context, new StubCommandFactory(_ => null), _scopeFactory, _loggerFactory.CreateLogger<SocketHandler>(), () => { });
@@ -275,7 +275,7 @@ namespace Game.Api.Tests.Unit
 
             var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
             var session = new SessionService(new NoOpSessionStore());
-            session.CreateSession(userId: 1, playerId: 1);
+            await session.CreateSession(userId: 1, playerId: 1);
             var context = new SocketContext(socket, playerId: 1, session, isAdmin: false, _loggerFactory.CreateLogger<SocketContext>());
             var handler = new SocketHandler(
                 context,
@@ -310,7 +310,7 @@ namespace Game.Api.Tests.Unit
 
             var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
             var session = new SessionService(new NoOpSessionStore());
-            session.CreateSession(userId: 1, playerId: 1);
+            await session.CreateSession(userId: 1, playerId: 1);
             var context = new SocketContext(socket, playerId: 1, session, isAdmin: false, _loggerFactory.CreateLogger<SocketContext>());
             var release = new TaskCompletionSource();
             var handler = new SocketHandler(
@@ -353,7 +353,7 @@ namespace Game.Api.Tests.Unit
 
             var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
             var session = new SessionService(new NoOpSessionStore());
-            session.CreateSession(userId: 1, playerId: 1);
+            await session.CreateSession(userId: 1, playerId: 1);
             session.SetPlayer(originalPlayer);
             var context = new SocketContext(socket, playerId: 1, session, isAdmin: false, _loggerFactory.CreateLogger<SocketContext>());
             var handler = new SocketHandler(
@@ -383,7 +383,7 @@ namespace Game.Api.Tests.Unit
         {
             var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
             var session = new SessionService(new NoOpSessionStore());
-            session.CreateSession(userId: 1, playerId: 1);
+            session.CreateSession(userId: 1, playerId: 1).GetAwaiter().GetResult();
             var context = new SocketContext(socket, playerId: 1, session, isAdmin: false, _loggerFactory.CreateLogger<SocketContext>());
             var handler = new SocketHandler(context, new StubCommandFactory(throwOn, throwOnCreate, selfDelivering), _scopeFactory,
                 _loggerFactory.CreateLogger<SocketHandler>(), () => { });

--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -148,7 +148,7 @@ namespace Game.Api.Tests.Unit
 
             var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
             var session = new SessionService(new NoOpSessionStore());
-            session.CreateSession(userId: 1, playerId: 42);
+            await session.CreateSession(userId: 1, playerId: 42);
 
             // The Subscribe failure propagates out of RegisterSocket...
             await Assert.ThrowsAsync<InvalidOperationException>(() => manager.RegisterSocket(socket, session, isAdmin: false));
@@ -197,7 +197,7 @@ namespace Game.Api.Tests.Unit
 
             var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
             var session = new SessionService(new NoOpSessionStore());
-            session.CreateSession(userId: 1, playerId: 77);
+            await session.CreateSession(userId: 1, playerId: 77);
             var context = await manager.RegisterSocket(socket, session, isAdmin: false);
 
             // The unsubscribe fault during teardown must be swallowed, not propagated...
@@ -244,7 +244,7 @@ namespace Game.Api.Tests.Unit
 
             var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
             var session = new SessionService(new NoOpSessionStore());
-            session.CreateSession(userId: 1, playerId: 1);
+            session.CreateSession(userId: 1, playerId: 1).GetAwaiter().GetResult();
             // RegisterSocket wires the real processor into the fake pub/sub via RegisterSocketCommandListener,
             // so the captured callback is the production GetSocketCommandProcessor closure under test.
             manager.RegisterSocket(socket, session, isAdmin: false).GetAwaiter().GetResult();

--- a/Game.Api.Tests/Unit/SocketReadLoopTests.cs
+++ b/Game.Api.Tests/Unit/SocketReadLoopTests.cs
@@ -145,7 +145,7 @@ namespace Game.Api.Tests.Unit
         private (SocketContext Context, SocketHandler Handler) CreateHandler(WebSocket socket, Action? onActivity = null)
         {
             var session = new SessionService(new NoOpSessionStore());
-            session.CreateSession(userId: 1, playerId: 1);
+            session.CreateSession(userId: 1, playerId: 1).GetAwaiter().GetResult();
             var context = new SocketContext(socket, playerId: 1, session, isAdmin: false, _loggerFactory.CreateLogger<SocketContext>());
             var handler = new SocketHandler(context, new StubCommandFactory(), _scopeFactory,
                 _loggerFactory.CreateLogger<SocketHandler>(), onActivity ?? (() => { }));

--- a/Game.Api/Controllers/LoginController.cs
+++ b/Game.Api/Controllers/LoginController.cs
@@ -125,7 +125,7 @@ namespace Game.Api.Controllers
 
             // Establish the session binding now that a character is chosen — a request-scoped presentation
             // concern, mirroring how login used to bind. The token returned already carries the player.
-            _sessionService.CreateSession(_sessionService.UserId, result.Player.Id);
+            await _sessionService.CreateSession(_sessionService.UserId, result.Player.Id, HttpContext.RequestAborted);
 
             return ApiResponse.Success(new SelectPlayerResult
             {
@@ -173,7 +173,7 @@ namespace Game.Api.Controllers
                 return ApiResponse.Error(SelectPlayerErrorMessage(result.Status), SelectPlayerErrorCategory(result.Status));
             }
 
-            _sessionService.CreateSession(_sessionService.UserId, result.Player.Id);
+            await _sessionService.CreateSession(_sessionService.UserId, result.Player.Id, HttpContext.RequestAborted);
 
             return ApiResponse.Success(new SelectPlayerResult
             {

--- a/Game.Api/Services/SessionService.cs
+++ b/Game.Api/Services/SessionService.cs
@@ -122,12 +122,22 @@ namespace Game.Api.Services
             _playerNeedsReload = true;
         }
 
-        public void CreateSession(int userId, int playerId)
+        /// <summary>
+        /// Establishes the session binding for <paramref name="playerId"/> (login's <c>SelectPlayer</c>, or an
+        /// in-game <c>SwitchPlayer</c>) and primes the session cache here — before any socket exists — so the
+        /// subsequent Status/socket reads hit the cache instead of rehydrating. When the cache already holds
+        /// state for this same player (a credential re-login, or switching back to the character already bound),
+        /// that cached state is kept rather than overwritten, since it may carry a cache-only in-flight battle
+        /// snapshot that exists nowhere else. A genuinely different (or absent) cached player still gets a
+        /// fresh <see cref="PlayerState"/>.
+        /// </summary>
+        public async Task CreateSession(int userId, int playerId, CancellationToken cancellationToken = default)
         {
             UserId = userId;
-            // Login establishes the binding before any socket exists, so it primes the session cache here; the
-            // subsequent Status/socket reads then hit the cache instead of rehydrating.
-            PlayerState = new PlayerState { PlayerId = playerId };
+            var existing = await _sessionStore.GetSession(userId, cancellationToken);
+            PlayerState = existing is not null && existing.PlayerId == playerId
+                ? existing
+                : new PlayerState { PlayerId = playerId };
             _sessionStore.Update(PlayerState, UserId);
         }
 


### PR DESCRIPTION
## Summary

`SessionService.CreateSession` (`Game.Api/Services/SessionService.cs`) always primed the session cache with a **fresh** `PlayerState`, discarding whatever was already cached — even when the cache already held state for the *same* player. `SessionStore`'s TTL is deliberately sized at the refresh-token lifetime specifically so "an active player's in-flight battle should not be dropped" (it's a cache-only snapshot, reconstructable nowhere else).

## Failure scenario this fixes

Quit mid-battle, then log back in with credentials (logout, new device, or any expired-refresh path): `Login → SelectPlayer` runs `CreateSession` before any socket connects, so by the time offline progress resolves, `HasActiveBattle` is already false — the interrupted battle is dropped without credit, even though the exact same battle *is* resumed fine after a plain socket reconnect. Behavior was inconsistent purely based on how the client re-entered.

## Changes

- `Game.Api/Services/SessionService.cs`: `CreateSession` now reads the existing cached session first. When it already holds state for the same `playerId`, that cached state (and its in-flight battle snapshot, if any) is kept instead of overwritten; a genuinely different (or absent) cached player still gets a fresh `PlayerState`. This required making `CreateSession` async (it needs the cache read), so all call sites were updated to await it.
- `Game.Api/Controllers/LoginController.cs`: `SelectPlayer`/`SwitchPlayer` now `await` the call.
- Test call sites across `Game.Api.Tests` updated mechanically for the new async signature (`ApiIntegrationTestBase.CreateAuthenticatedClient` also became async, with its handful of callers updated).

## Tests

- `SessionServiceTests.cs`: new cases — no existing cached session still primes fresh state; a cached session for the *same* player is preserved (including its in-flight battle); a cached session for a *different* player still resets (there's nothing to preserve in that cache slot for the new character, since it only ever holds one player's state per account).
- `LoginControllerTests.cs`: new integration test `SelectPlayer_ReEntersSameCharacterWithCachedInFlightBattle_PreservesTheBattle` — seeds an in-flight battle into the session cache, re-logs-in with credentials (not a socket reconnect) and re-selects the same character, and asserts the battle snapshot survives.

## Test plan

- [x] `dotnet build` — solution builds clean, 0 warnings.
- [x] `dotnet test` — full solution suite passes: 3058/3058 (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests), including the new tests above.
- [ ] Frontend unaffected (backend-only change) — no frontend verification needed.

Closes #1818


---
_Generated by [Claude Code](https://claude.ai/code/session_01XGWayhWzakCdhsG5WsKAHK)_