### PR TITLE
Reassign unlockedItems/unlockedMods in InventoryManager.initialize()

### DIFF
--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -98,15 +98,15 @@ export class InventoryManager {
 
 	public initialize() {
 		this.generation++;
-		this.unlockedItems.clear();
-		this.unlockedMods.clear();
-		this.equippedSlots = new Array(6).fill(undefined);
+		const unlockedItems: Map<number, Item> = new Map();
+		const unlockedMods: Set<number> = new Set();
+		const equippedSlots: (Item | undefined)[] = new Array(6).fill(undefined);
 
 		const data = playerManager.inventoryData;
 
 		// Load unlocked mods
 		for (const modId of data.unlockedMods) {
-			this.unlockedMods.add(modId);
+			unlockedMods.add(modId);
 		}
 
 		// Load unlocked items
@@ -117,13 +117,18 @@ export class InventoryManager {
 				logMessage(ELogType.Debug, `Skipped unlocked item with unknown id ${invItem.itemId}.`);
 				continue;
 			}
-			this.unlockedItems.set(invItem.itemId, item);
+			unlockedItems.set(invItem.itemId, item);
 
 			// Place equipped items into their equipment slots
 			if (invItem.equipped && invItem.equipmentSlotId != null) {
-				this.equippedSlots[invItem.equipmentSlotId] = item;
+				equippedSlots[invItem.equipmentSlotId] = item;
 			}
 		}
+
+		// Reassign (not mutate) so statify/$state tracks the change, mirroring addUnlockedMod.
+		this.unlockedItems = unlockedItems;
+		this.unlockedMods = unlockedMods;
+		this.equippedSlots = equippedSlots;
 
 		this.publish();
 		this.refreshEquipmentStats();

--- a/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
+++ b/UI/src/routes/game/screens/inventory/inventory-view.svelte.ts
@@ -76,8 +76,9 @@ export class InventoryView {
 
 	// Resolve selection/drag through the manager's itemId-keyed Map (its own O(1) access convention)
 	// rather than a linear scan of the list; `items` stays the source for list/count derivations.
-	// NOTE: unlockedItems is a plain (non-reactive) Map, so these re-resolve only on id changes, not on
-	// set changes — fine while items are add-only; if a removal path lands, clear the ids on removal.
+	// NOTE: unlockedItems is a plain (non-reactive) Map, so these re-resolve on a reassignment
+	// (initialize()'s resync) but not on an in-place add — fine while addUnlockedItem is add-only;
+	// if a removal path lands, clear the ids on removal.
 	readonly selected = $derived(
 		this.selectedId != null ? (inventoryManager.unlockedItems.get(this.selectedId) ?? null) : null
 	);

--- a/UI/src/tests/lib/engine/player/inventory-manager-reactivity.svelte.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager-reactivity.svelte.test.ts
@@ -175,4 +175,36 @@ describe('InventoryManager reactivity under statify (#1957)', () => {
 
 		cleanup();
 	});
+
+	it('observes unlockedItems/unlockedMods changes through a resync (initialize called again)', () => {
+		mockItems[1] = makeItem(1);
+		mockItemMods[10] = makeItemMod(10);
+		mockInventoryData.unlockedItems = [];
+		mockInventoryData.unlockedMods = [];
+		manager.initialize();
+
+		let itemCount: number | undefined;
+		let modUnlocked: boolean | undefined;
+		const cleanup = $effect.root(() => {
+			const derivedItemCount = $derived(manager.unlockedItems.size);
+			const derivedModUnlocked = $derived(manager.unlockedMods.has(10));
+			$effect(() => {
+				itemCount = derivedItemCount;
+				modUnlocked = derivedModUnlocked;
+			});
+		});
+		flushSync();
+		expect(itemCount).toBe(0);
+		expect(modUnlocked).toBe(false);
+
+		// Simulate a resync delivering an item/mod that weren't present at the last initialize.
+		mockInventoryData.unlockedItems = [makeInventoryItem({ itemId: 1 })];
+		mockInventoryData.unlockedMods = [10];
+		manager.initialize();
+		flushSync();
+		expect(itemCount).toBe(1);
+		expect(modUnlocked).toBe(true);
+
+		cleanup();
+	});
 });


### PR DESCRIPTION
## Summary

`InventoryManager.initialize()` — the mid-session resync path — rebuilt `unlockedItems`/`unlockedMods` **in place** via `.clear()` + re-populate, while `equippedSlots` was correctly reassigned. `statify`'s documented contract requires `Map`/`Set` fields to be **reassigned** to signal a change; `addUnlockedMod` already follows this, but `initialize()` didn't.

**Failure scenario:** the player is on the Inventory screen with the mod picker open when a `DefeatEnemy` response is lost or a `ChallengeCompleted` push dead-letters, triggering a resync via `resyncPlayerAndInventory()`. Because the containers were mutated in place, reactive consumers that read them directly (e.g. `compatibleMods` reading `inventoryManager.unlockedMods.has(m.id)`) wouldn't re-derive, so a mod/item delivered by the resync stayed invisible until something else forced a rebuild.

## Fix

- `initialize()` now builds fresh local `Map`/`Set` instances and reassigns `this.unlockedItems` / `this.unlockedMods` at the end, mirroring the existing `equippedSlots` reassignment and the reassign pattern already used by `addUnlockedMod`.
- Added a test case to `inventory-manager-reactivity.svelte.test.ts` covering the initialize/resync identity contract: a `$derived` reading `unlockedItems.size` and `unlockedMods.has(...)` now correctly observes a second `initialize()` call delivering new data.

## Test plan

- [x] `npx vitest run` on the touched test files — 73 tests passing
- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] Full frontend unit suite: `npm run test:unit:ci` — 299 files / 3730 tests passing

Backend is untouched; this is a frontend-only store/lifecycle fix.

Closes #2037

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AsXi3ZmdLNiEtyRpCxDrc8)_