### PR TITLE
Fold Item totalAttributes recompute into an instance method

### DIFF
--- a/UI/src/lib/battle/item.ts
+++ b/UI/src/lib/battle/item.ts
@@ -57,10 +57,12 @@ export class Item implements IItem {
 		this.favorite = invItem.favorite ?? false;
 		// Drop any applied mod whose own definition is missing/retired so one stale mod can't crash the item.
 		this.appliedMods = invItem.appliedMods.map((am) => newItemMod(am)).filter((mod): mod is ItemMod => mod != null);
-		this.totalAttributes = new BattleAttributes(
-			[...this.attributes, ...this.appliedMods.flatMap((mod) => mod.attributes)],
-			false
-		);
+		this.totalAttributes = this.recomputeTotalAttributes();
+	}
+
+	/** Rebuilds the cached totalAttributes from the item's base attributes plus its applied mods. */
+	recomputeTotalAttributes(): BattleAttributes {
+		return new BattleAttributes([...this.attributes, ...this.appliedMods.flatMap((mod) => mod.attributes)], false);
 	}
 }
 

--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -9,7 +9,7 @@ import {
 } from '$lib/api';
 import { PUNCH_SKILL_ID } from '$lib/api/types/game-constants';
 import { playerManager } from '$lib/engine';
-import { BattleAttributes, Item, newItem, newItemMod } from '$lib/battle';
+import { Item, newItem, newItemMod } from '$lib/battle';
 import { logMessage } from '$lib/engine/log';
 import { SerializedQueue } from '$lib/common';
 import { staticData } from '$stores';
@@ -440,8 +440,7 @@ export class InventoryManager {
 
 	/** Rebuilds an item's cached totalAttributes after its applied mods change. */
 	private refreshItemAttributes(item: Item) {
-		const allAttributes = [...item.attributes, ...item.appliedMods.flatMap((mod) => mod.attributes)];
-		item.totalAttributes = new BattleAttributes(allAttributes, false);
+		item.totalAttributes = item.recomputeTotalAttributes();
 	}
 
 	/** Refreshes the memoised equipmentStats only when the changed item is equipped — an unequipped

--- a/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
+++ b/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
@@ -9,7 +9,7 @@ import {
 	type IItemMod,
 	type IPlayerChallenge
 } from '$lib/api';
-import { BattleAttributes, type Item } from '$lib/battle';
+import { Item } from '$lib/battle';
 import {
 	challengeTypeColor,
 	challengeTypeName,
@@ -126,14 +126,7 @@ function targetName(ch: IChallenge): string | null {
 
 /** A non-owned preview item (base stats, empty mod slots) for the item tooltip. */
 function buildPreviewItem(itemData: IItem): Item {
-	return {
-		...itemData,
-		itemId: itemData.id,
-		equipped: false,
-		favorite: false,
-		appliedMods: [],
-		totalAttributes: new BattleAttributes(itemData.attributes, false)
-	};
+	return new Item(itemData, { itemId: itemData.id, equipped: false, favorite: false, appliedMods: [] });
 }
 
 /* ─── Reward resolution (+ reveal gating) ────────────────────────────── */


### PR DESCRIPTION
## Summary

Follow-up from #1964, which converted `Item`/`ItemMod` to classes. The logic that rebuilds an item's cached `totalAttributes` from its base attributes plus its applied mods lived in two places with the identical expression:

- `Item`'s constructor (`UI/src/lib/battle/item.ts`)
- `InventoryManager.refreshItemAttributes` (`UI/src/lib/engine/player/inventory-manager.ts`)

This adds `Item.recomputeTotalAttributes()` as the single owner of that aggregation formula:

- The `Item` constructor now calls it instead of inlining the expression.
- `InventoryManager.refreshItemAttributes` now calls it instead of rebuilding `BattleAttributes` inline.
- While making the change, I noticed `challenges-view.svelte.ts`'s `buildPreviewItem` was hand-building an object literal that also duplicated the same formula (a third copy, invisible to the issue's original two-copy count since `Item` wasn't yet a required-shape class member). Adding `recomputeTotalAttributes` to the `Item` class made that literal fail type-checking (missing method), so I switched it to construct a real `Item` instance via `new Item(itemData, { itemId: itemData.id, equipped: false, favorite: false, appliedMods: [] })` instead — removing that third copy too rather than patching around it.

No behavior change intended.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — 299 test files / 3722 tests pass, including `item.test.ts`, `inventory-manager.test.ts`, and `challenges-view.svelte.test.ts` which already cover the constructor/refresh/preview-item behavior this refactors

Closes #1967


---
_Generated by [Claude Code](https://claude.ai/code/session_017btx6S9iRPtBVWu5cCTaiG)_