### PR TITLE
Small frontend cleanups: rename stale parity scenario, drop dead exports

### DIFF
--- a/UI/src/lib/common/challenge-type.ts
+++ b/UI/src/lib/common/challenge-type.ts
@@ -1,5 +1,5 @@
 import { EChallengeType, type IChallengeType } from '$lib/api';
-import { normalizeText, tintColor } from './functions';
+import { normalizeText } from './functions';
 
 /*
  * Single source of truth for challenge-type accent visuals. The hues are
@@ -27,10 +27,6 @@ const CHALLENGE_TYPE_KEY: Record<EChallengeType, string> = {
 /** Themeable challenge-type accent hue, e.g. `var(--challenge-enemies-killed)`. */
 export const challengeTypeColor = (id: EChallengeType): string =>
 	`var(--challenge-${CHALLENGE_TYPE_KEY[id] ?? 'enemies-killed'})`;
-
-/** The challenge-type accent at a given opacity (themeable via `color-mix`). */
-export const challengeTypeTint = (id: EChallengeType, alpha: number): string =>
-	tintColor(challengeTypeColor(id), alpha);
 
 /**
  * The challenge type's display name — the authored name from the `ChallengeTypes` reference set

--- a/UI/src/routes/admin/workbench/progression/types.ts
+++ b/UI/src/routes/admin/workbench/progression/types.ts
@@ -17,9 +17,6 @@ export type WorkbenchProficiency = IProficiency;
 /** The "no skill" sentinel for the milestone reward-skill select (-1 ⇒ no skill chosen / cleared). */
 export const NO_SKILL = -1;
 
-/** The two record kinds the progression editor authors. */
-export type ProgressionKind = 'path' | 'tier';
-
 /** A detail-pane tab descriptor (shared header chrome). */
 export interface ProgressionTab {
 	key: string;

--- a/UI/src/tests/lib/engine/battle/battle-engine-parity.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine-parity.test.ts
@@ -136,11 +136,11 @@ interface EngineParityScenario {
 // exercises the seeded fractional crit AND an enemy firing back, a player defeat driven by DoT/HoT, and a
 // timeout draw — each with identical inputs/expected to its row in battle-simulation-parity.test.ts.
 const scenarios: EngineParityScenario[] = [
-	// drawOrderDodgeOnlyAlignsCrit: real skill CriticalChance 0.5 (so the outcome depends on the exact
+	// drawOrderEnemyFireAlignsCrit: real skill CriticalChance 0.5 (so the outcome depends on the exact
 	// seeded stream) against an enemy that fires every tick — pins both the seed lockstep and the
 	// enemy-attack path.
 	{
-		name: 'drawOrderDodgeOnlyAlignsCrit',
+		name: 'drawOrderEnemyFireAlignsCrit',
 		playerAttrs: [
 			{ id: EAttribute.Strength, amount: 10 },
 			{ id: EAttribute.CriticalDamage, amount: 0.5 }


### PR DESCRIPTION
## Summary

Three tiny, unrelated frontend cleanups from the health review (#1958):

1. **Stale scenario name in `battle-engine-parity.test.ts`.** The scenario was named `drawOrderDodgeOnlyAlignsCrit`, but no such row exists in the 69-row `battle-simulation-parity.test.ts` matrix or the backend's `BattleSimulatorParityTests.cs`. Its inputs/expected are exactly the matrix row `drawOrderEnemyFireAlignsCrit` (`battle-simulation-parity.test.ts:918`) — verified the inputs match exactly. Renamed to restore the "transcribed faithfully" cross-check the comment documents. Behavior/test outcome is unchanged.
2. **Dead export `challengeTypeTint`** (`src/lib/common/challenge-type.ts`) — zero references repo-wide (verified via grep). Deleted, along with the now-unused `tintColor` import.
3. **Dead type `ProgressionKind`** (`src/routes/admin/workbench/progression/types.ts`) — zero references outside its own definition (verified via grep). Deleted.

Left out of scope per the issue: `ApiSocketResponseType` is also reference-free but lives in a codegen'd file (`Game.Api.CodeGen`), so pruning it belongs in the generator, not a hand-edit.

## Test plan

- [x] `npm run lint` — clean (eslint + svelte-check, 0 errors/warnings)
- [x] `npm run test:unit:ci` — 299 test files / 3722 tests passing

Closes #1958


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9JWG1er8oxaqdVGi4kwf6)_