### PR TITLE
Filter pathReferences to gateways whose own path stays live

### DIFF
--- a/UI/src/routes/admin/workbench/references.ts
+++ b/UI/src/routes/admin/workbench/references.ts
@@ -5,6 +5,7 @@ import {
 	type IEnemy,
 	type IItem,
 	type IItemMod,
+	type IPath,
 	type IProficiency,
 	type ISkill,
 	type ISkillRecipe,
@@ -31,6 +32,7 @@ export interface ReferenceSources {
 	skillRecipes: ISkillRecipe[];
 	proficiencies: IProficiency[];
 	skills: ISkill[];
+	paths: IPath[];
 }
 
 /** A category of inbound reference and the names of the records that make it. */
@@ -148,15 +150,20 @@ const proficiencyReferences = (
 };
 
 /**
- * A path is referenced through its tiers: another (still-live) proficiency naming one of this
- * path's tiers as a cross-path prerequisite. Retiring the path freezes those tiers, so such a
- * gateway could then never open — the same soft-lock `AdminPaths.FindRetiredPathGatingLiveGateway`
- * rejects server-side. Marked `strong` since this is a real (not just advisory) save-time block.
+ * A path is referenced through its tiers: another proficiency naming one of this path's tiers as a
+ * cross-path prerequisite. Retiring the path freezes those tiers, so such a gateway could then
+ * never open — the same soft-lock `AdminPaths.FindRetiredPathGatingLiveGateway` rejects
+ * server-side, and only when the gateway's **own** path stays live (`PathStaysLive`) — a gateway
+ * on an already-retired path is already dead content, not a fresh soft-lock. Marked `strong` since
+ * this is a real (not just advisory) save-time block.
  */
-const pathReferences = (id: number, { proficiencies }: ReferenceSources): ReferenceGroup[] => {
+const pathReferences = (id: number, { proficiencies, paths }: ReferenceSources): ReferenceGroup[] => {
 	const tierIds = new Set(proficiencies.filter((p) => p.pathId === id).map((p) => p.id));
 	const prerequisiteOf = proficiencies
-		.filter((p) => p.pathId !== id && p.prerequisiteIds.some((prereqId) => tierIds.has(prereqId)))
+		.filter(
+			(p) =>
+				p.pathId !== id && p.prerequisiteIds.some((prereqId) => tierIds.has(prereqId)) && !paths[p.pathId]?.retiredAt
+		)
 		.map((p) => p.name);
 	return group('prerequisiteOf', prerequisiteOf, true);
 };

--- a/UI/src/routes/admin/workbench/retire-confirm.ts
+++ b/UI/src/routes/admin/workbench/retire-confirm.ts
@@ -20,6 +20,7 @@ export function referenceSourcesFromStatic(overrides: Partial<ReferenceSources> 
 		skillRecipes: staticData.skillRecipes ?? [],
 		proficiencies: staticData.proficiencies ?? [],
 		skills: staticData.skills ?? [],
+		paths: staticData.paths ?? [],
 		...overrides
 	};
 }

--- a/UI/src/tests/routes/admin/workbench/references.test.ts
+++ b/UI/src/tests/routes/admin/workbench/references.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+	EActivityKey,
 	EAttribute,
 	EChallengeType,
 	EEntityType,
@@ -13,6 +14,7 @@ import {
 	type IEnemy,
 	type IItem,
 	type IItemMod,
+	type IPath,
 	type IProficiency,
 	type ISkill,
 	type ISkillRecipe,
@@ -112,6 +114,15 @@ const recipe = (id: number, resultSkillId: number, opts: Partial<ISkillRecipe> =
 	...opts
 });
 
+const path = (id: number, name: string, opts: Partial<IPath> = {}): IPath => ({
+	id,
+	name,
+	description: '',
+	activityKey: EActivityKey.Fire,
+	designerNotes: '',
+	...opts
+});
+
 const proficiency = (id: number, name: string, opts: Partial<IProficiency> = {}): IProficiency => ({
 	id,
 	name,
@@ -195,7 +206,8 @@ const sources = (): ReferenceSources => ({
 	classes: [],
 	skillRecipes: [],
 	proficiencies: [],
-	skills: []
+	skills: [],
+	paths: []
 });
 
 describe('computeReferences — enemies', () => {
@@ -407,6 +419,32 @@ describe('computeReferences — paths', () => {
 	it('returns nothing for a path whose tiers gate nothing', () => {
 		const src = { ...sources(), proficiencies: [proficiency(0, 'Blades', { pathId: 5 })] };
 		expect(computeReferences('paths', 5, src)).toEqual([]);
+	});
+
+	it('excludes a gateway sitting on a path that is itself already retired, matching PathStaysLive (#1983)', () => {
+		const src = {
+			...sources(),
+			proficiencies: [
+				proficiency(0, 'Blades', { pathId: 5 }),
+				proficiency(6, 'Runeforging', { pathId: 9, prerequisiteIds: [0] })
+			],
+			paths: bySlot(path(9, 'Runeforging Path', { retiredAt: '2026-01-01T00:00:00Z' }))
+		};
+		expect(computeReferences('paths', 5, src)).toEqual([]);
+	});
+
+	it('still flags a gateway once its own path is confirmed live in the paths catalogue', () => {
+		const src = {
+			...sources(),
+			proficiencies: [
+				proficiency(0, 'Blades', { pathId: 5 }),
+				proficiency(6, 'Runeforging', { pathId: 9, prerequisiteIds: [0] })
+			],
+			paths: bySlot(path(9, 'Runeforging Path'))
+		};
+		expect(computeReferences('paths', 5, src)).toEqual([
+			{ kind: 'prerequisiteOf', names: ['Runeforging'], strong: true }
+		]);
 	});
 });
 

--- a/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
+++ b/UI/src/tests/routes/admin/workbench/retire-confirm.test.ts
@@ -23,7 +23,8 @@ const emptySources: ReferenceSources = {
 	classes: [],
 	skillRecipes: [],
 	proficiencies: [],
-	skills: []
+	skills: [],
+	paths: []
 };
 
 beforeEach(() => {
@@ -37,7 +38,8 @@ beforeEach(() => {
 		'classes',
 		'skillRecipes',
 		'proficiencies',
-		'skills'
+		'skills',
+		'paths'
 	]) {
 		delete staticData[key];
 	}


### PR DESCRIPTION
## Summary

Fixes #1983 — a nit from the review of #1975 (#1863).

`pathReferences` in `UI/src/routes/admin/workbench/references.ts` mirrors the backend soft-lock guard `AdminPaths.FindRetiredPathGatingLiveGateway`, but it approximated "the gateway's own path stays live" as `p.pathId !== id`, since it had no access to per-path retirement state. That over-reports: a gateway prerequisite sitting on a *different, already-retired* path was flagged as a `strong` ("re-point first") reference even though the backend's `PathStaysLive(gateway.PathId)` check would skip it — that content is already dead. This was advisory-only over-reporting (never missed a warning, never bypassed the confirm), so it was cosmetic rather than a correctness/safety gap.

## Changes

- Added `paths: IPath[]` to `ReferenceSources` (`references.ts`), threaded through `referenceSourcesFromStatic` (`retire-confirm.ts`) from `staticData.paths`, matching how every other catalogue is sourced.
- `pathReferences` now excludes a gateway whose own path (looked up by zero-based-id index, honouring the Id-as-index invariant) is retired, matching `PathStaysLive` exactly.
- Added unit tests covering: a gateway on an already-retired path is excluded, and a gateway on a confirmed-live path is still flagged.

## Test plan

- [x] Added/updated unit tests in `references.test.ts` and `retire-confirm.test.ts`.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — 299 files / 3724 tests passing.

Closes #1983


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pb1bHz75zUWHzxHHb7m911)_