### PR TITLE
Assert every tour anchor key resolves to a live rendered DOM anchor

### DIFF
--- a/UI/src/tests/routes/game/screens/fight/BattlerCard.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/BattlerCard.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
 import { EAttribute, type IAttribute } from '$lib/api';
-import { getTutorialAnchor } from '$components';
+import { getTutorialAnchor, TOUR_ANCHOR_KEYS } from '$components';
 
 // The card renders a Skills -> SkillTooltip subtree, which imports the battle engine and the
 // reference-data store at module load; both are mocked even though no hover happens here. The player
@@ -172,5 +172,22 @@ describe('BattlerCard', () => {
 
 		const enemy = render(BattlerCard, { props: { battler: makeBattler({ name: 'Dire Wolf' }), side: 'enemy' } });
 		expect(getTutorialAnchor('fight-hp-bar-enemy')).toBe(enemy.getByTestId('enemy-card').querySelector('.hp-bar-slot'));
+	});
+
+	// Frontend half of #1592/#1788: the screen-defs suite already checks lesson content ⊆ TOUR_ANCHOR_KEYS
+	// (every authored anchorKey resolves to a registered key). This closes the other direction — every
+	// registered key actually resolves to a live `use:tutorialAnchor` site — so a renamed/removed anchor
+	// can't silently drift from the registry. BattlerCard composes both CombatFloaters and Skills, so
+	// mounting one card per side registers all six keys.
+	it('resolves every TOUR_ANCHOR_KEYS entry to a live registration once both cards are mounted', () => {
+		const player = render(BattlerCard, { props: { battler: makeBattler(), side: 'player' } });
+		const enemy = render(BattlerCard, { props: { battler: makeBattler({ name: 'Dire Wolf' }), side: 'enemy' } });
+
+		for (const key of TOUR_ANCHOR_KEYS) {
+			expect(getTutorialAnchor(key)).toBeInstanceOf(HTMLElement);
+		}
+
+		player.unmount();
+		enemy.unmount();
 	});
 });


### PR DESCRIPTION
## Summary

Follow-up from PR #1753, which added the canonical `TOUR_ANCHOR_KEY` builder registry in `tutorial-anchor.ts` plus a test asserting every `anchorKey` referenced by seeded lessons resolves to a **registered** key (`screen-defs.test.ts`'s "committed lesson content" suite). That only checks *lesson content ⊆ registry* — the other direction, *registry ⊆ actually-rendered DOM anchors*, was unenforced, so a renamed/removed `use:tutorialAnchor` call site could silently drift from `TOUR_ANCHOR_KEYS` with nothing failing (a missing anchor just degrades gracefully to a centered callout at runtime).

## Change

Added a test to `BattlerCard.test.ts` (which already carries the mocks needed to render the fight subtree) that mounts one `BattlerCard` per side — `BattlerCard` composes both `CombatFloaters` and `Skills`, so this covers all three `use:tutorialAnchor` call sites for both sides — and asserts every entry of `TOUR_ANCHOR_KEYS` resolves to a live registration via `getTutorialAnchor`.

No production code changed — this is purely closing a test-coverage gap.

## Test plan

- [x] `npx vitest run src/tests/routes/game/screens/fight/BattlerCard.test.ts` — 14/14 passing (13 existing + 1 new)
- [x] `npm run test:unit:ci` — full suite: 3659/3659 passing, coverage floors intact
- [x] `npm run lint` (eslint + svelte-check) — clean
- Backend unaffected (frontend test-only change) — no backend verification needed

Closes #1788

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeAKj5tqoM3938R7e6i1C1)_