### PR TITLE
Combine hit-path GET+EXPIRE into a single GETEX

### DIFF
--- a/Game.Abstractions/Infrastructure/ICacheService.cs
+++ b/Game.Abstractions/Infrastructure/ICacheService.cs
@@ -28,6 +28,13 @@
         public Task Set(string key, string? value, TimeSpan expiry, CancellationToken cancellationToken = default);
         public Task Set<T>(string key, T value, TimeSpan expiry, CancellationToken cancellationToken = default);
         /// <summary>
+        /// Reads <paramref name="key"/> and resets its TTL to <paramref name="expiry"/> in a single round trip
+        /// (a no-op on a missing key, like <see cref="ExpireAndForget"/>). Lets a sliding-expiration cache hit
+        /// avoid the separate awaited get followed by a fire-and-forget expire.
+        /// </summary>
+        public Task<string?> GetAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default);
+        public Task<T?> GetAndRefreshExpiry<T>(string key, TimeSpan expiry, CancellationToken cancellationToken = default);
+        /// <summary>
         /// Resets the time-to-live on an existing key without awaiting the result (fire-and-forget).
         /// A no-op if the key does not exist. Lets a hot read path slide a sliding-expiration TTL
         /// without paying a round-trip.

--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -427,6 +427,8 @@ namespace Game.Api.Tests.Unit
             public Task<T?> GetDelete<T>(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task Set(string key, string? value, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task Set<T>(string key, T value, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task<string?> GetAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task<T?> GetAndRefreshExpiry<T>(string key, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void ExpireAndForget(string key, TimeSpan expiry) => throw new NotSupportedException();
             public void SetAndForget(string key, string? value, TimeSpan expiry) => throw new NotSupportedException();
             public void SetAndForget<T>(string key, T value, TimeSpan expiry) => throw new NotSupportedException();
@@ -497,6 +499,8 @@ namespace Game.Api.Tests.Unit
             public Task<T?> GetDelete<T>(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task Set(string key, string? value, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task Set<T>(string key, T value, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task<string?> GetAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task<T?> GetAndRefreshExpiry<T>(string key, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void SetAndForget(string key, string? value, TimeSpan expiry) => throw new NotSupportedException();
             public void SetAndForget<T>(string key, T value, TimeSpan expiry) => throw new NotSupportedException();
             public void DeleteAndForget(string key) => throw new NotSupportedException();

--- a/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
@@ -102,6 +102,37 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task GetAndRefreshExpiry_OnAnExistingKey_ReturnsValueAndRefreshesTtl()
+        {
+            var key = $"redis-getex-{Guid.NewGuid()}";
+            using var scope = CreateScope();
+            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+            await cache.Set(key, "player-a", TimeSpan.FromSeconds(2));
+
+            var value = await cache.GetAndRefreshExpiry(key, TimeSpan.FromSeconds(30));
+
+            // The value comes back unchanged and the TTL is refreshed past the 2s seed ceiling, in one round
+            // trip rather than a separate awaited get followed by a fire-and-forget expire.
+            Assert.Equal("player-a", value);
+            var ttl = await ReadTtlAsync(key);
+            Assert.NotNull(ttl);
+            Assert.True(ttl > TimeSpan.FromSeconds(10), $"Expected the TTL to be refreshed past the 2s seed but was {ttl}.");
+        }
+
+        [Fact]
+        public async Task GetAndRefreshExpiry_OnAMissingKey_ReturnsNullAndDoesNotCreateTheKey()
+        {
+            var key = $"redis-getex-{Guid.NewGuid()}";
+            using var scope = CreateScope();
+            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+
+            var value = await cache.GetAndRefreshExpiry(key, TimeSpan.FromSeconds(30));
+
+            Assert.Null(value);
+            Assert.Null(await cache.Get(key));
+        }
+
+        [Fact]
         public async Task ReclaimAndForget_OnAMissingKey_ClaimsItWithTtl()
         {
             // Mirrors a live socket's presence key having lapsed (TTL expiry or a registration rollback) while

--- a/Game.DataAccess/Repositories/PlayerRepository.cs
+++ b/Game.DataAccess/Repositories/PlayerRepository.cs
@@ -70,7 +70,9 @@ namespace Game.DataAccess.Repositories
             PlayerCacheModel? model;
             try
             {
-                model = await _cache.Get<PlayerCacheModel>(playerKey, cancellationToken);
+                // A hit's sliding TTL is refreshed in the same round trip as the read (GETEX), rather than a
+                // separate awaited get followed by a fire-and-forget expire.
+                model = await _cache.GetAndRefreshExpiry<PlayerCacheModel>(playerKey, PlayerCacheTtl, cancellationToken);
             }
             catch (JsonException ex)
             {
@@ -92,11 +94,6 @@ namespace Game.DataAccess.Repositories
                 }
 
                 _cache.SetAndForget(playerKey, model, PlayerCacheTtl);
-            }
-            else
-            {
-                // Sliding expiration: a cache hit refreshes the idle TTL so an active player never ages out.
-                _cache.ExpireAndForget(playerKey, PlayerCacheTtl);
             }
 
             return PlayerCacheMapper.ToCore(model, _items, _itemMods, _skills);

--- a/Game.DataAccess/Repositories/SessionStore.cs
+++ b/Game.DataAccess/Repositories/SessionStore.cs
@@ -42,7 +42,9 @@ namespace Game.DataAccess.Repositories
             PlayerState? session;
             try
             {
-                session = await _cache.Get<PlayerState>(sessionKey, cancellationToken);
+                // A hit's sliding TTL is refreshed in the same round trip as the read (GETEX), rather than a
+                // separate awaited get followed by a fire-and-forget expire.
+                session = await _cache.GetAndRefreshExpiry<PlayerState>(sessionKey, SessionCacheTtl, cancellationToken);
             }
             catch (JsonException ex)
             {
@@ -53,12 +55,6 @@ namespace Game.DataAccess.Repositories
                 _logger.LogError(ex, "Cached session for user {UserId} at key '{Key}' failed to deserialize; deleting the key.", userId, sessionKey);
                 await _cache.Delete(sessionKey, cancellationToken);
                 return null;
-            }
-
-            if (session is not null)
-            {
-                // Sliding expiration: a read refreshes the idle TTL so an active session never ages out.
-                _cache.ExpireAndForget(sessionKey, SessionCacheTtl);
             }
 
             return session;

--- a/Game.Infrastructure/Cache/Redis/RedisService.cs
+++ b/Game.Infrastructure/Cache/Redis/RedisService.cs
@@ -73,6 +73,19 @@ namespace Game.Infrastructure.Cache.Redis
             await Set(key, value?.Serialize(), expiry, cancellationToken);
         }
 
+        public async Task<string?> GetAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default)
+        {
+            // GETEX in one round trip rather than an awaited GET followed by a fire-and-forget EXPIRE, halving
+            // command volume on a sliding-expiration cache hit. A no-op on a missing key, same as ExpireAndForget.
+            return await ObserveWrite(Redis.StringGetSetExpiryAsync(key, expiry), cancellationToken);
+        }
+
+        public async Task<T?> GetAndRefreshExpiry<T>(string key, TimeSpan expiry, CancellationToken cancellationToken = default)
+        {
+            var val = await GetAndRefreshExpiry(key, expiry, cancellationToken);
+            return val.Deserialize<T>();
+        }
+
         public void ExpireAndForget(string key, TimeSpan expiry)
         {
             Redis.KeyExpire(key, expiry, CommandFlags.FireAndForget);


### PR DESCRIPTION
## Summary

- `PlayerRepository.GetPlayer` and `SessionStore.GetSession` paid a separate awaited `Get` plus a fire-and-forget `ExpireAndForget` on every sliding-TTL cache hit. Added `ICacheService.GetAndRefreshExpiry`/`GetAndRefreshExpiry<T>` (backed by Redis `GETEX` via `IDatabase.StringGetSetExpiryAsync`) and switched both call sites to it — one Redis round trip instead of two on a hit, and it removes each method's separate "refresh on hit" branch since `GETEX` is already a no-op on a miss (matching `ExpireAndForget`'s existing behavior).
- The issue's other claim — that the hot-path Lua scripts in `RedisService` resend the full `EVAL` text on every call — turned out not to hold for this codebase. I verified by decompiling StackExchange.Redis 3.0.0 (the version this repo pins): the string-based `ScriptEvaluateAsync` overload already self-upgrades to `EVALSHA` after the first call per server endpoint via its own script-hash cache (`ServerEndPoint.GetScriptHash`/`AddScript`, populated by an internal `SCRIPT LOAD` pre-flight), and the issue's suggested `LuaScript.Prepare`/`LoadedLuaScript` alternative routes through that exact same string-based call internally in this library version — so switching to it wouldn't change anything. Left the Lua scripts as-is; full details are in the [issue comment](https://github.com/ginderjeremiah/GameServer/issues/1925#issuecomment).

## Why

Halves Redis command volume on the two highest-frequency sliding-TTL cache reads (player load on every socket connection/reconnect, session load on every request), and slightly simplifies both call sites.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test` (`Game.Application.Tests`, `Game.Api.Tests`) — all green, including new `RedisServiceIntegrationTests` coverage for `GetAndRefreshExpiry` (hit refreshes TTL + returns value; miss returns null and doesn't create the key) and existing `PlayerCacheEvictionTests`/`SessionCacheEvictionTests` sliding-TTL integration tests (unchanged behavior, now exercised via GETEX)

## Follow-up noted (not in this PR)

`PlayerProgressRepository.GetCachedProgress` has the same GET+ExpireAndForget shape, but its key is a Redis **hash**, not a string, so `GETEX` doesn't apply — folding that one down would need a small custom Lua script (TYPE/HGETALL+PEXPIRE in one round trip, similar to the existing `HashGetAllIfExists` script). Left out as a separate, smaller-scope follow-up.

Closes #1925

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1W4pAB5FNdtv2FsXF7VNu

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1W4pAB5FNdtv2FsXF7VNu)_