### PR TITLE
Reflect this session's own live edits in generic Workbench retire-confirm

### DIFF
--- a/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
+++ b/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
@@ -133,7 +133,12 @@
 import { fieldsOf, type EntityConfig, type Identified } from '../entities/types';
 import type { EntityStore } from '../entity-store.svelte';
 import { recordsEqual } from '../entity-store.svelte';
-import { deleteWithConfirm, referenceSourcesFromStatic, retireWithConfirm } from '../retire-confirm';
+import {
+	deleteWithConfirm,
+	ownCatalogueOverride,
+	referenceSourcesFromStatic,
+	retireWithConfirm
+} from '../retire-confirm';
 import { sectionWarnings } from '../validation';
 import WorkbenchIcon from '../WorkbenchIcon.svelte';
 import SectionRenderer from './SectionRenderer.svelte';
@@ -157,14 +162,15 @@ const { entity, store, record, baseline, tab, onTab, onNew }: Props = $props();
  * retires without an extra prompt. Advisory only — confirming proceeds, and the record stays
  * resolvable by id either way (see references.ts).
  *
- * Sourced from `staticData` (last-saved), not this pane's own live `store.items`: every reference
- * fn here reads a *sibling* catalogue (an enemy is referenced by zones/challenges, an item by
- * challenges/classes, …), never the one this pane edits, and `store.items` isn't dense-by-id once a
- * record's been added this session (`EntityStore.addItem` prepends negative ids) — indexing it by
- * id, as `enemies[id]?.spawns` and `nameByIndex(skills, …)` do, would resolve the wrong record. See
- * the progression editor's `{ proficiencies: store.profs }` override for the shape this pane would
- * need (index-safe access to every referencing catalogue's own live store) to close this gap
- * generically — tracked as a follow-up rather than attempted here.
+ * Every catalogue but this pane's own comes from `staticData` (last-saved): each of their reference
+ * fns reads a *sibling* catalogue (an enemy is referenced by zones/challenges, an item by
+ * challenges/classes, …) this pane holds no live copy of — closing that gap generically would mean
+ * holding every reference-carrying entity's store alive across a tool switch (see
+ * `ownCatalogueOverride`'s comment), tracked as the remaining part of #1976 rather than attempted
+ * here. This pane's own catalogue is overridden with its live `store.items` for the two entity types
+ * whose reference lookup reads it (enemies' own spawns, a recipe named via the skills catalogue
+ * being retired from) — density-safe, since `store.items` isn't dense-by-id once a record's been
+ * added this session (`EntityStore.addItem` prepends negative ids).
  */
 const onRetire = (rec: Identified) =>
 	retireWithConfirm({
@@ -172,7 +178,7 @@ const onRetire = (rec: Identified) =>
 		id: rec.id,
 		name: entity.title?.(rec) || rec.name || entity.blankName,
 		title: `Retire ${entity.singular}?`,
-		sources: referenceSourcesFromStatic(),
+		sources: referenceSourcesFromStatic(ownCatalogueOverride(entity.key, store.items)),
 		onConfirmed: () => store.setRetired(rec.id, true)
 	});
 

--- a/UI/src/routes/admin/workbench/retire-confirm.ts
+++ b/UI/src/routes/admin/workbench/retire-confirm.ts
@@ -61,6 +61,9 @@ function denseByLiveId<T extends { id: number }>(live: T[]): T[] {
  * array index rather than `proficiencies`' always-`.filter()`-based lookups.
  */
 export function ownCatalogueOverride(entityKey: string, items: { id: number }[]): Partial<ReferenceSources> {
+	// The computed key can't narrow past `string`, and `items` is the generic `{ id }[]` shape rather
+	// than `IEnemy[]`/`ISkill[]` — sound here because the guard restricts entityKey to `enemies`/
+	// `skills`, and `items` (an EntityStore's `.items`) are always that entity's live full records.
 	return SELF_REFERENCING_KEYS.has(entityKey)
 		? ({ [entityKey]: denseByLiveId(items) } as unknown as Partial<ReferenceSources>)
 		: {};

--- a/UI/src/routes/admin/workbench/retire-confirm.ts
+++ b/UI/src/routes/admin/workbench/retire-confirm.ts
@@ -24,6 +24,48 @@ export function referenceSourcesFromStatic(overrides: Partial<ReferenceSources> 
 	};
 }
 
+/**
+ * Reference-source slots that a generic Workbench entity's own reference function reads (`enemies`
+ * reads its own `spawns`; `skills` names a referencing recipe via its own catalogue) — see
+ * `references.ts`'s `enemyReferences`/`skillReferences`. Every other generic-Workbench entity's
+ * reference function only reads *sibling* catalogues it has no live copy of, so overriding those
+ * slots would be a no-op (#1976's remaining, genuinely cross-catalogue gap — closing it generically
+ * would mean holding every reference-carrying entity's store alive across a tool switch, reversing
+ * the documented one-surface-mounted-at-a-time model in `dirty.svelte.ts`).
+ */
+const SELF_REFERENCING_KEYS = new Set(['enemies', 'skills']);
+
+/**
+ * Rebuilds a zero-based-id-indexed array from a store's live `items`, honouring the Id-as-index
+ * invariant `references.ts`'s self-referential lookups rely on (`docs/backend.md` → _Reference
+ * Data_). `EntityStore.addItem` prepends new records with negative ids, shifting every saved
+ * record's array position, so indexing the live array directly would resolve the wrong record. A
+ * never-saved (negative-id) record is dropped: only an already-saved record can be a retire target
+ * or a referencing recipe's result, so none is looked up by id here.
+ */
+function denseByLiveId<T extends { id: number }>(live: T[]): T[] {
+	const dense: T[] = [];
+	for (const record of live) {
+		if (record.id >= 0) {
+			dense[record.id] = record;
+		}
+	}
+	return dense;
+}
+
+/**
+ * Live override for the generic Workbench entity currently open, closing the self-referential half
+ * of #1976 ("this session's unsaved edits" of the entity's *own* catalogue) for the two entity types
+ * whose reference lookup reads it. A no-op for every other entity. Mirrors the progression editor's
+ * `{ proficiencies: store.profs }` override, but density-safe since enemies/skills are looked up by
+ * array index rather than `proficiencies`' always-`.filter()`-based lookups.
+ */
+export function ownCatalogueOverride(entityKey: string, items: { id: number }[]): Partial<ReferenceSources> {
+	return SELF_REFERENCING_KEYS.has(entityKey)
+		? ({ [entityKey]: denseByLiveId(items) } as unknown as Partial<ReferenceSources>)
+		: {};
+}
+
 interface ConfirmMutationOptions {
 	entityKey: string;
 	id: number;

--- a/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
+++ b/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
@@ -111,6 +111,26 @@ describe('ownCatalogueOverride (#1976)', () => {
 
 		expect(groups.find((g) => g.kind === 'spawnsIn')?.names).toEqual(['Sunken Ruins']);
 	});
+
+	it("reflects this session's renamed skill when naming a referencing recipe (skills self-reference)", () => {
+		staticData.skills = [
+			{ id: 0, name: 'Fire Bolt (last saved)' },
+			{ id: 1, name: 'Ice Shard' }
+		];
+		staticData.skillRecipes = [{ id: 0, resultSkillId: 0, inputSkillIds: [1], conditions: [] }];
+		const liveSkills = [
+			{ id: -1, name: 'New Skill (unsaved)' },
+			// This session renamed the recipe's result skill but hasn't saved — staticData still shows the old name.
+			{ id: 0, name: 'Fire Bolt (renamed this session)' },
+			{ id: 1, name: 'Ice Shard' }
+		];
+
+		const sources = referenceSourcesFromStatic(ownCatalogueOverride('skills', liveSkills));
+		// Retiring Ice Shard (id 1), an input of the recipe named after its live (renamed) result skill.
+		const groups = computeReferences('skills', 1, sources);
+
+		expect(groups.find((g) => g.kind === 'recipeInput')?.names).toEqual(['Fire Bolt (renamed this session)']);
+	});
 });
 
 describe('retireWithConfirm', () => {

--- a/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
+++ b/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
@@ -9,9 +9,11 @@ vi.mock('$stores', () => ({ dangerModal, staticData }));
 
 import {
 	deleteWithConfirm,
+	ownCatalogueOverride,
 	referenceSourcesFromStatic,
 	retireWithConfirm
 } from '$routes/admin/workbench/retire-confirm';
+import { computeReferences } from '$routes/admin/workbench/references';
 import type { ReferenceSources } from '$routes/admin/workbench/references';
 
 const emptySources: ReferenceSources = {
@@ -69,6 +71,45 @@ describe('referenceSourcesFromStatic', () => {
 
 		expect(sources.proficiencies).toBe(liveProficiencies);
 		expect(sources.enemies).toBe(staticData.enemies);
+	});
+});
+
+describe('ownCatalogueOverride (#1976)', () => {
+	it('is a no-op for an entity whose reference lookup never reads its own catalogue', () => {
+		const items = [{ id: 0, name: 'Verdant Hollow' }];
+		expect(ownCatalogueOverride('zones', items)).toEqual({});
+	});
+
+	it('rebuilds a dense-by-id enemies array from live store items, ignoring never-saved (negative-id) additions', () => {
+		// EntityStore.addItem prepends new records, so a session that added one enemy before retiring
+		// an original one sees array position 0 hold the new (negative-id) enemy, not id 0.
+		const liveItems = [
+			{ id: -1, name: 'New Enemy (unsaved)', spawns: [{ zoneId: 9, weight: 1 }] },
+			{ id: 0, name: 'Cave Bat', spawns: [{ zoneId: 2, weight: 7 }] },
+			{ id: 1, name: 'Catacomb Lich', spawns: [] }
+		];
+
+		const override = ownCatalogueOverride('enemies', liveItems);
+
+		expect(override.enemies?.[0]).toEqual(liveItems[1]);
+		expect(override.enemies?.[1]).toEqual(liveItems[2]);
+		expect(override.enemies?.[-1]).toBeUndefined();
+	});
+
+	it("reflects this session's edited spawns when computing an enemy's own referenced-by surface", () => {
+		staticData.enemies = [{ id: 0, name: 'Cave Bat (last saved)', spawns: [] }];
+		// staticData is server-dense (zero-based-id invariant), so index 0 must resolve to id 0 too.
+		staticData.zones = [{ id: 0, name: 'Sunken Ruins' }];
+		const liveEnemies = [
+			{ id: -1, name: 'New Enemy (unsaved)', spawns: [] },
+			// This session added a spawn row not yet saved — staticData still shows an empty spawn list.
+			{ id: 0, name: 'Cave Bat', spawns: [{ zoneId: 0, weight: 4 }] }
+		];
+
+		const sources = referenceSourcesFromStatic(ownCatalogueOverride('enemies', liveEnemies));
+		const groups = computeReferences('enemies', 0, sources);
+
+		expect(groups.find((g) => g.kind === 'spawnsIn')?.names).toEqual(['Sunken Ruins']);
 	});
 });
 


### PR DESCRIPTION
## Summary

Partial fix for #1976. The generic Workbench retire-confirm's "referenced by" surface (`references.ts` / `retire-confirm.ts`) is computed from `staticData` (last-saved state), so it can miss references introduced by this session's own unsaved edits. This PR closes the **self-referential** half of that gap:

- `enemyReferences` reads an enemy's own `spawns` field via `enemies[id]?.spawns`.
- `skillReferences` names a referencing recipe via `nameByIndex(skills, recipe.resultSkillId)` — both self-index into the *same* catalogue as the entity currently open in the Workbench pane.

An earlier attempt at this (#1975) was reverted because naively substituting `store.items` for the static array corrupts these lookups: `EntityStore.addItem` prepends new records with negative ids, shifting every saved record's array position out of the zero-based-id alignment `references.ts` assumes.

This PR adds `denseByLiveId` (`retire-confirm.ts`), which rebuilds a proper id-indexed array from the live store (dropping never-saved negative-id records, which can never be a retire target or a referencing recipe's result anyway), and `ownCatalogueOverride`, which applies it only for the two entity types where it matters (a no-op everywhere else). `WorkbenchDetail.svelte`'s `onRetire` now threads this through.

## What's intentionally left open

The issue's titular **cross-catalogue** gap (e.g. retiring an item while an unsaved edit to a *different* entity type, like classes, sits in a tab the admin isn't currently on) is not addressed here. Closing that generically would require holding every reference-carrying entity's `EntityStore` alive across a tool switch — which reverses the currently documented "only one editing surface mounted at a time, discard on switch" model (see `dirty.svelte.ts`'s doc comment and `discard-guard.ts`). That's a real architecture/UX decision (memory cost of N persistent stores, whether "discard on switch" still makes sense, etc.), not a scoped fix, so I left it for the maintainer to weigh in on rather than deciding unilaterally. I've left a comment on #1976 with this analysis and a couple of options.

## Test plan

- [x] Added unit tests in `retire-confirm.test.ts` covering `ownCatalogueOverride`: no-op for non-self-referencing entities, dense-by-id reconstruction ignoring negative ids, and an end-to-end case proving an enemy's own unsaved spawn edit now surfaces correctly in the confirm dialog.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — 299 files / 3725 tests passing.


---
_Generated by [Claude Code](https://claude.ai/code/session_016rTjyCM3zHFwXKmuAQQuwg)_