### PR TITLE
Abort Workbench child savers on an unresolved add id instead of falling back to it

### DIFF
--- a/UI/src/routes/admin/workbench/save-helpers.ts
+++ b/UI/src/routes/admin/workbench/save-helpers.ts
@@ -58,8 +58,22 @@ export const resolveNewIds = (
 	return idFor;
 };
 
-/** Resolve a possibly-local id through the new-id map (returns the input when already persisted). */
-export const resolveId = (id: number, idMap: Map<number, number>): number => idMap.get(id) ?? id;
+/**
+ * Resolve a possibly-local id through the new-id map (passes through an already-persisted id
+ * unchanged — entity ids are 0-based, so `0` is a legitimate persisted id, not a sentinel). Throws
+ * if `id` is a local (negative) id absent from the map — the refetch that should have confirmed its
+ * add landed didn't, so the caller must not silently write against the stale local id.
+ */
+export const resolveId = (id: number, idMap: Map<number, number>): number => {
+	const resolved = idMap.get(id);
+	if (resolved !== undefined) {
+		return resolved;
+	}
+	if (id < 0) {
+		throw new Error(`No persisted id found for record (local id ${id})`);
+	}
+	return id;
+};
 
 /** Returns whether it actually wrote — a no-op (unchanged collection) must report `false`. */
 type ChildSaver<T> = (id: number, record: T, baseline: T | undefined) => Promise<boolean>;
@@ -142,7 +156,7 @@ export async function persistEntity<T extends Identified, D>(opts: PersistOption
 		const idFor = resolveNewIds(fresh, diff.existingIds, diff.added);
 
 		const childTargets: { id: number; record: T; baseline: T | undefined }[] = [
-			...diff.added.map((record) => ({ id: idFor.get(record.id) ?? record.id, record, baseline: undefined })),
+			...diff.added.map((record) => ({ id: resolveId(record.id, idFor), record, baseline: undefined })),
 			...diff.modified.map(({ record, baseline }) => ({ id: record.id, record, baseline }))
 		];
 

--- a/UI/src/tests/routes/admin/workbench/save-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/save-helpers.test.ts
@@ -156,6 +156,15 @@ describe('resolveNewIds & resolveId', () => {
 		expect(resolveId(-1, map)).toBe(7);
 		expect(resolveId(3, map)).toBe(3);
 	});
+
+	it('resolveId throws when a local (negative) id has no persisted match', () => {
+		const map = new Map([[-1, 7]]);
+		expect(() => resolveId(-2, map)).toThrow();
+	});
+
+	it('resolveId passes through 0 unchanged — entity ids are 0-based, so 0 is a real persisted id', () => {
+		expect(resolveId(0, new Map())).toBe(0);
+	});
 });
 
 interface Row extends Identified {
@@ -334,6 +343,44 @@ describe('persistEntity', () => {
 				]
 			})
 		).rejects.toBe(cause);
+	});
+
+	it('aborts child savers (as PersistFailedError) when an add refetch returns fewer new records than expected', async () => {
+		const diff: SaveDiff<Row> = {
+			added: [
+				{ id: -1, name: 'A' },
+				{ id: -2, name: 'B' }
+			],
+			modified: [],
+			deleted: [],
+			existingIds: [0]
+		};
+		// Stale refetch: only one of the two adds shows up as a new id, so the second add's id can't
+		// be resolved positionally.
+		const fresh: Row[] = [
+			{ id: 0, name: 'X' },
+			{ id: 2, name: 'A' }
+		];
+		const childCalls: number[] = [];
+
+		await expect(
+			persistEntity<Row, Row>({
+				diff,
+				toPrimaryDto: (r) => ({ id: r.id, name: r.name }),
+				postPrimary: async () => undefined,
+				refresh: async () => fresh,
+				childSavers: [
+					async (id) => {
+						childCalls.push(id);
+						return true;
+					}
+				]
+			})
+		).rejects.toBeInstanceOf(PersistFailedError);
+
+		// The resolvable first add must not have its child saver run either — the whole batch aborts
+		// before any child saver sees an unresolved-id record, rather than partially applying.
+		expect(childCalls).toEqual([]);
 	});
 
 	it('wraps a post-commit refresh failure as PersistFailedError', async () => {


### PR DESCRIPTION
## Summary

`persistEntity` (`UI/src/routes/admin/workbench/save-helpers.ts`) resolves each added record's real persisted id positionally, from a post-save refetch (`resolveNewIds`). The lookup at the child-saver call site fell back to the local (negative) id whenever that lookup came up empty:

```ts
{ id: idFor.get(record.id) ?? record.id, record, baseline: undefined }
```

If the refetch returned fewer new records than were added (a stale read racing the server-side cache reload, or any other refetch anomaly), this silently posted the child-collection saves (skill portions/effects, item mod slots, proficiency modifiers) against the **local negative id** — after the identity Add had already committed.

## Changes

- `resolveId` (previously `idMap.get(id) ?? id`) now throws when given a local (negative) id that has no entry in the map. `0` still passes through unchanged, since this project's entity ids are 0-based — `0` is a legitimate persisted id, not a "new record" sentinel (only strictly-negative ids, from the workbench stores' `nextId` counters, mean "new/unsaved").
- `persistEntity`'s child-target resolution now calls `resolveId` instead of duplicating the fallback inline, so an unresolved add throws before any child saver runs. `persistEntity` already tracks whether anything committed, so this throw is automatically wrapped as `PersistFailedError` — the same path that already forces the caller to re-seed from server truth on any post-commit failure.
- `docs/frontend.md` is unaffected; no architectural decision here, just closing a silent-fallback gap in an existing documented contract (`PersistFailedError`'s re-seed-on-commit behavior).

## Bonus fix (same pattern, same file)

The issue's problem statement also flagged the progression store's proficiency/path save orchestration (`progression/progression-store.svelte.ts`) as having the same fallback pattern. It turned out those call sites already route through the shared `resolveId` helper, so hardening `resolveId` itself fixes both places with one change — no edits needed in `progression-store.svelte.ts`.

## Tests

- `save-helpers.test.ts`: new cases — `resolveId` throws on an unresolved negative id; `resolveId` passes `0` through unchanged (0-based ids); and a `persistEntity` case pinning that a stale refetch (fewer new records than added) aborts before any child saver runs, surfacing as `PersistFailedError`.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.
- [x] `npx vitest run` on the touched suites — all passing.
- [x] `npm run test:unit:ci` — full frontend suite passes (exit 0).
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1855


---
_Generated by [Claude Code](https://claude.ai/code/session_019fpUWf9QKTkm9CdpDcmtyT)_