### PR TITLE
Fix stale 10,000-tick comment in BattlePerformanceTests (#1861)

### DIFF
--- a/Game.Core.Tests/Battle/Performance/BattlePerformanceTests.cs
+++ b/Game.Core.Tests/Battle/Performance/BattlePerformanceTests.cs
@@ -64,7 +64,7 @@ namespace Game.Core.Tests.Battle.Performance
     public class BattlePerformanceTests
     {
         // Per-tick cost cancels the tick count, so the scaling gates use a modest fixed length to stay
-        // fast; the backstop uses the simulator's real default cap (DefaultMaxBattleMs / MsPerTick = 10000).
+        // fast; the backstop uses the simulator's real default cap (DefaultMaxBattleMs / MsPerTick).
         private const int ScalingTicks = 800;
         private const int WorstCaseTicks = GameConstants.DefaultMaxBattleMs / GameConstants.MsPerTick;
 
@@ -98,7 +98,7 @@ namespace Game.Core.Tests.Battle.Performance
         private const int TypicalBattleTicks = 750;         // ~30s at MsPerTick = 40
 
         // Coarse catastrophic-regression ceiling for the realistic worst-case battle (the typical full
-        // loadout — 4 skills, 2 multipliers + a churning effect each — run to the 10,000-tick cap). This is
+        // loadout — 4 skills, 2 multipliers + a churning effect each — run to the WorstCaseTicks cap). This is
         // the one machine-dependent gate: a uniform per-tick regression inflates every battle equally, which
         // the ratio gates cannot see. The margin is deliberately huge (the battle measures ~10ms on a dev
         // box, an order of magnitude under the ceiling); if extreme runner contention ever makes it flake,


### PR DESCRIPTION
## Summary

`BattlePerformanceTests.cs` had two comments claiming the worst-case battle backstop runs "to the 10,000-tick cap." That was never accurate: `WorstCaseTicks = GameConstants.DefaultMaxBattleMs / GameConstants.MsPerTick` computes `120000 / 40 = 3000`, not 10,000.

Rather than swap in the literal `3,000` (which would just go stale again the next time either constant changes), I reworded both comments to reference the formula/constant instead of a hardcoded tick count:

- Line 67: `DefaultMaxBattleMs / MsPerTick = 10000` → `DefaultMaxBattleMs / MsPerTick` (drops the stale literal, points at the formula already used two lines below).
- Line 101: "run to the 10,000-tick cap" → "run to the `WorstCaseTicks` cap" (names the actual constant).

No behavioral change — this is a comment-only fix. The gate itself (`WorstCaseTicks` computed from the real constants) was always correct; only the prose describing it was wrong.

Closes #1861

## Test plan

- [x] `dotnet build Game.sln` — clean, 0 warnings
- [x] `dotnet test Game.sln --no-build --no-restore` — all 3148 backend tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_019GeUVfHhHFGrzMBzKMEa11)_