### PR TITLE
Make PlayerUpdateBatch.PlayerSaveInProgress nesting-safe via a depth counter (#2001)

### DIFF
--- a/Game.Application.Tests/DataAccess/PlayerUpdateBatchTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerUpdateBatchTests.cs
@@ -28,6 +28,28 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public void PlayerSaveInProgress_StaysTrueAcrossNestedScope_UntilTheOutermostDisposes()
+        {
+            var batch = new PlayerUpdateBatch();
+
+            // Mirrors OfflineProgressService: an outer BeginBatch scope wraps a nested SavePlayer, whose own
+            // internal BeginPlayerSave must not end the outer caller's window when it disposes first (#2001).
+            using (batch.BeginPlayerSave())
+            {
+                Assert.True(batch.PlayerSaveInProgress);
+
+                using (batch.BeginPlayerSave())
+                {
+                    Assert.True(batch.PlayerSaveInProgress);
+                }
+
+                Assert.True(batch.PlayerSaveInProgress);
+            }
+
+            Assert.False(batch.PlayerSaveInProgress);
+        }
+
+        [Fact]
         public void RunFlushedCallbacks_RunsRegisteredActionsInOrder_ThenClearsThem()
         {
             var batch = new PlayerUpdateBatch();

--- a/Game.Application/Services/OfflineProgressService.cs
+++ b/Game.Application/Services/OfflineProgressService.cs
@@ -178,9 +178,6 @@ namespace Game.Application.Services
             // retry together rather than progress already being durably committed while the player save fails
             // (#1921) — the same failure atomicity SavePlayer already gives a progress save reached through its
             // own domain-event dispatch on the live battle-completion path.
-            // Ordering matters here: SavePlayer opens its own nested BeginBatch scope internally and that
-            // scope's disposal ends the shared window (PlayerUpdateBatch.PlayerSaveInProgress is a plain bool,
-            // not a refcount), so any progress save sharing this batch must run *before* SavePlayer, not after.
             using (_playerRepo.BeginBatch())
             {
                 rewards = await ApplyOfflineRewards(player, progress, result, awayWindowEnd, cancellationToken);

--- a/Game.DataAccess/PlayerUpdateBatch.cs
+++ b/Game.DataAccess/PlayerUpdateBatch.cs
@@ -25,12 +25,18 @@ namespace Game.DataAccess
         private readonly List<DomainEventEnvelope> _events = [];
         private readonly List<Action> _onFlushed = [];
 
+        private int _playerSaveDepth;
+
         /// <summary>
         /// True while a <see cref="Repositories.PlayerRepository.SavePlayer"/> is mid-flight — between
         /// <see cref="BeginPlayerSave"/> and the returned scope's disposal. A progress save observing this
-        /// joins the in-flight player save's single flush rather than publishing on its own.
+        /// joins the in-flight player save's single flush rather than publishing on its own. Tracked as a
+        /// depth counter rather than a flag so a nested <see cref="BeginPlayerSave"/> — e.g.
+        /// <c>SavePlayer</c>'s own internal scope opened while an outer caller already holds one via
+        /// <see cref="Repositories.PlayerRepository.BeginBatch"/> — doesn't end the outer scope's window when
+        /// the inner one disposes first.
         /// </summary>
-        public bool PlayerSaveInProgress { get; private set; }
+        public bool PlayerSaveInProgress => _playerSaveDepth > 0;
 
         public void Add(DomainEventEnvelope envelope)
         {
@@ -50,11 +56,12 @@ namespace Game.DataAccess
 
         /// <summary>
         /// Marks a player save as in progress until the returned scope is disposed, so a progress save raised
-        /// during its event dispatch joins this batch instead of publishing independently.
+        /// during its event dispatch joins this batch instead of publishing independently. Safe to nest — the
+        /// window stays open until every <see cref="BeginPlayerSave"/> call has had its scope disposed.
         /// </summary>
         public IDisposable BeginPlayerSave()
         {
-            PlayerSaveInProgress = true;
+            _playerSaveDepth++;
             return new PlayerSaveScope(this);
         }
 
@@ -96,7 +103,7 @@ namespace Game.DataAccess
 
         private sealed class PlayerSaveScope(PlayerUpdateBatch batch) : IDisposable
         {
-            public void Dispose() => batch.PlayerSaveInProgress = false;
+            public void Dispose() => batch._playerSaveDepth--;
         }
     }
 }


### PR DESCRIPTION
## Summary

`PlayerUpdateBatch.BeginPlayerSave()` marked a player save as in-progress with a plain `bool`, and the returned scope's `Dispose()` unconditionally cleared it. `OfflineProgressService` opens an outer `IPlayerRepository.BeginBatch()` scope and then calls `SavePlayer`, which opens its own **nested** `BeginPlayerSave` scope internally — that nested scope's disposal cleared the flag while the outer scope was still live, silently ending the shared-flush window early. The codebase worked around this today only via a documented ordering trap: any progress save sharing the outer batch had to run *before* `SavePlayer`, never after.

## Change

- `PlayerUpdateBatch` now tracks the in-progress state with a depth counter (`_playerSaveDepth`) instead of a bool. `BeginPlayerSave()` increments on entry, the scope's `Dispose()` decrements, and `PlayerSaveInProgress` is `_playerSaveDepth > 0`. The window now stays open for as long as *any* `BeginPlayerSave` scope (nested or not) is live, regardless of disposal order.
- Removed the now-stale "ordering matters" comment in `OfflineProgressService` — a progress save sharing the batch can safely run after `SavePlayer` too, since the fix removes the trap the comment was warning about.
- Added a unit test (`PlayerSaveInProgress_StaysTrueAcrossNestedScope_UntilTheOutermostDisposes`) covering the nested-scope case described in the issue, alongside the existing single-scope coverage.

## Test plan

- [x] `dotnet build` — succeeds
- [x] `dotnet test` (full solution: Core, Infrastructure, Application, Api) — all 3238 tests pass
- [x] New unit test specifically exercises the nested-scope scenario from the issue

Closes #2001


---
_Generated by [Claude Code](https://claude.ai/code/session_01H2cpPKesYBdNtvc3Yr3xDz)_