### PR TITLE
Only dirty-mark Max/Min statistics on a genuine value change

### DIFF
--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -976,6 +976,61 @@ namespace Game.Core.Tests.Progress
         }
 
         [Fact]
+        public void RecordBattleCompleted_UnimprovedMaxStatisticOnExistingRow_LeavesItCleanAndUntouched()
+        {
+            // An aggregate loaded with a prior HighestSingleAttackDamage records a battle whose attack
+            // doesn't beat it: the existing row's value is unchanged, so — like the zero-delta Sum case —
+            // it must stay out of both the persist set and the touched keys, not just get a no-op re-mark.
+            var progress = MakeProgress(statistics: [Stat(EStatisticType.HighestSingleAttackDamage, null, 40m)]);
+
+            var touched = progress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false,
+                totalMs: 1000, new BattleStats { HighestPlayerAttack = 25.0 }, isBossBattle: false, zoneId: 0);
+
+            Assert.Equal(40m, progress.GetStatisticValue(EStatisticType.HighestSingleAttackDamage, null));
+            Assert.DoesNotContain(progress.DirtyStatistics, s => s.Type == EStatisticType.HighestSingleAttackDamage);
+            Assert.DoesNotContain((EStatisticType.HighestSingleAttackDamage, (int?)null), touched);
+        }
+
+        [Fact]
+        public void RecordBattleCompleted_UnimprovedMinStatisticOnExistingRow_LeavesItCleanAndUntouched()
+        {
+            // An aggregate loaded with a prior FastestVictory (global and per-enemy) records a slower
+            // victory against the same enemy: the existing rows' values are unchanged, so they must stay
+            // out of both the persist set and the touched keys — the Min/Max analogue of the zero-delta Sum
+            // skip (#1821).
+            var enemy = MakeEnemy(id: 1);
+            var progress = MakeProgress(statistics:
+            [
+                Stat(EStatisticType.FastestVictory, null, 3m),
+                Stat(EStatisticType.FastestVictory, 1, 3m),
+            ]);
+
+            var touched = progress.RecordBattleCompleted(enemy, victory: true, playerDied: false,
+                totalMs: 8000, new BattleStats(), isBossBattle: false, zoneId: 0);
+
+            Assert.Equal(3m, progress.GetStatisticValue(EStatisticType.FastestVictory, null));
+            Assert.Equal(3m, progress.GetStatisticValue(EStatisticType.FastestVictory, 1));
+            Assert.DoesNotContain(progress.DirtyStatistics, s => s.Type == EStatisticType.FastestVictory);
+            Assert.DoesNotContain((EStatisticType.FastestVictory, (int?)null), touched);
+            Assert.DoesNotContain((EStatisticType.FastestVictory, (int?)1), touched);
+        }
+
+        [Fact]
+        public void RecordBattleCompleted_ImprovedMaxStatisticOnExistingRow_IsRecordedDirtiedAndTouched()
+        {
+            // The unimproved-value skip must not swallow a real improvement: a battle that beats the prior
+            // HighestSingleAttackDamage still records, dirties, and touches the stat.
+            var progress = MakeProgress(statistics: [Stat(EStatisticType.HighestSingleAttackDamage, null, 20m)]);
+
+            var touched = progress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false,
+                totalMs: 1000, new BattleStats { HighestPlayerAttack = 35.0 }, isBossBattle: false, zoneId: 0);
+
+            Assert.Equal(35m, progress.GetStatisticValue(EStatisticType.HighestSingleAttackDamage, null));
+            Assert.Contains(progress.DirtyStatistics, s => s.Type == EStatisticType.HighestSingleAttackDamage && s.EntityId == null);
+            Assert.Contains((EStatisticType.HighestSingleAttackDamage, (int?)null), touched);
+        }
+
+        [Fact]
         public void RecordBattleCompleted_ZeroDamageSkill_RecordsItsUsesButNoDamageDealtRow()
         {
             // A used utility skill that dealt no damage: the per-skill use count is a real delta, while its

--- a/Game.Core/Progress/PlayerProgress.cs
+++ b/Game.Core/Progress/PlayerProgress.cs
@@ -348,16 +348,19 @@ namespace Game.Core.Progress
 
             var stat = GetOrCreate(type, entityId, out _);
             stat.Value += amount;
+            _dirtyStatistics.Add((type, entityId));
         }
 
         private void SetMax(EStatisticType type, int? entityId, decimal value)
         {
             var stat = GetOrCreate(type, entityId, out var created);
             // Record on the first write (created) or a strictly greater value, so the first recorded value
-            // wins outright instead of racing the 0 a fresh row starts at.
+            // wins outright instead of racing the 0 a fresh row starts at. An unimproved value carries no
+            // new information, so it is neither persisted nor re-enters the challenge-eval touched set.
             if (created || value > stat.Value)
             {
                 stat.Value = value;
+                _dirtyStatistics.Add((type, entityId));
             }
         }
 
@@ -366,10 +369,12 @@ namespace Game.Core.Progress
             var stat = GetOrCreate(type, entityId, out var created);
             // Record on the first write (created) or a strictly lesser value. Keying off the explicit
             // created flag — not "Value == 0" — lets a legitimate 0 minimum lock in rather than being
-            // overwritten forever as if it were the empty placeholder.
+            // overwritten forever as if it were the empty placeholder. An unimproved value carries no new
+            // information, so it is neither persisted nor re-enters the challenge-eval touched set.
             if (created || value < stat.Value)
             {
                 stat.Value = value;
+                _dirtyStatistics.Add((type, entityId));
             }
         }
 
@@ -383,11 +388,6 @@ namespace Game.Core.Progress
                 _statistics[key] = stat;
             }
 
-            // GetOrCreate is reached only from the mutators (Increment/SetMax/SetMin); reads use
-            // GetStatisticValue/TryGetStatisticValue, which never land here. So marking dirty here covers
-            // exactly the mutated stats. A no-op SetMax/SetMin over-marks at worst, which is harmless — the
-            // persist is an idempotent absolute write.
-            _dirtyStatistics.Add(key);
             return stat;
         }
     }


### PR DESCRIPTION
## Summary

`PlayerProgress.GetOrCreate` (`Game.Core/Progress/PlayerProgress.cs`) unconditionally added the `(type, entityId)` key to `_dirtyStatistics`, so a `SetMax`/`SetMin` call that didn't actually improve the value still:

- re-enqueued the unchanged row in the write-behind persist, and
- entered the key into the touched set `RecordBattleCompleted` returns, which is the challenge-evaluation relevance scope (`ChallengeIndex.RelevantTo`).

`HighestSingleAttackDamage` and `FastestVictory` are recorded on nearly every battle (global + per-skill/per-enemy), and after the first battle they almost never improve — so every battle was persisting several unchanged rows and re-evaluating challenges keyed to them for no reason.

The in-code comment justified this as harmless ("the persist is an idempotent absolute write"), but it didn't account for the dirty set's second role as the challenge-eval scope, and it contradicted both `GetOrCreate`'s own doc comment ("marking dirty here covers exactly the mutated stats") and `docs/backend.md`'s claim that challenge evaluation is scoped to statistics that actually changed that battle.

## Fix

Moved `_dirtyStatistics.Add` out of `GetOrCreate` and into `SetMax`/`SetMin` themselves, marking dirty only when `created || value` actually improved — mirroring the zero-delta skip `Increment` already does for Sum statistics. `Increment` now marks dirty unconditionally after applying its (already zero-checked) delta, since it always mutates when reached.

No doc changes needed — `docs/backend.md`'s existing claim about challenge-eval scoping is now accurate rather than aspirational.

## Test plan

- [x] Added `PlayerProgressTests`: unimproved Max/Min on an existing row stays out of the persist set and the touched keys (mirroring the existing zero-delta-Sum coverage); an improving Max still records/dirties/touches.
- [x] `dotnet build` — solution builds clean.
- [x] `dotnet test` (full suite, including integration tests against the session's Postgres/Redis containers) — 3132/3132 passing.

Closes #1821


---
_Generated by [Claude Code](https://claude.ai/code/session_01TN1pfg1sDLw8sN2VGejFyW)_