### PR TITLE
Dismiss the tutorial tour via Escape in e2e harness instead of clicking Skip

### DIFF
--- a/UI/e2e-tests/helpers.ts
+++ b/UI/e2e-tests/helpers.ts
@@ -129,14 +129,19 @@ export async function createAccountAndStartGame(page: Page, prefix = 'e') {
 /**
  * A fresh account's first visit to the (default) Fight screen auto-plays the screen-anchored
  * `idle-loop-basics` tutorial tour (a full-screen coach-mark overlay), which would otherwise swallow
- * the very next click every journey makes. Dismiss it via its Skip control if it appeared, so tests
- * interact with the screen underneath rather than asserting anything about tutorial content — that's
- * covered by tutorial.test.ts.
+ * the very next click every journey makes. Dismiss it via Escape if it appeared, so tests interact
+ * with the screen underneath rather than asserting anything about tutorial content — that's covered
+ * by tutorial.test.ts (which exercises the Skip control itself).
  *
  * The tour opens from the welcome-back gate's async `entered` transition, not synchronously with the
  * `/game` navigation, so this waits for it rather than taking an immediate (and racy) snapshot —
  * mirroring how {@link selectFirstCharacter} waits out the similarly-async session-takeover modal.
  * Swallows the timeout if no tour appears (e.g. the lesson is retired later), rather than failing.
+ *
+ * Dismisses via Escape rather than clicking the Skip control: Escape routes through `focusTrap`'s
+ * `window`-level keydown listener (`onEscape`), so it needs no element-visibility/stability check —
+ * unlike a click, which on WebKit can time out waiting for the callout to pass its stability check
+ * while it's still repositioning (#1930).
  */
 export async function dismissTutorialTourIfPresent(page: Page) {
 	const tour = page.getByTestId('tutorial-tour');
@@ -145,7 +150,7 @@ export async function dismissTutorialTourIfPresent(page: Page) {
 	} catch {
 		return;
 	}
-	await page.getByTestId('tutorial-tour-skip').click();
+	await page.keyboard.press('Escape');
 	await expect(tour).not.toBeVisible();
 }
 


### PR DESCRIPTION
## Summary

WebKit was failing its first attempt on every CI run (`admin.test.ts` ×3 + `challenge-boss.test.ts`), always at the same spot: `dismissTutorialTourIfPresent` clicking `tutorial-tour-skip`. Playwright's click waits for the target to pass a visibility/stability check, and on WebKit the tour callout — which repositions itself via a resize/anchor effect (`TourPlayer.svelte`) — never settles in time, so the click times out and the test only passes on retry. Retries were quietly absorbing a 100%-reproducible first-attempt failure instead of real flake, per the issue's investigation of three recent green `main` runs.

## Fix

`TourPlayer.svelte`'s callout shell is wrapped in `focusTrap`, which attaches an `onEscape` handler via a `window`-level `keydown` listener (`focus-trap.ts`) — the same `onDismiss` callback the Skip button and backdrop already use. A `keydown` dispatch has no visibility/stability requirement, so switching the shared e2e helper to `page.keyboard.press('Escape')` dismisses the tour identically without depending on the callout having finished animating into place.

`tutorial.test.ts` is left clicking the Skip control directly, since that test exists specifically to pin the Skip control's own behavior.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings
- [x] `npm run test:unit:ci` — all unit tests pass
- [ ] Full Playwright WebKit run wasn't exercised locally (spinning up the backend + Postgres/Redis-backed dev stack for e2e is heavyweight per project convention, and this change is confined to e2e test harness code) — verified instead by reading `focus-trap.ts`'s `onKeydown` implementation, which confirms Escape reaches the trap through a `window` listener regardless of the callout's animation/positioning state. Will watch the CI run on this PR to confirm the WebKit job passes its first attempt (no `playwright-report-webkit` trace artifact expected).

Closes #1930


---
_Generated by [Claude Code](https://claude.ai/code/session_01MJJs5uv13VWztuohEABUoN)_