### PR TITLE
Close socket integration-test gaps: takeover-close assertion, registry lifecycle unit test, tighter assertions

### DIFF
--- a/Game.Api.Tests/Integration/LoginControllerTests.cs
+++ b/Game.Api.Tests/Integration/LoginControllerTests.cs
@@ -1210,7 +1210,7 @@ namespace Game.Api.Tests.Integration
         {
             // No bearer token — a pre-authentication request never reaches the creatable-class payload.
             var response = await Client.GetAsync("/api/Login/CharacterCreationData", CancellationToken);
-            Assert.NotEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
     }
 }

--- a/Game.Api.Tests/Integration/SocketConnectionTests.cs
+++ b/Game.Api.Tests/Integration/SocketConnectionTests.cs
@@ -91,8 +91,12 @@ namespace Game.Api.Tests.Integration
             // with no cached session is a different, authenticated case; see the rehydration test below.)
             var wsClient = Factory.Server.CreateWebSocketClient();
 
-            await Assert.ThrowsAnyAsync<Exception>(
+            // The TestServer client throws InvalidOperationException with the rejected status code baked
+            // into the message when the handshake doesn't complete with a 101 — tightened from ThrowsAny so
+            // this can't pass on, say, a 500 as readily as the intended 401-rejected upgrade.
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => wsClient.ConnectAsync(new Uri("ws://localhost/socket"), CancellationToken));
+            Assert.Contains("401", ex.Message);
         }
 
         [Fact]

--- a/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
+++ b/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
@@ -9,6 +9,7 @@ using Game.TestInfrastructure.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
+using System.Net.WebSockets;
 using Xunit;
 
 namespace Game.Api.Tests.Integration
@@ -56,6 +57,15 @@ namespace Game.Api.Tests.Integration
             // SocketReplaced is emitted with no command Id, so it surfaces as a null-Id server push.
             var replaced = await socketA.WaitForResponseAsync(null);
             Assert.Equal(nameof(SocketReplaced), replaced.Name);
+
+            // ...the superseded connection is actually closed, not just notified (#1959): dropping or
+            // reordering the Close() call inside SocketReplaced.ExecuteAsync would leave two live sockets
+            // for one player — the exact condition the single-connection model exists to prevent — with
+            // every assertion above this one still passing.
+            var (closeStatus, closeDescription) = await socketA.WaitForCloseAsync();
+            Assert.Equal(WebSocketState.Closed, socketA.State);
+            Assert.Equal(WebSocketCloseStatus.NormalClosure, closeStatus);
+            Assert.Equal(ESocketCloseReason.SocketReplaced.GetDescription(), closeDescription);
 
             // ...and the presence key now points at the new socket rather than the old one.
             await socketB.SendCommandAsync<object>("GetStatisticTypes");

--- a/Game.Api.Tests/Unit/SocketConnectionRegistryTests.cs
+++ b/Game.Api.Tests/Unit/SocketConnectionRegistryTests.cs
@@ -1,0 +1,49 @@
+using Game.Api.Services;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Game.Api.Tests.Unit
+{
+    /// <summary>
+    /// <see cref="SocketConnectionRegistry"/> is otherwise only driven through a real host in
+    /// <c>SocketDrainTests</c> (whose factory strips <see cref="IHostedService"/> registrations, so the
+    /// registry is constructed directly rather than resolved) — its <see cref="IHostApplicationLifetime"/>
+    /// wiring and the run-once drain guard are never exercised there. This pins the "both
+    /// <see cref="IHostApplicationLifetime.ApplicationStopping"/> and <see cref="SocketConnectionRegistry.StopAsync"/>
+    /// reach the same drain" contract cheaply, with a fake lifetime and no live sockets.
+    /// </summary>
+    public class SocketConnectionRegistryTests
+    {
+        [Fact]
+        public async Task EnsureDraining_ApplicationStoppingAndStopAsync_ShareTheSameDrainTask()
+        {
+            var lifetime = new FakeHostLifetime();
+            var registry = new SocketConnectionRegistry(lifetime, NullLogger<SocketConnectionRegistry>.Instance);
+            await registry.StartAsync(CancellationToken.None);
+
+            // Call StopAsync explicitly first, capturing the drain task it starts.
+            var explicitTask = registry.StopAsync(CancellationToken.None);
+
+            // The ApplicationStopping hook wired by StartAsync must reach the SAME in-flight drain rather
+            // than starting a second one — pin it by signalling shutdown and re-fetching via StopAsync.
+            lifetime.TriggerStopping();
+            var afterStopping = registry.StopAsync(CancellationToken.None);
+
+            Assert.Same(explicitTask, afterStopping);
+            await explicitTask;
+        }
+
+        private sealed class FakeHostLifetime : IHostApplicationLifetime
+        {
+            private readonly CancellationTokenSource _stopping = new();
+
+            public CancellationToken ApplicationStarted => CancellationToken.None;
+            public CancellationToken ApplicationStopping => _stopping.Token;
+            public CancellationToken ApplicationStopped => CancellationToken.None;
+
+            public void StopApplication() => _stopping.Cancel();
+            public void TriggerStopping() => _stopping.Cancel();
+        }
+    }
+}

--- a/Game.TestInfrastructure/Helpers/TestSocketClient.cs
+++ b/Game.TestInfrastructure/Helpers/TestSocketClient.cs
@@ -102,6 +102,25 @@ namespace Game.TestInfrastructure.Helpers
             return ReadUntilAsync(m => m.Deserialize<ApiSocketResponse>(), r => r.Id == commandId);
         }
 
+        /// <summary>
+        /// Reads the next frame — expected to be a server-initiated close (e.g. right after a push like
+        /// <c>SocketReplaced</c> that closes the connection) — and completes the closing handshake so
+        /// <see cref="State"/> settles at <see cref="WebSocketState.Closed"/> rather than lingering in
+        /// <see cref="WebSocketState.CloseReceived"/>. Returns the status/description the server sent.
+        /// </summary>
+        public async Task<(WebSocketCloseStatus? Status, string? Description)> WaitForCloseAsync()
+        {
+            var buffer = new byte[4096];
+            await _socket.ReceiveAsync(buffer, _cts.Token);
+
+            if (_socket.State == WebSocketState.CloseReceived)
+            {
+                await _socket.CloseAsync(WebSocketCloseStatus.NormalClosure, null, _cts.Token);
+            }
+
+            return (_socket.CloseStatus, _socket.CloseStatusDescription);
+        }
+
         public async Task CloseAsync()
         {
             if (_socket.State == WebSocketState.Open)


### PR DESCRIPTION
## Summary

Closes three test-coverage gaps around the socket lifecycle flagged by the codebase health review, all test-only — no production behavior changes.

1. **Takeover never asserted the superseded socket actually closes.** `RegisterSocket_SecondConnection_ReplacesPresenceKeyAndNotifiesOldSocket` (`SocketManagerServiceTests.cs`) checked that the `SocketReplaced` push reached the old client and that the presence key re-pointed, but never that the old connection transitioned to `Closed`. The close is a separate step inside `SocketReplaced.ExecuteAsync` (after the self-delivered send) — dropping or reordering it would leave two live sockets for one player with this test still green. Added `TestSocketClient.WaitForCloseAsync()` (reads the close frame and completes the handshake so `State` settles at `Closed` instead of lingering in `CloseReceived`) and asserted the resulting state, close status, and close description in the takeover test.

2. **`SocketConnectionRegistry`'s host-lifecycle wiring was untested.** `GameServerFactory` strips all `IHostedService` registrations for the test host, and `SocketDrainTests` constructs the registry directly, so the `ApplicationStopping → EnsureDraining` hook, the `StopAsync` await, and the run-once idempotency guard (`_drainTask ??= DrainAsync()`) were never driven through a lifetime. Added a cheap unit test (`SocketConnectionRegistryTests`) with a fake `IHostApplicationLifetime` that pins both paths (an explicit `StopAsync` call and a subsequent `ApplicationStopping` signal) resolving to the exact same in-flight drain task.

3. **Tightened two loose negative assertions:**
   - `SocketConnectionTests.Connect_Unauthenticated_Fails` used `Assert.ThrowsAnyAsync<Exception>`, which passes on any failure. Verified the TestServer client actually throws `InvalidOperationException` with `"Incomplete handshake, status code: 401"` on a rejected upgrade, and tightened the assertion to that specific exception type + status code.
   - `LoginControllerTests.CharacterCreationData_WithoutAuthentication_IsRejected` used `Assert.NotEqual(HttpStatusCode.OK, ...)`, which passes on a 500 as readily as the intended 401. Tightened to `Assert.Equal(HttpStatusCode.Unauthorized, ...)`, matching every other unauthenticated-endpoint test in the same file.

## Test plan

- [x] `dotnet build` — clean, 0 warnings/errors.
- [x] `dotnet format --verify-no-changes --no-restore` — clean.
- [x] `dotnet test` (full solution) — all green: `Game.Core.Tests` 1366, `Game.Infrastructure.Tests` 66, `Game.Api.Tests` 805, `Game.Application.Tests` 983.

Closes #1959


---
_Generated by [Claude Code](https://claude.ai/code/session_019XCJXkQkz3nYcCGujWwHm5)_