### PR TITLE
Move ApiSocket's connection onto instance state (#1770)

### DIFF
--- a/UI/src/lib/api/api-socket.ts
+++ b/UI/src/lib/api/api-socket.ts
@@ -59,8 +59,6 @@ export interface IApiSocketResponse<T extends ApiSocketCommand | void = void> {
 	data?: T extends ApiSocketCommand ? ApiSocketResponseTypes[T] : never;
 }
 
-let socket: WebSocket;
-
 const errorHook = createHook<[string]>();
 export const onSocketError = errorHook.onNotified;
 
@@ -76,6 +74,9 @@ type InFlightRequest = {
 };
 
 export class ApiSocket {
+	// Instance state, not module-level: each ApiSocket owns exactly one connection, so two instances can
+	// never silently fight over the same socket.
+	private socket?: WebSocket;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- heterogeneous queue of requests for differing commands; ApiSocketRequest<T> is invariant in T so a common supertype isn't expressible.
 	private socketCommandQueue: ApiSocketRequest<any>[] = [];
 	// Keyed by command id so a response is an O(1) lookup and a settled request can be pruned (rather
@@ -113,7 +114,7 @@ export class ApiSocket {
 	 * race to create (and leak) two sockets.
 	 */
 	private ensureSocket(): Promise<void> {
-		if (socket && socket.readyState !== socket.CLOSED) {
+		if (this.socket && this.socket.readyState !== this.socket.CLOSED) {
 			return Promise.resolve();
 		}
 		if (this.connecting) {
@@ -163,7 +164,8 @@ export class ApiSocket {
 		// Browsers can't set an Authorization header on the WebSocket handshake, so the access token
 		// is passed as a query-string parameter (the standard ASP.NET Core token-over-WS pattern).
 		const url = accessToken ? `/socket?access_token=${encodeURIComponent(accessToken)}` : '/socket';
-		socket = new WebSocket(url);
+		const socket = new WebSocket(url);
+		this.socket = socket;
 		socket.onopen = this.onStart.bind(this);
 		socket.onmessage = this.receiveResponse.bind(this);
 		socket.onerror = this.handleError.bind(this);
@@ -212,7 +214,7 @@ export class ApiSocket {
 			return;
 		}
 		void this.ensureSocket();
-		if (socket && socket.readyState === socket.OPEN) {
+		if (this.socket && this.socket.readyState === this.socket.OPEN) {
 			if (this.awaitingPong) {
 				this.missedPongs++;
 				if (this.missedPongs >= MAX_MISSED_PONGS) {
@@ -226,13 +228,13 @@ export class ApiSocket {
 					// Deliberately code-less: handleClose only stops the keepalive on ev.code ===
 					// NORMAL_CLOSURE, so this must surface as 1005/1006 to fall through to its
 					// reconnect branch. Passing NORMAL_CLOSURE here would silently disable auto-reconnect.
-					socket.close();
+					this.socket.close();
 					return;
 				}
 			}
 			this.lastPing = performance.now();
 			this.awaitingPong = true;
-			socket.send('ping');
+			this.socket.send('ping');
 		}
 	}
 
@@ -245,8 +247,8 @@ export class ApiSocket {
 	public disconnect() {
 		this.stopPingInterval();
 		this.clearConnectionStableTimer();
-		if (socket && socket.readyState !== socket.CLOSED) {
-			socket.close(NORMAL_CLOSURE);
+		if (this.socket && this.socket.readyState !== this.socket.CLOSED) {
+			this.socket.close(NORMAL_CLOSURE);
 		}
 	}
 
@@ -277,7 +279,7 @@ export class ApiSocket {
 
 	private async processCommandQueue() {
 		await this.ensureSocket();
-		if (socket && socket.readyState === socket.OPEN) {
+		if (this.socket && this.socket.readyState === this.socket.OPEN) {
 			let request: ApiSocketRequest | undefined;
 			while ((request = this.socketCommandQueue.shift())) {
 				// Arm the timeout only now that the command is actually sent — a command can sit queued
@@ -285,7 +287,7 @@ export class ApiSocket {
 				const id = request.id;
 				const timer = setTimeout(() => this.timeoutRequest(id), REQUEST_TIMEOUT_MS);
 				this.inFlightRequests.set(id, { startTime: performance.now(), timer, command: request });
-				socket.send(JSON.stringify(request.getCommandInfo()));
+				this.socket.send(JSON.stringify(request.getCommandInfo()));
 			}
 		}
 	}
@@ -298,7 +300,7 @@ export class ApiSocket {
 			pingHook.notify(now - this.lastPing);
 			return;
 		} else if (ev.data === 'ping') {
-			socket.send('pong');
+			this.socket?.send('pong');
 			return;
 		}
 

--- a/UI/src/tests/lib/api/api-socket.test.ts
+++ b/UI/src/tests/lib/api/api-socket.test.ts
@@ -28,6 +28,10 @@ interface MockWebSocket {
 
 let socketInstances: MockWebSocket[] = [];
 let lastSocketUrl: string | undefined;
+// Every mock socket ever created, never reset per-test — unlike socketInstances, which each test clears.
+// Only the module-level `apiSocket` singleton (see the fetchSocketData describe below) needs this: it
+// outlives any one test, so its own leftover socket has to be findable to force it closed.
+const allCreatedSockets: MockWebSocket[] = [];
 
 function createMockWebSocket(url?: string): MockWebSocket {
 	lastSocketUrl = url;
@@ -43,6 +47,7 @@ function createMockWebSocket(url?: string): MockWebSocket {
 		onclose: null
 	};
 	socketInstances.push(ws);
+	allCreatedSockets.push(ws);
 	return ws;
 }
 
@@ -66,10 +71,6 @@ describe('ApiSocket', () => {
 	let apiSocket: ApiSocket;
 
 	beforeEach(() => {
-		// Force any socket left from a previous test to read as CLOSED so ensureSocket creates a fresh one.
-		for (const s of socketInstances) {
-			s.readyState = s.CLOSED;
-		}
 		socketInstances = [];
 		lastSocketUrl = undefined;
 		webSocketMock.mockClear();
@@ -550,7 +551,16 @@ describe('ApiSocket', () => {
 
 	// fetchSocketData wraps the module-level `apiSocket` singleton (not the per-test instance above),
 	// driving it through the same mocked WebSocket. It mirrors ApiRequest.get's throw-on-error contract.
+	// Unlike the per-test instance, the singleton survives across these tests (it's a module import), so
+	// its own leftover socket from a prior test in this block must be marked closed before each one runs
+	// or ensureSocket sees it as still open and skips creating a fresh mock WebSocket to assert against.
 	describe('fetchSocketData', () => {
+		beforeEach(() => {
+			for (const s of allCreatedSockets) {
+				s.readyState = s.CLOSED;
+			}
+		});
+
 		it('resolves with the response data when the command succeeds', async () => {
 			const promise = fetchSocketData('GetZones');
 			await flushMicrotasks();


### PR DESCRIPTION
## Summary

`api-socket.ts` held the live `WebSocket` in a module-level `socket` variable while every other piece of connection state (request queue, in-flight map, retry budget, keepalive timers) lived on the `ApiSocket` instance. Two `ApiSocket` instances would have silently fought over the one module-level connection, and the test suite's per-test instances were only kept from interfering with each other by an explicit `beforeEach` workaround that forced any leftover socket to read as `CLOSED`.

## Changes

- `UI/src/lib/api/api-socket.ts`: moved `socket` from a module-level `let` into `private socket?: WebSocket` on the `ApiSocket` class; updated every read/write site (`ensureSocket`, `openSocket`, `attemptPing`, `disconnect`, `processCommandQueue`, `receiveResponse`) to use `this.socket`.
- `UI/src/tests/lib/api/api-socket.test.ts`: removed the now-unnecessary global "force any leftover socket closed" workaround from the top-level `beforeEach` (each freshly-constructed `ApiSocket` now owns its own `undefined` socket, so there's nothing to leak between per-test instances). The module-level `apiSocket` singleton used by `fetchSocketData` genuinely does persist across tests in that describe block, so a narrower, scoped version of the same reset was kept just there, backed by a small `allCreatedSockets` list that (unlike `socketInstances`) isn't cleared per test.

No behavior change for production code paths — this is purely an ownership fix plus a corresponding test-suite cleanup.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npx vitest run src/tests/lib/api/api-socket.test.ts` — 51/51 passing
- [x] `npm run test:unit:ci` (full frontend suite) — 3657/3657 passing

Closes #1770


---
_Generated by [Claude Code](https://claude.ai/code/session_01PW5e8HMHfGaHqN8ajSUefv)_