### PR TITLE
Make socket-id EmitSocketCommand overload return Task instead of Task<bool>

### DIFF
--- a/Game.Api/Services/SocketManagerService.cs
+++ b/Game.Api/Services/SocketManagerService.cs
@@ -177,13 +177,12 @@ namespace Game.Api.Services
             return TeardownSocketRegistration(context, "tearing down the socket");
         }
 
-        public async Task<bool> EmitSocketCommand(SocketCommandInfo commandInfo, string socketId)
+        public async Task EmitSocketCommand(SocketCommandInfo commandInfo, string socketId)
         {
             await _pubSub.Publish(SocketChannel(socketId), SocketQueueName(socketId), commandInfo);
             // Best-effort backstop (see SocketQueueTtl): the queue key normally drains in milliseconds and is
             // deleted outright on graceful teardown, so a missed refresh here just means the next push retries it.
             _cache.ExpireAndForget(SocketQueueName(socketId), SocketQueueTtl);
-            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- `SocketManagerService.EmitSocketCommand(SocketCommandInfo, string socketId)` always ended in `return true;` — a bool that carried no information.
- Changed its return type from `Task<bool>` to `Task`. The only meaningful boolean signal lives on the sibling `EmitSocketCommand(SocketCommandInfo, int playerId)` overload, which reports whether a live socket was found to publish to; that overload's own logic is unaffected.

## How this addresses the issue

Closes #1960. Removes a misleading success signal a future caller could mistake for delivery confirmation.

## Changes

- `Game.Api/Services/SocketManagerService.cs`: dropped the constant `bool` return and the now-unnecessary `<bool>` from the method signature. The one internal caller (`RegisterSocket`, notifying a replaced connection) was already only awaiting the call and not consuming the result.
- No test doubles or callers needed changes — every other call site (`Game.Api.Tests/Unit/SocketCommandProcessorTests.cs`, and the `EmitSocketCommand(..., int)` overload itself) already just `await`s the call without using a return value.

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings/errors.
- [x] `dotnet test Game.Api.Tests --filter "FullyQualifiedName~SocketManagerServiceTests|FullyQualifiedName~SocketCommandProcessorTests|FullyQualifiedName~SocketConnectionTests"` — 809 passed, 0 failed.

Closes #1960


---
_Generated by [Claude Code](https://claude.ai/code/session_01PEZKJSGeea7AJ2YXr5Hvsp)_