### PR TITLE
Derive coverage-floors.mjs area buckets from coverage.config.ts, remove unused micromatch

### DIFF
--- a/UI/package-lock.json
+++ b/UI/package-lock.json
@@ -7,9 +7,6 @@
 		"": {
 			"name": "svelte-game",
 			"version": "0.0.1",
-			"dependencies": {
-				"micromatch": "^4.0.8"
-			},
 			"devDependencies": {
 				"@emnapi/core": "^1.10.0",
 				"@emnapi/runtime": "^1.10.0",
@@ -2808,18 +2805,6 @@
 				"concat-map": "0.0.1"
 			}
 		},
-		"node_modules/braces": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"license": "MIT",
-			"dependencies": {
-				"fill-range": "^7.1.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3480,18 +3465,6 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/fill-range": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"license": "MIT",
-			"dependencies": {
-				"to-regex-range": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3759,15 +3732,6 @@
 			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12.0"
-			}
 		},
 		"node_modules/is-potential-custom-element-name": {
 			"version": "1.0.1",
@@ -4408,19 +4372,6 @@
 			"dev": true,
 			"license": "CC0-1.0"
 		},
-		"node_modules/micromatch": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"license": "MIT",
-			"dependencies": {
-				"braces": "^3.0.3",
-				"picomatch": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=8.6"
-			}
-		},
 		"node_modules/mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -4677,18 +4628,6 @@
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
 		},
 		"node_modules/pify": {
 			"version": "4.0.1",
@@ -5602,18 +5541,6 @@
 			"integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"license": "MIT",
-			"dependencies": {
-				"is-number": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
 		},
 		"node_modules/totalist": {
 			"version": "3.0.1",

--- a/UI/package.json
+++ b/UI/package.json
@@ -49,8 +49,5 @@
 		"vite": "^8.0.14",
 		"vitest": "^4.1.7"
 	},
-	"type": "module",
-	"dependencies": {
-		"micromatch": "^4.0.8"
-	}
+	"type": "module"
 }

--- a/UI/scripts/coverage-floors.mjs
+++ b/UI/scripts/coverage-floors.mjs
@@ -30,11 +30,13 @@ function blank() {
 }
 
 // Strip everything before the `src/` root so an absolute (or Windows-backslashed) path from the
-// summary matches the same repo-relative form the area/exclude globs are anchored against.
+// summary matches the same repo-relative form the area/exclude globs are anchored against. Anchors
+// on `/src/` (leading slash) rather than `src/` so a parent directory ending in `src` (e.g.
+// `.../mysrc/UI/src/lib/...`) doesn't match its own trailing `src/` prematurely.
 function toRelative(file) {
 	const norm = file.split('\\').join('/');
-	const idx = norm.indexOf('src/');
-	return idx === -1 ? norm : norm.slice(idx);
+	const idx = norm.indexOf('/src/');
+	return idx === -1 ? norm : norm.slice(idx + 1);
 }
 
 const unmatched = [];

--- a/UI/scripts/coverage-floors.mjs
+++ b/UI/scripts/coverage-floors.mjs
@@ -4,6 +4,8 @@
 //   node scripts/coverage-floors.mjs
 // Re-run when coverage rises to ratchet the floors upward.
 import { readFileSync } from 'node:fs';
+import { coverageThresholds, projectCoverageExclude } from '../coverage.config.ts';
+import { globToRegExp } from './coverage-glob.ts';
 
 const summaryPath = new URL('../coverage/coverage-summary.json', import.meta.url);
 let summary;
@@ -14,38 +16,54 @@ try {
 	process.exit(1);
 }
 
-// Area -> glob key used in vite.config.ts thresholds, and the predicate that buckets a file into it.
-// Order matters only for display; the predicates are mutually exclusive by construction.
-const AREAS = [
-	['src/lib/battle/**', (p) => p.includes('/src/lib/battle/')],
-	['src/lib/engine/**', (p) => p.includes('/src/lib/engine/')],
-	['src/lib/common/**', (p) => p.includes('/src/lib/common/')],
-	['src/lib/api/**', (p) => p.includes('/src/lib/api/') && !p.includes('/src/lib/api/types/')],
-	['src/lib/card-game/**', (p) => p.includes('/src/lib/card-game/')],
-	['src/stores/**', (p) => p.includes('/src/stores/')],
-	['src/components/**', (p) => p.includes('/src/components/')],
-	['src/routes/**', (p) => p.includes('/src/routes/')]
-];
+// Areas come straight from coverage.config.ts's coverageThresholds — the same source
+// src/tests/coverage-config.test.ts gates against — so a new area added there is picked up here
+// automatically instead of needing a hand-maintained duplicate list.
+const AREAS = Object.keys(coverageThresholds);
+const areaMatchers = AREAS.map((glob) => ({ glob, regExp: globToRegExp(glob) }));
+const excludeMatchers = projectCoverageExclude.map(globToRegExp);
 const METRICS = ['lines', 'functions', 'branches', 'statements'];
 
-const acc = Object.fromEntries(AREAS.map(([k]) => [k, blank()]));
+const acc = Object.fromEntries(AREAS.map((k) => [k, blank()]));
 function blank() {
 	return Object.fromEntries(METRICS.map((m) => [m, [0, 0]]));
 }
 
+// Strip everything before the `src/` root so an absolute (or Windows-backslashed) path from the
+// summary matches the same repo-relative form the area/exclude globs are anchored against.
+function toRelative(file) {
+	const norm = file.split('\\').join('/');
+	const idx = norm.indexOf('src/');
+	return idx === -1 ? norm : norm.slice(idx);
+}
+
+const unmatched = [];
 for (const [file, m] of Object.entries(summary)) {
 	if (file === 'total') {
 		continue;
 	}
-	const norm = file.split('\\').join('/');
-	const hit = AREAS.find(([, match]) => match(norm));
+	const rel = toRelative(file);
+	if (excludeMatchers.some((regExp) => regExp.test(rel))) {
+		continue;
+	}
+	const hit = areaMatchers.find(({ regExp }) => regExp.test(rel));
 	if (!hit) {
+		unmatched.push(rel);
 		continue;
 	}
 	for (const metric of METRICS) {
-		acc[hit[0]][metric][0] += m[metric].covered;
-		acc[hit[0]][metric][1] += m[metric].total;
+		acc[hit.glob][metric][0] += m[metric].covered;
+		acc[hit.glob][metric][1] += m[metric].total;
 	}
+}
+
+if (unmatched.length > 0) {
+	console.error(
+		'The following covered files match no coverage area and are not excluded — add an area to ' +
+			'coverageThresholds or an exclusion to projectCoverageExclude in coverage.config.ts:\n' +
+			unmatched.map((f) => `  ${f}`).join('\n')
+	);
+	process.exit(1);
 }
 
 const pct = ([c, t]) => (t === 0 ? 0 : (100 * c) / t);
@@ -53,13 +71,13 @@ const fmt = (v) => v.toFixed(1).padStart(5);
 
 console.log('\nCurrent coverage by area (covered/total):\n');
 console.log('area'.padEnd(22), METRICS.map((m) => m.padEnd(7)).join(''));
-for (const [k] of AREAS) {
+for (const k of AREAS) {
 	const row = METRICS.map((m) => fmt(pct(acc[k][m])) + '  ').join('');
 	console.log(k.padEnd(22), row);
 }
 
 console.log('\nPaste-ready ratchet floors for vite.config.ts (coverage.thresholds):\n');
-for (const [k] of AREAS) {
+for (const k of AREAS) {
 	const parts = METRICS.map((m) => `${m}: ${Math.floor(pct(acc[k][m]))}`).join(', ');
 	console.log(`\t\t\t\t'${k}': { ${parts} },`);
 }

--- a/UI/scripts/coverage-glob.ts
+++ b/UI/scripts/coverage-glob.ts
@@ -1,0 +1,29 @@
+// Shared by coverage-config.test.ts (which gates every source file against these areas) and
+// coverage-floors.mjs (which re-derives the same areas to compute ratchet floors) so the two never
+// drift apart on what counts as a match.
+
+// Minimal glob matcher for the vocabulary the coverage config uses: `**` (any number of path
+// segments, including none), `*` (anything within a single segment), and literal characters. This
+// mirrors how Vitest itself buckets files without pulling in an untyped runtime glob dependency.
+export function globToRegExp(glob: string): RegExp {
+	let source = '';
+	for (let i = 0; i < glob.length; i++) {
+		const char = glob[i];
+		if (char === '*' && glob[i + 1] === '*') {
+			i++;
+			if (glob[i + 1] === '/') {
+				i++;
+				source += '(?:.*/)?';
+			} else {
+				source += '.*';
+			}
+		} else if (char === '*') {
+			source += '[^/]*';
+		} else if ('.+^${}()|[]\\'.includes(char)) {
+			source += `\\${char}`;
+		} else {
+			source += char;
+		}
+	}
+	return new RegExp(`^${source}$`);
+}

--- a/UI/src/tests/coverage-config.test.ts
+++ b/UI/src/tests/coverage-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { coverageThresholds, projectCoverageExclude } from '../../coverage.config';
+import { globToRegExp } from '../../scripts/coverage-glob';
 
 // Enumerate every instrumented source file. Vite resolves this glob at transform time against the
 // package root, so the test sees the real tree. Declaration files carry no executable logic, so v8
@@ -8,32 +9,6 @@ const sourceFiles = Object.keys(import.meta.glob('/src/**/*.{ts,js,svelte}'))
 	.map((path) => path.replace(/^\//, ''))
 	.filter((path) => !path.endsWith('.d.ts'))
 	.sort();
-
-// Minimal glob matcher for the vocabulary the coverage config uses: `**` (any number of path
-// segments, including none), `*` (anything within a single segment), and literal characters. This
-// mirrors how Vitest itself buckets files without pulling in an untyped runtime glob dependency.
-function globToRegExp(glob: string): RegExp {
-	let source = '';
-	for (let i = 0; i < glob.length; i++) {
-		const char = glob[i];
-		if (char === '*' && glob[i + 1] === '*') {
-			i++;
-			if (glob[i + 1] === '/') {
-				i++;
-				source += '(?:.*/)?';
-			} else {
-				source += '.*';
-			}
-		} else if (char === '*') {
-			source += '[^/]*';
-		} else if ('.+^${}()|[]\\'.includes(char)) {
-			source += `\\${char}`;
-		} else {
-			source += char;
-		}
-	}
-	return new RegExp(`^${source}$`);
-}
 
 const areaMatchers = Object.keys(coverageThresholds).map((glob) => ({ glob, regExp: globToRegExp(glob) }));
 const excludeMatchers = projectCoverageExclude.map(globToRegExp);


### PR DESCRIPTION
## Summary

Two small, bundled frontend tooling cleanups from #1812:

1. **`coverage-floors.mjs` re-declared the area globs and silently dropped unmatched files.** It hardcoded its own copy of the eight coverage areas as ad-hoc predicates (including a special-cased `api/types` exclusion) instead of deriving them from `coverageThresholds` in `coverage.config.ts`, and `if (!hit) continue` silently skipped any covered file matching no area. `src/tests/coverage-config.test.ts` *forces* a new area to be added whenever a new top-level `src` folder appears, so `coverage-floors.mjs` could silently omit that new area from its ratchet suggestions.
2. **`micromatch` was an unused production dependency.** Nothing under `UI/src`, `UI/scripts`, `UI/e2e-tests`, or the configs imports it — `coverage-config.test.ts` explicitly hand-rolls its own glob matcher (`globToRegExp`) specifically to avoid "an untyped runtime glob dependency". Removed from `package.json`/`package-lock.json`.

## Changes

- Extracted `globToRegExp` out of `coverage-config.test.ts` into a new shared `UI/scripts/coverage-glob.ts` (excluded from coverage like the rest of `scripts/**`), so the test and the ratchet script use identical glob-matching logic instead of drifting.
- `coverage-floors.mjs` now derives its area list from `Object.keys(coverageThresholds)` (imported from `coverage.config.ts`) and applies the same `projectCoverageExclude` filtering the test does, instead of a hand-maintained predicate array. Node 26's native TS support lets the `.mjs` script import the `.ts` config/glob modules directly — no build step needed.
- A covered file that matches no area (and isn't excluded) now makes the script `exit(1)` with the offending paths listed, instead of being silently dropped.
- Removed `micromatch` from `UI/package.json` and regenerated `package-lock.json` via `npm install`.

## Test plan

- [x] `npm run test:unit:ci` — 297 test files / 3660 tests pass, coverage thresholds hold.
- [x] `npm run lint` (ESLint + svelte-check) — clean.
- [x] `npm run test:unit:coverage && node scripts/coverage-floors.mjs` — runs end-to-end against a real `coverage-summary.json`, prints the same 8 areas with no "unmatched" errors, output format unchanged from before.
- [x] Confirmed `micromatch` has no remaining references anywhere in `UI/` after removal.

Closes #1812

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLRJoagyPsBiFjFexgpepR)_