### PR TITLE
Record subscribed channel at subscribe time so UnSubscribe can't mismatch it (#1825)

### DIFF
--- a/Game.Abstractions/Infrastructure/IPubSubService.cs
+++ b/Game.Abstractions/Infrastructure/IPubSubService.cs
@@ -28,11 +28,15 @@
         public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null);
 
         // The worker-backed overload requires a non-null id: it spins up a BackgroundWorker (holding an OS wait
-        // handle) that can only be disposed via UnSubscribe(channel, id), so an id-less worker subscription could
+        // handle) that can only be disposed via UnSubscribe(id), so an id-less worker subscription could
         // never be torn down and would leak its handle (#954). The plain-action overload above creates no worker,
         // so its id stays optional.
         public Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id);
-        public Task UnSubscribe(string channel, string id);
+
+        // Takes only the id, not the channel: the channel a handle was subscribed on is recorded at subscribe
+        // time, so a caller can never unsubscribe against a mismatched channel and leave the real subscription
+        // routing to a disposed worker (#1825).
+        public Task UnSubscribe(string id);
 
         /// <summary>
         /// Returns a handle to the named queue without subscribing to any channel. Useful for writing to a

--- a/Game.Api.Tests/Integration/AdminCacheReloadBroadcastTests.cs
+++ b/Game.Api.Tests/Integration/AdminCacheReloadBroadcastTests.cs
@@ -70,7 +70,7 @@ namespace Game.Api.Tests.Integration
             }
             finally
             {
-                await pubsub.UnSubscribe(ReferenceDataChannel, subscriptionId);
+                await pubsub.UnSubscribe(subscriptionId);
             }
         }
     }

--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -385,7 +385,7 @@ namespace Game.Api.Tests.Unit
             public Task Publish<T>(string channel, string queueName, T queueData, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task Wake(string channel) => Task.CompletedTask;
-            public Task UnSubscribe(string channel, string id) => Task.CompletedTask;
+            public Task UnSubscribe(string id) => Task.CompletedTask;
             public IPubSubQueue GetQueue(string queueName) => DeadLetterQueue;
         }
 
@@ -446,7 +446,7 @@ namespace Game.Api.Tests.Unit
         {
             public override Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => throw toThrow;
 
-            public override Task UnSubscribe(string channel, string id) => Task.CompletedTask;
+            public override Task UnSubscribe(string id) => Task.CompletedTask;
         }
 
         /// <summary>A pub/sub whose <c>Subscribe</c> succeeds but <c>UnSubscribe</c> throws, to drive the
@@ -454,7 +454,7 @@ namespace Game.Api.Tests.Unit
         private sealed class ThrowingUnsubscribePubSubService(Exception toThrow) : NotSupportedPubSubService
         {
             public override Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => Task.CompletedTask;
-            public override Task UnSubscribe(string channel, string id) => throw toThrow;
+            public override Task UnSubscribe(string id) => throw toThrow;
         }
 
         /// <summary>Records the presence-key writes and releases so a rollback test can assert the exact

--- a/Game.Api/Services/SocketManagerService.cs
+++ b/Game.Api/Services/SocketManagerService.cs
@@ -209,7 +209,7 @@ namespace Game.Api.Services
 
         private async Task UnRegisterSocketCommandListener(string socketId)
         {
-            await _pubSub.UnSubscribe(SocketChannel(socketId), socketId);
+            await _pubSub.UnSubscribe(socketId);
         }
 
         private async Task RegisterSocketCommandListener(SocketHandler handler)

--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -1942,7 +1942,7 @@ namespace Game.Application.Tests.DataAccess
             public Task Wake(string channel) => inner.Wake(channel);
             public Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => Task.CompletedTask;
             public Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => Task.CompletedTask;
-            public Task UnSubscribe(string channel, string id) => inner.UnSubscribe(channel, id);
+            public Task UnSubscribe(string id) => inner.UnSubscribe(id);
             public IPubSubQueue GetQueue(string queueName) => inner.GetQueue(queueName);
         }
 
@@ -1959,7 +1959,7 @@ namespace Game.Application.Tests.DataAccess
 
             public override Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => Task.CompletedTask;
             public override Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => Task.CompletedTask;
-            public override Task UnSubscribe(string channel, string id) => Task.CompletedTask;
+            public override Task UnSubscribe(string id) => Task.CompletedTask;
         }
 
         /// <summary>

--- a/Game.Application.Tests/DataAccess/RedisPubSubServiceIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisPubSubServiceIntegrationTests.cs
@@ -10,7 +10,7 @@ namespace Game.Application.Tests.DataAccess
     /// Covers the keyed-subscription registry branches of the Redis-backed <see cref="IPubSubService"/>
     /// (RedisPubSubService) that the write-behind/backplane integration tests don't reach: rejecting a
     /// duplicate handle id (across both the plain and the queue/worker overloads), the remove-vs-unknown
-    /// branches of <see cref="IPubSubService.UnSubscribe(string, string)"/>, and the batched-publish path
+    /// branches of <see cref="IPubSubService.UnSubscribe(string)"/>, and the batched-publish path
     /// (<see cref="IPubSubService.PublishBatch{T}"/> — the multi-value LPUSH and its empty no-op). These are
     /// genuine logic (not connection-failure simulation), so per the testing guidelines they are pinned
     /// through an integration test against the DI-resolved service rather than mocked. Each test uses unique
@@ -78,7 +78,7 @@ namespace Game.Application.Tests.DataAccess
             }
             finally
             {
-                await pubsub.UnSubscribe(channel, id);
+                await pubsub.UnSubscribe(id);
             }
         }
 
@@ -100,7 +100,7 @@ namespace Game.Application.Tests.DataAccess
             }
             finally
             {
-                await pubsub.UnSubscribe(channel, id);
+                await pubsub.UnSubscribe(id);
             }
         }
 
@@ -113,11 +113,11 @@ namespace Game.Application.Tests.DataAccess
             var id = $"handle-{Guid.NewGuid()}";
 
             await pubsub.Subscribe(channel, _ => { }, id);
-            await pubsub.UnSubscribe(channel, id);
+            await pubsub.UnSubscribe(id);
 
             // Re-subscribing with the same id only succeeds because UnSubscribe removed the prior handle.
             await pubsub.Subscribe(channel, _ => { }, id);
-            await pubsub.UnSubscribe(channel, id);
+            await pubsub.UnSubscribe(id);
         }
 
         [Fact]
@@ -127,7 +127,33 @@ namespace Game.Application.Tests.DataAccess
             var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
 
             // Removing an id that was never registered takes the not-found branch and must not throw.
-            await pubsub.UnSubscribe($"pubsub-test-{Guid.NewGuid()}", $"missing-{Guid.NewGuid()}");
+            await pubsub.UnSubscribe($"missing-{Guid.NewGuid()}");
+        }
+
+        [Fact]
+        public async Task UnSubscribe_UnsubscribesTheChannelRecordedAtSubscribeTime()
+        {
+            using var scope = CreateScope();
+            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
+            var channel = $"pubsub-test-{Guid.NewGuid()}";
+            var id = $"handle-{Guid.NewGuid()}";
+            var received = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // UnSubscribe no longer takes a channel argument (#1825) — it can only tear down the channel this
+            // handle actually subscribed to, recorded at Subscribe time, so there is nothing left for a caller
+            // to mismatch.
+            await pubsub.Subscribe(channel, args => received.TrySetResult(args.message), id);
+            await pubsub.Publish(channel, "before-unsubscribe");
+            Assert.Equal("before-unsubscribe", await received.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+
+            await pubsub.UnSubscribe(id);
+
+            // A message published after UnSubscribe must never reach the handler — proving the real Redis
+            // subscription on `channel` was torn down, not left dangling under a stale/empty channel.
+            received = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            await pubsub.Publish(channel, "after-unsubscribe");
+            var completed = await Task.WhenAny(received.Task, Task.Delay(TimeSpan.FromSeconds(2)));
+            Assert.NotSame(received.Task, completed);
         }
     }
 }

--- a/Game.Application.Tests/DataAccess/ReferenceCacheSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/ReferenceCacheSynchronizerTests.cs
@@ -134,7 +134,7 @@ namespace Game.Application.Tests.DataAccess
             {
                 // Dispose doesn't remove the subscription StartAsync registered, so clean it up to avoid
                 // leaking a handler on the shared channel for later tests.
-                await pubsub.UnSubscribe(Constants.PUBSUB_REFERENCE_DATA_CHANNEL, synchronizer.InstanceId);
+                await pubsub.UnSubscribe(synchronizer.InstanceId);
             }
         }
 

--- a/Game.DataAccess/DataProviderSynchronizer.cs
+++ b/Game.DataAccess/DataProviderSynchronizer.cs
@@ -170,7 +170,7 @@ namespace Game.DataAccess
             // Remove this instance's worker subscription first so no further wakes arrive mid-drain, disposing the
             // worker's OS wait handle (id-scoped, so it tears down only this handler) — the teardown the leaked
             // id-less subscription could never reach (#954).
-            await _pubsub.UnSubscribe(Constants.PUBSUB_PLAYER_CHANNEL, InstanceId);
+            await _pubsub.UnSubscribe(InstanceId);
 
             // Signal the in-flight drain (startup or a pub/sub wake) to stop reserving new items and unwind at
             // a clean item boundary, then wait for it to release the gate so an in-progress apply finishes

--- a/Game.DataAccess/ReferenceCacheSynchronizer.cs
+++ b/Game.DataAccess/ReferenceCacheSynchronizer.cs
@@ -42,7 +42,7 @@ namespace Game.DataAccess
 
         public async Task StopAsync(CancellationToken cancellationToken)
         {
-            await _pubsub.UnSubscribe(Constants.PUBSUB_REFERENCE_DATA_CHANNEL, InstanceId);
+            await _pubsub.UnSubscribe(InstanceId);
             _stopping.Cancel();
             await _reloadLoop;
         }

--- a/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
@@ -12,7 +12,9 @@ namespace Game.Infrastructure.PubSub.Redis
     // or when it is discarded because its id was already taken — which is the correct ownership boundary.
     internal class RedisPubSubService : IPubSubService
     {
-        private static readonly ConcurrentDictionary<string, (Action<RedisChannel, RedisValue> handler, BackgroundWorker? worker)> _handles = [];
+        // Records the channel a handle was subscribed on, so UnSubscribe never has to trust a caller-supplied
+        // channel that might not match (#1825).
+        private static readonly ConcurrentDictionary<string, (string channel, Action<RedisChannel, RedisValue> handler, BackgroundWorker? worker)> _handles = [];
 
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger<RedisPubSubService> _logger;
@@ -88,7 +90,7 @@ namespace Game.Infrastructure.PubSub.Redis
         public async Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null)
         {
             _logger.LogInformation("Creating redis subscriber on channel '{Channel}'.", channel);
-            if (id is not null && !_handles.TryAdd(id, (handle, null)))
+            if (id is not null && !_handles.TryAdd(id, (channel, handle, null)))
             {
                 throw new InvalidOperationException($"Cannot create handle with id: {id} because one already exists.");
             }
@@ -135,7 +137,7 @@ namespace Game.Infrastructure.PubSub.Redis
         // its OS wait handle (#954).
         private async Task SubscribeWithWorker(string channel, BackgroundWorker worker, string id)
         {
-            if (!_handles.TryAdd(id, (handle, worker)))
+            if (!_handles.TryAdd(id, (channel, handle, worker)))
             {
                 worker.Dispose();
                 throw new InvalidOperationException($"Cannot create handle with id: {id} because one already exists.");
@@ -158,7 +160,7 @@ namespace Game.Infrastructure.PubSub.Redis
             }
         }
 
-        public async Task UnSubscribe(string channel, string id)
+        public async Task UnSubscribe(string id)
         {
             if (_handles.TryRemove(id, out var handle))
             {
@@ -166,7 +168,9 @@ namespace Game.Infrastructure.PubSub.Redis
                 // so disposing first leaves a window where a message still routed to the (now-removed-but-still-
                 // subscribed) handler calls Start() on a disposed worker — an ObjectDisposedException thrown on the
                 // StackExchange.Redis subscriber thread. Removing the subscription first closes that window.
-                await Subscriber.UnsubscribeAsync(RedisChannel.Literal(channel), handle.handler);
+                // The channel comes from the registered handle, not a caller-supplied argument, so it can never
+                // mismatch the channel the handler was actually subscribed on (#1825).
+                await Subscriber.UnsubscribeAsync(RedisChannel.Literal(handle.channel), handle.handler);
                 handle.worker?.Dispose();
             }
         }

--- a/Game.TestInfrastructure/Helpers/NotSupportedPubSubService.cs
+++ b/Game.TestInfrastructure/Helpers/NotSupportedPubSubService.cs
@@ -16,7 +16,7 @@ namespace Game.TestInfrastructure.Helpers
         public virtual Task Wake(string channel) => throw new NotSupportedException();
         public virtual Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => throw new NotSupportedException();
         public virtual Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => throw new NotSupportedException();
-        public virtual Task UnSubscribe(string channel, string id) => throw new NotSupportedException();
+        public virtual Task UnSubscribe(string id) => throw new NotSupportedException();
         public virtual IPubSubQueue GetQueue(string queueName) => throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
## Summary

`RedisPubSubService.UnSubscribe(channel, id)` removed the id→handler registry entry and disposed the worker, but unsubscribed the handler from whatever channel the **caller** passed in — the registry never recorded which channel a handle was actually subscribed on. A caller passing a mismatched channel would leave the real Redis subscription live while disposing the worker it routes to, so the next message on that channel calls `Start()` on a disposed worker — an `ObjectDisposedException` on the StackExchange.Redis subscriber thread, in exactly the window the method's own comment says its ordering exists to close.

Current callers (`DataProviderSynchronizer`, `ReferenceCacheSynchronizer`, `SocketManagerService`) always paired channel/id correctly, so this was hardening against a misuse class the API's shape made possible, not an active production bug.

## Changes

- **`RedisPubSubService`**: the handle registry now stores `(channel, handler, worker)` instead of `(handler, worker)`, recording the channel at `Subscribe`/`SubscribeWithWorker` time.
- **`IPubSubService.UnSubscribe`**: dropped the `channel` parameter entirely (now just `UnSubscribe(string id)`) — the channel is only ever the one recorded at subscribe time, removing the misuse class outright rather than just guarding against it.
- Updated all three production call sites (`DataProviderSynchronizer`, `ReferenceCacheSynchronizer`, `SocketManagerService`) and every test double/call site to match the new signature.
- Added a new integration test, `UnSubscribe_UnsubscribesTheChannelRecordedAtSubscribeTime`, that subscribes, confirms a published message is received, unsubscribes, and confirms a subsequent publish on the same channel no longer reaches the handler — pinning that the real Redis subscription is torn down using the internally-tracked channel.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` (full solution, using the session's Postgres/Redis containers) — 3,138/3,138 tests pass, including the new regression test
- [x] Verified no frontend references to `UnSubscribe` (this is a backend-only Redis pub/sub concern)

Closes #1825

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RoyQEvjJbsg7S3h1Ee88mc)_