### PR TITLE
Fix scroll-lock refcount, toast duration collapse, and stale tour-callout position

### DIFF
--- a/UI/src/components/focus-trap.ts
+++ b/UI/src/components/focus-trap.ts
@@ -17,6 +17,31 @@
 const trapStack: HTMLElement[] = [];
 
 /**
+ * Refcounts per scroll-lock class name, so two stacked traps sharing a class (e.g. both `Popover`s
+ * using `popover-open`) don't unlock background scroll when the inner one destroys while the outer
+ * is still open.
+ */
+const scrollLockRefs = new Map<string, number>();
+
+function acquireScrollLock(className: string) {
+	const count = (scrollLockRefs.get(className) ?? 0) + 1;
+	scrollLockRefs.set(className, count);
+	if (count === 1) {
+		document.body.classList.add(className);
+	}
+}
+
+function releaseScrollLock(className: string) {
+	const count = (scrollLockRefs.get(className) ?? 0) - 1;
+	if (count <= 0) {
+		scrollLockRefs.delete(className);
+		document.body.classList.remove(className);
+	} else {
+		scrollLockRefs.set(className, count);
+	}
+}
+
+/**
  * Tab-reachable elements. Intentionally broader than a bare `button` so a modal/popover containing a
  * link, input, or `[tabindex]` element still traps and anchors onto it.
  */
@@ -70,7 +95,7 @@ export function focusTrap(node: HTMLElement, options: FocusTrapOptions = {}) {
 	trapStack.push(node);
 	window.addEventListener('keydown', onKeydown);
 	if (opts.scrollLockClass) {
-		document.body.classList.add(opts.scrollLockClass);
+		acquireScrollLock(opts.scrollLockClass);
 	}
 
 	return {
@@ -78,10 +103,10 @@ export function focusTrap(node: HTMLElement, options: FocusTrapOptions = {}) {
 			// Swap the scroll-lock class if it changed (rare); options are otherwise read live.
 			if (opts.scrollLockClass !== next.scrollLockClass) {
 				if (opts.scrollLockClass) {
-					document.body.classList.remove(opts.scrollLockClass);
+					releaseScrollLock(opts.scrollLockClass);
 				}
 				if (next.scrollLockClass) {
-					document.body.classList.add(next.scrollLockClass);
+					acquireScrollLock(next.scrollLockClass);
 				}
 			}
 			opts = next;
@@ -93,7 +118,7 @@ export function focusTrap(node: HTMLElement, options: FocusTrapOptions = {}) {
 			}
 			window.removeEventListener('keydown', onKeydown);
 			if (opts.scrollLockClass) {
-				document.body.classList.remove(opts.scrollLockClass);
+				releaseScrollLock(opts.scrollLockClass);
 			}
 			restoreFocus?.focus();
 		}

--- a/UI/src/components/tour/TourPlayer.svelte
+++ b/UI/src/components/tour/TourPlayer.svelte
@@ -125,6 +125,10 @@ const SPOTLIGHT_PADDING = 6;
 
 $effect(() => {
 	void resizeTick;
+	// Re-run on every step change too, not just anchor/viewport changes: consecutive steps sharing an
+	// anchorKey (or both unanchored) leave `anchorEl` unchanged, but the callout's rendered height can
+	// still differ with the new step's text.
+	void stepIndex;
 	if (!open || !anchorEl) {
 		spotlightRect = null;
 		calloutPos = null;

--- a/UI/src/stores/toast.svelte.ts
+++ b/UI/src/stores/toast.svelte.ts
@@ -17,6 +17,8 @@ export interface ToastData {
 	id: number;
 	message: string;
 	type: ToastType;
+	/** Auto-dismiss delay in ms this toast was created with; preserved across duplicate-collapses. */
+	duration: number;
 	/** Whether a manual dismiss control is shown for the toast. */
 	dismissible: boolean;
 	/** Optional inline action button. */
@@ -100,14 +102,15 @@ export const showToast = (message: string, options: ToastOptions = {}): number =
 	// stacking identical messages on top of each other.
 	for (const toast of toastData.values()) {
 		if (toast.message === message && toast.type === type) {
-			// Collapsing keeps the existing toast's action/onDismiss; differing ones on a duplicate are ignored.
-			scheduleDismiss(toast.id, duration);
+			// Collapsing keeps the existing toast's own duration/action/onDismiss; a duplicate's differing
+			// duration is ignored so it can't turn a persistent toast timed or vice versa.
+			scheduleDismiss(toast.id, toast.duration);
 			return toast.id;
 		}
 	}
 
 	const id = nextId++;
-	toastData.set(id, { id, message, type, dismissible, action, onDismiss });
+	toastData.set(id, { id, message, type, duration, dismissible, action, onDismiss });
 	scheduleDismiss(id, duration);
 	return id;
 };

--- a/UI/src/tests/components/focus-trap.test.ts
+++ b/UI/src/tests/components/focus-trap.test.ts
@@ -87,6 +87,25 @@ describe('focusTrap', () => {
 		expect(document.body.classList.contains('test-lock')).toBe(false);
 	});
 
+	it('refcounts a scroll-lock class shared by stacked traps, only unlocking once the last one destroys', () => {
+		mount('<button>a</button>', { scrollLockClass: 'test-lock' });
+		expect(document.body.classList.contains('test-lock')).toBe(true);
+
+		const innerNode = document.createElement('div');
+		innerNode.innerHTML = '<button>b</button>';
+		document.body.appendChild(innerNode);
+		const innerHandle = focusTrap(innerNode, { scrollLockClass: 'test-lock' });
+
+		// Still locked while the outer trap is destroyed — the inner one still holds a reference.
+		handle?.destroy();
+		handle = undefined;
+		expect(document.body.classList.contains('test-lock')).toBe(true);
+
+		innerHandle.destroy();
+		innerNode.remove();
+		expect(document.body.classList.contains('test-lock')).toBe(false);
+	});
+
 	it('restores focus to the previously focused element on destroy', () => {
 		const outside = document.createElement('button');
 		document.body.appendChild(outside);

--- a/UI/src/tests/components/tour/TourPlayer.test.ts
+++ b/UI/src/tests/components/tour/TourPlayer.test.ts
@@ -63,6 +63,56 @@ describe('TourPlayer', () => {
 		anchorEl.remove();
 	});
 
+	it('recomputes the callout position for a step sharing the same anchor as the prior step', async () => {
+		const anchorEl = document.createElement('button');
+		document.body.appendChild(anchorEl);
+		const action = tutorialAnchor(anchorEl, 'skill-bar');
+		vi.spyOn(anchorEl, 'getBoundingClientRect').mockReturnValue({
+			top: 480,
+			left: 100,
+			width: 40,
+			height: 20,
+			bottom: 500,
+			right: 140,
+			x: 100,
+			y: 480,
+			toJSON: () => ({})
+		} as DOMRect);
+
+		const steps: TourStep[] = [
+			{ text: 'Short', anchorKey: 'skill-bar' },
+			{ text: 'A much longer line of tour text that renders a visibly taller callout box', anchorKey: 'skill-bar' }
+		];
+		const { container, getByRole } = setup(steps);
+		await tick();
+
+		const shell = container.querySelector('.tour-callout') as HTMLElement;
+		// jsdom never lays out real box sizes; stand in a height that tracks the current step's own text
+		// (not the surrounding chrome, which is present on every step) so a real difference is observable
+		// (short fits below the anchor, tall overflows the viewport and flips above it), then force one
+		// recompute so the effect picks up the getter.
+		Object.defineProperty(shell, 'offsetHeight', {
+			configurable: true,
+			get: () => {
+				const stepText = shell.querySelector('.tour-callout__text')?.textContent ?? '';
+				return stepText.length > 20 ? 300 : 60;
+			}
+		});
+		Object.defineProperty(shell, 'offsetWidth', { configurable: true, value: 300 });
+		await fireEvent(window, new Event('resize'));
+		await tick();
+		const firstTop = shell.style.top;
+
+		await fireEvent.click(getByRole('button', { name: 'Next' }));
+		await tick();
+		const secondTop = shell.style.top;
+
+		expect(secondTop).not.toBe(firstTop);
+
+		action.destroy();
+		anchorEl.remove();
+	});
+
 	it('navigates forward and back, disabling Back on the first step', async () => {
 		const { getByText, getByRole } = setup(threeSteps);
 

--- a/UI/src/tests/stores/toast.test.ts
+++ b/UI/src/tests/stores/toast.test.ts
@@ -75,6 +75,28 @@ describe('toast store', () => {
 		expect(current()).toHaveLength(0);
 	});
 
+	it('keeps a persistent toast persistent when a timed duplicate collapses into it', () => {
+		showToast('Connection error', { type: 'error', duration: 0 });
+		showToast('Connection error', { type: 'error', duration: 1000 });
+
+		vi.advanceTimersByTime(60_000);
+		expect(current()).toHaveLength(1);
+	});
+
+	it('keeps auto-dismissing a timed toast when a persistent duplicate collapses into it', () => {
+		showToast('Connection error', { type: 'error', duration: 1000 });
+		vi.advanceTimersByTime(800);
+
+		// Collapsing refreshes the timer (as any duplicate does) but must reuse the toast's own 1000ms
+		// duration, not the duplicate's 0 (which would otherwise make it persistent forever).
+		showToast('Connection error', { type: 'error', duration: 0 });
+		vi.advanceTimersByTime(999);
+		expect(current()).toHaveLength(1);
+
+		vi.advanceTimersByTime(1);
+		expect(current()).toHaveLength(0);
+	});
+
 	it('does not collapse identical messages of different types', () => {
 		showToast('Same text', { type: 'error' });
 		showToast('Same text', { type: 'success' });


### PR DESCRIPTION
## Summary

Three small, independently-verified bugs in shared UI primitives, per #1864:

1. **Focus-trap scroll-lock is not reference-counted.** `focus-trap.ts` toggled `document.body.classList` directly for its `scrollLockClass`. Two stacked traps sharing the same class (both `Popover`s hardcode `scrollLockClass: 'popover-open'`) would have the inner trap's `destroy()` remove the class while the outer overlay was still open, unlocking background scroll prematurely. Fixed with a module-level refcount map (`acquireScrollLock`/`releaseScrollLock`): the class is added on 0→1 and removed on 1→0.

2. **Toast duplicate-collapse silently rewrote the surviving toast's persistence.** `showToast` collapsed a duplicate message into the existing toast but re-armed its timer with the **new** call's `duration` — a persistent toast (`duration: 0`) hit by a duplicate omitting `duration` would start auto-dismissing after 6s, and a timed toast hit by a `duration: 0` duplicate would become permanent. `ToastData` now stores each toast's own `duration`, and a collapse reuses that stored value instead of the incoming duplicate's.

3. **Tour callout position went stale between same-anchor steps.** `TourPlayer`'s position `$effect` re-ran on `resizeTick`/`open`/`anchorEl` but not when the step's own text changed. Since `anchorEl` is a `$derived` reference (`getTutorialAnchor(anchorKey)`), two consecutive steps sharing an `anchorKey` (or both unanchored) left the object reference unchanged, so the effect never re-ran even though the callout's rendered height changed — leaving it slightly off / clipped near a viewport edge. Fixed by also tracking `stepIndex` in the effect (mirroring the existing `resizeTick` tracking convention).

## Test plan

- [x] `focus-trap.test.ts` — new case: two stacked traps sharing a scroll-lock class stay locked until the last one destroys.
- [x] `toast.test.ts` — new cases: a persistent toast stays persistent when a timed duplicate collapses into it, and a timed toast keeps auto-dismissing on its own schedule when a persistent duplicate collapses into it.
- [x] `TourPlayer.test.ts` — new case: a step sharing the prior step's anchor recomputes the callout position when the rendered height changes (mocked jsdom layout, since jsdom doesn't lay out real box sizes).
- [x] `npm run lint` (ESLint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — full suite, 298 files / 3674 tests passed.

Closes #1864

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7D47gWFsDZJoAaML4kSAN)_