### PR TITLE
Clear toasts, modals, navigation intent, and current enemy on stopGame teardown

### DIFF
--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -147,6 +147,9 @@ export class EnemyManager {
 			// Teardown (screen unmount / session end), not a user intent change, so don't sync the persisted
 			// loop mode — clobbering it to idle here would lose a disconnecting boss-farmer's mode.
 			this.returnToIdle(false);
+			// Otherwise the previous session's enemy would briefly render on the next session's re-entry,
+			// until the first fetch replaces it.
+			this.currentEnemy = undefined;
 		}
 	}
 

--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -30,7 +30,9 @@ import {
 	acknowledgeModal,
 	resetLogs,
 	toastSuccess,
-	navigation
+	navigation,
+	clearToasts,
+	clearModals
 } from '$stores';
 import {
 	apiSocket,
@@ -360,6 +362,12 @@ const stopGame = () => {
 	playerChallenges.reset();
 	playerProficiencies.reset();
 	resetLogs();
+	// Clear the other module-level UI stores stopEngines/the resets above don't touch, so a leftover toast,
+	// queued modal, or pending screen request can't leak into the next session (e.g. a "View" toast action
+	// queuing a navigation.requestScreen the next session's shell would silently consume on mount).
+	clearToasts();
+	clearModals();
+	navigation.reset();
 	// SocketReplaced routes back to login client-side (no reload), so the socket singleton survives. Tear
 	// it down explicitly, otherwise the keepalive ping would silently reconnect and fight the session that
 	// just took over.

--- a/UI/src/stores/navigation.svelte.ts
+++ b/UI/src/stores/navigation.svelte.ts
@@ -49,5 +49,14 @@ export const navigation = {
 	 *  target screen to consume on mount). */
 	clear() {
 		requestedScreen = null;
+	},
+
+	/** Clears every piece of navigation intent — the requested screen and any unconsumed payload.
+	 *  Used on game teardown so a request queued just before disconnect (e.g. a toast's "View" action)
+	 *  doesn't get silently consumed by the next session's game shell on mount. */
+	reset() {
+		requestedScreen = null;
+		pendingPayload = undefined;
+		payloadPending = false;
 	}
 };

--- a/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager.test.ts
@@ -385,6 +385,27 @@ describe('EnemyManager.getNewEnemy', () => {
 	});
 });
 
+describe('EnemyManager.stop', () => {
+	it('clears the current enemy so it does not briefly render on the next session before the first fetch replaces it', () => {
+		const manager = new EnemyManager();
+		manager.started = true;
+		manager.currentEnemy = makeEnemy(1);
+
+		manager.stop();
+
+		expect(manager.currentEnemy).toBeUndefined();
+	});
+
+	it('is a no-op when the manager was never started', () => {
+		const manager = new EnemyManager();
+		manager.currentEnemy = makeEnemy(1);
+
+		manager.stop();
+
+		expect(manager.currentEnemy).toEqual(makeEnemy(1));
+	});
+});
+
 describe('EnemyManager.start', () => {
 	let manager: EnemyManager;
 	let sendSocketCommand: ReturnType<typeof vi.spyOn>;

--- a/UI/src/tests/lib/engine/engine.test.ts
+++ b/UI/src/tests/lib/engine/engine.test.ts
@@ -19,7 +19,8 @@ const {
 	playerProficienciesStub,
 	resetLogs,
 	toastSuccess,
-	navigation
+	navigation,
+	clearToasts
 } = vi.hoisted(() => ({
 	staticDataStub: { loaded: true } as {
 		loaded: boolean;
@@ -44,7 +45,8 @@ const {
 	},
 	resetLogs: vi.fn(),
 	toastSuccess: vi.fn(),
-	navigation: { requestScreen: vi.fn() }
+	navigation: { requestScreen: vi.fn(), reset: vi.fn() },
+	clearToasts: vi.fn()
 }));
 vi.mock('$stores', async () => {
 	const modal = await vi.importActual<typeof import('$stores/modal.svelte')>('$stores/modal.svelte');
@@ -56,7 +58,8 @@ vi.mock('$stores', async () => {
 		playerProficiencies: playerProficienciesStub,
 		resetLogs,
 		toastSuccess,
-		navigation
+		navigation,
+		clearToasts
 	};
 });
 
@@ -158,7 +161,7 @@ import {
 	battleEngine,
 	inventoryManager
 } from '$lib/engine/engine';
-import { activeModal, clearModals, confirmActiveModal } from '$stores/modal.svelte';
+import { activeModal, clearModals, confirmActiveModal, showModal } from '$stores/modal.svelte';
 import { createHook } from '$lib/common/hooks';
 import { onDestroy } from 'svelte';
 import {
@@ -361,6 +364,29 @@ describe('startGame', () => {
 		void handleSocketReplaced();
 
 		expect(disconnect).toHaveBeenCalledTimes(1);
+	});
+
+	it('stopGame clears any active toasts so they cannot leak onto the next session/login screen (#2038)', () => {
+		startGame();
+		void handleSocketReplaced();
+
+		expect(clearToasts).toHaveBeenCalledTimes(1);
+	});
+
+	it('stopGame clears any queued modal rather than leaving it to show ahead of the session-replaced acknowledgement (#2038)', async () => {
+		const priorModal = showModal({ title: 'Old', body: 'A stale confirm dialog' });
+
+		void handleSocketReplaced();
+
+		await expect(priorModal).resolves.toBe(false);
+		expect(activeModal.current?.title).toBe(SESSION_REPLACED_TITLE);
+	});
+
+	it('stopGame resets the navigation intent so a queued screen request cannot leak into the next session (#2038)', () => {
+		startGame();
+		void handleSocketReplaced();
+
+		expect(navigation.reset).toHaveBeenCalledTimes(1);
 	});
 
 	it("unhooks the previous call's listeners before re-registering, so a remount cannot leak them (#1807)", () => {

--- a/UI/src/tests/stores/navigation.test.ts
+++ b/UI/src/tests/stores/navigation.test.ts
@@ -38,6 +38,14 @@ describe('navigation store', () => {
 		expect(navigation.hasPendingPayload).toBe(true);
 		expect(navigation.consumePayload()).toBeNull();
 	});
+
+	it('reset clears both the requested screen and any unconsumed payload', () => {
+		navigation.requestScreen('codex', { enemyId: 7 });
+		navigation.reset();
+		expect(navigation.requestedScreen).toBeNull();
+		expect(navigation.hasPendingPayload).toBe(false);
+		expect(navigation.consumePayload()).toBeUndefined();
+	});
 });
 
 describe('requiresRemount', () => {


### PR DESCRIPTION
## Summary

`stopGame` (`UI/src/lib/engine/engine.ts`) reset statistics/challenges/proficiencies/logs and disconnected the socket, but left several other module-level UI stores untouched:

- `clearToasts()` and `clearModals()` were never called on teardown.
- `navigation.svelte.ts`'s `requestedScreen`/`pendingPayload` had no reset path at all.
- `EnemyManager.stop()` left `currentEnemy` set, so the previous session's enemy could briefly render on re-entry until the first fetch replaced it.

**Failure scenario:** `SocketReplaced` mid-game → `stopGame()` → client-side `goto('/')` (the root layout and `ToastContainer` persist). Live game toasts survive onto the login screen, and a queued `navigation.requestScreen(...)` (e.g. from a toast's "View" action) would be silently consumed by the *next* session's game shell on mount, opening it on the wrong screen instead of Fight.

## Changes

- Added `navigation.reset()` (`UI/src/stores/navigation.svelte.ts`) to clear both the requested screen and any unconsumed payload.
- `EnemyManager.stop()` now clears `currentEnemy` (`UI/src/lib/engine/battle/enemy-manager.ts`).
- `stopGame()` now calls `clearToasts()`, `clearModals()`, and `navigation.reset()` in addition to its existing resets (`UI/src/lib/engine/engine.ts`). `clearModals()` runs before `handleSocketReplaced`'s own `acknowledgeModal(...)` call, so the new session-replaced dialog is unaffected.

## Test plan

- [x] Added unit tests covering `navigation.reset()`, `EnemyManager.stop()` clearing `currentEnemy` (and remaining a no-op when never started), and `stopGame`'s new toast/modal/navigation clearing (`enemy-manager.test.ts`, `engine.test.ts`, `navigation.test.ts`).
- [x] `npx vitest run` — full suite (299 files / 3744 tests) passes.
- [x] `npm run lint` — eslint + svelte-check clean.

Closes #2038


---
_Generated by [Claude Code](https://claude.ai/code/session_01HuLeBJyZt5HL69cHRMiDXH)_