### PR TITLE
Give admin reference-data load an error/retry state

### DIFF
--- a/UI/src/routes/admin/+page.svelte
+++ b/UI/src/routes/admin/+page.svelte
@@ -11,20 +11,20 @@
 				{#if reference.loaded}
 					<ContentHealthConsole />
 				{:else}
-					<Loading loading={true} delay={50} />
+					{@render referenceGate()}
 				{/if}
 			{:else if active === PROGRESSION_TOOL_KEY}
 				{#if reference.loaded}
 					<Progression />
 				{:else}
-					<Loading loading={true} delay={50} />
+					{@render referenceGate()}
 				{/if}
 			{:else if reference.loaded && activeEntity}
 				{#key active}
 					<Workbench entity={activeEntity} groupLabel={groupLabelFor(active)} />
 				{/key}
 			{:else}
-				<Loading loading={true} delay={50} />
+				{@render referenceGate()}
 			{/if}
 		</div>
 
@@ -38,6 +38,17 @@
 		/>
 	</div>
 {/if}
+
+{#snippet referenceGate()}
+	{#if loadError}
+		<div class="admin-load-error" role="alert" data-testid="admin-reference-error">
+			<p>{loadError}</p>
+			<button type="button" class="btn" onclick={loadReference}>Refresh</button>
+		</div>
+	{:else}
+		<Loading loading={true} delay={50} />
+	{/if}
+{/snippet}
 
 <script lang="ts">
 import { onMount } from 'svelte';
@@ -70,17 +81,27 @@ let sidebarPinned = $state(false);
 // (no token available) shows nothing, and a non-admin who deep-links here is redirected before the
 // workbench mounts or its reference data loads.
 let authorized = $state(false);
+let loadError = $state<string | null>(null);
 
 const activeEntity = $derived(entityByKey(active));
+
+async function loadReference() {
+	loadError = null;
+	try {
+		await reference.load();
+	} catch (ex) {
+		const message = ex instanceof Error ? ex.message : 'Failed to load admin reference data.';
+		loadError = message;
+		toastError(message);
+	}
+}
 
 // Guard the route to Admins, then load the shared reference catalogues (used by every entity's
 // select options, tag UI, and derived spawn shares) before rendering any workbench.
 onMount(() => {
 	authorized = ensureAdminAccess();
 	if (authorized && !reference.loaded) {
-		reference.load().catch((ex) => {
-			toastError(ex instanceof Error ? ex.message : 'Failed to load admin reference data.');
-		});
+		void loadReference();
 	}
 });
 
@@ -140,5 +161,45 @@ $effect(() => {
 	overflow: hidden;
 	// No outer padding: the Workbench is full-bleed (list pane flush to the rail,
 	// full-width header/save bar) and supplies its own internal insets.
+}
+
+.admin-load-error {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 14px;
+	padding: 20px;
+	text-align: center;
+
+	p {
+		max-width: 480px;
+		color: var(--error);
+		font-size: 13px;
+	}
+}
+
+.btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	background: transparent;
+	border: 1px solid var(--border-light);
+	color: var(--text-secondary);
+	font-family: var(--mono);
+	font-size: 11.5px;
+	letter-spacing: 0.6px;
+	text-transform: uppercase;
+	padding: 8px 15px;
+	border-radius: 3px;
+	cursor: pointer;
+	transition: all 0.14s ease;
+	white-space: nowrap;
+
+	&:hover:not(:disabled) {
+		border-color: color-mix(in srgb, var(--white) 32%, transparent);
+	}
 }
 </style>

--- a/UI/src/tests/routes/admin/admin-page.test.ts
+++ b/UI/src/tests/routes/admin/admin-page.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import AdminSidebarStub from './page/AdminSidebarStub.svelte';
+import WorkbenchStub from './page/WorkbenchStub.svelte';
+import DeadLetterConsoleStub from './page/DeadLetterConsoleStub.svelte';
+import ContentHealthConsoleStub from './page/ContentHealthConsoleStub.svelte';
+import ProgressionStub from './page/ProgressionStub.svelte';
+
+/*
+ * `admin/+page.svelte` gates every workbench tool behind `reference.loaded` (the shared reference
+ * catalogues backing every entity's select options, tag UI, and derived spawn shares). Before #1913
+ * a failed `reference.load()` left every tool spinning forever with only a one-shot toast — this
+ * pins the fix: an error state with a Refresh action that retries the real load.
+ *
+ * `reference` itself (and its `loaded` $state) is kept real so the fix's reactivity is genuinely
+ * exercised; only its transports (`fetchSocketData`/`ApiRequest`) are stubbed, mirroring
+ * reference-load.test.ts. The nav/entities modules and every heavy child (Workbench, AdminSidebar,
+ * the ops consoles, Progression) are replaced with minimal stubs so only the default 'enemies' tool's
+ * reference-gate wiring is under test.
+ */
+
+const { staticData, mockFetchSocket, mockGet, ensureAdminAccessMock } = vi.hoisted(() => ({
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	staticData: {} as any,
+	mockFetchSocket: vi.fn(),
+	mockGet: vi.fn(),
+	ensureAdminAccessMock: vi.fn(() => true)
+}));
+
+vi.mock('$app/navigation', () => ({ goto: vi.fn(), beforeNavigate: vi.fn() }));
+vi.mock('$app/paths', () => ({ resolve: (path: string) => path }));
+vi.mock('$stores', () => ({ staticData, toastError: vi.fn(), dangerModal: vi.fn() }));
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	class ApiRequest {
+		static get = mockGet;
+		static post = vi.fn();
+	}
+	return { ...actual, ApiRequest, fetchSocketData: mockFetchSocket };
+});
+vi.mock('$routes/admin/admin-access', () => ({ ensureAdminAccess: ensureAdminAccessMock }));
+vi.mock('$routes/admin/workbench/entities', () => ({
+	entityByKey: (key: string) => (key === 'enemies' ? { key: 'enemies', label: 'Enemies' } : undefined),
+	groupLabelFor: () => 'Combat'
+}));
+vi.mock('$routes/admin/workbench/nav', () => ({
+	adminGroups: [],
+	adminTools: [],
+	CONTENT_HEALTH_TOOL_KEY: 'content-health',
+	DEAD_LETTERS_TOOL_KEY: 'dead-letters',
+	PROGRESSION_TOOL_KEY: 'paths',
+	SOCKET_DEAD_LETTERS_TOOL_KEY: 'socket-dead-letters'
+}));
+vi.mock('$routes/admin/AdminSidebar.svelte', () => ({ default: AdminSidebarStub }));
+vi.mock('$routes/admin/workbench/Workbench.svelte', () => ({ default: WorkbenchStub }));
+vi.mock('$routes/admin/ops/DeadLetterConsole.svelte', () => ({ default: DeadLetterConsoleStub }));
+vi.mock('$routes/admin/ops/ContentHealthConsole.svelte', () => ({ default: ContentHealthConsoleStub }));
+vi.mock('$routes/admin/workbench/progression/Progression.svelte', () => ({ default: ProgressionStub }));
+
+import AdminPage from '$routes/admin/+page.svelte';
+
+// One distinct payload per socket command, matching reference-load.test.ts.
+const SOCKET_SETS: Record<string, { id: number; name: string }[]> = {
+	GetEnemies: [{ id: 0, name: 'Cave Bat' }],
+	GetSkills: [{ id: 0, name: 'Cleave' }],
+	GetZones: [{ id: 0, name: 'Verdant Hollow' }],
+	GetItems: [{ id: 0, name: 'Iron Helm' }],
+	GetItemMods: [{ id: 0, name: 'Sharp' }],
+	GetAttributes: [{ id: 0, name: 'Strength' }],
+	GetChallengeTypes: [{ id: 1, name: 'Enemies Killed' }],
+	GetChallenges: [{ id: 0, name: 'First Blood' }],
+	GetPaths: [{ id: 0, name: 'Fire Magic' }],
+	GetProficiencies: [{ id: 0, name: 'Fire' }],
+	GetLessons: [{ id: 0, name: 'Idle Combat' }],
+	GetClasses: [{ id: 0, name: 'Warrior' }],
+	GetSkillRecipes: [{ id: 0, name: 'Recipe' }]
+};
+const TAGS = [{ id: 10, name: 'Fire', tagCategoryId: 100 }];
+const TAG_CATEGORIES = [{ id: 100, name: 'Element' }];
+
+beforeEach(() => {
+	ensureAdminAccessMock.mockReturnValue(true);
+	mockGet
+		.mockReset()
+		.mockImplementation(async (path: string) =>
+			path === 'Tags' ? TAGS : path === 'Tags/TagCategories' ? TAG_CATEGORIES : []
+		);
+	for (const key of Object.keys(staticData)) {
+		delete staticData[key];
+	}
+});
+
+afterEach(cleanup);
+
+describe('Admin page — reference-data load failure', () => {
+	it('shows an error state with a Refresh action instead of spinning forever, and recovers on retry', async () => {
+		const { toastError } = await import('$stores');
+		// The first socket call (GetEnemies, first in reference.load()'s Promise.all) fails; every
+		// subsequent call — including the retry's — succeeds.
+		mockFetchSocket
+			.mockReset()
+			.mockImplementationOnce(async () => {
+				throw new Error('reference data unreachable');
+			})
+			.mockImplementation(async (command: string) => SOCKET_SETS[command] ?? []);
+
+		render(AdminPage);
+
+		await waitFor(() => expect(screen.getByTestId('admin-reference-error')).toBeTruthy());
+		expect(screen.getByTestId('admin-reference-error').textContent).toContain('reference data unreachable');
+		expect(screen.queryByTestId('workbench-stub')).toBeNull();
+		expect(toastError).toHaveBeenCalledWith('reference data unreachable');
+
+		await fireEvent.click(screen.getByText('Refresh'));
+
+		await waitFor(() => expect(screen.getByTestId('workbench-stub')).toBeTruthy());
+		expect(screen.queryByTestId('admin-reference-error')).toBeNull();
+		expect(screen.getByTestId('workbench-stub').textContent).toBe('Enemies');
+	});
+});

--- a/UI/src/tests/routes/admin/page/AdminSidebarStub.svelte
+++ b/UI/src/tests/routes/admin/page/AdminSidebarStub.svelte
@@ -1,0 +1,8 @@
+<!-- Test stub for AdminSidebar: not exercised by the reference-load tests (the default 'enemies'
+     tool never needs a nav switch), so it renders nothing but still accepts the bindable `pinned`
+     prop the real page wires up. -->
+<div data-testid="admin-sidebar-stub" data-pinned={pinned}></div>
+
+<script lang="ts">
+let { pinned = $bindable(false) } = $props();
+</script>

--- a/UI/src/tests/routes/admin/page/ContentHealthConsoleStub.svelte
+++ b/UI/src/tests/routes/admin/page/ContentHealthConsoleStub.svelte
@@ -1,0 +1,3 @@
+<!-- Test stub for ContentHealthConsole: not exercised by the reference-load tests (default tool is
+     'enemies'), so it just satisfies the import. -->
+<div data-testid="content-health-console-stub"></div>

--- a/UI/src/tests/routes/admin/page/DeadLetterConsoleStub.svelte
+++ b/UI/src/tests/routes/admin/page/DeadLetterConsoleStub.svelte
@@ -1,0 +1,3 @@
+<!-- Test stub for DeadLetterConsole: not exercised by the reference-load tests (default tool is
+     'enemies'), so it just satisfies the import. -->
+<div data-testid="dead-letter-console-stub"></div>

--- a/UI/src/tests/routes/admin/page/ProgressionStub.svelte
+++ b/UI/src/tests/routes/admin/page/ProgressionStub.svelte
@@ -1,0 +1,3 @@
+<!-- Test stub for Progression: not exercised by the reference-load tests (default tool is
+     'enemies'), so it just satisfies the import. -->
+<div data-testid="progression-stub"></div>

--- a/UI/src/tests/routes/admin/page/WorkbenchStub.svelte
+++ b/UI/src/tests/routes/admin/page/WorkbenchStub.svelte
@@ -1,0 +1,8 @@
+<!-- Test stub for Workbench: renders the entity label so the reference-load test can assert the
+     real tool content appears once the reference catalogues load successfully, without pulling in
+     the real entity-authoring subtree. -->
+<div data-testid="workbench-stub">{entity.label}</div>
+
+<script lang="ts">
+let { entity } = $props();
+</script>


### PR DESCRIPTION
## Summary

`admin/+page.svelte`'s `onMount` called `reference.load().catch(...)` and, on failure, fired a single one-shot `toastError` while leaving `reference.loaded` at `false` — every workbench tool stayed stuck on its loading spinner with no error message and no way to recover short of a full page reload.

`Workbench.svelte` and `Progression.svelte` already handle the identical class of failure (a failed seed/store load) correctly: catch, toast, store an `error`, and render a Refresh button. This PR brings the shared reference-catalogue load up to the same standard.

## Changes

- **`UI/src/routes/admin/+page.svelte`**: extracted the reference load into a `loadReference()` function that catches a failed `reference.load()`, stores the message in a new `loadError` state, and toasts it (mirroring `Workbench.svelte`/`Progression.svelte`). A new `referenceGate` snippet renders either that error state (message + Refresh button re-invoking `loadReference()`) or the existing `Loading` spinner, and replaces the three spots that previously fell back to an unconditional spinner while `reference.loaded` was false (Content Health, Progression, and the default entity-Workbench branch). The `DeadLetterConsole`/`SocketDeadLetterConsole` tools, which don't depend on the reference catalogues, are untouched.

## Tests

- **`UI/src/tests/routes/admin/admin-page.test.ts`** (new): renders the real page with `reference`'s real `$state`-backed `loaded` flag (only its transports — `fetchSocketData`/`ApiRequest` — are stubbed, mirroring `reference-load.test.ts`), the nav/entity modules stubbed to the default `'enemies'` tool, and every heavy child component (`Workbench`, `AdminSidebar`, the ops consoles, `Progression`) replaced with minimal stubs under `UI/src/tests/routes/admin/page/`. Asserts:
  - a failed load shows the error message + toast instead of spinning forever, with no tool content rendered
  - clicking Refresh retries the real load and renders the tool once it succeeds

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npx vitest run src/tests/routes/admin/admin-page.test.ts` — 1/1 passing
- [x] `npm run test:unit:ci` — full suite: 3657/3657 passing, coverage floors intact
- [ ] Backend unaffected (frontend-only change) — no backend verification needed

Closes #1913


---
_Generated by [Claude Code](https://claude.ai/code/session_01X3F8fAWzKHUqThm5YxbdQ5)_