### PR TITLE
Retry the offline-progress fetch once before skipping loop-mode reconciliation (#1999)

### DIFF
--- a/UI/src/routes/game/welcome-back/welcome-back-view.svelte.ts
+++ b/UI/src/routes/game/welcome-back/welcome-back-view.svelte.ts
@@ -36,11 +36,22 @@ export class WelcomeBackView {
 	 * Runs the gate flow. Fetches the offline summary, reconciles the persisted loop mode (always — even a
 	 * sub-threshold return should restore a boss-farmer's toggle), then passes straight through to the game
 	 * when there is no progress, or re-syncs state and shows the summary gate when there is.
+	 *
+	 * A failed fetch is retried once before giving up: `GetOfflineProgress` re-anchors the server's away-time
+	 * clock on every call (even a sub-threshold one), so an immediate retry is safe and turns a transient
+	 * failure into a normal empty-progress result instead of silently skipping reconciliation (#1999) — a
+	 * boss-farmer would otherwise enter with auto-fight off while the backend still thinks they're farming.
 	 */
 	async run(): Promise<void> {
-		const progress = await this.deps.fetchProgress();
+		let progress = await this.deps.fetchProgress();
 		if (this.cancelled) {
 			return;
+		}
+		if (!progress) {
+			progress = await this.deps.fetchProgress();
+			if (this.cancelled) {
+				return;
+			}
 		}
 
 		if (progress) {

--- a/UI/src/tests/routes/game/welcome-back/welcome-back-view.test.ts
+++ b/UI/src/tests/routes/game/welcome-back/welcome-back-view.test.ts
@@ -50,15 +50,45 @@ describe('WelcomeBackView', () => {
 		expect(view.summary).toBeNull();
 	});
 
-	it('enters the game and skips reconciliation when the offline check fails', async () => {
+	it('enters the game and skips reconciliation when the offline check fails twice in a row', async () => {
 		const view = makeView(null);
 
 		await view.run();
 
+		// One retry (#1999): a transient failure gets a second chance before reconciliation is skipped.
+		expect(deps.fetchProgress).toHaveBeenCalledTimes(2);
 		expect(deps.reconcileMode).not.toHaveBeenCalled();
 		expect(deps.resyncPlayer).not.toHaveBeenCalled();
 		expect(deps.enterGame).toHaveBeenCalledTimes(1);
 		expect(view.phase).toBe('entered');
+	});
+
+	it('retries once and reconciles mode when the retry succeeds (#1999)', async () => {
+		deps = {
+			fetchProgress: vi
+				.fn<WelcomeBackDeps['fetchProgress']>()
+				.mockResolvedValueOnce(null)
+				.mockResolvedValueOnce(progress({ hasProgress: false, autoChallengeBoss: true })),
+			resyncPlayer: vi.fn(() => Promise.resolve()),
+			reconcileMode: vi.fn(),
+			enterGame: vi.fn()
+		};
+		const view = new WelcomeBackView(deps as unknown as WelcomeBackDeps);
+
+		await view.run();
+
+		expect(deps.fetchProgress).toHaveBeenCalledTimes(2);
+		expect(deps.reconcileMode).toHaveBeenCalledWith(true);
+		expect(deps.enterGame).toHaveBeenCalledTimes(1);
+		expect(view.phase).toBe('entered');
+	});
+
+	it('does not retry when the first fetch succeeds', async () => {
+		const view = makeView(progress({ hasProgress: false }));
+
+		await view.run();
+
+		expect(deps.fetchProgress).toHaveBeenCalledTimes(1);
 	});
 
 	it('re-syncs state and shows the summary gate without starting the game when there is progress', async () => {
@@ -139,6 +169,30 @@ describe('WelcomeBackView', () => {
 			resolveFetch(progress({ hasProgress: false }));
 			await runPromise;
 
+			expect(deps.reconcileMode).not.toHaveBeenCalled();
+			expect(deps.enterGame).not.toHaveBeenCalled();
+			expect(view.phase).toBe('checking');
+		});
+
+		it('does not retry or enter the game when cancelled between the first fetch and its retry (#1999)', async () => {
+			let resolveFirstFetch: (value: IOfflineProgressModel | null) => void = () => {};
+			const fetchProgress = vi
+				.fn<WelcomeBackDeps['fetchProgress']>()
+				.mockImplementationOnce(() => new Promise((resolve) => (resolveFirstFetch = resolve)));
+			deps = {
+				fetchProgress,
+				resyncPlayer: vi.fn(() => Promise.resolve()),
+				reconcileMode: vi.fn(),
+				enterGame: vi.fn()
+			};
+			const view = new WelcomeBackView(deps as unknown as WelcomeBackDeps);
+
+			const runPromise = view.run();
+			view.cancel();
+			resolveFirstFetch(null);
+			await runPromise;
+
+			expect(fetchProgress).toHaveBeenCalledTimes(1);
 			expect(deps.reconcileMode).not.toHaveBeenCalled();
 			expect(deps.enterGame).not.toHaveBeenCalled();
 			expect(view.phase).toBe('checking');


### PR DESCRIPTION
## Summary

`WelcomeBackView.run()` only called `reconcileMode(progress.autoChallengeBoss)` when `GetOfflineProgress` succeeded. A failed (transiently errored) fetch fell straight through to `enter()` with no reconciliation, so a returning boss-farmer would enter with client-side auto-fight silently off while the backend still persisted `AutoChallengeBoss = true` — a client/server loop-mode disagreement that the *next* disconnect's offline simulation would then resume incorrectly.

## Fix

`run()` now retries `fetchProgress()` once when the first call returns `null`, before giving up on reconciliation. This is safe because `OfflineProgressService.SimulateProgress` (backing `GetOfflineProgress`) always re-anchors the server's `LastActivity` clock, even on a sub-threshold call — so an immediate retry either recovers the real summary (if the first attempt's response was merely lost in transit) or lands a cheap, side-effect-free empty-progress result (if the first attempt genuinely never reached the server). Either way it's a normal outcome, not a duplicate-reward risk.

`cancel()` is still honored between the first fetch and the retry, matching the existing cancellation contract (#1807).

### A note on the issue's suggested fallback

The issue also suggested reconciling "from a later authoritative read (the player payload the boot path already pulls carries the flag)". I checked this and it isn't accurate: the `Login/Status` DTO (`PlayerData`, the payload `resyncPlayer`/`refreshPlayer` pulls) doesn't carry `AutoChallengeBoss` anywhere — that flag is currently only ever sent to the frontend via `GetOfflineProgress`'s `OfflineProgressModel`. Threading it onto `PlayerData` would be a reasonable follow-up if a stronger fallback is ever wanted, but it's a larger, separate change (new backend field, DTO plumbing, frontend type update) than this bug fix warrants, so I went with the retry-based fix instead, which is fully contained to `WelcomeBackView`.

## Test plan

- [x] Added/updated unit tests in `welcome-back-view.test.ts`: retry-succeeds reconciles mode, retry-fails-twice still skips reconciliation, no retry on first-attempt success, and a new cancellation case (cancelled between the first fetch and the retry).
- [x] `npm run lint` — clean.
- [x] `npm run test:unit:ci` — 299 files / 3722 tests passed.

Closes #1999


---
_Generated by [Claude Code](https://claude.ai/code/session_014MbEnq7zBL73Ve6ZLc1Dyg)_