### PR TITLE
Route RedisPubSubService.Publish through RedisCommandBudget.Write

### DIFF
--- a/Game.Application.Tests/DataAccess/DataAccessCancellationTests.cs
+++ b/Game.Application.Tests/DataAccess/DataAccessCancellationTests.cs
@@ -113,6 +113,19 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task Publish_WhenTokenAlreadyCancelled_ThrowsOperationCanceled()
+        {
+            using var scope = CreateScope();
+            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
+
+            // RedisPubSubService.Publish now routes through RedisCommandBudget.Write like every other awaited
+            // write in the tier (#2002), so a pre-cancelled token unwinds it promptly instead of racing the
+            // bare WaitAsync it used to call directly.
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => pubsub.Publish($"pubsub-cancel-{Guid.NewGuid()}", "message", AlreadyCancelled()));
+        }
+
+        [Fact]
         public async Task CommitAsync_WithPendingChanges_WhenTokenAlreadyCancelled_ThrowsOperationCanceled()
         {
             using var scope = CreateScope();

--- a/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisPubSubService.cs
@@ -1,5 +1,6 @@
 ﻿using Game.Abstractions.Infrastructure;
 using Game.Core;
+using Game.Infrastructure.Redis;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 using System.Collections.Concurrent;
@@ -15,6 +16,10 @@ namespace Game.Infrastructure.PubSub.Redis
         // Records the channel a handle was subscribed on, so UnSubscribe never has to trust a caller-supplied
         // channel that might not match (#1825).
         private static readonly ConcurrentDictionary<string, (string channel, Action<RedisChannel, RedisValue> handler, BackgroundWorker? worker)> _handles = [];
+
+        // Mirrors RedisService/RedisQueue's WriteFaultMessage: an abandoned command that later faults has no other
+        // signal, so it is logged rather than lost.
+        private const string PublishFaultMessage = "A Redis publish faulted after its command budget was cancelled; the broadcast may not have been delivered.";
 
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger<RedisPubSubService> _logger;
@@ -36,9 +41,12 @@ namespace Game.Infrastructure.PubSub.Redis
         // them (e.g. the reference-data invalidation channel), so a genuine send failure must propagate to the
         // caller rather than vanish silently the way CommandFlags.FireAndForget would swallow it. Contrast with
         // Wake below, whose fire-and-forget is safe because a durable queue write already backs it.
-        public async Task Publish(string channel, string message, CancellationToken cancellationToken = default)
+        // Routed through RedisCommandBudget.Write like every other awaited write in the tier (#2002), so a
+        // cancellation that races an already-completed publish is honoured rather than silently swallowed, and a
+        // fault on an abandoned publish is logged instead of surfacing via TaskScheduler.UnobservedTaskException.
+        public Task Publish(string channel, string message, CancellationToken cancellationToken = default)
         {
-            await Redis.PublishAsync(RedisChannel.Literal(channel), message).WaitAsync(cancellationToken);
+            return RedisCommandBudget.Write(Redis.PublishAsync(RedisChannel.Literal(channel), message), cancellationToken, _logger, PublishFaultMessage);
         }
 
         // A bare channel wake: a fire-and-forget empty publish that only nudges the consumer to drain its queue.


### PR DESCRIPTION
## Summary

Every other awaited Redis write in the tier (`RedisService`, `RedisQueue`) routes through `RedisCommandBudget.Write`, which (a) guards the racy `WaitAsync` case where an already-cancelled token is silently swallowed by a completed task, and (b) attaches a continuation so a fault on an abandoned command is logged instead of surfacing via `TaskScheduler.UnobservedTaskException`.

The bare-channel `RedisPubSubService.Publish(channel, message, ct)` overload — the one method carrying the "must never fail silently" broadcast, backing the reference-data invalidation channel per #1888 — instead awaited `Redis.PublishAsync(...).WaitAsync(cancellationToken)` directly, missing both guards. Any caller passing a real token that cancels mid-publish got no cancellation-first guard, and if the abandoned publish later faulted, the send failure — a broadcast with no durable write behind it — would vanish unlogged.

## Changes

- `RedisPubSubService.Publish` now routes through `RedisCommandBudget.Write`, mirroring `RedisService`/`RedisQueue`'s `WriteFaultMessage` pattern with a publish-specific fault message.
- Added `Publish_WhenTokenAlreadyCancelled_ThrowsOperationCanceled` to `DataAccessCancellationTests` (the existing suite pinning cancellation-budget behavior across the data tier), covering the previously-untested already-cancelled-token race for this path.

The existing `RedisPubSubPublishFailureTests` (pinning #1888 — a genuine send failure propagates rather than vanishing) still passes unchanged, since `RedisCommandBudget.Write` only intercepts `OperationCanceledException`; a real `RedisConnectionException` still propagates.

## Test plan

- [x] `dotnet build` — clean, no warnings
- [x] `dotnet test` (full solution: Core, Infrastructure, Application, Api) — all 3,239 tests pass
- [x] Verified the new cancellation test fails against the pre-fix code path (bare `WaitAsync`) and passes against the fix

Closes #2002


---
_Generated by [Claude Code](https://claude.ai/code/session_01WWJFP2kFE6776htLy4g1LX)_