### PR TITLE
Reload admin reference catalogues on every /admin mount

### DIFF
--- a/UI/src/routes/admin/+page.svelte
+++ b/UI/src/routes/admin/+page.svelte
@@ -95,10 +95,13 @@ async function loadReference() {
 }
 
 // Guard the route to Admins, then load the shared reference catalogues (used by every entity's
-// select options, tag UI, and derived spawn shares) before rendering any workbench.
+// select options, tag UI, and derived spawn shares) before rendering any workbench. Reloaded on
+// every mount (not gated on reference.loaded, which stays a render gate only) so catalogues
+// changed by another admin session — or since a much earlier visit this app lifetime — aren't
+// left stale in sibling pickers; the socket reads are cheap and already run in parallel.
 onMount(() => {
 	authorized = ensureAdminAccess();
-	if (authorized && !reference.loaded) {
+	if (authorized) {
 		void loadReference();
 	}
 });

--- a/UI/src/tests/routes/admin/admin-page.test.ts
+++ b/UI/src/tests/routes/admin/admin-page.test.ts
@@ -118,3 +118,21 @@ describe('Admin page — reference-data load failure', () => {
 		expect(screen.getByTestId('workbench-stub').textContent).toBe('Enemies');
 	});
 });
+
+describe('Admin page — reference-data reload on every mount (#2046)', () => {
+	it('refetches the reference catalogues on a later mount instead of trusting the already-loaded flag', async () => {
+		mockFetchSocket.mockReset().mockImplementation(async (command: string) => SOCKET_SETS[command] ?? []);
+
+		const first = render(AdminPage);
+		await waitFor(() => expect(screen.getByTestId('workbench-stub')).toBeTruthy());
+		const callsAfterFirstMount = mockFetchSocket.mock.calls.length;
+		expect(callsAfterFirstMount).toBe(Object.keys(SOCKET_SETS).length);
+		first.unmount();
+
+		// A later mount (re-entering /admin) must not be skipped just because `reference.loaded`
+		// is already true from the first mount — it's a render gate only, not a "loaded once" guard.
+		render(AdminPage);
+		await waitFor(() => expect(mockFetchSocket.mock.calls.length).toBe(callsAfterFirstMount * 2));
+		await waitFor(() => expect(screen.getByTestId('workbench-stub')).toBeTruthy());
+	});
+});


### PR DESCRIPTION
## Summary

- `admin/+page.svelte`'s `onMount` gated the reference-catalogue load on `!reference.loaded`, so after the first successful load in a page's lifetime, re-entering `/admin` never refetched the shared catalogues (enemies, skills, zones, items, item mods, attributes, tags, tag categories, challenge types, challenges, paths, proficiencies, lessons, classes, skill recipes).
- Within a session this mostly self-healed because every entity's own `refresh()` writes through to `staticData`, but catalogues changed by another admin session (or by this one, hours earlier) stayed stale in **sibling** pickers until that specific entity's tool was opened — e.g. an item's Granted Skill picker wouldn't see a skill renamed via the Skills tool until the Skills tool itself was opened this visit.
- Fix: drop the `!reference.loaded` guard from the load condition and keep `reference.loaded` doing render-gating only (it still backs every `{#if reference.loaded}` check that shows the loading/error state on first entry). The reference load now runs on every `/admin` mount; the socket reads are cheap and already run in parallel via `Promise.all`.

## Test plan

- [x] Added a regression test (`admin-page.test.ts`) asserting a second mount of the admin page refetches the full reference catalogue set instead of skipping the reload because `reference.loaded` was already true from a prior mount.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — 299 test files / 3754 tests passed.

Closes #2046


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHMoTVSY76m7AjHjFEvn8x)_