### PR TITLE
Make Item/ItemMod classes so InventoryManager mutations reach the UI (#1957)

### DIFF
--- a/UI/src/lib/battle/item-mod.ts
+++ b/UI/src/lib/battle/item-mod.ts
@@ -1,7 +1,35 @@
-import { IAppliedModModel, IItemMod } from '$lib/api';
+import { EItemModType, ERarity, IAppliedModModel, IBattlerAttribute, IItemMod } from '$lib/api';
 import { staticData } from '$stores';
 
-export interface ItemMod extends Omit<IAppliedModModel, 'itemModId'>, IItemMod {}
+// A class (not a plain object literal) so `statify` recognizes it via its own per-field reactivity
+// (see `statify.svelte.ts`) instead of falling through to Svelte's native deep-proxy, which would give
+// the same underlying mod a different identity depending on which reactive array reads it (#1957).
+export class ItemMod implements IItemMod {
+	id: number;
+	name: string;
+	description: string;
+	itemModTypeId: EItemModType;
+	rarityId: ERarity;
+	attributes: IBattlerAttribute[];
+	tags: number[];
+	designerNotes: string;
+	retiredAt?: string;
+
+	itemModSlotId: number;
+
+	constructor(itemModData: IItemMod, itemModSlotId: number) {
+		this.id = itemModData.id;
+		this.name = itemModData.name;
+		this.description = itemModData.description;
+		this.itemModTypeId = itemModData.itemModTypeId;
+		this.rarityId = itemModData.rarityId;
+		this.attributes = itemModData.attributes;
+		this.tags = itemModData.tags;
+		this.designerNotes = itemModData.designerNotes;
+		this.retiredAt = itemModData.retiredAt;
+		this.itemModSlotId = itemModSlotId;
+	}
+}
 
 export const newItemMod = (appliedMod: IAppliedModModel): ItemMod | undefined => {
 	// Resolve the mod's static definition by id; a missing/retired id yields no record, so degrade
@@ -10,8 +38,5 @@ export const newItemMod = (appliedMod: IAppliedModModel): ItemMod | undefined =>
 	if (!itemModData) {
 		return undefined;
 	}
-	return {
-		...itemModData,
-		itemModSlotId: appliedMod.itemModSlotId
-	} satisfies ItemMod;
+	return new ItemMod(itemModData, appliedMod.itemModSlotId);
 };

--- a/UI/src/lib/battle/item.ts
+++ b/UI/src/lib/battle/item.ts
@@ -1,15 +1,67 @@
-import { IItem, IInventoryItem } from '$lib/api';
+import { EDamageType, EItemCategory, ERarity, IBattlerAttribute, IInventoryItem, IItem, IItemModSlot } from '$lib/api';
 import { ItemMod, newItemMod } from './item-mod';
 import { BattleAttributes } from './battle-attributes';
 import { staticData } from '$stores';
 
-export interface Item extends IItem {
+// A class (not a plain object literal) so `statify` recognizes it via its own per-field reactivity
+// (see `statify.svelte.ts`) instead of falling through to Svelte's native deep-proxy, which would give
+// the same underlying item a different identity depending on which reactive array reads it. That
+// divergence is what let `InventoryManager.unlockedItems` (a Map, never itself deep-proxied) hold a
+// raw item while the UI read a separately-proxied copy of the same object — mutations through the Map
+// were invisible to the UI (#1957). Keeping `Item`/`ItemMod` as classes preserves one shared identity
+// across every container (the Map, `items`, `equippedSlots`) that references the same item.
+export class Item implements IItem {
+	id: number;
+	name: string;
+	description: string;
+	itemCategoryId: EItemCategory;
+	rarityId: ERarity;
+	iconPath: string;
+	attributes: IBattlerAttribute[];
+	modSlots: IItemModSlot[];
+	tags: number[];
+	grantedSkillId?: number;
+	weaponType?: EDamageType;
+	requiredProficiencyId?: number;
+	requiredProficiencyLevel: number;
+	designerNotes: string;
+	retiredAt?: string;
+
 	itemId: number;
 	equipped: boolean;
 	equipmentSlotId?: number;
 	favorite: boolean;
 	appliedMods: ItemMod[];
 	totalAttributes: BattleAttributes;
+
+	constructor(itemData: IItem, invItem: IInventoryItem) {
+		this.id = itemData.id;
+		this.name = itemData.name;
+		this.description = itemData.description;
+		this.itemCategoryId = itemData.itemCategoryId;
+		this.rarityId = itemData.rarityId;
+		this.iconPath = itemData.iconPath;
+		this.attributes = itemData.attributes;
+		this.modSlots = itemData.modSlots;
+		this.tags = itemData.tags;
+		this.grantedSkillId = itemData.grantedSkillId;
+		this.weaponType = itemData.weaponType;
+		this.requiredProficiencyId = itemData.requiredProficiencyId;
+		this.requiredProficiencyLevel = itemData.requiredProficiencyLevel;
+		this.designerNotes = itemData.designerNotes;
+		this.retiredAt = itemData.retiredAt;
+
+		this.itemId = invItem.itemId;
+		this.equipped = invItem.equipped;
+		this.equipmentSlotId = invItem.equipmentSlotId;
+		this.favorite = invItem.favorite ?? false;
+		// Drop any applied mod whose own definition is missing/retired so one stale mod can't crash the item.
+		this.appliedMods = invItem.appliedMods.map((am) => newItemMod(am)).filter((mod): mod is ItemMod => mod != null);
+		this.totalAttributes = new BattleAttributes(
+			[...this.attributes, ...this.appliedMods.flatMap((mod) => mod.attributes)],
+			false
+		);
+	}
 }
 
 export const newItem = (invItem: IInventoryItem): Item | undefined => {
@@ -19,17 +71,5 @@ export const newItem = (invItem: IInventoryItem): Item | undefined => {
 	if (!itemData) {
 		return undefined;
 	}
-	// Drop any applied mod whose own definition is missing/retired so one stale mod can't crash the item.
-	const appliedMods = invItem.appliedMods.map((am) => newItemMod(am)).filter((mod): mod is ItemMod => mod != null);
-	const allAttributes = [...itemData.attributes, ...appliedMods.flatMap((mod) => mod.attributes)];
-	const totalAttributes = new BattleAttributes(allAttributes, false);
-	return {
-		...itemData,
-		itemId: invItem.itemId,
-		equipped: invItem.equipped,
-		equipmentSlotId: invItem.equipmentSlotId,
-		favorite: invItem.favorite ?? false,
-		appliedMods,
-		totalAttributes
-	} satisfies Item;
+	return new Item(itemData, invItem);
 };

--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -57,7 +57,13 @@ export class InventoryManager {
 	 * Reactive published view of `unlockedItems`. The manager is the single owner of the item objects
 	 * and the only place they are mutated. `statify` makes each item's fields (and this array) reactive
 	 * in place, so the array is rebuilt (`publish`) only when the item *set* changes; in-place field
-	 * edits (equip, favorite, mods) propagate to consumers on their own without a rebuild.
+	 * edits (equip, favorite, mods) propagate to consumers on their own without a rebuild. This relies on
+	 * `Item`/`ItemMod` being classes (not plain object literals): `statify` gives a class instance its
+	 * own reactive field accessors, defined once and shared by every container that references it —
+	 * `unlockedItems`, `items`, and `equippedSlots` all read/write the same object. A plain-object item
+	 * would instead pick up Svelte's own deep-proxy per container, giving the "same" item a different
+	 * proxied identity in the Map than in this array — mutations through one would be invisible to
+	 * consumers reading the other (#1957).
 	 */
 	public items: Item[] = [];
 

--- a/UI/src/tests/lib/engine/player/inventory-manager-reactivity.svelte.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager-reactivity.svelte.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { flushSync } from 'svelte';
+import { EAttribute, EItemCategory, EItemModType, ERarity } from '$lib/api';
+import type { IInventoryData, IInventoryItem, IItem, IItemMod } from '$lib/api';
+import { statify } from '$lib/common';
+
+const mockInventoryData: IInventoryData = {
+	unlockedItems: [],
+	unlockedMods: []
+};
+
+vi.mock('$lib/engine', () => ({
+	playerManager: {
+		get inventoryData() {
+			return mockInventoryData;
+		},
+		playerRating: 0
+	}
+}));
+
+const mockItems: IItem[] = [];
+const mockItemMods: IItemMod[] = [];
+
+vi.mock('$stores', () => ({
+	staticData: {
+		get items() {
+			return mockItems;
+		},
+		get itemMods() {
+			return mockItemMods;
+		},
+		get skills() {
+			return [];
+		}
+	}
+}));
+
+const { mockSendSocketCommand } = vi.hoisted(() => {
+	const mockSendSocketCommand = vi.fn();
+	return { mockSendSocketCommand };
+});
+
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		apiSocket: { sendSocketCommand: mockSendSocketCommand }
+	};
+});
+
+vi.mock('$lib/engine/log', () => ({ logMessage: vi.fn() }));
+
+import { InventoryManager, EEquipmentSlot } from '$lib/engine/player/inventory-manager';
+
+const makeItem = (id: number): IItem => ({
+	id,
+	name: `Item ${id}`,
+	description: `Description ${id}`,
+	designerNotes: '',
+	itemCategoryId: EItemCategory.Weapon,
+	rarityId: ERarity.Common,
+	iconPath: `/icons/${id}.png`,
+	requiredProficiencyLevel: 0,
+	attributes: [{ attributeId: EAttribute.Strength, amount: 5 }],
+	modSlots: [{ id: 0, itemId: id, itemModSlotTypeId: EItemModType.Component }],
+	tags: []
+});
+
+const makeItemMod = (id: number): IItemMod => ({
+	id,
+	name: `Mod ${id}`,
+	description: `Mod description ${id}`,
+	designerNotes: '',
+	itemModTypeId: EItemModType.Component,
+	rarityId: ERarity.Uncommon,
+	attributes: [{ attributeId: EAttribute.Agility, amount: 3 }],
+	tags: []
+});
+
+const makeInventoryItem = (overrides: Partial<IInventoryItem> & { itemId: number }): IInventoryItem => ({
+	equipped: false,
+	favorite: false,
+	appliedMods: [],
+	...overrides
+});
+
+// The real app wraps the manager in `statify` (`$lib/engine/engine.ts`), and every mutation path
+// resolves its target item via `unlockedItems.get(...)`. These guard that such a mutation is observed
+// by a `$derived` reading the same item through the reactive `items` array — the two access paths must
+// resolve to the same statified object, or the UI silently goes stale (#1957).
+describe('InventoryManager reactivity under statify (#1957)', () => {
+	let manager: InventoryManager;
+
+	beforeEach(() => {
+		manager = statify(new InventoryManager());
+		mockItems.length = 0;
+		mockItemMods.length = 0;
+		mockInventoryData.unlockedItems = [];
+		mockInventoryData.unlockedMods = [];
+		mockSendSocketCommand.mockReset().mockResolvedValue({});
+	});
+
+	it('observes a favorite toggle through the items array', async () => {
+		mockItems[1] = makeItem(1);
+		mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+		manager.initialize();
+
+		let favorite: boolean | undefined;
+		const cleanup = $effect.root(() => {
+			const derived = $derived(manager.items[0]?.favorite);
+			$effect(() => {
+				favorite = derived;
+			});
+		});
+		flushSync();
+		expect(favorite).toBe(false);
+
+		await manager.setFavorite(1, true);
+		flushSync();
+		expect(favorite).toBe(true);
+
+		cleanup();
+	});
+
+	it('observes an equip/unequip toggle through the items array', async () => {
+		mockItems[1] = makeItem(1);
+		mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+		manager.initialize();
+
+		let equipped: boolean | undefined;
+		const cleanup = $effect.root(() => {
+			const derived = $derived(manager.items[0]?.equipped);
+			$effect(() => {
+				equipped = derived;
+			});
+		});
+		flushSync();
+		expect(equipped).toBe(false);
+
+		await manager.equipItem(1, EEquipmentSlot.WeaponSlot);
+		flushSync();
+		expect(equipped).toBe(true);
+
+		await manager.unequipItem(EEquipmentSlot.WeaponSlot);
+		flushSync();
+		expect(equipped).toBe(false);
+
+		cleanup();
+	});
+
+	it('observes an applied mod change through the items array', async () => {
+		mockItems[1] = makeItem(1);
+		mockItemMods[10] = makeItemMod(10);
+		mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+		mockInventoryData.unlockedMods = [10];
+		manager.initialize();
+
+		let modCount: number | undefined;
+		const cleanup = $effect.root(() => {
+			const derived = $derived(manager.items[0]?.appliedMods.length);
+			$effect(() => {
+				modCount = derived;
+			});
+		});
+		flushSync();
+		expect(modCount).toBe(0);
+
+		await manager.applyMod(1, 10, 0);
+		flushSync();
+		expect(modCount).toBe(1);
+
+		await manager.removeMod(1, 0);
+		flushSync();
+		expect(modCount).toBe(0);
+
+		cleanup();
+	});
+});


### PR DESCRIPTION
## Summary

`InventoryManager.unlockedItems` (a `Map`) never rendered a mutation without a reload — favorite toggles, equip/unequip, and mod apply/remove all silently failed to update the grid, the equipped rail, and the item drawer until the page was refreshed.

**Root cause:** `Item` and `ItemMod` (`UI/src/lib/battle/item.ts`, `item-mod.ts`) were plain object literals, not classes. `statify`'s `isClass()` check only recognizes real class instances — a plain object falls through to Svelte's own native `$state` deep-proxy instead. That proxy wraps a value differently *per container that reads it*: the `items`/`equippedSlots` arrays each produced their own proxied copy of an item, while `unlockedItems` (a `Map`, which Svelte's `$state` never deep-proxies) kept the raw, unproxied object. Every mutation path (`setFavorite`, `equipItem`, `applyMod`, …) resolves its target via `unlockedItems.get(id)` and writes to that raw object — a different identity than whatever the UI actually reads through `items`/`equippedSlots`, so the write was invisible.

Verified empirically with a `$effect.root`/`$derived` harness against the real `InventoryManager` + `statify` (no mocks) before writing the fix — confirmed the divergence, then confirmed the fix closes it.

**Fix:** convert `Item`/`ItemMod` to real classes, matching the existing `Battler`/`Skill` convention (called out in the issue as already avoiding this pitfall). `statify` then defines each item's field accessors once, directly on the object, so every container that references it — the Map, `items`, `equippedSlots` — shares one identity and one set of reactive fields.

## Changes

- **`item.ts` / `item-mod.ts`**: `Item`/`ItemMod` are now classes constructed via `newItem`/`newItemMod`, preserving their existing public shape and call sites.
- **`inventory-manager.ts`**: expanded the `items` field's doc comment to explain the identity invariant the fix relies on (`Item`/`ItemMod` must stay classes), so a future regression is documented rather than silent.
- **New test** `inventory-manager-reactivity.svelte.test.ts`: a `statify`-wrapped `InventoryManager` exercised through a real `$derived`, asserting `favorite`, `equipped`, and `appliedMods` are observed live through `manager.items` after `setFavorite`/`equipItem`/`unequipItem`/`applyMod`/`removeMod` — this is the regression coverage the issue asked for (it fails on the pre-fix code, confirmed while developing the fix).

## Test plan

- [x] `npx vitest run` — 3665/3665 unit tests pass (including the 3 new regression tests)
- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run build` — succeeds
- [x] **Live browser verification**: ran the API + Postgres/Redis + Vite dev server locally, created a real player account, granted a test item via direct SQL, and drove the Inventory screen with Playwright — clicking the favorite star and Ctrl+clicking to equip both updated the grid **immediately, with no page reload** (screenshots attached in the issue/PR conversation). This is the exact previously-broken flow.

Closes #1957

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Fmw9koT61f6NuqBu7SQBV


---
_Generated by [Claude Code](https://claude.ai/code/session_016Fmw9koT61f6NuqBu7SQBV)_