### PR TITLE
Handle Workbench seed-load failures with an error/retry state

### DIFF
--- a/UI/src/routes/admin/workbench/Workbench.svelte
+++ b/UI/src/routes/admin/workbench/Workbench.svelte
@@ -28,6 +28,11 @@
 				onNew={newItem}
 			/>
 		</div>
+	{:else if error}
+		<div class="workbench-error" role="alert" data-testid="workbench-error">
+			<p>{error}</p>
+			<button type="button" class="btn" onclick={loadSeed}>Refresh</button>
+		</div>
 	{:else}
 		<Loading loading={true} delay={150} />
 	{/if}
@@ -36,6 +41,7 @@
 <script lang="ts">
 import { onMount, onDestroy } from 'svelte';
 import { Loading } from '$components';
+import { toastError } from '$stores';
 import './workbench.scss';
 import type { EntityConfig, Identified } from './entities/types';
 import { workbenchDirty } from './dirty.svelte';
@@ -52,14 +58,26 @@ interface Props {
 const { entity, groupLabel = '' }: Props = $props();
 
 let store = $state<EntityStore<Identified>>();
+let error = $state<string | null>(null);
 let selId = $state(0);
 let selectedTab = $state<string>();
 const tab = $derived(selectedTab ?? entity.sections[0]?.key);
 
-onMount(async () => {
-	const seed = await entity.refresh();
-	store = new EntityStore(entity, seed);
-	selId = seed[0]?.id ?? 0;
+async function loadSeed() {
+	error = null;
+	try {
+		const seed = await entity.refresh();
+		store = new EntityStore(entity, seed);
+		selId = seed[0]?.id ?? 0;
+	} catch (ex) {
+		const message = ex instanceof Error ? ex.message : 'Failed to load workbench data.';
+		error = message;
+		toastError(message);
+	}
+}
+
+onMount(() => {
+	void loadSeed();
 });
 
 // Cancel any pending "saved" flash timer so a save that lands near unmount can't
@@ -118,5 +136,22 @@ const newItem = () => {
 }
 .unsaved {
 	color: var(--text-secondary);
+}
+.workbench-error {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 14px;
+	padding: 20px;
+	text-align: center;
+
+	p {
+		max-width: 480px;
+		color: var(--error);
+		font-size: 13px;
+	}
 }
 </style>

--- a/UI/src/tests/routes/admin/workbench/Workbench.test.ts
+++ b/UI/src/tests/routes/admin/workbench/Workbench.test.ts
@@ -109,6 +109,31 @@ describe('Workbench', () => {
 		expect(screen.getByText('Admin Console · Combat')).toBeTruthy();
 	});
 
+	it('shows an error state with a Refresh action when the seed load fails, instead of spinning forever', async () => {
+		const { toastError } = await import('$stores');
+		const entity = makeConfig({ refresh: vi.fn(async () => Promise.reject(new Error('socket unreachable'))) });
+		render(Workbench, { props: { entity } });
+
+		await waitFor(() => expect(screen.getByTestId('workbench-error')).toBeTruthy());
+		expect(screen.getByTestId('workbench-error').textContent).toContain('socket unreachable');
+		expect(screen.queryByTestId('workbench-title')).toBeNull();
+		expect(toastError).toHaveBeenCalledWith('socket unreachable');
+	});
+
+	it('retries the seed load when Refresh is clicked after a failure, and renders normally once it succeeds', async () => {
+		const refresh = vi.fn().mockRejectedValueOnce(new Error('socket unreachable')).mockResolvedValueOnce(seed);
+		const entity = makeConfig({ refresh });
+		render(Workbench, { props: { entity } });
+
+		await waitFor(() => expect(screen.getByTestId('workbench-error')).toBeTruthy());
+
+		await fireEvent.click(screen.getByText('Refresh'));
+
+		await waitFor(() => expect(screen.getByTestId('workbench-title')).toBeTruthy());
+		expect(screen.queryByTestId('workbench-error')).toBeNull();
+		expect(refresh).toHaveBeenCalledTimes(2);
+	});
+
 	it('follows a newly-added record to its persisted id after save, instead of jumping to the first record', async () => {
 		const persist = vi.fn(async (diff: { added: Identified[] }) => [
 			...seed,


### PR DESCRIPTION
## Summary

`Workbench.svelte`'s `onMount(async () => { const seed = await entity.refresh(); ... })` had no catch. `fetchSocketData` throws on a server error, a dropped-connection settle, or the 30s request timeout, and the socket's `errorHook` toast only fires on WebSocket-level `error` events — not on these — so a failed seed load was an unhandled promise rejection: `store` stayed `undefined` and the admin saw an infinite `Loading` spinner with no toast and no retry.

The Progression surface (`progression-store.svelte.ts` / `Progression.svelte`) already handles the identical failure correctly: catch, toast, store an `error`, and render a Refresh button. This PR brings the other 9 admin tools (everything routed through `Workbench.svelte`) up to the same standard.

## Changes

- **`UI/src/routes/admin/workbench/Workbench.svelte`**: extracted the seed load into a `loadSeed()` function that catches a failed `entity.refresh()`, stores the message in a new `error` state, and toasts it (mirroring `ProgressionStore.load()`). The template gains an `{:else if error}` branch rendering the error message plus a `Refresh` button that re-invokes `loadSeed()`, styled to match `Progression.svelte`'s `.prog-error`.

## Not included

The issue also flagged `reference.load()`'s failure in `admin/+page.svelte` (leaves every tool stuck on `Loading` with only a one-shot toast) as an **optional** companion fix. I left that out to keep this PR focused on the required Workbench fix — happy to follow up separately if wanted.

## Tests

- `UI/src/tests/routes/admin/workbench/Workbench.test.ts`: two new cases — a failed `refresh()` shows the error state (message + toast) instead of the workbench content, and clicking Refresh retries the load and renders normally once it succeeds.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npx vitest run src/tests/routes/admin/workbench/Workbench.test.ts` — 10/10 passing.
- [x] `npm run test:unit:ci` — full suite: 3637/3637 passing, coverage floors intact.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1896


---
_Generated by [Claude Code](https://claude.ai/code/session_016UHrFxM4cTs8YPEd9cPbo9)_