### PR TITLE
Omit clientBattleMs on the fight loop's first NewEnemy request

### DIFF
--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -104,6 +104,12 @@ export class EnemyManager {
 	 *  redundant re-syncs (e.g. a returnToIdle when the persisted mode is already idle). `undefined` until
 	 *  the first sync, so the first authoritative state is always sent. */
 	private lastSyncedAutoChallengeBoss?: boolean;
+	/** Whether the fight loop has not yet sent a `NewEnemy` request since {@link start}. Re-armed by every
+	 *  `start()` and consumed by the first `runFetchLoop` dispatch, regardless of whether that `start()` was
+	 *  handed an `activeBattle` — a fresh `battleEngine` has no history for whatever battle the server may
+	 *  still be holding (e.g. a sub-5-minute reconnect the welcome-back gate didn't resume directly), so its
+	 *  untouched `timeElapsed` of 0 must not be reported as a genuine "never fought" claim (#1883). */
+	private isFirstFetch = true;
 
 	/**
 	 * Starts the fight loop. `activeBattle` is the server-handed-back battle a `GetOfflineProgress` summary
@@ -119,6 +125,7 @@ export class EnemyManager {
 	public start(activeBattle?: IEnemyInstance) {
 		if (!this.started) {
 			this.started = true;
+			this.isFirstFetch = true;
 			this.battleStageUnhook = onBattleStageChanged((stage) => this.watchBattleStage(stage));
 			if (activeBattle) {
 				this.mode = activeBattle.isBossBattle ? 'boss' : 'idle';
@@ -246,9 +253,16 @@ export class EnemyManager {
 			// How long the client actually simulated the battle this fetch supersedes, so the backend bounds
 			// its abandon re-simulation accurately. We only reach here for a prefetched battle that was *not*
 			// presented (absent or invalidated by a zone/build change during the cooldown) — the client never
-			// fought it, so report 0 and the backend records no phantom outcome. A plain fetch (no prefetch,
-			// e.g. after an idle loss/draw) reports the elapsed time the client did fight.
-			const clientBattleMs = prepared ? 0 : battleEngine.timeElapsed;
+			// fought it, so report 0 and the backend records no phantom outcome. The loop's first-ever fetch
+			// omits the field entirely instead: `battleEngine` has never held a battle yet, so its `timeElapsed`
+			// is an untouched 0 with no relation to whatever battle the server may still be holding (e.g. a
+			// sub-5-minute reconnect the welcome-back gate deliberately left for this fetch to resolve) — a
+			// literal 0 would falsely claim "never fought," discarding it with no outcome instead of letting the
+			// backend's wall-clock fallback settle or hand it back (#1883). A plain fetch after that (e.g. an
+			// idle loss/draw) reports the elapsed time the client genuinely did fight.
+			const isFirstFetch = this.isFirstFetch;
+			this.isFirstFetch = false;
+			const clientBattleMs = prepared ? 0 : isFirstFetch ? undefined : battleEngine.timeElapsed;
 
 			// Retry iteratively rather than via self-recursion: each attempt returns to a flat stack
 			// (a sustained outage no longer grows the async chain without bound). The loop ends as soon

--- a/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
@@ -14,7 +14,7 @@ vi.mock('$lib/engine/log', () => ({ logMessage: vi.fn() }));
 // index ('../'). Stub it so importing the unit doesn't spin up the whole engine — getNewEnemy only
 // reads playerManager.currentZone, and entering Home calls battleEngine.rest().
 vi.mock('$lib/engine', () => ({
-	battleEngine: { stage: 0, startLoading: vi.fn(), rest: vi.fn() },
+	battleEngine: { stage: 0, timeElapsed: 0, startLoading: vi.fn(), rest: vi.fn() },
 	BattleStage: { Idle: 0, Victorious: 1, Defeated: 2 },
 	onBattleStageChanged: vi.fn(() => () => {}),
 	playerManager: { currentZone: 3 }
@@ -70,6 +70,7 @@ describe('EnemyManager.getNewEnemy', () => {
 		// The retry loop runs while the manager is started; flip it on directly (start() would also
 		// hook battle-stage changes, which these focused unit tests don't exercise).
 		manager.started = true;
+		battleEngine.timeElapsed = 0;
 		vi.mocked(logMessage).mockClear();
 		vi.mocked(delay).mockClear();
 		sendSocketCommand = vi.spyOn(apiSocket, 'sendSocketCommand');
@@ -275,6 +276,39 @@ describe('EnemyManager.getNewEnemy', () => {
 		expect(loaded).toEqual([enemy]);
 		expect(manager.currentEnemy).toEqual(enemy);
 	});
+
+	// #1883: a fresh battleEngine's timeElapsed is a genuine 0, not "no history" — the loop's first-ever
+	// NewEnemy request must omit clientBattleMs rather than send that 0, or the backend reads it as "the
+	// client never fought this battle" and silently drops whatever stale battle it may still be holding
+	// (e.g. a sub-5-minute reconnect the welcome-back gate didn't resume directly).
+	it("omits clientBattleMs on the loop's first NewEnemy request even though timeElapsed is genuinely 0", async () => {
+		battleEngine.timeElapsed = 0;
+		sendSocketCommand.mockResolvedValue(enemyResponse(makeEnemy(1)));
+
+		await manager.getNewEnemy();
+
+		expect(sendSocketCommand).toHaveBeenCalledWith('NewEnemy', {
+			newZoneId: 3,
+			clientBattleMs: undefined,
+			forceAbandon: false
+		});
+	});
+
+	it('reports the real elapsed time on a later fetch once the loop has already made its first request', async () => {
+		sendSocketCommand.mockResolvedValue(enemyResponse(makeEnemy(1)));
+		await manager.getNewEnemy(); // consumes the first-fetch omission
+
+		battleEngine.timeElapsed = 4200;
+		sendSocketCommand.mockClear();
+		sendSocketCommand.mockResolvedValue(enemyResponse(makeEnemy(2)));
+		await manager.getNewEnemy(); // e.g. an idle loss/draw reporting genuine elapsed time
+
+		expect(sendSocketCommand).toHaveBeenCalledWith('NewEnemy', {
+			newZoneId: 3,
+			clientBattleMs: 4200,
+			forceAbandon: false
+		});
+	});
 });
 
 describe('EnemyManager.start', () => {
@@ -283,6 +317,7 @@ describe('EnemyManager.start', () => {
 
 	beforeEach(() => {
 		manager = new EnemyManager();
+		battleEngine.timeElapsed = 0;
 		vi.mocked(logMessage).mockClear();
 		sendSocketCommand = vi.spyOn(apiSocket, 'sendSocketCommand');
 		sendSocketCommand.mockReset();
@@ -330,6 +365,29 @@ describe('EnemyManager.start', () => {
 		expect(manager.mode).toBe('boss');
 		expect(manager.currentEnemy).toEqual(activeBossBattle);
 	});
+
+	// #1883: the first-fetch omission is re-armed per start() (e.g. a character switch), not consumed once
+	// for the manager's whole lifetime — a fresh loop always has no history for whatever battle the server
+	// may still be holding for the newly-selected character.
+	it('re-arms the first-fetch omission on a fresh start() after a stop()', async () => {
+		sendSocketCommand.mockResolvedValue(enemyResponse(makeEnemy(1)));
+		manager.start();
+		await vi.waitFor(() => expect(manager.currentEnemy).toEqual(makeEnemy(1)));
+		manager.stop();
+
+		sendSocketCommand.mockClear();
+		battleEngine.timeElapsed = 9000; // stale from the previous character's fight; must not leak through
+		sendSocketCommand.mockResolvedValue(enemyResponse(makeEnemy(2)));
+		manager.start();
+
+		await vi.waitFor(() =>
+			expect(sendSocketCommand).toHaveBeenCalledWith('NewEnemy', {
+				newZoneId: 3,
+				clientBattleMs: undefined,
+				forceAbandon: false
+			})
+		);
+	});
 });
 
 describe('EnemyManager Home zone', () => {
@@ -342,6 +400,7 @@ describe('EnemyManager Home zone', () => {
 	beforeEach(() => {
 		manager = new EnemyManager();
 		manager.started = true;
+		battleEngine.timeElapsed = 0;
 		staticData.zones = [];
 		staticData.zones[COMBAT_ZONE] = { isHome: false } as (typeof staticData.zones)[number];
 		staticData.zones[HOME_ZONE] = { isHome: true } as (typeof staticData.zones)[number];


### PR DESCRIPTION
## Summary

On a reconnect under the 5-minute offline floor, the welcome-back path deliberately leaves the stale battle for the idle loop's first `NewEnemy` to abandon (`OfflineProgressService.cs`, sub-threshold branch) — relying on the backend's wall-clock fallback (a `null` `clientBattleMs`) to settle it correctly.

But the client's first `getNewEnemy` after a page load always sent a **numeric** `clientBattleMs`: `clientBattleMs = prepared ? 0 : battleEngine.timeElapsed`, and a freshly-constructed `battleEngine` has never held a battle, so its `timeElapsed` is an untouched `0`. Server-side, `AbandonBattle` treats a numeric `0` as "the client never fought this battle" and clears it with **no outcome, no credit, and no #1595 hand-back** — silently dropping an in-flight battle (possibly a win) on every quick refresh/reconnect.

## Fix

`EnemyManager` now tracks whether the fight loop has sent its first `NewEnemy` request since `start()` (`isFirstFetch`, re-armed on every `start()`). On that first request, `clientBattleMs` is omitted entirely (`undefined`) instead of sending the engine's meaningless untouched `timeElapsed`, letting the backend's existing wall-clock fallback settle a concluded battle or hand back one still in progress. Every subsequent fetch in the session (idle loss/draw, etc.) still reports the genuine elapsed time as before.

This is a frontend-only change — the backend's `null`-`clientBattleMs` handling (`AbandonBattle`) was already correct; the bug was purely that the frontend never sent `null`/omitted the field on its very first request.

## Tests

- `enemy-manager.test.ts`: new cases pinning that the loop's first `NewEnemy` request omits `clientBattleMs` even when `battleEngine.timeElapsed` is genuinely `0`, that a later fetch in the same session reports the real elapsed time, and that the omission re-arms on a fresh `start()` after a `stop()` (e.g. a character switch) rather than being consumed once for the manager's whole lifetime.
- Updated the shared `battleEngine` mock to expose a real (mutable) `timeElapsed` instead of leaving it `undefined`, which also strengthens several pre-existing assertions that happened to pass only because the mock never set the field.

## Test plan

- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings.
- [x] `npm run lint` — clean.
- [x] `npm run test:unit:ci` — full suite passes: 3627/3627.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1883


---
_Generated by [Claude Code](https://claude.ai/code/session_01UTwMj529Rva42tTMPX8Au6)_