### PR TITLE
Arm the keepalive interval before the pre-emptive refresh in openSocket (#2035)

### DIFF
--- a/UI/src/lib/api/api-socket.ts
+++ b/UI/src/lib/api/api-socket.ts
@@ -131,6 +131,13 @@ export class ApiSocket {
 	private async openSocket(): Promise<void> {
 		this.socketOpened = false;
 		this.resetPongTracking();
+		// Armed before the refresh await (not after the handshake is built) so a retryable bail below still
+		// leaves the keepalive running to retry the connect — otherwise the very first connect of a page
+		// session (or any connect after the interval was last stopped) could bail with nothing left to ever
+		// call ensureSocket() again, stranding the queue forever.
+		if (this.pingIntervalId === null) {
+			this.pingIntervalId = setInterval(() => this.attemptPing(), PING_INTERVAL_MS);
+		}
 		// Pre-emptively refresh an access token that is missing or about to expire (mirroring the HTTP
 		// path) so a reconnect doesn't hand the server a stale token, eat a rejected handshake, and burn a
 		// single-use refresh token recovering in handleClose.
@@ -171,9 +178,6 @@ export class ApiSocket {
 		socket.onmessage = this.receiveResponse.bind(this);
 		socket.onerror = this.handleError.bind(this);
 		socket.onclose = this.handleClose.bind(this);
-		if (this.pingIntervalId === null) {
-			this.pingIntervalId = setInterval(() => this.attemptPing(), PING_INTERVAL_MS);
-		}
 	}
 
 	public async sendSocketCommand<T extends ApiSocketCommandNoRequest>(commandName: T): Promise<IApiSocketResponse<T>>;

--- a/UI/src/tests/lib/api/api-socket.test.ts
+++ b/UI/src/tests/lib/api/api-socket.test.ts
@@ -210,6 +210,33 @@ describe('ApiSocket', () => {
 			expect(handleAuthFailure).not.toHaveBeenCalled();
 			expect(webSocketMock).not.toHaveBeenCalled();
 			expect(getTokens()).toEqual({ accessToken: 'expired', refreshToken: 'r' });
+			// The keepalive must still be armed so its next tick retries the connect — otherwise, on the very
+			// first connect of a page session (no interval running yet), nothing would ever call
+			// ensureSocket() again and the queued command would await forever (#2035).
+			expect(internals(apiSocket).pingIntervalId).not.toBeNull();
+		});
+
+		it('retries the connect via the keepalive after a retryable refresh failure with no interval running yet', async () => {
+			vi.useFakeTimers();
+			try {
+				setTokens({ accessToken: 'expired', refreshToken: 'r' });
+				// The very first connect attempt (no keepalive running yet) hits a retryable refresh failure;
+				// a later keepalive tick's attempt succeeds. Reproduces the boot-time hang scenario from #2035.
+				vi.mocked(ensureValidAccessToken)
+					.mockResolvedValueOnce({ accessToken: null, rejected: false })
+					.mockResolvedValue({ accessToken: 'expired', rejected: false });
+
+				apiSocket.sendSocketCommand('DefeatEnemy', { clientTotalMs: 1 });
+				await flushMicrotasks();
+
+				expect(webSocketMock).not.toHaveBeenCalled();
+
+				await vi.advanceTimersByTimeAsync(10000);
+
+				expect(webSocketMock).toHaveBeenCalledTimes(1);
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary

`openSocket()` pre-emptively refreshes the access token *before* creating the WebSocket and *before* arming the keepalive interval (`pingIntervalId`). On a **retryable** refresh failure (network blip, 5xx/429) it bails early and deliberately leaves the queue intact — the inline comment says "the keepalive ping's next `ensureSocket()` call retries the connect." But since `pingIntervalId` was only ever set at the *end* of `openSocket()`, after that bail point, nothing was actually there to retry whenever the interval wasn't already running: the first connect of a page session with an expired access token, or any connect after a `NORMAL_CLOSURE` stopped the interval. A queued command would never be sent, never get a timeout armed, and never settle — the caller would `await` forever, violating the socket layer's "pending and queued commands are always settled" contract (`docs/frontend.md` § Socket request & connection lifecycle).

## Fix

Move the keepalive-interval arming to the top of `openSocket()`, before the pre-emptive refresh await, so a retryable bail still leaves the interval running to drive the retry. The interval-arming block that previously ran at the end of `openSocket()` (right before the handshake was opened) is removed since it's now redundant. The existing `stopPingInterval()` call on the terminal (definitively-rejected, no adoptable pair) branch still correctly tears the freshly-armed interval back down.

## Test plan

- [x] Added a test asserting the keepalive interval is armed even when the pre-emptive refresh bails as retryable.
- [x] Added a test reproducing the boot-time hang: a retryable refresh failure on the very first connect (no interval running yet), followed by the next keepalive tick successfully retrying the connect.
- [x] `npx vitest run src/tests/lib/api/api-socket.test.ts` — 55/55 passed.
- [x] `npm run test:unit:ci` — 3729/3729 passed.
- [x] `npm run lint` (eslint + svelte-check) — clean.

Closes #2035

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8ZCUhkQGDCto7zatuKeLw

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8ZCUhkQGDCto7zatuKeLw)_