### PR TITLE
Small frontend cleanups: encodeURIComponent, dead optional-chain, per-player attrMode key, battler typo

### DIFF
--- a/UI/src/lib/api/api-request.ts
+++ b/UI/src/lib/api/api-request.ts
@@ -175,7 +175,7 @@ export class ApiRequest<U extends ApiEndpoint> {
 
 		return keys(urlParams)
 			.filter((key) => urlParams[key] !== undefined)
-			.map((key) => key + '=' + window.encodeURIComponent(urlParams[key]))
+			.map((key) => key + '=' + encodeURIComponent(urlParams[key]))
 			.join('&');
 	}
 }

--- a/UI/src/lib/api/api-response.ts
+++ b/UI/src/lib/api/api-response.ts
@@ -53,7 +53,7 @@ export class ApiResponse<T extends ApiResponseType> {
 	}
 
 	public get error() {
-		return this.responseJson?.errorMessage || this.#raw.statusText || 'Failed to communicate with server.';
+		return this.responseJson.errorMessage || this.#raw.statusText || 'Failed to communicate with server.';
 	}
 
 	public get responseText() {

--- a/UI/src/lib/battle/battler.ts
+++ b/UI/src/lib/battle/battler.ts
@@ -132,7 +132,7 @@ export class Battler {
 
 	constructor(
 		battlerData?: BattlerData,
-		additionalAtttributes?: IBattlerAttribute[],
+		additionalAttributes?: IBattlerAttribute[],
 		grantedSkillIds?: number[],
 		additionalModifiers?: AttributeModifier[],
 		equippedWeaponType?: EDamageType,
@@ -140,7 +140,7 @@ export class Battler {
 	) {
 		this.reset(
 			battlerData,
-			additionalAtttributes,
+			additionalAttributes,
 			grantedSkillIds,
 			additionalModifiers,
 			equippedWeaponType,
@@ -386,7 +386,7 @@ export class Battler {
 
 	public reset(
 		battlerData?: BattlerData,
-		additionalAtttributes?: IBattlerAttribute[],
+		additionalAttributes?: IBattlerAttribute[],
 		grantedSkillIds?: number[],
 		additionalModifiers?: AttributeModifier[],
 		equippedWeaponType?: EDamageType,
@@ -404,9 +404,7 @@ export class Battler {
 		this.#elapsedMs = 0;
 		this.activeEffects = [];
 		if (battlerData) {
-			const atts = additionalAtttributes
-				? [...battlerData.attributes, ...additionalAtttributes]
-				: battlerData.attributes;
+			const atts = additionalAttributes ? [...battlerData.attributes, ...additionalAttributes] : battlerData.attributes;
 
 			// Proficiency bonuses ride the modifier pipeline (additive/multiplicative by their type), not the
 			// flat base data, so they compose through computeAttributes exactly like the backend's

--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -38,7 +38,8 @@ import { staticData, toastError } from '$stores';
 
 export type AttributeMode = 'guided' | 'theory';
 
-const MODE_STORAGE_KEY = 'ttf.attr.mode';
+/** Per-player prefix (see `readStoredMode`/`storeMode`) — each character keeps its own density mode. */
+const MODE_STORAGE_KEY_PREFIX = 'gameserver.attrMode.';
 
 const sum = (arr: number[]): number => arr.reduce((a, b) => a + b, 0);
 /** Rounds a per-point yield to clean floating-point noise while preserving the small increments a
@@ -528,14 +529,20 @@ function computeHexMax(draft: number[], committed: number[]): number {
 	return Math.max(10, Math.ceil((peak * 1.2) / 5) * 5);
 }
 
+/** Keyed by the live player id so switching characters doesn't inherit — or silently overwrite —
+ *  another character's density mode (docs/frontend-screens.md: "persisted per player"). */
+function modeStorageKey(): string {
+	return `${MODE_STORAGE_KEY_PREFIX}${playerManager.id}`;
+}
+
 function readStoredMode(): AttributeMode {
 	// Storage may be null (private mode / SSR); fall back to the default.
-	return safeLocalStorage()?.getItem(MODE_STORAGE_KEY) === 'theory' ? 'theory' : 'guided';
+	return safeLocalStorage()?.getItem(modeStorageKey()) === 'theory' ? 'theory' : 'guided';
 }
 
 function storeMode(mode: AttributeMode): void {
 	try {
-		safeLocalStorage()?.setItem(MODE_STORAGE_KEY, mode);
+		safeLocalStorage()?.setItem(modeStorageKey(), mode);
 	} catch {
 		// Persisting the preference is best-effort; ignore storage failures.
 	}

--- a/UI/src/tests/lib/api/api-request.test.ts
+++ b/UI/src/tests/lib/api/api-request.test.ts
@@ -46,7 +46,7 @@ const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
 vi.stubGlobal('fetch', fetchMock);
 // `location` is a minimal stand-in so handleAuthFailure's redirect guard (window.location.pathname) can
 // run without throwing; only the refresh-failure tests below inspect it.
-vi.stubGlobal('window', { encodeURIComponent, location: { href: '', pathname: '/game' } });
+vi.stubGlobal('window', { location: { href: '', pathname: '/game' } });
 
 // The "refresh definitively failed" tests below drive the real refreshTokens/handleAuthFailure so the
 // 401-retry and redirect wiring is exercised end to end; the "recovers from a concurrent tab" test

--- a/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
@@ -16,6 +16,7 @@ import {
 // stat-point pool from them live, exactly like the real (statified) PlayerManager.
 const { mockPlayerManager, mockInventoryManager, sendSocketCommand, toastError, staticData } = vi.hoisted(() => ({
 	mockPlayerManager: new (class MockPlayerManager {
+		id = 1;
 		attributes: IBattlerAttribute[] = [];
 		statPointsGained = 0;
 		statPointsUsed = 0;
@@ -104,6 +105,7 @@ beforeEach(() => {
 	sendSocketCommand.mockReset().mockResolvedValue({ data: { attributes: allFives(), statPointsUsed: 0 } });
 	toastError.mockReset();
 	localStorage.clear();
+	mockPlayerManager.id = 1;
 	mockPlayerManager.attributes = allFives();
 	mockPlayerManager.selectedSkills = [];
 	mockInventoryManager.equipmentStats = [];
@@ -578,11 +580,24 @@ describe('AttributesView mode persistence', () => {
 		expect(view.mode).toBe('guided');
 		view.setMode('theory');
 		expect(view.mode).toBe('theory');
-		expect(localStorage.getItem('ttf.attr.mode')).toBe('theory');
+		expect(localStorage.getItem('gameserver.attrMode.1')).toBe('theory');
 
 		const reopened = new AttributesView();
 		expect(reopened.mode).toBe('theory');
 		reopened.dispose();
+	});
+
+	it('keeps each player id on its own key, so switching characters does not inherit the mode', () => {
+		view.setMode('theory');
+
+		mockPlayerManager.id = 2;
+		const otherCharacter = new AttributesView();
+		expect(otherCharacter.mode).toBe('guided');
+
+		otherCharacter.setMode('theory');
+		expect(localStorage.getItem('gameserver.attrMode.2')).toBe('theory');
+		expect(localStorage.getItem('gameserver.attrMode.1')).toBe('theory');
+		otherCharacter.dispose();
 	});
 });
 


### PR DESCRIPTION
## Summary

Four grouped fix-in-passing nits from a health review (#1772), none worth an issue alone:

- **`UI/src/lib/api/api-request.ts:178`** — `window.encodeURIComponent` → the global `encodeURIComponent`. The `window.`-qualified form forced a `window` stub in tests and would break in any non-window context.
- **`UI/src/lib/api/api-response.ts:56`** — dropped the dead `?.` on `responseJson`, which is never nullish at that point (`responseJson`'s getter always returns an object via `??=`).
- **`UI/src/routes/game/screens/attributes/attributes-view.svelte.ts`** — the attributes density mode was persisted under the bare key `ttf.attr.mode` (a leftover from the original design mockup), breaking the `gameserver.*` localStorage prefix convention used everywhere else, and it was **device/account-wide** despite `docs/frontend-screens.md` documenting it as "persisted per player." Fixed both: the key is now `gameserver.attrMode.<playerId>`, so each character keeps its own mode instead of inheriting or silently overwriting another character's on the same account.
- **`UI/src/lib/battle/battler.ts:135,389`** — renamed the `additionalAtttributes` (triple-t typo) constructor/`reset` parameter to `additionalAttributes`. Positional-only parameter, so no other call sites reference the name.

## Test plan

- [x] `npx vitest run` (UI) — 3658/3658 passing, including a new case pinning that two different player ids keep independent `attrMode` keys.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] Verified no remaining references to `ttf.attr.mode` or `additionalAtttributes` anywhere in the frontend source.

Closes #1772

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCPPaDTwCHUuequ7n7NNv2)_