### PR TITLE
Re-derive the class signature passive in CloneWithAttributeDelta

### DIFF
--- a/Game.Core.Tests/Battle/BattlerTests.cs
+++ b/Game.Core.Tests/Battle/BattlerTests.cs
@@ -1,6 +1,7 @@
 using Game.Core.Attributes;
 using Game.Core.Attributes.Modifiers;
 using Game.Core.Battle;
+using Game.Core.Classes;
 using Game.Core.Skills;
 using Xunit;
 
@@ -283,6 +284,53 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(80, battler.TakeDamage(40, EDamageType.Physical), 0.001);
         }
 
+        // ── CloneWithAttributeDelta: signature-passive re-derivation (#1862) ────
+
+        [Fact]
+        public void CloneWithAttributeDelta_AttributeScaledSignaturePassive_ReDerivesAgainstBumpedAttribute()
+        {
+            // The passive scales off Endurance (+0.5 Toughness per point) on top of the static 2×Endurance
+            // derivation. Bumping Endurance by 10 must re-derive the passive's own contribution too, not copy
+            // through its pre-bump amount — the exact defect #1862 reports.
+            var passive = new ClassSignaturePassive
+            {
+                Attribute = EAttribute.Toughness,
+                Amount = 0m,
+                ScalingAttribute = EAttribute.Endurance,
+                ScalingAmount = 0.5m,
+                ModifierType = EModifierType.Additive,
+            };
+            var battler = MakeBattlerWithSignaturePassive(passive, (EAttribute.Endurance, 20));
+            Assert.Equal(50, battler.GetAttributeValue(EAttribute.Toughness), 0.001); // 2×20 + 0.5×20
+
+            var bumped = battler.CloneWithAttributeDelta(EAttribute.Endurance, 10);
+
+            // Endurance 30: static 2×30 = 60, passive re-derived at 0.5×30 = 15 → 75. A frozen-passive bug would
+            // instead yield 60 + 10 (the pre-bump amount) = 70.
+            Assert.Equal(75, bumped.GetAttributeValue(EAttribute.Toughness), 0.001);
+        }
+
+        [Fact]
+        public void CloneWithAttributeDelta_FlatSignaturePassive_CarriesThroughUnaffectedByAnUnrelatedBump()
+        {
+            // A flat (non-scaled) passive has nothing to re-derive; bumping an unrelated attribute must still
+            // leave its contribution exactly as assembled, with no duplication from the exclude/re-add swap.
+            var passive = new ClassSignaturePassive
+            {
+                Attribute = EAttribute.Strength,
+                Amount = 7m,
+                ScalingAttribute = null,
+                ScalingAmount = 0m,
+                ModifierType = EModifierType.Additive,
+            };
+            var battler = MakeBattlerWithSignaturePassive(passive, (EAttribute.Endurance, 5));
+            Assert.Equal(7, battler.GetAttributeValue(EAttribute.Strength), 0.001);
+
+            var bumped = battler.CloneWithAttributeDelta(EAttribute.Endurance, 10);
+
+            Assert.Equal(7, bumped.GetAttributeValue(EAttribute.Strength), 0.001);
+        }
+
         // ── Helpers ───────────────────────────────────────────────────────────
 
         /// <summary>
@@ -303,6 +351,31 @@ namespace Game.Core.Tests.Battle
                 .ToList();
 
             return new Battler(new AttributeCollection(modifiers), [], 1);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Battler"/> like <see cref="MakeBattler"/>, plus a resolved
+        /// <see cref="EAttributeModifierSource.Class"/> signature-passive modifier composed last (mirroring
+        /// <see cref="BattlerMaterials.Build"/>) and carried through for <see cref="Battler.CloneWithAttributeDelta"/>
+        /// to re-resolve.
+        /// </summary>
+        private static Battler MakeBattlerWithSignaturePassive(
+            ClassSignaturePassive passive, params (EAttribute Attribute, double Amount)[] attributes)
+        {
+            var modifiers = attributes
+                .Select(a => new AttributeModifier
+                {
+                    Attribute = a.Attribute,
+                    Amount = a.Amount,
+                    Type = EModifierType.Additive,
+                    Source = EAttributeModifierSource.AttributeDistribution,
+                })
+                .ToList();
+
+            var collection = new AttributeCollection(modifiers);
+            collection.AddModifier(passive.GetModifier(collection.GetAttributeValue));
+
+            return new Battler(collection, [], 1, signaturePassive: passive);
         }
     }
 }

--- a/Game.Core/Battle/BattleSnapshot.cs
+++ b/Game.Core/Battle/BattleSnapshot.cs
@@ -134,7 +134,8 @@ namespace Game.Core.Battle
             Func<int, Proficiency>? resolveProficiency = null, Func<int, Class>? resolveClass = null)
         {
             var baseModifiers = GetModifiers(resolveItem, resolveMod, resolveProficiency, resolveClass).ToList();
-            var signaturePassive = ResolveSignaturePassive(new AttributeCollection(baseModifiers), resolveClass);
+            var signaturePassiveDefinition = ResolveSignaturePassiveDefinition(resolveClass);
+            var signaturePassive = signaturePassiveDefinition?.GetModifier(new AttributeCollection(baseModifiers).GetAttributeValue);
 
             // The weapon-match gate reads each fielded id's type via the same resolver; an id that resolves to
             // no skill (a leftover/unauthored grant such as an unseeded punch) yields a null type and is dropped
@@ -152,7 +153,7 @@ namespace Game.Core.Battle
             var weapon = ResolveEquippedWeapon(resolveItem);
             var counterSkill = resolveSkill(weapon?.GrantedSkillId ?? GameConstants.PunchSkillId);
 
-            return new BattlerMaterials(baseModifiers, signaturePassive, skills, counterSkill, Level);
+            return new BattlerMaterials(baseModifiers, signaturePassive, signaturePassiveDefinition, skills, counterSkill, Level);
         }
 
         /// <summary>
@@ -181,6 +182,19 @@ namespace Game.Core.Battle
         /// </summary>
         private AttributeModifier? ResolveSignaturePassive(AttributeCollection attributes, Func<int, Class>? resolveClass)
         {
+            return ResolveSignaturePassiveDefinition(resolveClass)?.GetModifier(attributes.GetAttributeValue);
+        }
+
+        /// <summary>
+        /// The captured class's signature-passive <b>definition</b> (not yet resolved against any attributes),
+        /// or <c>null</c> when the snapshot carries no class state. Split out from <see cref="ResolveSignaturePassive"/>
+        /// so <see cref="GetBattlerMaterials"/> can hand the definition itself to <see cref="BattlerMaterials"/> —
+        /// which threads it onto the built <see cref="Battler"/> so <see cref="Battler.CloneWithAttributeDelta"/>
+        /// can re-resolve an attribute-scaled passive against a bumped clone (#1862) — while still resolving the
+        /// modifier once here for the battler's own initial assembly.
+        /// </summary>
+        private ClassSignaturePassive? ResolveSignaturePassiveDefinition(Func<int, Class>? resolveClass)
+        {
             if (ClassId is not int classId)
             {
                 return null;
@@ -192,7 +206,7 @@ namespace Game.Core.Battle
                     "A battle snapshot with a captured class requires a class resolver to compose its signature passive.");
             }
 
-            return resolveClass(classId).SignaturePassive.GetModifier(attributes.GetAttributeValue);
+            return resolveClass(classId).SignaturePassive;
         }
 
         /// <summary>
@@ -359,7 +373,7 @@ namespace Game.Core.Battle
     /// </summary>
     public sealed class BattlerMaterials(
         IReadOnlyList<AttributeModifier> baseModifiers, AttributeModifier? signaturePassive,
-        IReadOnlyList<Skill> skills, Skill? counterSkill, int level)
+        ClassSignaturePassive? signaturePassiveDefinition, IReadOnlyList<Skill> skills, Skill? counterSkill, int level)
     {
         /// <summary>Builds a fresh, single-use <see cref="Battler"/> from these materials.</summary>
         public Battler Build()
@@ -370,7 +384,7 @@ namespace Game.Core.Battle
                 attributes.AddModifier(signaturePassive);
             }
 
-            return new Battler(attributes, skills, level, counterSkill);
+            return new Battler(attributes, skills, level, counterSkill, signaturePassiveDefinition);
         }
     }
 }

--- a/Game.Core/Battle/Battler.cs
+++ b/Game.Core/Battle/Battler.cs
@@ -1,5 +1,6 @@
 using Game.Core.Attributes;
 using Game.Core.Attributes.Modifiers;
+using Game.Core.Classes;
 using Game.Core.Skills;
 using static Game.Core.EAttribute;
 
@@ -48,13 +49,25 @@ namespace Game.Core.Battle
         /// </summary>
         public Skill? CounterSkill { get; }
 
-        public Battler(AttributeCollection attributes, IEnumerable<Skill> skills, int level, Skill? counterSkill = null)
+        /// <summary>
+        /// The class signature passive this battler's <see cref="EAttributeModifierSource.Class"/> modifier was
+        /// resolved from, or <c>null</c> for a battler assembled without one (an enemy, or a hand-built test
+        /// battler). Carried only so <see cref="CloneWithAttributeDelta"/> can re-resolve an attribute-scaled
+        /// passive against the clone's bumped attributes — the live simulation never reads this, since the
+        /// modifier is already folded into <paramref name="attributes"/> at construction.
+        /// </summary>
+        private readonly ClassSignaturePassive? _signaturePassive;
+
+        public Battler(
+            AttributeCollection attributes, IEnumerable<Skill> skills, int level, Skill? counterSkill = null,
+            ClassSignaturePassive? signaturePassive = null)
         {
             _attributes = attributes;
             CurrentHealth = _attributes[MaxHealth];
             Skills = skills.Select(s => new BattleSkill(s)).ToList();
             Level = level;
             CounterSkill = counterSkill;
+            _signaturePassive = signaturePassive;
         }
 
         public void Update(BattleContext context)
@@ -175,13 +188,20 @@ namespace Game.Core.Battle
         /// not used by the live battle simulation. Excludes any live <see cref="EAttributeModifierSource.SkillEffect"/>
         /// modifiers (the marginal prices a permanent investment, not an in-battle timed-buff snapshot) and the
         /// static modifiers themselves — copying those too would double them, since the fresh
-        /// <see cref="AttributeCollection"/> constructor re-adds them automatically.
+        /// <see cref="AttributeCollection"/> constructor re-adds them automatically. The frozen
+        /// <see cref="EAttributeModifierSource.Class"/> signature-passive modifier is excluded too and, when this
+        /// battler carries a <see cref="_signaturePassive"/>, re-resolved against the clone's bumped attributes —
+        /// composed last, mirroring <see cref="BattlerMaterials.Build"/> — so an attribute-scaled
+        /// passive re-derives exactly like a real allocation would instead of copying through at its
+        /// already-resolved (pre-bump) amount (#1862).
         /// </summary>
         public Battler CloneWithAttributeDelta(EAttribute attribute, double delta)
         {
             var staticModifiers = new HashSet<AttributeModifier>(StaticAttributeModifiers.All);
             var modifiers = _attributes.AllModifiers()
-                .Where(m => m.Source != EAttributeModifierSource.SkillEffect && !staticModifiers.Contains(m))
+                .Where(m => m.Source != EAttributeModifierSource.SkillEffect
+                    && m.Source != EAttributeModifierSource.Class
+                    && !staticModifiers.Contains(m))
                 .ToList();
             modifiers.Add(new AttributeModifier
             {
@@ -191,7 +211,13 @@ namespace Game.Core.Battle
                 Source = EAttributeModifierSource.BaseValue,
             });
 
-            return new Battler(new AttributeCollection(modifiers), Skills.Select(s => s.Skill), Level, CounterSkill);
+            var attributes = new AttributeCollection(modifiers);
+            if (_signaturePassive is not null)
+            {
+                attributes.AddModifier(_signaturePassive.GetModifier(attributes.GetAttributeValue));
+            }
+
+            return new Battler(attributes, Skills.Select(s => s.Skill), Level, CounterSkill, _signaturePassive);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

`Battler.CloneWithAttributeDelta` rebuilds a battler's modifier set (minus `SkillEffect` and static modifiers) plus a fresh delta on one attribute, for `CombatRating.Marginal`'s finite-difference pricing. It was copying the `EAttributeModifierSource.Class` signature-passive modifier through at its **already-resolved** amount (frozen at battler assembly), instead of re-deriving it. For an attribute-scaled passive (`Amount + ScalingAttribute × ScalingAmount`), bumping the scaling attribute in the clone left the passive's contribution unchanged, so `CombatRating.Marginal` under-reported (in the worst case, exactly `0`) for a core attribute whose only combat contribution was feeding that passive — a false "dead stat" positive.

Currently latent per the issue: the only production caller of `Marginal` today is `ProgressionGraphChecker` with `isPlayer: false` on enemy battlers (no class passive), so nothing user-facing broke. But the documented contract on `CloneWithAttributeDelta` ("full cascade re-derivation included... exactly like a real allocation would") didn't hold, and a future player-side dead-stat lint would have silently inherited the gap.

## Changes

- `Battler` now optionally carries the `ClassSignaturePassive` definition it was assembled with (not just the resolved modifier already folded into its attributes).
- `CloneWithAttributeDelta` excludes the frozen `Class`-sourced modifier (alongside the existing `SkillEffect`/static exclusions) and, when a signature passive is carried, re-resolves it against the clone's bumped attributes as the final step — mirroring `BattlerMaterials.Build`'s own composition order (locked base → gear → proficiency → class passive last).
- `BattleSnapshot.GetBattlerMaterials` now threads the `ClassSignaturePassive` definition through `BattlerMaterials` in addition to the pre-resolved modifier used for the battler's initial assembly, so both the constructed battler and any future clone stay consistent with the snapshot's captured class.

## Test plan

- [x] Added `BattlerTests.CloneWithAttributeDelta_AttributeScaledSignaturePassive_ReDerivesAgainstBumpedAttribute` — pins the exact regression (an Endurance-scaled Toughness passive correctly re-derives on a bumped clone; a frozen-passive bug would instead yield a stale value).
- [x] Added `BattlerTests.CloneWithAttributeDelta_FlatSignaturePassive_CarriesThroughUnaffectedByAnUnrelatedBump` — confirms the common flat-passive case is unaffected (no duplication from the exclude/re-add swap).
- [x] `dotnet build` (full solution) — clean.
- [x] `dotnet test` (full solution: Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests) — all passing (3154 tests, 0 failures).

Closes #1862


---
_Generated by [Claude Code](https://claude.ai/code/session_015qMVJ95XKisuVVWcFU1vAh)_