### PR TITLE
CI workflow cleanups: dead test-results artifact, dead measureOnly key, unused fetch-depth

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -166,8 +166,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
 
     - name: Install .NET Core
       uses: actions/setup-dotnet@v5
@@ -196,13 +194,6 @@ jobs:
       shell: pwsh
       run: ./build/coverage.ps1 -NoBuild
 
-    - name: Upload test results
-      if: always()
-      uses: actions/upload-artifact@v7
-      with:
-        name: backend-test-results
-        path: '**/TestResults/'
-
     - name: Upload coverage report
       if: always()
       uses: actions/upload-artifact@v7
@@ -225,8 +216,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
 
     - name: Set up Node
       uses: actions/setup-node@v6
@@ -272,8 +261,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
 
     - name: Start backing stack (API + Postgres + Redis)
       # Build is parallelized across the matrix jobs, so it stays off the serial critical path.

--- a/build/coverage-floors.json
+++ b/build/coverage-floors.json
@@ -16,6 +16,5 @@
       "line": 94,
       "branch": 92
     }
-  },
-  "measureOnly": ["Game.Api", "Game.Infrastructure", "Game.Abstractions"]
+  }
 }


### PR DESCRIPTION
## Summary

Three small, unrelated CI/tooling cleanups bundled per #1931:

1. **Removed the `backend-test-results` artifact upload.** The test projects run under xunit.v3 + Microsoft.Testing.Platform with no TRX/structured reporting configured, so `**/TestResults/` glob never contained real test results — only a handful of default MTP console `.log` files. Rather than wire up TRX reporting (a materially larger change touching all 4 backend test `.csproj` files plus the coverage collection script, and reintroducing a version-coupling surface the existing `dotnet-coverage`-based collection deliberately avoids), this PR removes the misleading step. The coverage report artifact (which *does* contain real, useful data) is untouched.
2. **Removed the dead `measureOnly` key from `build/coverage-floors.json`.** Verified neither `build/coverage-gate.ps1` nor `build/coverage-floor-suggestions.ps1` reads it — `coverage-gate.ps1` derives measure-only assemblies dynamically (every reported assembly not present in `gated`/`gatedNamespaces`). Repo-wide grep found no other reference.
3. **Removed `fetch-depth: 0` from the five checkouts** in `test-backend`, `test-frontend`, and the 3-way `test-e2e` browser matrix. Nothing in the build/test/e2e path consumes git history — `dorny/paths-filter` in `detect-changes` (the only history consumer) already uses the default shallow checkout.

No behavior change intended — CI reliability/hygiene only.

## Test plan

- [x] `dotnet build -warnaserror` — succeeds, 0 warnings/errors
- [x] `dotnet test Game.sln --no-build --no-restore` — all 3,219 backend tests pass (Core, Infrastructure, Application, Api)
- [x] Verified `build/coverage-gate.ps1` never reads the removed `measureOnly` key (only reads `gated`/`gatedNamespaces`, then reports everything else as measure-only)
- [x] Validated resulting YAML and JSON parse correctly
- [x] `pwsh` isn't available in this sandbox to run `build/coverage.ps1` end-to-end; the coverage gate's behavior with the trimmed floors file was verified by code inspection instead. CI's `test-backend` job will run it for real.

Closes #1931


---
_Generated by [Claude Code](https://claude.ai/code/session_01P7CznKEnmdq7dgVaUrqf5w)_