### PR TITLE
Gate ExecuteBonus in CombatRating to player battlers only

### DIFF
--- a/Game.Core.Tests/Battle/CombatRatingTests.cs
+++ b/Game.Core.Tests/Battle/CombatRatingTests.cs
@@ -135,7 +135,7 @@ namespace Game.Core.Tests.Battle
             Assert.True(CombatRating.Rate(strong, isPlayer: true) > CombatRating.Rate(weak, isPlayer: true));
         }
 
-        // ── Rate: enemy asymmetry (crit/dodge/parry/riposte gated off) ──────
+        // ── Rate: enemy asymmetry (crit/dodge/parry/riposte/execute gated off) ──
 
         [Fact]
         public void Rate_EnemyWithAuthoredCriticalChance_IsUnaffectedByCrit()
@@ -153,6 +153,26 @@ namespace Game.Core.Tests.Battle
         {
             var asPlayer = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50, criticalChance: 1.0)]);
             var asEnemy = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50, criticalChance: 1.0)]);
+
+            Assert.True(CombatRating.Rate(asPlayer, isPlayer: true) > CombatRating.Rate(asEnemy, isPlayer: false));
+        }
+
+        [Fact]
+        public void Rate_EnemyWithAuthoredExecuteBonus_IsUnaffectedByExecute()
+        {
+            var withExecute = MakeBattlerWithSkills([(ExecuteBonus, 1.0)], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+            var withoutExecute = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+
+            Assert.Equal(
+                CombatRating.Rate(withoutExecute, isPlayer: false),
+                CombatRating.Rate(withExecute, isPlayer: false), 6);
+        }
+
+        [Fact]
+        public void Rate_PlayerWithAuthoredExecuteBonus_RatesHigherThanEnemyEquivalent()
+        {
+            var asPlayer = MakeBattlerWithSkills([(ExecuteBonus, 1.0)], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+            var asEnemy = MakeBattlerWithSkills([(ExecuteBonus, 1.0)], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
 
             Assert.True(CombatRating.Rate(asPlayer, isPlayer: true) > CombatRating.Rate(asEnemy, isPlayer: false));
         }

--- a/Game.Core/Battle/CombatRating.cs
+++ b/Game.Core/Battle/CombatRating.cs
@@ -13,7 +13,7 @@ namespace Game.Core.Battle
     /// </summary>
     public enum ECombatRatingClassification
     {
-        /// <summary>Feeds <see cref="CombatRating"/>'s offense rate (amplification, ExecuteBonus, …).</summary>
+        /// <summary>Feeds <see cref="CombatRating"/>'s offense rate (amplification, DamageReflection, …).</summary>
         Offense,
 
         /// <summary>Feeds <see cref="CombatRating"/>'s survivability (MaxHealth, resistances, Toughness, regen, …).</summary>
@@ -25,7 +25,7 @@ namespace Game.Core.Battle
         /// <summary>Deliberately unpriced — inert by design (obsolete) or read structurally rather than as a scalar term.</summary>
         NeutralByDesign,
 
-        /// <summary>Priced only for a player battler; skipped entirely for an enemy (crit/dodge/parry).</summary>
+        /// <summary>Priced only for a player battler; skipped entirely for an enemy (crit/dodge/parry/execute).</summary>
         AsymmetryGated,
     }
 
@@ -139,7 +139,7 @@ namespace Game.Core.Battle
                 DaggerAmplification => ECombatRatingClassification.Offense,
                 UnarmedAmplification => ECombatRatingClassification.Offense,
                 DamageReflection => ECombatRatingClassification.Offense,
-                ExecuteBonus => ECombatRatingClassification.Offense,
+                ExecuteBonus => ECombatRatingClassification.AsymmetryGated,
                 ParryChance => ECombatRatingClassification.AsymmetryGated,
                 ParryChanceMultiplier => ECombatRatingClassification.AsymmetryGated,
                 DodgeChanceMultiplier => ECombatRatingClassification.AsymmetryGated,
@@ -239,7 +239,12 @@ namespace Game.Core.Battle
                 ? 1.0 + skill.CriticalChance * effectiveCaster.GetAttributeValue(CriticalChanceMultiplier)
                       * (effectiveCaster.GetAttributeValue(CriticalDamage) - 1.0)
                 : 1.0;
-            var executeExpectation = 1.0 + effectiveCaster.GetAttributeValue(ExecuteBonus) * 0.5;
+            // Enemies never execute in this engine either — ResolvePlayerHit (BattleContext.DamageTarget) is the
+            // only pipeline that applies the Cull execute multiplier, so an authored enemy ExecuteBonus is never
+            // priced as a capability that cannot fire (the same asymmetry as critExpectation above).
+            var executeExpectation = isPlayer
+                ? 1.0 + effectiveCaster.GetAttributeValue(ExecuteBonus) * 0.5
+                : 1.0;
 
             return afterMitigation * critExpectation * executeExpectation;
         }


### PR DESCRIPTION
## Summary

`CombatRating.ExpectedDirectHit` priced `ExecuteBonus` into the offense rate unconditionally, while the crit expectation two lines above is correctly `isPlayer`-gated with a comment explaining why ("an authored enemy CriticalChance is never priced as a capability that cannot fire"). `Classify` also marked `ExecuteBonus => Offense` instead of `AsymmetryGated`.

The live engine only applies the Cull execute multiplier in `BattleContext.ResolvePlayerHit` — the enemy-attack branch has no execute path, pinned by the existing test `DamageTarget_EnemyAttacking_IgnoresEnemyExecuteBonusAndBooksNoCullBonus`. So an enemy authored with `ExecuteBonus` would rate higher than it actually fights, inflating its XP bounty (`XpScaleK × EnemyRating × min(ratio,1)²`) and the proficiency denominator `max(PlayerRating, EnemyRating)` — the "dead-LUK defect one level up" the class's own docs describe avoiding for crit/dodge/parry. Latent today only because no authored enemy currently carries `ExecuteBonus`.

## Changes

- `Game.Core/Battle/CombatRating.cs`: gated `executeExpectation` on `isPlayer` (mirroring `critExpectation`'s existing pattern) and reclassified `ExecuteBonus` from `Offense` to `AsymmetryGated`. Updated the enum's doc comments (the `Offense` example no longer cites `ExecuteBonus`; `AsymmetryGated`'s example now includes execute).
- `Game.Core.Tests/Battle/CombatRatingTests.cs`: added `Rate_EnemyWithAuthoredExecuteBonus_IsUnaffectedByExecute` and `Rate_PlayerWithAuthoredExecuteBonus_RatesHigherThanEnemyEquivalent`, mirroring the existing crit asymmetry tests.

## Test plan

- [x] `dotnet build Game.sln` — clean, 0 warnings/errors.
- [x] `dotnet test Game.sln` (full solution: Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests) — 3,121/3,121 passing.

Closes #1926


---
_Generated by [Claude Code](https://claude.ai/code/session_01WFUw4tmjrW2oL2gxa5fUgQ)_