### PR TITLE
Deduplicate WaitForTtlAsync test helper and add CancellationToken overload to PollingHelper

### DIFF
--- a/Game.Api.Tests/Unit/PollingHelperTests.cs
+++ b/Game.Api.Tests/Unit/PollingHelperTests.cs
@@ -1,0 +1,51 @@
+using Game.TestInfrastructure.Helpers;
+using Xunit;
+
+namespace Game.Api.Tests.Unit
+{
+    /// <summary>
+    /// Covers <see cref="PollingHelper"/>'s poll-loop semantics and the <see cref="CancellationToken"/> overload
+    /// (#1949): the token must flow into the delay so a caller can abort a stuck poll early instead of always
+    /// riding out the full timeout.
+    /// </summary>
+    public class PollingHelperTests
+    {
+        [Fact]
+        public async Task PollUntilAsync_SatisfiedOnFirstRead_ReturnsWithoutDelaying()
+        {
+            var result = await PollingHelper.PollUntilAsync(() => Task.FromResult(1), v => v == 1, timeoutMs: 5000);
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task PollUntilAsync_NeverSatisfied_ReturnsLastReadValueAfterTimeout()
+        {
+            var result = await PollingHelper.PollUntilAsync(() => Task.FromResult(0), v => v == 1, timeoutMs: 50);
+
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public async Task PollUntilAsync_WithAlreadyCancelledToken_ThrowsInsteadOfWaitingOutTheFullTimeout()
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                PollingHelper.PollUntilAsync(() => Task.FromResult(0), v => v == 1, cts.Token, timeoutMs: 5000));
+        }
+
+        [Fact]
+        public async Task PollUntilAsync_WithCancellationTokenOverload_SatisfiedOnFirstRead_ReturnsWithoutThrowing()
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // Satisfied on the first read, so the cancelled token is never consulted (no delay is awaited).
+            var result = await PollingHelper.PollUntilAsync(() => Task.FromResult(1), v => v == 1, cts.Token);
+
+            Assert.Equal(1, result);
+        }
+    }
+}

--- a/Game.Application.Tests/Services/PlayerCacheEvictionTests.cs
+++ b/Game.Application.Tests/Services/PlayerCacheEvictionTests.cs
@@ -43,7 +43,7 @@ namespace Game.Application.Tests.Services
             var player = await playerRepo.GetPlayer(playerEntity.Id);
             Assert.NotNull(player);
 
-            var ttl = await WaitForTtlAsync(db, playerKey);
+            var ttl = await TtlPollingHelper.WaitForTtlAsync(db, playerKey);
             Assert.NotNull(ttl);
             Assert.True(ttl > TtlFloor, $"expected a generous idle TTL, got {ttl}");
         }
@@ -68,7 +68,7 @@ namespace Game.Application.Tests.Services
             player.ChangeZone(1);
             await playerRepo.SavePlayer(player);
 
-            var ttl = await WaitForTtlAsync(db, playerKey);
+            var ttl = await TtlPollingHelper.WaitForTtlAsync(db, playerKey);
             Assert.NotNull(ttl);
             Assert.True(ttl > TtlFloor, $"expected a generous idle TTL, got {ttl}");
         }
@@ -88,14 +88,14 @@ namespace Game.Application.Tests.Services
 
             // Prime the cache, then shrink the TTL to a sliver to stand in for a key that has aged.
             await playerRepo.GetPlayer(playerEntity.Id);
-            await WaitForTtlAsync(db, playerKey);
+            await TtlPollingHelper.WaitForTtlAsync(db, playerKey);
             await db.KeyExpireAsync(playerKey, TimeSpan.FromSeconds(30));
 
             // A cache hit must slide the TTL back up to the full idle budget.
             var player = await playerRepo.GetPlayer(playerEntity.Id);
             Assert.NotNull(player);
 
-            var ttl = await WaitForTtlAsync(db, playerKey, predicate: t => t > TtlFloor);
+            var ttl = await TtlPollingHelper.WaitForTtlAsync(db, playerKey, predicate: t => t > TtlFloor);
             Assert.NotNull(ttl);
             Assert.True(ttl > TtlFloor, $"expected the hit to refresh the TTL, got {ttl}");
         }
@@ -115,7 +115,7 @@ namespace Game.Application.Tests.Services
 
             // Prime the cache, then delete the key to simulate the TTL lapsing / an eviction.
             await playerRepo.GetPlayer(playerEntity.Id);
-            await WaitForTtlAsync(db, playerKey);
+            await TtlPollingHelper.WaitForTtlAsync(db, playerKey);
             await db.KeyDeleteAsync(playerKey);
             Assert.False(await db.KeyExistsAsync(playerKey));
 
@@ -124,7 +124,7 @@ namespace Game.Application.Tests.Services
             Assert.NotNull(reloaded);
             Assert.Equal("Evicted", reloaded.Name);
 
-            var ttl = await WaitForTtlAsync(db, playerKey);
+            var ttl = await TtlPollingHelper.WaitForTtlAsync(db, playerKey);
             Assert.NotNull(ttl);
             Assert.True(ttl > TtlFloor, $"expected the reload to re-cache with a TTL, got {ttl}");
         }
@@ -151,21 +151,11 @@ namespace Game.Application.Tests.Services
             Assert.NotNull(player);
             Assert.Equal("Corrupted", player.Name);
 
-            var ttl = await WaitForTtlAsync(db, playerKey);
+            var ttl = await TtlPollingHelper.WaitForTtlAsync(db, playerKey);
             Assert.NotNull(ttl);
             Assert.True(ttl > TtlFloor, $"expected the self-heal reload to re-cache with a TTL, got {ttl}");
         }
 
         private static string PlayerKey(int playerId) => $"{Constants.CACHE_PLAYER_PREFIX}_{playerId}";
-
-        // Polls the key's TTL until it satisfies the predicate (defaults to "any TTL is set"), tolerating the
-        // fire-and-forget write not having landed yet. KeyTimeToLiveAsync returns null both for a missing key
-        // and a key with no expiry, so a non-null result proves an expiry is attached.
-        private static Task<TimeSpan?> WaitForTtlAsync(IDatabase db, string key, Func<TimeSpan, bool>? predicate = null)
-        {
-            predicate ??= _ => true;
-            return PollingHelper.PollUntilAsync(
-                () => db.KeyTimeToLiveAsync(key), ttl => ttl is not null && predicate(ttl.Value));
-        }
     }
 }

--- a/Game.Application.Tests/Services/SessionCacheEvictionTests.cs
+++ b/Game.Application.Tests/Services/SessionCacheEvictionTests.cs
@@ -39,7 +39,7 @@ namespace Game.Application.Tests.Services
 
             sessionStore.Update(new PlayerState { PlayerId = 7 }, userId);
 
-            var ttl = await WaitForTtlAsync(db, sessionKey);
+            var ttl = await TtlPollingHelper.WaitForTtlAsync(db, sessionKey);
             Assert.NotNull(ttl);
             Assert.True(ttl > TtlFloor, $"expected a generous idle TTL, got {ttl}");
         }
@@ -56,7 +56,7 @@ namespace Game.Application.Tests.Services
 
             // Prime the session, then shrink the TTL to a sliver to stand in for a key that has aged.
             sessionStore.Update(new PlayerState { PlayerId = 9 }, userId);
-            await WaitForTtlAsync(db, sessionKey);
+            await TtlPollingHelper.WaitForTtlAsync(db, sessionKey);
             await db.KeyExpireAsync(sessionKey, TimeSpan.FromSeconds(30));
 
             // A read hit must slide the TTL back up to the full idle budget and round-trip the state.
@@ -64,7 +64,7 @@ namespace Game.Application.Tests.Services
             Assert.NotNull(session);
             Assert.Equal(9, session.PlayerId);
 
-            var ttl = await WaitForTtlAsync(db, sessionKey, predicate: t => t > TtlFloor);
+            var ttl = await TtlPollingHelper.WaitForTtlAsync(db, sessionKey, predicate: t => t > TtlFloor);
             Assert.NotNull(ttl);
             Assert.True(ttl > TtlFloor, $"expected the hit to refresh the TTL, got {ttl}");
         }
@@ -109,15 +109,5 @@ namespace Game.Application.Tests.Services
         }
 
         private static string SessionKey(int userId) => $"{Constants.CACHE_SESSION_PREFIX}_{userId}";
-
-        // Polls the key's TTL until it satisfies the predicate (defaults to "any TTL is set"), tolerating the
-        // fire-and-forget write not having landed yet. KeyTimeToLiveAsync returns null both for a missing key
-        // and a key with no expiry, so a non-null result proves an expiry is attached.
-        private static Task<TimeSpan?> WaitForTtlAsync(IDatabase db, string key, Func<TimeSpan, bool>? predicate = null)
-        {
-            predicate ??= _ => true;
-            return PollingHelper.PollUntilAsync(
-                () => db.KeyTimeToLiveAsync(key), ttl => ttl is not null && predicate(ttl.Value));
-        }
     }
 }

--- a/Game.TestInfrastructure/Helpers/PollingHelper.cs
+++ b/Game.TestInfrastructure/Helpers/PollingHelper.cs
@@ -12,7 +12,16 @@ namespace Game.TestInfrastructure.Helpers
         /// on the read value. Returns the last read value even if <paramref name="satisfied"/> never holds
         /// before <paramref name="timeoutMs"/> elapses, leaving the pass/fail decision to the caller.
         /// </summary>
-        public static async Task<T> PollUntilAsync<T>(Func<Task<T>> read, Func<T, bool> satisfied, int timeoutMs = 5000)
+        public static Task<T> PollUntilAsync<T>(Func<Task<T>> read, Func<T, bool> satisfied, int timeoutMs = 5000)
+            => PollUntilAsync(read, satisfied, CancellationToken.None, timeoutMs);
+
+        /// <summary>
+        /// Overload of <see cref="PollUntilAsync{T}(Func{Task{T}}, Func{T, bool}, int)"/> that flows
+        /// <paramref name="cancellationToken"/> into the poll delay, so a caller can abort the wait early
+        /// instead of always riding out the full <paramref name="timeoutMs"/>.
+        /// </summary>
+        public static async Task<T> PollUntilAsync<T>(
+            Func<Task<T>> read, Func<T, bool> satisfied, CancellationToken cancellationToken, int timeoutMs = 5000)
         {
             var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
             T value;
@@ -24,7 +33,7 @@ namespace Game.TestInfrastructure.Helpers
                     return value;
                 }
 
-                await Task.Delay(25);
+                await Task.Delay(25, cancellationToken);
             } while (DateTime.UtcNow < deadline);
 
             return value;

--- a/Game.TestInfrastructure/Helpers/TtlPollingHelper.cs
+++ b/Game.TestInfrastructure/Helpers/TtlPollingHelper.cs
@@ -1,0 +1,22 @@
+using StackExchange.Redis;
+
+namespace Game.TestInfrastructure.Helpers
+{
+    /// <summary>
+    /// Shared TTL-polling helper for the sliding-idle-TTL cache-eviction integration tests (#439, #537).
+    /// </summary>
+    public static class TtlPollingHelper
+    {
+        /// <summary>
+        /// Polls the key's TTL until it satisfies <paramref name="predicate"/> (defaults to "any TTL is set"),
+        /// tolerating a fire-and-forget write not having landed yet. <c>KeyTimeToLiveAsync</c> returns null
+        /// both for a missing key and a key with no expiry, so a non-null result proves an expiry is attached.
+        /// </summary>
+        public static Task<TimeSpan?> WaitForTtlAsync(IDatabase db, string key, Func<TimeSpan, bool>? predicate = null)
+        {
+            predicate ??= _ => true;
+            return PollingHelper.PollUntilAsync(
+                () => db.KeyTimeToLiveAsync(key), ttl => ttl is not null && predicate(ttl.Value));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two small test-infrastructure cleanups from #1949 (a follow-up to #1945, which migrated the remaining integration-test polling loops onto `PollingHelper.PollUntilAsync`):

1. **Shared `WaitForTtlAsync` helper.** Extracted the identical private `WaitForTtlAsync` method from `PlayerCacheEvictionTests` and `SessionCacheEvictionTests` into a new `Game.TestInfrastructure.Helpers.TtlPollingHelper`, and updated both suites' call sites to use it directly.
2. **`CancellationToken` overload on `PollingHelper`.** `PollUntilAsync` used an uncancellable `Task.Delay(25)`, so a caller's `CancellationToken` was dropped from the delay. Added a `PollUntilAsync` overload that takes a `CancellationToken` and flows it into the delay, so a caller can abort a stuck poll early instead of always riding out the full timeout. The existing `int timeoutMs`-only overload is preserved (now delegating to the new one with `CancellationToken.None`), so no call sites needed to change.

Both are test-suite maintainability only — no production-code or behavior change.

## Follow-up

While picking this up, a comment on #1949 widened scope to more duplicated integration-test helpers (`SeedAsync`/`SeedAndLoginAsync`, `GetPresenceTtlAsync`/`PresenceKey`, dead-letter fixture helpers) found in the same health review pass. Kept this PR scoped to the original two items and split the rest out to #2023.

## Test plan

- [x] `dotnet build -warnaserror` — clean, 0 warnings.
- [x] `dotnet format --verify-no-changes --no-restore` — clean.
- [x] `dotnet test --no-build --no-restore` — full solution suite passes (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests all green), including new `PollingHelperTests` covering the `CancellationToken` overload (satisfied-on-first-read, timeout-without-cancellation, and cancel-aborts-early cases).

Closes #1949

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdtrEzmEZccEWcmMuyA1AR)_