### PR TITLE
Guard progress-store writes against in-flight fetches from a discarded session

### DIFF
--- a/UI/src/lib/common/coalesced-loader.ts
+++ b/UI/src/lib/common/coalesced-loader.ts
@@ -60,6 +60,13 @@ export class CoalescedLoader {
 		this.epoch += 1;
 	}
 
+	/** Current reset epoch, bumped by {@link reset}. `fetchFn` should capture this before its first
+	 *  `await` and compare it again before writing to store state: if it moved, a `reset()` ran
+	 *  mid-flight and the pending write belongs to a discarded session, so it must be dropped. */
+	get currentEpoch(): number {
+		return this.epoch;
+	}
+
 	/** Publishes `pipeline` as the awaitable in-flight load, clearing it once it settles unless a
 	 *  chained fetch has replaced it in the meantime. */
 	private track(pipeline: Promise<void>): Promise<void> {

--- a/UI/src/lib/common/coalesced-loader.ts
+++ b/UI/src/lib/common/coalesced-loader.ts
@@ -61,10 +61,15 @@ export class CoalescedLoader {
 	}
 
 	/** Current reset epoch, bumped by {@link reset}. `fetchFn` should capture this before its first
-	 *  `await` and compare it again before writing to store state: if it moved, a `reset()` ran
-	 *  mid-flight and the pending write belongs to a discarded session, so it must be dropped. */
+	 *  `await` and pass it to {@link isStale} afterward to detect a `reset()` that ran mid-flight. */
 	get currentEpoch(): number {
 		return this.epoch;
+	}
+
+	/** Whether `epoch` (captured from {@link currentEpoch} before an await) no longer matches — a
+	 *  `reset()` ran mid-flight, so a write gated on this epoch belongs to a discarded session. */
+	isStale(epoch: number): boolean {
+		return epoch !== this.epoch;
 	}
 
 	/** Publishes `pipeline` as the awaitable in-flight load, clearing it once it settles unless a

--- a/UI/src/stores/challenges.svelte.ts
+++ b/UI/src/stores/challenges.svelte.ts
@@ -16,7 +16,7 @@ const fetchChallenges = async () => {
 	try {
 		// fetchSocketData throws on a socket error, preserving this try/catch contract.
 		const result = (await fetchSocketData('GetPlayerChallenges')) ?? [];
-		if (loader.currentEpoch !== epoch) {
+		if (loader.isStale(epoch)) {
 			// reset() ran while this fetch was in flight; this write belongs to a discarded session.
 			return;
 		}
@@ -26,7 +26,7 @@ const fetchChallenges = async () => {
 	} catch {
 		// A failed load is not a genuine empty result; leave zones gated as-is and let the next
 		// load retry. The Challenges screen surfaces the error to the user.
-		if (loader.currentEpoch === epoch) {
+		if (!loader.isStale(epoch)) {
 			error = true;
 		}
 	}

--- a/UI/src/stores/challenges.svelte.ts
+++ b/UI/src/stores/challenges.svelte.ts
@@ -12,15 +12,23 @@ let loaded = $state(false);
 let error = $state(false);
 
 const fetchChallenges = async () => {
+	const epoch = loader.currentEpoch;
 	try {
 		// fetchSocketData throws on a socket error, preserving this try/catch contract.
-		challenges = (await fetchSocketData('GetPlayerChallenges')) ?? [];
+		const result = (await fetchSocketData('GetPlayerChallenges')) ?? [];
+		if (loader.currentEpoch !== epoch) {
+			// reset() ran while this fetch was in flight; this write belongs to a discarded session.
+			return;
+		}
+		challenges = result;
 		error = false;
 		loaded = true;
 	} catch {
 		// A failed load is not a genuine empty result; leave zones gated as-is and let the next
 		// load retry. The Challenges screen surfaces the error to the user.
-		error = true;
+		if (loader.currentEpoch === epoch) {
+			error = true;
+		}
 	}
 };
 

--- a/UI/src/stores/proficiencies.svelte.ts
+++ b/UI/src/stores/proficiencies.svelte.ts
@@ -15,15 +15,23 @@ let loaded = $state(false);
 let error = $state(false);
 
 const fetchProficiencies = async () => {
+	const epoch = loader.currentEpoch;
 	try {
 		// fetchSocketData throws on a socket error, preserving this try/catch contract.
-		proficiencies = (await fetchSocketData('GetPlayerProficiencies')) ?? [];
+		const result = (await fetchSocketData('GetPlayerProficiencies')) ?? [];
+		if (loader.currentEpoch !== epoch) {
+			// reset() ran while this fetch was in flight; this write belongs to a discarded session.
+			return;
+		}
+		proficiencies = result;
 		error = false;
 		loaded = true;
 	} catch {
 		// A failed load is not a genuine empty result; leave the live battler without proficiency
 		// bonuses and let the next load retry. The proficiency screen surfaces the error to the user.
-		error = true;
+		if (loader.currentEpoch === epoch) {
+			error = true;
+		}
 	}
 };
 

--- a/UI/src/stores/proficiencies.svelte.ts
+++ b/UI/src/stores/proficiencies.svelte.ts
@@ -19,7 +19,7 @@ const fetchProficiencies = async () => {
 	try {
 		// fetchSocketData throws on a socket error, preserving this try/catch contract.
 		const result = (await fetchSocketData('GetPlayerProficiencies')) ?? [];
-		if (loader.currentEpoch !== epoch) {
+		if (loader.isStale(epoch)) {
 			// reset() ran while this fetch was in flight; this write belongs to a discarded session.
 			return;
 		}
@@ -29,7 +29,7 @@ const fetchProficiencies = async () => {
 	} catch {
 		// A failed load is not a genuine empty result; leave the live battler without proficiency
 		// bonuses and let the next load retry. The proficiency screen surfaces the error to the user.
-		if (loader.currentEpoch === epoch) {
+		if (!loader.isStale(epoch)) {
 			error = true;
 		}
 	}

--- a/UI/src/stores/statistics.svelte.ts
+++ b/UI/src/stores/statistics.svelte.ts
@@ -16,7 +16,7 @@ const fetchStats = async () => {
 	try {
 		// fetchSocketData throws on a socket error, preserving this try/catch contract.
 		const result = (await fetchSocketData('GetPlayerStatistics')) ?? [];
-		if (loader.currentEpoch !== epoch) {
+		if (loader.isStale(epoch)) {
 			// reset() ran while this fetch was in flight; this write belongs to a discarded session.
 			return;
 		}
@@ -26,7 +26,7 @@ const fetchStats = async () => {
 	} catch {
 		// A failed load is not a genuine empty result; leave the seal hidden and let
 		// the next load retry. The Statistics screen surfaces the error to the user.
-		if (loader.currentEpoch === epoch) {
+		if (!loader.isStale(epoch)) {
 			error = true;
 		}
 	}

--- a/UI/src/stores/statistics.svelte.ts
+++ b/UI/src/stores/statistics.svelte.ts
@@ -12,15 +12,23 @@ let loaded = $state(false);
 let error = $state(false);
 
 const fetchStats = async () => {
+	const epoch = loader.currentEpoch;
 	try {
 		// fetchSocketData throws on a socket error, preserving this try/catch contract.
-		stats = (await fetchSocketData('GetPlayerStatistics')) ?? [];
+		const result = (await fetchSocketData('GetPlayerStatistics')) ?? [];
+		if (loader.currentEpoch !== epoch) {
+			// reset() ran while this fetch was in flight; this write belongs to a discarded session.
+			return;
+		}
+		stats = result;
 		error = false;
 		loaded = true;
 	} catch {
 		// A failed load is not a genuine empty result; leave the seal hidden and let
 		// the next load retry. The Statistics screen surfaces the error to the user.
-		error = true;
+		if (loader.currentEpoch === epoch) {
+			error = true;
+		}
 	}
 };
 

--- a/UI/src/tests/lib/common/coalesced-loader.test.ts
+++ b/UI/src/tests/lib/common/coalesced-loader.test.ts
@@ -204,4 +204,14 @@ describe('CoalescedLoader', () => {
 		h.settle(0);
 		await initial;
 	});
+
+	it('isStale reflects whether reset() has moved the epoch captured before an await', async () => {
+		const h = harness();
+		const epoch = h.loader.currentEpoch;
+		expect(h.loader.isStale(epoch)).toBe(false);
+
+		h.loader.reset();
+		expect(h.loader.isStale(epoch)).toBe(true);
+		expect(h.loader.isStale(h.loader.currentEpoch)).toBe(false);
+	});
 });

--- a/UI/src/tests/lib/common/coalesced-loader.test.ts
+++ b/UI/src/tests/lib/common/coalesced-loader.test.ts
@@ -192,4 +192,16 @@ describe('CoalescedLoader', () => {
 		h.settle(2);
 		await forced;
 	});
+
+	it('currentEpoch moves on reset() so an in-flight fetchFn can detect a discarded session', async () => {
+		const h = harness();
+		const before = h.loader.currentEpoch;
+
+		const initial = h.loader.load();
+		h.loader.reset();
+		expect(h.loader.currentEpoch).not.toBe(before);
+
+		h.settle(0);
+		await initial;
+	});
 });

--- a/UI/src/tests/stores/challenges.test.ts
+++ b/UI/src/tests/stores/challenges.test.ts
@@ -151,4 +151,18 @@ describe('challenges store', () => {
 		expect(playerChallenges.all).toEqual([challenge(4, true)]);
 		expect(playerChallenges.loaded).toBe(true);
 	});
+
+	it('does not flag an error when an in-flight fetch rejects after reset() ran', async () => {
+		const stale = Promise.withResolvers<IPlayerChallenge[]>();
+		mockFetchSocket.mockReturnValueOnce(stale.promise);
+
+		const initial = playerChallenges.load();
+		playerChallenges.reset();
+
+		// The discarded fetch rejects after the reset; its catch must not flag the new session.
+		stale.reject(new Error('boom'));
+		await initial;
+
+		expect(playerChallenges.error).toBe(false);
+	});
 });

--- a/UI/src/tests/stores/challenges.test.ts
+++ b/UI/src/tests/stores/challenges.test.ts
@@ -132,4 +132,23 @@ describe('challenges store', () => {
 		await playerChallenges.load();
 		expect(playerChallenges.isChallengeCompleted(4)).toBe(true);
 	});
+
+	it('drops an in-flight fetch write that resolves after reset() instead of leaking it into the next session', async () => {
+		const stale = Promise.withResolvers<IPlayerChallenge[]>();
+		mockFetchSocket.mockReturnValueOnce(stale.promise);
+
+		const initial = playerChallenges.load();
+		playerChallenges.reset();
+
+		// The new session's own load starts before the discarded fetch settles.
+		mockFetchSocket.mockResolvedValueOnce([challenge(4, true)]);
+		const fresh = playerChallenges.load();
+
+		// The stale fetch resolves with the previous character's data; its write must not land.
+		stale.resolve([challenge(3, true)]);
+		await Promise.all([initial, fresh]);
+
+		expect(playerChallenges.all).toEqual([challenge(4, true)]);
+		expect(playerChallenges.loaded).toBe(true);
+	});
 });

--- a/UI/src/tests/stores/proficiencies.svelte.test.ts
+++ b/UI/src/tests/stores/proficiencies.svelte.test.ts
@@ -134,6 +134,25 @@ describe('proficiencies store', () => {
 		expect(playerProficiencies.all).toEqual([playerProficiency(2, 1)]);
 	});
 
+	it('drops an in-flight fetch write that resolves after reset() instead of leaking it into the next session', async () => {
+		const stale = Promise.withResolvers<IPlayerProficiency[]>();
+		mockFetchSocket.mockReturnValueOnce(stale.promise);
+
+		const initial = playerProficiencies.load();
+		playerProficiencies.reset();
+
+		// The new session's own load starts before the discarded fetch settles.
+		mockFetchSocket.mockResolvedValueOnce([playerProficiency(1, 5)]);
+		const fresh = playerProficiencies.load();
+
+		// The stale fetch resolves with the previous character's data; its write must not land.
+		stale.resolve([playerProficiency(0, 9)]);
+		await Promise.all([initial, fresh]);
+
+		expect(playerProficiencies.all).toEqual([playerProficiency(1, 5)]);
+		expect(playerProficiencies.loaded).toBe(true);
+	});
+
 	describe('levelOf', () => {
 		it('returns the stored level for a known proficiency and 0 for an unopened one', async () => {
 			mockFetchSocket.mockResolvedValue([playerProficiency(0, 3)]);

--- a/UI/src/tests/stores/proficiencies.svelte.test.ts
+++ b/UI/src/tests/stores/proficiencies.svelte.test.ts
@@ -153,6 +153,20 @@ describe('proficiencies store', () => {
 		expect(playerProficiencies.loaded).toBe(true);
 	});
 
+	it('does not flag an error when an in-flight fetch rejects after reset() ran', async () => {
+		const stale = Promise.withResolvers<IPlayerProficiency[]>();
+		mockFetchSocket.mockReturnValueOnce(stale.promise);
+
+		const initial = playerProficiencies.load();
+		playerProficiencies.reset();
+
+		// The discarded fetch rejects after the reset; its catch must not flag the new session.
+		stale.reject(new Error('boom'));
+		await initial;
+
+		expect(playerProficiencies.error).toBe(false);
+	});
+
 	describe('levelOf', () => {
 		it('returns the stored level for a known proficiency and 0 for an unopened one', async () => {
 			mockFetchSocket.mockResolvedValue([playerProficiency(0, 3)]);

--- a/UI/src/tests/stores/statistics.test.ts
+++ b/UI/src/tests/stores/statistics.test.ts
@@ -173,4 +173,18 @@ describe('statistics store', () => {
 		expect(statistics.stats).toEqual([zonesCleared(4, 1)]);
 		expect(statistics.loaded).toBe(true);
 	});
+
+	it('does not flag an error when an in-flight fetch rejects after reset() ran', async () => {
+		const stale = Promise.withResolvers<IPlayerStatistic[]>();
+		mockFetchSocket.mockReturnValueOnce(stale.promise);
+
+		const initial = statistics.load();
+		statistics.reset();
+
+		// The discarded fetch rejects after the reset; its catch must not flag the new session.
+		stale.reject(new Error('boom'));
+		await initial;
+
+		expect(statistics.error).toBe(false);
+	});
 });

--- a/UI/src/tests/stores/statistics.test.ts
+++ b/UI/src/tests/stores/statistics.test.ts
@@ -154,4 +154,23 @@ describe('statistics store', () => {
 		await statistics.load();
 		expect(statistics.isZoneCleared(4)).toBe(true);
 	});
+
+	it('drops an in-flight fetch write that resolves after reset() instead of leaking it into the next session', async () => {
+		const stale = Promise.withResolvers<IPlayerStatistic[]>();
+		mockFetchSocket.mockReturnValueOnce(stale.promise);
+
+		const initial = statistics.load();
+		statistics.reset();
+
+		// The new session's own load starts before the discarded fetch settles.
+		mockFetchSocket.mockResolvedValueOnce([zonesCleared(4, 1)]);
+		const fresh = statistics.load();
+
+		// The stale fetch resolves with the previous character's data; its write must not land.
+		stale.resolve([zonesCleared(3, 1)]);
+		await Promise.all([initial, fresh]);
+
+		expect(statistics.stats).toEqual([zonesCleared(4, 1)]);
+		expect(statistics.loaded).toBe(true);
+	});
 });


### PR DESCRIPTION
## Summary

`CoalescedLoader.reset()` (`UI/src/lib/common/coalesced-loader.ts`) only epoch-guarded the *queued* fresh fetch triggered by a mid-flight `force`. The *original* in-flight `fetchFn()`'s own continuation — where the actual store write happens — ran unconditionally.

`stopGame()` calls `playerProficiencies.reset()` / `playerChallenges.reset()` / `statistics.reset()` synchronously and then disconnects the socket. If one of those stores had a fetch already in flight when `reset()` ran (e.g. a character switch mid-load), its continuation could still resolve afterward and write the **previous character's** data into the store — with `loaded` flipped back to `true` — so the next session's `load()` call would silently no-op and the live battler could compose against stale `battleModifiers`.

## Fix

- `CoalescedLoader` exposes a new `currentEpoch` getter, backed by the same epoch counter `reset()` already bumps.
- Each of the three progress stores (`proficiencies.svelte.ts`, `challenges.svelte.ts`, `statistics.svelte.ts`) captures `loader.currentEpoch` before its fetch's `await`, and re-checks it before writing to store state (success path) or setting `error` (failure path). If `reset()` ran in between, the epoch has moved and the write is dropped.

This follows the "give each store (or the loader) a session epoch" direction suggested in the issue — implemented once in the shared loader rather than three independent counters, since all three stores share the exact same race.

## Test plan

- Added `CoalescedLoader.currentEpoch` unit test (loader test suite).
- Added a store-level regression test to each of the three store suites: start a load, `reset()` before it resolves, start a fresh load, then resolve the stale fetch with different data — asserts the stale write is dropped and the fresh session's data wins.
- `npm run lint` — clean.
- Full frontend unit suite: `npx vitest run` — 299 files / 3733 tests passing.

Backend is untouched; this is a frontend-only store/lifecycle fix.

Closes #2036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4KUV7MqHghZnCfZpFKLUX

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4KUV7MqHghZnCfZpFKLUX)_