### PR TITLE
Keep staticData.classes raw instead of sentinel-widened

### DIFF
--- a/UI/src/routes/admin/workbench/entities/class.ts
+++ b/UI/src/routes/admin/workbench/entities/class.ts
@@ -23,14 +23,14 @@ export interface WorkbenchClass extends Omit<IClass, 'passiveScalingAttributeId'
 }
 
 // Classes load over the socket; the admin filter invalidates this cache on every write server-side, so a
-// plain refetch returns the freshly-saved list. The optional scaling attribute is normalised to the select's
-// "None" sentinel (-1) for the editable copy. Written through to staticData.classes so retire-confirm's
-// reference computation (starter-skill/starter-equipment groups) sees post-save edits (#1633).
+// plain refetch returns the freshly-saved list. Written through to staticData.classes so retire-confirm's
+// reference computation (starter-skill/starter-equipment groups) sees post-save edits (#1633). staticData.classes
+// stays raw (undefined = none) for the game/other screens, mirroring item.ts; the optional scaling attribute is
+// normalised to the select's "None" sentinel (-1) only in the returned editable copy.
 const refresh = async (): Promise<WorkbenchClass[]> => {
 	const classes = await fetchSocketData('GetClasses');
-	const workbenchClasses = classes.map((c) => ({ ...c, passiveScalingAttributeId: c.passiveScalingAttributeId ?? -1 }));
-	staticData.classes = workbenchClasses;
-	return workbenchClasses;
+	staticData.classes = classes;
+	return classes.map((c) => ({ ...c, passiveScalingAttributeId: c.passiveScalingAttributeId ?? -1 }));
 };
 
 export const classEntity: EntityConfig<WorkbenchClass> = {

--- a/UI/src/tests/routes/admin/workbench/entities/class.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/class.test.ts
@@ -56,13 +56,13 @@ describe('classEntity.refresh', () => {
 			}
 		];
 
-		const result = await classEntity.refresh();
+		await classEntity.refresh();
 
-		expect(staticData.classes).toBe(result);
+		expect(staticData.classes).toBe(socket.classes);
 		expect(staticData.classes[0]).toMatchObject({ name: 'Warrior', starterSkillIds: [3] });
 	});
 
-	it('normalises a missing scaling attribute to the -1 sentinel in the written-through copy', async () => {
+	it('normalises a missing scaling attribute to the -1 sentinel only in the returned editable copy, keeping staticData.classes raw', async () => {
 		socket.classes = [
 			{
 				id: 0,
@@ -80,9 +80,10 @@ describe('classEntity.refresh', () => {
 			}
 		];
 
-		await classEntity.refresh();
+		const result = await classEntity.refresh();
 
-		expect(staticData.classes[0].passiveScalingAttributeId).toBe(-1);
+		expect(result[0].passiveScalingAttributeId).toBe(-1);
+		expect(staticData.classes[0].passiveScalingAttributeId).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
## Summary

`class.ts`'s `refresh()` was writing the sentinel-widened `WorkbenchClass[]` (`passiveScalingAttributeId: -1` for "none") into the shared `staticData.classes` cache, while `reference.svelte.ts`'s `load()` writes raw `IClass[]` there — so the cache's shape depended on which loader ran last. The deliberate pattern elsewhere (`item.ts`) is the opposite: keep `staticData.*` raw for the game/other screens and only widen the copy returned to the editor.

This was latent (nothing currently does a `!= null`/truthiness check on `passiveScalingAttributeId` off `staticData.classes`), but any future consumer would misread `-1` as a real `EAttribute`.

## Change

- `class.ts`: `staticData.classes` is now assigned the raw fetched array; the `-1` sentinel is applied only to the array returned from `refresh()` (used by the Workbench editor).
- Updated `class.test.ts` to assert the new split: `staticData.classes` is the raw socket payload (by reference), and the sentinel normalization only shows up in `refresh()`'s return value.

Verified the one consumer of `staticData.classes` that isn't the game/creation flow — `computeReferences` in `references.ts` (retire-confirm's "referenced by" surface) — only reads `starterSkillIds`/`starterEquipment` off classes, never `passiveScalingAttributeId`, so this doesn't affect that surface.

## Test plan

- [x] `npx vitest run` on the affected Workbench test files — all pass
- [x] `npm run test:unit:ci` (full frontend suite) — 3658 passed, 0 failed
- [x] `npm run lint` (eslint + svelte-check) — clean

Closes #1783


---
_Generated by [Claude Code](https://claude.ai/code/session_01UfuLJ6T4hzF7hBF6HdTCL9)_