### PR TITLE
Loop EnemyManager.getNewEnemy's re-entrancy guard to catch a queued duplicate

### DIFF
--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -205,7 +205,12 @@ export class EnemyManager {
 	 */
 	public async getNewEnemy(prepared?: PreparedBattle, forceAbandon = false): Promise<void> {
 		const generation = this.fetchGeneration;
-		if (this.fetchingEnemy) {
+		// Looped (not a one-shot if): a fetch already running when we arrive is checked again after each
+		// wait. Two same-generation callers can both queue behind an older, superseded fetch — the first
+		// to resume starts a fresh fetch (synchronously re-arming fetchingEnemy/fetchingGeneration before
+		// its first await), and looping back here is what lets the second recognize that new fetch as its
+		// own genuine re-entrant duplicate instead of racing it into a double spawn.
+		while (this.fetchingEnemy) {
 			// A fetch is already running. If it captured this same generation it's a genuine re-entrant
 			// duplicate — overlapping stage handlers (e.g. an idle victory racing an Idle/Defeated change)
 			// each request-and-notify a spawn, and a double-spawn has anti-cheat consequences (the backend
@@ -215,7 +220,7 @@ export class EnemyManager {
 			}
 			// Otherwise this call's generation is newer, so the running fetch has been superseded (a
 			// transition bumped the generation) and will abandon without spawning. Wait for it to tear
-			// down, then fall through and fetch fresh so this fallback spawn isn't dropped by the guard.
+			// down, then loop back and re-check rather than assuming the guard is now clear.
 			await this.inFlightFetch;
 			// The wait can overlap a stop or a further supersession; bail if either landed meanwhile.
 			if (!this.started || generation !== this.fetchGeneration) {

--- a/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
@@ -292,6 +292,45 @@ describe('EnemyManager.getNewEnemy', () => {
 		expect(loaded).toEqual([]);
 	});
 
+	// #1934: two same-generation callers can both queue behind an older, superseded fetch (e.g. entering
+	// Home bumps the generation while a NewEnemy is in flight, then leaving Home calls getNewEnemy twice
+	// before the superseded fetch tears down). Both must not fall through past the guard and launch the
+	// current generation's fetch — the first genuinely restarts it, the second must recognize that as its
+	// own re-entrant duplicate and drop.
+	it('drops the second of two same-generation callers queued behind a superseded fetch', async () => {
+		let resolveOld!: (r: IApiSocketResponse<'NewEnemy'>) => void;
+		sendSocketCommand.mockReturnValueOnce(new Promise((resolve) => (resolveOld = resolve)));
+		const enemy = makeEnemy(13);
+		let resolveNew!: (r: IApiSocketResponse<'NewEnemy'>) => void;
+		sendSocketCommand.mockReturnValueOnce(new Promise((resolve) => (resolveNew = resolve)));
+		const loaded: IEnemyInstance[] = [];
+		onNewEnemyLoaded((e) => loaded.push(e), false);
+
+		const oldFetch = manager.getNewEnemy(); // starts the old-generation fetch
+		await flush(); // park it on the in-flight NewEnemy request
+
+		// Supersede it (e.g. enterHome/challengeBoss bumping the generation) while it's still in flight.
+		(manager as unknown as { interruptFetch(): void }).interruptFetch();
+
+		// Two same-generation callers both arrive while the superseded fetch is still tearing down.
+		const callerA = manager.getNewEnemy();
+		const callerB = manager.getNewEnemy();
+
+		// The superseded fetch's own request now resolves; its generation check makes it abandon without
+		// spawning, releasing the guard for the two waiters queued behind it.
+		resolveOld(enemyResponse(makeEnemy(0)));
+		await flush();
+
+		// Only one NewEnemy request should have gone out for the current generation.
+		expect(sendSocketCommand).toHaveBeenCalledTimes(2);
+		resolveNew(enemyResponse(enemy));
+		await Promise.all([oldFetch, callerA, callerB]);
+
+		expect(sendSocketCommand).toHaveBeenCalledTimes(2);
+		expect(loaded).toEqual([enemy]);
+		expect(manager.currentEnemy).toEqual(enemy);
+	});
+
 	it('drops a concurrent re-entrant call so a stage-change race spawns a single enemy', async () => {
 		// Two overlapping stage handlers (e.g. an idle victory racing an Idle change) can both reach
 		// getNewEnemy; each would request-and-notify an enemy, double-counting the spawn. Since the


### PR DESCRIPTION
## Summary

`EnemyManager.getNewEnemy`'s re-entrancy guard (`UI/src/lib/engine/battle/enemy-manager.ts`) only checked `fetchingEnemy`/`fetchingGeneration` once (`if`, not `while`). Two same-generation callers could both queue behind an older, already-superseded fetch:

1. A fetch for an old generation is in flight, then a transition (e.g. entering Home, or `challengeBoss`) bumps the generation, superseding it.
2. Two callers at the new generation both arrive while the superseded fetch is still tearing down — both see `fetchingEnemy === true` with a stale `fetchingGeneration`, so both `await this.inFlightFetch`.
3. When the superseded fetch settles, the first waiter resumes, passes its generation check, and synchronously restarts the fetch — re-arming `fetchingEnemy`/`fetchingGeneration` for the *current* generation.
4. The second waiter resumes right after, but its one-shot guard already evaluated `fetchingEnemy` back in step 2 — it never re-checks, so it falls through and launches a second `NewEnemy` request for the same generation: a double enemy spawn, which the backend's anti-cheat replay would flag.

## Fix

Turned the one-shot `if (this.fetchingEnemy)` into a `while (this.fetchingEnemy)` loop, per the issue's suggested direction. The second waiter now loops back after its wait and sees the first waiter's restarted fetch as a genuine re-entrant duplicate (same generation) and drops, rather than racing it.

## Test plan

- [x] Added a regression test (`drops the second of two same-generation callers queued behind a superseded fetch`) that reproduces the exact race — verified it fails against the old code (3 `sendSocketCommand` calls instead of 2) and passes with the fix.
- [x] `npm run test:unit:ci` — all 3660 tests pass.
- [x] `npm run lint` — clean (eslint + svelte-check).

Closes #1934


---
_Generated by [Claude Code](https://claude.ai/code/session_013KZhyB3dLCDug6QgwJjxEs)_