### PR TITLE
Guard CharacterSwitcher's reload effect against a stale-response race

### DIFF
--- a/UI/src/routes/game/CharacterSwitcher.svelte
+++ b/UI/src/routes/game/CharacterSwitcher.svelte
@@ -115,12 +115,20 @@ const reloadToBoot = () => {
 };
 const enterWorld = reloadToBoot;
 
+// Bumped on every invocation so a stale fetch (from an opened-then-cancelled-then-reopened switcher)
+// can detect it's no longer the latest and skip applying its result, mirroring SkillsView.commitSeq.
+let loadSeq = 0;
+
 const loadCharacters = async () => {
+	const seq = ++loadSeq;
 	phase = 'loading';
 	loadError = null;
 	view = null;
 
 	const response = await new ApiRequest('Login/Players').get();
+	if (seq !== loadSeq) {
+		return;
+	}
 	if (response.status !== 200 || !response.data) {
 		loadError = response.error ?? 'Could not load your characters.';
 		phase = 'error';

--- a/UI/src/tests/routes/game/character-switcher.test.ts
+++ b/UI/src/tests/routes/game/character-switcher.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { render, fireEvent, cleanup, screen, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
 
 // Doubles for the switcher's wiring: ApiRequest is keyed by route (get for the list, post for the
 // switch/create), and the socket teardown, engine stop, token storage, and takeover are mocked so the
@@ -183,6 +184,44 @@ describe('CharacterSwitcher', () => {
 		await fireEvent.keyDown(window, { key: 'Escape' });
 
 		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('ignores a stale character-list response that resolves after a fresher reopen', async () => {
+		// The first (cancelled-then-reopened) load's response resolves *after* the second load's, and must
+		// not clobber it — the exact race #2045 fixes with a generation counter.
+		const reopenedSummaries = [
+			SUMMARIES[0],
+			{ id: 3, name: 'Mage', level: 2, currentZoneId: 0, lastActivity: '2026-06-21T00:00:00Z' }
+		];
+		let resolveStale: (value: unknown) => void = () => {};
+		let playersCalls = 0;
+		getMock.mockImplementation((route: string) => {
+			if (route !== 'Login/Players') {
+				return Promise.resolve({ status: 200, data: [CREATABLE_CLASS] });
+			}
+			playersCalls += 1;
+			if (playersCalls === 1) {
+				return new Promise((resolve) => {
+					resolveStale = resolve;
+				});
+			}
+			return Promise.resolve({ status: 200, data: reopenedSummaries });
+		});
+
+		const { rerender } = render(CharacterSwitcher, { open: true, onClose: vi.fn() });
+		await waitFor(() => expect(playersCalls).toBe(1));
+
+		await rerender({ open: false, onClose: vi.fn() });
+		await rerender({ open: true, onClose: vi.fn() });
+		await waitFor(() => expect(screen.queryByText('Mage')).toBeTruthy());
+
+		// The stale first request resolves last, with the original (Rogue-included) list.
+		resolveStale({ status: 200, data: SUMMARIES });
+		await tick();
+		await tick();
+
+		expect(screen.getByText('Mage')).toBeTruthy();
+		expect(screen.queryByText('Rogue')).toBeNull();
 	});
 
 	it('does not load characters while closed', async () => {


### PR DESCRIPTION
## Summary

`CharacterSwitcher.svelte`'s reload effect (`$effect(() => { if (open) { void loadCharacters(); } })`) fires `loadCharacters()` on every `open` transition with no guard against overlapping requests. `loadCharacters` unconditionally writes `view`/`phase`/`loadError` when its `Login/Players` fetch resolves.

**Failure scenario:** open the switcher (fetch A starts), cancel, reopen (fetch B starts). Both are in flight; whichever resolves *last* wins. If stale A resolves after B, it replaces the freshly-built `PlayerSelectView` — resetting any in-progress create-form state — and on a failure path could flip a working list into the error state.

The codebase already has an established pattern for exactly this (`SkillsView.commitSeq` — a monotonically-increasing sequence number compared after the await, applying the result only if it's still current). This PR applies the same pattern to `CharacterSwitcher.loadCharacters`.

## Changes

- `UI/src/routes/game/CharacterSwitcher.svelte`: add a `loadSeq` counter, incremented at the start of each `loadCharacters()` call; after the `Login/Players` fetch resolves, bail out if the captured sequence number no longer matches the latest, so only the most recent load's result is ever applied.
- `UI/src/tests/routes/game/character-switcher.test.ts`: new regression test — opens the switcher, closes it, reopens it (triggering a second, faster-resolving fetch), then resolves the first (stale) fetch afterward and asserts the UI still reflects the second load's data, not the stale one.

## Test plan

- [x] New unit test `ignores a stale character-list response that resolves after a fresher reopen` passes.
- [x] `npm run test:unit:ci` — full frontend suite, 299 files / 3753 tests, all passing, no coverage-threshold regressions.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.

Closes #2045


---
_Generated by [Claude Code](https://claude.ai/code/session_01DEiK3hjWT2CCqrmrJqi1qK)_