### PR TITLE
Disable empty-state Add control when its option catalogue is empty

### DIFF
--- a/UI/src/routes/admin/workbench/components/EmptySection.svelte
+++ b/UI/src/routes/admin/workbench/components/EmptySection.svelte
@@ -5,7 +5,13 @@
 		<div class="es">{sub}</div>
 	</div>
 	{#if onAdd && addLabel}
-		<button type="button" class="btn sm" onclick={onAdd}>
+		<button
+			type="button"
+			class="btn sm"
+			onclick={onAdd}
+			disabled={noFree}
+			title={noFree ? 'Every option is already assigned' : undefined}
+		>
 			<WorkbenchIcon kind="plus" size={12} />{addLabel}
 		</button>
 	{/if}
@@ -20,7 +26,8 @@ interface Props {
 	sub: string;
 	addLabel?: string;
 	onAdd?: () => void;
+	noFree?: boolean;
 }
 
-const { icon, title, sub, addLabel, onAdd }: Props = $props();
+const { icon, title, sub, addLabel, onAdd, noFree = false }: Props = $props();
 </script>

--- a/UI/src/routes/admin/workbench/components/SectionTable.svelte
+++ b/UI/src/routes/admin/workbench/components/SectionTable.svelte
@@ -5,6 +5,7 @@
 		sub={section.emptySub}
 		addLabel={section.addLabel}
 		onAdd={add}
+		{noFree}
 	/>
 {:else}
 	<div>

--- a/UI/src/tests/routes/admin/workbench/SectionTable.test.ts
+++ b/UI/src/tests/routes/admin/workbench/SectionTable.test.ts
@@ -124,6 +124,29 @@ describe('SectionTable', () => {
 		expect((screen.getByText('Assign zone').closest('button') as HTMLButtonElement).disabled).toBe(true);
 	});
 
+	it('disables the empty-state Add control (instead of crashing) when the option catalogue is empty', () => {
+		const emptyOptsSection: TableSectionConfig<Row> = {
+			...section,
+			columns: [
+				{ key: 'zoneId', label: 'Zone', type: 'select', options: () => [], unique: true },
+				{ key: 'weight', label: 'Weight', type: 'number', align: 'r' },
+				{ key: '__share', label: 'Share', type: 'share', weightKey: 'weight' }
+			]
+		};
+		const { store, record, baseline } = setup([]);
+		render(SectionTable, {
+			props: {
+				section: emptyOptsSection as unknown as TableSectionConfig<Identified>,
+				record: record as Identified,
+				baseline,
+				store: store as unknown as EntityStore<Identified>
+			}
+		});
+		const button = screen.getByText('Assign zone').closest('button') as HTMLButtonElement;
+		expect(button.disabled).toBe(true);
+		expect(button.title).toBe('Every option is already assigned');
+	});
+
 	it('marks a newly added row with the added edge', () => {
 		const store = new EntityStore(config(), [{ id: 1, spawns: [{ zoneId: 0, weight: 5 }] }]);
 		store.patch(1, (d) => d.spawns.push({ zoneId: 1, weight: 2 }));


### PR DESCRIPTION
## Summary

`firstFree` (`UI/src/routes/admin/workbench/entities/helpers.ts:4-7`) ends with `(free ?? options[0]).value` — a `TypeError` when `options` is empty. The normal (non-empty-rows) Add button is already protected: `SectionTable` computes `noFree` (true once every unique option is assigned, vacuously true when the option catalogue is empty) and disables Add. But when a table has zero rows, `SectionTable` renders `EmptySection` instead, and never passed `noFree` through — so its Add button stayed enabled and calling `newRow` → `firstFree` on an empty catalogue crashed.

Reachable states (fresh DB or all-retired catalogues, since option lists filter retired records):
- enemy → Spawns → "Assign zone" with zero active zones
- recipe → Conditions → "Add condition" with zero active proficiencies
- zone → Enemies with zero active enemies

## Changes

- **`UI/src/routes/admin/workbench/components/SectionTable.svelte`**: pass the already-computed `noFree` through to `EmptySection`.
- **`UI/src/routes/admin/workbench/components/EmptySection.svelte`**: accept an optional `noFree` prop; when true, disable the Add button and set the same "Every option is already assigned" title the populated-rows path already uses.

`firstFree` itself is unchanged — once the button is correctly gated, it's never invoked with an empty `options` array (it has exactly one caller, `SectionTable`'s `add()`), so an extra guard there would just be defensive code for an unreachable path.

## Tests

- `UI/src/tests/routes/admin/workbench/SectionTable.test.ts`: new case rendering the empty state with an empty option catalogue, asserting the Add button is disabled with the expected title. Verified this test fails (button not disabled) without the fix and passes with it.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npx vitest run src/tests/routes/admin/workbench/SectionTable.test.ts` — 12/12 passing.
- [x] `npm run test:unit:ci` — full suite: 3635/3635 passing, coverage floors intact.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1894


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8QzWVriytwhLTCA3S6qe9)_