### PR TITLE
Defer identity-column commits to blur in Workbench SectionTable (#2039)

### DIFF
--- a/UI/src/routes/admin/workbench/components/NumInput.svelte
+++ b/UI/src/routes/admin/workbench/components/NumInput.svelte
@@ -7,7 +7,7 @@
 	value={text}
 	oninput={handleInput}
 	onfocus={() => (focused = true)}
-	onblur={() => (focused = false)}
+	onblur={handleBlur}
 />
 
 <script lang="ts">
@@ -19,6 +19,10 @@ interface Props {
 	allowNegative?: boolean;
 	/** Accessible name for the input — the visible field labels are presentational `<span>`s, not associated `<label>`s. */
 	ariaLabel?: string;
+	/** Defer the commit to blur instead of every keystroke — for identity columns (e.g. a tour step's
+	 *  author-editable `ordinal`), where a per-keystroke commit can transiently collide with (and swap)
+	 *  a sibling row's identity mid-edit. */
+	commitOnBlur?: boolean;
 }
 
 let {
@@ -27,7 +31,8 @@ let {
 	class: className = '',
 	style = undefined,
 	allowNegative = false,
-	ariaLabel = undefined
+	ariaLabel = undefined,
+	commitOnBlur = false
 }: Props = $props();
 
 // Keep the in-progress text locally so typing "1." or "0.5" isn't clobbered by
@@ -50,6 +55,16 @@ $effect(() => {
 
 const pattern = $derived(allowNegative ? /^-?\d*\.?\d*$/ : /^\d*\.?\d*$/);
 
+// Only commit a fully-parseable number. An empty or in-progress field ("", "-", ".", "-.") leaves
+// the stored value untouched rather than coercing it to 0 — navigating away mid-edit then restores
+// the prior value (via the blur effect) instead of silently persisting 0.
+const commit = (raw: string) => {
+	const parsed = parseFloat(raw);
+	if (!Number.isNaN(parsed)) {
+		onChange(parsed);
+	}
+};
+
 const handleInput = (event: Event) => {
 	const el = event.currentTarget as HTMLInputElement;
 	const raw = el.value;
@@ -58,12 +73,15 @@ const handleInput = (event: Event) => {
 		return;
 	}
 	inputText = raw;
-	// Only commit a fully-parseable number. An empty or in-progress field ("", "-", ".", "-.")
-	// leaves the stored value untouched rather than coercing it to 0 — navigating away mid-edit
-	// then restores the prior value (via the blur effect) instead of silently persisting 0.
-	const parsed = parseFloat(raw);
-	if (!Number.isNaN(parsed)) {
-		onChange(parsed);
+	if (!commitOnBlur) {
+		commit(raw);
+	}
+};
+
+const handleBlur = () => {
+	focused = false;
+	if (commitOnBlur && inputText !== undefined) {
+		commit(inputText);
 	}
 };
 </script>

--- a/UI/src/routes/admin/workbench/components/SectionTable.svelte
+++ b/UI/src/routes/admin/workbench/components/SectionTable.svelte
@@ -45,6 +45,7 @@
 								{rows}
 								{record}
 								dirty={!isNewRow && !recordsEqual(row[col.key], baseRow[col.key])}
+								identity={col.key === rowKey}
 								onChange={(value) => setCell(i, col.key, value)}
 							/>
 						{/each}
@@ -138,6 +139,8 @@ const setCell = (i: number, key: string, value: number | string | undefined) =>
 		// Editing a row's identity column (e.g. a tour step's author-editable `ordinal`) into another
 		// row's value would duplicate the {#each} key — crashing dev builds and mis-reconciling prod
 		// ones. Swap the two rows' identities instead, so the edit still lands and both keys stay unique.
+		// A number-type identity column commits once on blur (TableCell's `identity` prop → NumInput's
+		// `commitOnBlur`), so this only ever runs against the final typed value, not an in-progress digit.
 		if (key === rowKey) {
 			const collision = list.find((r, ri) => ri !== i && r[rowKey] === value);
 			if (collision) {

--- a/UI/src/routes/admin/workbench/components/TableCell.svelte
+++ b/UI/src/routes/admin/workbench/components/TableCell.svelte
@@ -30,6 +30,7 @@
 				class="inp num{dirty ? ' dirty' : ''}"
 				value={(row[col.key] as number) ?? 0}
 				allowNegative={col.allowNegative}
+				commitOnBlur={identity}
 				onChange={(n) => onChange(n)}
 			/>
 			{#if dirty}<DirtyDot />{/if}
@@ -73,10 +74,14 @@ interface Props {
 	rows: TableRow[];
 	record: unknown;
 	dirty: boolean;
+	/** True when this column is the section's row identity (`rowKey`). A `number` identity column
+	 *  defers its commit to blur (see NumInput) so an in-progress multi-digit edit can't transiently
+	 *  collide with a sibling row's identity mid-keystroke. */
+	identity?: boolean;
 	onChange: (value: number | string | undefined) => void;
 }
 
-const { col, row, idx, rows, record, dirty, onChange }: Props = $props();
+const { col, row, idx, rows, record, dirty, identity = false, onChange }: Props = $props();
 
 // For unique select/attribute columns, options already chosen in sibling rows are disabled.
 // These columns' values are always numeric ids, unlike a free-form `text` column's.

--- a/UI/src/tests/routes/admin/workbench/NumInput.test.ts
+++ b/UI/src/tests/routes/admin/workbench/NumInput.test.ts
@@ -106,3 +106,50 @@ describe('NumInput — in-progress text', () => {
 		expect(onChange).not.toHaveBeenCalled();
 	});
 });
+
+describe('NumInput — commitOnBlur', () => {
+	it('does not call onChange on keystrokes while commitOnBlur is set', async () => {
+		const onChange = vi.fn();
+		const { container } = render(NumInput, { props: { value: 0, onChange, commitOnBlur: true } });
+		const input = container.querySelector('input') as HTMLInputElement;
+		// Focus first (as a real keystroke would) so the not-focused resync effect doesn't clobber
+		// the in-progress text between keystrokes.
+		await fireEvent.focus(input);
+		await fireEvent.input(input, { target: { value: '1' } });
+		await fireEvent.input(input, { target: { value: '12' } });
+		expect(onChange).not.toHaveBeenCalled();
+		expect(input.value).toBe('12');
+	});
+
+	it('commits the final typed value once on blur', async () => {
+		const onChange = vi.fn();
+		const { container } = render(NumInput, { props: { value: 0, onChange, commitOnBlur: true } });
+		const input = container.querySelector('input') as HTMLInputElement;
+		await fireEvent.focus(input);
+		await fireEvent.input(input, { target: { value: '1' } });
+		await fireEvent.input(input, { target: { value: '12' } });
+		await fireEvent.blur(input);
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange).toHaveBeenCalledWith(12);
+	});
+
+	it('does not call onChange on blur when the in-progress text is not a parseable number', async () => {
+		const onChange = vi.fn();
+		const { container } = render(NumInput, { props: { value: 5, onChange, commitOnBlur: true } });
+		const input = container.querySelector('input') as HTMLInputElement;
+		await fireEvent.focus(input);
+		await fireEvent.input(input, { target: { value: '' } });
+		await fireEvent.blur(input);
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it('still commits on every keystroke when commitOnBlur is unset (default)', async () => {
+		const onChange = vi.fn();
+		const { container } = render(NumInput, { props: { value: 0, onChange } });
+		const input = container.querySelector('input') as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: '1' } });
+		await fireEvent.input(input, { target: { value: '12' } });
+		expect(onChange).toHaveBeenNthCalledWith(1, 1);
+		expect(onChange).toHaveBeenNthCalledWith(2, 12);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/SectionTable.test.ts
+++ b/UI/src/tests/routes/admin/workbench/SectionTable.test.ts
@@ -299,9 +299,12 @@ describe('SectionTable — editable-identity (rowKey) collections', () => {
 		});
 
 		// Editing the first row's ordinal (0) to the second row's ordinal (1) must not leave two
-		// rows sharing ordinal 1 — that duplicate key crashes Svelte's keyed {#each}.
+		// rows sharing ordinal 1 — that duplicate key crashes Svelte's keyed {#each}. An identity
+		// column commits on blur (not per keystroke), so the edit lands once focus leaves the cell.
 		const ordinalInputs = container.querySelectorAll('input.num');
+		await fireEvent.focus(ordinalInputs[0]);
 		await fireEvent.input(ordinalInputs[0], { target: { value: '1' } });
+		await fireEvent.blur(ordinalInputs[0]);
 
 		const ordinals = store.items[0].steps.map((s) => s.ordinal).sort();
 		expect(ordinals).toEqual([0, 1]);
@@ -309,6 +312,44 @@ describe('SectionTable — editable-identity (rowKey) collections', () => {
 		// The edited row took the new ordinal; its former sibling was swapped to the vacated one.
 		expect(store.items[0].steps.find((s) => s.text === 'First')?.ordinal).toBe(1);
 		expect(store.items[0].steps.find((s) => s.text === 'Second')?.ordinal).toBe(0);
+	});
+
+	it('does not commit (or swap sibling rows) per keystroke while typing a multi-digit ordinal', async () => {
+		// Regression for #2039: typing "12" over step 3's ordinal used to commit "1" on the first
+		// keystroke — colliding with the row holding ordinal 1 and silently swapping it to 3.
+		const store = new EntityStore(config(), [
+			{
+				id: 1,
+				steps: [
+					{ ordinal: 0, text: 'First' },
+					{ ordinal: 1, text: 'Second' },
+					{ ordinal: 2, text: 'Third' },
+					{ ordinal: 3, text: 'Fourth' }
+				]
+			}
+		]);
+		const { container } = render(SectionTable, {
+			props: {
+				section: stepSection as unknown as TableSectionConfig<Identified>,
+				record: store.items[0] as Identified,
+				baseline: store.baselineOf(1),
+				store: store as unknown as EntityStore<Identified>
+			}
+		});
+
+		const ordinalInputs = container.querySelectorAll('input.num');
+		// Retype step 3's (Fourth's) ordinal one keystroke at a time: "3" -> "1" -> "12".
+		await fireEvent.focus(ordinalInputs[3]);
+		await fireEvent.input(ordinalInputs[3], { target: { value: '1' } });
+		await fireEvent.input(ordinalInputs[3], { target: { value: '12' } });
+
+		// Nothing commits mid-edit, so every row (including the one holding ordinal 1) is untouched.
+		expect(store.items[0].steps.map((s) => s.ordinal)).toEqual([0, 1, 2, 3]);
+
+		await fireEvent.blur(ordinalInputs[3]);
+
+		// Only on blur does the final value land — no collision, so no swap is needed.
+		expect(store.items[0].steps.map((s) => s.ordinal)).toEqual([0, 1, 2, 12]);
 	});
 
 	it('typing into then erasing an optional cell returns the row to baseline-equal (not dirty)', async () => {

--- a/UI/src/tests/routes/admin/workbench/TableCell.test.ts
+++ b/UI/src/tests/routes/admin/workbench/TableCell.test.ts
@@ -173,6 +173,46 @@ describe('TableCell — number type', () => {
 		expect(input).toBeTruthy();
 		expect(input.getAttribute('inputmode')).toBe('decimal');
 	});
+
+	it('commits on every keystroke when this is not the identity column', async () => {
+		const onChange = vi.fn();
+		const { container } = render(TableCell, {
+			props: {
+				col: makeNumberCol(),
+				row: { weight: 10 },
+				idx: 0,
+				rows: [{ weight: 10 }],
+				record: {},
+				dirty: false,
+				onChange
+			}
+		});
+		const input = container.querySelector('input') as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: '5' } });
+		expect(onChange).toHaveBeenCalledWith(5);
+	});
+
+	it('defers commit to blur when this is the section rowKey (identity) column', async () => {
+		const onChange = vi.fn();
+		const { container } = render(TableCell, {
+			props: {
+				col: makeNumberCol({ key: 'ordinal' }),
+				row: { ordinal: 0 },
+				idx: 0,
+				rows: [{ ordinal: 0 }],
+				record: {},
+				dirty: false,
+				identity: true,
+				onChange
+			}
+		});
+		const input = container.querySelector('input') as HTMLInputElement;
+		await fireEvent.focus(input);
+		await fireEvent.input(input, { target: { value: '5' } });
+		expect(onChange).not.toHaveBeenCalled();
+		await fireEvent.blur(input);
+		expect(onChange).toHaveBeenCalledWith(5);
+	});
 });
 
 describe('TableCell — text type', () => {


### PR DESCRIPTION
## Summary

`NumInput` commits every fully-parseable keystroke to the record, and `SectionTable.setCell` swaps two rows' identities when a `rowKey` edit collides with a sibling row's current value. Lesson tour steps are the one table where the row identity (`ordinal`) is also an author-editable number column, so retyping a multi-digit ordinal (e.g. `3` → `12`) committed the intermediate `1` first — colliding with the sibling row holding ordinal `1` and silently swapping its identity (and, via the keyed `{#each}`, re-assigning the `<tr>` under the cursor to that other row).

## Fix

- `NumInput.svelte`: added a `commitOnBlur` prop. When set, keystrokes only update the local display text; the value is committed once on blur, after the full edit is typed.
- `TableCell.svelte`: added an `identity` prop and forwards `commitOnBlur={identity}` to `NumInput` for `number`-type columns.
- `SectionTable.svelte`: passes `identity={col.key === rowKey}` to `TableCell`, so only the section's identity column (when it happens to be a `number` column, as with lesson tour steps) defers its commit — every other column is unaffected.

This means the identity/collision-swap logic in `setCell` now only ever runs against the final typed value, not an in-progress digit, closing the corruption window described in the issue.

## Testing

- Added `NumInput` unit tests for the new `commitOnBlur` mode (no per-keystroke `onChange`, single commit on blur, no commit on an unparseable blur value, default per-keystroke behavior unchanged).
- Added a `TableCell` test asserting `identity` forwards `commitOnBlur` to `NumInput`.
- Updated the existing `SectionTable` collision-swap test to commit via blur, and added a regression test that types a multi-digit ordinal one keystroke at a time and asserts no sibling row is touched until blur.
- `npm run lint` — clean.
- `npm run test:unit:ci` — 3751/3751 passing, no coverage regressions.
- `npm run build` — clean.

Closes #2039

---
_Generated by [Claude Code](https://claude.ai/code/session_01M95hbwvvtGUZGZsuWjNjW8)_