### PR TITLE
Suppress live push on offline/switch stale-battle settlement

### DIFF
--- a/Game.Application.Tests/Events/BattleStatisticsEventHandlerTests.cs
+++ b/Game.Application.Tests/Events/BattleStatisticsEventHandlerTests.cs
@@ -402,6 +402,49 @@ namespace Game.Application.Tests.Events
             Assert.Equal(Math.Round((decimal)(ServerGameConstants.ProficiencyXpPerVictory * 1.5), 3, MidpointRounding.AwayFromZero), live.Xp);
         }
 
+        [Fact]
+        public async Task Victory_NotifyFalse_StillCompletesChallengeAndAccruesProficiency_ButSuppressesLivePushes()
+        {
+            using var scope = CreateScope();
+            var setup = await SeedScenarioAsync(scope, itemReward: true, modReward: false);
+
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var skill = await TestDataSeeder.CreateSkillAsync(context, name: "Firebolt");
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, setup.PlayerId, skill.Id);
+            var proficiency = await TestDataSeeder.CreateProficiencyAsync(context, name: "Fire");
+            await TestDataSeeder.LinkSkillToProficiencyAsync(context, proficiency.Id, skill.Id);
+            await ReferenceCacheReloader.ReloadAllAsync(scope.ServiceProvider);
+
+            var player = await scope.ServiceProvider.GetRequiredService<IPlayerRepository>().GetPlayer(setup.PlayerId);
+            Assert.NotNull(player);
+            var enemy = scope.ServiceProvider.GetRequiredService<IEnemies>().GetDomainEnemy(setup.EnemyId, level: 1);
+            Assert.NotNull(enemy);
+
+            const double power = 100.0;
+            var stats = new BattleStats { SkillStats = { [skill.Id] = new SkillStats { Uses = 1, TotalDamage = power } } };
+            stats.AddTypedDamageDealt(EDamageType.Physical, power);
+
+            // Mirrors BattleService.ResolveStaleBattle's offline/switch settlement (#1859): the player has no
+            // live socket, so the event carries Notify: false.
+            var battleEvent = new BattleCompletedEvent(
+                player, enemy, Victory: true, PlayerDied: false, TotalMs: 5000,
+                Stats: stats, IsBossBattle: false, ZoneId: player.CurrentZoneId, PlayerRating: power, Notify: false);
+
+            await MakeHandler(scope).HandleAsync(battleEvent, CancellationToken);
+
+            // The underlying statistics/challenge-completion/proficiency-accrual recording still happens
+            // regardless of Notify — only the live client pushes are suppressed.
+            Assert.Contains(setup.ItemId, player.Inventory.UnlockedItems.Select(u => u.ItemId));
+            var progressRepo = scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>();
+            Assert.NotEmpty(await progressRepo.GetCompletedChallengeIds(setup.PlayerId));
+            var proficiencyRow = Assert.Single(await progressRepo.GetProficiencies(setup.PlayerId));
+            Assert.Equal(proficiency.Id, proficiencyRow.ProficiencyId);
+            Assert.True(proficiencyRow.Xp > 0);
+
+            Assert.Empty(player.DomainEvents.OfType<ChallengeCompletedEvent>());
+            Assert.Empty(player.DomainEvents.OfType<ProficiencyXpGainedEvent>());
+        }
+
         private BattleStatisticsEventHandler MakeHandler(IServiceScope scope) => new(
             scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>(),
             scope.ServiceProvider.GetRequiredService<ChallengeRewardService>(),

--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -4,6 +4,7 @@ using Game.Application.Services;
 using Game.Core;
 using Game.Core.Attributes;
 using Game.Core.Battle;
+using Game.Core.Battle.Events;
 using Game.Core.Battle.Offline;
 using Game.Core.Players;
 using Game.Core.TestInfrastructure.Builders;
@@ -1618,6 +1619,43 @@ namespace Game.Application.Tests.Services
             // stale (10 minutes) the battle's wall-clock age was.
             Assert.NotNull(resolution.SettledBattleMs);
             Assert.InRange(resolution.SettledBattleMs.Value, 1, GameConstants.DefaultMaxBattleMs - 1);
+        }
+
+        [Fact]
+        public async Task RecordVictory_NotifyFalse_RaisesBattleCompletedEventWithNotifySuppressed()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            // BattleService.ResolveStaleBattle (the offline/switch stale-battle settlement, #1859) threads
+            // notify: false down through AbandonBattle into this call, since that settlement's player has no
+            // live socket by construction — verified here directly against RecordVictory (bypassing SavePlayer's
+            // dispatch, which would otherwise clear the event before this assertion could observe it).
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+            var zone = await TestDataSeeder.CreateZoneAsync(context, levelMin: 1, levelMax: 1);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+            await ReloadReferenceCachesAsync();
+
+            var player = await scope.ServiceProvider.GetRequiredService<IPlayerRepository>().GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+            await battleService.StartBattle(player, state, zoneId: zone.Id);
+
+            var coreEnemy = scope.ServiceProvider.GetRequiredService<IEnemies>().GetDomainEnemy(enemy.Id, level: 1);
+            Assert.NotNull(coreEnemy);
+            coreEnemy.SelectAllBattleSkills();
+            var result = new BattleResult(Victory: true, PlayerDied: false, TotalMs: 1000, new BattleStats());
+
+            battleService.RecordVictory(player, coreEnemy, result, state, DateTime.UtcNow, notify: false);
+
+            var evt = Assert.Single(player.DomainEvents.OfType<BattleCompletedEvent>());
+            Assert.True(evt.Victory);
+            Assert.False(evt.Notify);
         }
 
         [Fact]

--- a/Game.Application/Events/BattleStatisticsEventHandler.cs
+++ b/Game.Application/Events/BattleStatisticsEventHandler.cs
@@ -28,19 +28,21 @@ namespace Game.Application.Events
 
             // Evaluate only the challenges whose tracked statistic this battle actually moved (plus the
             // statistic-independent ones) and apply their rewards, raising the live per-challenge push. The
-            // offline-rewards batch runs this same step with the push suppressed.
+            // offline-rewards batch runs this same step with the push suppressed; a live battle whose completion
+            // was instead settled by the offline/switch stale-battle resolution (BattleService.ResolveStaleBattle)
+            // suppresses it here too, via domainEvent.Notify, since that settlement has no socket to push to.
             _challengeRewards.EvaluateAndApply(
-                progress, touchedStatistics, domainEvent.Player, DateTime.UtcNow, notify: true);
+                progress, touchedStatistics, domainEvent.Player, DateTime.UtcNow, notify: domainEvent.Notify);
 
             // Accrue proficiency XP on a victory: each path claims pie × activity ÷ max(playerRating,
             // enemyRating), routed to its frontier tier (the effect-based model, spike #1318, max-normalized per
-            // spike #1526 Decision 5). Raises the live per-battle push; the offline batch runs the same accrual
-            // with it suppressed.
+            // spike #1526 Decision 5). Raises the live per-battle push; the offline batch (and the stale-battle
+            // settlement above) runs the same accrual with it suppressed.
             if (domainEvent.Victory)
             {
                 var ratingDenominator = Math.Max(domainEvent.PlayerRating, domainEvent.EnemyRating);
                 _proficiencyRewards.AccrueAndApply(
-                    progress, domainEvent.Stats, ratingDenominator, domainEvent.Player, notify: true);
+                    progress, domainEvent.Stats, ratingDenominator, domainEvent.Player, notify: domainEvent.Notify);
             }
 
             await _progressRepo.Save(progress, cancellationToken);

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -65,7 +65,7 @@ namespace Game.Application.Services
 
             if (state.HasActiveBattle)
             {
-                var (handoff, _) = await AbandonBattle(player, state, clientBattleMs, cancellationToken);
+                var (handoff, _) = await AbandonBattle(player, state, clientBattleMs, cancellationToken: cancellationToken);
                 if (handoff is not null && !forceAbandon)
                 {
                     // A still-in-progress handoff (#1595) means the existing battle hasn't concluded yet —
@@ -220,7 +220,7 @@ namespace Game.Application.Services
                 // outcome (win/loss/draw) applies the post-battle cooldown to state.EnemyCooldown (#1851); one
                 // that resolves nothing (e.g. mid an already-running cooldown, where elapsedMs clamps to 0)
                 // leaves EnemyCooldown exactly as it found it. Either way, the general anchor below picks it up.
-                await AbandonBattle(player, state, clientBattleMs, cancellationToken);
+                await AbandonBattle(player, state, clientBattleMs, cancellationToken: cancellationToken);
             }
 
             // Anchor to the in-effect cooldown rather than always to now — ChallengeBoss has no command-level
@@ -409,8 +409,12 @@ namespace Game.Application.Services
         public Task<StaleBattleResolution> ResolveStaleBattle(Player player, PlayerState state, CancellationToken cancellationToken = default)
         {
             // No client elapsed for an offline/disconnect resolution — the abandon falls back to wall-clock
-            // (capped at DefaultMaxBattleMs), exactly as before.
-            return AbandonBattle(player, state, cancellationToken: cancellationToken);
+            // (capped at DefaultMaxBattleMs), exactly as before. Both callers (the login welcome-back gate and
+            // the character-switch credit) resolve a player who by construction has no live socket right now,
+            // so the outcome is recorded but the live push is suppressed (#1859) — mirroring the offline
+            // window's own notify: false, rather than tripping SocketManagerService's no-active-socket warning
+            // on every routine switch/reconnect.
+            return AbandonBattle(player, state, notify: false, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -450,7 +454,11 @@ namespace Game.Application.Services
         // (#1595): the caller must leave PlayerState untouched in that case (nothing was cleared or saved).
         // SettledBattleMs carries the resolved battle's own credited duration (its BattleResult.TotalMs) only
         // when an outcome was actually recorded; null for a handoff and for "nothing to resolve" alike.
-        private async Task<StaleBattleResolution> AbandonBattle(Player player, PlayerState state, int? clientBattleMs = null, CancellationToken cancellationToken = default)
+        // notify is the live client-push toggle threaded down to the recorded outcome (#1859): StartBattle and
+        // StartBossBattle abandon a still-live player's existing battle to start a new one, so they keep the
+        // default true; ResolveStaleBattle's offline/switch settlement passes false since that player has no
+        // socket by construction.
+        private async Task<StaleBattleResolution> AbandonBattle(Player player, PlayerState state, int? clientBattleMs = null, bool notify = true, CancellationToken cancellationToken = default)
         {
             var now = DateTime.UtcNow;
             // A stale battle can be far older than int.MaxValue ms (~24.9 days), so clamp before narrowing —
@@ -487,7 +495,7 @@ namespace Game.Application.Services
                 // abandon resolved as a real victory. Pay it out exactly like EndBattleVictory (exp +
                 // win/clear/challenge credit) rather than booking the win while silently withholding the
                 // earned exp (#206).
-                RecordVictory(player, enemy, result, state, now);
+                RecordVictory(player, enemy, result, state, now, notify);
             }
             else if (!result.PlayerDied && wallClockMs < GameConstants.DefaultMaxBattleMs)
             {
@@ -512,7 +520,7 @@ namespace Game.Application.Services
             }
             else
             {
-                player.RecordBattleCompleted(enemy, result, state.IsBossBattle, state.BattleZoneId ?? player.CurrentZoneId, now);
+                player.RecordBattleCompleted(enemy, result, state.IsBossBattle, state.BattleZoneId ?? player.CurrentZoneId, now, notify);
             }
 
             // Both outcome branches above (won or lost/drew) reach here — the still-in-progress branch
@@ -543,7 +551,7 @@ namespace Game.Application.Services
         // EndBattleVictory returns only a client-facing DefeatResult, and the BattleStats this mutates is
         // carried on the BattleCompletedEvent, which the dispatcher clears after handling — leaving no other
         // seam to observe that result.Stats.PlayerRating is set from the snapshot rather than the live aggregate.
-        internal DefeatRewards RecordVictory(Player player, CoreEnemy enemy, BattleResult result, PlayerState state, DateTime timestamp)
+        internal DefeatRewards RecordVictory(Player player, CoreEnemy enemy, BattleResult result, PlayerState state, DateTime timestamp, bool notify = true)
         {
             // Rate the player for the reward from the same frozen snapshot the battle was simulated against, not
             // the live aggregate. Valid mid-battle socket commands (stat reallocation, gear swaps) can shift live
@@ -571,7 +579,7 @@ namespace Game.Application.Services
             // (spike #1526 Decision 5) — the same snapshot-measured ratings the exp reward above used.
             player.RecordBattleVictory(
                 enemy, result, state.IsBossBattle, state.BattleZoneId ?? player.CurrentZoneId, timestamp,
-                rewards.PlayerRating, rewards.EnemyRating);
+                rewards.PlayerRating, rewards.EnemyRating, notify);
 
             return rewards;
         }

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -910,6 +910,32 @@ namespace Game.Core.Tests.Players
             Assert.Equal(0, evt.EnemyRating);
         }
 
+        [Fact]
+        public void RecordBattleCompleted_DefaultsToNotifyTrue()
+        {
+            var player = MakePlayer();
+            var result = new BattleResult(Victory: false, PlayerDied: true, TotalMs: 1000, Stats: new BattleStats());
+
+            player.RecordBattleCompleted(MakeEnemy(), result, isBossBattle: false, zoneId: 3, timestamp: DateTime.UtcNow);
+
+            Assert.True(Assert.Single(player.DomainEvents.OfType<BattleCompletedEvent>()).Notify);
+        }
+
+        [Fact]
+        public void RecordBattleCompleted_NotifyFalse_RaisesEventWithNotifySuppressed()
+        {
+            var player = MakePlayer();
+            var result = new BattleResult(Victory: false, PlayerDied: true, TotalMs: 1000, Stats: new BattleStats());
+
+            // The offline/switch stale-battle settlement (BattleService.ResolveStaleBattle, #1859) has no live
+            // socket to push to by construction, so it settles with notify: false — the statistics/challenge
+            // recording BattleStatisticsEventHandler drives off this event still runs regardless; only the
+            // live challenge-completion/proficiency-xp pushes it raises are suppressed.
+            player.RecordBattleCompleted(MakeEnemy(), result, isBossBattle: false, zoneId: 3, timestamp: DateTime.UtcNow, notify: false);
+
+            Assert.False(Assert.Single(player.DomainEvents.OfType<BattleCompletedEvent>()).Notify);
+        }
+
         // ── RecordBattleVictory ──────────────────────────────────────────────
 
         [Fact]
@@ -944,6 +970,22 @@ namespace Game.Core.Tests.Players
             var coreUpdated = player.DomainEvents.OfType<PlayerCoreUpdatedEvent>().SingleOrDefault();
             Assert.NotNull(coreUpdated);
             Assert.Equal(timestamp, coreUpdated.LastActivity);
+        }
+
+        [Fact]
+        public void RecordBattleVictory_NotifyFalse_RaisesEventWithNotifySuppressed()
+        {
+            var player = MakePlayer();
+            var enemy = MakeEnemy(id: 5);
+            var result = new BattleResult(Victory: true, PlayerDied: false, TotalMs: 1000, Stats: new BattleStats());
+
+            // Mirrors RecordBattleCompleted_NotifyFalse_RaisesEventWithNotifySuppressed: the won-abandon path
+            // through BattleService.AbandonBattle threads the same suppressed notify onto a victory.
+            player.RecordBattleVictory(
+                enemy, result, isBossBattle: false, zoneId: 3, timestamp: DateTime.UtcNow,
+                playerRating: 1, enemyRating: 1, notify: false);
+
+            Assert.False(Assert.Single(player.DomainEvents.OfType<BattleCompletedEvent>()).Notify);
         }
 
         // ── StampActivity ────────────────────────────────────────────────────

--- a/Game.Core/Battle/Events/BattleCompletedEvent.cs
+++ b/Game.Core/Battle/Events/BattleCompletedEvent.cs
@@ -18,7 +18,13 @@ namespace Game.Core.Battle.Events
         // for the effect-based proficiency accrual (spike #1526 Decision 5, #1532). Meaningful only on a
         // victory — XP accrues on wins — so the loss/abandon paths leave both at the default, and a default of
         // 0/0 yields no accrual (the normalization guard treats a non-positive denominator as no claim).
-        double PlayerRating = 0, double EnemyRating = 0) : IDomainEvent, ILoggableDomainEvent
+        double PlayerRating = 0, double EnemyRating = 0,
+        // Live client-push toggle for the challenge-completion and proficiency-xp pushes this event drives
+        // (mirrors Player.CompleteChallenge's notify). The offline/switch settlement of a stale battle
+        // (BattleService.ResolveStaleBattle) has no socket to push to by construction, so it settles with
+        // false; the statistics/challenge/proficiency recording itself still runs either way — only the live
+        // push is suppressed.
+        bool Notify = true) : IDomainEvent, ILoggableDomainEvent
     {
         // Curated safe scalars only — never the Player/Enemy aggregates, stats, or inventory.
         public IReadOnlyList<KeyValuePair<string, object?>> GetLogProperties() =>

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -466,29 +466,31 @@ namespace Game.Core.Players
         // Records a non-victory (loss/draw) battle outcome. No combat ratings are threaded onto the event —
         // XP only accrues on a win — so a victory MUST go through RecordBattleVictory instead, which requires
         // them; that split (rather than a defaultable parameter) makes a victory caller forgetting the ratings
-        // a compile error instead of a silent zero-XP accrual.
-        public void RecordBattleCompleted(Enemy enemy, BattleResult result, bool isBossBattle, int zoneId, DateTime timestamp)
+        // a compile error instead of a silent zero-XP accrual. notify mirrors CompleteChallenge's live-push
+        // toggle: the offline/switch settlement of a stale battle has no socket to push to, so it passes false.
+        public void RecordBattleCompleted(Enemy enemy, BattleResult result, bool isBossBattle, int zoneId, DateTime timestamp, bool notify = true)
         {
-            RecordBattleOutcome(enemy, result, isBossBattle, zoneId, timestamp, playerRating: 0, enemyRating: 0);
+            RecordBattleOutcome(enemy, result, isBossBattle, zoneId, timestamp, playerRating: 0, enemyRating: 0, notify);
         }
 
         // Records a victorious battle outcome, threading the combat ratings the win was rated against so the
         // progress handler can normalize proficiency accrual by max(playerRating, enemyRating) (spike #1526
         // Decision 5). Both current victory paths route through BattleService.RecordVictory, which supplies them.
+        // notify mirrors RecordBattleCompleted's live-push toggle.
         public void RecordBattleVictory(
             Enemy enemy, BattleResult result, bool isBossBattle, int zoneId, DateTime timestamp,
-            double playerRating, double enemyRating)
+            double playerRating, double enemyRating, bool notify = true)
         {
-            RecordBattleOutcome(enemy, result, isBossBattle, zoneId, timestamp, playerRating, enemyRating);
+            RecordBattleOutcome(enemy, result, isBossBattle, zoneId, timestamp, playerRating, enemyRating, notify);
         }
 
         private void RecordBattleOutcome(
             Enemy enemy, BattleResult result, bool isBossBattle, int zoneId, DateTime timestamp,
-            double playerRating, double enemyRating)
+            double playerRating, double enemyRating, bool notify)
         {
             RaiseEvent(new BattleCompletedEvent(
                 this, enemy, result.Victory, result.PlayerDied, result.TotalMs, result.Stats, isBossBattle, zoneId,
-                playerRating, enemyRating));
+                playerRating, enemyRating, notify));
 
             // Backstop mirroring the online auto-fight-off: a recorded dedicated-boss loss or draw drops the
             // persisted loop back to idle, so the offline sim doesn't resume boss-farming a loop the player has


### PR DESCRIPTION
## Summary

`BattleService.ResolveStaleBattle` (used by both the login welcome-back gate and the character-switch credit flow, `OfflineProgressService.SimulateOfflineProgress`/`SimulateSwitchProgress`) resolves a stale in-flight battle through the same live `BattleCompletedEvent` → `BattleStatisticsEventHandler` path as an online battle end — which always raised the live challenge-completion and proficiency-xp client pushes. Both callers resolve a player who **by construction has no live socket** (they're mid-switch or reconnecting), so every challenge or proficiency gain earned by that settlement tripped `SocketManagerService`'s "no active socket" warning — degrading that warning's signal value since it fired on every routine switch/reconnect that happened to settle a winning stale battle.

- Added a `Notify` flag to `BattleCompletedEvent` (default `true`), mirroring `Player.CompleteChallenge`'s existing `notify` toggle. The underlying statistics/challenge/proficiency **recording** still always runs — only the live push is suppressed.
- Threaded `notify` through `Player.RecordBattleCompleted`/`RecordBattleVictory` → `BattleCompletedEvent.Notify` → `BattleStatisticsEventHandler`'s `ChallengeRewardService.EvaluateAndApply`/`ProficiencyRewardService.AccrueAndApply` calls.
- `BattleService.AbandonBattle` gained a `notify` parameter (default `true`, matching its live callers `StartBattle`/`StartBossBattle`, which abandon an existing battle to start a new one for a still-connected player). `ResolveStaleBattle` passes `notify: false`.

No player-facing behavior change (clients re-sync on connect); this only quiets a misleading warning-level log.

Closes #1859

## Note

I also picked up #1739 (batching write-behind persistence handlers) but paused after design analysis surfaced real risk to `DataProviderSynchronizer`'s heavily-tested concurrency invariants — left a detailed comment there with an open question rather than pushing through blind. Also re-verified #1790 is already fixed on `main` and left a comment recommending it be closed.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `Game.Core.Tests` (full suite, 1357 tests) — pass, including new `PlayerTests` coverage for `RecordBattleCompleted`/`RecordBattleVictory` with `notify: false`
- [x] `Game.Application.Tests` (full suite, 968 tests) — pass, including:
  - new `BattleStatisticsEventHandlerTests` case confirming `Notify: false` still records statistics/challenge-completion/proficiency-accrual but suppresses `ChallengeCompletedEvent`/`ProficiencyXpGainedEvent`
  - new `BattleServiceIntegrationTests` case confirming `RecordVictory(notify: false)` raises `BattleCompletedEvent` with `Notify == false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXeZAaKeLHpY3koQTTrkMq

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXeZAaKeLHpY3koQTTrkMq)_