### PR TITLE
Socket hardening: Close() never throws; a null-deserialized frame closes instead of stranding the client

### DIFF
--- a/Game.Api.Tests/Unit/SocketContextTests.cs
+++ b/Game.Api.Tests/Unit/SocketContextTests.cs
@@ -55,8 +55,11 @@ namespace Game.Api.Tests.Unit
 
             socket.FailClose(new WebSocketException("close frame send failed"));
 
-            // The send fault propagates out of Close, but the waiter is still released (best-effort).
-            await Assert.ThrowsAsync<WebSocketException>(() => closeTask);
+            // The send fault (e.g. a peer RST) is caught and the connection aborted rather than propagating
+            // out of Close — every caller invokes it unguarded, so an escaping exception would fault their
+            // loop task (#1928) — and the waiter is still released (best-effort).
+            await closeTask.WaitAsync(WaitTimeout, cancellationToken);
+            Assert.True(socket.AbortCalled);
             await waitClosed.WaitAsync(WaitTimeout, cancellationToken);
             Assert.True(waitClosed.IsCompletedSuccessfully);
         }
@@ -412,6 +415,7 @@ namespace Game.Api.Tests.Unit
             /// <summary>Completes once <see cref="CloseAsync"/> has begun (and is blocking on the gate).</summary>
             public Task CloseStarted => _closeStarted.Task;
             public bool CloseAsyncCalled { get; private set; }
+            public bool AbortCalled { get; private set; }
             public WebSocketCloseStatus? CloseStatusUsed { get; private set; }
             public WebSocketState StateOverride { get; init; } = WebSocketState.Open;
 
@@ -434,7 +438,7 @@ namespace Game.Api.Tests.Unit
             public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken) => throw new NotSupportedException();
             public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken) => Task.CompletedTask;
             public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken) => Task.CompletedTask;
-            public override void Abort() { }
+            public override void Abort() => AbortCalled = true;
             public override void Dispose() { }
         }
 

--- a/Game.Api.Tests/Unit/SocketReadLoopTests.cs
+++ b/Game.Api.Tests/Unit/SocketReadLoopTests.cs
@@ -144,6 +144,29 @@ namespace Game.Api.Tests.Unit
             await handler.Completion.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
         }
 
+        [Fact]
+        public async Task HandleMessage_FrameDeserializesToNull_ClosesAsMalformedFrame()
+        {
+            // A frame containing the JSON literal "null" deserializes to a null SocketCommandInfo without
+            // throwing, so it carries no request id to correlate a structured rejection to. It must close the
+            // socket like the JsonException path rather than silently dropping the frame and stranding the
+            // client on its 30s request timeout (#1928).
+            var socket = new ScriptedReadWebSocket();
+            socket.QueueMessage("null");
+            var (context, handler) = CreateHandler(socket);
+
+            using var inactivityStop = new CancellationTokenSource();
+            handler.Listen(hostStopping: inactivityStop.Token);
+
+            await context.WaitSocketClosed().WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
+            inactivityStop.Cancel();
+            await handler.Completion.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
+
+            Assert.True(socket.CloseAsyncCalled);
+            Assert.Equal(WebSocketCloseStatus.InvalidPayloadData, socket.CloseStatusUsed);
+            Assert.Contains(_logs.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("deserialized to null"));
+        }
+
         private (SocketContext Context, SocketHandler Handler) CreateHandler(WebSocket socket, Action? onActivity = null)
         {
             var session = new SessionService(new NoOpSessionStore());

--- a/Game.Api/Sockets/SocketContext.cs
+++ b/Game.Api/Sockets/SocketContext.cs
@@ -259,6 +259,16 @@ namespace Game.Api.Sockets
                                     _logger.LogWarning("Timed out sending the close frame on socket ({Id}); aborting the connection.", SocketId);
                                     _socket.Abort();
                                 }
+                                catch (Exception ex)
+                                {
+                                    // A transport fault (e.g. the peer RST-ing between the state re-check above and
+                                    // this write) must not escape Close: every caller — including the read loop's
+                                    // unconditional terminal close and the inactivity watchdog — calls it unguarded,
+                                    // so an uncaught throw here would fault their loop tasks. Mirrors SendData's
+                                    // never-throws contract.
+                                    _logger.LogWarning(ex, "Failed to send the close frame on socket ({Id}); aborting the connection.", SocketId);
+                                    _socket.Abort();
+                                }
                             }
                         }
                         finally

--- a/Game.Api/Sockets/SocketHandler.cs
+++ b/Game.Api/Sockets/SocketHandler.cs
@@ -481,6 +481,15 @@ namespace Game.Api.Sockets
 
                     await ExecuteCommand(commandInfo);
                 }
+                else
+                {
+                    // A frame containing the JSON literal "null" deserializes to a null commandInfo without
+                    // throwing, so it would otherwise fall through silently — no response and no close. It
+                    // carries no request id to correlate a structured rejection to, so close instead, mirroring
+                    // the JsonException path below.
+                    _logger.LogWarning("Received socket frame that deserialized to null; closing the socket: {Message}", message);
+                    await _context.Close(ESocketCloseReason.MalformedFrame);
+                }
             }
             catch (JsonException)
             {


### PR DESCRIPTION
## Summary

Two small, independently-verified robustness gaps in the socket receive/teardown path (grouped together in #1928, filed from a scheduled codebase health review):

1. **`SocketContext.Close` only shielded the close frame from cancellation.** A `WebSocketException` (e.g. a peer RST between the `Open`/`CloseReceived` re-check and the frame write — realistic on abrupt client drops) propagated out of `Close`. Two callers invoke it unguarded: the read loop's unconditional terminal close (`SocketHandler.ReadLoop`) and the inactivity watchdog (`SocketHandler.InactivityCheckerLoop`). That faulted `_loops`/`Completion` — unobserved-task exceptions on the normal path, and a spurious "Error draining socket" warning during a drain — contradicting `ShutdownAsync`'s stated premise that the loops never fault on cancellation.

   **Fix:** `Close` now catches non-cancellation exceptions around `CloseAsync`, logs, and aborts the connection — mirroring `SendData`'s existing never-throws contract. Every call site is fixed at once.

2. **A frame that parses to JSON `null` was silently dropped.** `SocketHandler.HandleMessage` deserialized and ran `if (commandInfo is not null) { ... }` with no `else` branch. A frame containing the literal `null` passes the `IsNullOrWhiteSpace` filter, deserializes to `null`, and fell through with no response and no close — exactly the "client waits out its 30s request timeout with no diagnosable error" failure mode the adjacent guards (the missing-`name` check, the `JsonException` catch) exist to eliminate. Since a `null` frame carries no request id to correlate an error response to, it can't be answered like a normal malformed-parameters rejection.

   **Fix:** mirrors the `JsonException` path — log and `Close(ESocketCloseReason.MalformedFrame)`.

## Changes

- `Game.Api/Sockets/SocketContext.cs`: `Close` catches non-cancellation exceptions from `CloseAsync`, logs, and aborts.
- `Game.Api/Sockets/SocketHandler.cs`: `HandleMessage` closes the socket as `MalformedFrame` when a frame deserializes to `null`.
- `Game.Api.Tests/Unit/SocketContextTests.cs`: updated `Close_StillSettlesWaitSocketClosed_WhenCloseFrameSendThrows` to assert the new no-throw/abort contract instead of the old `Assert.ThrowsAsync<WebSocketException>` (which pinned the buggy behavior); added `AbortCalled` tracking to `GatedCloseWebSocket`.
- `Game.Api.Tests/Unit/SocketReadLoopTests.cs`: added `HandleMessage_FrameDeserializesToNull_ClosesAsMalformedFrame`, reusing the existing `ScriptedReadWebSocket` harness.

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings/errors
- [x] `dotnet test` (full backend suite, including integration tests against the session's Postgres/Redis containers) — all 3127 tests pass

Closes #1928


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptwd8FZmy6LvNvDHcEup1D)_