### PR TITLE
Skip reference-cache reload/broadcast when an admin write is rejected

### DIFF
--- a/Game.Api.Tests/Unit/AdminCacheReloadFilterTests.cs
+++ b/Game.Api.Tests/Unit/AdminCacheReloadFilterTests.cs
@@ -1,5 +1,6 @@
 using Game.Abstractions.DataAccess;
 using Game.Api.Filters;
+using Game.Api.Models.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -13,8 +14,9 @@ namespace Game.Api.Tests.Unit
     /// <summary>
     /// Covers the post-admin-write reload gate: on a successful write the filter broadcasts the change and
     /// reloads every cache; a broadcast failure is swallowed so the local read-your-writes reload still runs;
-    /// a faulted action skips both the broadcast and the reload entirely; and a wedged reload is cancelled and
-    /// surfaced as a <see cref="TimeoutException"/> rather than orphaned.
+    /// a faulted action or a rejected write (an <see cref="IApiResponse"/> error result) skips both the
+    /// broadcast and the reload entirely; and a wedged reload is cancelled and surfaced as a
+    /// <see cref="TimeoutException"/> rather than orphaned.
     /// </summary>
     public class AdminCacheReloadFilterTests
     {
@@ -25,7 +27,8 @@ namespace Game.Api.Tests.Unit
             return new ActionExecutingContext(actionContext, [], new Dictionary<string, object?>(), controller: new object());
         }
 
-        private static ActionExecutedContext BuildExecutedContext(Exception? exception, bool exceptionHandled)
+        private static ActionExecutedContext BuildExecutedContext(
+            Exception? exception, bool exceptionHandled, IActionResult? result = null)
         {
             var httpContext = new DefaultHttpContext();
             var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
@@ -33,17 +36,18 @@ namespace Game.Api.Tests.Unit
             {
                 Exception = exception!,
                 ExceptionHandled = exceptionHandled,
+                Result = result!,
             };
         }
 
         private static async Task<(int notified, int reloaded)> RunAsync(
-            Exception? exception, bool exceptionHandled, bool broadcastThrows = false)
+            Exception? exception, bool exceptionHandled, bool broadcastThrows = false, IActionResult? result = null)
         {
             var cache = new RecordingCache();
             var notifier = new RecordingNotifier(broadcastThrows);
             var filter = new AdminCacheReloadFilter([cache], notifier, NullLogger<AdminCacheReloadFilter>.Instance);
 
-            var executed = BuildExecutedContext(exception, exceptionHandled);
+            var executed = BuildExecutedContext(exception, exceptionHandled, result);
             await filter.OnActionExecutionAsync(BuildExecutingContext(), () => Task.FromResult(executed));
 
             return (notifier.NotifyCount, cache.ReloadCount);
@@ -73,6 +77,28 @@ namespace Game.Api.Tests.Unit
             var (notified, reloaded) = await RunAsync(new InvalidOperationException("boom"), exceptionHandled: false);
             Assert.Equal(0, notified);
             Assert.Equal(0, reloaded);
+        }
+
+        [Fact]
+        public async Task SkipsBroadcastAndReload_WhenTheWriteWasRejected()
+        {
+            // An AdminSaveResult.Failure-style rejection (e.g. "Enemy not found.") returns as a normal
+            // ApiResponse error rather than an exception. Per the admin repos' contract, rejections happen
+            // before anything is staged, so nothing changed and neither the broadcast nor the reload should run.
+            var result = new ObjectResult(ApiResponse.Error("Enemy not found."));
+            var (notified, reloaded) = await RunAsync(exception: null, exceptionHandled: false, result: result);
+            Assert.Equal(0, notified);
+            Assert.Equal(0, reloaded);
+        }
+
+        [Fact]
+        public async Task BroadcastsAndReloads_WhenResultIsASuccessfulApiResponse()
+        {
+            // A success ApiResponse (no ErrorMessage) must not be mistaken for a rejection.
+            var result = new ObjectResult(ApiResponse.Success());
+            var (notified, reloaded) = await RunAsync(exception: null, exceptionHandled: false, result: result);
+            Assert.Equal(1, notified);
+            Assert.Equal(1, reloaded);
         }
 
         [Fact]

--- a/Game.Api/Filters/AdminCacheReloadFilter.cs
+++ b/Game.Api/Filters/AdminCacheReloadFilter.cs
@@ -1,4 +1,5 @@
 using Game.Abstractions.DataAccess;
+using Game.Api.Models.Common;
 using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace Game.Api.Filters
@@ -10,7 +11,9 @@ namespace Game.Api.Filters
     /// preserving the Workbench's read-your-writes guarantee. A reload failure after a successful write
     /// surfaces as an error on the admin response (the write persisted; the admin can retry). The write is
     /// also broadcast to every other API instance (<see cref="IReferenceDataChangeNotifier"/>), each of which
-    /// reacts with a debounced background reload of its own caches (#359).
+    /// reacts with a debounced background reload of its own caches (#359). A rejected write (an
+    /// <see cref="IApiResponse"/> error result — a retirement-guard or validation rejection that changed
+    /// nothing per the admin repos' documented contract) skips both the broadcast and the reload.
     /// </summary>
     /// <remarks>
     /// Apply via <see cref="ReloadReferenceCachesAttribute"/> rather than a bare
@@ -43,7 +46,8 @@ namespace Game.Api.Filters
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
             var executedContext = await next();
-            if (executedContext.Exception is null || executedContext.ExceptionHandled)
+            if ((executedContext.Exception is null || executedContext.ExceptionHandled)
+                && !ApiResponseErrors.TryGetError(executedContext.Result, out _))
             {
                 // Broadcast first: the write is already committed at this point (this filter runs outside
                 // CommitFilter), so other instances can begin their background reloads while this instance

--- a/Game.Api/Filters/ApiResponseErrors.cs
+++ b/Game.Api/Filters/ApiResponseErrors.cs
@@ -1,0 +1,29 @@
+using Game.Api.Models.Common;
+using Microsoft.AspNetCore.Mvc;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Game.Api.Filters
+{
+    /// <summary>
+    /// Shared check for whether an action result carries an <see cref="IApiResponse"/> reporting an error.
+    /// Used both to rewrite the HTTP status (<see cref="ErrorStatusFilter"/>) and to skip reference-cache
+    /// reload/broadcast work for admin writes rejected before anything was staged
+    /// (<see cref="AdminCacheReloadFilter"/>).
+    /// </summary>
+    public static class ApiResponseErrors
+    {
+        public static bool TryGetError(IActionResult? result, [NotNullWhen(true)] out IApiResponse? response)
+        {
+            if (result is ObjectResult objectResult
+                && objectResult.Value is IApiResponse apiResponse
+                && apiResponse.ErrorMessage is not null and not "")
+            {
+                response = apiResponse;
+                return true;
+            }
+
+            response = null;
+            return false;
+        }
+    }
+}

--- a/Game.Api/Filters/ErrorStatusFilter.cs
+++ b/Game.Api/Filters/ErrorStatusFilter.cs
@@ -1,7 +1,6 @@
 ﻿using Game.Api.Models.Common;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Game.Api.Filters
 {
@@ -19,7 +18,7 @@ namespace Game.Api.Filters
         public void OnResultExecuting(ResultExecutingContext context)
         {
             if (context.HttpContext.Response.StatusCode == StatusCodes.Status200OK
-                && TryGetError(context.Result, out var response))
+                && ApiResponseErrors.TryGetError(context.Result, out var response))
             {
                 context.HttpContext.Response.StatusCode = StatusForCategory(response.ErrorCategory);
             }
@@ -40,25 +39,6 @@ namespace Game.Api.Filters
                 ApiErrorCategory.TooManyRequests => StatusCodes.Status429TooManyRequests,
                 _ => StatusCodes.Status400BadRequest,
             };
-        }
-
-        /// <summary>
-        /// Determines whether the given <paramref name="result"/> carries an <see cref="IApiResponse"/> with
-        /// a non-empty <see cref="IApiResponse.ErrorMessage"/>, surfacing the response so its category can
-        /// steer the status code.
-        /// </summary>
-        private static bool TryGetError(IActionResult result, [NotNullWhen(true)] out IApiResponse? response)
-        {
-            if (result is ObjectResult objectResult
-                && objectResult.Value is IApiResponse apiResponse
-                && apiResponse.ErrorMessage is not null and not "")
-            {
-                response = apiResponse;
-                return true;
-            }
-
-            response = null;
-            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary

`AdminCacheReloadFilter` gated its post-write reload/broadcast only on `executedContext.Exception is null || ExceptionHandled`. An `AdminSaveResult.Failure` rejection (a retirement-guard rejection, change-set validation failure, `"Enemy not found."`, etc.) returns as a normal `ApiResponse` carrying `ErrorMessage` — not an exception — so the filter still paid the full awaited local reload of every reference cache **plus** the cross-instance broadcast for a write that, per the admin repos' documented contract, changed nothing.

- Extracted `ErrorStatusFilter`'s private `TryGetError` check into a shared `ApiResponseErrors.TryGetError` helper (`Game.Api/Filters/ApiResponseErrors.cs`), since the issue's suggested fix is exactly this check duplicated.
- `AdminCacheReloadFilter` now also skips the broadcast + reload when the action result carries an `IApiResponse` error, in addition to the existing exception-based skip.
- `ErrorStatusFilter` now delegates to the shared helper instead of its own private copy — no behavior change there.

## How this addresses the issue

Closes #1929. The fix is exactly the one suggested in the issue: skip when `executedContext.Result` is an `ObjectResult` carrying an `IApiResponse` with a non-empty `ErrorMessage`, reusing `ErrorStatusFilter`'s existing check rather than duplicating it.

## Test plan

- [x] Added `SkipsBroadcastAndReload_WhenTheWriteWasRejected` — an `ApiResponse.Error(...)` result skips both the broadcast and the reload.
- [x] Added `BroadcastsAndReloads_WhenResultIsASuccessfulApiResponse` — a success `ApiResponse` (no `ErrorMessage`) is not mistaken for a rejection.
- [x] Existing `AdminCacheReloadFilterTests` and `ErrorStatusFilterTests` still pass unmodified (behavior-preserving extraction).
- [x] `dotnet build -warnaserror` — clean.
- [x] `dotnet test --no-build --no-restore` — full solution, all suites green (Game.Api.Tests 804, Game.Application.Tests 983, Game.Core.Tests 1366, Game.Infrastructure.Tests 66).
- [x] `dotnet format --verify-no-changes --no-restore` — clean.
- [x] `dotnet run --project Game.Api -- codegen` — no drift.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Ks3TPXayJR7vE1ZsvRUXh5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ks3TPXayJR7vE1ZsvRUXh5)_