### PR TITLE
Add least-privilege permissions block to run-tests.yml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# No job needs more than read access to repo contents (checkout); this also caps the third-party
+# dorny/paths-filter@v3 action (flagged above as uncertified) to the same least-privilege default.
+permissions:
+  contents: read
+
 # Cancel any in-progress run for the same ref (PR branch or main) when a newer push lands. The
 # heaviest path is the 3-browser test-e2e matrix, so superseding stale runs frees those minutes
 # for the run that actually matters.


### PR DESCRIPTION
## Summary

- `.github/workflows/run-tests.yml` had no `permissions:` block, so every job — including the third-party `dorny/paths-filter@v3` action — ran with the repository's default `GITHUB_TOKEN` permissions.
- No job in this workflow needs more than `contents: read` (checkout only; the paths-filter action's PR-read need is covered by `contents: read` for the `pull_request` event; artifact upload/download isn't gated by this permissions block).
- Added a top-level `permissions: contents: read`, applying least privilege to all jobs by default.

## Test plan

- [x] Validated the YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] Reviewed every job in the workflow to confirm none calls the GitHub API or needs any scope beyond `contents: read` for checkout.
- This is a CI-config-only change (no backend/frontend code touched), so `dotnet build`/`test` and `npm run lint`/`test:unit:ci` aren't applicable here — the workflow itself will validate on this PR's own CI run.

Closes #1814

---
_Generated by [Claude Code](https://claude.ai/code/session_012pBVSLEBCn54NNSLgdS16M)_