### PR TITLE
Reject applying the same item mod to a second slot of one item

### DIFF
--- a/Game.Api.Tests/Integration/InventorySocketTests.cs
+++ b/Game.Api.Tests/Integration/InventorySocketTests.cs
@@ -149,6 +149,40 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task ApplyMod_SameModAlreadyOnAnotherSlot_ReturnsErrorAndDoesNotDuplicate()
+        {
+            // Anti-cheat (#1994): the client's mod picker forbids applying the same mod to a second slot
+            // of one item, so a tampered client sending it directly over the socket must be rejected too.
+            var firstSlotId = 0;
+            var secondSlotId = 0;
+            var modId = 0;
+            var (userId, playerId, itemId) = await SeedPlayerWithInventoryAsync("dupmoduser", "dupmodpass",
+                async (context, playerId, item) =>
+                {
+                    var firstSlot = await TestDataSeeder.AddItemModSlotAsync(context, item.Id);
+                    var secondSlot = await TestDataSeeder.AddItemModSlotAsync(context, item.Id);
+                    await TestDataSeeder.LinkItemToPlayerAsync(context, playerId, item.Id, EEquipmentSlot.WeaponSlot);
+                    var mod = await TestDataSeeder.CreateItemModAsync(context, attributeId: EAttribute.Dexterity, attributeAmount: 7m);
+                    await TestDataSeeder.LinkModToPlayerAsync(context, playerId, mod.Id);
+                    await TestDataSeeder.ApplyModToItemAsync(context, playerId, item.Id, firstSlot.Id, mod.Id);
+                    firstSlotId = firstSlot.Id;
+                    secondSlotId = secondSlot.Id;
+                    modId = mod.Id;
+                });
+            await LoginAsync("dupmoduser", "dupmodpass");
+            await using var socketClient = await ConnectSocketAsync(userId);
+
+            var parameters = new { itemId, itemModId = modId, itemModSlotId = secondSlotId };
+            var response = await socketClient.SendCommandRawAsync("ApplyMod", parameters);
+
+            Assert.NotNull(response.Error);
+            var data = await GetPersistedPlayerAsync(playerId);
+            var appliedMods = data.InventoryData.UnlockedItems.Single(i => i.ItemId == itemId).AppliedMods;
+            var applied = Assert.Single(appliedMods);
+            Assert.Equal(firstSlotId, applied.ItemModSlotId);
+        }
+
+        [Fact]
         public async Task RemoveMod_AppliedMod_Succeeds()
         {
             var modSlotId = 0;

--- a/Game.Core.Tests/Players/InventoryTests.cs
+++ b/Game.Core.Tests/Players/InventoryTests.cs
@@ -335,6 +335,70 @@ namespace Game.Core.Tests.Players
         }
 
         [Fact]
+        public void TryApplyMod_SameModAlreadyOnAnotherSlot_ReturnsFalseAndDoesNotMutate()
+        {
+            // Anti-cheat: the client's mod picker forbids applying the same mod to a second slot of one
+            // item (#1994); the server must reject a tampered client that sends it anyway.
+            var inventory = new Inventory();
+            var item = MakeItem(1, modSlots:
+            [
+                new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 1, Type = EItemModType.Prefix },
+            ]);
+            AddUnlockedItem(inventory, item);
+            inventory.UnlockMod(10);
+            inventory.TryApplyMod(1, 10, 0, MakeMod(10, EItemModType.Prefix));
+
+            var result = inventory.TryApplyMod(1, 10, 1, MakeMod(10, EItemModType.Prefix));
+
+            Assert.False(result);
+            var applied = inventory.UnlockedItems.Single().AppliedMods;
+            Assert.Single(applied);
+            Assert.Equal(0, applied[0].ItemModSlotId);
+        }
+
+        [Fact]
+        public void TryApplyMod_SameModReappliedToSameSlot_Succeeds()
+        {
+            var inventory = new Inventory();
+            var item = MakeItem(1, modSlots:
+            [
+                new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
+            ]);
+            AddUnlockedItem(inventory, item);
+            inventory.UnlockMod(10);
+            inventory.TryApplyMod(1, 10, 0, MakeMod(10, EItemModType.Prefix));
+
+            var result = inventory.TryApplyMod(1, 10, 0, MakeMod(10, EItemModType.Prefix));
+
+            Assert.True(result);
+            var applied = inventory.UnlockedItems.Single().AppliedMods;
+            Assert.Single(applied);
+            Assert.Equal(10, applied[0].ItemModId);
+        }
+
+        [Fact]
+        public void TryApplyMod_DifferentModsOnDifferentSlots_Succeeds()
+        {
+            var inventory = new Inventory();
+            var item = MakeItem(1, modSlots:
+            [
+                new ItemModSlot { Id = 0, Type = EItemModType.Prefix },
+                new ItemModSlot { Id = 1, Type = EItemModType.Prefix },
+            ]);
+            AddUnlockedItem(inventory, item);
+            inventory.UnlockMod(10);
+            inventory.UnlockMod(11);
+            inventory.TryApplyMod(1, 10, 0, MakeMod(10, EItemModType.Prefix));
+
+            var result = inventory.TryApplyMod(1, 11, 1, MakeMod(11, EItemModType.Prefix));
+
+            Assert.True(result);
+            var applied = inventory.UnlockedItems.Single().AppliedMods;
+            Assert.Equal(2, applied.Count);
+        }
+
+        [Fact]
         public void TryApplyMod_ItemNotUnlocked_ReturnsFalse()
         {
             var inventory = new Inventory();

--- a/Game.Core/Players/Inventories/Inventory.cs
+++ b/Game.Core/Players/Inventories/Inventory.cs
@@ -130,6 +130,13 @@ namespace Game.Core.Players.Inventories
                 return false;
             }
 
+            // Anti-cheat: the client only offers a mod once per item across all its slots (mirror that
+            // rule here) — reject a tampered client applying the same mod to a second slot of one item.
+            if (unlocked.AppliedMods.Any(a => a.ItemModId == itemModId && a.ItemModSlotId != itemModSlotId))
+            {
+                return false;
+            }
+
             // Replace any existing mod in the slot
             var existing = unlocked.AppliedMods.FirstOrDefault(a => a.ItemModSlotId == itemModSlotId);
             if (existing is not null)


### PR DESCRIPTION
## Summary

`Inventory.TryApplyMod` (`Game.Core/Players/Inventories/Inventory.cs`) validated mod-unlocked, item-unlocked, slot-exists, and slot-type-matches, but never checked whether the same `ItemModId` was already applied to a *different* slot of the same item. The client's mod picker already enforces "one copy of a mod per item" (`compatibleMods` in `UI/src/routes/game/screens/inventory/inventory-view.svelte.ts` excludes mods already on the item across all its slots), so this was a client-only anti-cheat gate — a tampered client could apply the same mod to two slots of an item with same-type slots, and the mod's attributes would be composed twice (`Item.GetAttributeModifiers`/battle snapshot).

The DB schema doesn't prevent it either (`AppliedMod`'s PK is `(PlayerId, ItemId, ItemModSlotId)`, which permits duplicate `ItemModId`s across slots for one item), and it's currently latent since `content/item-mods.json` is empty — but it becomes silently exploitable the moment multi-slot-same-type mod content ships.

## Change

- `Inventory.TryApplyMod` now rejects the apply (no mutation) when the mod is already applied to a *different* slot of the same item, mirroring the client's rule. Re-applying the same mod to its own current slot (a no-op) is still allowed.

## Test plan

- [x] `Game.Core.Tests/Players/InventoryTests.cs` — new unit tests: rejects duplicate-mod-on-another-slot with no mutation, allows re-applying the same mod to its own slot, allows different mods on different slots.
- [x] `Game.Api.Tests/Integration/InventorySocketTests.cs` — new integration test exercising the `ApplyMod` socket command end-to-end: applying a mod already on another slot of the item returns an error and the persisted player still shows only the original application.
- [x] Full backend suite (`dotnet test Game.sln`) — 3211/3211 passing.
- [x] `dotnet build Game.sln` — clean.

No frontend changes needed; the client-side rule already existed and is unaffected.

Closes #1994


---
_Generated by [Claude Code](https://claude.ai/code/session_017CWyowCEfuHRfCYakAQhwo)_