### PR TITLE
Clamp AbandonBattle's wall-clock elapsed-time cast to avoid int overflow

### DIFF
--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -1479,6 +1479,46 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task ResolveStaleBattle_BattleStartedOverIntOverflowThresholdAgo_StillCreditsTheWin()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // Same one-shot setup as ResolveStaleBattle_Concludes_ReturnsNullAndCreditsTheWin, but the battle's
+            // wall-clock age (30 days) exceeds int.MaxValue ms (~24.9 days) — pinning that the abandon still
+            // resolves a definite outcome instead of the elapsed-time computation overflowing into garbage.
+            var playerSkill = await TestDataSeeder.CreateSkillAsync(context, "Smash", baseDamage: 1000m, cooldownMs: 500);
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+            var enemySkill = await TestDataSeeder.CreateSkillAsync(context, "Poke", baseDamage: 5000m, cooldownMs: 2000);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, enemySkill.Id);
+            var zone = await TestDataSeeder.CreateZoneAsync(context, levelMin: 10, levelMax: 10);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, playerSkill.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+            var expBefore = player.Exp;
+
+            await battleService.StartBattle(player, state, zoneId: zone.Id);
+            state.BattleStartTime = DateTime.UtcNow.AddDays(-30);
+
+            var handoff = await battleService.ResolveStaleBattle(player, state);
+
+            Assert.Null(handoff);
+            Assert.False(state.HasActiveBattle);
+            Assert.True(player.Exp > expBefore);
+        }
+
+        [Fact]
         public async Task ResolveStaleBattle_StillInProgressAndGenuineDrawAtCap()
         {
             using var scope = CreateScope();

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -437,7 +437,9 @@ namespace Game.Application.Services
         private async Task<BattleStartResult?> AbandonBattle(Player player, PlayerState state, int? clientBattleMs = null, CancellationToken cancellationToken = default)
         {
             var now = DateTime.UtcNow;
-            var wallClockMs = (int)(now - state.BattleStartTime).TotalMilliseconds;
+            // A stale battle can be far older than int.MaxValue ms (~24.9 days), so clamp before narrowing —
+            // an unchecked out-of-range double-to-int cast is unspecified rather than a safe saturation.
+            var wallClockMs = (int)Math.Clamp((now - state.BattleStartTime).TotalMilliseconds, 0, int.MaxValue);
 
             // Bound the re-simulation by how long the client actually simulated the battle being abandoned,
             // when it reports it — so a battle the client never fought (e.g. a server-prefetched next battle


### PR DESCRIPTION
## Summary

`BattleService.AbandonBattle` (`Game.Application/Services/BattleService.cs:440`) computed:

```csharp
var wallClockMs = (int)(now - state.BattleStartTime).TotalMilliseconds;
```

`TotalMilliseconds` exceeds `int.MaxValue` for a battle whose `BattleStartTime` is more than ~24.9 days in the past (e.g. a stale in-flight battle from a long-disconnected player, resolved via `ResolveStaleBattle`/offline login). Narrowing an out-of-range `double` to `int` in an unchecked context is unspecified behavior per the C# language spec — relying on it is fragile even though it isn't crashing today.

## What I verified vs. the issue's claim

The issue's suggested fix section asserted the cast "in practice ... saturates to `int.MinValue`", which would make `elapsedMs <= 0` clear the battle with no outcome. I checked this empirically on this repo's actual .NET 10 runtime: an out-of-range positive `double → int` cast currently saturates to `int.MaxValue`, not `int.MinValue`. Tracing that through the method, `int.MaxValue` still clears every downstream comparison (`Math.Min(elapsedMs, DefaultMaxBattleMs)`, `wallClockMs < DefaultMaxBattleMs`) the same way a correctly-computed huge value would — so the specific "silently clears with no outcome" symptom does not currently reproduce on this runtime.

That said, the underlying issue — relying on unspecified narrowing-conversion behavior instead of an explicit domain clamp — is real and worth fixing regardless of the current runtime's (undocumented-by-spec) saturation behavior. The fix is a one-line hardening with no behavior change today, and removes the fragility for other targets/runtimes.

## Changes

- `BattleService.AbandonBattle`: clamp the elapsed-`TotalMilliseconds` to `[0, int.MaxValue]` before narrowing to `int`, instead of an unchecked cast.
- New regression test `ResolveStaleBattle_BattleStartedOverIntOverflowThresholdAgo_StillCreditsTheWin`, mirroring the existing `ResolveStaleBattle_Concludes_ReturnsNullAndCreditsTheWin` but with `BattleStartTime` 30 days in the past (past the overflow threshold), pinning that the abandon still resolves and credits a definite win.

No documentation change — `docs/backend-battle.md`'s described contract (abandon resolves a definite outcome, capped at `DefaultMaxBattleMs`) already holds; this only hardens the internal computation, it doesn't change behavior.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] `dotnet test` (full backend suite, no build/restore) — 3,069/3,069 passing (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests including the new test, Game.Api.Tests).
- [ ] Frontend unaffected (backend-only change) — no frontend verification needed.

Closes #1852


---
_Generated by [Claude Code](https://claude.ai/code/session_01X66LrVVJ2oKVkZVT9dVWWB)_