### PR TITLE
Wrap each multiplexer dispose in DisposeAllAsync so one faulting close doesn't abort the rest

### DIFF
--- a/Game.Infrastructure.Tests/CapturingLogger.cs
+++ b/Game.Infrastructure.Tests/CapturingLogger.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Logging;
+
+namespace Game.Infrastructure.Tests
+{
+    /// <summary>
+    /// A minimal <see cref="ILogger"/> test double that records each call's level and exception. Shared by tests
+    /// whose only observable effect on a caught fault is the error log (<see cref="RedisCommandBudgetTests"/>,
+    /// <see cref="RedisMultiplexerFactoryTests"/>), so the capture logic isn't duplicated per test class.
+    /// </summary>
+    internal sealed class CapturingLogger : ILogger
+    {
+        private readonly object _gate = new();
+        private readonly List<(LogLevel Level, Exception? Exception)> _entries = [];
+
+        public IReadOnlyList<(LogLevel Level, Exception? Exception)> Entries
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _entries.ToList();
+                }
+            }
+        }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            lock (_gate)
+            {
+                _entries.Add((logLevel, exception));
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/Game.Infrastructure.Tests/RedisCommandBudgetTests.cs
+++ b/Game.Infrastructure.Tests/RedisCommandBudgetTests.cs
@@ -132,42 +132,5 @@ namespace Game.Infrastructure.Tests
             Assert.Equal(42, result);
             Assert.Empty(logger.Entries);
         }
-
-        // A minimal capturing logger: the fault continuation's only observable effect is the error log, so the
-        // level and whether an exception was carried are recorded. ExecuteSynchronously means a fault drives the
-        // continuation inline on the SetException call, so the captured entry is visible without extra waiting.
-        private sealed class CapturingLogger : ILogger
-        {
-            private readonly object _gate = new();
-            private readonly List<(LogLevel Level, Exception? Exception)> _entries = [];
-
-            public IReadOnlyList<(LogLevel Level, Exception? Exception)> Entries
-            {
-                get
-                {
-                    lock (_gate)
-                    {
-                        return _entries.ToList();
-                    }
-                }
-            }
-
-            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
-            public bool IsEnabled(LogLevel logLevel) => true;
-
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-            {
-                lock (_gate)
-                {
-                    _entries.Add((logLevel, exception));
-                }
-            }
-
-            private sealed class NullScope : IDisposable
-            {
-                public static readonly NullScope Instance = new();
-                public void Dispose() { }
-            }
-        }
     }
 }

--- a/Game.Infrastructure.Tests/RedisMultiplexerFactoryTests.cs
+++ b/Game.Infrastructure.Tests/RedisMultiplexerFactoryTests.cs
@@ -171,41 +171,5 @@ namespace Game.Infrastructure.Tests
                 return ValueTask.CompletedTask;
             }
         }
-
-        // A minimal capturing logger mirroring RedisCommandBudgetTests' CapturingLogger: the dispose-loop's only
-        // observable effect on a faulting entry is the error log, so the level and exception presence are recorded.
-        private sealed class CapturingLogger : ILogger
-        {
-            private readonly object _gate = new();
-            private readonly List<(LogLevel Level, Exception? Exception)> _entries = [];
-
-            public IReadOnlyList<(LogLevel Level, Exception? Exception)> Entries
-            {
-                get
-                {
-                    lock (_gate)
-                    {
-                        return _entries.ToList();
-                    }
-                }
-            }
-
-            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
-            public bool IsEnabled(LogLevel logLevel) => true;
-
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-            {
-                lock (_gate)
-                {
-                    _entries.Add((logLevel, exception));
-                }
-            }
-
-            private sealed class NullScope : IDisposable
-            {
-                public static readonly NullScope Instance = new();
-                public void Dispose() { }
-            }
-        }
     }
 }

--- a/Game.Infrastructure.Tests/RedisMultiplexerFactoryTests.cs
+++ b/Game.Infrastructure.Tests/RedisMultiplexerFactoryTests.cs
@@ -1,4 +1,6 @@
 using Game.Infrastructure.Redis;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Game.Infrastructure.Tests
@@ -111,7 +113,7 @@ namespace Game.Infrastructure.Tests
             cache["cache:6379"] = first;
             cache["pubsub:6380"] = second;
 
-            await RedisMultiplexerFactory.DisposeAllAsync(cache, syncRoot);
+            await RedisMultiplexerFactory.DisposeAllAsync(cache, syncRoot, NullLogger.Instance);
 
             // Every cached connection is disposed and the cache is emptied so a later request reconnects fresh —
             // the graceful-shutdown teardown the hosted service drives.
@@ -125,19 +127,84 @@ namespace Game.Infrastructure.Tests
         {
             var cache = new Dictionary<string, FakeAsyncDisposable>();
 
-            await RedisMultiplexerFactory.DisposeAllAsync(cache, new object());
+            await RedisMultiplexerFactory.DisposeAllAsync(cache, new object(), NullLogger.Instance);
 
             Assert.Empty(cache);
         }
 
-        private sealed class FakeAsyncDisposable : IAsyncDisposable
+        [Fact]
+        public async Task DisposeAllAsync_OneEntryFaultsOnDispose_StillDisposesTheRestAndClearsTheCache()
+        {
+            var cache = new Dictionary<string, FakeAsyncDisposable>();
+            var syncRoot = new object();
+            var faulting = new FakeAsyncDisposable(throwOnDispose: true);
+            var healthy = new FakeAsyncDisposable();
+            cache["cache:6379"] = faulting;
+            cache["pubsub:6380"] = healthy;
+            var logger = new CapturingLogger();
+
+            // The contract documented on DisposeAllAsync: one faulting close must not abort the rest of the drain,
+            // and must not throw out of the caller (the host's graceful-shutdown hook).
+            await RedisMultiplexerFactory.DisposeAllAsync(cache, syncRoot, logger);
+
+            Assert.Equal(1, faulting.DisposeCount);
+            Assert.Equal(1, healthy.DisposeCount);
+            Assert.Empty(cache);
+
+            var entry = Assert.Single(logger.Entries);
+            Assert.Equal(LogLevel.Error, entry.Level);
+            Assert.NotNull(entry.Exception);
+        }
+
+        private sealed class FakeAsyncDisposable(bool throwOnDispose = false) : IAsyncDisposable
         {
             public int DisposeCount { get; private set; }
 
             public ValueTask DisposeAsync()
             {
                 DisposeCount++;
+                if (throwOnDispose)
+                {
+                    throw new InvalidOperationException("redis close wedged");
+                }
+
                 return ValueTask.CompletedTask;
+            }
+        }
+
+        // A minimal capturing logger mirroring RedisCommandBudgetTests' CapturingLogger: the dispose-loop's only
+        // observable effect on a faulting entry is the error log, so the level and exception presence are recorded.
+        private sealed class CapturingLogger : ILogger
+        {
+            private readonly object _gate = new();
+            private readonly List<(LogLevel Level, Exception? Exception)> _entries = [];
+
+            public IReadOnlyList<(LogLevel Level, Exception? Exception)> Entries
+            {
+                get
+                {
+                    lock (_gate)
+                    {
+                        return _entries.ToList();
+                    }
+                }
+            }
+
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                lock (_gate)
+                {
+                    _entries.Add((logLevel, exception));
+                }
+            }
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new();
+                public void Dispose() { }
             }
         }
     }

--- a/Game.Infrastructure/Redis/RedisConnectionLifetime.cs
+++ b/Game.Infrastructure/Redis/RedisConnectionLifetime.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Game.Infrastructure.Redis
 {
@@ -13,7 +14,8 @@ namespace Game.Infrastructure.Redis
     {
         private readonly Func<Task> _disposeConnections;
 
-        public RedisConnectionLifetime() : this(RedisMultiplexerFactory.DisposeAllAsync) { }
+        public RedisConnectionLifetime(ILogger<RedisConnectionLifetime> logger)
+            : this(() => RedisMultiplexerFactory.DisposeAllAsync(logger)) { }
 
         // The disposal action is injectable so the stop hook can be unit-tested without opening real connections.
         internal RedisConnectionLifetime(Func<Task> disposeConnections)

--- a/Game.Infrastructure/Redis/RedisMultiplexerFactory.cs
+++ b/Game.Infrastructure/Redis/RedisMultiplexerFactory.cs
@@ -1,5 +1,7 @@
 ﻿using Game.Infrastructure.Cache;
 using Game.Infrastructure.PubSub;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using StackExchange.Redis;
 
 namespace Game.Infrastructure.Redis
@@ -49,18 +51,19 @@ namespace Game.Infrastructure.Redis
         /// lifetime connections are torn down cleanly on stop rather than left to be force-killed (#954). Each
         /// connection is closed independently so one faulting close still lets the rest tear down.
         /// </summary>
-        public static Task DisposeAllAsync()
+        public static Task DisposeAllAsync(ILogger logger)
         {
-            return DisposeAllAsync(_multiplexers, _lock);
+            return DisposeAllAsync(_multiplexers, _lock, logger);
         }
 
         /// <summary>
         /// Locked drain-and-dispose of a multiplexer cache: snapshots the values under <paramref name="syncRoot"/>,
         /// clears the cache, then disposes each entry. Generic and seam-extracted so the dispose/clear semantics
         /// are unit-testable with a fake disposable, mirroring how <see cref="GetOrAdd{T}"/> is tested without a
-        /// live connection (#954).
+        /// live connection (#954). Each entry's dispose is wrapped independently so a faulting close is logged and
+        /// skipped rather than aborting the rest of the drain.
         /// </summary>
-        internal static async Task DisposeAllAsync<T>(Dictionary<string, T> cache, object syncRoot)
+        internal static async Task DisposeAllAsync<T>(Dictionary<string, T> cache, object syncRoot, ILogger logger)
             where T : IAsyncDisposable
         {
             List<T> toDispose;
@@ -72,7 +75,14 @@ namespace Game.Infrastructure.Redis
 
             foreach (var disposable in toDispose)
             {
-                await disposable.DisposeAsync();
+                try
+                {
+                    await disposable.DisposeAsync();
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to close a cached Redis multiplexer during shutdown; continuing to close the rest.");
+                }
             }
         }
 
@@ -103,7 +113,7 @@ namespace Game.Infrastructure.Redis
         // duplicated the logic with synchronous Dispose() where the production seam uses DisposeAsync()).
         internal static Task ResetForTesting()
         {
-            return DisposeAllAsync();
+            return DisposeAllAsync(NullLogger.Instance);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

`RedisMultiplexerFactory.DisposeAllAsync` documents that "each connection is closed independently so one faulting close still lets the rest tear down," but the implementation was a bare `foreach { await disposable.DisposeAsync(); }` with no per-item try/catch. Since the cache dictionary is cleared *before* the loop runs, a faulting close on the first entry left every subsequent multiplexer permanently unreachable, and the exception escaped `RedisConnectionLifetime.StopAsync` (which only catches `OperationCanceledException`). `ResetForTesting()` delegates to the same method between integration-test runs, so a faulting close there could break subsequent test teardown/reconnect too.

## Changes

- `RedisMultiplexerFactory.DisposeAllAsync<T>` now wraps each `DisposeAsync()` call in its own try/catch, logging the failure and continuing to the next entry — matching the method's own documented contract.
- Both the public `DisposeAllAsync` and the generic seam now take an `ILogger`, following this codebase's existing pattern of passing an `ILogger` into static Redis helpers (see `RedisCommandBudget.Write`) rather than giving the static factory its own DI-resolved logger.
- `RedisConnectionLifetime` now takes an injected `ILogger<RedisConnectionLifetime>` (constructor-injected via its existing `IHostedService` DI registration) and hands it down to `DisposeAllAsync`.
- `ResetForTesting()` passes `NullLogger.Instance`, since test resets don't need to observe the log.
- Added a test (`DisposeAllAsync_OneEntryFaultsOnDispose_StillDisposesTheRestAndClearsTheCache`) with a fake disposable that throws, pinning: the faulting entry is caught and logged as an error, the healthy sibling is still disposed, and the cache is still cleared. Updated the two existing `DisposeAllAsync` tests to pass a logger.

## Test plan

- [x] `dotnet build` (full solution) — clean
- [x] `dotnet test` (full backend suite: Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests) — all green, including the new fault-tolerance test and the DI-resolution of `RedisConnectionLifetime`'s new constructor parameter via `Game.Api.Tests`' integration tests

Closes #1889


---
_Generated by [Claude Code](https://claude.ai/code/session_01McTLuKnmTQVPqZnDPadaKu)_