### PR TITLE
Track fight-screen skill tooltip by skill id, not slot index (#2044)

### DIFF
--- a/UI/src/routes/game/screens/fight/Skills.svelte
+++ b/UI/src/routes/game/screens/fight/Skills.svelte
@@ -18,10 +18,10 @@
 					class:ready={charge.ready}
 					style:--pulse-color={pulseColor}
 					onmousemove={handleMouseMove}
-					onmouseenter={(ev) => handleEnter(ev, index)}
-					onmouseleave={() => handleLeave(index)}
-					onfocus={(ev) => handleFocus(ev, index)}
-					onblur={() => handleLeave(index)}
+					onmouseenter={(ev) => handleEnter(ev, skill.id)}
+					onmouseleave={() => handleLeave(skill.id)}
+					onfocus={(ev) => handleFocus(ev, skill.id)}
+					onblur={() => handleLeave(skill.id)}
 					use:describedByTooltip={describedById}
 				>
 					<img class="skill-icon" src={skill.iconPath} alt={skill.name} />
@@ -70,9 +70,12 @@ type Props = {
 const { battler, side, accent }: Props = $props();
 
 let tooltip = $state<TooltipComponent>();
-let tooltipSkillIndex = $state(-1);
+// Tracked by skill id, not slot index: a battler's skills array is reassigned on every spawn, and the
+// keyed {#each} above destroys/recreates a slot's button when the id at that index changes, so a stale
+// index would silently re-derive to the new occupant instead of closing (mirrors ActiveEffectChips).
+let tooltipSkillId = $state<number>();
 
-const tooltipSkill = $derived(battler.skills[tooltipSkillIndex]);
+const tooltipSkill = $derived(battler.skills.find((skill) => skill?.id === tooltipSkillId));
 /** The accent the "ready" border/glow/label resolve to (CSS var, theme-overridable). */
 const readyAccent = $derived(accent ?? 'var(--accent)');
 const pulseColor = $derived(tintColor(accent ?? (side === 'player' ? 'var(--accent)' : 'var(--enemy-accent)'), 0.6));
@@ -84,31 +87,40 @@ const handleMouseMove = (ev: MouseEvent) => {
 };
 
 // Reveal the per-skill tooltip, anchoring at the cursor (mouse) or the slot's box (focus).
-const reveal = (index: number, anchor: TooltipAnchor) => {
-	tooltipSkillIndex = index;
+const reveal = (id: number, anchor: TooltipAnchor) => {
+	tooltipSkillId = id;
 	setTooltipPosition(anchorPosition(anchor));
 	showTooltip();
 };
 
-const handleEnter = (ev: MouseEvent, index: number) => {
-	reveal(index, ev);
+const handleEnter = (ev: MouseEvent, id: number) => {
+	reveal(id, ev);
 };
 
 // Keyboard focus anchors off the slot's box; a mouse click is left to the hover handlers so the
 // tooltip keeps tracking the cursor instead of jumping (#880).
-const handleFocus = (ev: FocusEvent, index: number) => {
+const handleFocus = (ev: FocusEvent, id: number) => {
 	const anchor = focusAnchor(ev);
 	if (anchor) {
-		reveal(index, anchor);
+		reveal(id, anchor);
 	}
 };
 
-const handleLeave = (index: number) => {
-	if (tooltipSkillIndex === index) {
-		tooltipSkillIndex = -1;
+const handleLeave = (id: number) => {
+	if (tooltipSkillId === id) {
+		tooltipSkillId = undefined;
 		hideTooltip();
 	}
 };
+
+// Self-heal if the hovered skill vanishes from the loadout without a mouseleave/blur ever firing (e.g.
+// a respawn whose new loadout has no skill at all at the old slot).
+$effect(() => {
+	if (tooltipSkillId != null && !tooltipSkill) {
+		tooltipSkillId = undefined;
+		hideTooltip();
+	}
+});
 </script>
 
 <style lang="scss">

--- a/UI/src/tests/routes/game/screens/fight/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/Skills.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { flushSync } from 'svelte';
 import { EAttribute, EModifierType, ESkillEffectTarget, type IAttribute } from '$lib/api';
 import { getTutorialAnchor } from '$components';
+import { statify } from '$lib/common';
 
 // Skills renders a SkillTooltip child, which resolves the opponent through the battle engine
 // and attribute names through the reference-data store; both are mocked.
@@ -112,6 +114,25 @@ describe('Skills', () => {
 
 		await fireEvent.mouseLeave(slot);
 		expect(queryByText('Damage breakdown')).toBeNull();
+	});
+
+	it('closes the tooltip when the hovered slot is replaced by a respawn with no mouseleave', async () => {
+		// A reactive battler so the wholesale skills reassignment (an enemy respawn) propagates.
+		const live = statify(makeBattler());
+		live.skills = [makeSkill(live, { id: 1, name: 'Slash' })];
+		const { container } = render(Skills, { props: { battler: live, side: 'enemy' } });
+
+		const slot = container.querySelector('.skill-slot') as HTMLElement;
+		await fireEvent.mouseEnter(slot);
+		expect((container.querySelector('.tt-title-name') as HTMLElement).textContent).toBe('Slash');
+
+		// A new enemy spawns: the skills array is reassigned wholesale with a different id at the
+		// same slot, and the keyed {#each} destroys/recreates the button with no mouseleave firing.
+		live.skills = [makeSkill(live, { id: 2, name: 'Bite' })];
+		flushSync();
+
+		// The tooltip must close rather than silently re-deriving to the new occupant's skill.
+		expect(container.querySelector('.tt-title-name')).toBeNull();
 	});
 
 	it('reveals the skill tooltip on keyboard focus and hides it on blur', async () => {


### PR DESCRIPTION
## Summary

`Skills.svelte`'s per-skill combat tooltip tracked the hovered slot by **index** (`tooltipSkillIndex` + `battler.skills[tooltipSkillIndex]`). A battler's `skills` array is reassigned wholesale on every spawn (`lib/battle/battler.ts:418`), and the keyed `{#each battler.skills as skill, index (skill?.id ?? -index - 1)}` destroys/recreates a slot's `<button>` when the id at that index changes — a destroyed DOM node never fires `mouseleave`.

**Failure scenario:** the player parks the cursor over an enemy skill slot; the enemy dies and the next one spawns (continuous in the idle farm). The old button is destroyed without a `mouseleave`, `tooltipSkillIndex` stays set, and the tooltip re-derives to the *new* enemy's skill at that index — anchored at the stale cursor position, showing wrong content for nothing hovered.

The codebase already treats this as a bug class: `ActiveEffectChips.svelte` added an explicit guard for exactly this ("a chip removed under the cursor never fires `mouseleave`"), but the skill slots never got the same treatment.

## Fix

- Track the hovered skill's **id** instead of its slot index (`tooltipSkillId`), and resolve `tooltipSkill` by searching `battler.skills` for that id.
- `handleEnter`/`handleFocus`/`handleLeave` now receive/compare the skill id rather than the index.
- Added a self-heal `$effect` (mirroring `ActiveEffectChips`) that closes the tooltip if the hovered id no longer resolves to a skill in the current loadout — covers the case where a respawn's new loadout has no skill at all at the old slot.

## Test plan

- [x] New regression test in `Skills.test.ts`: hovers a slot, reassigns `battler.skills` wholesale with a different id at the same index (simulating a respawn) on a `statify`-wrapped battler, and asserts the tooltip closes instead of silently swapping to the new occupant's data.
- [x] Existing `Skills.test.ts` coverage (hover/leave, focus/blur, ready state, effect badges, aria-describedby) still passes unchanged.
- [x] `npm run lint` — 0 errors, 0 warnings.
- [x] Full frontend unit suite (`vitest --run`) — 299 files, 3752 tests, 0 failures.

Closes #2044


---
_Generated by [Claude Code](https://claude.ai/code/session_01CQhkZjpLhsDvgMnCdqGk2T)_