### PR TITLE
Early-exit evaluateMechanicTriggers once all mechanic lessons unlock

### DIFF
--- a/UI/src/lib/engine/tutorials.ts
+++ b/UI/src/lib/engine/tutorials.ts
@@ -1,4 +1,4 @@
-import { ELessonTriggerType, EMechanicEvent, type ILesson } from '$lib/api';
+import { ELessonTriggerType, EMechanicEvent, type ILesson, type IPlayerLesson } from '$lib/api';
 import { isFirstCooldownRecharge, isFirstCrit, isFirstDodge } from '$lib/common/content-events';
 import type { SkillActivation } from '$lib/battle/battle-step';
 import { navigation, staticData, tutorialTour } from '$stores';
@@ -80,6 +80,16 @@ const mechanicFired = (
 	}
 };
 
+// Memoized "is there still a locked mechanic-anchored lesson" flag for evaluateMechanicTriggers
+// below, keyed against the two sources it derives from (#1900/#1901). Once every mechanic lesson
+// has unlocked — the common steady state past onboarding — this lets the hot tick loop skip
+// liveLessons()'s filter allocation and isLocked's linear scan entirely. Re-armed whenever either
+// source's reference changes (a reference-data reload, or the player data being re-initialized —
+// e.g. the welcome-back gate's refreshPlayer) rather than trusting the cached verdict to still hold.
+let mechanicLessonsSource: ILesson[] | undefined;
+let mechanicLessonsPlayerSource: IPlayerLesson[] | undefined;
+let anyLockedMechanicLesson = true;
+
 /**
  * Mechanic-anchored trigger (spike #1392, #1587): call with each battle tick's activations (wired
  * into `BattleEngine.logicalUpdate`). A locked mechanic lesson whose event fires this tick is
@@ -89,13 +99,25 @@ const mechanicFired = (
  * can't re-fire it.
  */
 export function evaluateMechanicTriggers(activations: readonly SkillActivation[]) {
+	if (staticData.lessons !== mechanicLessonsSource || playerManager.lessons !== mechanicLessonsPlayerSource) {
+		mechanicLessonsSource = staticData.lessons;
+		mechanicLessonsPlayerSource = playerManager.lessons;
+		anyLockedMechanicLesson = true;
+	}
+	if (!anyLockedMechanicLesson) {
+		return;
+	}
+
+	let stillLocked = false;
 	for (const lesson of liveLessons()) {
-		if (
-			lesson.triggerType === ELessonTriggerType.MechanicEvent &&
-			isLocked(lesson.id) &&
-			mechanicFired(lesson.triggerMechanicEvent, activations)
-		) {
+		if (lesson.triggerType !== ELessonTriggerType.MechanicEvent || !isLocked(lesson.id)) {
+			continue;
+		}
+		if (mechanicFired(lesson.triggerMechanicEvent, activations)) {
 			playerManager.unlockLesson(lesson.id);
+		} else {
+			stillLocked = true;
 		}
 	}
+	anyLockedMechanicLesson = stillLocked;
 }

--- a/UI/src/tests/lib/engine/tutorials.test.ts
+++ b/UI/src/tests/lib/engine/tutorials.test.ts
@@ -7,28 +7,30 @@ import { staticData, navigation, tutorialTour } from '$stores';
 // Controllable stub for the player-manager boundary — the same shape/behavior as the real
 // unlockLesson/markLessonRead (idempotent, absent-entry-tolerant), so the locked/unread/read
 // transitions under test reflect real gating rather than a hand-waved spy.
-const { mockLessons, mockUnlockLesson, mockMarkLessonRead } = vi.hoisted(() => {
-	const mockLessons: { lessonId: number; unlockedAt: string; readAt?: string }[] = [];
+const { mockLessonsRef, mockUnlockLesson, mockMarkLessonRead } = vi.hoisted(() => {
+	const mockLessonsRef: { current: { lessonId: number; unlockedAt: string; readAt?: string }[] } = {
+		current: []
+	};
 	const mockUnlockLesson = vi.fn((lessonId: number) => {
-		if (!mockLessons.some((lesson) => lesson.lessonId === lessonId)) {
-			mockLessons.push({ lessonId, unlockedAt: 'now' });
+		if (!mockLessonsRef.current.some((lesson) => lesson.lessonId === lessonId)) {
+			mockLessonsRef.current.push({ lessonId, unlockedAt: 'now' });
 		}
 	});
 	const mockMarkLessonRead = vi.fn((lessonId: number) => {
-		const lesson = mockLessons.find((l) => l.lessonId === lessonId);
+		const lesson = mockLessonsRef.current.find((l) => l.lessonId === lessonId);
 		if (lesson) {
 			lesson.readAt = 'now';
 		} else {
-			mockLessons.push({ lessonId, unlockedAt: 'now', readAt: 'now' });
+			mockLessonsRef.current.push({ lessonId, unlockedAt: 'now', readAt: 'now' });
 		}
 	});
-	return { mockLessons, mockUnlockLesson, mockMarkLessonRead };
+	return { mockLessonsRef, mockUnlockLesson, mockMarkLessonRead };
 });
 
 vi.mock('$lib/engine/player/player-manager', () => ({
 	playerManager: {
 		get lessons() {
-			return mockLessons;
+			return mockLessonsRef.current;
 		},
 		unlockLesson: mockUnlockLesson,
 		markLessonRead: mockMarkLessonRead
@@ -62,7 +64,7 @@ const activation = (overrides: Partial<SkillActivation> = {}): SkillActivation =
 });
 
 beforeEach(() => {
-	mockLessons.length = 0;
+	mockLessonsRef.current = [];
 	mockUnlockLesson.mockClear();
 	mockMarkLessonRead.mockClear();
 	staticData.lessons = [];
@@ -125,7 +127,7 @@ describe('evaluateScreenTrigger', () => {
 	it('does not re-fire once the lesson is already unlocked (no re-trigger on a later revisit)', () => {
 		const lesson = makeLesson({ id: 2, screenKey: 'attributes' });
 		staticData.lessons = [lesson];
-		mockLessons.push({ lessonId: 2, unlockedAt: 'now' });
+		mockLessonsRef.current.push({ lessonId: 2, unlockedAt: 'now' });
 
 		evaluateScreenTrigger('attributes');
 
@@ -135,7 +137,7 @@ describe('evaluateScreenTrigger', () => {
 	it('does not re-fire once the lesson has been read', () => {
 		const lesson = makeLesson({ id: 2, screenKey: 'attributes' });
 		staticData.lessons = [lesson];
-		mockLessons.push({ lessonId: 2, unlockedAt: 'now', readAt: 'now' });
+		mockLessonsRef.current.push({ lessonId: 2, unlockedAt: 'now', readAt: 'now' });
 
 		evaluateScreenTrigger('attributes');
 
@@ -178,7 +180,7 @@ describe('evaluateScreenTrigger', () => {
 		const readLesson = makeLesson({ id: 2, screenKey: 'attributes' });
 		const lockedLesson = makeLesson({ id: 6, screenKey: 'attributes', ordinal: 1 });
 		staticData.lessons = [readLesson, lockedLesson];
-		mockLessons.push({ lessonId: 2, unlockedAt: 'now', readAt: 'now' });
+		mockLessonsRef.current.push({ lessonId: 2, unlockedAt: 'now', readAt: 'now' });
 
 		evaluateScreenTrigger('attributes');
 
@@ -237,7 +239,7 @@ describe('evaluateMechanicTriggers', () => {
 			triggerMechanicEvent: EMechanicEvent.FirstCrit
 		});
 		staticData.lessons = [lesson];
-		mockLessons.push({ lessonId: 3, unlockedAt: 'now' });
+		mockLessonsRef.current.push({ lessonId: 3, unlockedAt: 'now' });
 
 		evaluateMechanicTriggers([activation({ byPlayer: true, crit: true })]);
 
@@ -251,7 +253,7 @@ describe('evaluateMechanicTriggers', () => {
 			triggerMechanicEvent: EMechanicEvent.FirstCrit
 		});
 		staticData.lessons = [lesson];
-		mockLessons.push({ lessonId: 3, unlockedAt: 'now', readAt: 'now' });
+		mockLessonsRef.current.push({ lessonId: 3, unlockedAt: 'now', readAt: 'now' });
 
 		evaluateMechanicTriggers([activation({ byPlayer: true, crit: true })]);
 
@@ -289,5 +291,101 @@ describe('evaluateMechanicTriggers', () => {
 
 		expect(mockUnlockLesson).toHaveBeenCalledTimes(1);
 		expect(mockUnlockLesson).toHaveBeenCalledWith(4);
+	});
+
+	// #1900/#1901: evaluateMechanicTriggers memoizes "is any mechanic-anchored lesson still locked"
+	// so the steady state (everything already unlocked) can skip its per-tick scan. These pin that the
+	// memoization never skips a tick that still has real work to do.
+	describe('locked-lesson memoization', () => {
+		it('keeps evaluating on a later tick while one of two lessons is still locked', () => {
+			const critLesson = makeLesson({
+				id: 3,
+				triggerType: ELessonTriggerType.MechanicEvent,
+				triggerMechanicEvent: EMechanicEvent.FirstCrit
+			});
+			const dodgeLesson = makeLesson({
+				id: 4,
+				triggerType: ELessonTriggerType.MechanicEvent,
+				triggerMechanicEvent: EMechanicEvent.FirstDodge
+			});
+			staticData.lessons = [critLesson, dodgeLesson];
+
+			// Tick 1: only the crit lesson fires — the dodge lesson stays locked, so the "any locked
+			// mechanic lesson" flag must not flip to exhausted.
+			evaluateMechanicTriggers([activation({ byPlayer: true, crit: true })]);
+			expect(mockUnlockLesson).toHaveBeenCalledWith(3);
+			mockUnlockLesson.mockClear();
+
+			// Tick 2, same staticData/player-lesson references: the dodge lesson must still be evaluated
+			// and unlocked, not skipped by a cache that wrongly assumed nothing was left locked.
+			evaluateMechanicTriggers([activation({ byPlayer: false, dodged: true })]);
+			expect(mockUnlockLesson).toHaveBeenCalledWith(4);
+		});
+
+		it('does not re-fire on a later tick once every mechanic lesson has unlocked', () => {
+			const lesson = makeLesson({
+				id: 3,
+				triggerType: ELessonTriggerType.MechanicEvent,
+				triggerMechanicEvent: EMechanicEvent.FirstCrit
+			});
+			staticData.lessons = [lesson];
+
+			evaluateMechanicTriggers([activation({ byPlayer: true, crit: true })]);
+			expect(mockUnlockLesson).toHaveBeenCalledTimes(1);
+			mockUnlockLesson.mockClear();
+
+			// Steady state: further ticks (even ones that would otherwise match) must stay a no-op.
+			evaluateMechanicTriggers([activation({ byPlayer: true, crit: true })]);
+			expect(mockUnlockLesson).not.toHaveBeenCalled();
+		});
+
+		it('recomputes after a reference-data reload adds a new mechanic lesson past exhaustion', () => {
+			const critLesson = makeLesson({
+				id: 3,
+				triggerType: ELessonTriggerType.MechanicEvent,
+				triggerMechanicEvent: EMechanicEvent.FirstCrit
+			});
+			staticData.lessons = [critLesson];
+
+			// Exhaust the cache: the only mechanic lesson unlocks, so the memoized flag flips to "none
+			// locked remain".
+			evaluateMechanicTriggers([activation({ byPlayer: true, crit: true })]);
+			expect(mockUnlockLesson).toHaveBeenCalledTimes(1);
+			mockUnlockLesson.mockClear();
+
+			// Reference data reloads with a new locked mechanic lesson — a new array reference, not a
+			// mutation of the old one, mirroring how the reference-data cache actually replaces its data.
+			const dodgeLesson = makeLesson({
+				id: 4,
+				triggerType: ELessonTriggerType.MechanicEvent,
+				triggerMechanicEvent: EMechanicEvent.FirstDodge
+			});
+			staticData.lessons = [critLesson, dodgeLesson];
+
+			evaluateMechanicTriggers([activation({ byPlayer: false, dodged: true })]);
+
+			expect(mockUnlockLesson).toHaveBeenCalledWith(4);
+		});
+
+		it('recomputes after the player-lesson array is replaced wholesale (e.g. refreshPlayer re-initializing the player)', () => {
+			const lesson = makeLesson({
+				id: 3,
+				triggerType: ELessonTriggerType.MechanicEvent,
+				triggerMechanicEvent: EMechanicEvent.FirstCrit
+			});
+			staticData.lessons = [lesson];
+
+			evaluateMechanicTriggers([activation({ byPlayer: true, crit: true })]);
+			expect(mockUnlockLesson).toHaveBeenCalledTimes(1);
+			mockUnlockLesson.mockClear();
+
+			// Simulate PlayerManager.initialize reassigning `lessons` to a freshly-fetched array (a new
+			// reference) rather than mutating the existing one in place.
+			mockLessonsRef.current = [];
+
+			evaluateMechanicTriggers([activation({ byPlayer: true, crit: true })]);
+
+			expect(mockUnlockLesson).toHaveBeenCalledWith(3);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

`evaluateMechanicTriggers` (`UI/src/lib/engine/tutorials.ts`) runs on every logical battle tick that had activations — wired into `BattleEngine.logicalUpdate`, so it stays at full rate even in hidden tabs and is amplified by `replayToOffset`'s up-to-3000-tick fast-forward. It was unconditionally allocating a fresh filtered array (`liveLessons()`) and linear-scanning `playerManager.lessons` (`isLocked`) for every mechanic-anchored lesson, even in the common steady state where every such lesson has already unlocked (i.e. past onboarding).

This adds a memoized "is there still a locked mechanic-anchored lesson" flag so the function can early-exit before touching `liveLessons()`/`isLocked()` once nothing is left to check. The flag is re-armed whenever either of its two sources changes by reference:
- `staticData.lessons` (a reference-data reload could add a new mechanic lesson)
- `playerManager.lessons` (e.g. the welcome-back gate's `refreshPlayer` re-initializing the player)

This avoids a subtler bug a naive "invalidate only on `unlockLesson`" implementation could introduce: a stale cached "nothing locked" verdict surviving a reference-data reload or player re-initialization that actually introduces newly-locked content.

No behavior change — purely a per-tick allocation/scan reduction.

## Issues addressed

Closes #1900, closes #1901 — these were near-duplicate issues (filed 4 seconds apart during the same codebase health review) describing the identical fix; both are resolved by this PR.

## Test plan

- [x] Added tests pinning the memoization's correctness: multi-tick evaluation while one of several lessons is still locked, no re-fire once every mechanic lesson has unlocked, recompute after a reference-data reload adds a new mechanic lesson past exhaustion, and recompute after the player-lesson array is replaced wholesale (`refreshPlayer`-style re-initialization).
- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — 3706/3706 tests passed across 299 files


---
_Generated by [Claude Code](https://claude.ai/code/session_0135mkdJLuV3LuZ8fwJdN2rR)_