### PR TITLE
Migrate remaining integration-test polling loops onto PollingHelper

### DIFF
--- a/Game.Api.Tests/Integration/LoginControllerTests.cs
+++ b/Game.Api.Tests/Integration/LoginControllerTests.cs
@@ -544,19 +544,11 @@ namespace Game.Api.Tests.Integration
         // until the departed character's level reflects the simulated away window.
         private async Task AssertPlayerLeveledAboveAsync(int playerId, int levelBefore)
         {
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
-            while (DateTime.UtcNow < deadline)
-            {
-                var persisted = await GetPersistedPlayerAsync(playerId);
-                if (persisted.Level > levelBefore)
-                {
-                    return;
-                }
+            var persisted = await PollingHelper.PollUntilAsync(
+                () => GetPersistedPlayerAsync(playerId), p => p.Level > levelBefore, timeoutMs: 5000);
 
-                await Task.Delay(25, CancellationToken);
-            }
-
-            Assert.Fail("The departed character was not credited (its level did not advance) after the switch.");
+            Assert.True(persisted.Level > levelBefore,
+                "The departed character was not credited (its level did not advance) after the switch.");
         }
 
         // The inverse of AssertPlayerLeveledAboveAsync: gives any write-behind credit a window to surface and
@@ -564,14 +556,11 @@ namespace Game.Api.Tests.Integration
         // this window, so a regression (credit not skipped while a socket is live) is caught here.
         private async Task AssertPlayerNotCreditedAsync(int playerId, int levelBefore)
         {
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
-            while (DateTime.UtcNow < deadline)
-            {
-                var persisted = await GetPersistedPlayerAsync(playerId);
-                Assert.False(persisted.Level > levelBefore,
-                    "The departed character was credited despite holding a live socket; the off-lock credit should have been skipped.");
-                await Task.Delay(25, CancellationToken);
-            }
+            var persisted = await PollingHelper.PollUntilAsync(
+                () => GetPersistedPlayerAsync(playerId), p => p.Level > levelBefore, timeoutMs: 2000);
+
+            Assert.False(persisted.Level > levelBefore,
+                "The departed character was credited despite holding a live socket; the off-lock credit should have been skipped.");
         }
 
         [Fact]
@@ -1088,18 +1077,10 @@ namespace Game.Api.Tests.Integration
         {
             using var scope = CreateScope();
             var sessionStore = scope.ServiceProvider.GetRequiredService<ISessionStore>();
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
-            while (DateTime.UtcNow < deadline)
-            {
-                if (await sessionStore.GetSession(userId) is not null)
-                {
-                    return;
-                }
+            var session = await PollingHelper.PollUntilAsync(
+                () => sessionStore.GetSession(userId), s => s is not null, timeoutMs: 5000);
 
-                await Task.Delay(25, CancellationToken);
-            }
-
-            Assert.Fail("The session was not established in the cache after login.");
+            Assert.True(session is not null, "The session was not established in the cache after login.");
         }
 
         // The Clear on logout is fire-and-forget, so poll until the session disappears.
@@ -1107,18 +1088,10 @@ namespace Game.Api.Tests.Integration
         {
             using var scope = CreateScope();
             var sessionStore = scope.ServiceProvider.GetRequiredService<ISessionStore>();
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
-            while (DateTime.UtcNow < deadline)
-            {
-                if (await sessionStore.GetSession(userId) is null)
-                {
-                    return;
-                }
+            var session = await PollingHelper.PollUntilAsync(
+                () => sessionStore.GetSession(userId), s => s is null, timeoutMs: 5000);
 
-                await Task.Delay(25, CancellationToken);
-            }
-
-            Assert.Fail("The session was not evicted from the cache on logout.");
+            Assert.True(session is null, "The session was not evicted from the cache on logout.");
         }
 
         [Fact]

--- a/Game.Api.Tests/Integration/SocketCommandTimeoutTests.cs
+++ b/Game.Api.Tests/Integration/SocketCommandTimeoutTests.cs
@@ -185,7 +185,7 @@ namespace Game.Api.Tests.Integration
             return (socket, handler, scopeFactory);
         }
 
-        private async Task WaitForSentMessageAsync(FakeWebSocket socket, Func<string, bool> predicate)
+        private static async Task WaitForSentMessageAsync(FakeWebSocket socket, Func<string, bool> predicate)
         {
             var found = await PollingHelper.PollUntilAsync(
                 () => Task.FromResult(socket.SentMessages.Any(predicate)), sent => sent, (int)WaitTimeout.TotalMilliseconds);

--- a/Game.Api.Tests/Integration/SocketCommandTimeoutTests.cs
+++ b/Game.Api.Tests/Integration/SocketCommandTimeoutTests.cs
@@ -187,18 +187,10 @@ namespace Game.Api.Tests.Integration
 
         private async Task WaitForSentMessageAsync(FakeWebSocket socket, Func<string, bool> predicate)
         {
-            var deadline = DateTime.UtcNow + WaitTimeout;
-            while (DateTime.UtcNow < deadline)
-            {
-                if (socket.SentMessages.Any(predicate))
-                {
-                    return;
-                }
+            var found = await PollingHelper.PollUntilAsync(
+                () => Task.FromResult(socket.SentMessages.Any(predicate)), sent => sent, (int)WaitTimeout.TotalMilliseconds);
 
-                await Task.Delay(20, CancellationToken);
-            }
-
-            Assert.Fail("Timed out waiting for the expected message to be sent.");
+            Assert.True(found, "Timed out waiting for the expected message to be sent.");
         }
 
         /// <summary>

--- a/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
+++ b/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
@@ -254,21 +254,8 @@ namespace Game.Api.Tests.Integration
         }
 
         /// <summary>Polls the condition until it holds or a short timeout elapses; returns whether it held.</summary>
-        private async Task<bool> WaitUntilAsync(Func<Task<bool>> condition, int timeoutMs = 5000)
-        {
-            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
-            while (DateTime.UtcNow < deadline)
-            {
-                if (await condition())
-                {
-                    return true;
-                }
-
-                await Task.Delay(100, CancellationToken);
-            }
-
-            return await condition();
-        }
+        private static Task<bool> WaitUntilAsync(Func<Task<bool>> condition, int timeoutMs = 5000) =>
+            PollingHelper.PollUntilAsync(condition, held => held, timeoutMs);
 
         private static string PresenceKey(int playerId)
         {

--- a/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
@@ -96,18 +96,9 @@ namespace Game.Application.Tests.DataAccess
 
         private static async Task AssertKeyEventuallyDeletedAsync(ICacheService cache, string key)
         {
-            var deadline = DateTime.UtcNow.AddSeconds(5);
-            while (DateTime.UtcNow < deadline)
-            {
-                if (await cache.Get(key) is null)
-                {
-                    return;
-                }
+            var value = await PollingHelper.PollUntilAsync(() => cache.Get(key), v => v is null);
 
-                await Task.Delay(25);
-            }
-
-            Assert.Fail($"Expected the fire-and-forget null write to delete key '{key}' within the timeout.");
+            Assert.True(value is null, $"Expected the fire-and-forget null write to delete key '{key}' within the timeout.");
         }
 
         [Fact]

--- a/Game.Application.Tests/Services/PlayerCacheEvictionTests.cs
+++ b/Game.Application.Tests/Services/PlayerCacheEvictionTests.cs
@@ -134,23 +134,11 @@ namespace Game.Application.Tests.Services
         // Polls the key's TTL until it satisfies the predicate (defaults to "any TTL is set"), tolerating the
         // fire-and-forget write not having landed yet. KeyTimeToLiveAsync returns null both for a missing key
         // and a key with no expiry, so a non-null result proves an expiry is attached.
-        private async Task<TimeSpan?> WaitForTtlAsync(IDatabase db, string key, Func<TimeSpan, bool>? predicate = null)
+        private static Task<TimeSpan?> WaitForTtlAsync(IDatabase db, string key, Func<TimeSpan, bool>? predicate = null)
         {
             predicate ??= _ => true;
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
-            TimeSpan? ttl = null;
-            while (DateTime.UtcNow < deadline)
-            {
-                ttl = await db.KeyTimeToLiveAsync(key);
-                if (ttl is not null && predicate(ttl.Value))
-                {
-                    return ttl;
-                }
-
-                await Task.Delay(25, CancellationToken);
-            }
-
-            return ttl;
+            return PollingHelper.PollUntilAsync(
+                () => db.KeyTimeToLiveAsync(key), ttl => ttl is not null && predicate(ttl.Value));
         }
     }
 }

--- a/Game.Application.Tests/Services/SessionCacheEvictionTests.cs
+++ b/Game.Application.Tests/Services/SessionCacheEvictionTests.cs
@@ -3,6 +3,7 @@ using Game.Core.Players;
 using Game.DataAccess;
 using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using StackExchange.Redis;
 using Xunit;
@@ -91,23 +92,11 @@ namespace Game.Application.Tests.Services
         // Polls the key's TTL until it satisfies the predicate (defaults to "any TTL is set"), tolerating the
         // fire-and-forget write not having landed yet. KeyTimeToLiveAsync returns null both for a missing key
         // and a key with no expiry, so a non-null result proves an expiry is attached.
-        private async Task<TimeSpan?> WaitForTtlAsync(IDatabase db, string key, Func<TimeSpan, bool>? predicate = null)
+        private static Task<TimeSpan?> WaitForTtlAsync(IDatabase db, string key, Func<TimeSpan, bool>? predicate = null)
         {
             predicate ??= _ => true;
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
-            TimeSpan? ttl = null;
-            while (DateTime.UtcNow < deadline)
-            {
-                ttl = await db.KeyTimeToLiveAsync(key);
-                if (ttl is not null && predicate(ttl.Value))
-                {
-                    return ttl;
-                }
-
-                await Task.Delay(25, CancellationToken);
-            }
-
-            return ttl;
+            return PollingHelper.PollUntilAsync(
+                () => db.KeyTimeToLiveAsync(key), ttl => ttl is not null && predicate(ttl.Value));
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up from PR #1754, which introduced `PollingHelper.PollUntilAsync` and converted the polling loops in `RedisServiceIntegrationTests` and `PlayerProgressRepositoryIntegrationTests`. Several other `while (DateTime.UtcNow < deadline)` polling loops remained scattered across the backend test suite with the identical poll-until-predicate-or-timeout shape — this consolidates them onto the shared helper:

- `LoginControllerTests`: `AssertPlayerLeveledAboveAsync`, `AssertPlayerNotCreditedAsync`, `AssertSessionPresentAsync`, `AssertSessionEvictedAsync`
- `SocketManagerServiceTests`: `WaitUntilAsync`
- `SocketCommandTimeoutTests`: `WaitForSentMessageAsync`
- `SessionCacheEvictionTests` / `PlayerCacheEvictionTests`: `WaitForTtlAsync` (identical duplicated helper in both files)
- `RedisServiceIntegrationTests`: `AssertKeyEventuallyDeletedAsync` — a loop that was missed when #1754 converted the rest of this file

No behavior change — test-suite maintainability only.

**Intentionally not migrated:** `BackgroundWorkerTests`' `WaitUntil`/`WaitUntilStablyNotRunning`. Both are synchronous (`Thread.Sleep`-based, called from non-`async` test methods) in a suite explicitly designed around avoiding non-deterministic timing complexity for its thread-pool synchronization tests. `WaitUntilStablyNotRunning` also needs N-consecutive-successful-polls semantics that `PollingHelper` doesn't support — bending it to fit would mean either sync-over-async bridging (an anti-pattern, and a real risk in a concurrency-sensitive suite) or extending `PollingHelper` with semantics no other caller needs. Forcing it wouldn't be a mechanical, no-behavior-change refactor, so it's left as-is.

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings/errors
- [x] `dotnet test` (full backend suite, including integration tests against the session's Postgres/Redis containers) — all 3126 tests pass

Closes #1789


---
_Generated by [Claude Code](https://claude.ai/code/session_01JizwiX643RVgM5KtfBg5dv)_