### PR TITLE
Resolve EntityStore.lastIdMap through persistEntity's identity map (#1962)

### DIFF
--- a/UI/src/routes/admin/workbench/entities/types.ts
+++ b/UI/src/routes/admin/workbench/entities/types.ts
@@ -268,6 +268,10 @@ export interface EntityConfig<T extends Identified> {
 	sections: SectionConfig<T>[];
 	/** Fetch the saved record list (with caches refreshed). */
 	refresh: () => Promise<T[]>;
-	/** Persist a diff against existing/new endpoints and return the fresh saved list. */
-	persist: (diff: SaveDiff<T>) => Promise<T[]>;
+	/**
+	 * Persist a diff against existing/new endpoints. Returns the fresh saved list plus the
+	 * identity-resolved map of each added record's local (negative) id to its persisted id, so a
+	 * caller tracking a selection by id doesn't need to re-derive it (see {@link resolveNewIds}).
+	 */
+	persist: (diff: SaveDiff<T>) => Promise<{ records: T[]; idMap: Map<number, number> }>;
 }

--- a/UI/src/routes/admin/workbench/entity-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/entity-store.svelte.ts
@@ -1,6 +1,6 @@
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { toastError } from '$stores';
-import { canonicalEqual, PersistFailedError, resolveNewIds } from './save-helpers';
+import { canonicalEqual, PersistFailedError } from './save-helpers';
 import { entityWarnings } from './validation';
 import type { EntityConfig, Identified, SaveDiff } from './entities/types';
 
@@ -219,10 +219,10 @@ export class EntityStore<T extends Identified> {
 		this.saving = true;
 		try {
 			const diff = this.diff();
-			const fresh = await this.config.persist(diff);
-			this.lastIdMap = new SvelteMap(resolveNewIds(fresh, diff.existingIds, diff.added));
-			this.items = fresh.map(clone);
-			this.base = fresh.map(clone);
+			const { records, idMap } = await this.config.persist(diff);
+			this.lastIdMap = new SvelteMap(idMap);
+			this.items = records.map(clone);
+			this.base = records.map(clone);
 			this.deleted.clear();
 			this.flashSaved();
 		} catch (ex) {

--- a/UI/src/routes/admin/workbench/save-helpers.ts
+++ b/UI/src/routes/admin/workbench/save-helpers.ts
@@ -158,12 +158,17 @@ export class PersistFailedError extends Error {
  * Generic per-entity save: persists identity-level Add/Edit/Delete in one call,
  * refetches to resolve the ids of newly-added records (positionally — the backend
  * appends adds in send order), then runs each child-section persister for every
- * added/modified record against its real id. Returns the final saved list.
+ * added/modified record against its real id. Returns the final saved list alongside
+ * the identity-resolved new-id map, so a caller doesn't need to recompute it (and risk
+ * a purely positional recompute disagreeing with the identity-matched ids the child
+ * savers actually wrote against — see #1962).
  *
  * A failure once anything has committed is rethrown as {@link PersistFailedError}; a pre-commit
  * failure propagates raw (see that type's docs).
  */
-export async function persistEntity<T extends Identified, D>(opts: PersistOptions<T, D>): Promise<T[]> {
+export async function persistEntity<T extends Identified, D>(
+	opts: PersistOptions<T, D>
+): Promise<{ records: T[]; idMap: Map<number, number> }> {
 	const { diff, toPrimaryDto, postPrimary, refresh, childSavers = [] } = opts;
 
 	// A record can be "modified" because only a child collection changed (e.g. a skill
@@ -209,10 +214,10 @@ export async function persistEntity<T extends Identified, D>(opts: PersistOption
 					committed ||= wrote;
 				}
 			}
-			return await refresh();
+			return { records: await refresh(), idMap: idFor };
 		}
 
-		return fresh;
+		return { records: fresh, idMap: idFor };
 	} catch (ex) {
 		if (committed) {
 			throw new PersistFailedError(ex);

--- a/UI/src/tests/routes/admin/workbench/Workbench.test.ts
+++ b/UI/src/tests/routes/admin/workbench/Workbench.test.ts
@@ -45,7 +45,7 @@ const makeConfig = (overrides: Partial<EntityConfig<Identified>> = {}): EntityCo
 		}
 	],
 	refresh: async () => seed,
-	persist: async () => [],
+	persist: async () => ({ records: [], idMap: new Map() }),
 	...overrides
 });
 
@@ -135,10 +135,10 @@ describe('Workbench', () => {
 	});
 
 	it('follows a newly-added record to its persisted id after save, instead of jumping to the first record', async () => {
-		const persist = vi.fn(async (diff: { added: Identified[] }) => [
-			...seed,
-			...diff.added.map((record, i) => ({ ...record, id: 3 + i }))
-		]);
+		const persist = vi.fn(async (diff: { added: Identified[] }) => ({
+			records: [...seed, ...diff.added.map((record, i) => ({ ...record, id: 3 + i }))],
+			idMap: new Map(diff.added.map((record, i) => [record.id, 3 + i]))
+		}));
 		render(Workbench, { props: { entity: makeConfig({ persist }) } });
 		await waitFor(() => expect(screen.getByTestId('workbench-title')).toBeTruthy());
 

--- a/UI/src/tests/routes/admin/workbench/WorkbenchList.test.ts
+++ b/UI/src/tests/routes/admin/workbench/WorkbenchList.test.ts
@@ -34,7 +34,7 @@ const makeConfig = (retireable = false): EntityConfig<Identified> => ({
 	meta: () => [],
 	sections: [],
 	refresh: async () => [],
-	persist: async () => []
+	persist: async () => ({ records: [], idMap: new Map() })
 });
 
 const seed: Identified[] = [

--- a/UI/src/tests/routes/admin/workbench/entity-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entity-store.test.ts
@@ -12,7 +12,13 @@ interface Row extends Identified {
 	value: number;
 }
 
-const makeConfig = (persist: (diff: SaveDiff<Row>) => Promise<Row[]> = async () => []): EntityConfig<Row> => ({
+/** Wraps a mock's records into the {@link EntityConfig.persist} return shape (an empty idMap unless supplied). */
+const persistResult = (records: Row[], idMap = new Map<number, number>()) => ({ records, idMap });
+
+const makeConfig = (
+	persist: (diff: SaveDiff<Row>) => Promise<{ records: Row[]; idMap: Map<number, number> }> = async () =>
+		persistResult([])
+): EntityConfig<Row> => ({
 	key: 'rows',
 	label: 'Rows',
 	singular: 'Row',
@@ -117,7 +123,7 @@ describe('EntityStore', () => {
 		let captured: SaveDiff<Row> | undefined;
 		const persist = vi.fn(async (diff: SaveDiff<Row>) => {
 			captured = diff;
-			return fresh;
+			return persistResult(fresh);
 		});
 		const store = new EntityStore(makeConfig(persist), seed);
 
@@ -142,7 +148,9 @@ describe('EntityStore', () => {
 			{ id: 2, name: 'Gamma', value: 3 }
 		];
 		const store = new EntityStore(
-			makeConfig(async () => fresh),
+			// A real config's persist (via persistEntity) resolves the idMap from its own diff.added;
+			// this mirrors that instead of hardcoding it, so the test still exercises the mapping.
+			makeConfig(async (diff) => persistResult(fresh, new Map(diff.added.map((record) => [record.id, 2])))),
 			seed
 		);
 		const newId = store.addItem();
@@ -154,7 +162,9 @@ describe('EntityStore', () => {
 
 	it('replaces the id map wholesale on a later save with no added records', async () => {
 		const fresh: Row[] = [...seed, { id: 2, name: 'Gamma', value: 3 }];
-		const persist = vi.fn(async () => fresh);
+		const persist = vi.fn(async (diff: SaveDiff<Row>) =>
+			persistResult(fresh, new Map(diff.added.map((record, index) => [record.id, 2 + index])))
+		);
 		const store = new EntityStore(makeConfig(persist), seed);
 
 		store.addItem();
@@ -234,7 +244,7 @@ describe('EntityStore', () => {
 	});
 
 	it('does not call persist when there are no changes', async () => {
-		const persist = vi.fn(async () => seed);
+		const persist = vi.fn(async () => persistResult(seed));
 		const store = new EntityStore(makeConfig(persist), seed);
 		await store.save();
 		expect(persist).not.toHaveBeenCalled();
@@ -245,7 +255,7 @@ describe('EntityStore', () => {
 			vi.useFakeTimers();
 			try {
 				const store = new EntityStore(
-					makeConfig(async () => seed),
+					makeConfig(async () => persistResult(seed)),
 					seed
 				);
 				store.addItem();
@@ -263,7 +273,7 @@ describe('EntityStore', () => {
 			vi.useFakeTimers();
 			try {
 				const store = new EntityStore(
-					makeConfig(async () => seed),
+					makeConfig(async () => persistResult(seed)),
 					seed
 				);
 				store.addItem();
@@ -285,7 +295,7 @@ describe('EntityStore', () => {
 			vi.useFakeTimers();
 			try {
 				const store = new EntityStore(
-					makeConfig(async () => seed),
+					makeConfig(async () => persistResult(seed)),
 					seed
 				);
 				store.addItem();

--- a/UI/src/tests/routes/admin/workbench/save-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/save-helpers.test.ts
@@ -294,7 +294,9 @@ describe('persistEntity', () => {
 
 		// refresh runs after the primary save and again after children.
 		expect(refresh).toHaveBeenCalledTimes(2);
-		expect(result).toEqual(fresh);
+		expect(result.records).toEqual(fresh);
+		expect(result.idMap.get(-1)).toBe(2);
+		expect(result.idMap.get(-2)).toBe(3);
 	});
 
 	it('resolves child-saver ids by identity content, not position, so a concurrent add from another admin cannot steal a write (#1856)', async () => {


### PR DESCRIPTION
## Summary

Closes #1962.

`EntityStore.save()` (`UI/src/routes/admin/workbench/entity-store.svelte.ts`) previously made its own, separate `resolveNewIds(fresh, diff.existingIds, diff.added)` call — with no `identityKey` — purely to populate `lastIdMap`, which the Workbench detail pane uses to keep the current selection pinned on a record across the save that just created it. This call used pure positional pairing, even though `persistEntity` (`save-helpers.ts`) had already resolved the same new-ids by identity content (via each entity's `toPrimaryDto`) for its own child savers, per the #1856 fix. Under a concurrent add from another admin landing in the same refetch, the two resolutions could disagree, and the UI could briefly follow the selection to the wrong record after a save (cosmetic — no data was ever corrupted, since the child-saver writes went through the correctly-resolved path independently).

## Change

- `EntityConfig.persist` (`entities/types.ts`) now returns `{ records: T[]; idMap: Map<number, number> }` instead of `T[]`.
- `persistEntity` (`save-helpers.ts`) returns its already-computed identity-resolved `idFor` map alongside the fresh records, instead of discarding it.
- `EntityStore.save()` consumes that returned `idMap` directly for `lastIdMap`, removing the duplicated, purely-positional `resolveNewIds` call entirely.
- All 10 entity configs (`entities/*.ts`) delegate `persist` straight to `persistEntity({...})`, so none needed changes — they pick up the new return shape automatically.

No production behavior changes beyond the bug fix itself (the child-saver id resolution was already correct); this only fixes the second, redundant resolution that fed `lastIdMap`.

## Test plan

- [x] Updated `save-helpers.test.ts` to assert `persistEntity`'s returned `idMap`.
- [x] Updated `entity-store.test.ts`'s save/lastIdMap tests to supply an identity-resolved `idMap` from the mock `persist`, mirroring what a real entity config now provides.
- [x] Updated `Workbench.test.ts` / `WorkbenchList.test.ts` mocks to the new `persist` return shape (including the existing "follows a newly-added record to its persisted id after save" behavioral test, which now exercises the fix directly).
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — 3722/3722 tests passing.
- [ ] No backend changes; backend build/tests not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TA6GC4ESvqTMvEzdnnQim7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA6GC4ESvqTMvEzdnnQim7)_