### PR TITLE
Harden token/notice persistence against localStorage write failures

### DIFF
--- a/UI/src/lib/api/token-store.ts
+++ b/UI/src/lib/api/token-store.ts
@@ -13,13 +13,17 @@ export interface StoredTokens {
 
 const STORAGE_KEY = 'gameserver.auth-tokens';
 
-/** The currently stored token pair, or null when the user is not logged in. */
-export const getTokens = (): StoredTokens | null => {
-	const raw = safeLocalStorage()?.getItem(STORAGE_KEY);
-	if (!raw) {
-		return null;
-	}
+/**
+ * In-memory shadow of the stored token pair. Storage is normally the source of truth for reads (so a
+ * pair rotated by another tab is picked up on the next read — see `auth.ts`'s multi-tab handling), but
+ * `setTokens` writes through to this mirror first. When the storage write itself then fails (quota
+ * exceeded, or storage blocked outright), reads fall back to the mirror instead of a stale/absent
+ * storage entry, so a freshly rotated single-use token isn't lost for the rest of this tab's session.
+ */
+let memoryTokens: StoredTokens | null = null;
+let storageWriteFailed = false;
 
+const parseStoredTokens = (raw: string): StoredTokens | null => {
 	try {
 		const parsed = JSON.parse(raw) as Partial<StoredTokens>;
 		if (parsed.accessToken && parsed.refreshToken) {
@@ -28,18 +32,54 @@ export const getTokens = (): StoredTokens | null => {
 	} catch {
 		// Malformed entry — treat as logged out.
 	}
-
 	return null;
+};
+
+/** The currently stored token pair, or null when the user is not logged in. */
+export const getTokens = (): StoredTokens | null => {
+	const storage = safeLocalStorage();
+	if (storage && !storageWriteFailed) {
+		try {
+			const raw = storage.getItem(STORAGE_KEY);
+			memoryTokens = raw ? parseStoredTokens(raw) : null;
+			return memoryTokens;
+		} catch {
+			// Reading storage threw — fall back to the in-memory mirror below.
+		}
+	}
+
+	return memoryTokens;
 };
 
 /** Persists a freshly issued token pair, replacing any previous one. */
 export const setTokens = (tokens: StoredTokens): void => {
-	safeLocalStorage()?.setItem(STORAGE_KEY, JSON.stringify(tokens));
+	memoryTokens = tokens;
+
+	const storage = safeLocalStorage();
+	if (!storage) {
+		storageWriteFailed = true;
+		return;
+	}
+
+	try {
+		storage.setItem(STORAGE_KEY, JSON.stringify(tokens));
+		storageWriteFailed = false;
+	} catch {
+		// Quota exceeded or storage blocked — the in-memory mirror keeps this tab's session usable
+		// until a write succeeds again; it won't survive a reload.
+		storageWriteFailed = true;
+	}
 };
 
 /** Removes the stored token pair (logout, or after an unrecoverable auth failure). */
 export const clearTokens = (): void => {
-	safeLocalStorage()?.removeItem(STORAGE_KEY);
+	memoryTokens = null;
+	storageWriteFailed = false;
+	try {
+		safeLocalStorage()?.removeItem(STORAGE_KEY);
+	} catch {
+		// Best-effort — nothing else to reasonably do if this throws.
+	}
 };
 
 export const getAccessToken = (): string | null => getTokens()?.accessToken ?? null;

--- a/UI/src/lib/engine/background-throttle-notice.ts
+++ b/UI/src/lib/engine/background-throttle-notice.ts
@@ -113,7 +113,12 @@ export class BackgroundThrottleMonitor {
 			return;
 		}
 		// Persist before showing so the one-time guarantee holds even if the toast is dismissed instantly.
-		storage?.setItem(NOTICE_SHOWN_KEY, '1');
+		try {
+			storage?.setItem(NOTICE_SHOWN_KEY, '1');
+		} catch {
+			// Quota exceeded or storage blocked — the notice still shows this session; a persistence
+			// failure here just means the one-time guarantee may not survive a reload.
+		}
 		toastWarning(backgroundThrottleGuidance(), { duration: 0 });
 	}
 }

--- a/UI/src/tests/lib/api/token-store.test.ts
+++ b/UI/src/tests/lib/api/token-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
 	clearTokens,
 	getAccessToken,
@@ -25,6 +25,9 @@ function makeAccessToken(exp: number): string {
 describe('token-store', () => {
 	beforeEach(() => {
 		localStorage.clear();
+		// Reset the module's in-memory mirror/write-failure flag between tests too, since they're
+		// module-level state that would otherwise leak across cases.
+		clearTokens();
 	});
 
 	it('returns null when no tokens are stored', () => {
@@ -150,5 +153,59 @@ describe('token-store', () => {
 
 		expect(getAccessTokenExpiry()).toBeNull();
 		expect(getRoles()).toEqual([]);
+	});
+
+	describe('degraded storage', () => {
+		it('serves the freshly set pair from memory when the storage write throws (quota exceeded)', () => {
+			const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+				throw new DOMException('quota exceeded', 'QuotaExceededError');
+			});
+
+			expect(() => setTokens({ accessToken: 'a', refreshToken: 'r' })).not.toThrow();
+			expect(getTokens()).toEqual({ accessToken: 'a', refreshToken: 'r' });
+			// The write genuinely never landed in storage.
+			expect(localStorage.getItem('gameserver.auth-tokens')).toBeNull();
+
+			spy.mockRestore();
+		});
+
+		it('resumes reading from storage once a write succeeds again after a prior failure', () => {
+			const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+				throw new DOMException('quota exceeded', 'QuotaExceededError');
+			});
+			setTokens({ accessToken: 'a', refreshToken: 'r' });
+			spy.mockRestore();
+
+			setTokens({ accessToken: 'a2', refreshToken: 'r2' });
+
+			expect(getTokens()).toEqual({ accessToken: 'a2', refreshToken: 'r2' });
+			expect(localStorage.getItem('gameserver.auth-tokens')).toBe(
+				JSON.stringify({ accessToken: 'a2', refreshToken: 'r2' })
+			);
+		});
+
+		it('falls back to memory when reading storage throws', () => {
+			setTokens({ accessToken: 'a', refreshToken: 'r' });
+
+			const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+				throw new DOMException('storage blocked', 'SecurityError');
+			});
+
+			expect(getTokens()).toEqual({ accessToken: 'a', refreshToken: 'r' });
+
+			spy.mockRestore();
+		});
+
+		it('clearTokens resets the memory mirror and the write-failure state', () => {
+			const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+				throw new DOMException('quota exceeded', 'QuotaExceededError');
+			});
+			setTokens({ accessToken: 'a', refreshToken: 'r' });
+			spy.mockRestore();
+
+			clearTokens();
+
+			expect(getTokens()).toBeNull();
+		});
 	});
 });

--- a/UI/src/tests/lib/engine/background-throttle-notice.test.ts
+++ b/UI/src/tests/lib/engine/background-throttle-notice.test.ts
@@ -7,6 +7,7 @@ const h = vi.hoisted(() => ({
 	state: {
 		lsStore: {} as Record<string, string>,
 		lsAvailable: true,
+		setItemThrows: false,
 		idleTimeLostCb: undefined as ((ms: number) => void) | undefined
 	}
 }));
@@ -19,6 +20,9 @@ vi.mock('$lib/common/local-storage', () => ({
 			? {
 					getItem: (k: string) => h.state.lsStore[k] ?? null,
 					setItem: (k: string, v: string) => {
+						if (h.state.setItemThrows) {
+							throw new DOMException('quota exceeded', 'QuotaExceededError');
+						}
 						h.state.lsStore[k] = v;
 					}
 				}
@@ -52,6 +56,7 @@ describe('BackgroundThrottleMonitor', () => {
 		vi.clearAllMocks();
 		h.state.lsStore = {};
 		h.state.lsAvailable = true;
+		h.state.setItemThrows = false;
 		h.state.idleTimeLostCb = undefined;
 		hidden = false;
 		Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
@@ -173,6 +178,16 @@ describe('BackgroundThrottleMonitor', () => {
 		lose(70_000);
 		goVisible();
 
+		expect(h.toastWarning).toHaveBeenCalledTimes(1);
+	});
+
+	it('still shows the notice when persisting the one-time flag throws (quota exceeded)', () => {
+		h.state.setItemThrows = true;
+		monitor.start();
+		goHidden();
+		lose(70_000);
+
+		expect(() => goVisible()).not.toThrow();
 		expect(h.toastWarning).toHaveBeenCalledTimes(1);
 	});
 


### PR DESCRIPTION
## Summary

`UI/src/lib/api/token-store.ts`'s `setTokens`/`clearTokens` called `setItem`/`removeItem` unguarded — `setItem` can throw `QuotaExceededError` (the reference cache shares the origin and grows with content) even though the shared `safeLocalStorage()` guard's own doc comment claims callers "degrade gracefully to in-memory only rather than throwing." No consumer actually implemented that in-memory fallback. `UI/src/lib/engine/background-throttle-notice.ts` had the same unguarded `setItem` call inside a visibility-change callback.

## Failure scenarios this fixes

1. Origin quota near-full: a token refresh succeeds server-side (the single-use refresh token is consumed), but persisting the new pair throws inside `refreshTokens().then` — the already-consumed pair is lost, forcing a re-login.
2. Storage-blocked privacy mode: login "succeeds" but every subsequent request is unauthenticated because nothing was ever persisted (and, before this fix, in-memory reads didn't fall back to anything either).

## Changes

- **`token-store.ts`**: `getTokens`/`setTokens`/`clearTokens` now maintain a write-through in-memory mirror. `setTokens` writes the mirror first, then best-effort persists to storage (try/catch). Reads normally still prefer storage (so a pair rotated by another tab — a supported state per `auth.ts` — is picked up), but fall back to the mirror when the last storage write is known to have failed, or when reading storage itself throws.
- **`background-throttle-notice.ts`**: wrapped the one-time notice's `setItem` call in try/catch — persistence failure there is low-stakes (the notice just might re-show after a reload), so no mirror is needed, just no uncaught throw.

## Tests

- `token-store.test.ts`: new `degraded storage` suite — a failed write still serves the freshly set pair from memory (and confirms the write genuinely never reached storage); a later successful write resumes normal storage-backed reads; a storage read throwing falls back to memory; `clearTokens` resets both the mirror and the write-failure state. Also updated `beforeEach` to reset the module's mirror/failure-flag state between cases (module-level state that would otherwise leak across tests).
- `background-throttle-notice.test.ts`: new case asserting the notice still shows (and nothing throws) when persisting the one-time flag fails.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npx vitest run src/tests/lib/api/token-store.test.ts src/tests/lib/engine/background-throttle-notice.test.ts` — 42/42 passing.
- [x] `npm run test:unit:ci` — full suite: 3634/3634 passing, coverage floors intact.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1769


---
_Generated by [Claude Code](https://claude.ai/code/session_01VEUQVe4ifSdzsivah9TquX)_