### PR TITLE
Flush partial-second DoT/HoT combat log on abandon-shaped battle ends

### DIFF
--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -180,6 +180,7 @@ export class BattleEngine {
 	 */
 	public rest() {
 		this.finishLoading?.();
+		this.flushEffectDamage();
 		this.timeElapsed = 0;
 		this.setBattleStage(Idle);
 	}
@@ -201,7 +202,7 @@ export class BattleEngine {
 		// Seed the battle RNG from the enemy instance's seed (the same value the backend simulates against),
 		// so the crit/dodge/block draws stay in lockstep with the anti-cheat replay.
 		this.rng = new Mulberry32(enemyInstance.seed);
-		this.resetEffectDamage();
+		this.flushEffectDamage();
 		this.resetPlayer();
 		this.enemy.reset({ ...enemyInstance, ...enemyData[enemyInstance.id] });
 		// A non-null elapsedOffsetMs (#1595/#1596) means the server handed back a battle already in

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -978,6 +978,75 @@ describe('BattleEngine', () => {
 			expect(effectCalls).toContainEqual([ELogType.SkillEffect, 'Goblin recovered 5 health.']);
 		});
 
+		it('flushes a partial-second DoT window when the player rests (retreat / Home / zone swap, #1857)', () => {
+			mockSkills[0].baseDamage = 0; // keep the focus on DoT — no skill kill
+			engine.start();
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				isBossBattle: false,
+				selectedSkills: [0],
+				attributes: [
+					{ attributeId: EAttribute.Endurance, amount: 200 }, // survive the partial window
+					{ attributeId: EAttribute.BleedDamagePerSecond, amount: 25 }
+				]
+			});
+
+			// 10 ticks of 40ms = 400ms — under the 1-second auto-flush threshold, so nothing has logged yet.
+			for (let i = 0; i < 10; i++) {
+				logicalUpdateCallbacks[0](40);
+			}
+			expect(logMessage).not.toHaveBeenCalledWith(ELogType.SkillEffect, expect.stringContaining('damage over time'));
+
+			engine.rest();
+
+			const dotCalls = vi
+				.mocked(logMessage)
+				.mock.calls.filter(([type, msg]) => type === ELogType.SkillEffect && String(msg).includes('damage over time'));
+			expect(dotCalls).toHaveLength(1);
+			expect(dotCalls[0][1]).toBe('Goblin took 10 damage over time.');
+		});
+
+		it('flushes a partial-second DoT window from the abandoned battle when the next one is armed (#1857)', () => {
+			mockSkills[0].baseDamage = 0;
+			engine.start();
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				isBossBattle: false,
+				selectedSkills: [0],
+				attributes: [
+					{ attributeId: EAttribute.Endurance, amount: 200 },
+					{ attributeId: EAttribute.BleedDamagePerSecond, amount: 25 }
+				]
+			});
+
+			for (let i = 0; i < 10; i++) {
+				logicalUpdateCallbacks[0](40);
+			}
+			expect(logMessage).not.toHaveBeenCalledWith(ELogType.SkillEffect, expect.stringContaining('damage over time'));
+
+			engine.reset({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
+
+			const dotCalls = vi
+				.mocked(logMessage)
+				.mock.calls.filter(([type, msg]) => type === ELogType.SkillEffect && String(msg).includes('damage over time'));
+			expect(dotCalls).toHaveLength(1);
+			expect(dotCalls[0][1]).toBe('Goblin took 10 damage over time.');
+		});
+
 		// The player-only crit/dodge outcomes (#178) and deterministic reflection (#1330) surface through the
 		// combat log. Forcing a chance of 1 makes every [0,1) RNG draw succeed, so the outcome is deterministic
 		// without a seed; reflection is deterministic and needs no forced roll.


### PR DESCRIPTION
## Summary

`BattleEngine` accumulates DoT/HoT combat-log lines per second and only flushed the partial second when a battle **concluded** (victory/defeat/draw, via `flushEffectDamage()`). The abandon-shaped ends never flushed:

- `rest()` — parking in the no-combat Home zone — dropped to Idle without flushing.
- `reset(enemyInstance)` — arming the next battle (including after a retreat/zone swap) — called `resetEffectDamage()` directly, discarding whatever the current partial second had accumulated.

This contradicts the documented contract in `docs/game-design.md` → Logs: "each over-time channel is accumulated and emitted as a single line per second (with any partial second flushed at battle end)." A player retreating from a boss (or stepping Home / swapping zones) mid-window could lose up to ~1s of DoT/HoT that they actually took/dealt from the combat log. Cosmetic only — no parity or state impact (`flushEffectDamage()` only logs; it doesn't touch game state beyond what `resetEffectDamage()` already did).

## Changes

- `UI/src/lib/engine/battle/battle-engine.ts`
  - `rest()`: calls `flushEffectDamage()` before dropping to Idle.
  - `reset()`: replaced the direct `resetEffectDamage()` call with `flushEffectDamage()` (which logs any pending partial-second summary, then resets — same net state as before, plus the log line). Order preserved: still runs before `resetPlayer()`/`enemy.reset()`, so the flushed line correctly references the enemy being left behind.

## Tests

Added two cases in `UI/src/tests/lib/engine/battle/battle-engine.test.ts`:
- `rest()` flushes a partial-second DoT window (10 ticks / 400ms, under the 1s auto-flush threshold) before dropping to Idle.
- `reset()` flushes a partial-second DoT window from the abandoned battle before arming the next one.

## Test plan

- [x] `npx vitest run src/tests/lib/engine/battle/battle-engine.test.ts` — 66/66 passing (including the 2 new cases).
- [x] `npm run test:unit:ci` — full suite: 3621/3621 passing across 296 files.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.
- [ ] Backend unaffected (frontend-only, presentation-log change) — no backend verification needed.

Closes #1857


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kx1Vwe2heKv6HDFhw3Y519)_