### PR TITLE
Self-heal Skills Compare-vs Toughness when maxToughness shrinks

### DIFF
--- a/UI/src/routes/game/screens/skills/CompareBar.svelte
+++ b/UI/src/routes/game/screens/skills/CompareBar.svelte
@@ -6,7 +6,7 @@
 				<button
 					type="button"
 					class="epill"
-					class:on={view.selectedPresetKey === preset.key}
+					class:on={view.activePresetKey === preset.key}
 					class:boss={preset.isBoss}
 					onclick={() => view.selectPreset(preset)}
 				>
@@ -24,11 +24,11 @@
 			type="range"
 			min="0"
 			max={view.maxToughness}
-			value={view.toughness}
+			value={view.effectiveToughness}
 			aria-label="Compare-vs enemy toughness"
 			oninput={(e) => view.setToughness(+e.currentTarget.value)}
 		/>
-		<span class="vs-defval">TGH <b>{Math.round(view.toughness)}</b></span>
+		<span class="vs-defval">TGH <b>{Math.round(view.effectiveToughness)}</b></span>
 	</div>
 </div>
 

--- a/UI/src/routes/game/screens/skills/SkillInspector.svelte
+++ b/UI/src/routes/game/screens/skills/SkillInspector.svelte
@@ -138,7 +138,7 @@ const rawNote = $derived.by(() => {
 	// Critical row and the crit-inclusive effective hit; omitted when no crit can occur.
 	const critBonus = view.critBonus(id);
 	const critPart = critBonus > 0 ? ` · +${fmt(critBonus)} crit` : '';
-	if (view.toughness <= 0) {
+	if (view.effectiveToughness <= 0) {
 		return `${raw} raw damage${critPart} · target has no toughness`;
 	}
 	const mitigated = fmt(view.mitigatedAmount(id));

--- a/UI/src/routes/game/screens/skills/skills-view.svelte.ts
+++ b/UI/src/routes/game/screens/skills/skills-view.svelte.ts
@@ -121,6 +121,22 @@ export function zoneSpawnLevel(zone: IZone): number {
 	return (zone.levelMin + zone.levelMax) / 2;
 }
 
+/** Clamp a stored Compare-vs Toughness to the live slider ceiling. `toughness` is only clamped at
+ *  the moment it's written (a slider drag or preset pick), so a `maxToughness` that later shrinks
+ *  (e.g. a zone relocation or reference-data refresh while the screen stays mounted) would otherwise
+ *  leave the stored value pinned above the new range — every consumer must read through this instead
+ *  of the raw stored value. */
+export function clampToughness(toughness: number, maxToughness: number): number {
+	return Math.min(toughness, maxToughness);
+}
+
+/** The Compare-vs preset key to treat as active — `selectedPresetKey` unless its preset no longer
+ *  exists among the live presets (e.g. a zone change dropped the pill it pointed at), in which case
+ *  the stale key resolves to no active pill rather than highlighting nothing that's shown. */
+export function resolveActivePresetKey(selectedPresetKey: string | null, presets: ComparePreset[]): string | null {
+	return selectedPresetKey != null && presets.some((p) => p.key === selectedPresetKey) ? selectedPresetKey : null;
+}
+
 /* ── reactive view-model ──────────────────────────────────────────────────── */
 
 export class SkillsView {
@@ -285,6 +301,15 @@ export class SkillsView {
 	 *  1 until zone/enemy reference data loads. */
 	readonly maxToughness = $derived(Math.max(1, ...this.comparePresets.map((p) => p.toughness)));
 
+	/** {@link toughness} re-clamped to the live {@link maxToughness} ceiling — see {@link clampToughness}.
+	 *  Every effective-value read and the slider display go through this instead of the raw stored value,
+	 *  so they can't get stuck on a now-unreachable stale value. */
+	readonly effectiveToughness = $derived(clampToughness(this.toughness, this.maxToughness));
+
+	/** {@link selectedPresetKey}, self-healed against {@link comparePresets} — see {@link resolveActivePresetKey}.
+	 *  Derived rather than mutating `selectedPresetKey` itself out from under a caller. */
+	readonly activePresetKey = $derived(resolveActivePresetKey(this.selectedPresetKey, this.comparePresets));
+
 	/** Core attributes any catalogue skill scales on (the offered filter chips). */
 	readonly usedAttributes = $derived(
 		FILTERABLE_ATTRIBUTES.filter((attr) =>
@@ -313,7 +338,7 @@ export class SkillsView {
 				}
 				return true;
 			});
-		return list.sort(sortMetrics(this.sort, this.toughness));
+		return list.sort(sortMetrics(this.sort, this.effectiveToughness));
 	});
 
 	/** Equipped rail rows, ordered by loadout slot (not by the active sort). Built from
@@ -401,7 +426,7 @@ export class SkillsView {
 	 *  applies before mitigation, so it scales first), then run through the Compare-vs Toughness curve. */
 	effective(id: number): number {
 		const critMultiplier = this.metricsById[id]?.critMultiplier ?? 1;
-		return toughnessMitigatedDamage(this.rawDamage(id) * critMultiplier, this.toughness);
+		return toughnessMitigatedDamage(this.rawDamage(id) * critMultiplier, this.effectiveToughness);
 	}
 
 	effectiveDps(id: number): number {

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -87,8 +87,11 @@ vi.mock('$lib/api/types/game-constants', async (importOriginal) => {
 
 import {
 	SkillsView,
+	clampToughness,
+	resolveActivePresetKey,
 	sortMetrics,
 	zoneSpawnLevel,
+	type ComparePreset,
 	type SkillMetrics
 } from '$routes/game/screens/skills/skills-view.svelte';
 import { damagePerSecond } from '$lib/common';
@@ -265,6 +268,19 @@ describe('pure helpers', () => {
 
 	it('takes the midpoint of a zone range as the representative spawn level', () => {
 		expect(zoneSpawnLevel(ZONES[0])).toBe(5); // (2 + 8) / 2
+	});
+
+	it('clamps a stored toughness to the live max, self-healing a stale value above a shrunken ceiling (#1998)', () => {
+		expect(clampToughness(150, 200)).toBe(150); // within range, unchanged
+		expect(clampToughness(250, 200)).toBe(200); // stale value above a ceiling that shrank re-clamps
+		expect(clampToughness(0, 200)).toBe(0);
+	});
+
+	it('resolves the active preset key against the live presets, dropping one whose pill no longer exists (#1998)', () => {
+		const presets: ComparePreset[] = [{ key: 'spawn-0', name: 'Imp', isBoss: false, toughness: 20 }];
+		expect(resolveActivePresetKey('spawn-0', presets)).toBe('spawn-0');
+		expect(resolveActivePresetKey('spawn-9', presets)).toBeNull(); // stale key, preset removed
+		expect(resolveActivePresetKey(null, presets)).toBeNull();
 	});
 
 	it('folds each metric’s own crit multiplier into the effective dps/damage ranking', () => {
@@ -659,6 +675,17 @@ describe('SkillsView — compare-vs enemy presets', () => {
 		view.setToughness(7);
 		expect(view.toughness).toBe(7);
 		expect(view.selectedPresetKey).toBeNull();
+	});
+
+	it('re-clamps the consumed toughness when a stored value ends up stale above the live ceiling (#1998)', () => {
+		// `toughness`/`selectedPresetKey` are only clamped/validated at write time (setToughness/selectPreset).
+		// Assigning past that guard simulates what a shrunken maxToughness (e.g. a zone relocation while the
+		// screen stays mounted) would otherwise leave behind: a stored value above the new range and a pill
+		// key for a preset that no longer exists.
+		view.toughness = 9999;
+		view.selectedPresetKey = 'spawn-9';
+		expect(view.effectiveToughness).toBe(view.maxToughness);
+		expect(view.activePresetKey).toBeNull();
 	});
 
 	it('resorts railList by effective dps when a preset is selected', () => {


### PR DESCRIPTION
## Summary

`SkillsView.setToughness`/`selectPreset` only clamp the Compare-vs Toughness against `maxToughness` at the moment of the write (`UI/src/routes/game/screens/skills/skills-view.svelte.ts`). Since `maxToughness` is itself derived from the current zone's live reference data, a mid-session zone relocation or reference-data refresh that shrinks the preset range could leave the stored `toughness` above the new max — and `selectedPresetKey` pointing at a preset that no longer exists.

This fixes it by introducing two self-healing derived reads that every consumer now goes through instead of the raw stored state:

- `effectiveToughness` — `toughness` re-clamped to the live `maxToughness` ceiling on every read, backed by a pure `clampToughness(toughness, maxToughness)` helper.
- `activePresetKey` — `selectedPresetKey` resolved against the live `comparePresets`, backed by a pure `resolveActivePresetKey(selectedPresetKey, presets)` helper, so a pill for a preset that's disappeared no longer renders "selected".

The raw `toughness`/`selectedPresetKey` state fields are unchanged (still clamped/validated at write time, matching existing tests) — only what the slider, the effective-dps/burst formulas, the sort, and the pill highlight actually *consume* changed.

Both helpers were pulled into the file's existing "pure helpers (no reactive state — unit-tested directly)" section (alongside `sortMetrics`/`zoneSpawnLevel`) rather than tested only through the reactive view, since the view's own test harness mocks `staticData`/`playerManager` as plain (non-`$state`) objects — a `$derived` chain rooted in them can't be exercised reactively there without constructing a fresh `SkillsView()`, so the pure-helper split is what makes the exact clamp/preset-resolution logic directly testable.

## Changes

- `skills-view.svelte.ts`: add `clampToughness`/`resolveActivePresetKey` pure helpers and `effectiveToughness`/`activePresetKey` derived fields; route `railList`'s sort and `effective()` through `effectiveToughness`.
- `CompareBar.svelte`: slider value/display and pill "on" state now read `effectiveToughness`/`activePresetKey`.
- `SkillInspector.svelte`: the raw-damage note's "target has no toughness" check now reads `effectiveToughness`.
- `skills-view.test.ts`: unit tests for the new pure helpers, plus a view-level test simulating a stored value/preset key left stale by a shrunken ceiling.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — full suite: 299 files / 3719 tests passed, no coverage-threshold regressions
- [x] New/updated tests specifically cover: `clampToughness`, `resolveActivePresetKey`, and `effectiveToughness`/`activePresetKey` re-clamping a stale stored value

Closes #1998


---
_Generated by [Claude Code](https://claude.ai/code/session_01AFTqFfELeN3srzeTdVE9P9)_