### PR TITLE
Reject flipping a spawn-populated combat zone to Home

### DIFF
--- a/Game.Application.Tests/DataAccess/AdminZonesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminZonesIntegrationTests.cs
@@ -350,6 +350,52 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SaveZones_FlipZoneToHomeWithSpawns_ReturnsFailure()
+        {
+            int combatZoneId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var zone = await TestDataSeeder.CreateZoneAsync(context, "Wilds");
+                var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+                await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id, weight: 1);
+                combatZoneId = zone.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // Flipping an already-spawn-populated combat zone to Home is the third way to leave the
+            // sanctuary with live spawns (the other two — a Home boss, and SetEnemies against a Home zone —
+            // are already guarded). The guard reasons over the zone's currently cached spawn table, not this
+            // save's own payload, since SaveZones never carries spawn data.
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminZones>();
+
+            var result = admin.SaveZones(
+            [
+                new Change<Contracts.Zone>
+                {
+                    ChangeType = EChangeType.Edit,
+                    Item = new Contracts.Zone
+                    {
+                        Id = combatZoneId,
+                        Name = "Wilds",
+                        Description = "",
+                        DesignerNotes = "",
+                        LevelMin = 1,
+                        LevelMax = 10,
+                        BossLevel = 1,
+                        IsHome = true,
+                    },
+                },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal(
+                "The Home zone cannot have enemy spawns. Home is a no-combat sanctuary where no enemies spawn; clear the zone's spawn table before making it Home.",
+                result.ErrorMessage);
+        }
+
+        [Fact]
         public async Task SaveZones_RetiredHomeZone_DoesNotBlockNewHome()
         {
             using (var seedScope = CreateScope())

--- a/Game.DataAccess/Repositories/Admin/AdminZones.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminZones.cs
@@ -50,6 +50,17 @@ namespace Game.DataAccess.Repositories.Admin
                     return AdminSaveResult.Failure("The Home zone cannot have a boss. Home is a no-combat sanctuary where no enemies spawn.");
                 }
 
+                // SetEnemies / AdminEnemies.SetSpawns block populating a Home zone's spawn table going
+                // forward, but neither fires against this save's own flip — an edit that sets IsHome on a
+                // combat zone whose spawn table is already populated would otherwise leave the sanctuary with
+                // live spawns. An Add can never carry pre-existing spawns, so this only applies to edits.
+                if (change.ChangeType == EChangeType.Edit
+                    && change.Item.IsHome
+                    && _zones.LookupZone(change.Item.Id) is { ZoneEnemies.Count: > 0 })
+                {
+                    return AdminSaveResult.Failure("The Home zone cannot have enemy spawns. Home is a no-combat sanctuary where no enemies spawn; clear the zone's spawn table before making it Home.");
+                }
+
                 // Challenges are zero-based-id reference data, so a valid id is an in-range index (an O(1)
                 // check, like the enemy/zone validators above).
                 if (change.Item.UnlockChallengeId is int unlockChallengeId


### PR DESCRIPTION
## Summary

`AdminZones.SaveZones` already guarded two of the three ways a Home zone could end up with enemies: declaring a boss on a Home zone, and `SetEnemies`/`AdminEnemies.SetSpawns` populating a Home zone's spawn table. The third was unguarded — editing an **existing combat zone that already has `ZoneEnemy` rows** and setting `IsHome = true`. No guard fired, and the spawn rows survived the save.

Post-save, `HasSpawnableEnemies(home) == true`, so `ZoneResolutionService.IsZoneViable` (which doesn't check `IsHomeZone`) would treat Home as a viable relocation destination, letting `EnsureViableZone` server-side `ChangeZone` a player into Home and bypassing the `StartBattle` anti-cheat that refuses Home moves — breaking the documented invariant that a player's persisted `CurrentZoneId` is never Home.

## Changes

- `Game.DataAccess/Repositories/Admin/AdminZones.cs`: `SaveZones` now rejects an `Edit` that sets `IsHome = true` on a zone whose currently cached `ZoneEnemies` set is non-empty, mirroring the existing boss guard's shape and message. Scoped to edits only — an `Add` can never carry pre-existing spawns.

## Tests

- `AdminZonesIntegrationTests.SaveZones_FlipZoneToHomeWithSpawns_ReturnsFailure`: seeds a combat zone with an active spawn, attempts to flip it to Home, and asserts the save fails with the spawn-table rejection message rather than persisting the flip.

## Test plan

- [x] `dotnet build Game.sln` — 0 warnings, 0 errors.
- [x] `dotnet test Game.sln --no-build --no-restore` — full backend suite: 3084/3084 passing (including the new regression test).
- [x] `dotnet format Game.sln --verify-no-changes` — clean.
- [ ] Frontend unaffected (backend-only change, no wire-contract change) — no frontend verification needed.

Closes #1887


---
_Generated by [Claude Code](https://claude.ai/code/session_01HZUJ5CquoXiwzRh7oxv6Ly)_