### PR TITLE
Validate admin relationship references up front instead of 500ing on FK faults

### DIFF
--- a/Game.Application.Tests/DataAccess/AdminEnemiesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminEnemiesIntegrationTests.cs
@@ -468,6 +468,36 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SetSpawns_UnknownZone_ReturnsFailure()
+        {
+            int enemyId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+                enemyId = enemy.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // A desired spawn referencing a zone that doesn't exist would otherwise FK-fault at commit
+            // instead of rejecting gracefully (the prior IsHome pattern match silently let a missing zone
+            // through since neither branch matched).
+            var data = new SetEnemySpawnsData
+            {
+                EnemyId = enemyId,
+                Spawns = [new Contracts.EnemySpawn { ZoneId = 99999, Weight = 1 }],
+            };
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminEnemies>();
+
+            var result = admin.SetSpawns(data);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Zone 99999 does not exist.", result.ErrorMessage);
+        }
+
+        [Fact]
         public async Task SetSpawns_NegativeWeight_ReturnsFailure()
         {
             int enemyId, zoneId;

--- a/Game.Application.Tests/DataAccess/AdminTagsTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminTagsTests.cs
@@ -66,5 +66,46 @@ namespace Game.Application.Tests.DataAccess
             Assert.Empty(store.Inserted);
             Assert.Empty(store.Updated);
         }
+
+        [Fact]
+        public void SaveTags_AddWithUndefinedCategory_ReturnsFailureWithoutStaging()
+        {
+            var store = new RecordingEntityStore();
+            var adminTags = new AdminTags(store);
+
+            // TagCategoryId 0 has no backing ETagCategory member (the enum starts at 1); without the up-front
+            // guard this would 500 on the FK at commit instead of rejecting gracefully.
+            var result = adminTags.SaveTags([Change(EChangeType.Add, id: 0, name: "Fire", categoryId: 0)]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("0 is not a valid tag category.", result.ErrorMessage);
+            Assert.Empty(store.Inserted);
+        }
+
+        [Fact]
+        public void SaveTags_EditWithUndefinedCategory_ReturnsFailureWithoutStaging()
+        {
+            var store = new RecordingEntityStore();
+            var adminTags = new AdminTags(store);
+
+            var result = adminTags.SaveTags([Change(EChangeType.Edit, id: 7, name: "Ice", categoryId: 99)]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("99 is not a valid tag category.", result.ErrorMessage);
+            Assert.Empty(store.Updated);
+        }
+
+        [Fact]
+        public void SaveTags_DeleteWithUndefinedCategoryPayload_Succeeds()
+        {
+            var store = new RecordingEntityStore();
+            var adminTags = new AdminTags(store);
+
+            // Deletes carry no meaningful category payload (the field just defaults to 0), so the reference
+            // guard skips them like every other change-type it's applied to.
+            var result = adminTags.SaveTags([Change(EChangeType.Delete, id: 42)]);
+
+            Assert.True(result.Succeeded);
+        }
     }
 }

--- a/Game.Application.Tests/DataAccess/AdminZonesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminZonesIntegrationTests.cs
@@ -190,6 +190,35 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SetEnemies_UnknownEnemy_ReturnsFailure()
+        {
+            int zoneId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var zone = await TestDataSeeder.CreateZoneAsync(context);
+                zoneId = zone.Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // A desired spawn referencing an enemy that doesn't exist would otherwise FK-fault at commit
+            // instead of rejecting gracefully.
+            var data = new SetZoneEnemiesData
+            {
+                ZoneId = zoneId,
+                ZoneEnemies = [new Contracts.ZoneEnemy { EnemyId = 99999, Weight = 1 }],
+            };
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminZones>();
+
+            var result = admin.SetEnemies(data);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Enemy 99999 does not exist.", result.ErrorMessage);
+        }
+
+        [Fact]
         public async Task SaveZones_HomeZoneWithBoss_ReturnsFailure()
         {
             int bossEnemyId;

--- a/Game.DataAccess/Repositories/Admin/AdminEnemies.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminEnemies.cs
@@ -145,15 +145,22 @@ namespace Game.DataAccess.Repositories.Admin
                 return AdminSaveResult.Failure("A spawn's weight cannot be negative.");
             }
 
-            // Authoring guard: the Home zone is a no-combat sanctuary where no enemies spawn (and never will),
-            // so reject a spawn that targets one. Mirrors the per-zone guard in AdminZones.SetEnemies so neither
-            // authoring direction can populate Home's spawn table.
+            // Every desired spawn must reference an existing zone; otherwise the insert FK-faults at commit
+            // instead of rejecting gracefully. Also enforces the Home-zone authoring guard (a no-combat
+            // sanctuary where no enemies spawn) — mirrors the per-zone guard in AdminZones.SetEnemies so
+            // neither authoring direction can populate Home's spawn table.
             foreach (var spawn in data.Spawns)
             {
-                if (_zones.LookupZone(spawn.ZoneId) is { IsHome: true } homeZone)
+                var zone = _zones.LookupZone(spawn.ZoneId);
+                if (zone is null)
+                {
+                    return AdminSaveResult.Failure($"Zone {spawn.ZoneId} does not exist.");
+                }
+
+                if (zone.IsHome)
                 {
                     return AdminSaveResult.Failure(
-                        $"'{enemy.Name}' cannot spawn in the Home zone ('{homeZone.Name}'). Home is a no-combat sanctuary where no enemies spawn.");
+                        $"'{enemy.Name}' cannot spawn in the Home zone ('{zone.Name}'). Home is a no-combat sanctuary where no enemies spawn.");
                 }
             }
 

--- a/Game.DataAccess/Repositories/Admin/AdminTags.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminTags.cs
@@ -1,5 +1,6 @@
 using Game.Abstractions.Contracts.Admin;
 using Game.Abstractions.DataAccess.Admin;
+using Game.Core;
 using Contracts = Game.Abstractions.Contracts;
 using Entities = Game.Infrastructure.Entities;
 
@@ -14,6 +15,13 @@ namespace Game.DataAccess.Repositories.Admin
 
         public AdminSaveResult SaveTags(IReadOnlyList<Change<Contracts.Tag>> changes)
         {
+            // A tag's category is a FK into the enum-seeded TagCategories table, so an unmapped value (a
+            // missing/0 payload) would 500 on the FK at commit — reject it up front as a clean failure.
+            if (ReferenceFieldValidation.FindUndefinedEnum(changes, t => (ETagCategory)t.TagCategoryId, "tag category") is { } categoryRejection)
+            {
+                return categoryRejection;
+            }
+
             // Tags carry their own identity and have no owner to miss, but they support a real delete, so a
             // duplicate Edit/Delete of one tag would double-track it in EF — reject such a malformed batch up
             // front as a graceful business failure rather than 500-ing (Add ids are store-generated sentinels,

--- a/Game.DataAccess/Repositories/Admin/AdminZones.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminZones.cs
@@ -172,6 +172,16 @@ namespace Game.DataAccess.Repositories.Admin
                 return AdminSaveResult.Failure("The Home zone cannot have enemy spawns. Home is a no-combat sanctuary where no enemies spawn.");
             }
 
+            // A desired spawn must reference an existing enemy; otherwise the insert FK-faults at commit
+            // instead of rejecting gracefully. Mirrors AdminEnemies.SetSkills' up-front skill-existence check.
+            foreach (var zoneEnemy in data.ZoneEnemies)
+            {
+                if (_enemies.GetEnemy(zoneEnemy.EnemyId) is null)
+                {
+                    return AdminSaveResult.Failure($"Enemy {zoneEnemy.EnemyId} does not exist.");
+                }
+            }
+
             return ChildCollectionReconciler.Reconcile(
                 existing: zone.ZoneEnemies,
                 desired: data.ZoneEnemies,


### PR DESCRIPTION
## Summary

Three admin relationship setters skipped the tier's own convention (`docs/backend-admin.md`, `ReferenceFieldValidation`, `AdminItems.SaveModSlots`'s up-front owner check) that a bad reference rejects as a graceful `AdminSaveResult` before staging. A tampered/buggy client hit an unhandled `DbUpdateException` 500 instead:

- **`AdminZones.SetEnemies`** never checked that a desired spawn's `EnemyId` exists (contrast `AdminEnemies.SetSkills`, which validates every skill id) — now rejects with `"Enemy {id} does not exist."`.
- **`AdminEnemies.SetSpawns`** — the Home guard `_zones.LookupZone(spawn.ZoneId) is { IsHome: true }` let a **missing** zone (null lookup) pass silently, since neither the Home nor the not-Home branch of the pattern match fires on `null`; the insert then FK-faulted at commit. Split into a missing-zone check (`"Zone {id} does not exist."`) followed by the existing `IsHome` rejection.
- **`AdminTags.SaveTags`** didn't validate `TagCategoryId` against `ETagCategory`, even though `ReferenceFieldValidation.FindUndefinedEnum` exists precisely for this and is already applied to rarity/category/mod-type/challenge-type everywhere else. Now wired in the same way.

No data corruption in any case (the FK constraints already held) — this replaces an opaque 500 with a clean, user-facing `AdminSaveResult.Failure`.

## Test plan

- [x] Added `AdminZonesIntegrationTests.SetEnemies_UnknownEnemy_ReturnsFailure`
- [x] Added `AdminEnemiesIntegrationTests.SetSpawns_UnknownZone_ReturnsFailure`
- [x] Added `AdminTagsTests.SaveTags_AddWithUndefinedCategory_ReturnsFailureWithoutStaging`, `SaveTags_EditWithUndefinedCategory_ReturnsFailureWithoutStaging`, `SaveTags_DeleteWithUndefinedCategoryPayload_Succeeds`
- [x] Full backend suite green: `dotnet build` + `dotnet test` (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests — 3143 tests, 0 failures)
- [x] No frontend changes in this PR

Closes #1858


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rs1UXHpqBC5wHa6S7ba5iJ)_