### PR TITLE
Document production deployment topology and align dev Vite port on 5173

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -10,8 +10,8 @@
     {
       "name": "svelte-ui",
       "runtimeExecutable": "npx",
-      "runtimeArgs": ["vite", "dev", "--port", "5174"],
-      "port": 5174,
+      "runtimeArgs": ["vite", "dev", "--port", "5173"],
+      "port": 5173,
       "cwd": "UI"
     }
   ]

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -71,7 +71,7 @@ services:
       Jwt__Audience: game-server-api
       # Origin of the SvelteKit dev server that fronts this stack (UI/vite.config.ts). Required:
       # startup validation fails fast when no CORS origin is configured.
-      Cors__AllowedOrigins__0: "http://localhost:5174"
+      Cors__AllowedOrigins__0: "http://localhost:5173"
       # 1 = Postgres, 0 = Redis (see Game.Abstractions/Infrastructure/Enums.cs).
       DataAccessOptions__DatabaseSystem: "1"
       DataAccessOptions__CacheSystem: "0"

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -75,6 +75,14 @@ The login-tracking IP (an audit surface) is read from `HttpContext.Connection.Re
 - A real deployment behind a load balancer / ingress must set the relevant proxy IPs or CIDRs so the player's true client IP is recorded.
 - **`ForwardLimit`** sets the trust-chain depth — how many `X-Forwarded-For` entries are walked back. It defaults to **1** (a single proxy), so single-proxy deployments need not set it. A legitimate multi-hop chain (e.g. CDN → ingress) must raise it to the chain length **and** trust every hop, or only the last entry is consumed and the recorded IP is the nearest proxy rather than the real client. `null` disables the limit (walk every entry) — only safe when every hop is on the allowlist. Validated on start (`null` or ≥ 1) so a misconfigured zero/negative fails fast.
 
+## Production deployment topology (Railway)
+
+The root **`Dockerfile`** (nginx-only, templating `nginx.conf`) is the **edge proxy image** — a separate deploy artifact from the API image (`Game.Api/Dockerfile`). It fronts two Railway services reached over Railway's private network (`*.railway.internal`, via Railway's IPv6 resolver): requests to `/api` and `/socket` route to the .NET API service, everything else routes to the SvelteKit SSR service.
+
+Because every request reaches the API through this nginx hop, `HttpContext.Connection.RemoteIpAddress` (the [login-tracking IP](#trusted-reverse-proxies-x-forwarded-for) and the auth rate-limiter's partition key) resolves to the **nginx sidecar's** address, not the player's, unless the deployment configures `ForwardedHeaders:KnownProxies`/`KnownNetworks` above to trust that hop. Left unconfigured, every player collapses into one shared per-IP auth rate-limit partition — exhausted under ordinary traffic, surfacing as login failures — and login-tracking records the proxy's IP instead of the real client's. Nothing fails loudly when this is missed: the app boots and plays normally, only the abuse/audit signal is silently wrong.
+
+A production deploy behind this edge nginx therefore needs, beyond the CORS/JWT/connection-string settings already covered here: the public-facing CORS origin(s), and `ForwardedHeaders:KnownProxies`/`KnownNetworks` covering the edge nginx's address.
+
 ## Battle-simulation performance tests
 
 The backend re-simulates **every** battle after the client reports it (the anti-cheat replay — see [game-design.md](./game-design.md#battle-mechanics)), so the battle hot path must stay cheap as new mechanics are added. `Game.Core.Tests/Battle/Performance` guards that with tests that measure **relatively** rather than against absolute wall-clock times, because raw machine speed varies wildly between a dev box and a CI runner (#283).


### PR DESCRIPTION
## Summary

- Adds a "Production deployment topology (Railway)" section to `docs/infrastructure.md` explaining that the root `Dockerfile`/`nginx.conf` is the edge proxy image (distinct from `Game.Api/Dockerfile`), fronting the API and SvelteKit SSR Railway services, and ties that topology to the existing `ForwardedHeaders` trusted-proxy config: left unconfigured for the nginx hop, the API sees only the sidecar's IP, collapsing every player into one shared auth rate-limit partition and mis-recording login IPs.
- Fixes the dev Vite port mismatch: `.claude/launch.json` explicitly launched Vite on `5174` and `docker-compose.local.yml`'s CORS origin matched that, while `README.md`, `Game.Api/appsettings.Development.json.example`, and `vite dev`'s own unconfigured default (`UI/vite.config.ts` sets no `server.port`) all use `5173`. Both are now aligned on `5173`.

## Why

Issue #1786 flagged both of the above from a codebase health review. The port fix also fully resolves #1870 (filed independently against the same inconsistency), so this PR closes both.

## Note on scope

I did not attempt to verify the actual live Railway environment variables (no deployment access from this session) — the new doc section documents the requirement (`ForwardedHeaders:KnownProxies`/`KnownNetworks` covering the edge nginx's address) so whoever manages the Railway deployment can check it against the doc.

## Test plan

- [x] Validated `.claude/launch.json` as JSON and `docker-compose.local.yml` via `docker compose config`.
- [x] Confirmed no other repo config, test, or CI job depends on the `5174` value being changed (remaining `5174` references are unrelated CORS-parsing unit-test fixtures in `Game.Api.Tests/Unit/CorsOptionsTests.cs` and `Game.TestInfrastructure/Base/GameServerFactory.cs`).
- Docs/config-only change — no application code touched, so no `dotnet build`/`dotnet test`/frontend suite run was needed.

Closes #1786
Closes #1870


---
_Generated by [Claude Code](https://claude.ai/code/session_01WNZcSTv1RUz6yCaJxx6ABJ)_