### PR TITLE
Gate the welcome-back offline-progress check on the boot gate resolving

### DIFF
--- a/UI/src/lib/engine/boot-state.svelte.ts
+++ b/UI/src/lib/engine/boot-state.svelte.ts
@@ -1,0 +1,23 @@
+/* Cross-route boot signal (#1898). The root layout's boot gate (`+layout.svelte`) decides where a
+   fresh page load lands — but Svelte mounts children before the parent's `onMount`, so a route
+   mounted directly (e.g. a refresh/tab-restore landing on `/game`) runs its own `onMount` at least
+   once *before* the boot gate has even started resuming the session. A route whose mount work isn't
+   safe to run pre-boot (`/game`'s welcome-back gate issues a non-idempotent `GetOfflineProgress`)
+   needs to know whether the boot decision has already resolved at least once this session.
+
+   Module-level rather than component state: the boot gate's resolution needs to be visible to a
+   route mounted independently of the layout, and it only ever needs to go false → true once per
+   session (a later route mount after the first boot always finds it already true). */
+
+let booted = $state(false);
+
+export const bootState = {
+	get booted() {
+		return booted;
+	},
+	/** Marks the boot gate's decision as resolved. Idempotent; called once by the root layout's boot
+	 *  `onMount` after `resumeSession` (or the no-tokens short-circuit) completes. */
+	markBooted() {
+		booted = true;
+	}
+};

--- a/UI/src/routes/+layout.svelte
+++ b/UI/src/routes/+layout.svelte
@@ -19,6 +19,7 @@ import { apiSocket, getTokens, onSocketError } from '$lib/api';
 import { handleSocketReplaced, playerManager } from '$lib/engine';
 import { resumeSession } from '$lib/engine/session';
 import { bootRedirect, shouldReturnToLogin } from '$lib/engine/boot-redirect';
+import { bootState } from '$lib/engine/boot-state.svelte';
 import { toastError } from '$stores';
 import BootSplash from './BootSplash.svelte';
 import '$styles/common.scss';
@@ -80,6 +81,9 @@ onMount(async () => {
 		// gate can never strand the player on the splash.
 		booting = false;
 		booted = true;
+		// Signals routes mounted independently of this layout (e.g. #1898) that the boot decision has
+		// resolved at least once, so their own pre-boot mount can defer non-idempotent work.
+		bootState.markBooted();
 	}
 });
 

--- a/UI/src/routes/game/+page.svelte
+++ b/UI/src/routes/game/+page.svelte
@@ -40,6 +40,7 @@ import { NavSidebar, LogPanel, TourPlayer } from '$components';
 import { GAME_SCREENS, visibleScreens } from './screens/screen-defs';
 import PlaceholderScreen from './screens/PlaceholderScreen.svelte';
 import { startGame, stopEngines, enemyManager } from '$lib/engine';
+import { bootState } from '$lib/engine/boot-state.svelte';
 import { refreshPlayer } from '$lib/engine/session';
 import { evaluateScreenTrigger, closeTutorialTour } from '$lib/engine/tutorials';
 import { navigation, requiresRemount, tutorialTour } from '$stores';
@@ -83,7 +84,18 @@ if (browser) {
 		welcome.cancel();
 	});
 	onMount(() => {
-		void welcome.run();
+		// The root layout's boot gate (`+layout.svelte`) resolves after this page's own `onMount`
+		// (Svelte mounts children before the parent), so a direct load/refresh of `/game` would
+		// otherwise fire `GetOfflineProgress` — a non-idempotent command — before the boot gate has
+		// even started resuming the session, then get unmounted mid-flight when the gate's splash
+		// takes over (see `welcome.cancel()` above). Skipping the pre-boot mount here is safe: the
+		// boot gate's `{#if booting}` toggle always tears this page down and remounts it once resolved
+		// (#1898), so the post-boot remount runs `welcome.run()` for real. A route reached by normal
+		// in-app navigation (e.g. from character-select) finds the boot gate already resolved and runs
+		// this on its only mount, same as before.
+		if (bootState.booted) {
+			void welcome.run();
+		}
 	});
 }
 

--- a/UI/src/tests/routes/game/page.test.ts
+++ b/UI/src/tests/routes/game/page.test.ts
@@ -29,7 +29,8 @@ const {
 	startGame,
 	stopEngines,
 	confirmQuit,
-	goto
+	goto,
+	bootState
 } = vi.hoisted(() => ({
 	sendSocketCommand: vi.fn(),
 	getRoles: vi.fn<() => string[]>(() => []),
@@ -38,12 +39,16 @@ const {
 	startGame: vi.fn(),
 	stopEngines: vi.fn(),
 	confirmQuit: vi.fn(),
-	goto: vi.fn()
+	goto: vi.fn(),
+	// Defaults to already-resolved, matching every mount except a direct/refresh load of `/game`
+	// (the scenario the #1898 regression test below overrides this for).
+	bootState: { booted: true }
 }));
 
 vi.mock('$app/environment', () => ({ browser: true }));
 vi.mock('$app/navigation', () => ({ goto }));
 vi.mock('$app/paths', () => ({ resolve: (path: string) => path }));
+vi.mock('$lib/engine/boot-state.svelte', () => ({ bootState }));
 vi.mock('$lib/api', async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, unknown>;
 	return { ...actual, apiSocket: { sendSocketCommand }, getRoles };
@@ -105,6 +110,7 @@ beforeEach(() => {
 	navigation.clear();
 	tutorialTour.clear();
 	mountTracker.fight = 0;
+	bootState.booted = true;
 });
 
 afterEach(cleanup);
@@ -247,5 +253,23 @@ describe('game +page.svelte shell', () => {
 		await Promise.resolve();
 
 		expect(startGame).not.toHaveBeenCalled();
+	});
+
+	it('does not run the welcome-back gate on a pre-boot mount, but does on the post-boot remount the layout always performs (#1898)', async () => {
+		// A direct load/refresh of `/game` mounts this page before the root layout's boot gate has
+		// resolved (children mount before the parent's onMount).
+		bootState.booted = false;
+		const { unmount } = render(GamePage);
+		await Promise.resolve();
+
+		expect(sendSocketCommand).not.toHaveBeenCalled();
+
+		// The boot gate's `{#if booting}` toggle always tears this page down and remounts it once the
+		// boot decision resolves — simulated here as the layout would drive it.
+		unmount();
+		bootState.booted = true;
+
+		render(GamePage);
+		await waitFor(() => expect(sendSocketCommand).toHaveBeenCalledWith('GetOfflineProgress'));
 	});
 });

--- a/UI/src/tests/routes/layout.svelte.test.ts
+++ b/UI/src/tests/routes/layout.svelte.test.ts
@@ -34,6 +34,9 @@ vi.mock('$components', () => ({
 }));
 
 import Layout from '../../routes/+layout.svelte';
+// Deliberately NOT mocked: the boot gate's `bootState.markBooted()` call is the seam #1898's fix on
+// `/game` hinges on (see the test below), so this suite asserts against the real module.
+import { bootState } from '$lib/engine/boot-state.svelte';
 
 const childSnippet = createRawSnippet(() => ({
 	render: () => '<div data-testid="child">child content</div>'
@@ -92,6 +95,28 @@ describe('root layout boot gate', () => {
 
 		await waitFor(() => expect(goto).toHaveBeenCalledWith('/game'));
 		expect(resumeSession).toHaveBeenCalledTimes(1);
+	});
+
+	it('marks the shared boot state resolved on both the no-tokens short-circuit and a token-bearing resume (#1898)', async () => {
+		// Both branches hit the same `finally`, which is the seam a route mounted independently of this
+		// layout (e.g. `/game`) relies on to know the boot decision has resolved. Spying on the call
+		// (rather than only reading the resulting boolean) catches a regression that removes/misplaces
+		// the call even though `bootState.booted` — once true — never resets and would otherwise mask it
+		// via an earlier test's render.
+		const markBooted = vi.spyOn(bootState, 'markBooted');
+
+		renderLayout();
+		await waitFor(() => expect(markBooted).toHaveBeenCalledTimes(1));
+		expect(bootState.booted).toBe(true);
+
+		markBooted.mockClear();
+		getTokens.mockReturnValue({ accessToken: 'a', refreshToken: 'r' });
+		resumeSession.mockResolvedValue('game');
+		renderLayout();
+		await waitFor(() => expect(goto).toHaveBeenCalledWith('/game'));
+		expect(markBooted).toHaveBeenCalledTimes(1);
+
+		markBooted.mockRestore();
 	});
 
 	it('keeps a fully-restorable session on the route it refreshed on (e.g. /admin)', async () => {


### PR DESCRIPTION
## Summary

`routes/game/+page.svelte` ran `welcome.run()` (which issues the non-idempotent `GetOfflineProgress` command) unconditionally on its own `onMount`, while the root layout's boot gate (`+layout.svelte`) only flips `booting = true` inside its **own** `onMount` — and Svelte mounts children before the parent (`child-onMount → parent-onMount`).

On a direct load/refresh of `/game` (the most common way a player returns) this meant:

1. The page mounted and immediately fired `GetOfflineProgress`.
2. The layout's boot gate then set `booting = true`, tearing the page down (`welcome.cancel()`), before the response came back.
3. The server still executed the command in full (applies rewards, resolves/clears the stale in-flight battle, persists) — the client just discarded the response.
4. After the boot gate resolved, the page remounted and ran `welcome.run()` again with an away window of ~0, so the gate passed straight through with nothing to show.

Net effect: no economy loss (Login/Status re-pulls the credited aggregate), but the away-summary gate (#1043) never showed on a direct `/game` load, and the in-progress battle hand-back was silently dropped, defeating the replay-to-offset resume (#1595/#1596/#1597) on this path.

## Changes

- **`UI/src/lib/engine/boot-state.svelte.ts`** (new): a small module-level `bootState` signal (`booted` / `markBooted()`) that lets a route mounted independently of the root layout know whether the boot gate has resolved at least once this session.
- **`UI/src/routes/+layout.svelte`**: calls `bootState.markBooted()` in the boot `onMount`'s `finally` block, alongside the existing local `booted` flag it already uses for its own post-boot safety net.
- **`UI/src/routes/game/+page.svelte`**: only calls `welcome.run()` on mount when `bootState.booted` is already `true`. On a pre-boot mount this is a no-op — safe because the boot gate's `{#if booting}` toggle always tears the page down and remounts it once boot resolves, and by that point `bootState.booted` is already `true`, so the remount runs the check for real. A route reached by normal in-app navigation (e.g. from character-select, after the boot gate has already resolved once) runs this on its only mount, unchanged from before.

## Tests

- `UI/src/tests/routes/game/page.test.ts`: new case pinning that a pre-boot mount does **not** send `GetOfflineProgress`, and that the post-boot remount the layout always performs does.
- Existing layout/page suites pass unchanged — `bootState` defaults to already-resolved in the page test file (matching every mount except the direct-load scenario the new test covers).

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npx vitest run src/tests/routes/game/page.test.ts src/tests/routes/layout.svelte.test.ts` — passing.
- [x] `npm run test:unit:ci` — full suite: 3638/3638 passing, coverage floors intact.
- [ ] Backend unaffected (frontend-only change) — no backend verification needed.

Closes #1898


---
_Generated by [Claude Code](https://claude.ai/code/session_01FeqjxNhJcYWnA6FeLJ5Hor)_