### PR TITLE
Battle tick-loop micro-optimizations: precompute amp/resist arrays; gate log formatting on enabled types

### DIFF
--- a/UI/src/lib/battle/damage-types.ts
+++ b/UI/src/lib/battle/damage-types.ts
@@ -69,24 +69,36 @@ export function attributesForKey(key: EDamageTypeKey): DamageTypeKeyAttributes {
 	return DAMAGE_TYPE_KEY_ATTRIBUTES[key];
 }
 
+// Amplification/resistance attribute lists per leaf type, precomputed once (mirrors the backend's
+// `DamageTypes.AmplificationByType`/`ResistanceByType`) so the per-hit/per-tick lookup in the damage
+// pipeline is a map read rather than rebuilding an array on every call.
+const AMPLIFICATION_ATTRIBUTES_BY_TYPE: ReadonlyMap<EDamageType, readonly EAttribute[]> = new Map(
+	Object.entries(DAMAGE_TYPE_APPLIES).map(([type, keys]) => [
+		Number(type) as EDamageType,
+		keys.map((key) => DAMAGE_TYPE_KEY_ATTRIBUTES[key].amplification)
+	])
+);
+
+const RESISTANCE_ATTRIBUTES_BY_TYPE: ReadonlyMap<EDamageType, readonly EAttribute[]> = new Map(
+	Object.entries(DAMAGE_TYPE_APPLIES).map(([type, keys]) => [
+		Number(type) as EDamageType,
+		keys
+			.map((key): EAttribute | null => DAMAGE_TYPE_KEY_ATTRIBUTES[key].resistance)
+			.filter((resistance): resistance is EAttribute => resistance !== null)
+	])
+);
+
 /** The attacker-side amplification attributes summed for a hit of the given leaf `type`, in fixed
  *  iteration order (per-hit lookup helper for the damage pipeline). */
-export function amplificationAttributes(type: EDamageType): EAttribute[] {
-	return applies(type).map((key) => DAMAGE_TYPE_KEY_ATTRIBUTES[key].amplification);
+export function amplificationAttributes(type: EDamageType): readonly EAttribute[] {
+	return AMPLIFICATION_ATTRIBUTES_BY_TYPE.get(type) ?? [];
 }
 
 /** The defender-side resistance attributes summed for a hit of the given leaf `type`, in fixed
  *  iteration order (per-hit lookup helper for the damage pipeline). Amplification-only weapon keys (#1340)
  *  contribute no resistance, so they drop out — a weapon hit resists via the shared `Physical` key only. */
-export function resistanceAttributes(type: EDamageType): EAttribute[] {
-	const resistances: EAttribute[] = [];
-	for (const key of applies(type)) {
-		const { resistance } = DAMAGE_TYPE_KEY_ATTRIBUTES[key];
-		if (resistance !== null) {
-			resistances.push(resistance);
-		}
-	}
-	return resistances;
+export function resistanceAttributes(type: EDamageType): readonly EAttribute[] {
+	return RESISTANCE_ATTRIBUTES_BY_TYPE.get(type) ?? [];
 }
 
 // The attribute → key inverse, precomputed once (mirrors the backend's `DamageTypes.KeyByAttribute`)

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -366,29 +366,35 @@ export class BattleEngine {
 		if (this.stage === Active) {
 			this.timeElapsed += timeDelta;
 			const activations = battleStep(this.player, this.enemy, timeDelta, this.rng, this.stepLog);
+			const damageLogEnabled = playerManager.logTypeEnabled(ELogType.Damage);
 			for (const { skill, damage, byPlayer, crit, dodged, parried, counter, reflected } of activations) {
 				const outcome = damageLogOutcome(byPlayer, crit, dodged, parried, counter);
 				const damageType = skill.primaryDamageType;
-				// Classify the hit's resist outcome from the defender's live resistance to its type (a dodged or
-				// parried hit never resolved, so it can't be resisted). Computed here, not in the parity-critical
-				// battleStep, so the headless simulator stays byte-identical — like the existing crit/dodge log flags.
-				const resist =
-					dodged || parried
-						? 'normal'
-						: classifyResist(resistanceTotal(damageType, (byPlayer ? this.enemy : this.player).attributes), damage);
-				logMessage(
-					ELogType.Damage,
-					damageLogMessage(skill.name, damage, outcome, damageType, resist, this.enemy.name),
-					outcome,
-					resist === 'normal' ? undefined : resist
-				);
+				// Skip the resist classification and message formatting when the Damage log is disabled — it's
+				// the busiest channel in a hidden tab, and `logMessage` would only discard the built string
+				// anyway. Classification is computed here, not in the parity-critical battleStep, so the
+				// headless simulator stays byte-identical — like the existing crit/dodge log flags.
+				if (damageLogEnabled) {
+					const resist =
+						dodged || parried
+							? 'normal'
+							: classifyResist(resistanceTotal(damageType, (byPlayer ? this.enemy : this.player).attributes), damage);
+					logMessage(
+						ELogType.Damage,
+						damageLogMessage(skill.name, damage, outcome, damageType, resist, this.enemy.name),
+						outcome,
+						resist === 'normal' ? undefined : resist
+					);
+				}
 				notifyCombatFloat(combatFloatEvent(outcome, damage, damageType, skill.damagePortions));
 				// Deterministic reflection (#1330): the defender returned part of this hit to the attacker. The
 				// reflector is the opposite side of the activation — a player hit is reflected by the enemy, and an
 				// enemy hit by the player — and it deals raw, untyped damage, so the line carries no resist note.
 				if (reflected > 0) {
-					const reflectOutcome: ReflectOutcome = byPlayer ? 'enemy-reflect' : 'player-reflect';
-					logMessage(ELogType.Damage, reflectLogMessage(reflectOutcome, reflected, this.enemy.name), reflectOutcome);
+					if (damageLogEnabled) {
+						const reflectOutcome: ReflectOutcome = byPlayer ? 'enemy-reflect' : 'player-reflect';
+						logMessage(ELogType.Damage, reflectLogMessage(reflectOutcome, reflected, this.enemy.name), reflectOutcome);
+					}
 					// Float the returned damage over the original attacker (the side that took it): a player hit
 					// reflected by the enemy lands back on the player, an enemy hit reflected by the player on the enemy.
 					notifyCombatFloat({ target: byPlayer ? 'player' : 'enemy', kind: 'reflect', amount: reflected });
@@ -438,6 +444,9 @@ export class BattleEngine {
 	 *  follows the shared `.find`-by-id convention (#297), falling back to the formatted enum name when
 	 *  the reference set is unavailable. */
 	private logEffectApplications() {
+		if (!playerManager.logTypeEnabled(ELogType.SkillEffect)) {
+			return;
+		}
 		for (const { effect, onPlayer, amount } of this.stepLog.appliedEffects) {
 			const name = attributeName(effect.attributeId, staticData.attributes);
 			const isHarmful = attributeIsHarmful(effect.attributeId, staticData.attributes);

--- a/UI/src/tests/lib/engine/battle/battle-engine-parity.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine-parity.test.ts
@@ -31,7 +31,10 @@ const mockPlayerManager = {
 	selectedSkills: [] as number[],
 	attributes: [] as IBattlerAttribute[],
 	battleLockedBaseModifiers: [] as unknown[],
-	battleSignaturePassiveModifier: () => ({ attribute: 0, amount: 0, type: 1, source: 9 })
+	battleSignaturePassiveModifier: () => ({ attribute: 0, amount: 0, type: 1, source: 9 }),
+	// Every log type enabled, mirroring the real manager's `?? true` fallback — irrelevant to the parity
+	// assertions themselves (logging is outside `battleStep`), just needed so `logicalUpdate` doesn't throw.
+	logTypeEnabled: () => true
 };
 // The weapon-match gate's equipped weapon type is left undefined so the player is ungated, matching the
 // comparison simulator battlers (which field their full loadout); the scenarios use weapon-agnostic skills.

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -47,7 +47,14 @@ const { mockSkills, mockEnemies, mockAttributes, mockPlayerManager, mockInventor
 				amount: 0,
 				type: 1,
 				source: 9
-			})
+			}),
+			// Every log type enabled by default, mirroring the real manager's `?? true` fallback. Typed with
+			// the real `ELogType` param (type-only, erased at runtime) so tests can override with a
+			// type-checked predicate without referencing the enum's runtime value from this hoisted factory.
+			logTypeEnabled: (logType: ELogType) => {
+				void logType;
+				return true;
+			}
 		};
 		const mockInventoryManager = {
 			equipmentStats: [] as { attributeId: number; amount: number }[],
@@ -745,6 +752,34 @@ describe('BattleEngine', () => {
 			);
 		});
 
+		it('skips building the damage log line when the Damage log type is disabled, but still floats the hit', () => {
+			mockPlayerManager.logTypeEnabled = (logType: ELogType) => logType !== ELogType.Damage;
+			const events: CombatFloatEvent[] = [];
+			const unhook = onCombatFloat((event) => events.push(event));
+			engine.start();
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
+
+			logicalUpdateCallbacks[0](500);
+			unhook();
+			mockPlayerManager.logTypeEnabled = () => true;
+
+			expect(logMessage).not.toHaveBeenCalledWith(
+				ELogType.Damage,
+				expect.anything(),
+				expect.anything(),
+				expect.anything()
+			);
+			expect(events).toContainEqual(expect.objectContaining({ target: 'enemy', kind: 'hit' }));
+		});
+
 		it('surfaces the damage type and resist outcome for a typed hit on a resistant defender (#1320)', () => {
 			// A fire skill into a fire-resistant enemy: the engine names the type and flags the resist on the line.
 			mockSkills[0].damagePortions = [{ type: EDamageType.Fire, weight: 1 }];
@@ -893,6 +928,37 @@ describe('BattleEngine', () => {
 			logicalUpdateCallbacks[0](500); // the 500ms-cooldown skill fires, applying its self buff
 
 			expect(logMessage).toHaveBeenCalledWith(ELogType.SkillEffect, expect.stringContaining('empowered'));
+		});
+
+		it('skips building skill-effect log lines when the SkillEffect log type is disabled', () => {
+			mockSkills[0].effects = [
+				{
+					id: 1,
+					target: ESkillEffectTarget.Self,
+					attributeId: EAttribute.Strength,
+					modifierTypeId: EModifierType.Additive,
+					amount: 15,
+					durationMs: 1000,
+					scalingAttributeId: EAttribute.Strength,
+					scalingAmount: 0
+				}
+			];
+			mockPlayerManager.logTypeEnabled = (logType: ELogType) => logType !== ELogType.SkillEffect;
+			engine.start();
+			enemyLoadedCallbacks[0]({
+				id: 1,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			});
+
+			logicalUpdateCallbacks[0](500); // the 500ms-cooldown skill fires, applying its self buff
+
+			mockPlayerManager.logTypeEnabled = () => true;
+			expect(logMessage).not.toHaveBeenCalledWith(ELogType.SkillEffect, expect.anything());
 		});
 
 		it('aggregates damage-over-time into a single per-second summary line', () => {


### PR DESCRIPTION
## Summary

Two zero-parity-risk perf fixes in the always-on 25Hz logical battle loop (`UI/src/lib/engine/battle/battle-engine.ts`), which keeps running at full rate in hidden tabs and is amplified by `replayToOffset`'s synchronous up-to-3000-tick fast-forward:

1. **Per-call array building in the typed-damage lookups.** `amplificationAttributes()`/`resistanceAttributes()` (`UI/src/lib/battle/damage-types.ts`) rebuilt an array on every call — per portion per hit, per DoT type per tick, plus per activation in `classifyResist`. Both are now precomputed once into `ReadonlyMap<EDamageType, readonly EAttribute[]>` at module load, keyed by leaf damage type, mirroring the backend's already-precomputed `DamageTypes.AmplificationByType`/`ResistanceByType`. Same values, same fixed iteration order — no parity surface (the fold order downstream in `battle-formulas.ts` is unchanged).
2. **Log-line strings built before the enabled check.** `logMessage` (`log.ts`) already discards a message if the player disabled that log channel, but `battle-engine.ts` built `damageLogMessage`/`reflectLogMessage` (plus `classifyResist`/`resistanceTotal`) and `effectLogMessage` (plus `attributeName`/`attributeIsHarmful`) unconditionally before calling it — Damage is the busiest channel in a hidden tab. Both paths now check `playerManager.logTypeEnabled(...)` first and skip the formatting work entirely when disabled. The combat floaters (`notifyCombatFloat`) are untouched — they don't depend on the log text, only on the (still-computed) `outcome`/`damageType`.

No behavior change: `applies()`/`attributesForKey()` and their fixed iteration order are untouched, and the existing damage-types/battle-formulas/battle-simulation-parity suites (which pin exact values and order) all pass unchanged.

## Changes

- `UI/src/lib/battle/damage-types.ts`: `amplificationAttributes`/`resistanceAttributes` now read from precomputed maps instead of rebuilding arrays; return type widened to `readonly EAttribute[]` since the arrays are now shared/cached (callers only ever iterate them).
- `UI/src/lib/engine/battle/battle-engine.ts`: `logicalUpdate`'s damage/reflect log lines and `logEffectApplications`'s skill-effect log lines are now gated behind `playerManager.logTypeEnabled(...)`.
- Test mocks (`battle-engine.test.ts`, `battle-engine-parity.test.ts`) updated with a `logTypeEnabled` stub (defaulting to enabled, matching the real manager's `?? true` fallback), plus two new tests pinning that disabling a log channel skips `logMessage` for that channel while the combat float still fires.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npx vitest run` (`test:unit:ci`, full suite with coverage) — 3624/3624 passing.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1734


---
_Generated by [Claude Code](https://claude.ai/code/session_016juTUTqQRBgiSZnnmVWuce)_