### PR TITLE
Self-heal corrupted player/session cache blobs on deserialization failure

### DIFF
--- a/Game.Application.Tests/Services/OfflineProgressServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/OfflineProgressServiceIntegrationTests.cs
@@ -13,6 +13,7 @@ using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Game.Application.Tests.Services
@@ -176,7 +177,8 @@ namespace Game.Application.Tests.Services
                 scope.ServiceProvider.GetRequiredService<PlayerUpdateBatch>(),
                 scope.ServiceProvider.GetRequiredService<IItems>(),
                 scope.ServiceProvider.GetRequiredService<IItemMods>(),
-                scope.ServiceProvider.GetRequiredService<ISkills>());
+                scope.ServiceProvider.GetRequiredService<ISkills>(),
+                scope.ServiceProvider.GetRequiredService<ILogger<PlayerRepository>>());
 
             var progressRepo = scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>();
             var brokenOfflineService = new OfflineProgressService(

--- a/Game.Application.Tests/Services/PlayerCacheEvictionTests.cs
+++ b/Game.Application.Tests/Services/PlayerCacheEvictionTests.cs
@@ -129,6 +129,33 @@ namespace Game.Application.Tests.Services
             Assert.True(ttl > TtlFloor, $"expected the reload to re-cache with a TTL, got {ttl}");
         }
 
+        [Fact]
+        public async Task GetPlayer_OnCorruptCacheEntry_DeletesKeyAndReloadsFromDb()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, name: "Corrupted");
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            using var multiplexer = await ConnectionMultiplexer.ConnectAsync(Containers.CacheConnectionString);
+            var db = multiplexer.GetDatabase();
+            var playerKey = PlayerKey(playerEntity.Id);
+
+            // Stand in for a corrupted/unparsable blob (e.g. a PlayerCacheModel shape change hitting an
+            // already-cached value, or a truncated write) with malformed JSON that reliably throws on deserialize.
+            await db.StringSetAsync(playerKey, "{not valid json");
+
+            // A corrupt entry must self-heal (delete + DB reload) rather than throw and lock the player out (#1924).
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+            Assert.Equal("Corrupted", player.Name);
+
+            var ttl = await WaitForTtlAsync(db, playerKey);
+            Assert.NotNull(ttl);
+            Assert.True(ttl > TtlFloor, $"expected the self-heal reload to re-cache with a TTL, got {ttl}");
+        }
+
         private static string PlayerKey(int playerId) => $"{Constants.CACHE_PLAYER_PREFIX}_{playerId}";
 
         // Polls the key's TTL until it satisfies the predicate (defaults to "any TTL is set"), tolerating the

--- a/Game.Application.Tests/Services/PlayerWriteBehindTests.cs
+++ b/Game.Application.Tests/Services/PlayerWriteBehindTests.cs
@@ -10,6 +10,7 @@ using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 using Xunit;
 
@@ -140,7 +141,8 @@ namespace Game.Application.Tests.Services
                 scope.ServiceProvider.GetRequiredService<PlayerUpdateBatch>(),
                 scope.ServiceProvider.GetRequiredService<IItems>(),
                 scope.ServiceProvider.GetRequiredService<IItemMods>(),
-                scope.ServiceProvider.GetRequiredService<ISkills>());
+                scope.ServiceProvider.GetRequiredService<ISkills>(),
+                scope.ServiceProvider.GetRequiredService<ILogger<PlayerRepository>>());
 
             player.ChangeZone(1);
             var ex = await Assert.ThrowsAsync<PlayerPersistenceFlushFailedException>(() => throwingRepo.SavePlayer(player));
@@ -185,7 +187,8 @@ namespace Game.Application.Tests.Services
                 batch,
                 scope.ServiceProvider.GetRequiredService<IItems>(),
                 scope.ServiceProvider.GetRequiredService<IItemMods>(),
-                scope.ServiceProvider.GetRequiredService<ISkills>());
+                scope.ServiceProvider.GetRequiredService<ISkills>(),
+                scope.ServiceProvider.GetRequiredService<ILogger<PlayerRepository>>());
 
             player.ChangeZone(1);
             var ex = await Assert.ThrowsAsync<PlayerPersistenceFlushFailedException>(() => throwingRepo.SavePlayer(player));

--- a/Game.Application.Tests/Services/SessionCacheEvictionTests.cs
+++ b/Game.Application.Tests/Services/SessionCacheEvictionTests.cs
@@ -87,6 +87,27 @@ namespace Game.Application.Tests.Services
             Assert.False(await db.KeyExistsAsync(sessionKey));
         }
 
+        [Fact]
+        public async Task GetSession_OnCorruptCacheEntry_DeletesKeyAndReturnsNull()
+        {
+            using var scope = CreateScope();
+            var sessionStore = scope.ServiceProvider.GetRequiredService<ISessionStore>();
+            using var multiplexer = await ConnectionMultiplexer.ConnectAsync(Containers.CacheConnectionString);
+            var db = multiplexer.GetDatabase();
+            const int userId = 4104;
+            var sessionKey = SessionKey(userId);
+
+            // Stand in for a corrupted/unparsable blob (e.g. a truncated write) with malformed JSON that
+            // reliably throws on deserialize.
+            await db.StringSetAsync(sessionKey, "{not valid json");
+
+            // A corrupt entry must self-heal (delete + treat as a miss) rather than throw on every read (#1924).
+            var session = await sessionStore.GetSession(userId);
+
+            Assert.Null(session);
+            Assert.False(await db.KeyExistsAsync(sessionKey));
+        }
+
         private static string SessionKey(int userId) => $"{Constants.CACHE_SESSION_PREFIX}_{userId}";
 
         // Polls the key's TTL until it satisfies the predicate (defaults to "any TTL is set"), tolerating the

--- a/Game.DataAccess/Repositories/PlayerRepository.cs
+++ b/Game.DataAccess/Repositories/PlayerRepository.cs
@@ -6,6 +6,8 @@ using Game.Core.Players;
 using Game.DataAccess.Mapping;
 using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
 
 namespace Game.DataAccess.Repositories
 {
@@ -35,6 +37,7 @@ namespace Game.DataAccess.Repositories
         private readonly IItems _items;
         private readonly IItemMods _itemMods;
         private readonly ISkills _skills;
+        private readonly ILogger<PlayerRepository> _logger;
 
         public PlayerRepository(
             GameContext context,
@@ -44,7 +47,8 @@ namespace Game.DataAccess.Repositories
             PlayerUpdateBatch updateBatch,
             IItems items,
             IItemMods itemMods,
-            ISkills skills)
+            ISkills skills,
+            ILogger<PlayerRepository> logger)
         {
             _context = context;
             _cache = cache;
@@ -54,6 +58,7 @@ namespace Game.DataAccess.Repositories
             _items = items;
             _itemMods = itemMods;
             _skills = skills;
+            _logger = logger;
         }
 
         public async Task<Player?> GetPlayer(int playerId, CancellationToken cancellationToken = default)
@@ -62,7 +67,22 @@ namespace Game.DataAccess.Repositories
             // The cache and the database both yield the lean PlayerCacheModel, so the reference graph is
             // re-resolved from the in-memory catalogs through one rehydration path regardless of the source —
             // a cached player can never serve stale reference data (#1155).
-            var model = await _cache.Get<PlayerCacheModel>(playerKey, cancellationToken);
+            PlayerCacheModel? model;
+            try
+            {
+                model = await _cache.Get<PlayerCacheModel>(playerKey, cancellationToken);
+            }
+            catch (JsonException ex)
+            {
+                // A blob that no longer deserializes (e.g. a shape change to PlayerCacheModel's required
+                // members) is corruption, not data - Postgres remains the durable copy, so this self-heals
+                // the same way HashGetAllIfExists treats a wrong-representation key: delete it and fall
+                // through to the DB reload below instead of locking the player out for the rest of the TTL (#1924).
+                _logger.LogError(ex, "Cached player {PlayerId} at key '{Key}' failed to deserialize; deleting the key and reloading from the database.", playerId, playerKey);
+                await _cache.Delete(playerKey, cancellationToken);
+                model = null;
+            }
+
             if (model is null)
             {
                 model = await GetPlayerModelFromDb(playerId, cancellationToken);

--- a/Game.DataAccess/Repositories/SessionStore.cs
+++ b/Game.DataAccess/Repositories/SessionStore.cs
@@ -2,6 +2,8 @@
 using Game.Abstractions.DataAccess;
 using Game.Abstractions.Infrastructure;
 using Game.Core.Players;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
 
 
 namespace Game.DataAccess.Repositories
@@ -26,16 +28,33 @@ namespace Game.DataAccess.Repositories
         private static readonly TimeSpan SessionCacheTtl = AuthConstants.RefreshTokenLifetime;
 
         private readonly ICacheService _cache;
+        private readonly ILogger<SessionStore> _logger;
 
-        public SessionStore(ICacheService cache)
+        public SessionStore(ICacheService cache, ILogger<SessionStore> logger)
         {
             _cache = cache;
+            _logger = logger;
         }
 
         public async Task<PlayerState?> GetSession(int userId, CancellationToken cancellationToken = default)
         {
             var sessionKey = SessionKey(userId);
-            var session = await _cache.Get<PlayerState>(sessionKey, cancellationToken);
+            PlayerState? session;
+            try
+            {
+                session = await _cache.Get<PlayerState>(sessionKey, cancellationToken);
+            }
+            catch (JsonException ex)
+            {
+                // A blob that no longer deserializes is corruption, not data: the session is reconstructable
+                // (SessionInitializer rehydrates it in-memory from the token's selected-player claim), so this
+                // self-heals the same way a corrupt player cache entry does - delete it and treat this read as
+                // a miss instead of throwing on every access for the rest of the TTL (#1924).
+                _logger.LogError(ex, "Cached session for user {UserId} at key '{Key}' failed to deserialize; deleting the key.", userId, sessionKey);
+                await _cache.Delete(sessionKey, cancellationToken);
+                return null;
+            }
+
             if (session is not null)
             {
                 // Sliding expiration: a read refreshes the idle TTL so an active session never ages out.


### PR DESCRIPTION
## Summary

`PlayerRepository.GetPlayer` only fell through to Postgres when the cached value was **absent**; a blob that exists but no longer deserializes (e.g. a `PlayerCacheModel` shape change — all members are `required`, so any additive/renamed field hard-fails `System.Text.Json` on an older blob) threw a `JsonException` on every load. Since Redis is the rehydration source of truth for the player aggregate and carries a 48h sliding TTL, one such change deployed to a live fleet would lock every cached player's connect/load out until the key aged out or an operator flushed Redis — despite Postgres holding a durable copy. `SessionStore.GetSession` (the `PlayerState` blob) had the same gap.

This mirrors a self-heal pattern the codebase already applies elsewhere: `RedisService.HashGetAllIfExists` treats a wrong-representation progress-hash key as a miss and deletes it, "rather than needing an explicit migration step, since Postgres remains the durable copy."

## Changes

- `PlayerRepository.GetPlayer`: catch a deserialization failure on the cached blob, log it, delete the corrupted key, and fall through to the existing DB-miss reload path (which then re-caches a valid blob).
- `SessionStore.GetSession`: catch a deserialization failure, log it, delete the corrupted key, and return `null` — a session miss is reconstructable, since `SessionInitializer` rehydrates it in-memory from the token's selected-player claim (never a silent logout).
- Both repositories now take an `ILogger<T>` so the self-heal is logged loudly rather than silently, matching the "log loudly" fix direction in the issue.
- Updated the three test call sites that construct `PlayerRepository` directly to pass the new logger dependency.

## Test plan

- [x] `dotnet build` — succeeds with 0 warnings/errors.
- [x] Added `PlayerCacheEvictionTests.GetPlayer_OnCorruptCacheEntry_DeletesKeyAndReloadsFromDb` — writes malformed JSON directly into the player's Redis key, asserts `GetPlayer` still returns the player (from the DB) instead of throwing, and that the key is re-cached with a fresh TTL.
- [x] Added `SessionCacheEvictionTests.GetSession_OnCorruptCacheEntry_DeletesKeyAndReturnsNull` — same setup for the session key, asserts `GetSession` returns `null` and the corrupted key is deleted rather than left behind.
- [x] `dotnet test --no-build` on `Game.Application.Tests` (the affected assembly): 981/981 passed, including the two new tests and the three updated `PlayerRepository`-construction call sites.

Closes #1924


---
_Generated by [Claude Code](https://claude.ai/code/session_016H8HEBGpjjnK6GtqB4biG3)_