### PR TITLE
Fix nginx SSR Connection-upgrade map bypass and stale EXPOSE port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,3 @@ FROM nginx:alpine
 
 # Copy to the default server block template directory
 COPY nginx.conf /etc/nginx/templates/default.conf.template
-
-EXPOSE 80

--- a/nginx.conf
+++ b/nginx.conf
@@ -56,7 +56,7 @@ server {
 				
 				# WebSocket support for SSR frameworks (HMR, hydration, etc.)
 				proxy_set_header Upgrade $http_upgrade;
-				proxy_set_header Connection "upgrade";
+				proxy_set_header Connection $connection_upgrade;
 				
 				proxy_set_header Host $host;
 				proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary

Two small deploy-plumbing inconsistencies noted in the scheduled codebase health review:

- **`nginx.conf`** defines `map $http_upgrade $connection_upgrade` specifically so non-WebSocket requests get `Connection: close` instead of a spurious `Connection: upgrade`. The `/socket` location already used the map correctly, but the `location /` SSR catch-all hardcoded `proxy_set_header Connection "upgrade"`, sending `Connection: upgrade` with an empty `Upgrade` header on every ordinary page/asset request to the Node SSR app. Now routed through `$connection_upgrade` like `/socket`.
- **`Dockerfile`** declared `EXPOSE 80`, but per `docs/infrastructure.md`'s description of this image as the nginx edge proxy, `nginx.conf` actually listens on the Railway-templated `${PORT}` — a value injected at deploy time and unknowable at build time. Since there's no correct static value to "align" it to, the misleading `EXPOSE` line is dropped rather than replaced with another wrong port.

## How this addresses the issue

Closes #2007 — implements both suggested fixes exactly as described.

## Test plan

- [x] Read the affected files end-to-end and confirmed both are pure static config with no associated test suite (no code compiles/runs against them in this repo).
- [x] Verified no other file references the removed `EXPOSE 80`.
- [ ] Not deployed to Railway — the templating behavior (`${PORT}` substitution, `$connection_upgrade` map) is standard nginx `envsubst`/map behavior, not something this repo can integration-test locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FAwMHdzSEyCkH5QJtX7m1U)_