### PR TITLE
Mirror EndBattleVictory's diagnostics on EndBattleLoss and thread ClientTotalMs through BattleLost

### DIFF
--- a/Game.Api.Tests/Integration/BattleLostSocketTests.cs
+++ b/Game.Api.Tests/Integration/BattleLostSocketTests.cs
@@ -111,7 +111,7 @@ namespace Game.Api.Tests.Integration
             await socketClient.ConnectAsync(wsClient, userId);
             Assert.Equal(WebSocketState.Open, socketClient.State);
 
-            var response = await socketClient.SendCommandAsync<BattleLostResponse>("BattleLost");
+            var response = await socketClient.SendCommandAsync<BattleLostResponse>("BattleLost", new { });
 
             Assert.NotNull(response.Error);
         }
@@ -147,8 +147,11 @@ namespace Game.Api.Tests.Integration
             await using var socketClient = new TestSocketClient();
             await socketClient.ConnectAsync(wsClient, userId);
 
-            // Report loss
-            var response = await socketClient.SendCommandAsync<BattleLostResponse>("BattleLost");
+            // Report loss, including the client-simulated duration (diagnostic only — the server validates
+            // off its own clock, exercised at the BattleService level in EndBattleLoss_DivergentClientTotalMs_
+            // IsDiagnosticOnly_StillReturnsTrue).
+            var response = await socketClient.SendCommandAsync<BattleLostResponse>(
+                "BattleLost", new { ClientTotalMs = 1234 });
 
             Assert.Null(response.Error);
             Assert.NotNull(response.Data);
@@ -175,7 +178,7 @@ namespace Game.Api.Tests.Integration
 
             // Report the loss immediately: the battle just started, so far less server time has elapsed than
             // its replay duration and the claim could not have finished yet — rejected (#1630).
-            var response = await socketClient.SendCommandAsync<BattleLostResponse>("BattleLost");
+            var response = await socketClient.SendCommandAsync<BattleLostResponse>("BattleLost", new { });
 
             Assert.NotNull(response.Error);
         }

--- a/Game.Api/Models/Enemies/BattleLostRequest.cs
+++ b/Game.Api/Models/Enemies/BattleLostRequest.cs
@@ -1,0 +1,12 @@
+namespace Game.Api.Models.Enemies
+{
+    public class BattleLostRequest
+    {
+        /// <summary>
+        /// The total battle duration (ms) the client simulated for this loss. Diagnostic only — it is
+        /// not validated as anti-cheat; the server logs when it diverges from its own parity replay so a
+        /// front/back battle-logic drift is visible. Null when the client did not report a duration.
+        /// </summary>
+        public int? ClientTotalMs { get; set; }
+    }
+}

--- a/Game.Api/Sockets/Commands/BattleLost.cs
+++ b/Game.Api/Sockets/Commands/BattleLost.cs
@@ -4,7 +4,7 @@ using Game.Application.Services;
 
 namespace Game.Api.Sockets.Commands
 {
-    public class BattleLost : AbstractSocketCommandWithResponseData<BattleLostResponse>
+    public class BattleLost : AbstractSocketCommand<BattleLostResponse, BattleLostRequest>
     {
         private readonly BattleService _battleService;
         private readonly ILogger<BattleLost> _logger;
@@ -30,7 +30,7 @@ namespace Game.Api.Sockets.Commands
                 });
             }
 
-            var success = await _battleService.EndBattleLoss(player, state, cancellationToken);
+            var success = await _battleService.EndBattleLoss(player, state, Parameters.ClientTotalMs, cancellationToken);
 
             if (success)
             {

--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -933,6 +933,95 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task EndBattleLoss_DivergentClientTotalMs_IsDiagnosticOnly_StillReturnsTrue()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var skill = await TestDataSeeder.CreateSkillAsync(context, "Poke", baseDamage: 1m, cooldownMs: 2000);
+            var strongEnemy = await TestDataSeeder.CreateStrongEnemyAsync(context);
+            var enemySkill = await TestDataSeeder.CreateSkillAsync(context, "Crush", baseDamage: 100m, cooldownMs: 500);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, strongEnemy.Id, enemySkill.Id);
+            var zone = await TestDataSeeder.CreateZoneAsync(context);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, strongEnemy.Id);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id, level: 1);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, skill.Id);
+
+            // Override player attributes to be weak
+            var existingAttrs = context.PlayerAttributes.Where(pa => pa.PlayerId == playerEntity.Id);
+            context.PlayerAttributes.RemoveRange(existingAttrs);
+            context.PlayerAttributes.AddRange(
+                new Infrastructure.Entities.PlayerAttribute { PlayerId = playerEntity.Id, AttributeId = (int)Core.EAttribute.Strength, Amount = 1m },
+                new Infrastructure.Entities.PlayerAttribute { PlayerId = playerEntity.Id, AttributeId = (int)Core.EAttribute.Endurance, Amount = 1m });
+            playerEntity.StatPointsGained = 2;
+            playerEntity.StatPointsUsed = 2;
+            await context.SaveChangesAsync(CancellationToken);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+
+            await battleService.StartBattle(player, state, zoneId: zone.Id);
+            state.BattleStartTime = DateTime.UtcNow.AddMinutes(-10);
+
+            // A wildly divergent client-reported duration is logged but never gates the claim — the field
+            // is diagnostic only, not anti-cheat — so the loss must still resolve to true.
+            var result = await battleService.EndBattleLoss(player, state, clientTotalMs: int.MaxValue);
+
+            Assert.True(result);
+            Assert.False(state.HasActiveBattle);
+        }
+
+        [Fact]
+        public async Task EndBattleLoss_ReplayWasVictory_ReturnsFalseAndLeavesStateActive()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+            var enemy = await TestDataSeeder.CreateEnemyAsync(context);
+            await TestDataSeeder.LinkSkillToEnemyAsync(context, enemy.Id, skill.Id);
+            var zone = await TestDataSeeder.CreateZoneAsync(context);
+            await TestDataSeeder.LinkEnemyToZoneAsync(context, zone.Id, enemy.Id);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, playerEntity.Id, skill.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+            var state = new PlayerState();
+
+            await battleService.StartBattle(player, state, zoneId: zone.Id);
+            Assert.True(state.HasActiveBattle);
+
+            // Backdate the battle start so the elapsed-time gate is satisfied — the rejection under test is
+            // the outcome mismatch below, not the too-early-claim gate.
+            state.BattleStartTime = DateTime.UtcNow.AddMinutes(-10);
+
+            // The default player/enemy matchup is a straightforward win (mirrors
+            // EndBattleVictory_EnoughTimeElapsed_ReturnsDefeatResult), so a BattleLost claim against this
+            // exact battle is the client/server divergence the parity invariant says must be surfaced —
+            // rejected rather than silently booking a loss for what the server replayed as a win.
+            var result = await battleService.EndBattleLoss(player, state);
+
+            Assert.False(result);
+            Assert.True(state.HasActiveBattle);
+        }
+
+        [Fact]
         public async Task StartBossBattle_ZoneWithBoss_StartsDeterministicBossBattle()
         {
             using var scope = CreateScope();

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -368,7 +368,7 @@ namespace Game.Application.Services
             };
         }
 
-        public async Task<bool> EndBattleLoss(Player player, PlayerState state, CancellationToken cancellationToken = default)
+        public async Task<bool> EndBattleLoss(Player player, PlayerState state, int? clientTotalMs = null, CancellationToken cancellationToken = default)
         {
             // Idempotency backstop (#1874/#1993): mirrors EndBattleVictory's guard — see BattleAlreadyCredited.
             if (BattleAlreadyCredited(state, player))
@@ -383,11 +383,38 @@ namespace Game.Application.Services
 
             if (!TryResolveActiveBattle(state, out var enemy, out var result, out _))
             {
+                // No battle to resolve. After the caller's HasActiveBattle gate this means a torn state
+                // (an enemy id set without its snapshot), which the set/clear invariant should prevent.
+                _logger.LogWarning(
+                    "EndBattleLoss rejected for player {PlayerId}: no resolvable active battle "
+                    + "(activeEnemyId: {ActiveEnemyId}, hasSnapshot: {HasSnapshot}).",
+                    player.Id, state.ActiveEnemyId, state.Snapshot is not null);
                 return false;
+            }
+
+            // Diagnostic only (not anti-cheat): mirrors EndBattleVictory's divergence log so a front/back
+            // battle-logic drift is visible on the loss path too. Logged regardless of the outcome below.
+            if (clientTotalMs is int reportedMs && reportedMs != result.TotalMs)
+            {
+                _logger.LogWarning(
+                    "EndBattleLoss battle-duration divergence for player {PlayerId}: client reported "
+                    + "{ClientTotalMs}ms but server replay was {ServerTotalMs}ms (delta: {DeltaMs}, "
+                    + "enemyId: {EnemyId}, enemyLevel: {EnemyLevel}, seed: {Seed}).",
+                    player.Id, reportedMs, result.TotalMs, reportedMs - result.TotalMs,
+                    enemy.Id, enemy.Level, state.BattleSeed);
             }
 
             if (result.Victory)
             {
+                // The server's parity replay of the exact reported battle ended in a win despite a loss
+                // claim — precisely the client/server battle-logic divergence the parity invariant says must
+                // be surfaced. Seed + enemy + level reproduce it.
+                _logger.LogWarning(
+                    "EndBattleLoss rejected for player {PlayerId}: server replay was a victory, not a loss "
+                    + "(enemyId: {EnemyId}, enemyLevel: {EnemyLevel}, seed: {Seed}, replayMs: {ReplayMs}, "
+                    + "isBoss: {IsBoss}, zoneId: {ZoneId}).",
+                    player.Id, enemy.Id, enemy.Level, state.BattleSeed, result.TotalMs, state.IsBossBattle,
+                    state.BattleZoneId);
                 return false;
             }
 

--- a/UI/src/lib/api/types/api-socket-type-map.ts
+++ b/UI/src/lib/api/types/api-socket-type-map.ts
@@ -5,6 +5,7 @@ import type {
 	IApplyModRequest,
 	IAttribute,
 	IAttributeUpdate,
+	IBattleLostRequest,
 	IBattleLostResponse,
 	IChallenge,
 	IChallengeBossRequest,
@@ -85,6 +86,7 @@ export type ApiSocketResponseTypes = {
 
 export type ApiSocketRequestTypes = {
 	'ApplyMod': IApplyModRequest;
+	'BattleLost': IBattleLostRequest;
 	'ChallengeBoss': IChallengeBossRequest;
 	'DefeatEnemy': IDefeatEnemyRequest;
 	'EquipItem': IEquipRequest;

--- a/UI/src/lib/api/types/interfaces/enemies.ts
+++ b/UI/src/lib/api/types/interfaces/enemies.ts
@@ -3,6 +3,10 @@
 
 import type { IBattlerAttribute } from '../';
 
+export interface IBattleLostRequest {
+	clientTotalMs?: number;
+}
+
 export interface IBattleLostResponse {
 	cooldown: number;
 	nextEnemy?: IEnemyInstance;

--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -687,8 +687,11 @@ export class EnemyManager {
 		// getNewEnemy call and clobber the fight the supersession already started (#1696).
 		const generation = this.transitionGeneration;
 		// Record the loss explicitly (turning auto-fight off) and drop back to the boss-available
-		// state — the normal idle farm loop — honoring the post-loss cooldown.
-		const lostResponse = await apiSocket.sendSocketCommand('BattleLost');
+		// state — the normal idle farm loop — honoring the post-loss cooldown. Report the duration the
+		// client simulated alongside the claim, mirroring claimVictory's diagnostic-only clientTotalMs.
+		const lostResponse = await apiSocket.sendSocketCommand('BattleLost', {
+			clientTotalMs: battleEngine.timeElapsed
+		});
 		// A retreat/challenge superseded this resolution while BattleLost was in flight; the superseding
 		// transition already owns the loop's state, so abandon rather than clobber it below.
 		if (!this.transitionCurrent(generation)) {

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -531,7 +531,7 @@ describe('EnemyManager boss mode', () => {
 
 		await fireStage(h.BattleStage.Defeated);
 
-		expect(send).toHaveBeenCalledWith('BattleLost');
+		expect(send).toHaveBeenCalledWith('BattleLost', { clientTotalMs: h.battleEngine.timeElapsed });
 		expect(manager.mode).toBe('idle');
 		expect(manager.autoFight).toBe(false);
 		expect(h.battleEngine.startLoading).toHaveBeenCalledWith(5000);
@@ -619,7 +619,7 @@ describe('EnemyManager boss mode', () => {
 		// A draw is not a death, so no loss is recorded and the zone is not cleared; the player drops back
 		// to the idle farm (boss available) rather than re-spawning the boss, with auto-fight turned off.
 		// The unresolved boss battle is recorded as abandoned by the backend when the next enemy starts.
-		expect(send).not.toHaveBeenCalledWith('BattleLost');
+		expect(send).not.toHaveBeenCalledWith('BattleLost', expect.anything());
 		expect(send).not.toHaveBeenCalledWith('DefeatEnemy', expect.anything());
 		expect(manager.mode).toBe('idle');
 		expect(manager.autoFight).toBe(false);
@@ -993,7 +993,7 @@ describe('EnemyManager boss mode', () => {
 		await fireStage(h.BattleStage.Drawn);
 
 		expect(send).not.toHaveBeenCalledWith('DefeatEnemy', expect.anything());
-		expect(send).not.toHaveBeenCalledWith('BattleLost');
+		expect(send).not.toHaveBeenCalledWith('BattleLost', expect.anything());
 		// The drawn battle was fought to the cap, so the fetch reports the elapsed time the client simulated
 		// (battleEngine.timeElapsed) — the backend abandon re-simulates that window and records the draw.
 		expect(send).toHaveBeenCalledWith('NewEnemy', { newZoneId: 3, clientBattleMs: 8880, forceAbandon: false });
@@ -1127,7 +1127,7 @@ describe('EnemyManager boss mode', () => {
 
 		await fireStage(h.BattleStage.Defeated);
 
-		expect(send).toHaveBeenCalledWith('BattleLost');
+		expect(send).toHaveBeenCalledWith('BattleLost', { clientTotalMs: h.battleEngine.timeElapsed });
 		expect(h.battleEngine.startLoading).toHaveBeenCalledWith(5000);
 		expect(send).not.toHaveBeenCalledWith('NewEnemy', expect.anything());
 		expect(manager.currentEnemy).toEqual(preparedInstance);


### PR DESCRIPTION
## Summary

`EndBattleVictory` logs three distinct diagnostics (no resolvable battle, client/server duration divergence, replay-outcome mismatch with seed/enemy/level for reproduction). `EndBattleLoss` only logged the too-early-claim rejection — a `BattleLost` claim whose server replay actually resolved as a *victory* (precisely the frontend/backend battle-logic divergence the parity invariant says must be surfaced) returned `false` with no log at all, and the command had no `ClientTotalMs` to compare against the server's replay duration.

This mirrors all three of `EndBattleVictory`'s structured warnings onto `EndBattleLoss` and threads an optional `ClientTotalMs` through the `BattleLost` command end-to-end:

- **Backend**: `BattleService.EndBattleLoss` now accepts `clientTotalMs` and logs (a) no resolvable active battle, (b) duration divergence, and (c) outcome mismatch (replay was a victory, not a loss) — each with the seed/enemy/level needed to reproduce it.
- **`BattleLostRequest`** (new model) carries the optional `ClientTotalMs`, mirroring `DefeatEnemyRequest`; the `BattleLost` socket command now takes it as a request parameter instead of no parameters.
- **Frontend**: `enemy-manager.ts`'s `resolveBossLoss()` now sends `clientTotalMs: battleEngine.timeElapsed` alongside the `BattleLost` claim, mirroring `claimVictory`'s existing diagnostic report.
- Regenerated the TypeScript client (`dotnet run --project Game.Api -- codegen`) so `IBattleLostRequest` and the socket type map pick up the new parameter — no manual edits to the generated files.

## Why this matters

A real parity bug that flips a win into a client-perceived loss would previously manifest as a player losing earned rewards with nothing in the logs to reproduce it from. This closes that gap.

## Testing

- `Game.Application.Tests`: added `EndBattleLoss_DivergentClientTotalMs_IsDiagnosticOnly_StillReturnsTrue` (mirrors the existing victory-path test — a wildly divergent value is logged but never gates the claim) and `EndBattleLoss_ReplayWasVictory_ReturnsFalseAndLeavesStateActive` (a normal win-shaped battle claimed as a loss is rejected, battle stays active for a legitimate retry).
- `Game.Api.Tests`: updated `BattleLostSocketTests` call sites for the new required request parameter; `BattleLost_ValidLoss_Succeeds` now exercises `ClientTotalMs` end-to-end through the socket layer.
- `UI` unit tests: updated `enemy-manager-boss.test.ts` assertions for the new `BattleLost` call shape.

### Checklist
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` (all 4 backend test projects) — 3213/3213 passed
- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — 3722/3722 passed
- [x] Codegen re-run with no further drift beyond this PR's diff

Closes #1923


---
_Generated by [Claude Code](https://claude.ai/code/session_01BH9ty12mnbJEWgZ7vSywDa)_