### PR TITLE
Add reflection-based architecture guard for admin controller attributes

### DIFF
--- a/Game.Api.Tests/Architecture/AdminControllerGuardTests.cs
+++ b/Game.Api.Tests/Architecture/AdminControllerGuardTests.cs
@@ -69,6 +69,8 @@ namespace Game.Api.Tests.Architecture
 
         private static bool IsAdminSurfaceController(Type type)
         {
+            // Off-convention admin controllers (ones that don't route under /api/AdminTools) must be
+            // special-cased here too, or they silently fall outside this guard's coverage.
             if (type == typeof(TagsController))
             {
                 return true;

--- a/Game.Api.Tests/Architecture/AdminControllerGuardTests.cs
+++ b/Game.Api.Tests/Architecture/AdminControllerGuardTests.cs
@@ -1,0 +1,97 @@
+using System.Reflection;
+using Game.Api.Controllers;
+using Game.Api.Controllers.Admin;
+using Game.Api.Filters;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Game.Api.Tests.Architecture
+{
+    /// <summary>
+    /// Architecture guard for the admin surface (#1891). Both <see cref="AdminRoleAuthorizationFilter"/> and
+    /// <see cref="ReloadReferenceCachesAttribute"/> are opt-in per controller rather than applied by convention,
+    /// so a new (or moved) admin controller that forgets one silently exposes an admin action to any
+    /// authenticated player, or serves stale reference data after a write. This enumerates every controller in
+    /// the assembly rather than a fixed list, so a controller added later is checked automatically instead of
+    /// only when someone remembers to add it here.
+    /// </summary>
+    public class AdminControllerGuardTests
+    {
+        /// <summary>
+        /// Content-writing admin controllers documented as owning no reference cache to reload: user accounts
+        /// and the write-behind dead-letter queues aren't list-cached in memory (see their own class remarks).
+        /// </summary>
+        private static readonly HashSet<Type> ReloadCacheExemptControllers =
+        [
+            typeof(AdminUsersController),
+            typeof(AdminDeadLettersController),
+        ];
+
+        public static IEnumerable<object[]> AdminSurfaceControllers()
+        {
+            return typeof(Startup).Assembly
+                .GetTypes()
+                .Where(IsAdminSurfaceController)
+                .Select(type => new object[] { type });
+        }
+
+        [Theory]
+        [MemberData(nameof(AdminSurfaceControllers))]
+        public void AdminSurfaceController_RequiresAdminRole(Type controllerType)
+        {
+            Assert.True(
+                HasServiceFilter(controllerType, typeof(AdminRoleAuthorizationFilter)),
+                $"{controllerType.Name} sits on the admin surface but is missing [ServiceFilter(typeof(AdminRoleAuthorizationFilter))].");
+        }
+
+        [Theory]
+        [MemberData(nameof(AdminSurfaceControllers))]
+        public void ContentWritingAdminController_ReloadsReferenceCaches(Type controllerType)
+        {
+            if (ReloadCacheExemptControllers.Contains(controllerType))
+            {
+                return;
+            }
+
+            var writesContent = controllerType
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Any(method => method.GetCustomAttributes(inherit: true).Any(IsWriteHttpMethodAttribute));
+
+            if (!writesContent)
+            {
+                return;
+            }
+
+            Assert.True(
+                controllerType.GetCustomAttributes(typeof(ReloadReferenceCachesAttribute), inherit: true).Length > 0,
+                $"{controllerType.Name} writes content but is missing [ReloadReferenceCaches].");
+        }
+
+        private static bool IsAdminSurfaceController(Type type)
+        {
+            if (type == typeof(TagsController))
+            {
+                return true;
+            }
+
+            if (!typeof(ControllerBase).IsAssignableFrom(type) || type.IsAbstract)
+            {
+                return false;
+            }
+
+            var route = type.GetCustomAttribute<RouteAttribute>(inherit: true);
+            return route?.Template.StartsWith("/api/AdminTools", StringComparison.OrdinalIgnoreCase) ?? false;
+        }
+
+        private static bool HasServiceFilter(Type type, Type serviceType)
+        {
+            return type.GetCustomAttributes<ServiceFilterAttribute>(inherit: true)
+                .Any(attribute => attribute.ServiceType == serviceType);
+        }
+
+        private static bool IsWriteHttpMethodAttribute(object attribute)
+        {
+            return attribute is HttpPostAttribute or HttpPutAttribute or HttpDeleteAttribute or HttpPatchAttribute;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Admin-role gating (`[ServiceFilter(typeof(AdminRoleAuthorizationFilter))]`) and reference-cache reload (`[ReloadReferenceCaches]`) are opt-in attributes each admin controller must remember to add — there was no test enforcing either invariant, so a future admin controller (or an action moved to a new one) that omits the role filter would be silently reachable by any authenticated player, and one that omits the cache-reload attribute would serve stale reference data after a write.

Added `Game.Api.Tests/Architecture/AdminControllerGuardTests.cs`, following the same reflection-based pattern as the existing `EntityIsolationTests`:

- **`AdminSurfaceController_RequiresAdminRole`** — enumerates every controller in the `Game.Api` assembly whose route is prefixed `/api/AdminTools`, plus `TagsController` (which lives under `/api/[controller]/[action]` but still requires the Admin role), and asserts each carries `[ServiceFilter(typeof(AdminRoleAuthorizationFilter))]`.
- **`ContentWritingAdminController_ReloadsReferenceCaches`** — for the same admin-surface controllers, asserts any controller with at least one `HttpPost`/`HttpPut`/`HttpDelete`/`HttpPatch` action also carries `[ReloadReferenceCaches]`, unless it's one of the two controllers explicitly documented (in their own class remarks) as not owning a reference cache to reload: `AdminUsersController` (user accounts aren't list-cached) and `AdminDeadLettersController` (touches no reference cache). Read-only admin controllers (`AdminContentHealthController`, `TagsController`) are naturally excluded since they have no write actions.

Both tests enumerate the assembly rather than a fixed list, so a controller added later is checked automatically instead of only when someone remembers to add it here — closing the exact gap the issue describes.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test` (full backend suite, `Game.Api.Tests` included) — 791/791 passed, including the two new architecture tests exercised against every current admin controller
- [x] `dotnet format --verify-no-changes` on the new file — clean

Closes #1891


---
_Generated by [Claude Code](https://claude.ai/code/session_01HpxhZzCQp2fcmt3AqVTM1n)_