### PR TITLE
Derive Statistics/Codex view-model stats from the live store

### DIFF
--- a/UI/src/routes/game/screens/codex/Codex.svelte
+++ b/UI/src/routes/game/screens/codex/Codex.svelte
@@ -35,9 +35,9 @@ const view = new CodexView(navigation.consumePayload<CodexNavPayload>());
 
 onMount(async () => {
 	// Force-refresh the player's statistics (the dossier's "your record"); challenge progress is
-	// loaded once at boot, so a plain load is enough.
+	// loaded once at boot, so a plain load is enough. view.stats reads the store live, so no
+	// snapshot assignment is needed here.
 	await Promise.all([statistics.load(true), playerChallenges.load()]);
-	view.stats = statistics.stats;
 	view.statsError = statistics.error;
 	view.statsLoading = false;
 	view.challengesError = playerChallenges.error;

--- a/UI/src/routes/game/screens/codex/codex-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/codex-view.svelte.ts
@@ -22,13 +22,12 @@
    The reactive layer is composed from one class per tab (`EnemiesTabView`, `ZonesTabView`,
    `SkillsTabView`, each in its own `*-tab-view.svelte.ts` file) so every tab's derivations stay
    independently readable/testable. This CodexView is the thin orchestrator: it owns only what's
-   genuinely cross-tab — the active tab, the once-fetched player statistics + challenge-error state,
+   genuinely cross-tab — the active tab, the live player statistics + challenge-error state,
    the shared statistics query engine, and the cross-links between dossiers — and every other
    property/method below simply delegates to the owning tab's instance, so consuming components (and
    the existing tests) keep reading `view.<x>` exactly as before. */
 
-import type { IPlayerStatistic } from '$lib/api';
-import { staticData } from '$stores';
+import { staticData, statistics } from '$stores';
 import {
 	CODEX_TABS,
 	type CodexTab,
@@ -99,8 +98,10 @@ export class CodexView {
 	/** Active top-level tab. */
 	tab = $state<CodexTab>('enemies');
 
-	/** The player's statistic values (fetched on mount via the shared statistics store). */
-	stats = $state<IPlayerStatistic[]>([]);
+	/** The player's statistic values, read live from the shared store (fetched on mount) so a
+	 *  background update — e.g. the fight screen's optimistic zone-clear — is reflected in every
+	 *  dossier's "your record" section without remounting the Codex. */
+	readonly stats = $derived(statistics.stats);
 	statsLoading = $state(true);
 	statsError = $state(false);
 	/** Whether the mount-time challenge-progress fetch failed — surfaced so the enemy dossier's

--- a/UI/src/routes/game/screens/stats/Statistics.svelte
+++ b/UI/src/routes/game/screens/stats/Statistics.svelte
@@ -44,9 +44,9 @@ const view = new StatisticsView();
 
 onMount(async () => {
 	// Force a fresh fetch so values reflect play since the store was last loaded
-	// (it is loaded once at game boot to back the fight screen's boss seal).
+	// (it is loaded once at game boot to back the fight screen's boss seal). view.stats reads
+	// the store live, so no snapshot assignment is needed here.
 	await statistics.load(true);
-	view.stats = statistics.stats;
 	view.error = statistics.error;
 	if (statistics.error) {
 		// Don't conflate a failed load with a genuine empty result (the

--- a/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
+++ b/UI/src/routes/game/screens/stats/statistics-view.svelte.ts
@@ -15,7 +15,7 @@
 
 import { EDamageTypeKey, EEntityType, EStatisticType, type IPlayerStatistic, type IStatisticType } from '$lib/api';
 import { damageTypeKeyName } from '$lib/common';
-import { navigation, staticData } from '$stores';
+import { navigation, staticData, statistics } from '$stores';
 import { statCategoryLabel } from './statistics-display';
 import type { CodexNavPayload } from '../codex/codex-view.svelte';
 
@@ -310,8 +310,10 @@ const EMPTY_SUMMARY: StatSummary = { rows: [], maxVal: 1, headline: 0 };
 /* ── reactive view-model ──────────────────────────────────────────────────── */
 
 export class StatisticsView {
-	/** The player's statistic values, fetched via the `GetPlayerStatistics` socket command on mount. */
-	stats = $state<IPlayerStatistic[]>([]);
+	/** The player's statistic values, read live from the shared store (fetched via the
+	 *  `GetPlayerStatistics` socket command on mount) so a background update — e.g. the fight
+	 *  screen's optimistic zone-clear — is reflected without remounting this screen. */
+	readonly stats = $derived(statistics.stats);
 	/** True until the statistic values have been fetched. */
 	loading = $state(true);
 	/** True when the fetch failed (distinct from a genuine empty result). */

--- a/UI/src/tests/routes/game/screens/codex/Codex.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/Codex.test.ts
@@ -253,6 +253,22 @@ describe('Codex screen', () => {
 		expect(screen.getByText('Zones Cleared')).toBeTruthy();
 	});
 
+	it('reflects a background zone-clear in the open dossier without remounting', async () => {
+		render(Codex);
+		await fireEvent.click(screen.getByTestId('codex-tab-zones'));
+		// Ashfen Marsh (zone 1) has no recorded clear in the fetched STATS fixture.
+		await fireEvent.click(screen.getByTestId('codex-zone-1'));
+		await screen.findByText('No statistics recorded for this zone yet.');
+		expect(screen.queryByText('Zones Cleared')).toBeNull();
+
+		// The fight screen marks a zone cleared optimistically the moment its boss is defeated,
+		// while the Codex may already be sitting open on that zone's dossier.
+		statistics.markZoneCleared(1);
+
+		expect(await screen.findByTestId('codex-zone-stats')).toBeTruthy();
+		expect(screen.getByText('Zones Cleared')).toBeTruthy();
+	});
+
 	it('cross-links a zone boss card into the enemy dossier', async () => {
 		render(Codex);
 		await fireEvent.click(screen.getByTestId('codex-tab-zones'));

--- a/UI/src/tests/routes/game/screens/codex/codex-view.svelte.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/codex-view.svelte.test.ts
@@ -16,20 +16,31 @@ import { SERVER_STAT_TYPES } from '../stats/stat-fixtures';
 // CodexView reads reference data + challenge progress + per-zone clears from the stores, and reuses
 // the Statistics screen's query engine — all mocked here. (The Statistics view-model also imports
 // `navigation`.)
-const { staticData, playerChallenges, navigation, statistics } = vi.hoisted(() => ({
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	staticData: {} as any,
-	playerChallenges: {
+const { staticData, playerChallenges, navigation, statistics } = vi.hoisted(() => {
+	let mockStats: IPlayerStatistic[] = [];
+	return {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		all: [] as any[],
-		isChallengeCompleted(id: number) {
+		staticData: {} as any,
+		playerChallenges: {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			return this.all.some((c: any) => c.challengeId === id && c.completed);
+			all: [] as any[],
+			isChallengeCompleted(id: number) {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				return this.all.some((c: any) => c.challengeId === id && c.completed);
+			}
+		},
+		navigation: { requestScreen: vi.fn(), consumePayload: vi.fn(), clear: vi.fn() },
+		statistics: {
+			isZoneCleared: vi.fn<(id: number) => boolean>(() => false),
+			get stats() {
+				return mockStats;
+			},
+			set stats(value: IPlayerStatistic[]) {
+				mockStats = value;
+			}
 		}
-	},
-	navigation: { requestScreen: vi.fn(), consumePayload: vi.fn(), clear: vi.fn() },
-	statistics: { isZoneCleared: vi.fn<(id: number) => boolean>(() => false) }
-}));
+	};
+});
 vi.mock('$stores', () => ({ staticData, playerChallenges, navigation, statistics }));
 
 import { CodexView, type EnemyRowVM, type ZoneProjectionVM } from '$routes/game/screens/codex/codex-view.svelte';
@@ -200,6 +211,7 @@ beforeEach(() => {
 	// Zone 0 (Emberreach) is cleared by default; individual tests override as needed.
 	statistics.isZoneCleared.mockReset();
 	statistics.isZoneCleared.mockImplementation((id: number) => id === 0);
+	statistics.stats = [];
 });
 
 describe('CodexView tabs', () => {
@@ -466,8 +478,8 @@ describe('CodexView dossier projections', () => {
 	});
 
 	it('reuses the statistics query for the player’s per-enemy record', () => {
+		statistics.stats = STATS;
 		const view = new CodexView();
-		view.stats = STATS;
 		view.selectEnemy(0);
 		const killed = view.statistics.find((s) => s.label === 'Enemies Killed');
 		expect(killed?.value).toBe('100');
@@ -610,8 +622,8 @@ describe('CodexView zone dossier', () => {
 	});
 
 	it('reuses the statistics query for the player’s per-zone record', () => {
+		statistics.stats = STATS;
 		const view = new CodexView();
-		view.stats = STATS;
 		view.selectZone(1); // Ashfen Marsh — 3 clears recorded
 		expect(view.zoneStatistics.find((s) => s.label === 'Zones Cleared')?.value).toBe('3');
 		// A zone with no recorded statistics yields an empty record.
@@ -752,8 +764,8 @@ describe('CodexView skill dossier', () => {
 	});
 
 	it('reuses the statistics query for the player’s per-skill record', () => {
+		statistics.stats = STATS;
 		const view = new CodexView();
-		view.stats = STATS;
 		view.selectSkill(0); // Cleave — 4,500 damage dealt recorded
 		expect(view.skillStatistics.find((s) => s.label === 'Damage Dealt')?.value).toBe('4,500');
 		// A skill with no recorded statistics yields an empty record.

--- a/UI/src/tests/routes/game/screens/stats/Statistics.test.ts
+++ b/UI/src/tests/routes/game/screens/stats/Statistics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+import { render, cleanup, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import { EDamageTypeKey, EStatisticType, type IPlayerStatistic } from '$lib/api';
 import { SERVER_STAT_TYPES } from './stat-fixtures';
 
@@ -23,7 +23,7 @@ vi.mock('$stores', async (importOriginal) => {
 });
 
 import Statistics from '$routes/game/screens/stats/Statistics.svelte';
-import { navigation } from '$stores';
+import { navigation, statistics } from '$stores';
 
 const STATS: IPlayerStatistic[] = [
 	{ statisticTypeId: EStatisticType.EnemiesKilled, entityId: 0, value: 300 },
@@ -67,6 +67,20 @@ describe('Statistics screen', () => {
 		await fireEvent.click(screen.getByTestId('tab-time'));
 		expect(screen.getByText('Total Battle Time')).toBeTruthy();
 		expect(screen.getByText('Fastest Victory')).toBeTruthy();
+	});
+
+	it('reflects a background zone-clear in the exploration card without remounting', async () => {
+		render(Statistics);
+		await screen.findByText('Enemies Killed');
+		await fireEvent.click(screen.getByTestId('tab-exploration'));
+		const card = await screen.findByTestId(`stat-card-${EStatisticType.ZonesCleared}`);
+		expect(card.querySelector('.value')?.textContent).toBe('0');
+
+		// The fight screen marks a zone cleared optimistically the moment its boss is defeated,
+		// while the Statistics screen may already be sitting open on the Exploration tab.
+		statistics.markZoneCleared(0);
+
+		await waitFor(() => expect(card.querySelector('.value')?.textContent).toBe('1'));
 	});
 
 	it('shows the damage-type breakdown card with a non-interactive per-key row', async () => {

--- a/UI/src/tests/routes/game/screens/stats/statistics-view.test.ts
+++ b/UI/src/tests/routes/game/screens/stats/statistics-view.test.ts
@@ -2,13 +2,25 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EDamageTypeKey, EEntityType, EStatisticType, type IPlayerStatistic } from '$lib/api';
 
 // StatisticsView reads the statistic-type catalogue + entity lists from the in-memory staticData
-// store, and deep-links enemies into the Codex via the navigation store — both mocked here.
-const { staticData, navigation } = vi.hoisted(() => ({
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	staticData: {} as any,
-	navigation: { requestScreen: vi.fn() }
-}));
-vi.mock('$stores', () => ({ staticData, navigation }));
+// store, deep-links enemies into the Codex via the navigation store, and reads the player's
+// statistic values live from the statistics store — all mocked here.
+const { staticData, navigation, statistics } = vi.hoisted(() => {
+	let mockStats: IPlayerStatistic[] = [];
+	return {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		staticData: {} as any,
+		navigation: { requestScreen: vi.fn() },
+		statistics: {
+			get stats() {
+				return mockStats;
+			},
+			set stats(value: IPlayerStatistic[]) {
+				mockStats = value;
+			}
+		}
+	};
+});
+vi.mock('$stores', () => ({ staticData, navigation, statistics }));
 
 import {
 	buildStatTypes,
@@ -61,8 +73,8 @@ function seedStaticData(): void {
 
 /** A view seeded with the standard stats fixture (loading already finished). */
 function seededView(): StatisticsView {
+	statistics.stats = stats;
 	const view = new StatisticsView();
-	view.stats = stats;
 	view.loading = false;
 	return view;
 }
@@ -70,6 +82,7 @@ function seededView(): StatisticsView {
 beforeEach(() => {
 	seedStaticData();
 	navigation.requestScreen.mockClear();
+	statistics.stats = [];
 });
 
 describe('buildStatTypes', () => {


### PR DESCRIPTION
## Summary

`Statistics.svelte` and `Codex.svelte` copied `statistics.stats` into view-local `$state` after their mount-time forced load (`view.stats = statistics.stats`), while other parts of the same screens read the store live (e.g. `zones-tab-view.svelte.ts` uses `statistics.isZoneCleared`). This split the store's single-source-of-truth guarantee: a background write to the store — e.g. the fight screen's optimistic `markZoneCleared` the moment a boss is defeated — updated the zone rail live but left the dossier's "Your record" section (fed from the mount-time snapshot) stale until remount.

## Changes

- `StatisticsView.stats` (`statistics-view.svelte.ts`) and `CodexView.stats` (`codex-view.svelte.ts`) are now `readonly stats = $derived(statistics.stats)` instead of a `$state` field assigned once in `onMount`. The forced load (`statistics.load(true)`) stays as the freshness trigger; the view just stops snapshotting the result.
- Removed the now-redundant `view.stats = statistics.stats` assignments in `Statistics.svelte` and `Codex.svelte`.
- Updated the pure view-model unit tests (`statistics-view.test.ts`, `codex-view.svelte.test.ts`) to seed the mocked `statistics` store directly (`statistics.stats = ...`) instead of assigning the now-readonly `view.stats`.
- Added regression tests against the **real** (unmocked) `statistics` store in `Statistics.test.ts` and `Codex.test.ts` that mount the screen, then call `statistics.markZoneCleared(...)` — mirroring the exact background-write scenario from the issue — and assert the rendered stat card / dossier record updates without remounting.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — 299 files / 3759 tests pass, coverage thresholds hold
- [x] New regression tests specifically reproduce the issue's stale-dossier / stale-card scenario and fail without the fix (verified locally before applying it)

Closes #2005


---
_Generated by [Claude Code](https://claude.ai/code/session_01FXwrK4aNqj2hbEvL28CPMv)_