### PR TITLE
Fix CreateAccount 500 for 21-25 char usernames

### DIFF
--- a/Game.Api.Tests/Integration/LoginControllerTests.cs
+++ b/Game.Api.Tests/Integration/LoginControllerTests.cs
@@ -5,10 +5,12 @@ using Game.Api.Http;
 using Game.Api.Models.Auth;
 using Game.Api.Models.Common;
 using Game.Core;
+using Game.Core.Identity;
 using Game.Infrastructure.Database;
 using Game.Infrastructure.Entities;
 using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
@@ -598,6 +600,37 @@ namespace Game.Api.Tests.Integration
             var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
             Assert.NotNull(result);
             Assert.NotNull(result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task CreateAccount_UsernameAtMaxLength_Succeeds()
+        {
+            // Exactly the 20-char column limit (UsernamePolicy.MaxLength) — the boundary that must still fit storage.
+            var creds = new { Username = new string('u', UsernamePolicy.MaxLength), Password = "newpass" };
+
+            var response = await Client.PostAsJsonAsync("/api/Login/CreateAccount", creds, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Null(result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task CreateAccount_UsernameOverMaxLength_ReturnsValidationErrorNotServerError()
+        {
+            // One character past the 20-char column limit — [ApiController]'s automatic model validation must
+            // reject it (as a ValidationProblemDetails 400, its standard shape for a DataAnnotations failure)
+            // before it ever reaches the database, rather than letting a Postgres string-truncation error
+            // escape the self-commit as a 500.
+            var creds = new { Username = new string('u', UsernamePolicy.MaxLength + 1), Password = "newpass" };
+
+            var response = await Client.PostAsJsonAsync("/api/Login/CreateAccount", creds, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>(CancellationToken);
+            Assert.NotNull(problem);
+            Assert.Contains(nameof(CreateAccountRequest.Username), problem.Errors.Keys);
         }
 
         [Fact]

--- a/Game.Api/Models/Auth/CreateAccountRequest.cs
+++ b/Game.Api/Models/Auth/CreateAccountRequest.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Game.Core.Identity;
 
 namespace Game.Api.Models.Auth
 {
@@ -9,7 +10,7 @@ namespace Game.Api.Models.Auth
     /// </summary>
     public class CreateAccountRequest : IModel
     {
-        [Length(1, 25)]
+        [Length(UsernamePolicy.MinLength, UsernamePolicy.MaxLength)]
         public required string Username { get; set; }
 
         [Length(1, 256)]

--- a/Game.Api/Models/Player/LoginCredentials.cs
+++ b/Game.Api/Models/Player/LoginCredentials.cs
@@ -1,10 +1,11 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Game.Core.Identity;
 
 namespace Game.Api.Models.Player
 {
     public class LoginCredentials : IModel
     {
-        [Length(1, 25)]
+        [Length(UsernamePolicy.MinLength, UsernamePolicy.MaxLength)]
         public required string Username { get; set; }
 
         [Length(1, 256)]

--- a/Game.Core/Identity/UsernamePolicy.cs
+++ b/Game.Core/Identity/UsernamePolicy.cs
@@ -1,0 +1,18 @@
+namespace Game.Core.Identity
+{
+    /// <summary>
+    /// Length bounds for a user's login username. <see cref="MaxLength"/> mirrors the persisted
+    /// <c>User.Username</c> column (see <see cref="Game.Core.Players.PlayerName"/> for the equivalent
+    /// player-name rule) so a valid username always fits storage. Named <c>UsernamePolicy</c> rather than
+    /// <c>Username</c> so it doesn't collide with the <c>Username</c> property on the request models that
+    /// reference it.
+    /// </summary>
+    public static class UsernamePolicy
+    {
+        /// <summary>The shortest a username may be.</summary>
+        public const int MinLength = 1;
+
+        /// <summary>The longest a username may be — mirrors the persisted <c>User.Username</c> column.</summary>
+        public const int MaxLength = 20;
+    }
+}


### PR DESCRIPTION
## Summary

`CreateAccountRequest`/`LoginCredentials` allowed a 25-character username (`[Length(1, 25)]`), but the `User.Username` column is capped at 20 (`GameContext.cs` — `HasMaxLength(20)`). A 21–25 char username passed model validation and the availability check, then blew up as an unhandled Postgres string-truncation error at `Users.CreateAccount`'s self-commit — surfacing as a 500 instead of a clean validation message.

- Added `Game.Core.Identity.UsernamePolicy` (`MinLength`/`MaxLength = 20`), mirroring the existing `Game.Core.Players.PlayerName.MaxLength` pattern for the equivalent player-name rule.
- Pointed both `CreateAccountRequest.Username` and `LoginCredentials.Username`'s `[Length]` attributes at the shared constant instead of the wrong hardcoded `25`.
- Added boundary integration tests: a 20-char username still succeeds, a 21-char username is rejected with a structured 400 (`ValidationProblemDetails`), never a 500.

## Closes

Closes #2040

## Test plan

- [x] `dotnet build` — solution builds clean
- [x] `dotnet test` — full backend suite passes (3228 tests: Core, Infrastructure, Application, Api)
- [x] New tests specifically cover the 20-char boundary (succeeds) and 21-char boundary (400, not 500)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wqi8brZou2xeQkKvKm5oZ9)_