### PR TITLE
Clamp replayToOffset's fast-forward to DEFAULT_MAX_BATTLE_MS

### DIFF
--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -222,12 +222,14 @@ export class BattleEngine {
 	 * backend `BattleSimulator.Simulate`'s loop exactly (tick death-checks, then the `totalMs - tickSize`
 	 * exit value) so the two stay in lockstep. Resolves into whichever stage {@link logicalUpdate} would
 	 * have reached by that point — defensive: the server only ever hands back an unconcluded, under-cap
-	 * battle (#1595/#1596), but the tick boundary makes replaying a conclusion possible. Bounded by
-	 * `DEFAULT_MAX_BATTLE_MS` (the server never reports a larger offset), so at most ~3000 ticks.
+	 * battle (#1595/#1596), but the tick boundary makes replaying a conclusion possible. Clamped to
+	 * `DEFAULT_MAX_BATTLE_MS` (the server never reports a larger offset, but a malformed hand-back
+	 * shouldn't run the main thread through an unbounded replay), so at most ~3000 ticks.
 	 */
 	private replayToOffset(offsetMs: number) {
+		const cappedOffsetMs = Math.min(offsetMs, DEFAULT_MAX_BATTLE_MS);
 		let totalMs = tickSize;
-		for (; totalMs <= offsetMs; totalMs += tickSize) {
+		for (; totalMs <= cappedOffsetMs; totalMs += tickSize) {
 			battleStep(this.player, this.enemy, tickSize, this.rng);
 			if (this.enemy.isDead || this.player.isDead) {
 				break;

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -582,6 +582,27 @@ describe('BattleEngine', () => {
 			expect(engine.timeElapsed).toBe(DEFAULT_MAX_BATTLE_MS);
 			expect(logMessage).toHaveBeenCalledWith(ELogType.EnemyDefeated, expect.stringContaining('draw'));
 		});
+
+		// Defensive: a malformed hand-back (e.g. a raw away-window offset) must not run the replay past the
+		// 2-minute cap — the loop clamps rather than trusting offsetMs outright.
+		it('clamps an oversized offset to the 2-minute cap instead of replaying past it', () => {
+			mockSkills[0].baseDamage = 0; // a true stalemate: neither side can ever land the killing blow
+			engine.start();
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				isBossBattle: false,
+				selectedSkills: [0],
+				attributes: [],
+				elapsedOffsetMs: DEFAULT_MAX_BATTLE_MS * 100
+			});
+
+			expect(engine.stage).toBe(BattleStage.Drawn);
+			expect(engine.timeElapsed).toBe(DEFAULT_MAX_BATTLE_MS);
+			expect(logMessage).toHaveBeenCalledWith(ELogType.EnemyDefeated, expect.stringContaining('draw'));
+		});
 	});
 
 	describe('startLoading', () => {


### PR DESCRIPTION
## Summary

`BattleEngine.replayToOffset`'s doc comment (`UI/src/lib/engine/battle/battle-engine.ts`) claimed the fast-forward replay was "Bounded by `DEFAULT_MAX_BATTLE_MS` … so at most ~3000 ticks," but the loop actually ran to whatever `offsetMs` arrived — nothing clamped it.

Today only the trusted server supplies the offset (bounded server-side, matching the backend's own `BattleSimulator.Simulate`, which already bounds its tick loop by `limit`), so this was defensive rather than a live defect. But a malformed hand-back (e.g. a backend regression returning a raw away-window offset) would have synchronously run an unbounded number of `battleStep` calls on the main thread, and could then declare a `Drawn` at a `timeElapsed` past the cap — a state the headless parity simulator can never reach.

## Changes

- `battle-engine.ts`: `replayToOffset` now clamps `offsetMs` to `DEFAULT_MAX_BATTLE_MS` via `Math.min` before the replay loop, and the doc comment is updated to describe the clamp instead of merely asserting it.
- `battle-engine.test.ts`: new test pinning that an oversized offset (`DEFAULT_MAX_BATTLE_MS * 100`) stops the replay at the cap and resolves `Drawn`, mirroring the existing "offset lands exactly on the cap" test.

No behavior change for the trusted-server path — this only changes what happens with an out-of-contract offset.

## Test plan

- [x] `npx vitest run src/tests/lib/engine/battle/battle-engine.test.ts` — 67/67 passing, including the new clamp test.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — full frontend suite passes: 3622/3622.
- [ ] Backend unaffected (frontend-only defensive fix; the backend simulator already bounds its own loop) — no backend verification needed.

Closes #1733

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBvpKPUox6evW8vuoxQ442)_