### PR TITLE
Confirm before hard-deleting a tag, showing referenced items/mods

### DIFF
--- a/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
+++ b/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
@@ -50,7 +50,7 @@
 							</button>
 						{/if}
 					{:else}
-						<button type="button" class="hdr-action danger" onclick={() => store.removeItem(record.id)}>
+						<button type="button" class="hdr-action danger" onclick={() => onDelete(record)}>
 							<WorkbenchIcon kind="x" size={11} />Delete
 						</button>
 					{/if}
@@ -133,7 +133,7 @@
 import { fieldsOf, type EntityConfig, type Identified } from '../entities/types';
 import type { EntityStore } from '../entity-store.svelte';
 import { recordsEqual } from '../entity-store.svelte';
-import { referenceSourcesFromStatic, retireWithConfirm } from '../retire-confirm';
+import { deleteWithConfirm, referenceSourcesFromStatic, retireWithConfirm } from '../retire-confirm';
 import { sectionWarnings } from '../validation';
 import WorkbenchIcon from '../WorkbenchIcon.svelte';
 import SectionRenderer from './SectionRenderer.svelte';
@@ -174,6 +174,20 @@ const onRetire = (rec: Identified) =>
 		title: `Retire ${entity.singular}?`,
 		sources: referenceSourcesFromStatic(),
 		onConfirmed: () => store.setRetired(rec.id, true)
+	});
+
+/**
+ * Hard-delete confirm for the one non-retireable entity (tags): surfaces what currently applies
+ * the tag before the cascade strips it from every one of them (see `references.ts`'s tag case).
+ */
+const onDelete = (rec: Identified) =>
+	deleteWithConfirm({
+		entityKey: entity.key,
+		id: rec.id,
+		name: entity.title?.(rec) || rec.name || entity.blankName,
+		title: `Delete ${entity.singular}?`,
+		sources: referenceSourcesFromStatic(),
+		onConfirmed: () => store.removeItem(rec.id)
 	});
 
 const sectionDirty = (section: EntityConfig<Identified>['sections'][number]): boolean => {

--- a/UI/src/routes/admin/workbench/references.ts
+++ b/UI/src/routes/admin/workbench/references.ts
@@ -4,6 +4,7 @@ import {
 	type IClass,
 	type IEnemy,
 	type IItem,
+	type IItemMod,
 	type IProficiency,
 	type ISkill,
 	type ISkillRecipe,
@@ -25,6 +26,7 @@ export interface ReferenceSources {
 	zones: IZone[];
 	challenges: IChallenge[];
 	items: IItem[];
+	itemMods: IItemMod[];
 	classes: IClass[];
 	skillRecipes: ISkillRecipe[];
 	proficiencies: IProficiency[];
@@ -56,7 +58,9 @@ export type ReferenceKind =
 	| 'milestoneReward'
 	| 'gearGate'
 	| 'recipeCondition'
-	| 'prerequisiteOf';
+	| 'prerequisiteOf'
+	| 'taggedItems'
+	| 'taggedMods';
 
 /** Zero-based-id lookup honouring the retirement Id-as-index invariant (a retired record keeps its slot). */
 const nameByIndex = (records: { name: string }[], id: number): string => records[id]?.name ?? `#${id}`;
@@ -157,6 +161,18 @@ const pathReferences = (id: number, { proficiencies }: ReferenceSources): Refere
 	return group('prerequisiteOf', prerequisiteOf, true);
 };
 
+/**
+ * A tag is applied directly to items/mods (not "reference data referencing reference data" like
+ * every other kind here) — deleting it cascades to strip it from every one of them (see
+ * `GameContext` → `ItemTag`/`ItemModTag` `OnDelete(DeleteBehavior.Cascade)`), a real mutation
+ * rather than an advisory retire consequence, so both groups are marked `strong`.
+ */
+const tagReferences = (id: number, { items, itemMods }: ReferenceSources): ReferenceGroup[] => {
+	const taggedItems = items.filter((i) => i.tags.includes(id)).map((i) => i.name);
+	const taggedMods = itemMods.filter((m) => m.tags.includes(id)).map((m) => m.name);
+	return [...group('taggedItems', taggedItems, true), ...group('taggedMods', taggedMods, true)];
+};
+
 /** Every record that references the given retireable record, grouped by relationship (empty when none). */
 export function computeReferences(entityKey: string, id: number, sources: ReferenceSources): ReferenceGroup[] {
 	switch (entityKey) {
@@ -176,6 +192,8 @@ export function computeReferences(entityKey: string, id: number, sources: Refere
 			return proficiencyReferences(id, sources);
 		case 'paths':
 			return pathReferences(id, sources);
+		case 'tags':
+			return tagReferences(id, sources);
 		default:
 			return [];
 	}
@@ -239,6 +257,10 @@ const clauseFor = (entityKey: string, ref: ReferenceGroup): string => {
 			return entityKey === 'paths'
 				? `home to a tier that gates ${count(n, 'proficiency', 'proficiencies')} (${names})`
 				: `a prerequisite for ${count(n, 'proficiency', 'proficiencies')} (${names})`;
+		case 'taggedItems':
+			return `applied to ${count(n, 'item')} (${names})`;
+		case 'taggedMods':
+			return `applied to ${count(n, 'mod')} (${names})`;
 	}
 };
 
@@ -254,15 +276,26 @@ const joinClauses = (clauses: string[]): string => {
 };
 
 /**
- * Prose body for the retire confirm dialog, enumerating the inbound references. Plain text (the
- * modal renders the body as-is), matching the existing confirm-dialog convention.
+ * Prose body for the retire/delete confirm dialog, enumerating the inbound references. Plain text
+ * (the modal renders the body as-is), matching the existing confirm-dialog convention.
  */
 export function formatReferenceBody(entityKey: string, name: string, groups: ReferenceGroup[]): string {
 	const list = joinClauses(groups.map((g) => clauseFor(entityKey, g)));
-	// A strong reference (the gate-lockout case) has a real consequence for new players that
-	// "the id still resolves" doesn't soften, so close by pointing at the fix rather than reassuring.
-	const closing = groups.some((g) => g.strong)
-		? 'Existing references still resolve by id, but re-point the affected records first if that consequence is unintended.'
-		: 'Retiring takes it out of circulation for new content, though existing references still resolve by id.';
-	return `${name} is ${list}. ${closing}`;
+	return `${name} is ${list}. ${closingFor(entityKey, groups)}`;
 }
+
+/**
+ * Tags are hard-deleted (not retired) and the cascade actually strips them off every item/mod
+ * listed above, so the retire framing ("still resolves by id") would be false for them — every
+ * other entity here is retired, where a strong reference has a real consequence for new players
+ * that "the id still resolves" doesn't soften, so it closes by pointing at the fix instead.
+ */
+const closingFor = (entityKey: string, groups: ReferenceGroup[]): string => {
+	if (entityKey === 'tags') {
+		return 'Deleting removes it from every item and mod listed above, and this cannot be undone.';
+	}
+	if (groups.some((g) => g.strong)) {
+		return 'Existing references still resolve by id, but re-point the affected records first if that consequence is unintended.';
+	}
+	return 'Retiring takes it out of circulation for new content, though existing references still resolve by id.';
+};

--- a/UI/src/routes/admin/workbench/retire-confirm.ts
+++ b/UI/src/routes/admin/workbench/retire-confirm.ts
@@ -15,6 +15,7 @@ export function referenceSourcesFromStatic(overrides: Partial<ReferenceSources> 
 		zones: staticData.zones ?? [],
 		challenges: staticData.challenges ?? [],
 		items: staticData.items ?? [],
+		itemMods: staticData.itemMods ?? [],
 		classes: staticData.classes ?? [],
 		skillRecipes: staticData.skillRecipes ?? [],
 		proficiencies: staticData.proficiencies ?? [],
@@ -23,13 +24,7 @@ export function referenceSourcesFromStatic(overrides: Partial<ReferenceSources> 
 	};
 }
 
-/**
- * Shared retire flow: compute the referenced-by surface for a record, confirm via a danger modal
- * only when something actually references it, then run the retire action. Used by both the
- * generic Workbench detail pane and the bespoke progression editor (paths/proficiencies aren't a
- * generic `EntityConfig`, so they can't go through {@link ../components/WorkbenchDetail.svelte}).
- */
-export async function retireWithConfirm(options: {
+interface ConfirmMutationOptions {
 	entityKey: string;
 	id: number;
 	/** Display name used in the confirm dialog body. */
@@ -38,18 +33,35 @@ export async function retireWithConfirm(options: {
 	title: string;
 	sources: ReferenceSources;
 	onConfirmed: () => void;
-}): Promise<void> {
+}
+
+/**
+ * Shared flow behind {@link retireWithConfirm} and {@link deleteWithConfirm}: compute the
+ * referenced-by surface for a record, confirm via a danger modal only when something actually
+ * references it, then run the action.
+ */
+async function confirmMutation(options: ConfirmMutationOptions, confirmLabel: string): Promise<void> {
 	const { entityKey, id, name, title, sources, onConfirmed } = options;
 	const groups = computeReferences(entityKey, id, sources);
 	if (groups.length > 0) {
-		const confirmed = await dangerModal({
-			title,
-			body: formatReferenceBody(entityKey, name, groups),
-			confirmLabel: 'Retire anyway'
-		});
+		const confirmed = await dangerModal({ title, body: formatReferenceBody(entityKey, name, groups), confirmLabel });
 		if (!confirmed) {
 			return;
 		}
 	}
 	onConfirmed();
+}
+
+/**
+ * Used by both the generic Workbench detail pane and the bespoke progression editor
+ * (paths/proficiencies aren't a generic `EntityConfig`, so they can't go through
+ * {@link ../components/WorkbenchDetail.svelte}).
+ */
+export function retireWithConfirm(options: ConfirmMutationOptions): Promise<void> {
+	return confirmMutation(options, 'Retire anyway');
+}
+
+/** Used by the Workbench detail pane for tags — the one non-retireable entity, hard-deleted instead. */
+export function deleteWithConfirm(options: ConfirmMutationOptions): Promise<void> {
+	return confirmMutation(options, 'Delete anyway');
 }

--- a/UI/src/tests/routes/admin/workbench/WorkbenchDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/WorkbenchDetail.test.ts
@@ -59,6 +59,8 @@ beforeEach(() => {
 	staticData.zones = [];
 	staticData.enemies = [];
 	staticData.challenges = [];
+	staticData.items = [];
+	staticData.itemMods = [];
 	dangerModal.mockReset();
 });
 afterEach(cleanup);
@@ -297,5 +299,64 @@ describe('WorkbenchDetail — retire confirm dialog', () => {
 
 		expect(dangerModal).not.toHaveBeenCalled();
 		expect(s.isRetired(s.items.find((r) => r.id === rec.id)!)).toBe(true);
+	});
+});
+
+describe('WorkbenchDetail — delete confirm dialog (tags)', () => {
+	const renderTag = (s: EntityStore<Identified>, rec: Identified) =>
+		render(WorkbenchDetail, {
+			props: {
+				entity: makeConfig(false, 'tags'),
+				store: s,
+				record: rec,
+				baseline: s.baselineOf(rec.id),
+				tab: 'identity',
+				onTab: vi.fn(),
+				onNew: vi.fn()
+			}
+		});
+
+	it('opens a confirm dialog enumerating applied items/mods and deletes only on confirm', async () => {
+		staticData.items = [{ id: 0, name: 'Iron Helm', tags: [1] }];
+		dangerModal.mockResolvedValue(true);
+
+		const s = new EntityStore(makeConfig(false, 'tags'), seed);
+		const rec = s.items[0];
+		renderTag(s, rec);
+
+		await fireEvent.click(screen.getByText('Delete'));
+
+		expect(dangerModal).toHaveBeenCalledOnce();
+		const call = dangerModal.mock.calls[0][0];
+		expect(call.body).toContain('Iron Helm');
+		expect(call.confirmLabel).toBe('Delete anyway');
+		await waitFor(() => expect(s.status(rec)).toBe('deleted'));
+	});
+
+	it('does not delete when the confirm dialog is cancelled', async () => {
+		staticData.items = [{ id: 0, name: 'Iron Helm', tags: [1] }];
+		dangerModal.mockResolvedValue(false);
+
+		const s = new EntityStore(makeConfig(false, 'tags'), seed);
+		const rec = s.items[0];
+		renderTag(s, rec);
+
+		await fireEvent.click(screen.getByText('Delete'));
+
+		expect(dangerModal).toHaveBeenCalledOnce();
+		expect(s.status(rec)).toBe('clean');
+	});
+
+	it('deletes an unapplied tag without prompting', async () => {
+		dangerModal.mockResolvedValue(true);
+
+		const s = new EntityStore(makeConfig(false, 'tags'), seed);
+		const rec = s.items[0];
+		renderTag(s, rec);
+
+		await fireEvent.click(screen.getByText('Delete'));
+
+		expect(dangerModal).not.toHaveBeenCalled();
+		expect(s.status(rec)).toBe('deleted');
 	});
 });

--- a/UI/src/tests/routes/admin/workbench/references.test.ts
+++ b/UI/src/tests/routes/admin/workbench/references.test.ts
@@ -4,6 +4,7 @@ import {
 	EChallengeType,
 	EEntityType,
 	EItemCategory,
+	EItemModType,
 	EModifierType,
 	ERarity,
 	ESkillAcquisition,
@@ -11,6 +12,7 @@ import {
 	type IClass,
 	type IEnemy,
 	type IItem,
+	type IItemMod,
 	type IProficiency,
 	type ISkill,
 	type ISkillRecipe,
@@ -69,6 +71,18 @@ const item = (id: number, name: string, opts: Partial<IItem> = {}): IItem => ({
 	modSlots: [],
 	tags: [],
 	requiredProficiencyLevel: 1,
+	designerNotes: '',
+	...opts
+});
+
+const itemMod = (id: number, name: string, opts: Partial<IItemMod> = {}): IItemMod => ({
+	id,
+	name,
+	description: '',
+	itemModTypeId: EItemModType.Prefix,
+	rarityId: ERarity.Common,
+	attributes: [],
+	tags: [],
 	designerNotes: '',
 	...opts
 });
@@ -177,6 +191,7 @@ const sources = (): ReferenceSources => ({
 		challenge(3, 'Skill Spammer', { entityType: EEntityType.Skill, targetEntityId: 1 })
 	],
 	items: [],
+	itemMods: [],
 	classes: [],
 	skillRecipes: [],
 	proficiencies: [],
@@ -395,6 +410,30 @@ describe('computeReferences — paths', () => {
 	});
 });
 
+describe('computeReferences — tags', () => {
+	it('lists the items and mods the tag is applied to, both marked strong', () => {
+		const src = {
+			...sources(),
+			items: [item(0, 'Iron Helm', { tags: [10] }), item(1, 'Dragon Blade', { tags: [10, 20] })],
+			itemMods: [itemMod(0, 'Sharp', { tags: [10] })]
+		};
+		expect(computeReferences('tags', 10, src)).toEqual([
+			{ kind: 'taggedItems', names: ['Iron Helm', 'Dragon Blade'], strong: true },
+			{ kind: 'taggedMods', names: ['Sharp'], strong: true }
+		]);
+	});
+
+	it('reports only the applied mods when no item carries the tag', () => {
+		const src = { ...sources(), itemMods: [itemMod(0, 'Sharp', { tags: [10] })] };
+		expect(computeReferences('tags', 10, src)).toEqual([{ kind: 'taggedMods', names: ['Sharp'], strong: true }]);
+	});
+
+	it('returns nothing for an unused tag', () => {
+		const src = { ...sources(), items: [item(0, 'Iron Helm', { tags: [20] })] };
+		expect(computeReferences('tags', 10, src)).toEqual([]);
+	});
+});
+
 describe('computeReferences — unknown entity', () => {
 	it('returns no references for an unrecognized entity key', () => {
 		expect(computeReferences('widgets', 0, sources())).toEqual([]);
@@ -456,6 +495,15 @@ describe('formatReferenceBody', () => {
 			'out of circulation for new content'
 		);
 		expect(formatReferenceBody('items', 'Iron Helm', normal)).toContain('out of circulation for new content');
+	});
+
+	it('closes a tag reference with the cascade-delete wording instead of the retire framing', () => {
+		const groups: ReferenceGroup[] = [{ kind: 'taggedItems', names: ['Iron Helm'], strong: true }];
+		const body = formatReferenceBody('tags', 'Fire', groups);
+		expect(body).toContain('Fire is applied to 1 item (Iron Helm)');
+		expect(body).toContain('Deleting removes it from every item and mod listed above, and this cannot be undone.');
+		expect(body).not.toContain('still resolve by id');
+		expect(body).not.toContain('out of circulation');
 	});
 
 	it('caps long name lists with a "+N more" tail', () => {

--- a/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
+++ b/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
@@ -7,7 +7,11 @@ const { dangerModal, staticData } = vi.hoisted(() => ({
 }));
 vi.mock('$stores', () => ({ dangerModal, staticData }));
 
-import { referenceSourcesFromStatic, retireWithConfirm } from '$routes/admin/workbench/retire-confirm';
+import {
+	deleteWithConfirm,
+	referenceSourcesFromStatic,
+	retireWithConfirm
+} from '$routes/admin/workbench/retire-confirm';
 import type { ReferenceSources } from '$routes/admin/workbench/references';
 
 const emptySources: ReferenceSources = {
@@ -15,6 +19,7 @@ const emptySources: ReferenceSources = {
 	zones: [],
 	challenges: [],
 	items: [],
+	itemMods: [],
 	classes: [],
 	skillRecipes: [],
 	proficiencies: [],
@@ -23,7 +28,17 @@ const emptySources: ReferenceSources = {
 
 beforeEach(() => {
 	dangerModal.mockReset();
-	for (const key of ['enemies', 'zones', 'challenges', 'items', 'classes', 'skillRecipes', 'proficiencies', 'skills']) {
+	for (const key of [
+		'enemies',
+		'zones',
+		'challenges',
+		'items',
+		'itemMods',
+		'classes',
+		'skillRecipes',
+		'proficiencies',
+		'skills'
+	]) {
 		delete staticData[key];
 	}
 });
@@ -163,5 +178,68 @@ describe('retireWithConfirm', () => {
 		const body = dangerModal.mock.calls[0][0].body as string;
 		expect(body).toContain('Warrior');
 		expect(onConfirmed).toHaveBeenCalledOnce();
+	});
+});
+
+describe('deleteWithConfirm', () => {
+	it('deletes immediately, without prompting, when nothing carries the tag', async () => {
+		const onConfirmed = vi.fn();
+		await deleteWithConfirm({
+			entityKey: 'tags',
+			id: 10,
+			name: 'Fire',
+			title: 'Delete Tag?',
+			sources: emptySources,
+			onConfirmed
+		});
+
+		expect(dangerModal).not.toHaveBeenCalled();
+		expect(onConfirmed).toHaveBeenCalledOnce();
+	});
+
+	it('prompts with the applied-to body under a "Delete anyway" label and deletes only when confirmed', async () => {
+		dangerModal.mockResolvedValue(true);
+		const onConfirmed = vi.fn();
+		const sources: ReferenceSources = {
+			...emptySources,
+			items: [{ id: 0, name: 'Iron Helm', tags: [10] }] as unknown as ReferenceSources['items']
+		};
+
+		await deleteWithConfirm({
+			entityKey: 'tags',
+			id: 10,
+			name: 'Fire',
+			title: 'Delete Tag?',
+			sources,
+			onConfirmed
+		});
+
+		expect(dangerModal).toHaveBeenCalledOnce();
+		const call = dangerModal.mock.calls[0][0];
+		expect(call.title).toBe('Delete Tag?');
+		expect(call.confirmLabel).toBe('Delete anyway');
+		expect(call.body).toContain('Iron Helm');
+		expect(onConfirmed).toHaveBeenCalledOnce();
+	});
+
+	it('does not delete when the confirm dialog is cancelled', async () => {
+		dangerModal.mockResolvedValue(false);
+		const onConfirmed = vi.fn();
+		const sources: ReferenceSources = {
+			...emptySources,
+			itemMods: [{ id: 0, name: 'Sharp', tags: [10] }] as unknown as ReferenceSources['itemMods']
+		};
+
+		await deleteWithConfirm({
+			entityKey: 'tags',
+			id: 10,
+			name: 'Fire',
+			title: 'Delete Tag?',
+			sources,
+			onConfirmed
+		});
+
+		expect(dangerModal).toHaveBeenCalledOnce();
+		expect(onConfirmed).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

Tags are the only non-`retireable` Workbench entity, so the detail header's Delete button called `store.removeItem(record.id)` directly with no confirmation of any kind — unlike every retire path, which surfaces a referenced-by confirm dialog. Since `ItemTag`/`ItemModTag` cascade-delete (`Game.Infrastructure/Database/GameContext.cs`), deleting a tag applied to 40 items silently strips it from all 40 records in one save, with no warning and no visibility into what's affected.

## Changes

- **`references.ts`**: added `itemMods: IItemMod[]` to `ReferenceSources`, a `tagReferences` function that finds every item/mod currently carrying the tag (both marked `strong`, since the cascade is a real mutation, not an advisory retire consequence), and a `'tags'` case in `computeReferences`. `formatReferenceBody`'s closing text now branches on `entityKey === 'tags'` — the retire framing ("existing references still resolve by id") is false for a hard delete, so tags get delete-specific copy instead.
- **`retire-confirm.ts`**: generalized the shared "compute references → confirm via danger modal → run the action" flow into a private `confirmMutation(options, confirmLabel)`, with `retireWithConfirm` and the new `deleteWithConfirm` as thin wrappers (`'Retire anyway'` / `'Delete anyway'`). `referenceSourcesFromStatic` now also populates `itemMods`.
- **`WorkbenchDetail.svelte`**: the non-retireable-entity Delete button now calls a new `onDelete` handler routed through `deleteWithConfirm`, mirroring the existing `onRetire` handler.

No other entity is affected — tags remain the only non-retireable Workbench entity, so `computeReferences`'s other cases and `retireWithConfirm`'s three existing call sites (generic Workbench, `PathDetail`, `TierDetail`) are unchanged.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — full suite, 3696/3696 passed, including new coverage:
  - `computeReferences('tags', …)` — applied items/mods, strong flag, unused-tag empty case
  - `formatReferenceBody` — tag-specific closing copy, no "still resolves by id" language
  - `deleteWithConfirm` — prompts only when the tag is applied, `'Delete anyway'` label, cancels correctly
  - `WorkbenchDetail` — confirm dialog opens/blocks/passes-through for the tag delete flow, mirroring the existing retire-dialog tests

Closes #1893


---
_Generated by [Claude Code](https://claude.ai/code/session_01B6itoQfAQd9oKkJzwxVLAE)_