### PR TITLE
Align CharacterSwitcher test mock with the AccessTokenResult contract

### DIFF
--- a/UI/src/tests/routes/game/character-switcher.test.ts
+++ b/UI/src/tests/routes/game/character-switcher.test.ts
@@ -81,7 +81,7 @@ beforeEach(() => {
 	postMock.mockReset();
 	disconnectMock.mockReset();
 	stopEnginesMock.mockReset();
-	ensureValidAccessTokenMock.mockReset().mockResolvedValue('a');
+	ensureValidAccessTokenMock.mockReset().mockResolvedValue({ accessToken: 'a', rejected: false });
 	getRefreshTokenMock.mockReset().mockReturnValue('r');
 	setTokensMock.mockReset();
 	confirmTakeoverMock.mockReset().mockResolvedValue(true);
@@ -134,7 +134,7 @@ describe('CharacterSwitcher', () => {
 		// exact race #1767 fixed: reading the token first would capture the now-stale 'r'.
 		ensureValidAccessTokenMock.mockImplementation(async () => {
 			getRefreshTokenMock.mockReturnValue('rotated');
-			return 'a2';
+			return { accessToken: 'a2', rejected: false };
 		});
 		postMock.mockResolvedValue({
 			status: 200,


### PR DESCRIPTION
## Summary

PR #1795 changed `ensureValidAccessToken`/`refreshTokens` to return a discriminated `AccessTokenResult`/`RefreshOutcome` (`{ accessToken, rejected }` / `success` \| `rejected` \| `retryable`) instead of `StoredTokens | null`. The `CharacterSwitcher` test suite still mocked `ensureValidAccessToken` resolving a bare string (`'a'` / `'a2'`), the old shape.

This was harmless at runtime — `CharacterSwitcher.svelte` only `await`s the call and discards the result (`switchPlayer` calls it purely to settle any in-flight refresh before reading the refresh token) — but the mock no longer matched the real contract, which could mislead a future reader or a future consumer that starts relying on the returned outcome.

## Changes

- `UI/src/tests/routes/game/character-switcher.test.ts`: updated both `ensureValidAccessTokenMock` resolutions (the `beforeEach` default and the token-rotation-race test) to resolve `{ accessToken, rejected: false }` instead of a bare string.

Test-only cleanup — no production code changed.

## Test plan

- [x] `npx vitest run src/tests/routes/game/character-switcher.test.ts` — 9/9 passing.
- [x] `npm run test:unit:ci` — full suite: 3670/3670 passing.
- [x] `npm run lint` — clean (eslint + svelte-check, 0 errors/warnings).

Closes #1841


---
_Generated by [Claude Code](https://claude.ai/code/session_012WNp3qjTjEobES4jiAKns2)_