### PR TITLE
Memoize offline simulator's combat rating and battler materials

### DIFF
--- a/Game.Core/Battle/BattleSnapshot.cs
+++ b/Game.Core/Battle/BattleSnapshot.cs
@@ -115,20 +115,35 @@ namespace Game.Core.Battle
         /// </summary>
         public Battler ToBattler(
             Func<int, Item> resolveItem, Func<int, ItemMod> resolveMod, Func<int, Skill?> resolveSkill,
+            Func<int, Proficiency>? resolveProficiency = null, Func<int, Class>? resolveClass = null) =>
+            GetBattlerMaterials(resolveItem, resolveMod, resolveSkill, resolveProficiency, resolveClass).Build();
+
+        /// <summary>
+        /// Composes this snapshot's battler assembly ingredients without the final, always-fresh
+        /// <see cref="AttributeCollection"/>/<see cref="Battler"/> construction — everything <see cref="ToBattler"/>
+        /// otherwise redoes on every call. A <see cref="Battler"/> is single-use (simulation mutates its health
+        /// and active effects), but the resolver/LINQ composition behind it is invariant for as long as this
+        /// snapshot's <see cref="StatAllocations"/>, <see cref="EquippedItems"/>, <see cref="SkillIds"/>,
+        /// <see cref="Level"/>, and <see cref="ProficiencyLevels"/> are — so a caller replaying many battles
+        /// against the same snapshot state (the offline simulator, #1730) can cache the returned
+        /// <see cref="BattlerMaterials"/> and call <see cref="BattlerMaterials.Build"/> per battle instead of
+        /// re-walking this composition every time.
+        /// </summary>
+        public BattlerMaterials GetBattlerMaterials(
+            Func<int, Item> resolveItem, Func<int, ItemMod> resolveMod, Func<int, Skill?> resolveSkill,
             Func<int, Proficiency>? resolveProficiency = null, Func<int, Class>? resolveClass = null)
         {
-            var attributes = new AttributeCollection(GetModifiers(resolveItem, resolveMod, resolveProficiency, resolveClass));
-            if (ResolveSignaturePassive(attributes, resolveClass) is { } passive)
-            {
-                attributes.AddModifier(passive);
-            }
+            var baseModifiers = GetModifiers(resolveItem, resolveMod, resolveProficiency, resolveClass).ToList();
+            var signaturePassive = ResolveSignaturePassive(new AttributeCollection(baseModifiers), resolveClass);
+
             // The weapon-match gate reads each fielded id's type via the same resolver; an id that resolves to
             // no skill (a leftover/unauthored grant such as an unseeded punch) yields a null type and is dropped
             // by OrderSkillIds, so the following Select only ever sees ids that resolve (OfType filters the
             // never-null nullable away without a null-forgiving operator).
             var skills = GetBattleSkillIds(resolveItem, id => resolveSkill(id)?.PrimaryDamageType)
                 .Select(resolveSkill)
-                .OfType<Skill>();
+                .OfType<Skill>()
+                .ToList();
 
             // The parry counter skill (#1457): the equipped weapon's signature — the virtual fists' punch
             // bare-handed — resolved once at assembly like the weapon-match gate. An unresolvable id (an
@@ -137,7 +152,7 @@ namespace Game.Core.Battle
             var weapon = ResolveEquippedWeapon(resolveItem);
             var counterSkill = resolveSkill(weapon?.GrantedSkillId ?? GameConstants.PunchSkillId);
 
-            return new Battler(attributes, skills, Level, counterSkill);
+            return new BattlerMaterials(baseModifiers, signaturePassive, skills, counterSkill, Level);
         }
 
         /// <summary>
@@ -333,5 +348,29 @@ namespace Game.Core.Battle
         /// The IDs of item mods applied to this item at battle start.
         /// </summary>
         public required List<int> AppliedModIds { get; set; }
+    }
+
+    /// <summary>
+    /// The reusable ingredients of a <see cref="BattleSnapshot"/>'s battler assembly — its composed base
+    /// attribute modifiers, resolved signature passive, fielded skills, and counter skill — everything
+    /// <see cref="BattleSnapshot.ToBattler"/> composes except the final, always-fresh
+    /// <see cref="AttributeCollection"/>/<see cref="Battler"/> construction (<see cref="Build"/>). See
+    /// <see cref="BattleSnapshot.GetBattlerMaterials"/> for when it is safe to cache and reuse an instance.
+    /// </summary>
+    public sealed class BattlerMaterials(
+        IReadOnlyList<AttributeModifier> baseModifiers, AttributeModifier? signaturePassive,
+        IReadOnlyList<Skill> skills, Skill? counterSkill, int level)
+    {
+        /// <summary>Builds a fresh, single-use <see cref="Battler"/> from these materials.</summary>
+        public Battler Build()
+        {
+            var attributes = new AttributeCollection(baseModifiers);
+            if (signaturePassive is not null)
+            {
+                attributes.AddModifier(signaturePassive);
+            }
+
+            return new Battler(attributes, skills, level, counterSkill);
+        }
     }
 }

--- a/Game.Core/Battle/DefeatRewards.cs
+++ b/Game.Core/Battle/DefeatRewards.cs
@@ -45,9 +45,22 @@ namespace Game.Core.Battle
         /// production call site by the time a victory is recorded.
         /// </summary>
         public DefeatRewards(Battler playerBattler, Enemy enemy)
+            : this(CombatRating.Rate(playerBattler, isPlayer: true), CombatRating.Rate(enemy.ToBattler(), isPlayer: false))
         {
-            EnemyRating = CombatRating.Rate(enemy.ToBattler(), isPlayer: false);
-            PlayerRating = CombatRating.Rate(playerBattler, isPlayer: true);
+        }
+
+        /// <summary>
+        /// Computes the rewards directly from already-known combat ratings, skipping the
+        /// <see cref="CombatRating.Rate"/> re-derivation the <see cref="Battler"/>-based constructor performs. For
+        /// a caller that replays many battles against an unchanged player build and/or a deterministic enemy (the
+        /// offline simulator, #1730 — the player's rating is invariant between level-ups, and a boss's rating is
+        /// invariant for the whole run), computing each rating once and passing it here is the identical reward
+        /// math with the redundant rating work removed.
+        /// </summary>
+        public DefeatRewards(double playerRating, double enemyRating)
+        {
+            PlayerRating = playerRating;
+            EnemyRating = enemyRating;
 
             // (enemyRating / playerRating)² is the time-to-kill ratio (spike #1526 Decision 1), so clamping the
             // ratio at 1 before squaring is what makes the curve saturate at a matched-or-easier fight rather than

--- a/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
+++ b/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
@@ -64,13 +64,21 @@ namespace Game.Core.Battle.Offline
             var catalog = new ProficiencyCatalog(
                 parameters.ResolveProficiency, parameters.ResolvePath, parameters.PathsForActivityKey, parameters.DependentsOf);
 
-            // The battler that measures each victory's exp reward is re-derived whenever a level-up grows the
-            // class locked base (and, through it, the signature passive) — rebuilding it eagerly here and again
-            // after every level-up, rather than lazily on next use, keeps the "current rating battler" a single
-            // invariant read at each DefeatRewards call below. It is never simulated (CombatRating.Rate only
-            // reads it), so reusing the same instance across battles between level-ups is safe even though a
-            // Battler is otherwise single-use.
-            var playerBattlerForRating = BuildRatingBattler(workingSnapshot, parameters);
+            // The materials that assemble the player's battler are re-derived whenever a level-up grows the
+            // class locked base (and, through it, the signature passive) or a proficiency level-up grows its
+            // bonuses — rebuilding them eagerly here and again after every such growth, rather than on every
+            // battle, is what lets SimulateBattle build a fresh single-use Battler per battle without re-walking
+            // the resolver/LINQ composition each time. playerRating is memoized alongside them: CombatRating.Rate
+            // is not cheap (it materializes a full attribute set twice, #1730), and it depends only on these same
+            // materials, so it is recomputed exactly when they are — not every battle.
+            var playerMaterials = BuildMaterials(workingSnapshot, parameters);
+            var playerRating = CombatRating.Rate(playerMaterials.Build(), isPlayer: true);
+
+            // The boss's own rating, memoized for the whole run: CreateBossEnemy is fully deterministic (fixed
+            // level, full authored loadout, no random roll), so in Boss mode every battle's enemy rates
+            // identically and re-deriving it per victory would be pure waste. Left null (and never consulted)
+            // in Idle mode, where each battle's random encounter genuinely differs.
+            double? bossEnemyRating = null;
 
             // Tracks whether any battle has produced progress (a win or a loss). A run that is nothing but
             // draws is a stalemate the player can neither win nor lose; the cutoff below stops it early.
@@ -84,7 +92,7 @@ namespace Game.Core.Battle.Offline
 
                 var enemy = BuildEnemy(parameters);
                 var seed = parameters.SeedSource();
-                var result = SimulateBattle(workingSnapshot, parameters, enemy, seed);
+                var result = SimulateBattle(playerMaterials, enemy, seed);
 
                 if (result.TotalMs > remainingMs)
                 {
@@ -97,10 +105,16 @@ namespace Game.Core.Battle.Offline
                 }
 
                 // Rewards are earned only on a victory, measured from the current (possibly mid-window-grown)
-                // rating battler like the live path. The same DefeatRewards yields both the exp and the combat
+                // player rating like the live path. The same DefeatRewards yields both the exp and the combat
                 // ratings the offline proficiency-XP accrual normalizes each path's activity by, so the two
-                // payouts share one evaluation.
-                var rewards = result.Victory ? new DefeatRewards(playerBattlerForRating, enemy) : null;
+                // payouts share one evaluation. The enemy rating reuses the memoized boss rating in Boss mode
+                // (populating it on the first victory) and is re-derived per victory in Idle mode, where each
+                // random encounter genuinely differs.
+                var rewards = result.Victory
+                    ? new DefeatRewards(playerRating, parameters.Mode == OfflineLoopMode.Boss
+                        ? bossEnemyRating ??= CombatRating.Rate(enemy.ToBattler(), isPlayer: false)
+                        : CombatRating.Rate(enemy.ToBattler(), isPlayer: false))
+                    : null;
                 var proficiencyGains = ProficiencyAccrualResult.Empty;
                 if (rewards is not null)
                 {
@@ -151,14 +165,16 @@ namespace Game.Core.Battle.Offline
                         workingSnapshot.Level = progression.Level;
                     }
 
-                    // Re-derive the rating battler whenever either growth vector actually moved an attribute
-                    // modifier: a player level-up (the locked base) or a proficiency level-up (its per-level/
-                    // milestone bonus) — never on XP alone, which changes nothing ModifiersForLevel reads. This
-                    // is what makes the reward-power measurement — and through it the proficiency accrual's own
-                    // rating denominator on the next battle — grow with proficiency, not just level.
+                    // Re-derive the materials (and the rating they measure) whenever either growth vector
+                    // actually moved an attribute modifier: a player level-up (the locked base) or a proficiency
+                    // level-up (its per-level/milestone bonus) — never on XP alone, which changes nothing
+                    // ModifiersForLevel reads. This is what makes the reward-power measurement — and through it
+                    // the proficiency accrual's own rating denominator on the next battle — grow with
+                    // proficiency, not just level.
                     if (progression.LevelsGained > 0 || proficiencyLeveledUp)
                     {
-                        playerBattlerForRating = BuildRatingBattler(workingSnapshot, parameters);
+                        playerMaterials = BuildMaterials(workingSnapshot, parameters);
+                        playerRating = CombatRating.Rate(playerMaterials.Build(), isPlayer: true);
                     }
                 }
 
@@ -218,11 +234,12 @@ namespace Game.Core.Battle.Offline
         };
 
         /// <summary>
-        /// Builds the battler <see cref="DefeatRewards"/> measures the player's power from — reused across
-        /// battles until the next level-up requires rebuilding it.
+        /// Builds the materials both the per-battle simulated battler and the <see cref="DefeatRewards"/> rating
+        /// battler assemble from — reused across battles until the next level-up or proficiency level-up
+        /// requires rebuilding them (#1730).
         /// </summary>
-        private static Battler BuildRatingBattler(BattleSnapshot snapshot, OfflineSimulationParameters parameters) =>
-            snapshot.ToBattler(
+        private static BattlerMaterials BuildMaterials(BattleSnapshot snapshot, OfflineSimulationParameters parameters) =>
+            snapshot.GetBattlerMaterials(
                 parameters.ResolveItem, parameters.ResolveMod, parameters.ResolveSkill,
                 parameters.ResolveProficiency, parameters.ResolveClass);
 
@@ -244,18 +261,15 @@ namespace Game.Core.Battle.Offline
 
         /// <summary>
         /// Runs one battle with the given seed (the caller draws it up front so it can carry the same seed
-        /// forward on a pending-battle hand-back, #1596), rebuilding the player from
-        /// <paramref name="snapshot"/> — the current, possibly mid-window-grown level (#1601) — which mirrors
-        /// the live replay path. Both battlers are rebuilt per battle because the simulation mutates battler
-        /// health/effects (a battler is single-use).
+        /// forward on a pending-battle hand-back, #1596), building the player from
+        /// <paramref name="playerMaterials"/> — the current, possibly mid-window-grown level (#1601) — which
+        /// mirrors the live replay path. Both battlers are rebuilt per battle because the simulation mutates
+        /// battler health/effects (a battler is single-use); the player's materials are cached by the caller and
+        /// only actually recomposed on a level-up or proficiency level-up (#1730).
         /// </summary>
-        private static BattleResult SimulateBattle(BattleSnapshot snapshot, OfflineSimulationParameters parameters, Enemy enemy, uint seed)
+        private static BattleResult SimulateBattle(BattlerMaterials playerMaterials, Enemy enemy, uint seed)
         {
-            var playerBattler = snapshot.ToBattler(
-                parameters.ResolveItem, parameters.ResolveMod, parameters.ResolveSkill,
-                parameters.ResolveProficiency, parameters.ResolveClass);
-
-            return new BattleSimulator(playerBattler, enemy.ToBattler(), seed).Simulate();
+            return new BattleSimulator(playerMaterials.Build(), enemy.ToBattler(), seed).Simulate();
         }
     }
 }

--- a/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
+++ b/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
@@ -107,14 +107,26 @@ namespace Game.Core.Battle.Offline
                 // Rewards are earned only on a victory, measured from the current (possibly mid-window-grown)
                 // player rating like the live path. The same DefeatRewards yields both the exp and the combat
                 // ratings the offline proficiency-XP accrual normalizes each path's activity by, so the two
-                // payouts share one evaluation. The enemy rating reuses the memoized boss rating in Boss mode
-                // (populating it on the first victory) and is re-derived per victory in Idle mode, where each
-                // random encounter genuinely differs.
-                var rewards = result.Victory
-                    ? new DefeatRewards(playerRating, parameters.Mode == OfflineLoopMode.Boss
-                        ? bossEnemyRating ??= CombatRating.Rate(enemy.ToBattler(), isPlayer: false)
-                        : CombatRating.Rate(enemy.ToBattler(), isPlayer: false))
-                    : null;
+                // payouts share one evaluation.
+                DefeatRewards? rewards = null;
+                if (result.Victory)
+                {
+                    // The enemy rating reuses the memoized boss rating in Boss mode (populating it on the first
+                    // victory) and is re-derived per victory in Idle mode, where each random encounter genuinely
+                    // differs. Kept as an explicit local — not folded into the DefeatRewards call — so the
+                    // bossEnemyRating cache write-back stays visible rather than buried in a ternary argument.
+                    double enemyRating;
+                    if (parameters.Mode == OfflineLoopMode.Boss)
+                    {
+                        enemyRating = bossEnemyRating ??= CombatRating.Rate(enemy.ToBattler(), isPlayer: false);
+                    }
+                    else
+                    {
+                        enemyRating = CombatRating.Rate(enemy.ToBattler(), isPlayer: false);
+                    }
+
+                    rewards = new DefeatRewards(playerRating, enemyRating);
+                }
                 var proficiencyGains = ProficiencyAccrualResult.Empty;
                 if (rewards is not null)
                 {


### PR DESCRIPTION
## Summary

`OfflineProgressSimulator` was doing constant per-battle work that only actually changes on a level-up or proficiency level-up:

- Every victory re-ran `new DefeatRewards(playerBattlerForRating, enemy)`, which calls `CombatRating.Rate` — not cheap, it materializes a full ~50-modifier attribute set twice (`BuildEffectiveCaster`/`BuildReferenceDefense`) — even though `playerBattlerForRating` itself was already only rebuilt on a level/proficiency level-up.
- In Boss mode, the enemy is fully deterministic (`CreateBossEnemy`: fixed level, full authored loadout, no random roll), so its rating was being recomputed identically on every single boss victory in a run.
- `SimulateBattle` called `snapshot.ToBattler(...)` every battle, re-walking the whole resolver/LINQ modifier composition (stat allocations, gear, class locked base, proficiency bonuses) even though everything except the level/proficiency-driven pieces is frozen for the entire run.

A 10-hour away window can credit thousands of battles, so this was a real constant-factor cost on the offline path (and on character switching, which reuses the simulator).

## Changes

- **`Game.Core/Battle/DefeatRewards.cs`**: adds a `DefeatRewards(double playerRating, double enemyRating)` overload so a caller with already-known ratings can skip re-deriving them. The existing `DefeatRewards(Battler, Enemy)` constructor now delegates to it.
- **`Game.Core/Battle/BattleSnapshot.cs`**: splits `ToBattler` into `GetBattlerMaterials` (the reusable, resolver/LINQ-composed ingredients — base attribute modifiers, resolved signature passive, fielded skills, counter skill) and a new `BattlerMaterials.Build()` (the cheap, always-fresh `AttributeCollection`/`Battler` construction a single-use battler needs every battle). `ToBattler` itself is now a thin wrapper (`GetBattlerMaterials(...).Build()`), so its existing callers and tests are unaffected.
- **`Game.Core/Battle/Offline/OfflineProgressSimulator.cs`**:
  - Caches `BattlerMaterials` and the player's `CombatRating.Rate` result, rebuilding both only when a level-up or proficiency level-up actually moves an attribute modifier (the same trigger the old rating-battler rebuild already used).
  - Memoizes the boss's rating for the whole run in Boss mode; still recomputed per victory in Idle mode, where each random encounter genuinely differs.
  - `SimulateBattle` now builds its per-battle `Battler` from the cached `BattlerMaterials` instead of re-walking `ToBattler`'s full composition.

No behavior change — this is a pure memoization refactor. The reward/rating math itself is untouched (same `CombatRating.Rate` calls, same `DefeatRewards` formula, same composition order for parity).

## Test plan

- [x] `dotnet build` — solution builds clean, 0 warnings.
- [x] `dotnet test` — full backend suite passes: 3080/3080 (`Game.Core.Tests` 1347, `Game.Infrastructure.Tests` 62, `Game.Application.Tests` 917, `Game.Api.Tests` 754), including the existing offline-simulator suite that pins in-loop growth, boundary math, and rating stationarity between level-ups (`Simulate_MidWindowLevelUps_GrowClassLockedBaseAndPlayerRating`, `Simulate_BossMode_LevelUps_GrowPlayerRatingAcrossTheWindow`, `Simulate_PendingBattle_SnapshotReflectsMidWindowGrowth_NotTheWindowStartSnapshot`, etc.) and the `DefeatRewards`/`BattleSnapshot`/`CombatRating`/battle-simulator-parity suites.
- [ ] Frontend unaffected (backend-only change) — no frontend verification needed.

Closes #1730

---
_Generated by [Claude Code](https://claude.ai/code/session_012uZkkYh7MDsSx9BtsYuTjC)_