### PR TITLE
Self-heal progress hash rows that fail to deserialize (#2000)

### DIFF
--- a/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
@@ -15,6 +15,7 @@ using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 using Xunit;
 
@@ -195,7 +196,9 @@ namespace Game.Application.Tests.DataAccess
             // Save must wrap it the same way SavePlayer does, so the socket layer can force the connection's
             // in-memory Player to reload afterward rather than letting the caller's already-applied mutations
             // ride along un-persisted (#1819).
-            var throwingRepo = new PlayerProgressRepository(context, challenges, cache, new ThrowingPubSubService(), batch);
+            var throwingRepo = new PlayerProgressRepository(
+                context, challenges, cache, new ThrowingPubSubService(), batch,
+                scope.ServiceProvider.GetRequiredService<ILogger<PlayerProgressRepository>>());
 
             var progress = await throwingRepo.Load(MakeDomainPlayer(playerId));
             progress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000,
@@ -457,6 +460,79 @@ namespace Game.Application.Tests.DataAccess
             // A subsequent read falls through to the DB (the write-behind synchronizer is disabled in this
             // harness, so the just-enqueued event never applied) and correctly serves the original 5 kills —
             // not a shadowed/regressed value from a resurrected partial hash.
+            using (var scope = CreateScope())
+            {
+                var repo = scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>();
+                var stats = await repo.GetStatistics(playerId);
+                var kills = Assert.Single(stats, s => s.Type == EStatisticType.EnemiesKilled && s.EntityId == null);
+                Assert.Equal(5m, kills.Value);
+            }
+        }
+
+        [Fact]
+        public async Task GetStatistics_OnUnparsableHashField_DeletesTheKeyAndReloadsFromDb()
+        {
+            var playerId = await SeedPlayerAsync();
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                await TestDataSeeder.AddPlayerStatisticAsync(context, playerId, EStatisticType.EnemiesKilled, 5m);
+            }
+
+            using var multiplexer = await ConnectRedisAsync();
+            var redis = multiplexer.GetDatabase();
+            var hashKey = $"Progress_{playerId}";
+
+            // Prime the cache from the DB, then corrupt the one field in place with malformed JSON — standing
+            // in for a truncated write.
+            using (var scope = CreateScope())
+            {
+                var repo = scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>();
+                await repo.GetStatistics(playerId);
+            }
+            var fields = await WaitForHashFieldCountAsync(redis, hashKey, minCount: 1);
+            var statField = Assert.Single(fields, f => f.Name.ToString().StartsWith("S_", StringComparison.Ordinal));
+            await redis.HashSetAsync(hashKey, statField.Name, "{not valid json");
+
+            // A row that no longer parses at all must self-heal (delete the whole hash, reload from the DB)
+            // rather than throw and lock progress reads out for the rest of the TTL (#2000).
+            using (var scope = CreateScope())
+            {
+                var repo = scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>();
+                var stats = await repo.GetStatistics(playerId);
+                var kills = Assert.Single(stats, s => s.Type == EStatisticType.EnemiesKilled && s.EntityId == null);
+                Assert.Equal(5m, kills.Value);
+            }
+        }
+
+        [Fact]
+        public async Task GetStatistics_OnShapeDriftedHashField_SelfHealsInsteadOfZeroingTheAggregate()
+        {
+            var playerId = await SeedPlayerAsync();
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                await TestDataSeeder.AddPlayerStatisticAsync(context, playerId, EStatisticType.EnemiesKilled, 5m);
+            }
+
+            using var multiplexer = await ConnectRedisAsync();
+            var redis = multiplexer.GetDatabase();
+            var hashKey = $"Progress_{playerId}";
+
+            using (var scope = CreateScope())
+            {
+                var repo = scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>();
+                await repo.GetStatistics(playerId);
+            }
+            var fields = await WaitForHashFieldCountAsync(redis, hashKey, minCount: 1);
+            var statField = Assert.Single(fields, f => f.Name.ToString().StartsWith("S_", StringComparison.Ordinal));
+
+            // Stand in for a pre-shape-change row: valid JSON, but missing every one of the row model's
+            // required members — exactly what an old blob looks like after a field is added. Before #2000 this
+            // deserialized successfully with defaulted (zeroed) values instead of throwing, and Save would have
+            // gone on to fold deltas onto that zeroed aggregate and upsert it to Postgres as an absolute value.
+            await redis.HashSetAsync(hashKey, statField.Name, "{}");
+
             using (var scope = CreateScope())
             {
                 var repo = scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>();

--- a/Game.DataAccess/PlayerProgressCacheModels.cs
+++ b/Game.DataAccess/PlayerProgressCacheModels.cs
@@ -16,24 +16,24 @@ namespace Game.DataAccess
 
     internal sealed class CachedPlayerStatistic
     {
-        public int StatisticTypeId { get; set; }
-        public int? EntityId { get; set; }
-        public decimal Value { get; set; }
+        public required int StatisticTypeId { get; set; }
+        public required int? EntityId { get; set; }
+        public required decimal Value { get; set; }
     }
 
     internal sealed class CachedPlayerChallenge
     {
-        public int ChallengeId { get; set; }
-        public decimal Progress { get; set; }
-        public bool Completed { get; set; }
-        public DateTime? CompletedAt { get; set; }
+        public required int ChallengeId { get; set; }
+        public required decimal Progress { get; set; }
+        public required bool Completed { get; set; }
+        public required DateTime? CompletedAt { get; set; }
     }
 
     internal sealed class CachedPlayerProficiency
     {
-        public int ProficiencyId { get; set; }
-        public int Level { get; set; }
-        public decimal Xp { get; set; }
+        public required int ProficiencyId { get; set; }
+        public required int Level { get; set; }
+        public required decimal Xp { get; set; }
     }
 
     /// <summary>

--- a/Game.DataAccess/Repositories/PlayerProgressRepository.cs
+++ b/Game.DataAccess/Repositories/PlayerProgressRepository.cs
@@ -7,6 +7,8 @@ using Game.Core.Players;
 using Game.Core.Progress;
 using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
 using CoreChallenge = Game.Core.Progress.PlayerChallenge;
 using CoreProficiency = Game.Core.Progress.PlayerProficiency;
 using CoreStat = Game.Core.Progress.PlayerStatistic;
@@ -18,13 +20,15 @@ namespace Game.DataAccess.Repositories
         IChallenges challenges,
         ICacheService cache,
         IPubSubService pubsub,
-        PlayerUpdateBatch updateBatch) : IPlayerProgressRepository
+        PlayerUpdateBatch updateBatch,
+        ILogger<PlayerProgressRepository> logger) : IPlayerProgressRepository
     {
         private readonly GameContext _context = context;
         private readonly IChallenges _challenges = challenges;
         private readonly ICacheService _cache = cache;
         private readonly IPubSubService _pubsub = pubsub;
         private readonly PlayerUpdateBatch _updateBatch = updateBatch;
+        private readonly ILogger<PlayerProgressRepository> _logger = logger;
 
         // Sliding idle TTL for the cached progress aggregate, mirroring the player cache (#439): written on
         // every save and load-miss re-cache, refreshed on every hit, so an active player never ages out while
@@ -180,8 +184,30 @@ namespace Game.DataAccess.Repositories
 
             var key = ProgressKey(playerId);
             var raw = await _cache.HashGetAllIfExists(key, cancellationToken);
-            CachedPlayerProgress progress;
-            if (raw is null)
+            CachedPlayerProgress? progress = null;
+            if (raw is not null)
+            {
+                try
+                {
+                    progress = FromHashFields(raw);
+
+                    // Sliding expiration: a cache hit refreshes the idle TTL so an active player never ages out.
+                    _cache.ExpireAndForget(key, ProgressCacheTtl);
+                }
+                catch (JsonException ex)
+                {
+                    // A row that no longer deserializes (e.g. a shape change to one of the cached row models'
+                    // required members) is corruption, not data — the row models are all-required specifically so
+                    // this throws instead of silently defaulting a shrunken/zeroed row that Save would then upsert
+                    // to Postgres as an absolute value. Postgres remains the durable copy, so this self-heals the
+                    // same way PlayerRepository.GetPlayer treats a corrupt player blob: delete the key and fall
+                    // through to the DB reload below rather than locking progress reads for the rest of the TTL (#2000).
+                    _logger.LogError(ex, "Cached progress for player {PlayerId} at key '{Key}' failed to deserialize; deleting the key and reloading from the database.", playerId, key);
+                    await _cache.Delete(key, cancellationToken);
+                }
+            }
+
+            if (progress is null)
             {
                 // This reload just read the authoritative full state from the DB, so it's the one place that
                 // may safely *create* the hash — Save's advance (above) only ever holds this save's dirty
@@ -192,12 +218,6 @@ namespace Game.DataAccess.Repositories
                 progress = await LoadFromDb(playerId, cancellationToken);
                 var fields = ToHashFields(progress);
                 _cache.HashSetAndForget(key, fields.Count > 0 ? fields : PresenceMarkerFields, ProgressCacheTtl);
-            }
-            else
-            {
-                // Sliding expiration: a cache hit refreshes the idle TTL so an active player never ages out.
-                _cache.ExpireAndForget(key, ProgressCacheTtl);
-                progress = FromHashFields(raw);
             }
 
             _memo = (playerId, progress);
@@ -370,27 +390,22 @@ namespace Game.DataAccess.Repositories
             {
                 if (field.StartsWith("S_", StringComparison.Ordinal))
                 {
-                    var stat = value.Deserialize<CachedPlayerStatistic>();
-                    if (stat is not null)
-                    {
-                        progress.Statistics.Add(stat);
-                    }
+                    // A row that deserializes to null (e.g. a literal "null" blob) is corruption exactly like a
+                    // required-member mismatch — throwing here (rather than silently skipping) routes it through
+                    // the same delete-and-reload self-heal instead of shadowing the row's DB copy behind a
+                    // present-but-incomplete key (#2000).
+                    var stat = value.Deserialize<CachedPlayerStatistic>() ?? throw new JsonException($"Progress field '{field}' deserialized to null.");
+                    progress.Statistics.Add(stat);
                 }
                 else if (field.StartsWith("C_", StringComparison.Ordinal))
                 {
-                    var challenge = value.Deserialize<CachedPlayerChallenge>();
-                    if (challenge is not null)
-                    {
-                        progress.Challenges.Add(challenge);
-                    }
+                    var challenge = value.Deserialize<CachedPlayerChallenge>() ?? throw new JsonException($"Progress field '{field}' deserialized to null.");
+                    progress.Challenges.Add(challenge);
                 }
                 else if (field.StartsWith("P_", StringComparison.Ordinal))
                 {
-                    var proficiency = value.Deserialize<CachedPlayerProficiency>();
-                    if (proficiency is not null)
-                    {
-                        progress.Proficiencies.Add(proficiency);
-                    }
+                    var proficiency = value.Deserialize<CachedPlayerProficiency>() ?? throw new JsonException($"Progress field '{field}' deserialized to null.");
+                    progress.Proficiencies.Add(proficiency);
                 }
             }
 


### PR DESCRIPTION
## Summary

`CachedPlayerStatistic`/`CachedPlayerChallenge`/`CachedPlayerProficiency` (the rows in the `Progress_{playerId}` Redis hash) had no `required` members and no post-deserialize validation, unlike `PlayerCacheModel`. A field rename/retype shipped after a hash was already cached would deserialize old rows *successfully* with defaulted (zeroed) values instead of failing loudly — no exception, no self-heal. Battle completion would then fold deltas onto the zeroed aggregate, and `Save` would upsert it to Postgres as an **absolute value**, permanently regressing the player's real statistics/challenge/proficiency rows. A row that deserialized to a null object was likewise silently dropped, shadowing its DB row behind a present key.

This addresses #2000, a sibling of #1924 (cached player/session blobs) on a third cache surface with a worse failure mode — #1924's gap threw loudly (a lockout); this one failed silently (data loss).

## Changes

- `Game.DataAccess/PlayerProgressCacheModels.cs`: marked every member of the three cached row models `required`, so a shape mismatch throws `JsonException` on deserialize instead of silently defaulting.
- `Game.DataAccess/Repositories/PlayerProgressRepository.cs`:
  - `FromHashFields` now throws (rather than silently skipping) when a row deserializes to `null`, so that failure mode routes through the same self-heal as a shape mismatch.
  - `GetCachedProgress` catches `JsonException` from a hash read, logs it, deletes the corrupted key, and falls through to the existing DB-reload path — mirroring the convention `PlayerRepository.GetPlayer`/`SessionStore.GetSession` already apply (#1924) and the same reasoning `RedisService.HashGetAllIfExists` already applies to a wrong-representation key.
  - Added an `ILogger<PlayerProgressRepository>` dependency (DI-resolved automatically; updated the one test that constructs the repository directly).

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings/errors.
- [x] `dotnet test` (full solution) — 3226 tests passed, 0 failed.
- [x] Added `GetStatistics_OnUnparsableHashField_DeletesTheKeyAndReloadsFromDb` — malformed JSON in one hash field self-heals via delete + DB reload.
- [x] Added `GetStatistics_OnShapeDriftedHashField_SelfHealsInsteadOfZeroingTheAggregate` — a row missing all required members (simulating a pre-shape-change blob) self-heals instead of silently zeroing the aggregate.

Closes #2000


---
_Generated by [Claude Code](https://claude.ai/code/session_01GLcRxY3SvEvxM1YLF1FFr4)_