### PR TITLE
Split CodexView's reactive layer into per-tab view classes

### DIFF
--- a/UI/src/routes/game/screens/codex/StatisticsPanel.svelte
+++ b/UI/src/routes/game/screens/codex/StatisticsPanel.svelte
@@ -24,7 +24,7 @@
 </div>
 
 <script lang="ts">
-import type { EntityStatVM } from './codex-view.svelte';
+import type { EntityStatVM } from './codex-display';
 
 interface Props {
 	/** The statistics referencing this entity (label + formatted value). */

--- a/UI/src/routes/game/screens/codex/codex-display.ts
+++ b/UI/src/routes/game/screens/codex/codex-display.ts
@@ -19,6 +19,13 @@ export type EnemySort = 'level' | 'name';
 /** A zone's progression status on the Zones rail. */
 export type ZoneStatus = 'cleared' | 'unlocked' | 'locked';
 
+/** A single per-entity statistic row shown in a dossier's "Your record" section
+ *  (shared by the enemy, zone and skill dossiers). */
+export interface EntityStatVM {
+	label: string;
+	value: string;
+}
+
 export const CODEX_TABS: CodexTab[] = ['enemies', 'zones', 'skills'];
 
 export const ENEMY_FILTERS: { key: EnemyFilter; label: string }[] = [

--- a/UI/src/routes/game/screens/codex/codex-display.ts
+++ b/UI/src/routes/game/screens/codex/codex-display.ts
@@ -3,6 +3,7 @@
    restyles with the theme. Kept store-free (no reactive state) so the view-model and its tests import
    the types/formatters without a cycle. */
 
+import type { IEnemy, ISkill, IZone } from '$lib/api';
 import { formatNum } from '$lib/common';
 import type { LevelRange } from './enemy-level';
 import type { SkillAcquisitionStatus } from './skill-provenance';
@@ -119,3 +120,16 @@ export function sortEnemyRows(sort: EnemySort): (a: EnemySearchSortFields, b: En
 			return (a, b) => a.level - b.level || a.name.localeCompare(b.name);
 	}
 }
+
+/* ── catalogue helpers (shared by every tab's reactive layer) — retirement keeps a slot resolvable
+   but out of the glossary. ── */
+
+/** Live (non-retired) enemies. */
+export const liveEnemies = (enemies: IEnemy[] | undefined): IEnemy[] => (enemies ?? []).filter((e) => !e.retiredAt);
+
+/** Live (non-retired) zones in authored progression order. */
+export const liveZones = (zones: IZone[] | undefined): IZone[] =>
+	(zones ?? []).filter((z) => !z.retiredAt).sort((a, b) => a.order - b.order);
+
+/** Live (non-retired) skills in catalogue order. */
+export const liveSkills = (skills: ISkill[] | undefined): ISkill[] => (skills ?? []).filter((s) => !s.retiredAt);

--- a/UI/src/routes/game/screens/codex/codex-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/codex-view.svelte.ts
@@ -35,6 +35,7 @@ import {
 	type EnemyFilter,
 	type EnemySort,
 	type EnemySubTab,
+	type EntityStatVM,
 	tabAccent,
 	tabLabel
 } from './codex-display';
@@ -90,13 +91,6 @@ export interface CodexTabVM {
 	count: number;
 	accent: string;
 	active: boolean;
-}
-
-/** A single per-entity statistic row shown in a dossier's "Your record" section
- *  (shared by the enemy, zone and skill dossiers). */
-export interface EntityStatVM {
-	label: string;
-	value: string;
 }
 
 /* ── reactive view-model ──────────────────────────────────────────────────── */

--- a/UI/src/routes/game/screens/codex/codex-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/codex-view.svelte.ts
@@ -19,55 +19,61 @@
    section, and the Statistics screen deep-links an entity into the matching dossier instead of
    rendering its own in-place one.
 
-   The view-model only wires reactive state to the pure helpers; the projection maths live in
-   `enemy-level` and the shared `$lib/common/enemy-attributes` (unit-tested directly). */
+   The reactive layer is composed from one class per tab (`EnemiesTabView`, `ZonesTabView`,
+   `SkillsTabView`, each in its own `*-tab-view.svelte.ts` file) so every tab's derivations stay
+   independently readable/testable. This CodexView is the thin orchestrator: it owns only what's
+   genuinely cross-tab — the active tab, the once-fetched player statistics + challenge-error state,
+   the shared statistics query engine, and the cross-links between dossiers — and every other
+   property/method below simply delegates to the owning tab's instance, so consuming components (and
+   the existing tests) keep reading `view.<x>` exactly as before. */
 
-import { EEntityType, ERarity, type IEnemy, type IPlayerStatistic, type ISkill, type IZone } from '$lib/api';
+import type { IPlayerStatistic } from '$lib/api';
+import { staticData } from '$stores';
 import {
-	type EnemyAttributes,
-	attributeCode,
-	attributeColor,
-	attributeIsHarmful,
-	attributeName,
-	challengeTypeColor,
-	challengeTypeName,
-	describeEffect,
-	effectDirectionColor,
-	enemyAttributesAtLevel,
-	formatNum,
-	rarityColor,
-	rarityLabel
-} from '$lib/common';
-import { playerChallenges, staticData, statistics } from '$stores';
-import { fmtValue } from '../stats/statistics-display';
-import {
-	type StatEntityKind,
-	StatisticsData,
-	buildStatEntities,
-	buildStatTypes
-} from '../stats/statistics-view.svelte';
-import {
+	CODEX_TABS,
 	type CodexTab,
 	type EnemyFilter,
 	type EnemySort,
 	type EnemySubTab,
-	type ZoneStatus,
-	CODEX_TABS,
-	enemyAccent,
-	enemyKindLabel,
-	formatBand,
-	formatBaseDamage,
-	formatCooldown,
-	matchesEnemySearch,
-	resolveZoneStatus,
-	sortEnemyRows,
 	tabAccent,
-	tabLabel,
-	SKILL_ACQUISITION_EMPTY,
-	SKILL_SOURCE_LABEL
+	tabLabel
 } from './codex-display';
-import { type LevelRange, levelRange, spawnShare, zoneTotalWeight } from './enemy-level';
-import { type SkillAcquisitionStatus, resolveSkillProvenance } from './skill-provenance';
+import {
+	EnemiesTabView,
+	type EnemyChallengeVM,
+	type EnemyRowVM,
+	type EnemySkillVM,
+	type EnemySpawnVM,
+	type SubTabVM
+} from './enemies-tab-view.svelte';
+import {
+	SkillsTabView,
+	type SkillEffectVM,
+	type SkillProvenanceVM,
+	type SkillRarityVM,
+	type SkillRowVM,
+	type SkillScalingVM,
+	type SkillUserVM
+} from './skills-tab-view.svelte';
+import {
+	ZonesTabView,
+	type ZoneBossVM,
+	type ZoneProjectionVM,
+	type ZoneRowVM,
+	type ZoneSpawnVM,
+	type ZoneUnlockVM
+} from './zones-tab-view.svelte';
+import { fmtValue } from '../stats/statistics-display';
+import {
+	StatisticsData,
+	type StatEntityKind,
+	buildStatEntities,
+	buildStatTypes
+} from '../stats/statistics-view.svelte';
+
+// Re-exported so importers of the pre-split `CodexView` module still resolve these tab-projection
+// types (e.g. the CodexView test suite) without reaching into the per-tab files directly.
+export type { EnemyRowVM, ZoneProjectionVM };
 
 /** A one-shot payload handed to the Codex via the navigation store (e.g. from the Statistics screen). */
 export interface CodexNavPayload {
@@ -78,45 +84,12 @@ export interface CodexNavPayload {
 	sub?: EnemySubTab;
 }
 
-/* ── projected row/card view-models (presentational shapes the components render) ── */
-
 export interface CodexTabVM {
 	key: CodexTab;
 	label: string;
 	count: number;
 	accent: string;
 	active: boolean;
-}
-
-export interface EnemyRowVM {
-	id: number;
-	name: string;
-	isBoss: boolean;
-	band: string;
-	/** Numeric sort key for the level metric (the band's low end). */
-	level: number;
-	zoneCount: number;
-	skillCount: number;
-	/** Pre-lowercased search haystack: name + kind + zone names (spawn zones, or a boss's encounter zone). */
-	searchText: string;
-}
-
-export interface SubTabVM {
-	key: EnemySubTab;
-	label: string;
-}
-
-export interface EnemySkillVM {
-	id: number;
-	name: string;
-	meta: string;
-}
-
-export interface EnemySpawnVM {
-	zoneId: number;
-	zoneName: string;
-	share: number;
-	weightLabel: string;
 }
 
 /** A single per-entity statistic row shown in a dossier's "Your record" section
@@ -126,159 +99,11 @@ export interface EntityStatVM {
 	value: string;
 }
 
-export interface EnemyChallengeVM {
-	id: number;
-	name: string;
-	typeLabel: string;
-	accent: string;
-	progressText: string;
-	completed: boolean;
-}
-
-/** The immutable per-zone fields (everything the rail row needs except the live progression status). */
-export interface ZoneProjectionVM {
-	id: number;
-	name: string;
-	band: string;
-	/** Enemies (excluding the boss) that spawn in this zone. */
-	spawnCount: number;
-	hasBoss: boolean;
-}
-
-export interface ZoneRowVM extends ZoneProjectionVM {
-	status: ZoneStatus;
-}
-
-export interface ZoneBossVM {
-	enemyId: number;
-	name: string;
-	level: number;
-}
-
-export interface ZoneSpawnVM {
-	enemyId: number;
-	enemyName: string;
-	share: number;
-	weightLabel: string;
-}
-
-export interface ZoneUnlockVM {
-	challengeId: number;
-	challengeName: string;
-	/** Whether the gate is still sealed (the gating challenge isn't complete). */
-	sealed: boolean;
-}
-
-export interface SkillRowVM {
-	id: number;
-	name: string;
-	/** Base damage, or `—` for a utility skill. */
-	baseDamageLabel: string;
-	/** Cooldown, or `—` for an instant/utility skill. */
-	cooldownLabel: string;
-	/** How many (non-retired) enemies have this skill in their pool. */
-	usedByCount: number;
-	/** Themeable rarity hue for the row's tier mark. */
-	rarityColor: string;
-}
-
-/** The selected skill's rarity tier (hue + label) for the dossier header. */
-export interface SkillRarityVM {
-	color: string;
-	label: string;
-}
-
-export interface SkillScalingVM {
-	attributeId: number;
-	name: string;
-	code: string;
-	/** Magnitude badge, e.g. `×1.5`. */
-	multiplierLabel: string;
-	color: string;
-}
-
-export interface SkillEffectVM {
-	id: number;
-	/** Signed/`×` magnitude badge, e.g. `+15` or `×0.5`. */
-	magnitude: string;
-	attributeName: string;
-	/** `self` / `enemy`, the side the effect lands on. */
-	targetLabel: string;
-	/** Duration in seconds, e.g. `5s`. */
-	duration: string;
-	/** Themed buff/debuff accent for the magnitude. */
-	color: string;
-}
-
-export interface SkillUserVM {
-	enemyId: number;
-	name: string;
-	isBoss: boolean;
-	accent: string;
-}
-
-/** A "how to obtain" source row — an item that grants the skill. */
-export interface SkillSourceVM {
-	kind: 'item';
-	id: number;
-	/** "Granted by" lead-in. */
-	label: string;
-	name: string;
-	/** Themed accent: the granting item's rarity hue. */
-	accent: string;
-}
-
-/** The skill dossier's acquisition section: concrete sources, plus the wording for the no-source case. */
-export interface SkillProvenanceVM {
-	status: SkillAcquisitionStatus;
-	sources: SkillSourceVM[];
-	/** Wording for the no-source case (empty when sources exist). */
-	emptyLabel: string;
-}
-
-const SUB_TAB_DEFS: SubTabVM[] = [
-	{ key: 'attributes', label: 'Attributes' },
-	{ key: 'statistics', label: 'Statistics' },
-	{ key: 'skills', label: 'Skills' },
-	{ key: 'spawns', label: 'Spawns' }
-];
-
-/* ── catalogue helpers (one definition, reused by the reactive deriveds and the constructor's
-   non-reactive store reads) — retirement keeps a slot resolvable but out of the glossary. ── */
-
-/** Live (non-retired) enemies. */
-const liveEnemies = (enemies: IEnemy[] | undefined): IEnemy[] => (enemies ?? []).filter((e) => !e.retiredAt);
-
-/** Live (non-retired) zones in authored progression order. */
-const liveZones = (zones: IZone[] | undefined): IZone[] =>
-	(zones ?? []).filter((z) => !z.retiredAt).sort((a, b) => a.order - b.order);
-
-/** Live (non-retired) skills in catalogue order. */
-const liveSkills = (skills: ISkill[] | undefined): ISkill[] => (skills ?? []).filter((s) => !s.retiredAt);
-
 /* ── reactive view-model ──────────────────────────────────────────────────── */
 
 export class CodexView {
 	/** Active top-level tab. */
 	tab = $state<CodexTab>('enemies');
-	/** Inspected enemy id (falls back to the head of the list when unresolved). */
-	selectedEnemyId = $state<number>(-1);
-	/** Inspected zone id (falls back to the head of the rail when unresolved). */
-	selectedZoneId = $state<number>(-1);
-	/** Inspected skill id (falls back to the head of the catalogue when unresolved). */
-	selectedSkillId = $state<number>(-1);
-	/** Active dossier sub-tab. */
-	sub = $state<EnemySubTab>('attributes');
-	/** Level the Attributes sub-tab scales the selected enemy to. */
-	level = $state<number>(1);
-	/** Whether the Attributes sub-tab reveals the base + per-level scaling breakdown. */
-	scaling = $state<boolean>(false);
-	/** Enemy-table filter chip. */
-	filter = $state<EnemyFilter>('all');
-	/** Enemy-table search query (matched against name, kind and spawn zones). */
-	search = $state('');
-	/** Enemy-table sort metric. */
-	sort = $state<EnemySort>('level');
 
 	/** The player's statistic values (fetched on mount via the shared statistics store). */
 	stats = $state<IPlayerStatistic[]>([]);
@@ -288,42 +113,43 @@ export class CodexView {
 	 *  Challenges sub-tab doesn't render zero-progress/sealed as if it were authoritative. */
 	challengesError = $state(false);
 
+	private readonly enemiesTab: EnemiesTabView;
+	private readonly zonesTab: ZonesTabView;
+	private readonly skillsTab: SkillsTabView;
+
 	constructor(payload?: CodexNavPayload) {
 		if (payload?.tab) {
 			this.tab = payload.tab;
 		}
-		if (payload?.sub) {
-			this.sub = payload.sub;
-		}
-		// Resolve the initial enemy (the deep-link target, else the head of the list) so the table
-		// highlights what the dossier shows. Reads stores directly to avoid touching a $derived here.
-		const initial = this.resolveEnemy(payload?.enemyId ?? -1);
-		if (initial) {
-			this.selectedEnemyId = initial.id;
-		}
-		this.level = this.levelFor(initial);
-		// Same for the zone rail, so its selection is highlighted from the first render.
-		const initialZone = this.resolveZone(payload?.zoneId ?? -1);
-		if (initialZone) {
-			this.selectedZoneId = initialZone.id;
-		}
-		// …and the skill table (the deep-link target, else the head of the catalogue).
-		const initialSkill = this.resolveSkill(payload?.skillId ?? -1);
-		if (initialSkill) {
-			this.selectedSkillId = initialSkill.id;
-		}
+		const projectStats = (kind: StatEntityKind, id: number): EntityStatVM[] => this.statVMsFor(kind, id);
+		this.enemiesTab = new EnemiesTabView({ enemyId: payload?.enemyId, sub: payload?.sub }, projectStats);
+		this.zonesTab = new ZonesTabView({ zoneId: payload?.zoneId }, projectStats);
+		this.skillsTab = new SkillsTabView({ skillId: payload?.skillId }, projectStats);
 	}
 
-	/* ── catalogue ───────────────────────────────────────────────────────────── */
+	/* ── shared statistics query (feeds every tab's "your record" dossier section) ──────────────── */
 
-	readonly enemies = $derived(liveEnemies(staticData.enemies));
+	/** The statistic query engine, rebuilt from the live reference data + fetched values. */
+	readonly statData = $derived(
+		new StatisticsData(buildStatTypes(staticData.statisticTypes ?? []), this.stats, buildStatEntities())
+	);
+
+	/** Project the statistics referencing an entity into dossier "your record" rows. */
+	private statVMsFor(kind: StatEntityKind, id: number): EntityStatVM[] {
+		return this.statData.statsForEntity(kind, id).map((info) => ({
+			label: info.stat.name,
+			value: fmtValue(info.value, info.stat.unit)
+		}));
+	}
+
+	/* ── tabs ─────────────────────────────────────────────────────────────────── */
 
 	/** Top-level tabs with live counts + section accents. */
 	readonly tabs = $derived.by<CodexTabVM[]>(() => {
 		const counts: Record<CodexTab, number> = {
-			enemies: this.enemies.length,
-			zones: this.zones.length,
-			skills: this.skillsCatalogue.length
+			enemies: this.enemiesTab.enemies.length,
+			zones: this.zonesTab.zones.length,
+			skills: this.skillsTab.skillsCatalogue.length
 		};
 		return CODEX_TABS.map((key) => ({
 			key,
@@ -334,487 +160,214 @@ export class CodexView {
 		}));
 	});
 
-	/** Immutable per-enemy view-models — depends only on reference data (enemies + zones), so the heavy
-	 *  projection (level band, the zone-name search haystack incl. the per-boss `zones.find`) is built
-	 *  once and reused, rather than rebuilt on every search keystroke / sort / filter change. */
-	readonly enemyProjections = $derived.by<EnemyRowVM[]>(() => {
-		const zones = staticData.zones ?? [];
-		return this.enemies.map((e) => {
-			const range = levelRange(e, zones);
-			// Bosses don't populate `spawns`; resolve their encounter zone the same way the dossier
-			// does so a boss is findable by that zone name. Normal enemies use their spawn zones.
-			const zoneNames = e.isBoss
-				? [zones.find((z) => z?.bossEnemyId === e.id)?.name ?? '']
-				: e.spawns.map((sp) => zones[sp.zoneId]?.name ?? '');
-			return {
-				id: e.id,
-				name: e.name,
-				isBoss: e.isBoss,
-				band: formatBand(range),
-				level: range.min,
-				zoneCount: e.isBoss ? 1 : e.spawns.length,
-				skillCount: e.skillPool.length,
-				searchText: [e.name, enemyKindLabel(e.isBoss), ...zoneNames].join(' ').toLowerCase()
-			};
-		});
-	});
-
-	/** Enemy table rows: the immutable projections narrowed by the active filter + search query and
-	 *  ordered by the active sort — the only work that reruns as the player types or re-sorts. The
-	 *  filter/search/sort maths are the pure helpers in `codex-display`. */
-	readonly enemyRows = $derived.by<EnemyRowVM[]>(() =>
-		this.enemyProjections
-			.filter((row) => this.filter === 'all' || (this.filter === 'boss' ? row.isBoss : !row.isBoss))
-			.filter((row) => matchesEnemySearch(row, this.search))
-			.sort(sortEnemyRows(this.sort))
-	);
-
-	/** Number of enemies shown under the active filter + search (the "N shown" readout). */
-	readonly shownCount = $derived(this.enemyRows.length);
-
-	/* ── selected enemy + dossier ──────────────────────────────────────────────── */
-
-	/** The inspected enemy: an explicitly-requested id resolves even when retired (retirement keeps a
-	 *  record's slot resolvable by design — see backend.md → _Reference Data_), so a cross-link into a
-	 *  retired enemy opens it rather than silently falling back. With no resolvable explicit id, falls
-	 *  back to the head of the visible rows, then the full live list. */
-	readonly selectedEnemy = $derived.by<IEnemy | undefined>(() => {
-		const explicit = (staticData.enemies ?? [])[this.selectedEnemyId];
-		if (explicit) {
-			return explicit;
-		}
-		const firstVisible = this.enemyRows[0];
-		return (firstVisible && (staticData.enemies ?? [])[firstVisible.id]) ?? this.enemies[0];
-	});
-
-	readonly range = $derived.by<LevelRange | undefined>(() => {
-		const e = this.selectedEnemy;
-		return e ? levelRange(e, staticData.zones ?? []) : undefined;
-	});
-
-	/** Header chrome for the dossier (kind label + section accent). */
-	readonly dossierAccent = $derived(
-		this.selectedEnemy ? enemyAccent(this.selectedEnemy.isBoss) : 'var(--enemy-accent)'
-	);
-	readonly dossierKind = $derived(this.selectedEnemy ? enemyKindLabel(this.selectedEnemy.isBoss) : '');
-
-	/** Primary + derived-secondary attribute values for the selected enemy at the current level. */
-	readonly attributes = $derived.by<EnemyAttributes>(() => {
-		const e = this.selectedEnemy;
-		return e ? enemyAttributesAtLevel(e, this.level) : { primary: [], secondary: [] };
-	});
-
-	/** Bar denominator for the primary stat bars (the leading value, floored at 1). */
-	readonly maxPrimary = $derived(Math.max(1, ...this.attributes.primary.map((p) => p.value)));
-
-	readonly enemySkillRows = $derived.by<EnemySkillVM[]>(() => {
-		const e = this.selectedEnemy;
-		const skills = staticData.skills ?? [];
-		if (!e) {
-			return [];
-		}
-		return e.skillPool
-			.map((id) => skills[id])
-			.filter(Boolean)
-			.map((sk) => ({
-				id: sk.id,
-				name: sk.name,
-				meta: `${sk.baseDamage > 0 ? `base ${sk.baseDamage}` : 'utility'} · ${formatCooldown(sk.cooldownMs)} cd`
-			}));
-	});
-
-	readonly spawnHeading = $derived.by(() => {
-		const e = this.selectedEnemy;
-		if (!e) {
-			return '';
-		}
-		if (e.isBoss) {
-			return 'Encounter';
-		}
-		const n = e.spawns.length;
-		return `Spawns in ${n} ${n === 1 ? 'zone' : 'zones'}`;
-	});
-
-	readonly spawns = $derived.by<EnemySpawnVM[]>(() => {
-		const e = this.selectedEnemy;
-		const zones = staticData.zones ?? [];
-		if (!e) {
-			return [];
-		}
-		if (e.isBoss) {
-			const zone = zones.find((z) => z?.bossEnemyId === e.id);
-			return zone ? [{ zoneId: zone.id, zoneName: zone.name, share: 100, weightLabel: 'boss fight' }] : [];
-		}
-		return e.spawns
-			.map((sp) => ({
-				zoneId: sp.zoneId,
-				zoneName: zones[sp.zoneId]?.name ?? `Zone ${sp.zoneId}`,
-				share: spawnShare(sp.weight, zoneTotalWeight(sp.zoneId, this.enemies)),
-				weightLabel: `weight ${sp.weight}`
-			}))
-			.sort((a, b) => b.share - a.share);
-	});
-
-	/** The statistic query engine, rebuilt from the live reference data + fetched values. */
-	readonly statData = $derived(
-		new StatisticsData(buildStatTypes(staticData.statisticTypes ?? []), this.stats, buildStatEntities())
-	);
-
-	/** Every statistic that references the selected enemy (the dossier's "your record"). */
-	readonly statistics = $derived.by<EntityStatVM[]>(() =>
-		this.selectedEnemy ? this.statVMsFor('enemy', this.selectedEnemy.id) : []
-	);
-
-	/** Challenges scoped to the selected enemy, with progress from the shared challenge store. */
-	readonly challenges = $derived.by<EnemyChallengeVM[]>(() => {
-		const e = this.selectedEnemy;
-		if (!e) {
-			return [];
-		}
-		// eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient lookup, not held state
-		const progressById = new Map(playerChallenges.all.map((pc) => [pc.challengeId, pc]));
-		return (
-			(staticData.challenges ?? [])
-				.filter((c) => c.entityType === EEntityType.Enemy && c.targetEntityId === e.id)
-				// A retired challenge is out of circulation: hide it unless the player already completed it
-				// (mirrors the Challenges screen's retired-unless-completed rule).
-				.filter((c) => c.retiredAt == null || progressById.get(c.id)?.completed)
-				.map((c) => {
-					const pc = progressById.get(c.id);
-					const progress = pc?.progress ?? 0;
-					const completed = pc?.completed ?? false;
-					const progressText =
-						c.progressGoal === 1 ? (completed ? 'done' : 'sealed') : `${Math.round(progress)}/${c.progressGoal}`;
-					return {
-						id: c.id,
-						name: c.name,
-						typeLabel: challengeTypeName(c.challengeTypeId, staticData.challengeTypes),
-						accent: challengeTypeColor(c.challengeTypeId),
-						progressText,
-						completed
-					};
-				})
-		);
-	});
-
-	/** Dossier sub-tabs — Challenges only when the enemy has related challenges. */
-	readonly subTabs = $derived.by<SubTabVM[]>(() =>
-		this.challenges.length > 0 ? [...SUB_TAB_DEFS, { key: 'challenges', label: 'Challenges' }] : SUB_TAB_DEFS
-	);
-
-	/* ── zones catalogue (the progression rail) ─────────────────────────────────── */
-
-	readonly zones = $derived(liveZones(staticData.zones));
-
-	/** Immutable per-zone view-models — depends only on reference data (zones + enemies). The spawn-pool
-	 *  count is O(zones×enemies), so it's built once here rather than rebuilt every time a zone's
-	 *  cleared/locked status changes (which happens continuously during idle play). */
-	readonly zoneProjections = $derived.by<ZoneProjectionVM[]>(() => {
-		const enemies = this.enemies;
-		return this.zones.map((z) => ({
-			id: z.id,
-			name: z.name,
-			band: formatBand({ min: z.levelMin, max: z.levelMax, fixed: false }),
-			spawnCount: enemies.filter((e) => e.spawns.some((s) => s.zoneId === z.id)).length,
-			hasBoss: z.bossEnemyId != null
-		}));
-	});
-
-	/** Zone rail rows: the immutable projections overlaid with each zone's live progression status
-	 *  (cleared / unlocked / locked) — the only part that reruns as zones clear or gates open. Zipped
-	 *  by index since `zoneProjections` and `zones` share the same authored order and length. */
-	readonly zoneRows = $derived.by<ZoneRowVM[]>(() =>
-		this.zones.map((z, i) => ({
-			...this.zoneProjections[i],
-			status: resolveZoneStatus(statistics.isZoneCleared(z.id), this.isZoneLocked(z))
-		}))
-	);
-
-	/* ── selected zone + dossier ────────────────────────────────────────────────── */
-
-	/** The inspected zone: an explicitly-requested id resolves even when retired (see `selectedEnemy`),
-	 *  falling back to the head of the rail otherwise. */
-	readonly selectedZone = $derived<IZone | undefined>((staticData.zones ?? [])[this.selectedZoneId] ?? this.zones[0]);
-
-	/** The selected zone's level band (`11–22`). */
-	readonly zoneBand = $derived.by<string>(() => {
-		const z = this.selectedZone;
-		return z ? formatBand({ min: z.levelMin, max: z.levelMax, fixed: false }) : '';
-	});
-
-	/** The selected zone's progression status (drives the dossier seal + header accent). */
-	readonly selectedZoneStatus = $derived.by<ZoneStatus>(() => {
-		const z = this.selectedZone;
-		return z ? resolveZoneStatus(statistics.isZoneCleared(z.id), this.isZoneLocked(z)) : 'unlocked';
-	});
-
-	/** The zone's dedicated boss (its card cross-links to the enemy dossier), or null when none is authored. */
-	readonly zoneBoss = $derived.by<ZoneBossVM | null>(() => {
-		const z = this.selectedZone;
-		if (!z || z.bossEnemyId == null) {
-			return null;
-		}
-		const boss = (staticData.enemies ?? [])[z.bossEnemyId];
-		return boss ? { enemyId: boss.id, name: boss.name, level: z.bossLevel } : null;
-	});
-
-	/** The zone's spawn table — every non-retired enemy that spawns here, with its share of the zone's
-	 *  total spawn weight, ordered by share. Bosses don't populate `spawns`, so they're naturally absent. */
-	readonly zoneSpawns = $derived.by<ZoneSpawnVM[]>(() => {
-		const z = this.selectedZone;
-		if (!z) {
-			return [];
-		}
-		const total = zoneTotalWeight(z.id, this.enemies);
-		return this.enemies
-			.flatMap((e) => {
-				const spawn = e.spawns.find((s) => s.zoneId === z.id);
-				return spawn ? [{ enemy: e, weight: spawn.weight }] : [];
-			})
-			.map(({ enemy, weight }) => ({
-				enemyId: enemy.id,
-				enemyName: enemy.name,
-				share: spawnShare(weight, total),
-				weightLabel: `weight ${weight}`
-			}))
-			.sort((a, b) => b.share - a.share);
-	});
-
-	/** Number of distinct enemies in the zone's spawn pool (the dossier's "N spawns" readout). */
-	readonly zoneSpawnCount = $derived(this.zoneSpawns.length);
-
-	/** The zone's unlock condition — the gating challenge's name plus whether it's still sealed — or
-	 *  null for an always-open zone. */
-	readonly zoneUnlock = $derived.by<ZoneUnlockVM | null>(() => {
-		const z = this.selectedZone;
-		if (!z || z.unlockChallengeId == null) {
-			return null;
-		}
-		const challenge = (staticData.challenges ?? [])[z.unlockChallengeId];
-		return {
-			challengeId: z.unlockChallengeId,
-			challengeName: challenge?.name ?? `Challenge ${z.unlockChallengeId}`,
-			sealed: !playerChallenges.isChallengeCompleted(z.unlockChallengeId)
-		};
-	});
-
-	/** Every statistic that references the selected zone (the zone dossier's "your record"). */
-	readonly zoneStatistics = $derived.by<EntityStatVM[]>(() =>
-		this.selectedZone ? this.statVMsFor('zone', this.selectedZone.id) : []
-	);
-
-	/* ── skills catalogue (the reference skill table) ────────────────────────────── */
-
-	readonly skillsCatalogue = $derived(liveSkills(staticData.skills));
-
-	/** Skill table rows: name, base damage, cooldown and how many enemies use the skill. */
-	readonly skillRows = $derived.by<SkillRowVM[]>(() => {
-		const enemies = this.enemies;
-		return this.skillsCatalogue.map((sk) => ({
-			id: sk.id,
-			name: sk.name,
-			baseDamageLabel: formatBaseDamage(sk.baseDamage),
-			cooldownLabel: formatCooldown(sk.cooldownMs),
-			usedByCount: enemies.filter((e) => e.skillPool.includes(sk.id)).length,
-			rarityColor: rarityColor(sk.rarityId)
-		}));
-	});
-
-	/* ── selected skill + dossier ─────────────────────────────────────────────────── */
-
-	/** The inspected skill: an explicitly-requested id resolves even when retired (see `selectedEnemy`),
-	 *  falling back to the head of the catalogue otherwise. */
-	readonly selectedSkill = $derived<ISkill | undefined>(
-		(staticData.skills ?? [])[this.selectedSkillId] ?? this.skillsCatalogue[0]
-	);
-
-	/** The selected skill's rarity tier (hue + label) for the dossier header accent. */
-	readonly selectedSkillRarity = $derived.by<SkillRarityVM | null>(() => {
-		const sk = this.selectedSkill;
-		return sk ? { color: rarityColor(sk.rarityId), label: rarityLabel(sk.rarityId) } : null;
-	});
-
-	/** The attributes the selected skill's damage scales with, each tinted by its attribute accent. */
-	readonly skillScaling = $derived.by<SkillScalingVM[]>(() => {
-		const sk = this.selectedSkill;
-		if (!sk) {
-			return [];
-		}
-		return sk.damageMultipliers.map((m) => ({
-			attributeId: m.attributeId,
-			name: attributeName(m.attributeId, staticData.attributes),
-			code: attributeCode(m.attributeId, staticData.attributes),
-			multiplierLabel: `×${formatNum(m.multiplier)}`,
-			color: attributeColor(m.attributeId)
-		}));
-	});
-
-	/** The selected skill's authored effects, described via the shared helper so the wording and the
-	 *  buff/debuff direction match every other surface that shows an effect. */
-	readonly skillEffects = $derived.by<SkillEffectVM[]>(() => {
-		const sk = this.selectedSkill;
-		if (!sk) {
-			return [];
-		}
-		return sk.effects.map((effect) => {
-			const desc = describeEffect(
-				effect,
-				attributeName(effect.attributeId, staticData.attributes),
-				attributeIsHarmful(effect.attributeId, staticData.attributes)
-			);
-			return {
-				id: effect.id,
-				magnitude: desc.magnitude,
-				attributeName: desc.attributeName,
-				targetLabel: desc.targetLabel,
-				duration: desc.duration,
-				color: effectDirectionColor(desc.direction)
-			};
-		});
-	});
-
-	/** The (non-retired) enemies whose skill pool includes the selected skill — pills that cross-link
-	 *  into the enemy dossier. Empty for a player-only skill. */
-	readonly skillUsedBy = $derived.by<SkillUserVM[]>(() => {
-		const sk = this.selectedSkill;
-		if (!sk) {
-			return [];
-		}
-		return this.enemies
-			.filter((e) => e.skillPool.includes(sk.id))
-			.map((e) => ({
-				enemyId: e.id,
-				name: e.name,
-				isBoss: e.isBoss,
-				accent: enemyAccent(e.isBoss)
-			}));
-	});
-
-	/** How the selected skill is obtained — derived from actual item-grant references, with the
-	 *  acquisition flag wording the no-source case. Item sources tint by the granting item's rarity. */
-	readonly skillProvenance = $derived.by<SkillProvenanceVM>(() => {
-		const sk = this.selectedSkill;
-		if (!sk) {
-			return { status: 'unobtainable', sources: [], emptyLabel: SKILL_ACQUISITION_EMPTY.unobtainable };
-		}
-		const allItems = staticData.items ?? [];
-		const provenance = resolveSkillProvenance(
-			sk,
-			allItems.filter((i) => !i.retiredAt)
-		);
-		const sources = provenance.sources.map<SkillSourceVM>((src) => ({
-			kind: src.kind,
-			id: src.id,
-			label: SKILL_SOURCE_LABEL,
-			name: src.name,
-			accent: rarityColor(allItems[src.id]?.rarityId ?? ERarity.Common)
-		}));
-		return {
-			status: provenance.status,
-			sources,
-			emptyLabel: sources.length > 0 ? '' : SKILL_ACQUISITION_EMPTY[provenance.status]
-		};
-	});
-
-	/** Every statistic that references the selected skill (the skill dossier's "your record"). */
-	readonly skillStatistics = $derived.by<EntityStatVM[]>(() =>
-		this.selectedSkill ? this.statVMsFor('skill', this.selectedSkill.id) : []
-	);
-
-	/* ── handlers ──────────────────────────────────────────────────────────────── */
-
 	selectTab(tab: CodexTab): void {
 		this.tab = tab;
 	}
 
-	/** Select an enemy: reset to the Attributes sub-tab and reseed the level to its band. */
+	/* ── enemies tab (delegates to EnemiesTabView) ───────────────────────────────── */
+
+	get enemies() {
+		return this.enemiesTab.enemies;
+	}
+	get enemyProjections(): EnemyRowVM[] {
+		return this.enemiesTab.enemyProjections;
+	}
+	get enemyRows(): EnemyRowVM[] {
+		return this.enemiesTab.enemyRows;
+	}
+	get shownCount() {
+		return this.enemiesTab.shownCount;
+	}
+
+	get selectedEnemyId() {
+		return this.enemiesTab.selectedEnemyId;
+	}
+	set selectedEnemyId(id: number) {
+		this.enemiesTab.selectedEnemyId = id;
+	}
+	get selectedEnemy() {
+		return this.enemiesTab.selectedEnemy;
+	}
+	get range() {
+		return this.enemiesTab.range;
+	}
+	get dossierAccent() {
+		return this.enemiesTab.dossierAccent;
+	}
+	get dossierKind() {
+		return this.enemiesTab.dossierKind;
+	}
+	get attributes() {
+		return this.enemiesTab.attributes;
+	}
+	get maxPrimary() {
+		return this.enemiesTab.maxPrimary;
+	}
+	get enemySkillRows(): EnemySkillVM[] {
+		return this.enemiesTab.enemySkillRows;
+	}
+	get spawnHeading() {
+		return this.enemiesTab.spawnHeading;
+	}
+	get spawns(): EnemySpawnVM[] {
+		return this.enemiesTab.spawns;
+	}
+	get statistics(): EntityStatVM[] {
+		return this.enemiesTab.statistics;
+	}
+	get challenges(): EnemyChallengeVM[] {
+		return this.enemiesTab.challenges;
+	}
+	get subTabs(): SubTabVM[] {
+		return this.enemiesTab.subTabs;
+	}
+
+	get sub() {
+		return this.enemiesTab.sub;
+	}
+	get level() {
+		return this.enemiesTab.level;
+	}
+	get scaling() {
+		return this.enemiesTab.scaling;
+	}
+	get filter() {
+		return this.enemiesTab.filter;
+	}
+	get search() {
+		return this.enemiesTab.search;
+	}
+	set search(value: string) {
+		this.enemiesTab.search = value;
+	}
+	get sort() {
+		return this.enemiesTab.sort;
+	}
+	set sort(value: EnemySort) {
+		this.enemiesTab.sort = value;
+	}
+
 	selectEnemy(id: number): void {
-		this.selectedEnemyId = id;
-		this.sub = 'attributes';
-		this.level = this.levelFor(this.resolveEnemy(id));
+		this.enemiesTab.selectEnemy(id);
 	}
-
 	selectSub(sub: EnemySubTab): void {
-		this.sub = sub;
+		this.enemiesTab.selectSub(sub);
 	}
-
 	setLevel(level: number): void {
-		this.level = level;
+		this.enemiesTab.setLevel(level);
 	}
-
 	toggleScaling(): void {
-		this.scaling = !this.scaling;
+		this.enemiesTab.toggleScaling();
+	}
+	setFilter(filter: EnemyFilter): void {
+		this.enemiesTab.setFilter(filter);
 	}
 
-	setFilter(filter: EnemyFilter): void {
-		this.filter = filter;
+	/* ── zones tab (delegates to ZonesTabView) ───────────────────────────────────── */
+
+	get zones() {
+		return this.zonesTab.zones;
+	}
+	get zoneProjections(): ZoneProjectionVM[] {
+		return this.zonesTab.zoneProjections;
+	}
+	get zoneRows(): ZoneRowVM[] {
+		return this.zonesTab.zoneRows;
+	}
+
+	get selectedZoneId() {
+		return this.zonesTab.selectedZoneId;
+	}
+	set selectedZoneId(id: number) {
+		this.zonesTab.selectedZoneId = id;
+	}
+	get selectedZone() {
+		return this.zonesTab.selectedZone;
+	}
+	get zoneBand() {
+		return this.zonesTab.zoneBand;
+	}
+	get selectedZoneStatus() {
+		return this.zonesTab.selectedZoneStatus;
+	}
+	get zoneBoss(): ZoneBossVM | null {
+		return this.zonesTab.zoneBoss;
+	}
+	get zoneSpawns(): ZoneSpawnVM[] {
+		return this.zonesTab.zoneSpawns;
+	}
+	get zoneSpawnCount() {
+		return this.zonesTab.zoneSpawnCount;
+	}
+	get zoneUnlock(): ZoneUnlockVM | null {
+		return this.zonesTab.zoneUnlock;
+	}
+	get zoneStatistics(): EntityStatVM[] {
+		return this.zonesTab.zoneStatistics;
 	}
 
 	selectZone(id: number): void {
-		this.selectedZoneId = id;
+		this.zonesTab.selectZone(id);
+	}
+
+	/* ── skills tab (delegates to SkillsTabView) ─────────────────────────────────── */
+
+	get skillsCatalogue() {
+		return this.skillsTab.skillsCatalogue;
+	}
+	get skillRows(): SkillRowVM[] {
+		return this.skillsTab.skillRows;
+	}
+
+	get selectedSkillId() {
+		return this.skillsTab.selectedSkillId;
+	}
+	set selectedSkillId(id: number) {
+		this.skillsTab.selectedSkillId = id;
+	}
+	get selectedSkill() {
+		return this.skillsTab.selectedSkill;
+	}
+	get selectedSkillRarity(): SkillRarityVM | null {
+		return this.skillsTab.selectedSkillRarity;
+	}
+	get skillScaling(): SkillScalingVM[] {
+		return this.skillsTab.skillScaling;
+	}
+	get skillEffects(): SkillEffectVM[] {
+		return this.skillsTab.skillEffects;
+	}
+	get skillUsedBy(): SkillUserVM[] {
+		return this.skillsTab.skillUsedBy;
+	}
+	get skillProvenance(): SkillProvenanceVM {
+		return this.skillsTab.skillProvenance;
+	}
+	get skillStatistics(): EntityStatVM[] {
+		return this.skillsTab.skillStatistics;
 	}
 
 	selectSkill(id: number): void {
-		this.selectedSkillId = id;
+		this.skillsTab.selectSkill(id);
 	}
+
+	/* ── cross-tab links ──────────────────────────────────────────────────────── */
 
 	/** Cross-link: jump to an enemy's dossier from the Zones / Skills tab (boss card, spawn / used-by row). */
 	openEnemy(id: number): void {
 		this.tab = 'enemies';
-		this.selectEnemy(id);
+		this.enemiesTab.selectEnemy(id);
 	}
 
 	/** Cross-link: jump to a zone's dossier from the enemy dossier's Spawns rows. */
 	openZone(id: number): void {
 		this.tab = 'zones';
-		this.selectZone(id);
+		this.zonesTab.selectZone(id);
 	}
 
 	/** Cross-link: jump to a skill's dossier from the enemy dossier's Skills rows. */
 	openSkill(id: number): void {
 		this.tab = 'skills';
-		this.selectSkill(id);
-	}
-
-	/* ── helpers (store reads, kept off the reactive graph for the constructor) ──── */
-
-	/** Project the statistics referencing an entity into dossier "your record" rows. */
-	private statVMsFor(kind: StatEntityKind, id: number): EntityStatVM[] {
-		return this.statData.statsForEntity(kind, id).map((info) => ({
-			label: info.stat.name,
-			value: fmtValue(info.value, info.stat.unit)
-		}));
-	}
-
-	/** Resolve an enemy id against the full catalogue (an explicit id resolves even when retired),
-	 *  falling back to the head of the live list. */
-	private resolveEnemy(id: number): IEnemy | undefined {
-		return (staticData.enemies ?? [])[id] ?? liveEnemies(staticData.enemies)[0];
-	}
-
-	/** Resolve a zone id against the full catalogue (an explicit id resolves even when retired),
-	 *  falling back to the head of the rail (authored order). */
-	private resolveZone(id: number): IZone | undefined {
-		return (staticData.zones ?? [])[id] ?? liveZones(staticData.zones)[0];
-	}
-
-	/** Resolve a skill id against the full catalogue (an explicit id resolves even when retired),
-	 *  falling back to the head of the live catalogue. */
-	private resolveSkill(id: number): ISkill | undefined {
-		return (staticData.skills ?? [])[id] ?? liveSkills(staticData.skills)[0];
-	}
-
-	/** A zone is locked when it carries an unlock gate the player hasn't completed yet. */
-	private isZoneLocked(zone: IZone): boolean {
-		return zone.unlockChallengeId != null && !playerChallenges.isChallengeCompleted(zone.unlockChallengeId);
-	}
-
-	/** The level to scale an enemy to by default: the boss's fixed level, else its band midpoint. */
-	private levelFor(enemy: IEnemy | undefined): number {
-		if (!enemy) {
-			return 1;
-		}
-		const r = levelRange(enemy, staticData.zones ?? []);
-		return r.fixed ? r.min : Math.round((r.min + r.max) / 2);
+		this.skillsTab.selectSkill(id);
 	}
 }

--- a/UI/src/routes/game/screens/codex/enemies-tab-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/enemies-tab-view.svelte.ts
@@ -10,6 +10,7 @@ import {
 	type EnemyFilter,
 	type EnemySort,
 	type EnemySubTab,
+	type EntityStatVM,
 	enemyAccent,
 	enemyKindLabel,
 	formatBand,
@@ -18,7 +19,6 @@ import {
 	matchesEnemySearch,
 	sortEnemyRows
 } from './codex-display';
-import type { EntityStatVM } from './codex-view.svelte';
 import { type LevelRange, levelRange, spawnShare, zoneTotalWeight } from './enemy-level';
 import type { StatEntityKind } from '../stats/statistics-view.svelte';
 

--- a/UI/src/routes/game/screens/codex/enemies-tab-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/enemies-tab-view.svelte.ts
@@ -1,0 +1,323 @@
+/* The Enemies tab's reactive layer: table filter/search/sort + the selected enemy's dossier
+   (attributes, skills, spawns, challenges, statistics). Split out of CodexView so each tab's
+   derivations are independently readable/testable — see codex-view.svelte.ts for the composing
+   orchestrator and the cross-tab concerns (active tab, stats fetch, cross-links). */
+
+import { EEntityType, type IEnemy } from '$lib/api';
+import { type EnemyAttributes, challengeTypeColor, challengeTypeName, enemyAttributesAtLevel } from '$lib/common';
+import { playerChallenges, staticData } from '$stores';
+import {
+	type EnemyFilter,
+	type EnemySort,
+	type EnemySubTab,
+	enemyAccent,
+	enemyKindLabel,
+	formatBand,
+	formatCooldown,
+	liveEnemies,
+	matchesEnemySearch,
+	sortEnemyRows
+} from './codex-display';
+import type { EntityStatVM } from './codex-view.svelte';
+import { type LevelRange, levelRange, spawnShare, zoneTotalWeight } from './enemy-level';
+import type { StatEntityKind } from '../stats/statistics-view.svelte';
+
+export interface EnemyRowVM {
+	id: number;
+	name: string;
+	isBoss: boolean;
+	band: string;
+	/** Numeric sort key for the level metric (the band's low end). */
+	level: number;
+	zoneCount: number;
+	skillCount: number;
+	/** Pre-lowercased search haystack: name + kind + zone names (spawn zones, or a boss's encounter zone). */
+	searchText: string;
+}
+
+export interface SubTabVM {
+	key: EnemySubTab;
+	label: string;
+}
+
+export interface EnemySkillVM {
+	id: number;
+	name: string;
+	meta: string;
+}
+
+export interface EnemySpawnVM {
+	zoneId: number;
+	zoneName: string;
+	share: number;
+	weightLabel: string;
+}
+
+export interface EnemyChallengeVM {
+	id: number;
+	name: string;
+	typeLabel: string;
+	accent: string;
+	progressText: string;
+	completed: boolean;
+}
+
+const SUB_TAB_DEFS: SubTabVM[] = [
+	{ key: 'attributes', label: 'Attributes' },
+	{ key: 'statistics', label: 'Statistics' },
+	{ key: 'skills', label: 'Skills' },
+	{ key: 'spawns', label: 'Spawns' }
+];
+
+/** The initial-selection payload a deep-link into the Enemies tab can carry. */
+export interface EnemiesTabPayload {
+	enemyId?: number;
+	sub?: EnemySubTab;
+}
+
+export class EnemiesTabView {
+	/** Inspected enemy id (falls back to the head of the list when unresolved). */
+	selectedEnemyId = $state<number>(-1);
+	/** Active dossier sub-tab. */
+	sub = $state<EnemySubTab>('attributes');
+	/** Level the Attributes sub-tab scales the selected enemy to. */
+	level = $state<number>(1);
+	/** Whether the Attributes sub-tab reveals the base + per-level scaling breakdown. */
+	scaling = $state<boolean>(false);
+	/** Enemy-table filter chip. */
+	filter = $state<EnemyFilter>('all');
+	/** Enemy-table search query (matched against name, kind and spawn zones). */
+	search = $state('');
+	/** Enemy-table sort metric. */
+	sort = $state<EnemySort>('level');
+
+	/** Projects the player's per-entity statistics (owned by the CodexView orchestrator, which fetches
+	 *  them once for every tab's dossier). */
+	private readonly statVMsFor: (kind: StatEntityKind, id: number) => EntityStatVM[];
+
+	constructor(
+		payload: EnemiesTabPayload | undefined,
+		statVMsFor: (kind: StatEntityKind, id: number) => EntityStatVM[]
+	) {
+		this.statVMsFor = statVMsFor;
+		if (payload?.sub) {
+			this.sub = payload.sub;
+		}
+		// Resolve the initial enemy (the deep-link target, else the head of the list) so the table
+		// highlights what the dossier shows. Reads stores directly to avoid touching a $derived here.
+		const initial = this.resolveEnemy(payload?.enemyId ?? -1);
+		if (initial) {
+			this.selectedEnemyId = initial.id;
+		}
+		this.level = this.levelFor(initial);
+	}
+
+	/* ── catalogue ───────────────────────────────────────────────────────────── */
+
+	readonly enemies = $derived(liveEnemies(staticData.enemies));
+
+	/** Immutable per-enemy view-models — depends only on reference data (enemies + zones), so the heavy
+	 *  projection (level band, the zone-name search haystack incl. the per-boss `zones.find`) is built
+	 *  once and reused, rather than rebuilt on every search keystroke / sort / filter change. */
+	readonly enemyProjections = $derived.by<EnemyRowVM[]>(() => {
+		const zones = staticData.zones ?? [];
+		return this.enemies.map((e) => {
+			const range = levelRange(e, zones);
+			// Bosses don't populate `spawns`; resolve their encounter zone the same way the dossier
+			// does so a boss is findable by that zone name. Normal enemies use their spawn zones.
+			const zoneNames = e.isBoss
+				? [zones.find((z) => z?.bossEnemyId === e.id)?.name ?? '']
+				: e.spawns.map((sp) => zones[sp.zoneId]?.name ?? '');
+			return {
+				id: e.id,
+				name: e.name,
+				isBoss: e.isBoss,
+				band: formatBand(range),
+				level: range.min,
+				zoneCount: e.isBoss ? 1 : e.spawns.length,
+				skillCount: e.skillPool.length,
+				searchText: [e.name, enemyKindLabel(e.isBoss), ...zoneNames].join(' ').toLowerCase()
+			};
+		});
+	});
+
+	/** Enemy table rows: the immutable projections narrowed by the active filter + search query and
+	 *  ordered by the active sort — the only work that reruns as the player types or re-sorts. The
+	 *  filter/search/sort maths are the pure helpers in `codex-display`. */
+	readonly enemyRows = $derived.by<EnemyRowVM[]>(() =>
+		this.enemyProjections
+			.filter((row) => this.filter === 'all' || (this.filter === 'boss' ? row.isBoss : !row.isBoss))
+			.filter((row) => matchesEnemySearch(row, this.search))
+			.sort(sortEnemyRows(this.sort))
+	);
+
+	/** Number of enemies shown under the active filter + search (the "N shown" readout). */
+	readonly shownCount = $derived(this.enemyRows.length);
+
+	/* ── selected enemy + dossier ──────────────────────────────────────────────── */
+
+	/** The inspected enemy: an explicitly-requested id resolves even when retired (retirement keeps a
+	 *  record's slot resolvable by design — see backend.md → _Reference Data_), so a cross-link into a
+	 *  retired enemy opens it rather than silently falling back. With no resolvable explicit id, falls
+	 *  back to the head of the visible rows, then the full live list. */
+	readonly selectedEnemy = $derived.by<IEnemy | undefined>(() => {
+		const explicit = (staticData.enemies ?? [])[this.selectedEnemyId];
+		if (explicit) {
+			return explicit;
+		}
+		const firstVisible = this.enemyRows[0];
+		return (firstVisible && (staticData.enemies ?? [])[firstVisible.id]) ?? this.enemies[0];
+	});
+
+	readonly range = $derived.by<LevelRange | undefined>(() => {
+		const e = this.selectedEnemy;
+		return e ? levelRange(e, staticData.zones ?? []) : undefined;
+	});
+
+	/** Header chrome for the dossier (kind label + section accent). */
+	readonly dossierAccent = $derived(
+		this.selectedEnemy ? enemyAccent(this.selectedEnemy.isBoss) : 'var(--enemy-accent)'
+	);
+	readonly dossierKind = $derived(this.selectedEnemy ? enemyKindLabel(this.selectedEnemy.isBoss) : '');
+
+	/** Primary + derived-secondary attribute values for the selected enemy at the current level. */
+	readonly attributes = $derived.by<EnemyAttributes>(() => {
+		const e = this.selectedEnemy;
+		return e ? enemyAttributesAtLevel(e, this.level) : { primary: [], secondary: [] };
+	});
+
+	/** Bar denominator for the primary stat bars (the leading value, floored at 1). */
+	readonly maxPrimary = $derived(Math.max(1, ...this.attributes.primary.map((p) => p.value)));
+
+	readonly enemySkillRows = $derived.by<EnemySkillVM[]>(() => {
+		const e = this.selectedEnemy;
+		const skills = staticData.skills ?? [];
+		if (!e) {
+			return [];
+		}
+		return e.skillPool
+			.map((id) => skills[id])
+			.filter(Boolean)
+			.map((sk) => ({
+				id: sk.id,
+				name: sk.name,
+				meta: `${sk.baseDamage > 0 ? `base ${sk.baseDamage}` : 'utility'} · ${formatCooldown(sk.cooldownMs)} cd`
+			}));
+	});
+
+	readonly spawnHeading = $derived.by(() => {
+		const e = this.selectedEnemy;
+		if (!e) {
+			return '';
+		}
+		if (e.isBoss) {
+			return 'Encounter';
+		}
+		const n = e.spawns.length;
+		return `Spawns in ${n} ${n === 1 ? 'zone' : 'zones'}`;
+	});
+
+	readonly spawns = $derived.by<EnemySpawnVM[]>(() => {
+		const e = this.selectedEnemy;
+		const zones = staticData.zones ?? [];
+		if (!e) {
+			return [];
+		}
+		if (e.isBoss) {
+			const zone = zones.find((z) => z?.bossEnemyId === e.id);
+			return zone ? [{ zoneId: zone.id, zoneName: zone.name, share: 100, weightLabel: 'boss fight' }] : [];
+		}
+		return e.spawns
+			.map((sp) => ({
+				zoneId: sp.zoneId,
+				zoneName: zones[sp.zoneId]?.name ?? `Zone ${sp.zoneId}`,
+				share: spawnShare(sp.weight, zoneTotalWeight(sp.zoneId, this.enemies)),
+				weightLabel: `weight ${sp.weight}`
+			}))
+			.sort((a, b) => b.share - a.share);
+	});
+
+	/** Every statistic that references the selected enemy (the dossier's "your record"). */
+	readonly statistics = $derived.by<EntityStatVM[]>(() =>
+		this.selectedEnemy ? this.statVMsFor('enemy', this.selectedEnemy.id) : []
+	);
+
+	/** Challenges scoped to the selected enemy, with progress from the shared challenge store. */
+	readonly challenges = $derived.by<EnemyChallengeVM[]>(() => {
+		const e = this.selectedEnemy;
+		if (!e) {
+			return [];
+		}
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient lookup, not held state
+		const progressById = new Map(playerChallenges.all.map((pc) => [pc.challengeId, pc]));
+		return (
+			(staticData.challenges ?? [])
+				.filter((c) => c.entityType === EEntityType.Enemy && c.targetEntityId === e.id)
+				// A retired challenge is out of circulation: hide it unless the player already completed it
+				// (mirrors the Challenges screen's retired-unless-completed rule).
+				.filter((c) => c.retiredAt == null || progressById.get(c.id)?.completed)
+				.map((c) => {
+					const pc = progressById.get(c.id);
+					const progress = pc?.progress ?? 0;
+					const completed = pc?.completed ?? false;
+					const progressText =
+						c.progressGoal === 1 ? (completed ? 'done' : 'sealed') : `${Math.round(progress)}/${c.progressGoal}`;
+					return {
+						id: c.id,
+						name: c.name,
+						typeLabel: challengeTypeName(c.challengeTypeId, staticData.challengeTypes),
+						accent: challengeTypeColor(c.challengeTypeId),
+						progressText,
+						completed
+					};
+				})
+		);
+	});
+
+	/** Dossier sub-tabs — Challenges only when the enemy has related challenges. */
+	readonly subTabs = $derived.by<SubTabVM[]>(() =>
+		this.challenges.length > 0 ? [...SUB_TAB_DEFS, { key: 'challenges', label: 'Challenges' }] : SUB_TAB_DEFS
+	);
+
+	/* ── handlers ──────────────────────────────────────────────────────────────── */
+
+	/** Select an enemy: reset to the Attributes sub-tab and reseed the level to its band. */
+	selectEnemy(id: number): void {
+		this.selectedEnemyId = id;
+		this.sub = 'attributes';
+		this.level = this.levelFor(this.resolveEnemy(id));
+	}
+
+	selectSub(sub: EnemySubTab): void {
+		this.sub = sub;
+	}
+
+	setLevel(level: number): void {
+		this.level = level;
+	}
+
+	toggleScaling(): void {
+		this.scaling = !this.scaling;
+	}
+
+	setFilter(filter: EnemyFilter): void {
+		this.filter = filter;
+	}
+
+	/* ── helpers (store reads, kept off the reactive graph for the constructor) ──── */
+
+	/** Resolve an enemy id against the full catalogue (an explicit id resolves even when retired),
+	 *  falling back to the head of the live list. */
+	private resolveEnemy(id: number): IEnemy | undefined {
+		return (staticData.enemies ?? [])[id] ?? liveEnemies(staticData.enemies)[0];
+	}
+
+	/** The level to scale an enemy to by default: the boss's fixed level, else its band midpoint. */
+	private levelFor(enemy: IEnemy | undefined): number {
+		if (!enemy) {
+			return 1;
+		}
+		const r = levelRange(enemy, staticData.zones ?? []);
+		return r.fixed ? r.min : Math.round((r.min + r.max) / 2);
+	}
+}

--- a/UI/src/routes/game/screens/codex/skills-tab-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/skills-tab-view.svelte.ts
@@ -19,13 +19,13 @@ import { staticData } from '$stores';
 import {
 	SKILL_ACQUISITION_EMPTY,
 	SKILL_SOURCE_LABEL,
+	type EntityStatVM,
 	enemyAccent,
 	formatBaseDamage,
 	formatCooldown,
 	liveEnemies,
 	liveSkills
 } from './codex-display';
-import type { EntityStatVM } from './codex-view.svelte';
 import { type SkillAcquisitionStatus, resolveSkillProvenance } from './skill-provenance';
 import type { StatEntityKind } from '../stats/statistics-view.svelte';
 

--- a/UI/src/routes/game/screens/codex/skills-tab-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/skills-tab-view.svelte.ts
@@ -1,0 +1,255 @@
+/* The Skills tab's reactive layer: the reference skill table + the selected skill's dossier (scaling,
+   effects, used-by, provenance, statistics). Split out of CodexView so each tab's derivations are
+   independently readable/testable — see codex-view.svelte.ts for the composing orchestrator and the
+   cross-tab concerns (active tab, stats fetch, cross-links). */
+
+import { ERarity, type ISkill } from '$lib/api';
+import {
+	attributeCode,
+	attributeColor,
+	attributeIsHarmful,
+	attributeName,
+	describeEffect,
+	effectDirectionColor,
+	formatNum,
+	rarityColor,
+	rarityLabel
+} from '$lib/common';
+import { staticData } from '$stores';
+import {
+	SKILL_ACQUISITION_EMPTY,
+	SKILL_SOURCE_LABEL,
+	enemyAccent,
+	formatBaseDamage,
+	formatCooldown,
+	liveEnemies,
+	liveSkills
+} from './codex-display';
+import type { EntityStatVM } from './codex-view.svelte';
+import { type SkillAcquisitionStatus, resolveSkillProvenance } from './skill-provenance';
+import type { StatEntityKind } from '../stats/statistics-view.svelte';
+
+export interface SkillRowVM {
+	id: number;
+	name: string;
+	/** Base damage, or `—` for a utility skill. */
+	baseDamageLabel: string;
+	/** Cooldown, or `—` for an instant/utility skill. */
+	cooldownLabel: string;
+	/** How many (non-retired) enemies have this skill in their pool. */
+	usedByCount: number;
+	/** Themeable rarity hue for the row's tier mark. */
+	rarityColor: string;
+}
+
+/** The selected skill's rarity tier (hue + label) for the dossier header. */
+export interface SkillRarityVM {
+	color: string;
+	label: string;
+}
+
+export interface SkillScalingVM {
+	attributeId: number;
+	name: string;
+	code: string;
+	/** Magnitude badge, e.g. `×1.5`. */
+	multiplierLabel: string;
+	color: string;
+}
+
+export interface SkillEffectVM {
+	id: number;
+	/** Signed/`×` magnitude badge, e.g. `+15` or `×0.5`. */
+	magnitude: string;
+	attributeName: string;
+	/** `self` / `enemy`, the side the effect lands on. */
+	targetLabel: string;
+	/** Duration in seconds, e.g. `5s`. */
+	duration: string;
+	/** Themed buff/debuff accent for the magnitude. */
+	color: string;
+}
+
+export interface SkillUserVM {
+	enemyId: number;
+	name: string;
+	isBoss: boolean;
+	accent: string;
+}
+
+/** A "how to obtain" source row — an item that grants the skill. */
+export interface SkillSourceVM {
+	kind: 'item';
+	id: number;
+	/** "Granted by" lead-in. */
+	label: string;
+	name: string;
+	/** Themed accent: the granting item's rarity hue. */
+	accent: string;
+}
+
+/** The skill dossier's acquisition section: concrete sources, plus the wording for the no-source case. */
+export interface SkillProvenanceVM {
+	status: SkillAcquisitionStatus;
+	sources: SkillSourceVM[];
+	/** Wording for the no-source case (empty when sources exist). */
+	emptyLabel: string;
+}
+
+/** The initial-selection payload a deep-link into the Skills tab can carry. */
+export interface SkillsTabPayload {
+	skillId?: number;
+}
+
+export class SkillsTabView {
+	/** Inspected skill id (falls back to the head of the catalogue when unresolved). */
+	selectedSkillId = $state<number>(-1);
+
+	/** Projects the player's per-entity statistics (owned by the CodexView orchestrator, which fetches
+	 *  them once for every tab's dossier). */
+	private readonly statVMsFor: (kind: StatEntityKind, id: number) => EntityStatVM[];
+
+	constructor(payload: SkillsTabPayload | undefined, statVMsFor: (kind: StatEntityKind, id: number) => EntityStatVM[]) {
+		this.statVMsFor = statVMsFor;
+		// …resolve the skill table (the deep-link target, else the head of the catalogue).
+		const initialSkill = this.resolveSkill(payload?.skillId ?? -1);
+		if (initialSkill) {
+			this.selectedSkillId = initialSkill.id;
+		}
+	}
+
+	/* ── skills catalogue (the reference skill table) ────────────────────────────── */
+
+	readonly skillsCatalogue = $derived(liveSkills(staticData.skills));
+
+	/** Live (non-retired) enemies — needed for the used-by projections below. */
+	private readonly enemies = $derived(liveEnemies(staticData.enemies));
+
+	/** Skill table rows: name, base damage, cooldown and how many enemies use the skill. */
+	readonly skillRows = $derived.by<SkillRowVM[]>(() => {
+		const enemies = this.enemies;
+		return this.skillsCatalogue.map((sk) => ({
+			id: sk.id,
+			name: sk.name,
+			baseDamageLabel: formatBaseDamage(sk.baseDamage),
+			cooldownLabel: formatCooldown(sk.cooldownMs),
+			usedByCount: enemies.filter((e) => e.skillPool.includes(sk.id)).length,
+			rarityColor: rarityColor(sk.rarityId)
+		}));
+	});
+
+	/* ── selected skill + dossier ─────────────────────────────────────────────────── */
+
+	/** The inspected skill: an explicitly-requested id resolves even when retired (see the enemy tab's
+	 *  `selectedEnemy`), falling back to the head of the catalogue otherwise. */
+	readonly selectedSkill = $derived<ISkill | undefined>(
+		(staticData.skills ?? [])[this.selectedSkillId] ?? this.skillsCatalogue[0]
+	);
+
+	/** The selected skill's rarity tier (hue + label) for the dossier header accent. */
+	readonly selectedSkillRarity = $derived.by<SkillRarityVM | null>(() => {
+		const sk = this.selectedSkill;
+		return sk ? { color: rarityColor(sk.rarityId), label: rarityLabel(sk.rarityId) } : null;
+	});
+
+	/** The attributes the selected skill's damage scales with, each tinted by its attribute accent. */
+	readonly skillScaling = $derived.by<SkillScalingVM[]>(() => {
+		const sk = this.selectedSkill;
+		if (!sk) {
+			return [];
+		}
+		return sk.damageMultipliers.map((m) => ({
+			attributeId: m.attributeId,
+			name: attributeName(m.attributeId, staticData.attributes),
+			code: attributeCode(m.attributeId, staticData.attributes),
+			multiplierLabel: `×${formatNum(m.multiplier)}`,
+			color: attributeColor(m.attributeId)
+		}));
+	});
+
+	/** The selected skill's authored effects, described via the shared helper so the wording and the
+	 *  buff/debuff direction match every other surface that shows an effect. */
+	readonly skillEffects = $derived.by<SkillEffectVM[]>(() => {
+		const sk = this.selectedSkill;
+		if (!sk) {
+			return [];
+		}
+		return sk.effects.map((effect) => {
+			const desc = describeEffect(
+				effect,
+				attributeName(effect.attributeId, staticData.attributes),
+				attributeIsHarmful(effect.attributeId, staticData.attributes)
+			);
+			return {
+				id: effect.id,
+				magnitude: desc.magnitude,
+				attributeName: desc.attributeName,
+				targetLabel: desc.targetLabel,
+				duration: desc.duration,
+				color: effectDirectionColor(desc.direction)
+			};
+		});
+	});
+
+	/** The (non-retired) enemies whose skill pool includes the selected skill — pills that cross-link
+	 *  into the enemy dossier. Empty for a player-only skill. */
+	readonly skillUsedBy = $derived.by<SkillUserVM[]>(() => {
+		const sk = this.selectedSkill;
+		if (!sk) {
+			return [];
+		}
+		return this.enemies
+			.filter((e) => e.skillPool.includes(sk.id))
+			.map((e) => ({
+				enemyId: e.id,
+				name: e.name,
+				isBoss: e.isBoss,
+				accent: enemyAccent(e.isBoss)
+			}));
+	});
+
+	/** How the selected skill is obtained — derived from actual item-grant references, with the
+	 *  acquisition flag wording the no-source case. Item sources tint by the granting item's rarity. */
+	readonly skillProvenance = $derived.by<SkillProvenanceVM>(() => {
+		const sk = this.selectedSkill;
+		if (!sk) {
+			return { status: 'unobtainable', sources: [], emptyLabel: SKILL_ACQUISITION_EMPTY.unobtainable };
+		}
+		const allItems = staticData.items ?? [];
+		const provenance = resolveSkillProvenance(
+			sk,
+			allItems.filter((i) => !i.retiredAt)
+		);
+		const sources = provenance.sources.map<SkillSourceVM>((src) => ({
+			kind: src.kind,
+			id: src.id,
+			label: SKILL_SOURCE_LABEL,
+			name: src.name,
+			accent: rarityColor(allItems[src.id]?.rarityId ?? ERarity.Common)
+		}));
+		return {
+			status: provenance.status,
+			sources,
+			emptyLabel: sources.length > 0 ? '' : SKILL_ACQUISITION_EMPTY[provenance.status]
+		};
+	});
+
+	/** Every statistic that references the selected skill (the skill dossier's "your record"). */
+	readonly skillStatistics = $derived.by<EntityStatVM[]>(() =>
+		this.selectedSkill ? this.statVMsFor('skill', this.selectedSkill.id) : []
+	);
+
+	/* ── handlers ──────────────────────────────────────────────────────────────── */
+
+	selectSkill(id: number): void {
+		this.selectedSkillId = id;
+	}
+
+	/* ── helpers (store reads, kept off the reactive graph for the constructor) ──── */
+
+	/** Resolve a skill id against the full catalogue (an explicit id resolves even when retired),
+	 *  falling back to the head of the live catalogue. */
+	private resolveSkill(id: number): ISkill | undefined {
+		return (staticData.skills ?? [])[id] ?? liveSkills(staticData.skills)[0];
+	}
+}

--- a/UI/src/routes/game/screens/codex/zones-tab-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/zones-tab-view.svelte.ts
@@ -5,8 +5,14 @@
 
 import type { IZone } from '$lib/api';
 import { playerChallenges, staticData, statistics } from '$stores';
-import { type ZoneStatus, formatBand, liveEnemies, liveZones, resolveZoneStatus } from './codex-display';
-import type { EntityStatVM } from './codex-view.svelte';
+import {
+	type EntityStatVM,
+	type ZoneStatus,
+	formatBand,
+	liveEnemies,
+	liveZones,
+	resolveZoneStatus
+} from './codex-display';
 import { spawnShare, zoneTotalWeight } from './enemy-level';
 import type { StatEntityKind } from '../stats/statistics-view.svelte';
 

--- a/UI/src/routes/game/screens/codex/zones-tab-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/zones-tab-view.svelte.ts
@@ -1,0 +1,194 @@
+/* The Zones tab's reactive layer: the progression rail + the selected zone's dossier (band, boss,
+   spawn table, unlock condition, statistics). Split out of CodexView so each tab's derivations are
+   independently readable/testable — see codex-view.svelte.ts for the composing orchestrator and the
+   cross-tab concerns (active tab, stats fetch, cross-links). */
+
+import type { IZone } from '$lib/api';
+import { playerChallenges, staticData, statistics } from '$stores';
+import { type ZoneStatus, formatBand, liveEnemies, liveZones, resolveZoneStatus } from './codex-display';
+import type { EntityStatVM } from './codex-view.svelte';
+import { spawnShare, zoneTotalWeight } from './enemy-level';
+import type { StatEntityKind } from '../stats/statistics-view.svelte';
+
+/** The immutable per-zone fields (everything the rail row needs except the live progression status). */
+export interface ZoneProjectionVM {
+	id: number;
+	name: string;
+	band: string;
+	/** Enemies (excluding the boss) that spawn in this zone. */
+	spawnCount: number;
+	hasBoss: boolean;
+}
+
+export interface ZoneRowVM extends ZoneProjectionVM {
+	status: ZoneStatus;
+}
+
+export interface ZoneBossVM {
+	enemyId: number;
+	name: string;
+	level: number;
+}
+
+export interface ZoneSpawnVM {
+	enemyId: number;
+	enemyName: string;
+	share: number;
+	weightLabel: string;
+}
+
+export interface ZoneUnlockVM {
+	challengeId: number;
+	challengeName: string;
+	/** Whether the gate is still sealed (the gating challenge isn't complete). */
+	sealed: boolean;
+}
+
+/** The initial-selection payload a deep-link into the Zones tab can carry. */
+export interface ZonesTabPayload {
+	zoneId?: number;
+}
+
+export class ZonesTabView {
+	/** Inspected zone id (falls back to the head of the rail when unresolved). */
+	selectedZoneId = $state<number>(-1);
+
+	/** Projects the player's per-entity statistics (owned by the CodexView orchestrator, which fetches
+	 *  them once for every tab's dossier). */
+	private readonly statVMsFor: (kind: StatEntityKind, id: number) => EntityStatVM[];
+
+	constructor(payload: ZonesTabPayload | undefined, statVMsFor: (kind: StatEntityKind, id: number) => EntityStatVM[]) {
+		this.statVMsFor = statVMsFor;
+		// Resolve the initial zone (the deep-link target, else the head of the rail) so the rail
+		// highlights what the dossier shows. Reads stores directly to avoid touching a $derived here.
+		const initialZone = this.resolveZone(payload?.zoneId ?? -1);
+		if (initialZone) {
+			this.selectedZoneId = initialZone.id;
+		}
+	}
+
+	/* ── zones catalogue (the progression rail) ─────────────────────────────────── */
+
+	readonly zones = $derived(liveZones(staticData.zones));
+
+	/** Live (non-retired) enemies, memoized so the O(zones×enemies) projections below aren't rebuilt
+	 *  independently of one another. */
+	private readonly enemies = $derived(liveEnemies(staticData.enemies));
+
+	/** Immutable per-zone view-models — depends only on reference data (zones + enemies). The spawn-pool
+	 *  count is O(zones×enemies), so it's built once here rather than rebuilt every time a zone's
+	 *  cleared/locked status changes (which happens continuously during idle play). */
+	readonly zoneProjections = $derived.by<ZoneProjectionVM[]>(() => {
+		const enemies = this.enemies;
+		return this.zones.map((z) => ({
+			id: z.id,
+			name: z.name,
+			band: formatBand({ min: z.levelMin, max: z.levelMax, fixed: false }),
+			spawnCount: enemies.filter((e) => e.spawns.some((s) => s.zoneId === z.id)).length,
+			hasBoss: z.bossEnemyId != null
+		}));
+	});
+
+	/** Zone rail rows: the immutable projections overlaid with each zone's live progression status
+	 *  (cleared / unlocked / locked) — the only part that reruns as zones clear or gates open. Zipped
+	 *  by index since `zoneProjections` and `zones` share the same authored order and length. */
+	readonly zoneRows = $derived.by<ZoneRowVM[]>(() =>
+		this.zones.map((z, i) => ({
+			...this.zoneProjections[i],
+			status: resolveZoneStatus(statistics.isZoneCleared(z.id), this.isZoneLocked(z))
+		}))
+	);
+
+	/* ── selected zone + dossier ────────────────────────────────────────────────── */
+
+	/** The inspected zone: an explicitly-requested id resolves even when retired (see the enemy tab's
+	 *  `selectedEnemy`), falling back to the head of the rail otherwise. */
+	readonly selectedZone = $derived<IZone | undefined>((staticData.zones ?? [])[this.selectedZoneId] ?? this.zones[0]);
+
+	/** The selected zone's level band (`11–22`). */
+	readonly zoneBand = $derived.by<string>(() => {
+		const z = this.selectedZone;
+		return z ? formatBand({ min: z.levelMin, max: z.levelMax, fixed: false }) : '';
+	});
+
+	/** The selected zone's progression status (drives the dossier seal + header accent). */
+	readonly selectedZoneStatus = $derived.by<ZoneStatus>(() => {
+		const z = this.selectedZone;
+		return z ? resolveZoneStatus(statistics.isZoneCleared(z.id), this.isZoneLocked(z)) : 'unlocked';
+	});
+
+	/** The zone's dedicated boss (its card cross-links to the enemy dossier), or null when none is authored. */
+	readonly zoneBoss = $derived.by<ZoneBossVM | null>(() => {
+		const z = this.selectedZone;
+		if (!z || z.bossEnemyId == null) {
+			return null;
+		}
+		const boss = (staticData.enemies ?? [])[z.bossEnemyId];
+		return boss ? { enemyId: boss.id, name: boss.name, level: z.bossLevel } : null;
+	});
+
+	/** The zone's spawn table — every non-retired enemy that spawns here, with its share of the zone's
+	 *  total spawn weight, ordered by share. Bosses don't populate `spawns`, so they're naturally absent. */
+	readonly zoneSpawns = $derived.by<ZoneSpawnVM[]>(() => {
+		const z = this.selectedZone;
+		if (!z) {
+			return [];
+		}
+		const enemies = this.enemies;
+		const total = zoneTotalWeight(z.id, enemies);
+		return enemies
+			.flatMap((e) => {
+				const spawn = e.spawns.find((s) => s.zoneId === z.id);
+				return spawn ? [{ enemy: e, weight: spawn.weight }] : [];
+			})
+			.map(({ enemy, weight }) => ({
+				enemyId: enemy.id,
+				enemyName: enemy.name,
+				share: spawnShare(weight, total),
+				weightLabel: `weight ${weight}`
+			}))
+			.sort((a, b) => b.share - a.share);
+	});
+
+	/** Number of distinct enemies in the zone's spawn pool (the dossier's "N spawns" readout). */
+	readonly zoneSpawnCount = $derived(this.zoneSpawns.length);
+
+	/** The zone's unlock condition — the gating challenge's name plus whether it's still sealed — or
+	 *  null for an always-open zone. */
+	readonly zoneUnlock = $derived.by<ZoneUnlockVM | null>(() => {
+		const z = this.selectedZone;
+		if (!z || z.unlockChallengeId == null) {
+			return null;
+		}
+		const challenge = (staticData.challenges ?? [])[z.unlockChallengeId];
+		return {
+			challengeId: z.unlockChallengeId,
+			challengeName: challenge?.name ?? `Challenge ${z.unlockChallengeId}`,
+			sealed: !playerChallenges.isChallengeCompleted(z.unlockChallengeId)
+		};
+	});
+
+	/** Every statistic that references the selected zone (the zone dossier's "your record"). */
+	readonly zoneStatistics = $derived.by<EntityStatVM[]>(() =>
+		this.selectedZone ? this.statVMsFor('zone', this.selectedZone.id) : []
+	);
+
+	/* ── handlers ──────────────────────────────────────────────────────────────── */
+
+	selectZone(id: number): void {
+		this.selectedZoneId = id;
+	}
+
+	/* ── helpers (store reads, kept off the reactive graph for the constructor) ──── */
+
+	/** Resolve a zone id against the full catalogue (an explicit id resolves even when retired),
+	 *  falling back to the head of the rail (authored order). */
+	private resolveZone(id: number): IZone | undefined {
+		return (staticData.zones ?? [])[id] ?? liveZones(staticData.zones)[0];
+	}
+
+	/** A zone is locked when it carries an unlock gate the player hasn't completed yet. */
+	private isZoneLocked(zone: IZone): boolean {
+		return zone.unlockChallengeId != null && !playerChallenges.isChallengeCompleted(zone.unlockChallengeId);
+	}
+}


### PR DESCRIPTION
## Summary

`UI/src/routes/game/screens/codex/codex-view.svelte.ts` had grown into one 820-line class holding the Enemies/Zones/Skills tabs' selection state, ~30 deriveds and the deep-link constructor together. The screen already renders per-tab components (`EnemiesTab`/`ZonesTab`/`SkillsTab`), so this splits the reactive layer to mirror that structure.

## Changes

- **New `enemies-tab-view.svelte.ts`, `zones-tab-view.svelte.ts`, `skills-tab-view.svelte.ts`**: each holds the `$state`/`$derived` layer and handler methods for its own tab (table filter/search/sort, selected-entity dossier projections, cross-tab-agnostic helpers), plus the VM interfaces that tab's projections produce.
- **`codex-view.svelte.ts`**: now a thin orchestrator (373 lines, down from 820). It owns only what's genuinely cross-tab — the active tab, the once-fetched player statistics + challenge-error state, the shared `StatisticsData` query engine, and the cross-dossier links (`openEnemy`/`openZone`/`openSkill`) — and delegates every other property/method to the owning tab's instance via forwarding getters/setters. Its public API is unchanged, so every consuming `.svelte` component keeps reading `view.<x>` exactly as before.
- **`codex-display.ts`**: gained the shared catalogue filters (`liveEnemies`/`liveZones`/`liveSkills`), moved out of `codex-view.svelte.ts` so all three tab views can reuse them without an inter-tab import.

No behavior change — the existing `codex-view.svelte.test.ts` suite (unmodified) pins the seams, and it (along with every other Codex test) still passes as-is against the new internal structure.

## Test plan

- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings.
- [x] `npm run lint` — clean.
- [x] `npm run test:unit:ci` — full suite passes: 3624/3624, coverage thresholds intact.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1737


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8CAn7dUdrxa11qtY8Sdys)_