### PR TITLE
Keep boss-gated Workbench pickers from silently dropping an unflagged current value

### DIFF
--- a/UI/src/routes/admin/workbench/entities/challenge.ts
+++ b/UI/src/routes/admin/workbench/entities/challenge.ts
@@ -2,7 +2,7 @@ import { ApiRequest, EChallengeType, EEntityType, fetchSocketData, type IChallen
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import { persistEntity } from '../save-helpers';
-import { challengeSentence, deriveFromType, fmtNum } from './challenge-helpers';
+import { challengeSentence, deriveFromType, fmtNum, typeBossOnly } from './challenge-helpers';
 import type { EntityConfig } from './types';
 
 // Challenges load over the socket; the admin filter invalidates this cache on every
@@ -95,6 +95,12 @@ export const challengeEntity: EntityConfig<IChallenge> = {
 				}
 				if (c.entityType === EEntityType.DamageType && c.targetEntityId == null) {
 					return 'Must target a damage type — this statistic has no global total';
+				}
+				// The target picker keeps a boss target visible even if it's since lost the
+				// boss flag (reference.entityOptions' `keep` exception); flag that drift here.
+				const target = c.targetEntityId != null ? staticData.enemies?.[c.targetEntityId] : undefined;
+				if (target && typeBossOnly(reference.challengeTypes, c.challengeTypeId) && !target.isBoss) {
+					return 'Target enemy is no longer flagged as a boss';
 				}
 				return null;
 			}

--- a/UI/src/routes/admin/workbench/entities/zone.ts
+++ b/UI/src/routes/admin/workbench/entities/zone.ts
@@ -66,6 +66,16 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 			glyph: 'tag',
 			desc: 'Name, level range & ordering',
 			kind: 'fields',
+			// The dedicated-boss picker keeps an authored value visible even if it loses its
+			// boss flag (reference.bossEnemyOptions' `keep` exception); flag that drift here
+			// since the zone would otherwise silently point at a non-boss enemy.
+			warn: (z) => {
+				if (z.bossEnemyId == null || z.bossEnemyId < 0) {
+					return null;
+				}
+				const boss = staticData.enemies?.[z.bossEnemyId];
+				return boss && !boss.isBoss ? 'Dedicated boss is no longer flagged as a boss' : null;
+			},
 			fields: [
 				{
 					key: 'name',

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -159,11 +159,15 @@ class WorkbenchReference {
 	zoneOptions = (keep?: number): SelectOption[] =>
 		this.retireableOptions(staticData.zones ?? [], keep, (z) => `${z.name} · L${z.levelMin}–${z.levelMax}`);
 	enemyOptions = (keep?: number): SelectOption[] => this.retireableOptions(staticData.enemies ?? [], keep);
-	/** Dedicated-boss picker options: a "None" sentinel (-1) plus every active boss enemy. */
+	/**
+	 * Dedicated-boss picker options: a "None" sentinel (-1) plus every active boss enemy. The
+	 * current value stays visible even if it's since lost the boss flag, so an already-authored
+	 * assignment isn't silently dropped from the list.
+	 */
 	bossEnemyOptions = (keep?: number): SelectOption[] => [
 		{ value: -1, text: 'None' },
 		...this.retireableOptions(
-			(staticData.enemies ?? []).filter((e) => e.isBoss),
+			(staticData.enemies ?? []).filter((e) => e.isBoss || e.id === keep),
 			keep
 		)
 	];
@@ -277,19 +281,19 @@ class WorkbenchReference {
 	/**
 	 * The reference records backing a statistic's entity dimension (Enemy / Zone / Skill).
 	 * When `bossOnly` is set (a boss-only statistic such as BossesDefeated) the Enemy
-	 * dimension is restricted to enemies flagged `isBoss`, so the editor can't author a
-	 * challenge against a non-boss that the statistic would never increment for.
+	 * dimension is restricted to enemies flagged `isBoss` — plus `keep`, so a current target
+	 * that's since lost the flag stays visible instead of silently vanishing from the picker.
 	 */
-	private entityRecords = (entityType: EEntityType, bossOnly: boolean): RetireableRef[] =>
+	private entityRecords = (entityType: EEntityType, bossOnly: boolean, keep?: number): RetireableRef[] =>
 		entityType === EEntityType.Enemy
-			? (staticData.enemies ?? []).filter((e) => !bossOnly || e.isBoss)
+			? (staticData.enemies ?? []).filter((e) => !bossOnly || e.isBoss || e.id === keep)
 			: (this.entitySource(entityType) ?? []);
 
 	entityCatalog = (entityType: EEntityType, bossOnly = false): { id: number; name: string }[] =>
 		this.entityRecords(entityType, bossOnly).map((e) => ({ id: e.id, name: e.name }));
 	/** Target-entity picker options. Retired records are excluded unless `keep` is the current target. */
 	entityOptions = (entityType: EEntityType, bossOnly = false, keep?: number): SelectOption[] =>
-		this.retireableOptions(this.entityRecords(entityType, bossOnly), keep);
+		this.retireableOptions(this.entityRecords(entityType, bossOnly, keep), keep);
 	entityName = (entityType: EEntityType, id: number): string | null =>
 		this.entitySource(entityType)?.[id]?.name ?? null;
 

--- a/UI/src/tests/routes/admin/workbench/entities/challenge.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/challenge.test.ts
@@ -137,5 +137,55 @@ describe('challengeEntity', () => {
 			const c = { ...challengeEntity.newItem(1), entityType: EEntityType.Enemy, targetEntityId: undefined };
 			expect(conditionWarn?.(c)).toBeNull();
 		});
+
+		it('flags a boss-only target enemy that has since lost its boss flag (#1996)', () => {
+			const bossOnlyType: IChallengeType = {
+				id: EChallengeType.BossesDefeated,
+				name: 'Bosses Defeated',
+				goalComparison: EChallengeGoalComparison.AtLeast,
+				statisticType: {
+					id: EStatisticType.EnemiesKilled,
+					entityType: EEntityType.Enemy,
+					bossOnly: true,
+					name: 'Bosses Defeated'
+				}
+			};
+			reference.challengeTypes = [...TYPES, bossOnlyType];
+			const enemies: unknown[] = [];
+			enemies[7] = { id: 7, name: 'Warden', isBoss: false };
+			staticData.enemies = enemies;
+			const c = {
+				...challengeEntity.newItem(1),
+				challengeTypeId: bossOnlyType.id,
+				entityType: EEntityType.Enemy,
+				targetEntityId: 7
+			};
+			expect(conditionWarn?.(c)).toBe('Target enemy is no longer flagged as a boss');
+		});
+
+		it('passes a boss-only target that still has the boss flag', () => {
+			const bossOnlyType: IChallengeType = {
+				id: EChallengeType.BossesDefeated,
+				name: 'Bosses Defeated',
+				goalComparison: EChallengeGoalComparison.AtLeast,
+				statisticType: {
+					id: EStatisticType.EnemiesKilled,
+					entityType: EEntityType.Enemy,
+					bossOnly: true,
+					name: 'Bosses Defeated'
+				}
+			};
+			reference.challengeTypes = [...TYPES, bossOnlyType];
+			const enemies: unknown[] = [];
+			enemies[7] = { id: 7, name: 'Warden', isBoss: true };
+			staticData.enemies = enemies;
+			const c = {
+				...challengeEntity.newItem(1),
+				challengeTypeId: bossOnlyType.id,
+				entityType: EEntityType.Enemy,
+				targetEntityId: 7
+			};
+			expect(conditionWarn?.(c)).toBeNull();
+		});
 	});
 });

--- a/UI/src/tests/routes/admin/workbench/entities/zone.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/zone.test.ts
@@ -172,4 +172,28 @@ describe('zoneEntity', () => {
 			['enemy', 1]
 		]);
 	});
+
+	describe('identity section warn (#1996)', () => {
+		const identityWarn = zoneEntity.sections.find((s) => s.key === 'identity')?.warn;
+
+		it('flags a dedicated boss that has since lost its boss flag', () => {
+			const enemies: unknown[] = [];
+			enemies[7] = { id: 7, name: 'Warden', isBoss: false };
+			staticData.enemies = enemies;
+			const z = { ...zoneEntity.newItem(1), bossEnemyId: 7 };
+			expect(identityWarn?.(z)).toBe('Dedicated boss is no longer flagged as a boss');
+		});
+
+		it('passes when the dedicated boss still has the boss flag', () => {
+			const enemies: unknown[] = [];
+			enemies[7] = { id: 7, name: 'Warden', isBoss: true };
+			staticData.enemies = enemies;
+			const z = { ...zoneEntity.newItem(1), bossEnemyId: 7 };
+			expect(identityWarn?.(z)).toBeNull();
+		});
+
+		it('passes when no dedicated boss is assigned', () => {
+			expect(identityWarn?.(zoneEntity.newItem(1))).toBeNull();
+		});
+	});
 });

--- a/UI/src/tests/routes/admin/workbench/reference.test.ts
+++ b/UI/src/tests/routes/admin/workbench/reference.test.ts
@@ -157,6 +157,14 @@ describe('reference-data-backed select options', () => {
 		]);
 	});
 
+	it('keeps the current boss picker value visible after it loses the isBoss flag (#1996)', () => {
+		// Cave Bat (id 0) isn't a boss, but it's the zone's currently-authored value — it must
+		// stay selectable/visible rather than silently vanishing from the option list.
+		expect(reference.bossEnemyOptions(0)).toContainEqual({ value: 0, text: 'Cave Bat' });
+		// Dropping `keep` (or picking a different current value) excludes it again.
+		expect(reference.bossEnemyOptions().map((o) => o.value)).not.toContain(0);
+	});
+
 	it('prefixes the unlock-gate picker with an always-open sentinel and lists every challenge', () => {
 		expect(reference.unlockChallengeOptions()).toEqual([
 			{ value: -1, text: 'None (always open)' },
@@ -337,6 +345,12 @@ describe('entityOptions / entityCatalog target-entity picker', () => {
 	it('ignores the boss-only flag for non-enemy dimensions', () => {
 		expect(reference.entityOptions(EEntityType.Zone, true).map((o) => o.value)).toEqual([0, 1]);
 		expect(reference.entityOptions(EEntityType.Skill, true).map((o) => o.value)).toEqual([0, 1]);
+	});
+
+	it('keeps a boss-only target visible after it loses the isBoss flag (#1996)', () => {
+		// Cave Bat (id 0) isn't a boss, but it's the challenge's currently-authored target.
+		expect(reference.entityOptions(EEntityType.Enemy, true, 0)).toContainEqual({ value: 0, text: 'Cave Bat' });
+		expect(reference.entityOptions(EEntityType.Enemy, true).map((o) => o.value)).not.toContain(0);
 	});
 
 	it('returns an empty catalogue for the None / unknown dimension', () => {


### PR DESCRIPTION
## Summary

- `bossEnemyOptions` (zone's Dedicated Boss picker) and `entityOptions`/`entityRecords` (the boss-only challenge target picker used by `ScopeField`) filtered enemies on `isBoss` *before* the retired-record `keep` exception ran, so an enemy whose `isBoss` flag was later turned off vanished from the option list entirely — the native `<select>` rendered blank, indistinguishable from "None", and the existing zone/challenge assignment couldn't be seen or re-picked.
- Both pickers now add the `|| e.id === keep` exception, matching the existing convention used by `grantedSkillOptions`/`synthesisResultSkillOptions`/`playerSkillOptions`.
- Added a section `warn` to the zone editor's Identity section and the challenge editor's Condition section (mirroring the skill-recipe editor's stale-flag warning) so an author sees "Dedicated boss is no longer flagged as a boss" / "Target enemy is no longer flagged as a boss" instead of the drift sitting silently — the state is reachable at save time since unflagging a referenced boss is only a content-health lint, not a hard block.

## How this addresses the issue

Closes #1996. Implements exactly the fix direction proposed in the issue: the `keep` exception on both boss-filtered pickers, plus a section warning for the "assigned enemy is no longer flagged as a boss" case.

## Test plan

- [x] Added unit tests to `reference.test.ts` covering `bossEnemyOptions(keep)` and `entityOptions(EEntityType.Enemy, true, keep)` keeping a non-boss current value visible.
- [x] Added unit tests to `zone.test.ts` and `challenge.test.ts` for the new section `warn`s (flags the stale boss flag, passes when the flag is intact or no boss is assigned).
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npx vitest --run` — full suite (299 files / 3714 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DcWSoXNYuBbgXVmeSRxTFh)_