### PR TITLE
Per-record memoize Workbench EntityStore's recordStates

### DIFF
--- a/UI/src/routes/admin/workbench/entity-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/entity-store.svelte.ts
@@ -65,16 +65,35 @@ export class EntityStore<T extends Identified> {
 		return recordsEqual(record, baseline) ? 'clean' : 'modified';
 	}
 
+	/** Bumped whenever a record's status can change *without* its object reference changing — only
+	 *  {@link removeItem}/{@link restoreItem} toggling a saved record's membership in {@link deleted}.
+	 *  Every other mutator ({@link patch}, {@link addItem}, {@link resetItem}, `save`, `discard`)
+	 *  replaces the affected record(s) with a new object, which already misses the reference cache
+	 *  below on its own. */
+	private statusEpoch = $state(0);
+	private stateCacheEpoch = -1;
+	private stateCache = new WeakMap<T, RecordState>();
+
 	/**
-	 * Per-record status + validation warnings, keyed by id. Memoised here so the consumers (the list
-	 * rows, the page summary, the save-bar counts) read O(1) lookups instead of each re-running the
-	 * structural diff per record. Recomputes only when the records, baseline, or pending deletes
-	 * change — a search keystroke or a selection change (which touch neither) reuses the cached map.
+	 * Per-record status + validation warnings, keyed by id. Memoised **per record object** so an edit
+	 * keystroke — which replaces only the one record {@link patch} touched — re-diffs just that record
+	 * instead of re-canonicalizing the whole catalogue; every other record is a same-reference cache
+	 * hit. The cache is a `WeakMap` keyed on the record itself (not its id) so a superseded record from
+	 * an earlier edit is garbage-collected instead of accumulating for the life of the store.
 	 */
 	recordStates = $derived.by<Record<number, RecordState>>(() => {
+		if (this.statusEpoch !== this.stateCacheEpoch) {
+			this.stateCache = new WeakMap();
+			this.stateCacheEpoch = this.statusEpoch;
+		}
 		const map: Record<number, RecordState> = {};
 		for (const record of this.items) {
-			map[record.id] = { status: this.status(record), warnings: entityWarnings(this.config, record) };
+			let state = this.stateCache.get(record);
+			if (!state) {
+				state = { status: this.status(record), warnings: entityWarnings(this.config, record) };
+				this.stateCache.set(record, state);
+			}
+			map[record.id] = state;
 		}
 		return map;
 	});
@@ -147,7 +166,10 @@ export class EntityStore<T extends Identified> {
 			// Never-saved record: just drop it.
 			this.items = this.items.filter((record) => record.id !== id);
 		} else {
+			// The record's own object reference is untouched, so the status cache must be invalidated
+			// explicitly — nothing else would tell recordStates this record just became 'deleted'.
 			this.deleted.add(id);
+			this.statusEpoch++;
 		}
 		this.saved = false;
 	}
@@ -156,7 +178,9 @@ export class EntityStore<T extends Identified> {
 		if (this.saving) {
 			return;
 		}
+		// Same reasoning as removeItem: the reference is unchanged, so bump the epoch to invalidate.
 		this.deleted.delete(id);
+		this.statusEpoch++;
 		this.saved = false;
 	}
 

--- a/UI/src/tests/routes/admin/workbench/entity-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entity-store.test.ts
@@ -436,5 +436,35 @@ describe('EntityStore', () => {
 
 			expect(store.counts).toMatchObject({ added: 1, modified: 1, deleted: 1, total: 3 });
 		});
+
+		it("an unrelated record's state object is reference-stable across a patch (per-record cache hit)", () => {
+			const store = new EntityStore(requiredNameConfig(), seed);
+			const untouched = store.recordStates[0];
+
+			store.patch(1, (draft) => (draft.value = 99));
+
+			expect(store.recordStates[0]).toBe(untouched);
+			expect(store.recordStates[1]).not.toBe(untouched);
+		});
+
+		it('removeItem flips a previously-cached record to deleted (cache invalidation without a reference change)', () => {
+			const store = new EntityStore(requiredNameConfig(), seed);
+			// Populate the memo for record 0 before its deleted-ness changes.
+			expect(store.recordStates[0].status).toBe('clean');
+
+			store.removeItem(0);
+
+			expect(store.recordStates[0].status).toBe('deleted');
+		});
+
+		it('restoreItem flips a previously-cached deleted record back to clean', () => {
+			const store = new EntityStore(requiredNameConfig(), seed);
+			store.removeItem(0);
+			expect(store.recordStates[0].status).toBe('deleted');
+
+			store.restoreItem(0);
+
+			expect(store.recordStates[0].status).toBe('clean');
+		});
 	});
 });


### PR DESCRIPTION
## Summary

`EntityStore.recordStates` (`UI/src/routes/admin/workbench/entity-store.svelte.ts`) recomputed **every** record's status + validation warnings on every edit, even though `patch()` only ever replaces the one edited record's object reference. Each keystroke was paying O(total catalogue JSON) — a full `canonicalize` + `JSON.stringify` diff (`canonicalEqual` in `save-helpers.ts`) plus `entityWarnings()` for every record — dominated by items/skills whose child collections stringify on every pass.

## Changes

- `recordStates` now memoizes each record's `{ status, warnings }` in a `WeakMap<T, RecordState>` keyed on the record **object itself**. Since `patch()` (and `addItem`/`resetItem`) only replace the reference of the record(s) they touch, every other record is a same-reference cache hit and skips recomputation entirely. Using a `WeakMap` (not a plain `Map`) means a superseded record from an earlier edit is garbage-collected instead of accumulating for the life of the store.
- Two mutations change a record's status **without** replacing its object reference: `removeItem`/`restoreItem` toggling a saved record's membership in the `deleted` set. Those now bump a `statusEpoch` counter that the derived checks to invalidate the whole cache — every other mutator (`patch`, `addItem`, `resetItem`, `save`, `discard`) already invalidates itself via reference replacement.

## Test plan

- [x] Added `entity-store.test.ts` cases:
  - an unrelated record's `RecordState` object stays reference-stable across a `patch()` to another record (proves the cache hit)
  - `removeItem`/`restoreItem` correctly flip a previously-cached record's status despite no reference change (proves the epoch invalidation)
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings
- [x] `npm run test:unit:ci` — full suite, 3757/3757 passing

Closes #2004


---
_Generated by [Claude Code](https://claude.ai/code/session_01C5vFfvFrbZhpVnjqDZ63J9)_