### PR TITLE
Delete CodexView's pass-through shim; remove dead WorkbenchReference test-only members

### DIFF
--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -255,9 +255,6 @@ class WorkbenchReference {
 		{ value: -1, text: 'None (ungated)' },
 		...this.retireableOptions(staticData.proficiencies ?? [], keep)
 	];
-	pathName = (id: number) => staticData.paths?.[id]?.name;
-	proficiencyName = (id: number) => staticData.proficiencies?.[id]?.name;
-
 	// ── Challenges ──
 	challengeTypeOptions = (): SelectOption[] => this.challengeTypes.map((t) => ({ value: t.id, text: t.name }));
 	challengeTypeById = (id: number) => this.challengeTypes.find((t) => t.id === id);
@@ -289,8 +286,6 @@ class WorkbenchReference {
 			? (staticData.enemies ?? []).filter((e) => !bossOnly || e.isBoss || e.id === keep)
 			: (this.entitySource(entityType) ?? []);
 
-	entityCatalog = (entityType: EEntityType, bossOnly = false): { id: number; name: string }[] =>
-		this.entityRecords(entityType, bossOnly).map((e) => ({ id: e.id, name: e.name }));
 	/** Target-entity picker options. Retired records are excluded unless `keep` is the current target. */
 	entityOptions = (entityType: EEntityType, bossOnly = false, keep?: number): SelectOption[] =>
 		this.retireableOptions(this.entityRecords(entityType, bossOnly, keep), keep);
@@ -309,9 +304,7 @@ class WorkbenchReference {
 		const mod = staticData.itemMods?.[id];
 		return mod ? this.modTypeName(mod.itemModTypeId) : undefined;
 	};
-	skillRecords = () => staticData.skills ?? [];
 	skillName = (id: number) => staticData.skills?.[id]?.name;
-	skillBaseDamage = (id: number) => staticData.skills?.[id]?.baseDamage;
 	skillRetired = (id: number) => !!staticData.skills?.[id]?.retiredAt;
 
 	// ── Name lookups ──

--- a/UI/src/routes/game/screens/codex/AttributesPanel.svelte
+++ b/UI/src/routes/game/screens/codex/AttributesPanel.svelte
@@ -8,21 +8,21 @@
 		<button
 			type="button"
 			class="scaling-toggle"
-			class:on={view.scaling}
-			aria-pressed={view.scaling}
+			class:on={view.enemiesTab.scaling}
+			aria-pressed={view.enemiesTab.scaling}
 			data-testid="codex-scaling-toggle"
-			onclick={() => view.toggleScaling()}
+			onclick={() => view.enemiesTab.toggleScaling()}
 		>
 			Show scaling
 		</button>
 	</div>
 
-	{#if view.range}
-		{#if view.range.fixed}
+	{#if view.enemiesTab.range}
+		{#if view.enemiesTab.range.fixed}
 			<div class="fixed-level">
 				<span>FIXED ENCOUNTER</span>
 				<span class="rule"></span>
-				<span class="fixed-val">LVL {view.level}</span>
+				<span class="fixed-val">LVL {view.enemiesTab.level}</span>
 			</div>
 		{:else}
 			<div class="level-control">
@@ -30,41 +30,41 @@
 				<input
 					type="range"
 					class="level-range"
-					min={view.range.min}
-					max={view.range.max}
-					value={view.level}
+					min={view.enemiesTab.range.min}
+					max={view.enemiesTab.range.max}
+					value={view.enemiesTab.level}
 					aria-label="Level"
 					data-testid="codex-level-slider"
-					oninput={(e) => view.setLevel(+e.currentTarget.value)}
+					oninput={(e) => view.enemiesTab.setLevel(+e.currentTarget.value)}
 				/>
-				<span class="lvl-val">{view.level}</span>
+				<span class="lvl-val">{view.enemiesTab.level}</span>
 			</div>
 		{/if}
 	{/if}
 
 	<div class="primary">
-		{#each view.attributes.primary as stat (stat.attributeId)}
+		{#each view.enemiesTab.attributes.primary as stat (stat.attributeId)}
 			<div class="stat">
 				<div class="stat-row">
 					<span class="code">{attributeCode(stat.attributeId, staticData.attributes)}</span>
 					<span class="bar-wrap" style:--bar-fill={attributeColor(stat.attributeId)}>
-						<Bar value={stat.value} max={view.maxPrimary} presentational />
+						<Bar value={stat.value} max={view.enemiesTab.maxPrimary} presentational />
 					</span>
 					<span class="val">{stat.value}</span>
 				</div>
-				{#if view.scaling}
-					<div class="scale-line">{stat.base} base + {stat.perLevel}/lvl × {view.level}</div>
+				{#if view.enemiesTab.scaling}
+					<div class="scale-line">{stat.base} base + {stat.perLevel}/lvl × {view.enemiesTab.level}</div>
 				{/if}
 			</div>
 		{/each}
 	</div>
 
 	<div class="secondary">
-		{#each view.attributes.secondary as stat (stat.attributeId)}
+		{#each view.enemiesTab.attributes.secondary as stat (stat.attributeId)}
 			<div class="card">
 				<div class="card-label">{attributeName(stat.attributeId, staticData.attributes)}</div>
 				<div class="card-val" style:color={secondaryColor(stat.attributeId)}>{stat.value}</div>
-				{#if view.scaling}
+				{#if view.enemiesTab.scaling}
 					<div class="card-scale">+{roundDelta(stat.perLevel)}/lvl</div>
 				{/if}
 			</div>

--- a/UI/src/routes/game/screens/codex/EnemiesTab.svelte
+++ b/UI/src/routes/game/screens/codex/EnemiesTab.svelte
@@ -8,10 +8,10 @@
 				<input
 					class="search-input"
 					type="search"
-					placeholder="search {view.enemies.length} enemies"
+					placeholder="search {view.enemiesTab.enemies.length} enemies"
 					aria-label="Search enemies"
 					data-testid="codex-search"
-					bind:value={view.search}
+					bind:value={view.enemiesTab.search}
 				/>
 			</label>
 			<div class="chips">
@@ -19,19 +19,24 @@
 					<button
 						type="button"
 						class="chip"
-						class:on={view.filter === chip.key}
+						class:on={view.enemiesTab.filter === chip.key}
 						data-testid="codex-filter-{chip.key}"
-						onclick={() => view.setFilter(chip.key)}
+						onclick={() => view.enemiesTab.setFilter(chip.key)}
 					>
 						{chip.label}
 					</button>
 				{/each}
 			</div>
 			<span class="spacer"></span>
-			<span class="count">{view.shownCount} shown</span>
+			<span class="count">{view.enemiesTab.shownCount} shown</span>
 			<label class="sort">
 				<span class="sort-label">sort:</span>
-				<select class="sort-select" aria-label="Sort enemies" data-testid="codex-sort" bind:value={view.sort}>
+				<select
+					class="sort-select"
+					aria-label="Sort enemies"
+					data-testid="codex-sort"
+					bind:value={view.enemiesTab.sort}
+				>
 					{#each ENEMY_SORTS as option (option.key)}
 						<option value={option.key}>{option.label}</option>
 					{/each}

--- a/UI/src/routes/game/screens/codex/EnemyChallengesPanel.svelte
+++ b/UI/src/routes/game/screens/codex/EnemyChallengesPanel.svelte
@@ -1,11 +1,11 @@
 <!-- Challenges sub-tab: the challenges scoped to this enemy, with the player's progress. -->
 <div class="challenges">
-	<div class="label">Related challenges · {view.challenges.length}</div>
+	<div class="label">Related challenges · {view.enemiesTab.challenges.length}</div>
 	{#if view.challengesError}
 		<div class="note">Your challenge progress could not be loaded.</div>
 	{:else}
 		<div class="list">
-			{#each view.challenges as challenge (challenge.id)}
+			{#each view.enemiesTab.challenges as challenge (challenge.id)}
 				<div class="challenge" style:--ch-accent={challenge.accent}>
 					<div class="text">
 						<div class="name">{challenge.name}</div>

--- a/UI/src/routes/game/screens/codex/EnemyDossier.svelte
+++ b/UI/src/routes/game/screens/codex/EnemyDossier.svelte
@@ -1,24 +1,24 @@
 <!-- The enemy dossier (right panel): a section-accented header (kind + name), a row of sub-tabs, and
      the active sub-tab's body. Sub-tab content lives in its own small panel component. -->
 <DossierShell
-	selectedItem={view.selectedEnemy}
+	selectedItem={view.enemiesTab.selectedEnemy}
 	testid="codex-dossier"
-	accent={view.dossierAccent}
-	kind={view.dossierKind}
-	name={view.selectedEnemy?.name ?? ''}
+	accent={view.enemiesTab.dossierAccent}
+	kind={view.enemiesTab.dossierKind}
+	name={view.enemiesTab.selectedEnemy?.name ?? ''}
 >
 	<div class="sub-tabs" role="tablist" aria-label="Enemy detail">
-		{#each view.subTabs as tab (tab.key)}
+		{#each view.enemiesTab.subTabs as tab (tab.key)}
 			<button
 				type="button"
 				id="codex-subtab-{tab.key}"
 				role="tab"
-				aria-selected={view.sub === tab.key}
+				aria-selected={view.enemiesTab.sub === tab.key}
 				aria-controls="codex-subpanel"
 				class="sub-tab"
-				class:active={view.sub === tab.key}
+				class:active={view.enemiesTab.sub === tab.key}
 				data-testid="codex-subtab-{tab.key}"
-				onclick={() => view.selectSub(tab.key)}
+				onclick={() => view.enemiesTab.selectSub(tab.key)}
 			>
 				{tab.label}
 				<span class="underline"></span>
@@ -26,22 +26,22 @@
 		{/each}
 	</div>
 
-	<div class="body" id="codex-subpanel" role="tabpanel" aria-labelledby="codex-subtab-{view.sub}">
-		{#if view.sub === 'attributes'}
+	<div class="body" id="codex-subpanel" role="tabpanel" aria-labelledby="codex-subtab-{view.enemiesTab.sub}">
+		{#if view.enemiesTab.sub === 'attributes'}
 			<AttributesPanel {view} />
-		{:else if view.sub === 'statistics'}
+		{:else if view.enemiesTab.sub === 'statistics'}
 			<StatisticsPanel
-				stats={view.statistics}
+				stats={view.enemiesTab.statistics}
 				loading={view.statsLoading}
 				error={view.statsError}
 				emptyMessage="No battles recorded against this enemy yet."
 				testid="codex-enemy-stats"
 			/>
-		{:else if view.sub === 'skills'}
+		{:else if view.enemiesTab.sub === 'skills'}
 			<EnemySkillsPanel {view} />
-		{:else if view.sub === 'spawns'}
+		{:else if view.enemiesTab.sub === 'spawns'}
 			<EnemySpawnsPanel {view} />
-		{:else if view.sub === 'challenges'}
+		{:else if view.enemiesTab.sub === 'challenges'}
 			<EnemyChallengesPanel {view} />
 		{/if}
 	</div>

--- a/UI/src/routes/game/screens/codex/EnemySkillsPanel.svelte
+++ b/UI/src/routes/game/screens/codex/EnemySkillsPanel.svelte
@@ -1,8 +1,8 @@
 <!-- Skills sub-tab: the enemy's skill pool. Each row cross-links into that skill's dossier. -->
 <div class="skills">
-	<div class="label">Skill pool · {view.enemySkillRows.length}</div>
+	<div class="label">Skill pool · {view.enemiesTab.enemySkillRows.length}</div>
 	<div class="list">
-		{#each view.enemySkillRows as skill (skill.id)}
+		{#each view.enemiesTab.enemySkillRows as skill (skill.id)}
 			<button
 				type="button"
 				class="skill"

--- a/UI/src/routes/game/screens/codex/EnemySpawnsPanel.svelte
+++ b/UI/src/routes/game/screens/codex/EnemySpawnsPanel.svelte
@@ -1,8 +1,8 @@
 <!-- Spawns sub-tab: the zones this enemy spawns in (with its share of each zone's spawn table), or a
      single "Encounter" row for a boss. Each row cross-links into that zone's dossier. -->
 <SpawnRowList
-	heading={view.spawnHeading}
-	rows={view.spawns.map((spawn) => ({
+	heading={view.enemiesTab.spawnHeading}
+	rows={view.enemiesTab.spawns.map((spawn) => ({
 		id: spawn.zoneId,
 		name: spawn.zoneName,
 		share: spawn.share,

--- a/UI/src/routes/game/screens/codex/EnemyTable.svelte
+++ b/UI/src/routes/game/screens/codex/EnemyTable.svelte
@@ -10,14 +10,14 @@
 	</div>
 
 	<div class="rows" data-testid="codex-enemy-rows">
-		{#each view.enemyRows as row (row.id)}
+		{#each view.enemiesTab.enemyRows as row (row.id)}
 			<button
 				type="button"
 				class="row"
-				class:selected={row.id === view.selectedEnemyId}
+				class:selected={row.id === view.enemiesTab.selectedEnemyId}
 				class:boss={row.isBoss}
 				data-testid="codex-enemy-{row.id}"
-				onclick={() => view.selectEnemy(row.id)}
+				onclick={() => view.enemiesTab.selectEnemy(row.id)}
 			>
 				<span class="c-name name-cell">
 					<span class="mark"></span>

--- a/UI/src/routes/game/screens/codex/SkillDossier.svelte
+++ b/UI/src/routes/game/screens/codex/SkillDossier.svelte
@@ -4,9 +4,9 @@
      not-obtainable wording), the attributes the skill scales with, its authored effects (wording
      from the shared skill-effect-display helper), and the enemies that use it. The "used by" pills
      cross-link into the enemy dossier. A reference card only — no equip/loadout, no DPS. -->
-{#if view.selectedSkill}
-	{@const skill = view.selectedSkill}
-	{@const rarity = view.selectedSkillRarity}
+{#if view.skillsTab.selectedSkill}
+	{@const skill = view.skillsTab.selectedSkill}
+	{@const rarity = view.skillsTab.selectedSkillRarity}
 	<DossierShell
 		selectedItem={skill}
 		testid="codex-skill-dossier"
@@ -36,9 +36,9 @@
 
 			<div class="section">
 				<div class="section-label">How to obtain</div>
-				{#if view.skillProvenance.sources.length > 0}
+				{#if view.skillsTab.skillProvenance.sources.length > 0}
 					<div class="sources">
-						{#each view.skillProvenance.sources as source (source.kind + '-' + source.id)}
+						{#each view.skillsTab.skillProvenance.sources as source (source.kind + '-' + source.id)}
 							<div
 								class="source"
 								style:--src={source.accent}
@@ -50,15 +50,15 @@
 						{/each}
 					</div>
 				{:else}
-					<div class="empty">{view.skillProvenance.emptyLabel}</div>
+					<div class="empty">{view.skillsTab.skillProvenance.emptyLabel}</div>
 				{/if}
 			</div>
 
 			<div class="section">
 				<div class="section-label">Scales with</div>
-				{#if view.skillScaling.length > 0}
+				{#if view.skillsTab.skillScaling.length > 0}
 					<div class="chips">
-						{#each view.skillScaling as scale (scale.attributeId)}
+						{#each view.skillsTab.skillScaling as scale (scale.attributeId)}
 							<span class="scale-chip" style:--chip={scale.color}>
 								<span class="mult">{scale.multiplierLabel}</span>
 								<span class="attr">{scale.name}</span>
@@ -70,11 +70,11 @@
 				{/if}
 			</div>
 
-			{#if view.skillEffects.length > 0}
+			{#if view.skillsTab.skillEffects.length > 0}
 				<div class="section">
 					<div class="section-label">Effects</div>
 					<div class="effects">
-						{#each view.skillEffects as effect (effect.id)}
+						{#each view.skillsTab.skillEffects as effect (effect.id)}
 							<div class="effect-row">
 								<span class="emag" style:color={effect.color}>{effect.magnitude}</span>
 								<span class="eattr">{effect.attributeName}</span>
@@ -86,10 +86,10 @@
 			{/if}
 
 			<div class="section">
-				<div class="section-label">Used by · {view.skillUsedBy.length}</div>
-				{#if view.skillUsedBy.length > 0}
+				<div class="section-label">Used by · {view.skillsTab.skillUsedBy.length}</div>
+				{#if view.skillsTab.skillUsedBy.length > 0}
 					<div class="pills">
-						{#each view.skillUsedBy as user (user.enemyId)}
+						{#each view.skillsTab.skillUsedBy as user (user.enemyId)}
 							<button
 								type="button"
 								class="pill"
@@ -109,7 +109,7 @@
 
 			<div class="section">
 				<StatisticsPanel
-					stats={view.skillStatistics}
+					stats={view.skillsTab.skillStatistics}
 					loading={view.statsLoading}
 					error={view.statsError}
 					emptyMessage="No statistics recorded for this skill yet."

--- a/UI/src/routes/game/screens/codex/SkillTable.svelte
+++ b/UI/src/routes/game/screens/codex/SkillTable.svelte
@@ -9,13 +9,13 @@
 	</div>
 
 	<div class="rows" data-testid="codex-skill-rows">
-		{#each view.skillRows as row (row.id)}
+		{#each view.skillsTab.skillRows as row (row.id)}
 			<button
 				type="button"
 				class="row"
-				class:selected={row.id === view.selectedSkillId}
+				class:selected={row.id === view.skillsTab.selectedSkillId}
 				data-testid="codex-skill-{row.id}"
-				onclick={() => view.selectSkill(row.id)}
+				onclick={() => view.skillsTab.selectSkill(row.id)}
 			>
 				<span class="c-name name-cell">
 					<span class="mark" style:--mark={row.rarityColor}></span>

--- a/UI/src/routes/game/screens/codex/ZoneDossier.svelte
+++ b/UI/src/routes/game/screens/codex/ZoneDossier.svelte
@@ -2,17 +2,20 @@
      level band / spawn-pool meta, the zone boss card, the spawn table and the unlock condition. The
      boss card and spawn rows cross-link into the enemy dossier. -->
 <DossierShell
-	selectedItem={view.selectedZone}
+	selectedItem={view.zonesTab.selectedZone}
 	testid="codex-zone-dossier"
 	accent="var(--accent)"
 	kind="Zone"
-	name={view.selectedZone?.name ?? ''}
-	description={view.selectedZone?.description}
+	name={view.zonesTab.selectedZone?.name ?? ''}
+	description={view.zonesTab.selectedZone?.description}
 >
 	{#snippet headExtra()}
 		<span class="spacer"></span>
-		<span class="seal" data-testid="codex-zone-status" style:--status-color={zoneStatusColor(view.selectedZoneStatus)}
-			>{ZONE_STATUS_LABELS[view.selectedZoneStatus]}</span
+		<span
+			class="seal"
+			data-testid="codex-zone-status"
+			style:--status-color={zoneStatusColor(view.zonesTab.selectedZoneStatus)}
+			>{ZONE_STATUS_LABELS[view.zonesTab.selectedZoneStatus]}</span
 		>
 	{/snippet}
 
@@ -20,16 +23,19 @@
 		<div class="meta">
 			<div class="meta-card">
 				<div class="meta-label">Level Range</div>
-				<div class="meta-val">{view.zoneBand}</div>
+				<div class="meta-val">{view.zonesTab.zoneBand}</div>
 			</div>
 			<div class="meta-card">
 				<div class="meta-label">Spawn Pool</div>
-				<div class="meta-val">{view.zoneSpawnCount} {view.zoneSpawnCount === 1 ? 'enemy' : 'enemies'}</div>
+				<div class="meta-val">
+					{view.zonesTab.zoneSpawnCount}
+					{view.zonesTab.zoneSpawnCount === 1 ? 'enemy' : 'enemies'}
+				</div>
 			</div>
 		</div>
 
-		{#if view.zoneBoss}
-			{@const boss = view.zoneBoss}
+		{#if view.zonesTab.zoneBoss}
+			{@const boss = view.zonesTab.zoneBoss}
 			<div class="section">
 				<div class="section-label">Zone boss</div>
 				<button
@@ -54,8 +60,8 @@
 
 		<div class="section">
 			<div class="section-label">Unlock condition</div>
-			{#if view.zoneUnlock}
-				{@const unlock = view.zoneUnlock}
+			{#if view.zonesTab.zoneUnlock}
+				{@const unlock = view.zonesTab.zoneUnlock}
 				<div class="unlock" class:sealed={unlock.sealed}>
 					<span class="unlock-text">
 						<span class="unlock-lead">Complete challenge</span>
@@ -75,7 +81,7 @@
 
 		<div class="section">
 			<StatisticsPanel
-				stats={view.zoneStatistics}
+				stats={view.zonesTab.zoneStatistics}
 				loading={view.statsLoading}
 				error={view.statsError}
 				emptyMessage="No statistics recorded for this zone yet."

--- a/UI/src/routes/game/screens/codex/ZoneRail.svelte
+++ b/UI/src/routes/game/screens/codex/ZoneRail.svelte
@@ -2,17 +2,17 @@
      with a status node (cleared / unlocked / locked), the zone name + level band, the spawn-pool size
      and a BOSS tag when the zone has a dedicated boss. -->
 <div class="rail">
-	<div class="rail-head">Progression · {view.zoneRows.length}</div>
+	<div class="rail-head">Progression · {view.zonesTab.zoneRows.length}</div>
 
 	<div class="rows" data-testid="codex-zone-rows">
-		{#each view.zoneRows as row (row.id)}
+		{#each view.zonesTab.zoneRows as row (row.id)}
 			<button
 				type="button"
 				class="row"
-				class:selected={row.id === view.selectedZoneId}
+				class:selected={row.id === view.zonesTab.selectedZoneId}
 				style:--status-color={zoneStatusColor(row.status)}
 				data-testid="codex-zone-{row.id}"
-				onclick={() => view.selectZone(row.id)}
+				onclick={() => view.zonesTab.selectZone(row.id)}
 			>
 				<span class="node">
 					<span class="dot" class:cleared={row.status === 'cleared'} class:locked={row.status === 'locked'}></span>

--- a/UI/src/routes/game/screens/codex/ZoneSpawnPanel.svelte
+++ b/UI/src/routes/game/screens/codex/ZoneSpawnPanel.svelte
@@ -1,8 +1,8 @@
 <!-- Zone dossier spawn table: every non-retired enemy that spawns in the zone, with its share of the
      zone's total spawn weight. Each row is a cross-link into that enemy's dossier. -->
 <SpawnRowList
-	heading={`Spawn table · ${view.zoneSpawnCount}`}
-	rows={view.zoneSpawns.map((spawn) => ({
+	heading={`Spawn table · ${view.zonesTab.zoneSpawnCount}`}
+	rows={view.zonesTab.zoneSpawns.map((spawn) => ({
 		id: spawn.enemyId,
 		name: spawn.enemyName,
 		share: spawn.share,

--- a/UI/src/routes/game/screens/codex/codex-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/codex-view.svelte.ts
@@ -22,47 +22,16 @@
    The reactive layer is composed from one class per tab (`EnemiesTabView`, `ZonesTabView`,
    `SkillsTabView`, each in its own `*-tab-view.svelte.ts` file) so every tab's derivations stay
    independently readable/testable. This CodexView is the thin orchestrator: it owns only what's
-   genuinely cross-tab — the active tab, the live player statistics + challenge-error state,
-   the shared statistics query engine, and the cross-links between dossiers — and every other
-   property/method below simply delegates to the owning tab's instance, so consuming components (and
-   the existing tests) keep reading `view.<x>` exactly as before. */
+   genuinely cross-tab — the active tab, the live player statistics + challenge-error state, the
+   shared statistics query engine, and the cross-links between dossiers — and exposes the three tab
+   instances (`enemiesTab`/`zonesTab`/`skillsTab`) directly; consuming components read/call through
+   the owning tab instance (e.g. `view.enemiesTab.selectedEnemy`) rather than a flat pass-through API. */
 
 import { staticData, statistics } from '$stores';
-import {
-	CODEX_TABS,
-	type CodexTab,
-	type EnemyFilter,
-	type EnemySort,
-	type EnemySubTab,
-	type EntityStatVM,
-	tabAccent,
-	tabLabel
-} from './codex-display';
-import {
-	EnemiesTabView,
-	type EnemyChallengeVM,
-	type EnemyRowVM,
-	type EnemySkillVM,
-	type EnemySpawnVM,
-	type SubTabVM
-} from './enemies-tab-view.svelte';
-import {
-	SkillsTabView,
-	type SkillEffectVM,
-	type SkillProvenanceVM,
-	type SkillRarityVM,
-	type SkillRowVM,
-	type SkillScalingVM,
-	type SkillUserVM
-} from './skills-tab-view.svelte';
-import {
-	ZonesTabView,
-	type ZoneBossVM,
-	type ZoneProjectionVM,
-	type ZoneRowVM,
-	type ZoneSpawnVM,
-	type ZoneUnlockVM
-} from './zones-tab-view.svelte';
+import { CODEX_TABS, type CodexTab, type EnemySubTab, type EntityStatVM, tabAccent, tabLabel } from './codex-display';
+import { EnemiesTabView, type EnemyRowVM } from './enemies-tab-view.svelte';
+import { SkillsTabView } from './skills-tab-view.svelte';
+import { ZonesTabView, type ZoneProjectionVM } from './zones-tab-view.svelte';
 import { fmtValue } from '../stats/statistics-display';
 import {
 	StatisticsData,
@@ -108,9 +77,9 @@ export class CodexView {
 	 *  Challenges sub-tab doesn't render zero-progress/sealed as if it were authoritative. */
 	challengesError = $state(false);
 
-	private readonly enemiesTab: EnemiesTabView;
-	private readonly zonesTab: ZonesTabView;
-	private readonly skillsTab: SkillsTabView;
+	readonly enemiesTab: EnemiesTabView;
+	readonly zonesTab: ZonesTabView;
+	readonly skillsTab: SkillsTabView;
 
 	constructor(payload?: CodexNavPayload) {
 		if (payload?.tab) {
@@ -157,193 +126,6 @@ export class CodexView {
 
 	selectTab(tab: CodexTab): void {
 		this.tab = tab;
-	}
-
-	/* ── enemies tab (delegates to EnemiesTabView) ───────────────────────────────── */
-
-	get enemies() {
-		return this.enemiesTab.enemies;
-	}
-	get enemyProjections(): EnemyRowVM[] {
-		return this.enemiesTab.enemyProjections;
-	}
-	get enemyRows(): EnemyRowVM[] {
-		return this.enemiesTab.enemyRows;
-	}
-	get shownCount() {
-		return this.enemiesTab.shownCount;
-	}
-
-	get selectedEnemyId() {
-		return this.enemiesTab.selectedEnemyId;
-	}
-	set selectedEnemyId(id: number) {
-		this.enemiesTab.selectedEnemyId = id;
-	}
-	get selectedEnemy() {
-		return this.enemiesTab.selectedEnemy;
-	}
-	get range() {
-		return this.enemiesTab.range;
-	}
-	get dossierAccent() {
-		return this.enemiesTab.dossierAccent;
-	}
-	get dossierKind() {
-		return this.enemiesTab.dossierKind;
-	}
-	get attributes() {
-		return this.enemiesTab.attributes;
-	}
-	get maxPrimary() {
-		return this.enemiesTab.maxPrimary;
-	}
-	get enemySkillRows(): EnemySkillVM[] {
-		return this.enemiesTab.enemySkillRows;
-	}
-	get spawnHeading() {
-		return this.enemiesTab.spawnHeading;
-	}
-	get spawns(): EnemySpawnVM[] {
-		return this.enemiesTab.spawns;
-	}
-	get statistics(): EntityStatVM[] {
-		return this.enemiesTab.statistics;
-	}
-	get challenges(): EnemyChallengeVM[] {
-		return this.enemiesTab.challenges;
-	}
-	get subTabs(): SubTabVM[] {
-		return this.enemiesTab.subTabs;
-	}
-
-	get sub() {
-		return this.enemiesTab.sub;
-	}
-	get level() {
-		return this.enemiesTab.level;
-	}
-	get scaling() {
-		return this.enemiesTab.scaling;
-	}
-	get filter() {
-		return this.enemiesTab.filter;
-	}
-	get search() {
-		return this.enemiesTab.search;
-	}
-	set search(value: string) {
-		this.enemiesTab.search = value;
-	}
-	get sort() {
-		return this.enemiesTab.sort;
-	}
-	set sort(value: EnemySort) {
-		this.enemiesTab.sort = value;
-	}
-
-	selectEnemy(id: number): void {
-		this.enemiesTab.selectEnemy(id);
-	}
-	selectSub(sub: EnemySubTab): void {
-		this.enemiesTab.selectSub(sub);
-	}
-	setLevel(level: number): void {
-		this.enemiesTab.setLevel(level);
-	}
-	toggleScaling(): void {
-		this.enemiesTab.toggleScaling();
-	}
-	setFilter(filter: EnemyFilter): void {
-		this.enemiesTab.setFilter(filter);
-	}
-
-	/* ── zones tab (delegates to ZonesTabView) ───────────────────────────────────── */
-
-	get zones() {
-		return this.zonesTab.zones;
-	}
-	get zoneProjections(): ZoneProjectionVM[] {
-		return this.zonesTab.zoneProjections;
-	}
-	get zoneRows(): ZoneRowVM[] {
-		return this.zonesTab.zoneRows;
-	}
-
-	get selectedZoneId() {
-		return this.zonesTab.selectedZoneId;
-	}
-	set selectedZoneId(id: number) {
-		this.zonesTab.selectedZoneId = id;
-	}
-	get selectedZone() {
-		return this.zonesTab.selectedZone;
-	}
-	get zoneBand() {
-		return this.zonesTab.zoneBand;
-	}
-	get selectedZoneStatus() {
-		return this.zonesTab.selectedZoneStatus;
-	}
-	get zoneBoss(): ZoneBossVM | null {
-		return this.zonesTab.zoneBoss;
-	}
-	get zoneSpawns(): ZoneSpawnVM[] {
-		return this.zonesTab.zoneSpawns;
-	}
-	get zoneSpawnCount() {
-		return this.zonesTab.zoneSpawnCount;
-	}
-	get zoneUnlock(): ZoneUnlockVM | null {
-		return this.zonesTab.zoneUnlock;
-	}
-	get zoneStatistics(): EntityStatVM[] {
-		return this.zonesTab.zoneStatistics;
-	}
-
-	selectZone(id: number): void {
-		this.zonesTab.selectZone(id);
-	}
-
-	/* ── skills tab (delegates to SkillsTabView) ─────────────────────────────────── */
-
-	get skillsCatalogue() {
-		return this.skillsTab.skillsCatalogue;
-	}
-	get skillRows(): SkillRowVM[] {
-		return this.skillsTab.skillRows;
-	}
-
-	get selectedSkillId() {
-		return this.skillsTab.selectedSkillId;
-	}
-	set selectedSkillId(id: number) {
-		this.skillsTab.selectedSkillId = id;
-	}
-	get selectedSkill() {
-		return this.skillsTab.selectedSkill;
-	}
-	get selectedSkillRarity(): SkillRarityVM | null {
-		return this.skillsTab.selectedSkillRarity;
-	}
-	get skillScaling(): SkillScalingVM[] {
-		return this.skillsTab.skillScaling;
-	}
-	get skillEffects(): SkillEffectVM[] {
-		return this.skillsTab.skillEffects;
-	}
-	get skillUsedBy(): SkillUserVM[] {
-		return this.skillsTab.skillUsedBy;
-	}
-	get skillProvenance(): SkillProvenanceVM {
-		return this.skillsTab.skillProvenance;
-	}
-	get skillStatistics(): EntityStatVM[] {
-		return this.skillsTab.skillStatistics;
-	}
-
-	selectSkill(id: number): void {
-		this.skillsTab.selectSkill(id);
 	}
 
 	/* ── cross-tab links ──────────────────────────────────────────────────────── */

--- a/UI/src/tests/routes/admin/workbench/SectionRenderer.test.ts
+++ b/UI/src/tests/routes/admin/workbench/SectionRenderer.test.ts
@@ -16,8 +16,7 @@ const { mockReference } = vi.hoisted(() => ({
 		entityOptions: vi.fn(() => []),
 		entityName: vi.fn(() => null),
 		itemRecords: vi.fn(() => []),
-		itemModRecords: vi.fn(() => []),
-		skillRecords: vi.fn(() => [])
+		itemModRecords: vi.fn(() => [])
 	}
 }));
 vi.mock('$routes/admin/workbench/reference.svelte', () => ({ reference: mockReference }));

--- a/UI/src/tests/routes/admin/workbench/reference.test.ts
+++ b/UI/src/tests/routes/admin/workbench/reference.test.ts
@@ -332,7 +332,7 @@ describe('challenge-type lookups', () => {
 	});
 });
 
-describe('entityOptions / entityCatalog target-entity picker', () => {
+describe('entityOptions target-entity picker', () => {
 	it('lists every enemy when the statistic is not boss-only', () => {
 		expect(reference.entityOptions(EEntityType.Enemy).map((o) => o.value)).toEqual([0, 1, 2, 3]);
 	});
@@ -351,10 +351,6 @@ describe('entityOptions / entityCatalog target-entity picker', () => {
 		// Cave Bat (id 0) isn't a boss, but it's the challenge's currently-authored target.
 		expect(reference.entityOptions(EEntityType.Enemy, true, 0)).toContainEqual({ value: 0, text: 'Cave Bat' });
 		expect(reference.entityOptions(EEntityType.Enemy, true).map((o) => o.value)).not.toContain(0);
-	});
-
-	it('returns an empty catalogue for the None / unknown dimension', () => {
-		expect(reference.entityCatalog(EEntityType.None)).toEqual([]);
 	});
 
 	it('resolves a target name across all enemies regardless of the boss filter', () => {
@@ -382,17 +378,15 @@ describe('entityOptions / entityCatalog target-entity picker', () => {
 });
 
 describe('reward record lookups', () => {
-	it('exposes the raw item / mod / skill record lists', () => {
+	it('exposes the raw item / mod record lists', () => {
 		expect(reference.itemRecords()).toHaveLength(2);
 		expect(reference.itemModRecords()).toHaveLength(2);
-		expect(reference.skillRecords()).toHaveLength(2);
 	});
 
-	it('resolves item name, rarity and skill name/damage by id', () => {
+	it('resolves item name, rarity and skill name by id', () => {
 		expect(reference.itemRecName(1)).toBe('Dragon Blade');
 		expect(reference.itemRarityId(1)).toBe(ERarity.Legendary);
 		expect(reference.skillName(1)).toBe('Fireball');
-		expect(reference.skillBaseDamage(1)).toBe(25);
 	});
 
 	it('resolves item-mod name and its type name', () => {

--- a/UI/src/tests/routes/game/screens/codex/codex-view.svelte.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/codex-view.svelte.test.ts
@@ -227,21 +227,21 @@ describe('CodexView tabs', () => {
 
 describe('CodexView enemy rows', () => {
 	it('projects zone + skill counts (boss shows a single zone)', () => {
-		const rows = new CodexView().enemyRows;
+		const rows = new CodexView().enemiesTab.enemyRows;
 		expect(rows.find((r) => r.id === 0)).toMatchObject({ zoneCount: 2, skillCount: 2, band: '1–22' });
 		expect(rows.find((r) => r.id === 2)).toMatchObject({ zoneCount: 1, skillCount: 2, band: 'L10', isBoss: true });
 	});
 
 	it('filters by normal / boss', () => {
 		const view = new CodexView();
-		view.setFilter('boss');
-		expect(view.enemyRows.map((r) => r.id)).toEqual([2]);
-		view.setFilter('normal');
-		expect(view.enemyRows.map((r) => r.id)).toEqual([0, 1]);
+		view.enemiesTab.setFilter('boss');
+		expect(view.enemiesTab.enemyRows.map((r) => r.id)).toEqual([2]);
+		view.enemiesTab.setFilter('normal');
+		expect(view.enemiesTab.enemyRows.map((r) => r.id)).toEqual([0, 1]);
 	});
 
 	it('exposes the level sort key + search haystack on each row', () => {
-		const rows = new CodexView().enemyRows;
+		const rows = new CodexView().enemiesTab.enemyRows;
 		// Dust Skitterer spans 1–22 (low end 1); the haystack carries name, kind and spawn zones.
 		const skitterer = rows.find((r) => r.id === 0);
 		expect(skitterer?.level).toBe(1);
@@ -257,18 +257,18 @@ describe('CodexView enemy projections', () => {
 	it('projects every enemy independent of the active filter, search and sort', () => {
 		const view = new CodexView();
 		// The immutable projection ignores the interaction state the thin `enemyRows` layers on top.
-		view.setFilter('boss');
-		view.search = 'griffin';
-		view.sort = 'name';
-		expect(view.enemyProjections.map((p) => p.id)).toEqual([0, 1, 2]);
-		expect(view.enemyProjections.find((p) => p.id === 2)).toMatchObject({
+		view.enemiesTab.setFilter('boss');
+		view.enemiesTab.search = 'griffin';
+		view.enemiesTab.sort = 'name';
+		expect(view.enemiesTab.enemyProjections.map((p) => p.id)).toEqual([0, 1, 2]);
+		expect(view.enemiesTab.enemyProjections.find((p) => p.id === 2)).toMatchObject({
 			band: 'L10',
 			level: 10,
 			isBoss: true,
 			zoneCount: 1,
 			skillCount: 2
 		});
-		expect(view.enemyProjections.find((p) => p.id === 0)?.searchText).toContain('emberreach');
+		expect(view.enemiesTab.enemyProjections.find((p) => p.id === 0)?.searchText).toContain('emberreach');
 	});
 
 	it('memoizes the projection on a single instance: the same reference survives search / sort / filter changes', () => {
@@ -281,10 +281,10 @@ describe('CodexView enemy projections', () => {
 		let rows: EnemyRowVM[] | undefined;
 		const cleanup = $effect.root(() => {
 			$effect(() => {
-				projection = view.enemyProjections;
+				projection = view.enemiesTab.enemyProjections;
 			});
 			$effect(() => {
-				rows = view.enemyRows;
+				rows = view.enemiesTab.enemyRows;
 			});
 		});
 
@@ -293,9 +293,9 @@ describe('CodexView enemy projections', () => {
 		const rowsBefore = rows;
 
 		// Mutate the reactive interaction state (`filter`/`search`/`sort` are `$state`) the row layer reads.
-		view.setFilter('boss');
-		view.search = 'griffin';
-		view.sort = 'name';
+		view.enemiesTab.setFilter('boss');
+		view.enemiesTab.search = 'griffin';
+		view.enemiesTab.sort = 'name';
 		flushSync();
 
 		// The interaction change genuinely moved the reactive graph — the thin row layer recomputed…
@@ -303,7 +303,7 @@ describe('CodexView enemy projections', () => {
 		expect(rows).toEqual([]); // boss filter + a query that matches nothing
 		// …yet the projection was memoized: the same array reference, never rebuilt.
 		expect(projection).toBe(projectionBefore);
-		expect(view.enemyProjections).toBe(projectionBefore);
+		expect(view.enemiesTab.enemyProjections).toBe(projectionBefore);
 
 		cleanup();
 	});
@@ -312,122 +312,122 @@ describe('CodexView enemy projections', () => {
 describe('CodexView enemy search', () => {
 	it('matches by name, case-insensitively', () => {
 		const view = new CodexView();
-		view.search = 'BOG';
-		expect(view.enemyRows.map((r) => r.id)).toEqual([1]);
+		view.enemiesTab.search = 'BOG';
+		expect(view.enemiesTab.enemyRows.map((r) => r.id)).toEqual([1]);
 	});
 
 	it('matches by zone name (spawn zones + a boss encounter zone)', () => {
 		const view = new CodexView();
 		// Dust Skitterer spawns in Emberreach; Cinder Tyrant's boss encounter is in Emberreach too.
-		view.search = 'emberreach';
-		expect(view.enemyRows.map((r) => r.id)).toEqual([0, 2]);
+		view.enemiesTab.search = 'emberreach';
+		expect(view.enemiesTab.enemyRows.map((r) => r.id)).toEqual([0, 2]);
 	});
 
 	it('matches a boss by its encounter-zone name', () => {
 		const view = new CodexView();
-		view.setFilter('boss');
-		view.search = 'emberreach'; // Cinder Tyrant's encounter zone (it has no spawns)
-		expect(view.enemyRows.map((r) => r.id)).toEqual([2]);
+		view.enemiesTab.setFilter('boss');
+		view.enemiesTab.search = 'emberreach'; // Cinder Tyrant's encounter zone (it has no spawns)
+		expect(view.enemiesTab.enemyRows.map((r) => r.id)).toEqual([2]);
 	});
 
 	it('matches the boss kind', () => {
 		const view = new CodexView();
-		view.search = 'boss';
-		expect(view.enemyRows.map((r) => r.id)).toEqual([2]);
+		view.enemiesTab.search = 'boss';
+		expect(view.enemiesTab.enemyRows.map((r) => r.id)).toEqual([2]);
 	});
 
 	it('shows everything for an empty query', () => {
 		const view = new CodexView();
-		view.search = '   ';
-		expect(view.enemyRows).toHaveLength(3);
+		view.enemiesTab.search = '   ';
+		expect(view.enemiesTab.enemyRows).toHaveLength(3);
 	});
 
 	it('shows nothing when the query matches no enemy', () => {
 		const view = new CodexView();
-		view.search = 'griffin';
-		expect(view.enemyRows).toHaveLength(0);
-		expect(view.shownCount).toBe(0);
+		view.enemiesTab.search = 'griffin';
+		expect(view.enemiesTab.enemyRows).toHaveLength(0);
+		expect(view.enemiesTab.shownCount).toBe(0);
 	});
 
 	it('reflects the search in the shown count and combines with the filter', () => {
 		const view = new CodexView();
-		view.setFilter('normal');
-		view.search = 'lurker';
-		expect(view.enemyRows.map((r) => r.id)).toEqual([1]);
-		expect(view.shownCount).toBe(1);
+		view.enemiesTab.setFilter('normal');
+		view.enemiesTab.search = 'lurker';
+		expect(view.enemiesTab.enemyRows.map((r) => r.id)).toEqual([1]);
+		expect(view.enemiesTab.shownCount).toBe(1);
 	});
 
 	it('keeps an explicitly selected enemy in the dossier even when the search excludes it', () => {
 		// Mirrors the filter behavior: a deliberate selection stays resolvable so the dossier
 		// doesn't jump out from under the player when they type a query.
 		const view = new CodexView();
-		view.selectEnemy(0); // explicitly inspecting Dust Skitterer
-		view.search = 'bog'; // the table shows only Bog Lurker…
-		expect(view.enemyRows.map((r) => r.id)).toEqual([1]);
-		expect(view.selectedEnemy?.id).toBe(0); // …but the dossier holds the selection
+		view.enemiesTab.selectEnemy(0); // explicitly inspecting Dust Skitterer
+		view.enemiesTab.search = 'bog'; // the table shows only Bog Lurker…
+		expect(view.enemiesTab.enemyRows.map((r) => r.id)).toEqual([1]);
+		expect(view.enemiesTab.selectedEnemy?.id).toBe(0); // …but the dossier holds the selection
 	});
 
 	it('falls back the dossier to the first visible row when nothing is explicitly selected', () => {
 		const view = new CodexView();
-		view.selectedEnemyId = -1; // no resolvable selection
-		view.search = 'bog'; // only Bog Lurker is visible
-		expect(view.selectedEnemy?.id).toBe(1);
+		view.enemiesTab.selectedEnemyId = -1; // no resolvable selection
+		view.enemiesTab.search = 'bog'; // only Bog Lurker is visible
+		expect(view.enemiesTab.selectedEnemy?.id).toBe(1);
 	});
 });
 
 describe('CodexView enemy sort', () => {
 	it('defaults to ascending level (boss fixed level ranks among normals)', () => {
 		// Dust Skitterer (1) < Cinder Tyrant (boss, 10) < Bog Lurker (11).
-		expect(new CodexView().enemyRows.map((r) => r.id)).toEqual([0, 2, 1]);
+		expect(new CodexView().enemiesTab.enemyRows.map((r) => r.id)).toEqual([0, 2, 1]);
 	});
 
 	it('sorts alphabetically by name', () => {
 		const view = new CodexView();
-		view.sort = 'name';
+		view.enemiesTab.sort = 'name';
 		// Bog Lurker, Cinder Tyrant, Dust Skitterer.
-		expect(view.enemyRows.map((r) => r.id)).toEqual([1, 2, 0]);
+		expect(view.enemiesTab.enemyRows.map((r) => r.id)).toEqual([1, 2, 0]);
 	});
 });
 
 describe('CodexView selection', () => {
 	it('falls back to the head of the list when no enemy is selected', () => {
-		expect(new CodexView().selectedEnemy?.id).toBe(0);
+		expect(new CodexView().enemiesTab.selectedEnemy?.id).toBe(0);
 	});
 
 	it('seeds the level to the band midpoint for a normal enemy', () => {
 		// Dust Skitterer spans 1–22 → midpoint 12.
-		expect(new CodexView().level).toBe(12);
+		expect(new CodexView().enemiesTab.level).toBe(12);
 	});
 
 	it('selectEnemy reseeds the level (fixed for a boss) and resets the sub-tab', () => {
 		const view = new CodexView();
-		view.selectSub('skills');
-		view.selectEnemy(2);
-		expect(view.selectedEnemy?.id).toBe(2);
-		expect(view.level).toBe(10); // boss fixed level
-		expect(view.sub).toBe('attributes');
-		expect(view.range?.fixed).toBe(true);
+		view.enemiesTab.selectSub('skills');
+		view.enemiesTab.selectEnemy(2);
+		expect(view.enemiesTab.selectedEnemy?.id).toBe(2);
+		expect(view.enemiesTab.level).toBe(10); // boss fixed level
+		expect(view.enemiesTab.sub).toBe('attributes');
+		expect(view.enemiesTab.range?.fixed).toBe(true);
 	});
 });
 
 describe('CodexView dossier projections', () => {
 	it('includes the Challenges sub-tab only when the enemy has related challenges', () => {
 		const view = new CodexView();
-		view.selectEnemy(0); // has challenge 0
-		expect(view.subTabs.map((t) => t.key)).toContain('challenges');
-		view.selectEnemy(1); // no challenges
-		expect(view.subTabs.map((t) => t.key)).not.toContain('challenges');
+		view.enemiesTab.selectEnemy(0); // has challenge 0
+		expect(view.enemiesTab.subTabs.map((t) => t.key)).toContain('challenges');
+		view.enemiesTab.selectEnemy(1); // no challenges
+		expect(view.enemiesTab.subTabs.map((t) => t.key)).not.toContain('challenges');
 	});
 
 	it('builds enemy-scoped challenge rows with progress text', () => {
 		const view = new CodexView();
-		view.selectEnemy(0);
-		expect(view.challenges).toEqual([
+		view.enemiesTab.selectEnemy(0);
+		expect(view.enemiesTab.challenges).toEqual([
 			expect.objectContaining({ id: 0, typeLabel: 'Enemies Killed', progressText: '62/100', completed: false })
 		]);
 		// A goal-of-1 boss challenge with no progress reads as "sealed".
-		view.selectEnemy(2);
-		expect(view.challenges[0].progressText).toBe('sealed');
+		view.enemiesTab.selectEnemy(2);
+		expect(view.enemiesTab.challenges[0].progressText).toBe('sealed');
 	});
 
 	it('hides a retired enemy-scoped challenge unless it was already completed', () => {
@@ -444,34 +444,34 @@ describe('CodexView dossier projections', () => {
 			}
 		];
 		const uncompleted = new CodexView();
-		uncompleted.selectEnemy(0);
-		expect(uncompleted.challenges.map((c) => c.id)).toEqual([0]);
+		uncompleted.enemiesTab.selectEnemy(0);
+		expect(uncompleted.enemiesTab.challenges.map((c) => c.id)).toEqual([0]);
 
 		playerChallenges.all = [...playerChallenges.all, { challengeId: 2, progress: 50, completed: true }];
 		const completed = new CodexView();
-		completed.selectEnemy(0);
-		expect(completed.challenges.map((c) => c.id)).toEqual(expect.arrayContaining([0, 2]));
+		completed.enemiesTab.selectEnemy(0);
+		expect(completed.enemiesTab.challenges.map((c) => c.id)).toEqual(expect.arrayContaining([0, 2]));
 	});
 
 	it('sorts spawn shares descending and collapses a boss to a single Encounter', () => {
 		const view = new CodexView();
-		view.selectEnemy(0);
-		expect(view.spawnHeading).toBe('Spawns in 2 zones');
-		expect(view.spawns).toEqual([
+		view.enemiesTab.selectEnemy(0);
+		expect(view.enemiesTab.spawnHeading).toBe('Spawns in 2 zones');
+		expect(view.enemiesTab.spawns).toEqual([
 			expect.objectContaining({ zoneName: 'Emberreach', share: 100 }),
 			expect.objectContaining({ zoneName: 'Ashfen Marsh', share: 33 })
 		]);
-		view.selectEnemy(2);
-		expect(view.spawnHeading).toBe('Encounter');
-		expect(view.spawns).toEqual([
+		view.enemiesTab.selectEnemy(2);
+		expect(view.enemiesTab.spawnHeading).toBe('Encounter');
+		expect(view.enemiesTab.spawns).toEqual([
 			expect.objectContaining({ zoneName: 'Emberreach', share: 100, weightLabel: 'boss fight' })
 		]);
 	});
 
 	it('lists the enemy’s skill pool with base/cooldown meta', () => {
 		const view = new CodexView();
-		view.selectEnemy(0);
-		expect(view.enemySkillRows).toEqual([
+		view.enemiesTab.selectEnemy(0);
+		expect(view.enemiesTab.enemySkillRows).toEqual([
 			{ id: 0, name: 'Cleave', meta: 'base 14 · 1.8s cd' },
 			{ id: 1, name: 'War Cry', meta: 'utility · 6s cd' }
 		]);
@@ -480,23 +480,26 @@ describe('CodexView dossier projections', () => {
 	it('reuses the statistics query for the player’s per-enemy record', () => {
 		statistics.stats = STATS;
 		const view = new CodexView();
-		view.selectEnemy(0);
-		const killed = view.statistics.find((s) => s.label === 'Enemies Killed');
+		view.enemiesTab.selectEnemy(0);
+		const killed = view.enemiesTab.statistics.find((s) => s.label === 'Enemies Killed');
 		expect(killed?.value).toBe('100');
 	});
 
 	it('scales primary attributes to the current level', () => {
 		const view = new CodexView();
-		view.selectEnemy(0); // level → 12
-		const str = view.attributes.primary.find((p) => p.attributeId === EAttribute.Strength);
+		view.enemiesTab.selectEnemy(0); // level → 12
+		const str = view.enemiesTab.attributes.primary.find((p) => p.attributeId === EAttribute.Strength);
 		expect(str?.value).toBe(Math.round(10 + 1 * 12)); // 22
-		expect(view.attributes.secondary.map((s) => s.attributeId)).toEqual([EAttribute.MaxHealth, EAttribute.Toughness]);
+		expect(view.enemiesTab.attributes.secondary.map((s) => s.attributeId)).toEqual([
+			EAttribute.MaxHealth,
+			EAttribute.Toughness
+		]);
 	});
 });
 
 describe('CodexView zone rail', () => {
 	it('projects status / band / spawn-pool / boss per zone in authored order', () => {
-		const rows = new CodexView().zoneRows;
+		const rows = new CodexView().zonesTab.zoneRows;
 		expect(rows.map((r) => r.id)).toEqual([0, 1, 2]);
 		// Zone 0 is cleared; zone 1 is gated on the uncompleted challenge 0; zone 2 is open.
 		expect(rows.find((r) => r.id === 0)).toMatchObject({
@@ -521,24 +524,24 @@ describe('CodexView zone rail', () => {
 
 	it('marks a gated zone unlocked once its challenge is completed', () => {
 		playerChallenges.all = [{ challengeId: 0, progress: 100, completed: true }];
-		expect(new CodexView().zoneRows.find((r) => r.id === 1)?.status).toBe('unlocked');
+		expect(new CodexView().zonesTab.zoneRows.find((r) => r.id === 1)?.status).toBe('unlocked');
 	});
 
 	it('keeps a cleared zone cleared even behind an unmet gate', () => {
 		statistics.isZoneCleared.mockImplementation((id: number) => id === 1);
-		expect(new CodexView().zoneRows.find((r) => r.id === 1)?.status).toBe('cleared');
+		expect(new CodexView().zonesTab.zoneRows.find((r) => r.id === 1)?.status).toBe('cleared');
 	});
 
 	it('orders the rail by authored order, not by id', () => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		staticData.zones = staticData.zones.map((z: any) => ({ ...z, order: 3 - z.order }));
-		expect(new CodexView().zoneRows.map((r) => r.id)).toEqual([2, 1, 0]);
+		expect(new CodexView().zonesTab.zoneRows.map((r) => r.id)).toEqual([2, 1, 0]);
 	});
 });
 
 describe('CodexView zone projections', () => {
 	it('projects the immutable per-zone fields without the live status, in authored order', () => {
-		const rows = new CodexView().zoneProjections;
+		const rows = new CodexView().zonesTab.zoneProjections;
 		expect(rows.map((r) => r.id)).toEqual([0, 1, 2]);
 		expect(rows.find((r) => r.id === 1)).toEqual({
 			id: 1,
@@ -560,7 +563,7 @@ describe('CodexView zone projections', () => {
 		let projection: ZoneProjectionVM[] | undefined;
 		const cleanup = $effect.root(() => {
 			$effect(() => {
-				projection = view.zoneProjections;
+				projection = view.zonesTab.zoneProjections;
 			});
 		});
 
@@ -573,7 +576,7 @@ describe('CodexView zone projections', () => {
 		playerChallenges.all = [{ challengeId: 0, progress: 100, completed: true }];
 		flushSync();
 
-		expect(view.zoneProjections).toBe(before);
+		expect(view.zonesTab.zoneProjections).toBe(before);
 		cleanup();
 	});
 });
@@ -581,54 +584,58 @@ describe('CodexView zone projections', () => {
 describe('CodexView zone dossier', () => {
 	it('falls back to the head of the rail when no zone is selected', () => {
 		const view = new CodexView();
-		view.selectedZoneId = -1;
-		expect(view.selectedZone?.id).toBe(0);
+		view.zonesTab.selectedZoneId = -1;
+		expect(view.zonesTab.selectedZone?.id).toBe(0);
 	});
 
 	it('resolves the zone boss card (enemy + fixed level), null when none is authored', () => {
 		const view = new CodexView();
-		view.selectZone(0);
-		expect(view.zoneBoss).toEqual({ enemyId: 2, name: 'Cinder Tyrant', level: 10 });
-		view.selectZone(1);
-		expect(view.zoneBoss).toBeNull();
+		view.zonesTab.selectZone(0);
+		expect(view.zonesTab.zoneBoss).toEqual({ enemyId: 2, name: 'Cinder Tyrant', level: 10 });
+		view.zonesTab.selectZone(1);
+		expect(view.zonesTab.zoneBoss).toBeNull();
 	});
 
 	it('builds the spawn table ordered by share with weight labels', () => {
 		const view = new CodexView();
-		view.selectZone(1); // Bog Lurker (40) + Dust Skitterer (20) → 67% / 33%
-		expect(view.zoneSpawns).toEqual([
+		view.zonesTab.selectZone(1); // Bog Lurker (40) + Dust Skitterer (20) → 67% / 33%
+		expect(view.zonesTab.zoneSpawns).toEqual([
 			expect.objectContaining({ enemyId: 1, enemyName: 'Bog Lurker', share: 67, weightLabel: 'weight 40' }),
 			expect.objectContaining({ enemyId: 0, enemyName: 'Dust Skitterer', share: 33, weightLabel: 'weight 20' })
 		]);
-		expect(view.zoneSpawnCount).toBe(2);
+		expect(view.zonesTab.zoneSpawnCount).toBe(2);
 	});
 
 	it('reports the unlock condition (sealed when locked), null for an always-open zone', () => {
 		const view = new CodexView();
-		view.selectZone(1);
-		expect(view.selectedZoneStatus).toBe('locked');
-		expect(view.zoneUnlock).toMatchObject({ challengeId: 0, challengeName: 'Cull the Skitterers', sealed: true });
-		view.selectZone(2);
-		expect(view.zoneUnlock).toBeNull();
-		expect(view.zoneSpawns).toEqual([]);
+		view.zonesTab.selectZone(1);
+		expect(view.zonesTab.selectedZoneStatus).toBe('locked');
+		expect(view.zonesTab.zoneUnlock).toMatchObject({
+			challengeId: 0,
+			challengeName: 'Cull the Skitterers',
+			sealed: true
+		});
+		view.zonesTab.selectZone(2);
+		expect(view.zonesTab.zoneUnlock).toBeNull();
+		expect(view.zonesTab.zoneSpawns).toEqual([]);
 	});
 
 	it('unseals the unlock condition once the gating challenge completes', () => {
 		playerChallenges.all = [{ challengeId: 0, progress: 100, completed: true }];
 		const view = new CodexView();
-		view.selectZone(1);
-		expect(view.selectedZoneStatus).toBe('unlocked');
-		expect(view.zoneUnlock?.sealed).toBe(false);
+		view.zonesTab.selectZone(1);
+		expect(view.zonesTab.selectedZoneStatus).toBe('unlocked');
+		expect(view.zonesTab.zoneUnlock?.sealed).toBe(false);
 	});
 
 	it('reuses the statistics query for the player’s per-zone record', () => {
 		statistics.stats = STATS;
 		const view = new CodexView();
-		view.selectZone(1); // Ashfen Marsh — 3 clears recorded
-		expect(view.zoneStatistics.find((s) => s.label === 'Zones Cleared')?.value).toBe('3');
+		view.zonesTab.selectZone(1); // Ashfen Marsh — 3 clears recorded
+		expect(view.zonesTab.zoneStatistics.find((s) => s.label === 'Zones Cleared')?.value).toBe('3');
 		// A zone with no recorded statistics yields an empty record.
-		view.selectZone(2);
-		expect(view.zoneStatistics).toEqual([]);
+		view.zonesTab.selectZone(2);
+		expect(view.zonesTab.zoneStatistics).toEqual([]);
 	});
 });
 
@@ -638,37 +645,37 @@ describe('CodexView zone → enemy cross-link', () => {
 		view.selectTab('zones');
 		view.openEnemy(2);
 		expect(view.tab).toBe('enemies');
-		expect(view.selectedEnemyId).toBe(2);
-		expect(view.sub).toBe('attributes'); // selectEnemy resets the sub-tab
-		expect(view.level).toBe(10); // boss fixed level
+		expect(view.enemiesTab.selectedEnemyId).toBe(2);
+		expect(view.enemiesTab.sub).toBe('attributes'); // selectEnemy resets the sub-tab
+		expect(view.enemiesTab.level).toBe(10); // boss fixed level
 	});
 });
 
 describe('CodexView enemy → zone cross-link', () => {
 	it('openZone switches to the Zones tab and selects the zone', () => {
 		const view = new CodexView();
-		view.selectEnemy(0); // a normal enemy with spawn zones
+		view.enemiesTab.selectEnemy(0); // a normal enemy with spawn zones
 		view.openZone(1);
 		expect(view.tab).toBe('zones');
-		expect(view.selectedZoneId).toBe(1);
-		expect(view.selectedZone?.id).toBe(1);
+		expect(view.zonesTab.selectedZoneId).toBe(1);
+		expect(view.zonesTab.selectedZone?.id).toBe(1);
 	});
 });
 
 describe('CodexView enemy → skill cross-link', () => {
 	it('openSkill switches to the Skills tab and selects the skill', () => {
 		const view = new CodexView();
-		view.selectEnemy(0); // skill pool [0, 1]
+		view.enemiesTab.selectEnemy(0); // skill pool [0, 1]
 		view.openSkill(1);
 		expect(view.tab).toBe('skills');
-		expect(view.selectedSkillId).toBe(1);
-		expect(view.selectedSkill?.id).toBe(1);
+		expect(view.skillsTab.selectedSkillId).toBe(1);
+		expect(view.skillsTab.selectedSkill?.id).toBe(1);
 	});
 });
 
 describe('CodexView skill table', () => {
 	it('lists every skill in catalogue order with base/cooldown/used-by projections', () => {
-		const rows = new CodexView().skillRows;
+		const rows = new CodexView().skillsTab.skillRows;
 		expect(rows.map((r) => r.id)).toEqual([0, 1, 2]);
 		// Cleave is a 14-dmg attack used by Dust Skitterer + the boss; War Cry is utility used by all
 		// three; Focus is player-only (used by none) and still appears.
@@ -684,35 +691,35 @@ describe('CodexView skill table', () => {
 
 	it('tracks the selected skill (the row highlight reads selectedSkillId, kept out of the projection)', () => {
 		const view = new CodexView();
-		view.selectSkill(1);
-		expect(view.selectedSkillId).toBe(1);
-		expect(view.selectedSkill?.id).toBe(1);
+		view.skillsTab.selectSkill(1);
+		expect(view.skillsTab.selectedSkillId).toBe(1);
+		expect(view.skillsTab.selectedSkill?.id).toBe(1);
 	});
 
 	it('tints each row by its rarity tier and exposes the selected skill rarity for the dossier', () => {
 		const view = new CodexView();
 		// Cleave is authored Rare; its row mark and the dossier accent resolve to the rarity hue + label.
-		expect(view.skillRows.find((r) => r.id === 0)?.rarityColor).toContain('--rarity-');
-		view.selectSkill(0);
-		expect(view.selectedSkillRarity).toEqual({ color: expect.stringContaining('--rarity-'), label: 'Rare' });
+		expect(view.skillsTab.skillRows.find((r) => r.id === 0)?.rarityColor).toContain('--rarity-');
+		view.skillsTab.selectSkill(0);
+		expect(view.skillsTab.selectedSkillRarity).toEqual({ color: expect.stringContaining('--rarity-'), label: 'Rare' });
 	});
 });
 
 describe('CodexView skill dossier', () => {
 	it('defaults the selection to the head of the catalogue', () => {
-		expect(new CodexView().selectedSkill?.id).toBe(0);
+		expect(new CodexView().skillsTab.selectedSkill?.id).toBe(0);
 	});
 
 	it('selectSkill changes the inspected skill', () => {
 		const view = new CodexView();
-		view.selectSkill(2);
-		expect(view.selectedSkill?.id).toBe(2);
+		view.skillsTab.selectSkill(2);
+		expect(view.skillsTab.selectedSkill?.id).toBe(2);
 	});
 
 	it('projects the damage-scaling attributes tinted by their accent', () => {
 		const view = new CodexView();
-		view.selectSkill(0); // Cleave scales ×1.5 Strength
-		expect(view.skillScaling).toEqual([
+		view.skillsTab.selectSkill(0); // Cleave scales ×1.5 Strength
+		expect(view.skillsTab.skillScaling).toEqual([
 			{
 				attributeId: EAttribute.Strength,
 				name: 'Strength',
@@ -722,14 +729,14 @@ describe('CodexView skill dossier', () => {
 			}
 		]);
 		// War Cry has no damage scaling.
-		view.selectSkill(1);
-		expect(view.skillScaling).toEqual([]);
+		view.skillsTab.selectSkill(1);
+		expect(view.skillsTab.skillScaling).toEqual([]);
 	});
 
 	it('describes effects via the shared helper, classifying buff vs debuff', () => {
 		const view = new CodexView();
-		view.selectSkill(1); // War Cry: +15 STR (self, buff) and ×0.5 Toughness (enemy, debuff)
-		expect(view.skillEffects).toEqual([
+		view.skillsTab.selectSkill(1); // War Cry: +15 STR (self, buff) and ×0.5 Toughness (enemy, debuff)
+		expect(view.skillsTab.skillEffects).toEqual([
 			{
 				id: 0,
 				magnitude: '+15',
@@ -748,46 +755,46 @@ describe('CodexView skill dossier', () => {
 			}
 		]);
 		// Cleave applies no effects.
-		view.selectSkill(0);
-		expect(view.skillEffects).toEqual([]);
+		view.skillsTab.selectSkill(0);
+		expect(view.skillsTab.skillEffects).toEqual([]);
 	});
 
 	it('lists the enemies that use the skill, flagging bosses, and is empty for a player-only skill', () => {
 		const view = new CodexView();
-		view.selectSkill(0); // Cleave — Dust Skitterer (normal) + Cinder Tyrant (boss)
-		expect(view.skillUsedBy).toEqual([
+		view.skillsTab.selectSkill(0); // Cleave — Dust Skitterer (normal) + Cinder Tyrant (boss)
+		expect(view.skillsTab.skillUsedBy).toEqual([
 			{ enemyId: 0, name: 'Dust Skitterer', isBoss: false, accent: 'var(--enemy-accent)' },
 			{ enemyId: 2, name: 'Cinder Tyrant', isBoss: true, accent: 'var(--boss-accent)' }
 		]);
-		view.selectSkill(2); // Focus — player-only
-		expect(view.skillUsedBy).toEqual([]);
+		view.skillsTab.selectSkill(2); // Focus — player-only
+		expect(view.skillsTab.skillUsedBy).toEqual([]);
 	});
 
 	it('reuses the statistics query for the player’s per-skill record', () => {
 		statistics.stats = STATS;
 		const view = new CodexView();
-		view.selectSkill(0); // Cleave — 4,500 damage dealt recorded
-		expect(view.skillStatistics.find((s) => s.label === 'Damage Dealt')?.value).toBe('4,500');
+		view.skillsTab.selectSkill(0); // Cleave — 4,500 damage dealt recorded
+		expect(view.skillsTab.skillStatistics.find((s) => s.label === 'Damage Dealt')?.value).toBe('4,500');
 		// A skill with no recorded statistics yields an empty record.
-		view.selectSkill(2);
-		expect(view.skillStatistics).toEqual([]);
+		view.skillsTab.selectSkill(2);
+		expect(view.skillsTab.skillStatistics).toEqual([]);
 	});
 
 	it('surfaces an item grant as a "Granted by" source, tinted by the item rarity', () => {
 		const view = new CodexView();
-		view.selectSkill(1); // War Cry — granted by the Rare Ember Staff
-		expect(view.skillProvenance.status).toBe('obtainable');
-		expect(view.skillProvenance.sources).toEqual([
+		view.skillsTab.selectSkill(1); // War Cry — granted by the Rare Ember Staff
+		expect(view.skillsTab.skillProvenance.status).toBe('obtainable');
+		expect(view.skillsTab.skillProvenance.sources).toEqual([
 			{ kind: 'item', id: 0, label: 'Granted by', name: 'Ember Staff', accent: 'var(--rarity-rare)' }
 		]);
 	});
 
 	it('words an enemy-flagged skill with no player source as enemy-only', () => {
 		const view = new CodexView();
-		view.selectSkill(2); // Focus — Enemy-flagged, no reward/grant
-		expect(view.skillProvenance.status).toBe('enemy-only');
-		expect(view.skillProvenance.sources).toEqual([]);
-		expect(view.skillProvenance.emptyLabel).toContain('Enemy-only');
+		view.skillsTab.selectSkill(2); // Focus — Enemy-flagged, no reward/grant
+		expect(view.skillsTab.skillProvenance.status).toBe('enemy-only');
+		expect(view.skillsTab.skillProvenance.sources).toEqual([]);
+		expect(view.skillsTab.skillProvenance.emptyLabel).toContain('Enemy-only');
 	});
 
 	it('words a flagged-but-unreferenced skill as not obtainable (intent ≠ reality)', () => {
@@ -795,10 +802,10 @@ describe('CodexView skill dossier', () => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		staticData.skills[2] = { ...(staticData.skills[2] as any), acquisition: ESkillAcquisition.Item };
 		const view = new CodexView();
-		view.selectSkill(2);
-		expect(view.skillProvenance.status).toBe('unobtainable');
-		expect(view.skillProvenance.sources).toEqual([]);
-		expect(view.skillProvenance.emptyLabel).toBe('Not currently obtainable.');
+		view.skillsTab.selectSkill(2);
+		expect(view.skillsTab.skillProvenance.status).toBe('unobtainable');
+		expect(view.skillsTab.skillProvenance.sources).toEqual([]);
+		expect(view.skillsTab.skillProvenance.emptyLabel).toBe('Not currently obtainable.');
 	});
 
 	it('excludes a retired item grant from the sources', () => {
@@ -806,9 +813,9 @@ describe('CodexView skill dossier', () => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		staticData.items[0] = { ...(staticData.items[0] as any), retiredAt: '2026-01-01T00:00:00Z' };
 		const view = new CodexView();
-		view.selectSkill(1); // War Cry — Item-flagged, but its granting item is retired
-		expect(view.skillProvenance.sources).toEqual([]);
-		expect(view.skillProvenance.status).toBe('unobtainable');
+		view.skillsTab.selectSkill(1); // War Cry — Item-flagged, but its granting item is retired
+		expect(view.skillsTab.skillProvenance.sources).toEqual([]);
+		expect(view.skillsTab.skillProvenance.status).toBe('unobtainable');
 	});
 });
 
@@ -818,7 +825,7 @@ describe('CodexView skill → enemy cross-link', () => {
 		view.selectTab('skills');
 		view.openEnemy(2);
 		expect(view.tab).toBe('enemies');
-		expect(view.selectedEnemyId).toBe(2);
+		expect(view.enemiesTab.selectedEnemyId).toBe(2);
 	});
 });
 
@@ -829,40 +836,40 @@ describe('CodexView retired-record resolution', () => {
 	it('resolves a deep-linked retired enemy id instead of falling back to the head of the list', () => {
 		staticData.enemies[1] = { ...staticData.enemies[1], retiredAt: '2026-01-01T00:00:00Z' };
 		const view = new CodexView({ tab: 'enemies', enemyId: 1 });
-		expect(view.selectedEnemy?.id).toBe(1);
+		expect(view.enemiesTab.selectedEnemy?.id).toBe(1);
 	});
 
 	it('selectEnemy resolves a retired id (a cross-link into a retired record)', () => {
 		staticData.enemies[1] = { ...staticData.enemies[1], retiredAt: '2026-01-01T00:00:00Z' };
 		const view = new CodexView();
-		view.selectEnemy(1);
-		expect(view.selectedEnemy?.id).toBe(1);
+		view.enemiesTab.selectEnemy(1);
+		expect(view.enemiesTab.selectedEnemy?.id).toBe(1);
 	});
 
 	it('resolves a deep-linked retired zone id', () => {
 		staticData.zones[1] = { ...staticData.zones[1], retiredAt: '2026-01-01T00:00:00Z' };
 		const view = new CodexView({ tab: 'zones', zoneId: 1 });
-		expect(view.selectedZone?.id).toBe(1);
+		expect(view.zonesTab.selectedZone?.id).toBe(1);
 	});
 
 	it('selectZone resolves a retired id', () => {
 		staticData.zones[1] = { ...staticData.zones[1], retiredAt: '2026-01-01T00:00:00Z' };
 		const view = new CodexView();
-		view.selectZone(1);
-		expect(view.selectedZone?.id).toBe(1);
+		view.zonesTab.selectZone(1);
+		expect(view.zonesTab.selectedZone?.id).toBe(1);
 	});
 
 	it('resolves a deep-linked retired skill id', () => {
 		staticData.skills[1] = { ...staticData.skills[1], retiredAt: '2026-01-01T00:00:00Z' };
 		const view = new CodexView({ tab: 'skills', skillId: 1 });
-		expect(view.selectedSkill?.id).toBe(1);
+		expect(view.skillsTab.selectedSkill?.id).toBe(1);
 	});
 
 	it('selectSkill resolves a retired id', () => {
 		staticData.skills[1] = { ...staticData.skills[1], retiredAt: '2026-01-01T00:00:00Z' };
 		const view = new CodexView();
-		view.selectSkill(1);
-		expect(view.selectedSkill?.id).toBe(1);
+		view.skillsTab.selectSkill(1);
+		expect(view.skillsTab.selectedSkill?.id).toBe(1);
 	});
 });
 
@@ -870,20 +877,20 @@ describe('CodexView nav payload', () => {
 	it('seeds tab / enemy / sub-tab / level from a deep-link payload', () => {
 		const view = new CodexView({ tab: 'enemies', enemyId: 2, sub: 'statistics' });
 		expect(view.tab).toBe('enemies');
-		expect(view.selectedEnemyId).toBe(2);
-		expect(view.sub).toBe('statistics');
-		expect(view.level).toBe(10); // boss fixed level
+		expect(view.enemiesTab.selectedEnemyId).toBe(2);
+		expect(view.enemiesTab.sub).toBe('statistics');
+		expect(view.enemiesTab.level).toBe(10); // boss fixed level
 	});
 
 	it('seeds the tab + zone from a deep-link payload', () => {
 		const view = new CodexView({ tab: 'zones', zoneId: 2 });
 		expect(view.tab).toBe('zones');
-		expect(view.selectedZoneId).toBe(2);
+		expect(view.zonesTab.selectedZoneId).toBe(2);
 	});
 
 	it('seeds the tab + skill from a deep-link payload', () => {
 		const view = new CodexView({ tab: 'skills', skillId: 2 });
 		expect(view.tab).toBe('skills');
-		expect(view.selectedSkillId).toBe(2);
+		expect(view.skillsTab.selectedSkillId).toBe(2);
 	});
 });


### PR DESCRIPTION
## Summary

Two same-flavor dead-surface cleanups from the issue:

**1. `CodexView`'s ~250-line hand-maintained pass-through shim**

`codex-view.svelte.ts` used to re-declare every `EnemiesTabView`/`ZonesTabView`/`SkillsTabView` member as a one-line forward (`get selectedEnemy() { return this.enemiesTab.selectedEnemy; }`, etc.), acknowledged in its own comment as pre-split compatibility. That's now pure carrying cost — a missed forward on a new tab member is a silent runtime `undefined` rather than a compile error.

- `enemiesTab`/`zonesTab`/`skillsTab` are now public (`private readonly` → `readonly`).
- Every tab-specific getter/setter/method delegate on `CodexView` is deleted (~194 net lines off `codex-view.svelte.ts`). What remains is genuinely cross-tab: the active tab, the shared stats/challenge-error state, the statistics query engine, and the `openEnemy`/`openZone`/`openSkill` cross-links.
- Every consuming component (`EnemiesTab`, `EnemyTable`, `EnemyDossier`, `EnemyChallengesPanel`, `EnemySkillsPanel`, `EnemySpawnsPanel`, `AttributesPanel`, `ZoneRail`, `ZoneDossier`, `ZoneSpawnPanel`, `SkillTable`, `SkillDossier`) now reads/calls through the owning tab instance directly (e.g. `view.enemiesTab.selectedEnemy`, `view.zonesTab.selectZone(id)`) instead of the flat `view.<x>` API. Components still take the whole `view: CodexView` prop (they also need the cross-tab links and shared stats state), just address through the tab instance for tab-scoped data.
- `codex-view.svelte.test.ts` updated to match (156+ call sites); no test scenarios changed, only the access path.

**2. Test-only `WorkbenchReference` members**

`pathName`, `entityCatalog`, `skillRecords`, and `skillBaseDamage` had no production caller — verified repo-wide excluding tests — and existed only to be exercised by `reference.test.ts`. Deleted them and their now-orphaned test coverage. While in there, also removed `proficiencyName`, which turned out to have **zero** callers, not even in tests (a stricter case of the same problem, one line, same file/region already being edited).

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — 0 errors across 1199 files. Since `CodexView` is fully typed, a missed/incorrect access-path conversion would have failed type-checking.
- [x] `npm run test:unit:ci` — 3758/3758 tests passed (299 files), including the full `CodexView` suite (search/filter/sort/selection/cross-links/sub-tabs/retired-record resolution/deep-link payloads) and the trimmed `WorkbenchReference` suite.
- [x] `npm run build` — production build succeeds.
- Pure refactor (no behavior/logic change — only property-access paths moved), so no new test scenarios were needed.

Closes #2006


---
_Generated by [Claude Code](https://claude.ai/code/session_01UXj9oqYuAEK9DFwNvwvbZu)_