### PR TITLE
Use a process-stable hash for CombatRatingCalibrator seeds

### DIFF
--- a/Game.Application.Tests/Content/Calibration/CombatRatingCalibratorTests.cs
+++ b/Game.Application.Tests/Content/Calibration/CombatRatingCalibratorTests.cs
@@ -206,7 +206,7 @@ namespace Game.Application.Tests.Content.Calibration
         }
 
         [Fact]
-        public void MatchupSeed_DiffersForDifferentBuildNamesWithTheSameHashCode()
+        public void MatchupSeed_DiffersForDifferentBuildNames()
         {
             // .NET's built-in string hashing (used by HashCode.Combine) is randomized per process; MatchupSeed
             // must not derive from it. Distinct matchup keys should (in practice) yield distinct seeds.

--- a/Game.Application.Tests/Content/Calibration/CombatRatingCalibratorTests.cs
+++ b/Game.Application.Tests/Content/Calibration/CombatRatingCalibratorTests.cs
@@ -193,6 +193,29 @@ namespace Game.Application.Tests.Content.Calibration
             Assert.Equal(first[0].AvgBattleSeconds, second[0].AvgBattleSeconds, 6);
         }
 
+        // ── MatchupSeed ──────────────────────────────────────────────────────
+
+        [Fact]
+        public void MatchupSeed_IsPinnedAcrossProcesses()
+        {
+            // In-process determinism alone doesn't catch the bug this guards against: HashCode.Combine is also
+            // stable within a single process (it reseeds once at process start), so a same-process comparison
+            // would have passed even with the old, non-reproducible implementation. Pinning the literal value
+            // is the only way a unit test can assert stability *across* processes/runs.
+            Assert.Equal(3800752286u, CombatRatingCalibrator.MatchupSeed(3, 5, "Build A", 7, 2));
+        }
+
+        [Fact]
+        public void MatchupSeed_DiffersForDifferentBuildNamesWithTheSameHashCode()
+        {
+            // .NET's built-in string hashing (used by HashCode.Combine) is randomized per process; MatchupSeed
+            // must not derive from it. Distinct matchup keys should (in practice) yield distinct seeds.
+            var seedA = CombatRatingCalibrator.MatchupSeed(0, 1, "Build A", 0, 0);
+            var seedB = CombatRatingCalibrator.MatchupSeed(0, 1, "Build B", 0, 0);
+
+            Assert.NotEqual(seedA, seedB);
+        }
+
         // ── Helpers ───────────────────────────────────────────────────────────
 
         private static ZonePlacementRow MakeZonePlacementRow(

--- a/Game.Application/Content/Calibration/CombatRatingCalibrator.cs
+++ b/Game.Application/Content/Calibration/CombatRatingCalibrator.cs
@@ -1,6 +1,7 @@
 using Game.Core;
 using Game.Core.Battle;
 using Game.Core.Enemies;
+using System.Buffers.Binary;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -247,7 +248,7 @@ namespace Game.Application.Content.Calibration
         {
             var key = $"{zoneId}|{level}|{buildName}|{enemyId}|{drawIndex}";
             var hash = SHA256.HashData(Encoding.UTF8.GetBytes(key));
-            return BitConverter.ToUInt32(hash, 0);
+            return BinaryPrimitives.ReadUInt32LittleEndian(hash);
         }
 
         // Evenly-spaced, deduplicated levels across [min, max] — samples ≤ 1 or a single-level range collapse

--- a/Game.Application/Content/Calibration/CombatRatingCalibrator.cs
+++ b/Game.Application/Content/Calibration/CombatRatingCalibrator.cs
@@ -1,6 +1,8 @@
 using Game.Core;
 using Game.Core.Battle;
 using Game.Core.Enemies;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Game.Application.Content.Calibration
 {
@@ -227,7 +229,7 @@ namespace Game.Application.Content.Calibration
             {
                 for (var i = 0; i < seedsPerMatchup; i++)
                 {
-                    var seed = unchecked((uint)HashCode.Combine(zone.ZoneId, level, build.Name, spawn.EnemyId, i));
+                    var seed = MatchupSeed(zone.ZoneId, level, build.Name, spawn.EnemyId, i);
                     var result = new BattleSimulator(build.BuildBattler(level), spawn.Resolve(level).ToBattler(), seed).Simulate();
 
                     weightedWins += spawn.Weight * (result.Victory ? 1 : 0);
@@ -237,6 +239,15 @@ namespace Game.Application.Content.Calibration
             }
 
             return weightUnits > 0 ? (weightedWins / weightUnits, weightedMs / weightUnits / 1000.0) : (0.0, 0.0);
+        }
+
+        // A seed that's stable across processes, unlike HashCode.Combine (which reseeds itself, and hashes
+        // strings, randomly per process) — required for the report to actually be reproducible run-to-run.
+        internal static uint MatchupSeed(int zoneId, int level, string buildName, int enemyId, int drawIndex)
+        {
+            var key = $"{zoneId}|{level}|{buildName}|{enemyId}|{drawIndex}";
+            var hash = SHA256.HashData(Encoding.UTF8.GetBytes(key));
+            return BitConverter.ToUInt32(hash, 0);
         }
 
         // Evenly-spaced, deduplicated levels across [min, max] — samples ≤ 1 or a single-level range collapse


### PR DESCRIPTION
## Summary

`CombatRatingCalibrator.ComputeRewardCurve`'s matchup seeds were built with `HashCode.Combine(zone.ZoneId, level, build.Name, spawn.EnemyId, i)`. `System.HashCode` reseeds itself randomly per process, and .NET's string hashing (used for `build.Name`) is randomized too — so every run of the calibration report simulated a different set of battles, contradicting the method's own XML doc claim that "seeds are deterministic... so the report is reproducible across runs against unchanged content."

With only 5 seeds per matchup, run-to-run RNG noise in win rate / average duration was indistinguishable from real content-driven drift, defeating the tool's stated purpose (re-running after content changes to spot pricing drift).

## Fix

- Replaced the seed derivation with `MatchupSeed`, which SHA256-hashes a stable string key (`"{zoneId}|{level}|{buildName}|{enemyId}|{drawIndex}"`) and takes the first 4 bytes as the `uint` seed. SHA256 has no per-process randomization, unlike `HashCode`/`string.GetHashCode`. This mirrors an existing pattern already used in the codebase for deterministic content hashing (`ReferenceDataVersioning.ComputeVersion`).
- Added `MatchupSeed_IsPinnedAcrossProcesses`, which asserts a literal expected seed value for a fixed input. This is the only way a single-process unit test can actually catch cross-process instability — the existing `ComputeRewardCurve_IsDeterministicAcrossRuns` test only compares two calls within the same process, which would have passed even with the old buggy implementation (since `HashCode`'s per-process seed is fixed once the process starts).
- Added `MatchupSeed_DiffersForDifferentBuildNamesWithTheSameHashCode` as a basic distinctness sanity check.

## Test plan

- [x] `dotnet build Game.sln` — clean, 0 warnings/errors.
- [x] `dotnet test Game.sln` (full solution: Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests) — 3,121/3,121 passing.
- [x] Verified the pinned seed value (`3800752286`) is identical across two independent process runs of the hash function before hardcoding it into the test.

Closes #1922


---
_Generated by [Claude Code](https://claude.ai/code/session_015L1KoWcHeXpRPgpSA8RPaM)_