### PR TITLE
Guard zero-based FK fixup against re-pointing propagated temp FKs at record 0 (#1824)

### DIFF
--- a/Game.Infrastructure.Tests/GameContextZeroBasedIdentityFixupTests.cs
+++ b/Game.Infrastructure.Tests/GameContextZeroBasedIdentityFixupTests.cs
@@ -56,7 +56,7 @@ namespace Game.Infrastructure.Tests
             Assert.Null(enemySkillFixup.KeyProperty);
             Assert.Equal(
                 [nameof(EnemySkill.EnemyId), nameof(EnemySkill.SkillId)],
-                enemySkillFixup.ForeignKeyProperties.OrderBy(p => p));
+                enemySkillFixup.ForeignKeyProperties.Select(fk => fk.PropertyName).OrderBy(p => p));
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace Game.Infrastructure.Tests
             Assert.True(fixups.TryGetValue(playerType, out var playerFixup));
             Assert.Equal(
                 [nameof(Player.ClassId), nameof(Player.CurrentZoneId)],
-                playerFixup.ForeignKeyProperties.OrderBy(p => p));
+                playerFixup.ForeignKeyProperties.Select(fk => fk.PropertyName).OrderBy(p => p));
         }
 
         [Fact]
@@ -151,6 +151,48 @@ namespace Game.Infrastructure.Tests
 
             Assert.False(enemyIdEntry.IsTemporary);
             Assert.Equal(0, enemyIdEntry.CurrentValue);
+            Assert.False(skillIdEntry.IsTemporary);
+            Assert.Equal(0, skillIdEntry.CurrentValue);
+        }
+
+        [Fact]
+        public void ApplyZeroBasedIdentityFixups_ForNavigationAddedChildOfANewPrincipal_LeavesThePropagatedForeignKeyTemporary()
+        {
+            using var context = CreateContext();
+
+            // Adding a brand-new Enemy together with an EnemySkill attached via navigation, mirroring #1824's
+            // failure scenario: EF's own relationship fixup propagates the new Enemy's still-pending temp key
+            // onto EnemySkill.EnemyId. Before the fix, ForceZero blindly rewrote any temporary FK to the literal
+            // 0, which would have silently repointed this insert at the existing record 0 instead of the real
+            // new Enemy once its id is generated.
+            var enemy = new Enemy
+            {
+                Id = 0,
+                Name = "New enemy",
+                DesignerNotes = "",
+                EnemySkills = [new EnemySkill { SkillId = 0 }],
+            };
+            context.Add(enemy);
+
+            var enemyKeyEntry = context.Entry(enemy).Property(nameof(Enemy.Id));
+            Assert.True(enemyKeyEntry.IsTemporary, "Precondition: the new Enemy's key should be temporary until insert.");
+
+            var enemySkill = enemy.EnemySkills[0];
+            var enemyIdEntry = context.Entry(enemySkill).Property(nameof(EnemySkill.EnemyId));
+            var skillIdEntry = context.Entry(enemySkill).Property(nameof(EnemySkill.SkillId));
+            Assert.True(enemyIdEntry.IsTemporary, "Precondition: EF should propagate the new Enemy's temp key onto EnemyId.");
+            Assert.True(skillIdEntry.IsTemporary, "Precondition: EF should mark the FK to record 0 temporary.");
+
+            context.ApplyZeroBasedIdentityFixups();
+
+            // EnemyId must be left untouched — still the propagated temp value, not forced to 0 — so EF's own
+            // key-fixup (which runs during the real SaveChanges insert) can still resolve it to the new Enemy's
+            // real generated id.
+            Assert.True(enemyIdEntry.IsTemporary);
+            Assert.Equal(enemyKeyEntry.CurrentValue, enemyIdEntry.CurrentValue);
+
+            // SkillId is unrelated to any Added principal in this save (no Skill is being added), so the FK
+            // branch still forces it to the literal 0 as before.
             Assert.False(skillIdEntry.IsTemporary);
             Assert.Equal(0, skillIdEntry.CurrentValue);
         }

--- a/Game.Infrastructure/Database/GameContext.cs
+++ b/Game.Infrastructure/Database/GameContext.cs
@@ -951,7 +951,13 @@ namespace Game.Infrastructure.Database
         // write-behind path, where a save touches 1–2 rows per battle tick per connected player.
         private static readonly ConcurrentDictionary<IModel, IReadOnlyDictionary<IEntityType, ZeroBasedFixup>> ZeroBasedFixupsByModel = new();
 
-        internal sealed record ZeroBasedFixup(string? KeyProperty, IReadOnlyList<string> ForeignKeyProperties);
+        internal sealed record ZeroBasedFixup(string? KeyProperty, IReadOnlyList<ForeignKeyFixup> ForeignKeyProperties);
+
+        // A non-nullable int FK targeting a zero-based-identity principal, paired with that principal's entity
+        // type so the FK branch below can tell apart the two reasons EF might mark such an FK temporary (#1824):
+        // a genuinely unset FK (misread as record 0) versus a real reference to a same-save Added principal
+        // whose own id is still pending — see PrincipalEntityType's use in ApplyZeroBasedIdentityFixups.
+        internal sealed record ForeignKeyFixup(string PropertyName, IEntityType PrincipalEntityType);
 
         internal void ApplyZeroBasedIdentityFixups()
         {
@@ -959,6 +965,23 @@ namespace Game.Infrastructure.Database
             if (fixups.Count == 0)
             {
                 return;
+            }
+
+            // Same-save Added zero-based-identity principals still carry a temporary key (their real id isn't
+            // assigned until the insert commits). A dependent FK pointing at one of these is legitimately
+            // temporary — EF's own relationship fixup propagated that exact temp value — so the FK branch below
+            // must leave it alone and let EF resolve it to the principal's real generated id, rather than
+            // ForceZero silently repointing it at record 0 (#1824).
+            var addedPrincipalTempKeys = new HashSet<(IEntityType EntityType, object TempValue)>();
+            foreach (var entry in ChangeTracker.Entries())
+            {
+                if (entry.State == EntityState.Added
+                    && fixups.TryGetValue(entry.Metadata, out var principalFixup)
+                    && principalFixup.KeyProperty is not null
+                    && entry.Property(principalFixup.KeyProperty) is { IsTemporary: true, CurrentValue: { } tempValue })
+                {
+                    addedPrincipalTempKeys.Add((entry.Metadata, tempValue));
+                }
             }
 
             foreach (var entry in ChangeTracker.Entries())
@@ -986,10 +1009,20 @@ namespace Game.Infrastructure.Database
                     ForceZero(entry.Property(fixup.KeyProperty));
                 }
 
-                // FK branch: a non-nullable int FK pointing at record 0 of a zero-based principal.
-                foreach (var foreignKeyProperty in fixup.ForeignKeyProperties)
+                // FK branch: a non-nullable int FK pointing at record 0 of a zero-based principal — unless its
+                // temporary value is actually propagated from a same-save Added principal (see
+                // addedPrincipalTempKeys above), in which case it is left for EF to resolve to that principal's
+                // real generated id instead of being forced to 0.
+                foreach (var foreignKey in fixup.ForeignKeyProperties)
                 {
-                    ForceZero(entry.Property(foreignKeyProperty));
+                    var property = entry.Property(foreignKey.PropertyName);
+                    if (property is { IsTemporary: true, CurrentValue: { } fkTempValue }
+                        && addedPrincipalTempKeys.Contains((foreignKey.PrincipalEntityType, fkTempValue)))
+                    {
+                        continue;
+                    }
+
+                    ForceZero(property);
                 }
             }
         }
@@ -1020,7 +1053,7 @@ namespace Game.Infrastructure.Database
                         .FirstOrDefault(p => p.Name == nameof(IZeroBasedIdentityEntity.Id))?.Name;
                 }
 
-                var foreignKeyProperties = new List<string>();
+                var foreignKeyProperties = new List<ForeignKeyFixup>();
                 foreach (var property in entityType.GetProperties())
                 {
                     if (property.ClrType != typeof(int) || !property.IsForeignKey())
@@ -1033,7 +1066,7 @@ namespace Game.Infrastructure.Database
                     if (containingForeignKey is not null
                         && containingForeignKey.PrincipalEntityType.ClrType.IsAssignableTo(typeof(IZeroBasedIdentityEntity)))
                     {
-                        foreignKeyProperties.Add(property.Name);
+                        foreignKeyProperties.Add(new ForeignKeyFixup(property.Name, containingForeignKey.PrincipalEntityType));
                     }
                 }
 


### PR DESCRIPTION
## Summary

`GameContext.ApplyZeroBasedIdentityFixups`'s FK branch forced *any* temporary int FK referencing a zero-based-identity principal (`Item`, `Enemy`, `Zone`, …) to the literal `0`, without distinguishing:

- **"EF read an intended 0 as unset"** — the case the fixup exists for (a genuine FK to record 0 gets misread as an unset store-generated value and needs forcing back to the literal `0`).
- **"EF's relationship fixup propagated a temporary key from an `Added` principal in the same save"** — e.g. adding a new `Item` with `ItemAttribute` rows attached via navigation in one `SaveChangesAsync`. Here, forcing the child's FK to `0` silently re-points the insert at the *existing* record 0 instead of letting EF resolve it to the *new* principal's real generated id once the insert commits — a silent data-corruption failure mode.

No current production path triggers this (admin repos build navigation-free entities against existing parents; the content seeder bypasses the change tracker), so the bug was latent — but the fix is cheap and closes the gap before any future navigation-based add hits it.

## Changes

- **`GameContext.cs`**: `ApplyZeroBasedIdentityFixups` now does a pre-pass over the change tracker to collect `(EntityType, TempKeyValue)` for every zero-based-identity principal that is `Added` with a still-temporary key in this save. The FK branch then skips `ForceZero` for any FK whose temporary value matches one of those — leaving it for EF's own key-fixup (which runs during the real insert) to resolve to the principal's real generated id — and still forces to `0` in every other case, exactly as before.
- `ZeroBasedFixup.ForeignKeyProperties` now carries a `ForeignKeyFixup(PropertyName, PrincipalEntityType)` per FK instead of a bare property name, so the guard can identify which principal type/entry each FK targets.
- **Tests**: updated the existing `BuildZeroBasedFixups` assertions for the new `ForeignKeyFixup` shape, and added a new regression test (`ApplyZeroBasedIdentityFixups_ForNavigationAddedChildOfANewPrincipal_LeavesThePropagatedForeignKeyTemporary`) that adds a new `Enemy` with an `EnemySkill` attached via navigation — mirroring the issue's exact failure scenario — and asserts the propagated `EnemyId` FK is left temporary while an unrelated `SkillId` FK (still genuinely referencing record 0) is correctly forced to `0`.

## Test plan

- [x] `dotnet build` — solution builds clean, 0 warnings
- [x] `dotnet test Game.Infrastructure.Tests` — all 64 tests pass, including the new regression test
- [x] `dotnet test` (full solution, against the session's Postgres/Redis containers) — 3137 tests pass (`Game.Core.Tests`, `Game.Infrastructure.Tests`, `Game.Application.Tests`, `Game.Api.Tests`)

Closes #1824

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LFPere1ttNWzQqMqrrW8Q


---
_Generated by [Claude Code](https://claude.ai/code/session_012LFPere1ttNWzQqMqrrW8Q)_