### PR TITLE
Only spend socket auth-retry budget on an actual token rotation

### DIFF
--- a/UI/src/lib/api/api-socket.ts
+++ b/UI/src/lib/api/api-socket.ts
@@ -450,9 +450,11 @@ export class ApiSocket {
 			return;
 		}
 
-		this.socketAuthRetries++;
 		refreshTokens().then((outcome) => {
 			if (outcome.status === 'success') {
+				// Only a rotation that still failed to open spends budget — a retryable outage never burns
+				// a refresh token, so it must not count toward the bound that exists to stop that burn.
+				this.socketAuthRetries++;
 				// processCommandQueue ensures the socket (now with the freshly refreshed token) and flushes
 				// any queued-but-unsent commands.
 				void this.processCommandQueue();
@@ -471,8 +473,9 @@ export class ApiSocket {
 				handleAuthFailure();
 			}
 			// Otherwise the refresh attempt was retryable (network blip, transient server error): leave the
-			// queue and tokens intact — the keepalive ping's next ensureSocket() call retries the reconnect,
-			// which will attempt the refresh again, rather than forcing a logout over a transient failure.
+			// queue and tokens intact and spend no budget — the keepalive ping's next ensureSocket() call
+			// retries the reconnect, which will attempt the refresh again, rather than forcing a logout over
+			// a transient failure.
 		});
 	}
 

--- a/UI/src/tests/lib/api/api-socket.test.ts
+++ b/UI/src/tests/lib/api/api-socket.test.ts
@@ -1056,6 +1056,27 @@ describe('ApiSocket', () => {
 			warnSpy.mockRestore();
 		});
 
+		it('never exhausts the budget or logs out across a long outage of only-retryable refresh failures', async () => {
+			setTokens({ accessToken: 'a', refreshToken: 'r' });
+			vi.mocked(refreshTokens).mockResolvedValue({ status: 'retryable' });
+
+			apiSocket.sendSocketCommand('DefeatEnemy', { clientTotalMs: 1 });
+			await flushMicrotasks();
+
+			// Every reconnect attempt during the outage fails pre-open (e.g. code 1006, network down), and
+			// each refresh comes back retryable (no rotation spent) — well past MAX_SOCKET_AUTH_RETRIES (5)
+			// worth of cycles, since a retryable outcome must never count toward the budget.
+			for (let i = 0; i < 10; i++) {
+				rejectHandshake(lastWs());
+				await flushMicrotasks();
+			}
+
+			expect(refreshTokens).toHaveBeenCalledTimes(10);
+			expect(internals(apiSocket).socketAuthRetries).toBe(0);
+			expect(handleAuthFailure).not.toHaveBeenCalled();
+			expect(getTokens()).toEqual({ accessToken: 'a', refreshToken: 'r' });
+		});
+
 		it('stops the keepalive and routes to re-auth when the retry budget is exhausted', async () => {
 			vi.useFakeTimers();
 			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});


### PR DESCRIPTION
## Summary

- `ApiSocket.handleClose` incremented `socketAuthRetries` **before** the refresh outcome was known, so a `retryable` refresh (network blip, transient server error) still burned budget even though no refresh token was actually spent.
- Failure scenario: a backend restart or network drop lasting ~6 keepalive cycles (~60s at the 10s ping) exhausts the 5-attempt budget purely on retryable failures, forcing `handleAuthFailure()` to clear a still-valid token pair and log the player out — exactly the outcome the retryable branch's own comment says to avoid.
- Fix: move the increment into the `refreshTokens().then()` callback, incrementing only on `outcome.status === 'success'` (a rotation happened and the reconnect still failed to open). A `retryable` outcome now leaves the budget untouched entirely, matching the bound's actual purpose — stopping a flapping/broken server from burning single-use refresh tokens — while a genuine outage recovers without penalty once the network returns.

Closes #1992

## Test plan

- [x] Added `never exhausts the budget or logs out across a long outage of only-retryable refresh failures` to `UI/src/tests/lib/api/api-socket.test.ts` — 10 consecutive retryable refresh failures never touch `socketAuthRetries` or call `handleAuthFailure`, and tokens stay intact.
- [x] Existing `stops refreshing after the retry limit when no reconnect ever becomes stable` test (5 consecutive `success`-but-still-rejected reconnects exhaust the budget) still passes unchanged, confirming a genuinely flapping server is still bounded.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — full suite, 3707/3707 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143JiyMP79TnsKzuz5TRfzZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0143JiyMP79TnsKzuz5TRfzZ)_