### PR TITLE
Treat added-with-empty-collection as unchanged in childChanged

### DIFF
--- a/UI/src/routes/admin/workbench/save-helpers.ts
+++ b/UI/src/routes/admin/workbench/save-helpers.ts
@@ -33,9 +33,17 @@ export const canonicalEqual = (a: unknown, b: unknown): boolean =>
 
 export const listsEqual = canonicalEqual;
 
-/** True when a child collection differs from its saved baseline (added records have none). */
-export const childChanged = <T>(current: T, baseline: T | undefined): boolean =>
-	baseline === undefined || !listsEqual(current, baseline);
+/**
+ * True when a child collection differs from its saved baseline (added records have none). An
+ * added record with an empty current collection is treated as unchanged — nothing was actually
+ * added to it — so a brand-new record doesn't trigger a no-op write for every empty child section.
+ */
+export const childChanged = <T>(current: T, baseline: T | undefined): boolean => {
+	if (baseline === undefined) {
+		return !(Array.isArray(current) && current.length === 0);
+	}
+	return !listsEqual(current, baseline);
+};
 
 /**
  * Map the local (negative) ids of added records to their persisted ids. Purely positional pairing (the

--- a/UI/src/tests/routes/admin/workbench/entities/enemy.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/enemy.test.ts
@@ -180,6 +180,28 @@ describe('enemyEntity', () => {
 		expect(postBodyTo('AdminTools/SetEnemySpawns')).toEqual({ enemyId: 7, spawns: [{ zoneId: 1, weight: 8 }] });
 	});
 
+	it('persist Adds a bare new enemy without posting empty child collections (#1895)', async () => {
+		const added: WorkbenchEnemy = {
+			id: -1,
+			name: 'New Enemy',
+			designerNotes: '',
+			isBoss: false,
+			attributeDistribution: [],
+			skillPool: [],
+			spawns: [],
+			bossZones: []
+		};
+		socket.enemies = [{ ...added, id: 7 }];
+
+		await enemyEntity.persist({ added: [added], modified: [], deleted: [], existingIds: [] });
+
+		expect(postBodyTo('AdminTools/AddEditEnemies')[0].changeType).toBe(EChangeType.Add);
+		// Nothing was ever added to any child collection, so none of their setters should post.
+		expect(postBodyTo('AdminTools/SetEnemyAttributeDistributions')).toBeUndefined();
+		expect(postBodyTo('AdminTools/SetEnemySkills')).toBeUndefined();
+		expect(postBodyTo('AdminTools/SetEnemySpawns')).toBeUndefined();
+	});
+
 	it('refresh derives bossZones from the zones whose dedicated boss is this enemy', async () => {
 		socket.enemies = [
 			{ id: 0, name: 'Bat', isBoss: false, attributeDistribution: [], skillPool: [], spawns: [] },

--- a/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
@@ -336,6 +336,36 @@ describe('save orchestration', () => {
 		expect(store.totalChanges).toBe(0);
 	});
 
+	it('does not post empty child collections for a brand-new path/tier with no modifiers, rewards, or prerequisites (#1895)', async () => {
+		const store = new ProgressionStore();
+		await store.load();
+
+		store.addPath();
+		const pathLocal = store.selectedPathId as number;
+		store.patchPath(pathLocal, (d) => {
+			d.name = 'Fire';
+			d.activityKey = EActivityKey.Fire;
+		});
+		const tierLocal = store.currentTiers[0].id;
+		store.patchProf(tierLocal, (d) => {
+			d.name = 'Fire T0';
+			d.word = 'fyr';
+			d.pronunciation = 'fyoor';
+			d.translation = 'Fire';
+			d.iconPath = 'fire.png';
+		});
+
+		await store.save();
+
+		// The identity batches still post (path + proficiency), but nothing was ever added to the
+		// new tier's modifiers/rewards/prerequisites, so those child setters must stay untouched.
+		expect(callsTo('AdminTools/AddEditPaths')).toHaveLength(1);
+		expect(callsTo('AdminTools/AddEditProficiencies')).toHaveLength(1);
+		expect(callsTo('AdminTools/SetProficiencyModifiers')).toHaveLength(0);
+		expect(callsTo('AdminTools/SetProficiencyRewards')).toHaveLength(0);
+		expect(callsTo('AdminTools/SetProficiencyPrerequisites')).toHaveLength(0);
+	});
+
 	it('resolves a same-save-new-path proficiency by identity content, not position, when a concurrent add lands at a lower id (#1856)', async () => {
 		const store = new ProgressionStore();
 		await store.load();
@@ -460,8 +490,9 @@ describe('save orchestration', () => {
 
 		const prereqCalls = callsTo('AdminTools/SetProficiencyPrerequisites');
 		expect(prereqCalls).toHaveLength(1);
+		// The new tier (id 2) never has a prerequisite added to it — its prerequisiteIds stay empty
+		// against its (nonexistent) baseline, which is a no-op and must not post (#1895).
 		expect(prereqCalls[0]).toEqual([
-			{ id: 2, prerequisiteIds: [] },
 			{ id: 0, prerequisiteIds: [2] },
 			{ id: 1, prerequisiteIds: [0] }
 		]);

--- a/UI/src/tests/routes/admin/workbench/save-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/save-helpers.test.ts
@@ -11,6 +11,7 @@ import {
 import {
 	attributeChanges,
 	canonicalEqual,
+	childChanged,
 	modSlotChanges,
 	persistEntity,
 	PersistFailedError,
@@ -39,6 +40,24 @@ describe('canonicalEqual', () => {
 	it('compares nested arrays and objects structurally', () => {
 		expect(canonicalEqual({ xs: [{ a: 1, b: 2 }] }, { xs: [{ b: 2, a: 1 }] })).toBe(true);
 		expect(canonicalEqual([1, 2], [2, 1])).toBe(false);
+	});
+});
+
+describe('childChanged', () => {
+	it('treats a newly-added record with an empty current collection as unchanged (#1895)', () => {
+		expect(childChanged([], undefined)).toBe(false);
+	});
+
+	it('still reports a newly-added record with a non-empty current collection as changed', () => {
+		expect(childChanged([{ id: 1 }], undefined)).toBe(true);
+	});
+
+	it('still reports changed when baseline is defined and differs, even if now empty', () => {
+		expect(childChanged([], [{ id: 1 }])).toBe(true);
+	});
+
+	it('reports unchanged when current equals a defined baseline', () => {
+		expect(childChanged([{ id: 1 }], [{ id: 1 }])).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Summary

`childChanged(current, baseline)` (`UI/src/routes/admin/workbench/save-helpers.ts`) unconditionally returned `true` whenever `baseline === undefined` — i.e. for **every** newly-added Workbench record's child collection, even when that collection is empty. Saving one brand-new enemy with only a name therefore posted `SetEnemyAttributeDistributions {[]}`, `SetEnemySkills {[]}`, and `SetEnemySpawns {[]}` — three no-op HTTP writes, each triggering the all-sets reference-cache rebuild + cross-instance broadcast documented in #1708. The same pattern existed in `zone.ts`, `class.ts`, `skill-recipe.ts`, `lesson.ts`, and (worse) the Progression store, where a new path's auto-created tier posted `SetProficiencyModifiers {[]}`, `SetProficiencyRewards {[]}`, and `SetProficiencyPrerequisites [{prerequisiteIds: []}]` on top of its two identity batches.

## Change

`childChanged` now treats an added record (`baseline === undefined`) whose current collection is an empty array as unchanged, so a new record only posts the child writes that actually carry data. This is the single shared helper every `EntityConfig`'s child savers and the Progression store's save orchestration route through, so the fix applies uniformly across all entities without touching each call site.

## Test plan

- [x] Added unit tests for `childChanged` covering the new empty-vs-non-empty-add and defined-baseline cases (`save-helpers.test.ts`).
- [x] Added an entity-level regression test: adding a bare new enemy (all child collections empty) no longer posts `SetEnemyAttributeDistributions`/`SetEnemySkills`/`SetEnemySpawns` (`enemy.test.ts`).
- [x] Added a Progression-store regression test: a brand-new path + auto-created tier with no modifiers/rewards/prerequisites no longer posts those three child setters (`progression-store.test.ts`).
- [x] Updated an existing prerequisite-batching test whose expectation baked in the old over-posting behavior (an unmodified new tier no longer appears in the prerequisites batch with an empty array).
- [x] `npm run lint` — clean.
- [x] `npm run test:unit:ci` — 299 files / 3702 tests passing.

Closes #1895


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lan7Ve4JeGEkvAtLb5jyhg)_