### PR TITLE
Reject negative spawn weights in AdminZones.SetEnemies/AdminEnemies.SetSpawns

### DIFF
--- a/Game.Application.Tests/DataAccess/AdminEnemiesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminEnemiesIntegrationTests.cs
@@ -468,6 +468,37 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SetSpawns_NegativeWeight_ReturnsFailure()
+        {
+            int enemyId, zoneId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+                var zone = await TestDataSeeder.CreateZoneAsync(context);
+                enemyId = enemy.Id;
+                zoneId = zone.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // A negative weight would otherwise commit and then throw inside ProbabilityTable's constructor
+            // when the enemy snapshot next rebuilds — reject it up front instead.
+            var data = new SetEnemySpawnsData
+            {
+                EnemyId = enemyId,
+                Spawns = [new Contracts.EnemySpawn { ZoneId = zoneId, Weight = -1 }],
+            };
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminEnemies>();
+
+            var result = admin.SetSpawns(data);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("A spawn's weight cannot be negative.", result.ErrorMessage);
+        }
+
+        [Fact]
         public async Task SaveEnemies_RetiringLastActiveEnemyOfLiveZone_ReturnsFailure()
         {
             int enemyId;

--- a/Game.Application.Tests/DataAccess/AdminZonesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminZonesIntegrationTests.cs
@@ -115,6 +115,37 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SetEnemies_NegativeWeight_ReturnsFailure()
+        {
+            int zoneId, enemyId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var zone = await TestDataSeeder.CreateZoneAsync(context);
+                var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+                zoneId = zone.Id;
+                enemyId = enemy.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // A negative weight would otherwise commit and then throw inside ProbabilityTable's constructor
+            // when the enemy snapshot next rebuilds — reject it up front instead.
+            var data = new SetZoneEnemiesData
+            {
+                ZoneId = zoneId,
+                ZoneEnemies = [new Contracts.ZoneEnemy { EnemyId = enemyId, Weight = -1 }],
+            };
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminZones>();
+
+            var result = admin.SetEnemies(data);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("A zone enemy's spawn weight cannot be negative.", result.ErrorMessage);
+        }
+
+        [Fact]
         public void SetEnemies_UnknownZone_ReturnsNotFound()
         {
             using var scope = CreateScope();

--- a/Game.DataAccess/Repositories/Admin/AdminEnemies.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminEnemies.cs
@@ -135,6 +135,16 @@ namespace Game.DataAccess.Repositories.Admin
                 return AdminSaveResult.NotFound("Enemy");
             }
 
+            // Anti-tamper: a negative weight commits cleanly but throws inside ProbabilityTable's
+            // constructor when the enemy snapshot next rebuilds, permanently poisoning every instance's
+            // reload (and boot) since the Workbench's own corrective save then collides with the already-
+            // committed row. Reject it up front. Zero is safe — ProbabilityTable treats an all-zero set
+            // as uniform.
+            if (data.Spawns.Any(s => s.Weight < 0))
+            {
+                return AdminSaveResult.Failure("A spawn's weight cannot be negative.");
+            }
+
             // Authoring guard: the Home zone is a no-combat sanctuary where no enemies spawn (and never will),
             // so reject a spawn that targets one. Mirrors the per-zone guard in AdminZones.SetEnemies so neither
             // authoring direction can populate Home's spawn table.

--- a/Game.DataAccess/Repositories/Admin/AdminZones.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminZones.cs
@@ -143,6 +143,16 @@ namespace Game.DataAccess.Repositories.Admin
                 return AdminSaveResult.NotFound("Zone");
             }
 
+            // Anti-tamper: a negative weight commits cleanly but throws inside ProbabilityTable's
+            // constructor when the enemy snapshot next rebuilds, permanently poisoning every instance's
+            // reload (and boot) since the Workbench's own corrective save then collides with the already-
+            // committed row. Reject it up front. Zero is safe — ProbabilityTable treats an all-zero set
+            // as uniform.
+            if (data.ZoneEnemies.Any(ze => ze.Weight < 0))
+            {
+                return AdminSaveResult.Failure("A zone enemy's spawn weight cannot be negative.");
+            }
+
             // The Home zone is a no-combat sanctuary: no enemies spawn there and never will. Reject assigning
             // a spawn table to it (clearing it to empty stays allowed). Mirrors the per-enemy guard in
             // AdminEnemies.SetSpawns so neither authoring direction can populate Home's spawn table.


### PR DESCRIPTION
## Summary

`ZoneEnemy.Weight`/`EnemySpawn.Weight` are plain `int`s and neither `AdminZones.SetEnemies` nor `AdminEnemies.SetSpawns` validated them before staging. The enemy snapshot build (`EnemiesCacheHolder.BuildZoneEnemyTables`) constructs a `ProbabilityTable<int>` straight from these weights, and `ProbabilityTable`'s constructor **throws `ArgumentException` on any negative weight**.

So a save carrying `Weight = -1` committed cleanly, and the awaited post-commit reload then threw — poisoning every instance's reload (readers stuck on the stale snapshot, background sweep permanently `LogError`s), failing boot on any restart (the eager startup load throws), and leaving the Workbench unable to self-repair (the corrective `SetEnemies` diffs against the stale snapshot, so its "fix" stages as an insert that collides with the already-committed row's PK).

## Changes

- `AdminZones.SetEnemies` and `AdminEnemies.SetSpawns` now reject any `Weight < 0` up front via `AdminSaveResult.Failure`, mirroring the existing `AdminSkills.SetPortions` anti-tamper guard (non-positive weight check). Zero stays allowed — `ProbabilityTable` already treats an all-zero weight set as uniform, so it's not a landmine.
- New integration tests in `AdminZonesIntegrationTests` and `AdminEnemiesIntegrationTests` cover the negative-weight rejection for both setters.

## Test plan

- [x] `dotnet build` — solution builds clean, 0 warnings.
- [x] `dotnet test` — full solution suite passes: 3066/3066 (`Game.Core.Tests`, `Game.Infrastructure.Tests`, `Game.Application.Tests`, `Game.Api.Tests`), including the two new negative-weight rejection tests.
- [ ] Frontend unaffected (backend-only change) — no frontend verification needed.

Closes #1850


---
_Generated by [Claude Code](https://claude.ai/code/session_0184soDDPBrctZGurZPht9AL)_