### PR TITLE
Guard browser Back/Forward against discarding unsaved Workbench edits

### DIFF
--- a/UI/src/routes/admin/+page.svelte
+++ b/UI/src/routes/admin/+page.svelte
@@ -99,7 +99,7 @@ const backToGame = async () => {
 	}
 };
 
-// Guards the browser Back/Forward buttons, the client-side exit `handleNavigate`/`backToGame`
+// Guards the browser Back/Forward buttons — a client-side exit that handleNavigate/backToGame
 // don't cover (see discard-guard.ts).
 beforeNavigate(createPopStateDiscardGuard(() => workbenchDirty.total));
 

--- a/UI/src/routes/admin/+page.svelte
+++ b/UI/src/routes/admin/+page.svelte
@@ -41,7 +41,7 @@
 
 <script lang="ts">
 import { onMount } from 'svelte';
-import { goto } from '$app/navigation';
+import { beforeNavigate, goto } from '$app/navigation';
 import { resolve } from '$app/paths';
 import { Loading } from '$components';
 import AdminSidebar from './AdminSidebar.svelte';
@@ -61,7 +61,7 @@ import {
 } from './workbench/nav';
 import { reference } from './workbench/reference.svelte';
 import { ensureAdminAccess } from './admin-access';
-import { confirmDiscard, guardBeforeUnload } from './discard-guard';
+import { confirmDiscard, createPopStateDiscardGuard, guardBeforeUnload } from './discard-guard';
 import { toastError } from '$stores';
 
 let active = $state('enemies');
@@ -98,6 +98,10 @@ const backToGame = async () => {
 		goto(resolve('/game'));
 	}
 };
+
+// Guards the browser Back/Forward buttons, the client-side exit `handleNavigate`/`backToGame`
+// don't cover (see discard-guard.ts).
+beforeNavigate(createPopStateDiscardGuard(() => workbenchDirty.total));
 
 $effect(() => {
 	const handler = (event: BeforeUnloadEvent) => guardBeforeUnload(event, workbenchDirty.total);

--- a/UI/src/routes/admin/discard-guard.ts
+++ b/UI/src/routes/admin/discard-guard.ts
@@ -1,3 +1,4 @@
+import type { BeforeNavigate } from '@sveltejs/kit';
 import { dangerModal } from '$stores';
 
 /**
@@ -27,4 +28,40 @@ export function guardBeforeUnload(event: BeforeUnloadEvent, pending: number): vo
 		event.preventDefault();
 		event.returnValue = '';
 	}
+}
+
+/**
+ * Creates a `beforeNavigate` handler guarding the browser Back/Forward buttons — a client-side
+ * popstate navigation that unmounts `/admin` without firing `beforeunload` and isn't reached by
+ * {@link confirmDiscard}'s other two call sites (sidebar tool switch, "Return to Game"). `pending`
+ * is read lazily via a getter so the handler stays valid as the dirty count changes across its
+ * lifetime.
+ *
+ * Cancels the popstate navigation, prompts via {@link confirmDiscard}, and re-issues the same
+ * history delta once confirmed. The re-issued navigation is itself a popstate the handler would
+ * otherwise re-prompt for, so a one-shot bypass flag lets it through.
+ */
+export function createPopStateDiscardGuard(getPending: () => number): (navigation: BeforeNavigate) => void {
+	let bypassNext = false;
+
+	return (navigation: BeforeNavigate) => {
+		if (navigation.type !== 'popstate') {
+			return;
+		}
+		if (bypassNext) {
+			bypassNext = false;
+			return;
+		}
+		const pending = getPending();
+		if (pending === 0) {
+			return;
+		}
+		navigation.cancel();
+		void confirmDiscard(pending).then((confirmed) => {
+			if (confirmed) {
+				bypassNext = true;
+				history.go(navigation.delta);
+			}
+		});
+	};
 }

--- a/UI/src/tests/routes/admin/discard-guard.test.ts
+++ b/UI/src/tests/routes/admin/discard-guard.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 const { dangerModal } = vi.hoisted(() => ({ dangerModal: vi.fn() }));
 vi.mock('$stores', () => ({ dangerModal }));
 
-import { confirmDiscard, guardBeforeUnload } from '$routes/admin/discard-guard';
+import type { BeforeNavigate } from '@sveltejs/kit';
+import { confirmDiscard, createPopStateDiscardGuard, guardBeforeUnload } from '$routes/admin/discard-guard';
 
 beforeEach(() => dangerModal.mockReset());
 
@@ -62,5 +63,97 @@ describe('guardBeforeUnload', () => {
 
 		expect(event.preventDefault).toHaveBeenCalledOnce();
 		expect(event.returnValue).not.toBe(true);
+	});
+});
+
+describe('createPopStateDiscardGuard', () => {
+	const fakeNavigation = (overrides: Partial<BeforeNavigate> = {}) =>
+		({
+			type: 'popstate',
+			delta: -1,
+			cancel: vi.fn(),
+			...overrides
+		}) as unknown as BeforeNavigate & { cancel: ReturnType<typeof vi.fn> };
+
+	let historyGoSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		historyGoSpy = vi.spyOn(window.history, 'go').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		historyGoSpy.mockRestore();
+	});
+
+	it('ignores non-popstate navigations regardless of pending changes', () => {
+		const guard = createPopStateDiscardGuard(() => 1);
+		const navigation = fakeNavigation({ type: 'link' });
+
+		guard(navigation);
+
+		expect(navigation.cancel).not.toHaveBeenCalled();
+		expect(dangerModal).not.toHaveBeenCalled();
+	});
+
+	it('lets a popstate navigation through when nothing is pending', () => {
+		const guard = createPopStateDiscardGuard(() => 0);
+		const navigation = fakeNavigation();
+
+		guard(navigation);
+
+		expect(navigation.cancel).not.toHaveBeenCalled();
+		expect(dangerModal).not.toHaveBeenCalled();
+	});
+
+	it('cancels a dirty popstate navigation and prompts to discard', () => {
+		dangerModal.mockResolvedValue(false);
+		const guard = createPopStateDiscardGuard(() => 2);
+		const navigation = fakeNavigation();
+
+		guard(navigation);
+
+		expect(navigation.cancel).toHaveBeenCalledOnce();
+		expect(dangerModal).toHaveBeenCalledOnce();
+	});
+
+	it('does not replay the navigation when the prompt is declined', async () => {
+		dangerModal.mockResolvedValue(false);
+		const guard = createPopStateDiscardGuard(() => 2);
+
+		guard(fakeNavigation());
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(historyGoSpy).not.toHaveBeenCalled();
+	});
+
+	it('replays the same history delta when the prompt is confirmed', async () => {
+		dangerModal.mockResolvedValue(true);
+		const guard = createPopStateDiscardGuard(() => 2);
+
+		guard(fakeNavigation({ delta: -3 }));
+
+		await vi.waitFor(() => expect(historyGoSpy).toHaveBeenCalledWith(-3));
+	});
+
+	it('lets the replayed popstate through once without re-prompting, then re-arms', async () => {
+		dangerModal.mockResolvedValue(true);
+		const guard = createPopStateDiscardGuard(() => 2);
+
+		guard(fakeNavigation());
+		await vi.waitFor(() => expect(historyGoSpy).toHaveBeenCalledOnce());
+
+		dangerModal.mockClear();
+		const replayed = fakeNavigation();
+		guard(replayed);
+
+		expect(replayed.cancel).not.toHaveBeenCalled();
+		expect(dangerModal).not.toHaveBeenCalled();
+
+		const another = fakeNavigation();
+		guard(another);
+
+		expect(another.cancel).toHaveBeenCalledOnce();
+		expect(dangerModal).toHaveBeenCalledOnce();
 	});
 });


### PR DESCRIPTION
## Summary

The Workbench's dirty-edit guard (`discard-guard.ts`) covered three exits: sidebar tool switch and "Return to Game" (via `confirmDiscard`), and full page unload (`beforeunload`). Browser Back/Forward is a fourth, uncovered exit: it's a client-side popstate navigation, so SvelteKit unmounts `/admin` without firing `beforeunload`, and there was no `beforeNavigate` anywhere in the app — all pending Workbench/Progression edits were silently discarded with no prompt.

## Changes

- **`UI/src/routes/admin/discard-guard.ts`**: new `createPopStateDiscardGuard(getPending)` factory returning a `beforeNavigate` handler. On a dirty `popstate` navigation it cancels the navigation, prompts via the existing `confirmDiscard`, and — if confirmed — replays the same history delta (`history.go(navigation.delta)`) to actually complete the Back/Forward. The replay is itself a popstate the handler would otherwise re-prompt for, so a one-shot bypass flag lets it through once before re-arming.
- **`UI/src/routes/admin/+page.svelte`**: wires the guard via `beforeNavigate(createPopStateDiscardGuard(() => workbenchDirty.total))`, mirroring how the existing `beforeunload` listener reads `workbenchDirty.total`.

Non-popstate navigation types (`link`, `goto`, `form`) are intentionally left alone — those are already guarded by `confirmDiscard` at their call sites (`handleNavigate`, `backToGame`), so a generic handler would have double-prompted.

## Tests

- `UI/src/tests/routes/admin/discard-guard.test.ts`: new `createPopStateDiscardGuard` suite — ignores non-popstate navigations; lets a clean popstate through; cancels and prompts a dirty one; declining leaves the navigation cancelled (no `history.go`); confirming replays the exact delta; the replayed popstate passes through once without re-prompting and then re-arms for a subsequent one.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npx vitest run src/tests/routes/admin/discard-guard.test.ts` — 12/12 passing.
- [x] `npm run test:unit:ci` — full suite: 3635/3635 passing, coverage floors intact.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1892


---
_Generated by [Claude Code](https://claude.ai/code/session_016vDzEnmNC9pNjNaUtWkjVW)_