### PR TITLE
Extract duplicated admin load-error/retry block into shared AdminLoadError

### DIFF
--- a/UI/src/routes/admin/+page.svelte
+++ b/UI/src/routes/admin/+page.svelte
@@ -41,10 +41,7 @@
 
 {#snippet referenceGate()}
 	{#if loadError}
-		<div class="admin-load-error" role="alert" data-testid="admin-reference-error">
-			<p>{loadError}</p>
-			<button type="button" class="btn" onclick={loadReference}>Refresh</button>
-		</div>
+		<AdminLoadError testid="admin-reference-error" message={loadError} onRetry={loadReference} />
 	{:else}
 		<Loading loading={true} delay={50} />
 	{/if}
@@ -55,6 +52,7 @@ import { onMount } from 'svelte';
 import { beforeNavigate, goto } from '$app/navigation';
 import { resolve } from '$app/paths';
 import { Loading } from '$components';
+import AdminLoadError from './AdminLoadError.svelte';
 import AdminSidebar from './AdminSidebar.svelte';
 import Workbench from './workbench/Workbench.svelte';
 import DeadLetterConsole from './ops/DeadLetterConsole.svelte';
@@ -161,45 +159,5 @@ $effect(() => {
 	overflow: hidden;
 	// No outer padding: the Workbench is full-bleed (list pane flush to the rail,
 	// full-width header/save bar) and supplies its own internal insets.
-}
-
-.admin-load-error {
-	flex: 1;
-	min-height: 0;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	gap: 14px;
-	padding: 20px;
-	text-align: center;
-
-	p {
-		max-width: 480px;
-		color: var(--error);
-		font-size: 13px;
-	}
-}
-
-.btn {
-	display: inline-flex;
-	align-items: center;
-	gap: 7px;
-	background: transparent;
-	border: 1px solid var(--border-light);
-	color: var(--text-secondary);
-	font-family: var(--mono);
-	font-size: 11.5px;
-	letter-spacing: 0.6px;
-	text-transform: uppercase;
-	padding: 8px 15px;
-	border-radius: 3px;
-	cursor: pointer;
-	transition: all 0.14s ease;
-	white-space: nowrap;
-
-	&:hover:not(:disabled) {
-		border-color: color-mix(in srgb, var(--white) 32%, transparent);
-	}
 }
 </style>

--- a/UI/src/routes/admin/AdminLoadError.svelte
+++ b/UI/src/routes/admin/AdminLoadError.svelte
@@ -1,0 +1,56 @@
+<div class="admin-load-error" role="alert" data-testid={testid}>
+	<p>{message}</p>
+	<button type="button" class="btn" onclick={onRetry}>Refresh</button>
+</div>
+
+<script lang="ts">
+interface Props {
+	message: string;
+	testid: string;
+	onRetry: () => void;
+}
+
+const { message, testid, onRetry }: Props = $props();
+</script>
+
+<style lang="scss">
+.admin-load-error {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 14px;
+	padding: 20px;
+	text-align: center;
+
+	p {
+		max-width: 480px;
+		color: var(--error);
+		font-size: 13px;
+	}
+}
+
+.btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	background: transparent;
+	border: 1px solid var(--border-light);
+	color: var(--text-secondary);
+	font-family: var(--mono);
+	font-size: 11.5px;
+	letter-spacing: 0.6px;
+	text-transform: uppercase;
+	padding: 8px 15px;
+	border-radius: 3px;
+	cursor: pointer;
+	transition: all 0.14s ease;
+	white-space: nowrap;
+
+	&:hover:not(:disabled) {
+		border-color: color-mix(in srgb, var(--white) 32%, transparent);
+	}
+}
+</style>

--- a/UI/src/routes/admin/workbench/Workbench.svelte
+++ b/UI/src/routes/admin/workbench/Workbench.svelte
@@ -29,10 +29,7 @@
 			/>
 		</div>
 	{:else if error}
-		<div class="workbench-error" role="alert" data-testid="workbench-error">
-			<p>{error}</p>
-			<button type="button" class="btn" onclick={loadSeed}>Refresh</button>
-		</div>
+		<AdminLoadError testid="workbench-error" message={error} onRetry={loadSeed} />
 	{:else}
 		<Loading loading={true} delay={150} />
 	{/if}
@@ -49,6 +46,7 @@ import { EntityStore } from './entity-store.svelte';
 import WorkbenchIcon from './WorkbenchIcon.svelte';
 import WorkbenchList from './components/WorkbenchList.svelte';
 import WorkbenchDetail from './components/WorkbenchDetail.svelte';
+import AdminLoadError from '../AdminLoadError.svelte';
 
 interface Props {
 	entity: EntityConfig<Identified>;
@@ -136,22 +134,5 @@ const newItem = () => {
 }
 .unsaved {
 	color: var(--text-secondary);
-}
-.workbench-error {
-	flex: 1;
-	min-height: 0;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	gap: 14px;
-	padding: 20px;
-	text-align: center;
-
-	p {
-		max-width: 480px;
-		color: var(--error);
-		font-size: 13px;
-	}
 }
 </style>

--- a/UI/src/routes/admin/workbench/progression/Progression.svelte
+++ b/UI/src/routes/admin/workbench/progression/Progression.svelte
@@ -35,10 +35,7 @@
 	</div>
 
 	{#if store.error}
-		<div class="prog-error" role="alert" data-testid="progression-error">
-			<p>{store.error}</p>
-			<button type="button" class="btn" onclick={() => store.load()}>Refresh</button>
-		</div>
+		<AdminLoadError testid="progression-error" message={store.error} onRetry={() => store.load()} />
 	{:else if !store.loaded}
 		<div class="prog-loading"><Loading loading={true} delay={120} /></div>
 	{:else}
@@ -112,6 +109,7 @@ import { onDestroy, onMount } from 'svelte';
 import Loading from '$components/Loading.svelte';
 import { workbenchDirty } from '../dirty.svelte';
 import WorkbenchIcon from '../WorkbenchIcon.svelte';
+import AdminLoadError from '../../AdminLoadError.svelte';
 import { ProgressionStore } from './progression-store.svelte';
 import ProgressionList from './ProgressionList.svelte';
 import ProgressionMap from './ProgressionMap.svelte';
@@ -214,23 +212,6 @@ $effect(() => {
 .prog-loading {
 	flex: 1;
 	min-height: 0;
-}
-.prog-error {
-	flex: 1;
-	min-height: 0;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	gap: 14px;
-	padding: 20px;
-	text-align: center;
-
-	p {
-		max-width: 480px;
-		color: var(--error);
-		font-size: 13px;
-	}
 }
 .prog-body {
 	display: flex;


### PR DESCRIPTION
## Summary

`Workbench.svelte`, `Progression.svelte`, and `admin/+page.svelte` each hand-rolled the same error/retry affordance: a `role="alert"` container, an `<p>{error}</p>`, and a Refresh button re-invoking the load — plus, for `Progression.svelte` and `+page.svelte`, a byte-identical local `.btn` base style (Workbench.svelte inherits its `.btn` from the shared `workbench.scss` design system, so it never redeclared one).

- Added `UI/src/routes/admin/AdminLoadError.svelte`: a small `message` + `onRetry` + `testid` component owning its own scoped `.admin-load-error` container and `.btn` styles.
- `Workbench.svelte`, `Progression.svelte`, and `+page.svelte`'s `referenceGate` snippet now render `<AdminLoadError>` instead of their own markup, passing through the same `data-testid` each already used (`workbench-error`, `progression-error`, `admin-reference-error`) so existing tests didn't need to change.
- Removed the now-dead `.workbench-error` / `.prog-error` / `.admin-load-error` (+ page-local `.btn`) style blocks. `Progression.svelte` keeps its local `.btn` (with `.primary`/`.sm`/`:disabled` modifiers) since it's still used by the Discard/Save/New-path buttons elsewhere on that page.

No behavior change — pure refactor.

Closes #1917

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — 299 files / 3706 tests passed
- [x] Targeted re-check of the three affected suites (`admin-page.test.ts`, `Workbench.test.ts`, `Progression.test.ts`) — all pass unchanged, confirming the extracted component preserves the existing error/retry contract (testid, message text, Refresh click re-triggers load)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WFZVjgEWMrjhreRe3FiGKV)_