### PR TITLE
Re-snapshot player currentHealth after the signature passive lands on full rebuild

### DIFF
--- a/Game.Core.Tests/Battle/BattleSnapshotTests.cs
+++ b/Game.Core.Tests/Battle/BattleSnapshotTests.cs
@@ -296,6 +296,10 @@ namespace Game.Core.Tests.Battle
 
             // Strength = 6 (free pool) + 4 (flat signature passive) = 10.
             Assert.Equal(10, battler.GetAttributeValue(EAttribute.Strength));
+            // The passive lands in the AttributeCollection before the ctor snapshots CurrentHealth (#1933's FE
+            // counterpart), so a passive that raises MaxHealth (Strength feeds it) must not leave the battler
+            // under-full.
+            Assert.Equal(battler.GetAttributeValue(EAttribute.MaxHealth), battler.CurrentHealth);
         }
 
         [Fact]

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -9,7 +9,7 @@ import {
 } from '$lib/battle';
 import { Mulberry32 } from '$lib/engine/mulberry32';
 import { staticData, playerProficiencies } from '$stores';
-import { ELogType, EDamageType, IBattlerAttribute, IEnemyInstance, ISkillDamagePortion } from '$lib/api';
+import { ELogType, EAttribute, EDamageType, IBattlerAttribute, IEnemyInstance, ISkillDamagePortion } from '$lib/api';
 import { DEFAULT_MAX_BATTLE_MS } from '$lib/api/types/game-constants';
 import { logMessage } from '../log';
 import {
@@ -290,6 +290,10 @@ export class BattleEngine {
 		// composePlayerBattleAttributes canonicalises. The data-less re-arm above keeps this modifier (setData
 		// isn't re-run), so it is applied only here, on a full rebuild.
 		applySignaturePassive(this.player.attributes, (resolve) => playerManager.battleSignaturePassiveModifier(resolve));
+		// reset() already snapshotted currentHealth off MaxHealth before the passive above could touch it
+		// (#1933) — re-snapshot now so a passive that raises MaxHealth doesn't leave the battler under-full,
+		// matching the backend's Battler ctor which snapshots CurrentHealth after the passive is composed in.
+		this.player.currentHealth = this.player.attributes.getValue(EAttribute.MaxHealth);
 		this.lastEquipmentStats = equipmentStats;
 		this.lastPlayerAttributes = attributes;
 		this.lastSelectedSkills = selectedSkills;

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -1666,6 +1666,9 @@ describe('BattleEngine', () => {
 			// The full rebuild composes the passive last: Strength = 50 (alloc) + 7 (passive), added exactly once.
 			engine.start();
 			expect(engine.player.attributes.getValue(EAttribute.Strength)).toBe(57);
+			// #1933: Strength feeds MaxHealth, so the passive raises it too — the battler must start full
+			// against the post-passive MaxHealth, not the value reset() snapshotted before the passive landed.
+			expect(engine.player.currentHealth).toBe(engine.player.attributes.getValue(EAttribute.MaxHealth));
 
 			// A data-less re-arm (unchanged inputs) skips setData, so the already-composed passive persists — it is
 			// neither lost (→ 50) nor re-applied (→ 64).
@@ -1679,6 +1682,7 @@ describe('BattleEngine', () => {
 				isBossBattle: false
 			});
 			expect(engine.player.attributes.getValue(EAttribute.Strength)).toBe(57);
+			expect(engine.player.currentHealth).toBe(engine.player.attributes.getValue(EAttribute.MaxHealth));
 		});
 
 		// The additionalModifiers passed to reset must be [...lockedBase, ...proficiency] in that order — the


### PR DESCRIPTION
## Summary

`BattleEngine.resetPlayer`'s full-rebuild path called `this.player.reset(...)`, which snapshots `currentHealth = MaxHealth` at the end of `Battler.reset` (`UI/src/lib/battle/battler.ts:439`), and only *then* composed the class signature passive via `applySignaturePassive` (`UI/src/lib/engine/battle/battle-engine.ts`). Since `MaxHealth` derives from Strength/Endurance, any passive touching those attributes left the frontend battler under-full on every full rebuild (session start, level-up, equip/loadout/proficiency change).

The backend does the opposite and correct order: `BattlerMaterials.Build()` adds the passive to the `AttributeCollection` first, then the `Battler` ctor snapshots `CurrentHealth` from the post-passive `MaxHealth` (`Game.Core/Battle/BattleSnapshot.cs`). This was a latent FE/BE parity bug — harmless only because the one currently-authored class has a 0-amount passive — that would surface once a real passive ships (#1226) and could cause the backend replay to reject legitimately-won client battles.

## Fix

- In `BattleEngine.resetPlayer`, re-snapshot `this.player.currentHealth = this.player.attributes.getValue(EAttribute.MaxHealth)` immediately after `applySignaturePassive` runs on the full-rebuild path, matching the backend's ordering.
- Extended the existing signature-passive test (`battle-engine.test.ts`, uses a +7 Strength passive) to assert `currentHealth` equals post-passive `MaxHealth`, both after the full rebuild and after a subsequent data-less re-arm. Confirmed this assertion fails without the fix (900 vs. expected 935) and passes with it.

## Test plan

- [x] `npx vitest run` (full frontend suite) — 297 files / 3659 tests pass
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings
- [x] Manually reverted the fix and confirmed the new assertion fails, then re-applied and confirmed it passes

Closes #1933


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gp6Ezk99G2zZWU57MQD32o)_