### PR TITLE
Fix stale MaxExpPerGrant doc comment and add EnemyBountyCap content lint

### DIFF
--- a/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
+++ b/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
@@ -479,6 +479,57 @@ namespace Game.Application.Tests.Content
             AssertHasFinding(graph, "EnemyInertAttribute", ContentGraphSeverity.Warning, "Enemy", 9);
         }
 
+        // --- Enemy bounty cap (silent MaxExpPerGrant truncation, #1860) --------------------------------
+
+        [Fact]
+        public void Enemy_MatchedBountyAtOrAboveMaxExpPerGrant_IsWarning()
+        {
+            // A grossly over-authored Strength distribution drives the rating (and so the matched-fight
+            // bounty XpScaleK × EnemyRating) far past MaxExpPerGrant.
+            var graph = HealthyGraph() with
+            {
+                Enemies = [Enemy(0, skillPool: [2], spawns: [(0, 1), (1, 1)], attributeDistribution: [(EAttribute.Strength, 100_000_000_000, 0)]), Enemy(1, isBoss: true)],
+            };
+            AssertHasFinding(graph, "EnemyBountyCap", ContentGraphSeverity.Warning, "Enemy", 0);
+        }
+
+        [Fact]
+        public void Enemy_MatchedBountyBelowMaxExpPerGrant_ProducesNoFinding()
+        {
+            var graph = HealthyGraph() with
+            {
+                Enemies = [Enemy(0, skillPool: [2], spawns: [(0, 1), (1, 1)], attributeDistribution: [(EAttribute.Strength, 50, 1)]), Enemy(1, isBoss: true)],
+            };
+            Assert.DoesNotContain(_checker.Check(graph), f => f.Check == "EnemyBountyCap");
+        }
+
+        [Fact]
+        public void Enemy_RetiredWithOverCapBounty_ProducesNoFinding()
+        {
+            // A retired enemy is out of circulation, so its bounty is never actually paid out.
+            var graph = HealthyGraph() with
+            {
+                Enemies = HealthyGraph().Enemies
+                    .Append(Enemy(9, skillPool: [2], spawns: [(0, 1)], retiredAt: Retired, attributeDistribution: [(EAttribute.Strength, 100_000_000_000, 0)]))
+                    .ToList(),
+            };
+            Assert.DoesNotContain(_checker.Check(graph), f => f.Check == "EnemyBountyCap");
+        }
+
+        [Fact]
+        public void Enemy_NotPlacedWithOverCapBounty_ProducesNoFinding()
+        {
+            // No spawn table entry and no dedicated-boss slot means no representative level to rate at, so
+            // the check is skipped rather than rating at a made-up level — mirrors CheckEnemyAttributeConsumption.
+            var graph = HealthyGraph() with
+            {
+                Enemies = HealthyGraph().Enemies
+                    .Append(Enemy(9, skillPool: [2], spawns: [], attributeDistribution: [(EAttribute.Strength, 100_000_000_000, 0)]))
+                    .ToList(),
+            };
+            Assert.DoesNotContain(_checker.Check(graph), f => f.Check == "EnemyBountyCap");
+        }
+
         // --- Classes ----------------------------------------------------------------------------------
 
         [Fact]

--- a/Game.Application/Content/ProgressionGraphChecker.cs
+++ b/Game.Application/Content/ProgressionGraphChecker.cs
@@ -92,6 +92,7 @@ namespace Game.Application.Content
                 CheckEmptyCombatZones();
                 CheckZoneOrderUniqueness();
                 CheckEnemyAttributeConsumption();
+                CheckEnemyBountyCap();
                 CheckLessons();
             }
 
@@ -259,21 +260,10 @@ namespace Game.Application.Content
                     // No live placement (spawn table or dedicated boss slot) means no representative encounter
                     // level to rate the enemy at — mirrors the combat-rating calibration report's own omission
                     // of unplaced enemies from its pricing pass.
-                    if (ResolveRatingLevel(enemy) is not int level)
+                    if (ResolveRatingBattler(enemy) is not Battler battler)
                     {
                         continue;
                     }
-
-                    var kit = new List<Contracts.Skill>();
-                    foreach (var skillId in enemy.SkillPool)
-                    {
-                        if (_skills.TryGetValue(skillId, out var skill) && skill.RetiredAt is null)
-                        {
-                            kit.Add(skill);
-                        }
-                    }
-
-                    var battler = BuildRatingBattler(enemy, kit, level);
 
                     foreach (var distribution in enemy.AttributeDistribution)
                     {
@@ -330,6 +320,31 @@ namespace Game.Application.Content
             }
 
             /// <summary>
+            /// Assembles the rating <see cref="Battler"/> for a live enemy at its representative level
+            /// (<see cref="ResolveRatingLevel"/>), or <c>null</c> if it has no live placement to rate at.
+            /// Shared by <see cref="CheckEnemyAttributeConsumption"/> and <see cref="CheckEnemyBountyCap"/> —
+            /// both need the same rated battler, just different terms read off it.
+            /// </summary>
+            private Battler? ResolveRatingBattler(Contracts.Enemy enemy)
+            {
+                if (ResolveRatingLevel(enemy) is not int level)
+                {
+                    return null;
+                }
+
+                var kit = new List<Contracts.Skill>();
+                foreach (var skillId in enemy.SkillPool)
+                {
+                    if (_skills.TryGetValue(skillId, out var skill) && skill.RetiredAt is null)
+                    {
+                        kit.Add(skill);
+                    }
+                }
+
+                return BuildRatingBattler(enemy, kit, level);
+            }
+
+            /// <summary>
             /// Assembles a rating <see cref="Battler"/> for a live enemy's full authored kit (every live skill in
             /// <see cref="Contracts.Enemy.SkillPool"/>, not a random per-encounter draw — the check asks whether
             /// anything in the <em>kit</em> consumes the attribute) at <paramref name="level"/>. Mirrors
@@ -378,6 +393,31 @@ namespace Game.Application.Content
                         ScalingAmount = (double)e.ScalingAmount,
                     }).ToList(),
             };
+
+            /// <summary>
+            /// Flags a live enemy whose matched-or-easier-fight bounty (<c>XpScaleK × EnemyRating</c> —
+            /// <see cref="DefeatRewards"/>'s reward at <c>DifficultyMultiplier == 1</c>, its ceiling for this
+            /// enemy) would be silently truncated by <see cref="ServerGameConstants.MaxExpPerGrant"/>. Reuses
+            /// <see cref="ResolveRatingBattler"/> — no live placement means no representative level, so an
+            /// unplaced enemy is skipped here too, same as <see cref="CheckEnemyAttributeConsumption"/> (#1529).
+            /// </summary>
+            private void CheckEnemyBountyCap()
+            {
+                foreach (var enemy in Live(_graph.Enemies, e => e.RetiredAt))
+                {
+                    if (ResolveRatingBattler(enemy) is not Battler battler)
+                    {
+                        continue;
+                    }
+
+                    var bounty = ServerGameConstants.XpScaleK * CombatRating.Rate(battler, isPlayer: false);
+                    if (bounty >= ServerGameConstants.MaxExpPerGrant)
+                    {
+                        Warn("EnemyBountyCap", "Enemy", enemy.Id,
+                            $"has a matched-fight bounty of {bounty:F0} XP, at or above the {ServerGameConstants.MaxExpPerGrant} MaxExpPerGrant clamp — its victory reward is silently truncated.");
+                    }
+                }
+            }
 
             // --- Classes ----------------------------------------------------------------------------------
 

--- a/Game.Application/Content/ProgressionGraphChecker.cs
+++ b/Game.Application/Content/ProgressionGraphChecker.cs
@@ -395,7 +395,7 @@ namespace Game.Application.Content
             };
 
             /// <summary>
-            /// Flags a live enemy whose matched-or-easier-fight bounty (<c>XpScaleK × EnemyRating</c> —
+            /// Flags a live enemy whose matched-or-harder-fight bounty (<c>XpScaleK × EnemyRating</c> —
             /// <see cref="DefeatRewards"/>'s reward at <c>DifficultyMultiplier == 1</c>, its ceiling for this
             /// enemy) would be silently truncated by <see cref="ServerGameConstants.MaxExpPerGrant"/>. Reuses
             /// <see cref="ResolveRatingBattler"/> — no live placement means no representative level, so an

--- a/Game.Core/ServerGameConstants.cs
+++ b/Game.Core/ServerGameConstants.cs
@@ -31,11 +31,16 @@ namespace Game.Core
         public const double XpScaleK = 0.3262;
 
         /// <summary>
-        /// Defensive ceiling on the experience a single <c>Player.GrantExp</c> call applies. Legitimate
-        /// per-battle exp is already clamped well below this by <see cref="MaxExpRewardMultiplier"/>; this
-        /// is a backstop that bounds the level-up loop (and its per-level event burst) against a
-        /// tampered/replayed grant, keeping a single command's work on the serialized per-player path
-        /// finite regardless of the caller.
+        /// Defensive ceiling on the experience a single <c>Player.GrantExp</c> call applies — bounds the
+        /// level-up loop (and its per-level event burst) against a tampered/replayed grant, keeping a single
+        /// command's work on the serialized per-player path finite regardless of the caller.
+        /// <see cref="MaxExpRewardMultiplier"/> no longer bounds legitimate exp (it's calibration-legacy
+        /// only, see its own doc comment); the live ceiling on a matched-or-easier victory's reward is
+        /// <c><see cref="XpScaleK"/> × EnemyRating</c> (<see cref="Battle.DefeatRewards"/>), bounded only by
+        /// authored enemy power. An enemy whose combat rating exceeds
+        /// <c>MaxExpPerGrant ÷ XpScaleK</c> (currently ≈306k) has its legitimate reward silently cut to this
+        /// clamp — the <c>EnemyBountyCap</c> content-health lint (<c>ProgressionGraphChecker</c>, docs/backend-content.md)
+        /// flags any live enemy whose bounty would be truncated.
         /// </summary>
         public const int MaxExpPerGrant = 100_000;
 

--- a/Game.Core/ServerGameConstants.cs
+++ b/Game.Core/ServerGameConstants.cs
@@ -35,7 +35,7 @@ namespace Game.Core
         /// level-up loop (and its per-level event burst) against a tampered/replayed grant, keeping a single
         /// command's work on the serialized per-player path finite regardless of the caller.
         /// <see cref="MaxExpRewardMultiplier"/> no longer bounds legitimate exp (it's calibration-legacy
-        /// only, see its own doc comment); the live ceiling on a matched-or-easier victory's reward is
+        /// only, see its own doc comment); the live ceiling on a matched-or-harder victory's reward is
         /// <c><see cref="XpScaleK"/> × EnemyRating</c> (<see cref="Battle.DefeatRewards"/>), bounded only by
         /// authored enemy power. An enemy whose combat rating exceeds
         /// <c>MaxExpPerGrant ÷ XpScaleK</c> (currently ≈306k) has its legitimate reward silently cut to this


### PR DESCRIPTION
## Summary

`ServerGameConstants.MaxExpPerGrant`'s doc comment claimed legitimate per-battle exp was "already clamped well below this by `MaxExpRewardMultiplier`" — true under the old ±20%-band curve, but stale since #1532 replaced that curve with the combat-rating bounty formula `ExpReward = XpScaleK × EnemyRating × min(ratio,1)²`. Under the live formula, reward is bounded only by authored enemy power: any enemy rated above `MaxExpPerGrant ÷ XpScaleK` (≈306k) has its legitimate victory reward silently cut to the clamp, with no log, lint, or content-pipeline warning.

- Rewrote the `MaxExpPerGrant` doc comment to state the real bound (the bounty curve × authored enemy rating) and point at the new lint.
- Added an `EnemyBountyCap` check to `ProgressionGraphChecker` (the existing whole-graph content-health lint, `docs/backend-content.md`) that rates each live, placed enemy the same way `CheckEnemyAttributeConsumption` (#1529) already does, and flags any enemy whose matched-fight bounty (`XpScaleK × EnemyRating`, the reward ceiling for that enemy) would be truncated by `MaxExpPerGrant`. This runs both in CI (against the committed content export) and in the admin Content Health view.
- Extracted the level/kit/battler assembly shared by `CheckEnemyAttributeConsumption` and the new check into one `ResolveRatingBattler` helper to avoid duplicating that logic.

I went with the content-lint route rather than a runtime warning log (the issue's other suggested option): `Player`/`DefeatRewards` are plain domain objects with no logging seam today, and the project already has a dedicated content-quality-check subsystem for exactly this kind of "authored content silently mints a wrong value" case — that's a better architectural fit than adding ad hoc logging to the domain reward path.

No current seeded content trips the new check (confirmed against the committed `content/*.json` export via `ContentGraphLintTests`).

Closes #1860

## Test plan

- [x] `dotnet build Game.sln` — clean, 0 warnings
- [x] `dotnet test Game.sln` — all 3152 backend tests pass, including the new `EnemyBountyCap` unit tests (fires on an over-cap bounty; stays silent when below cap, on a retired enemy, or on an unplaced enemy) and the existing `ContentGraphLintTests` against the committed content export (no new warnings)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RFJBVkkf7pgb884tTT1acP)_