### PR TITLE
Source the gateway prerequisite picker from the live draft tiers (#1997)

### DIFF
--- a/UI/src/routes/admin/workbench/progression/GatewaysEditor.svelte
+++ b/UI/src/routes/admin/workbench/progression/GatewaysEditor.svelte
@@ -12,7 +12,7 @@
 		<div class="chips">
 			{#each tier.prerequisiteIds as prereqId (prereqId)}
 				<span class="chip">
-					{reference.proficiencyName(prereqId) ?? `#${prereqId}`}
+					{prereqName(prereqId)}
 					<span class="star">✦</span>
 					<button
 						type="button"
@@ -39,7 +39,6 @@
 
 <script lang="ts">
 import WorkbenchIcon from '../WorkbenchIcon.svelte';
-import { reference } from '../reference.svelte';
 import type { ProgressionStore } from './progression-store.svelte';
 import type { WorkbenchProficiency } from './types';
 import ProgSelect from './ProgSelect.svelte';
@@ -51,12 +50,22 @@ interface Props {
 
 const { store, tier }: Props = $props();
 
-const ADD_PLACEHOLDER = -1;
+// Draft (never-saved) tiers count down from -1 (ProgressionStore.nextId), so the placeholder can't
+// live in that range without colliding with a real unsaved tier's id.
+const ADD_PLACEHOLDER = -Infinity;
 let addPick = $state(ADD_PLACEHOLDER);
+
+/**
+ * Sourced from the store's live draft tiers (not the last-saved `reference` snapshot) so a tier
+ * added or renamed earlier in this session is offered/labelled correctly (#1997).
+ */
+const prereqName = (id: number) => store.profs.find((p) => p.id === id)?.name || `#${id}`;
 
 const addOptions = $derived([
 	{ value: ADD_PLACEHOLDER, text: '+ Add prerequisite…' },
-	...reference.proficiencyOptions().filter((o) => o.value !== tier.id && !tier.prerequisiteIds.includes(o.value))
+	...store.profs
+		.filter((p) => p.id !== tier.id && !p.retiredAt && !tier.prerequisiteIds.includes(p.id))
+		.map((p) => ({ value: p.id, text: p.name || 'Unnamed tier' }))
 ]);
 
 const onAddPrereq = (value: number) => {

--- a/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
@@ -244,13 +244,10 @@ describe('TierDetail — tab bodies', () => {
 	});
 
 	it('lists an existing prerequisite chip, removes it, and adds a new one', async () => {
-		// staticData.proficiencies is index-addressed (the zero-based-id/index invariant), so each
-		// entry must sit at its own id as the array index.
-		const byId: unknown[] = [];
-		byId[3] = { id: 3, name: 'Basics' };
-		byId[7] = { id: 7, name: 'Advanced' };
-		staticData.proficiencies = byId;
-		const store = makeStore(tier({ prerequisiteIds: [3] }), { tierTab: 'gateways' });
+		const basics = tier({ id: 3, name: 'Basics', prerequisiteIds: [] });
+		const advanced = tier({ id: 7, name: 'Advanced', prerequisiteIds: [] });
+		const gatedTier = tier({ prerequisiteIds: [3] });
+		const store = makeStore(gatedTier, { profs: [gatedTier, basics, advanced], tierTab: 'gateways' });
 		render(TierDetail, { props: { store } });
 
 		expect(screen.getByText('Basics')).toBeTruthy();
@@ -259,5 +256,27 @@ describe('TierDetail — tab bodies', () => {
 
 		await fireEvent.change(screen.getByLabelText('Add prerequisite'), { target: { value: '7' } });
 		expect(store.addPrerequisite).toHaveBeenCalledWith(5, 7);
+	});
+
+	it('offers an unsaved tier (negative id, never in staticData) as a prerequisite option (#1997)', async () => {
+		// id -1 is the first id ProgressionStore.nextId hands out to a brand-new tier — deliberately
+		// chosen here to also pin that it doesn't collide with the picker's own placeholder value.
+		const draftTier = tier({ id: -1, name: 'Brand New Tier', prerequisiteIds: [] });
+		const gatedTier = tier({ prerequisiteIds: [] });
+		const store = makeStore(gatedTier, { profs: [gatedTier, draftTier], tierTab: 'gateways' });
+		render(TierDetail, { props: { store } });
+
+		await fireEvent.change(screen.getByLabelText('Add prerequisite'), { target: { value: '-1' } });
+		expect(store.addPrerequisite).toHaveBeenCalledWith(5, -1);
+	});
+
+	it('excludes a retired tier from the prerequisite options', () => {
+		const retiredTier = tier({ id: 3, name: 'Retired Tier', retiredAt: '2026-01-01T00:00:00Z' });
+		const gatedTier = tier({ prerequisiteIds: [] });
+		const store = makeStore(gatedTier, { profs: [gatedTier, retiredTier], tierTab: 'gateways' });
+		render(TierDetail, { props: { store } });
+
+		const select = screen.getByLabelText('Add prerequisite') as HTMLSelectElement;
+		expect(Array.from(select.options).some((o) => o.text.includes('Retired Tier'))).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

`GatewaysEditor`'s "Add prerequisite" dropdown and chip labels were built from `reference.proficiencyOptions()` / `reference.proficiencyName()`, which only reflect the last-saved `staticData.proficiencies` snapshot. A tier added (or renamed) earlier in the same Workbench session was invisible to the picker, even though the save pipeline (`progression-store`'s `resolveId` prerequisite remap) already supports gating on a brand-new, not-yet-persisted tier.

- Both the add-options list and the chip labels now read from `store.profs` — the in-session draft catalogue — instead of the last-saved reference snapshot. This mirrors the `{ proficiencies: store.profs }` override `PathDetail`/`TierDetail` already use for their retire-confirm dialogs.
- Options now exclude retired tiers directly (rather than relying on the reference layer's retired-tag convention), matching the fix direction in the issue.

## An additional latent bug found and fixed in the same PR

Making draft tiers selectable surfaced a real collision: the picker's placeholder sentinel value was `-1`, which is also the very first id `ProgressionStore.nextId` hands a brand-new tier. Once unsaved tiers became selectable options, a same-session tier with id `-1` would collide with the placeholder (Svelte even throws a duplicate-key error in that case). Moved the sentinel to `-Infinity`, a value outside the real id range (persisted ids are `>= 0`; draft ids count down from `-1`). Covered by a new test that specifically uses a draft tier with id `-1`.

## Test plan

- [x] Extended `TierDetail.test.ts`'s existing gateway-picker test to source proficiencies from `store.profs` instead of `staticData.proficiencies`
- [x] Added a test asserting an unsaved (negative-id) tier is offered as a prerequisite option and is selectable (including the id `-1` collision case)
- [x] Added a test asserting a retired tier is excluded from the options
- [x] `npm run test:unit:ci` — all 3716 tests pass
- [x] `npm run lint` — clean (eslint + svelte-check)

Closes #1997

---
_Generated by [Claude Code](https://claude.ai/code/session_016tkSz9Rx9saKfxShA9jYrj)_