### PR TITLE
Fix misleading doc comment on IAttributeUpdate.Amount

### DIFF
--- a/Game.Core/Players/IAttributeUpdate.cs
+++ b/Game.Core/Players/IAttributeUpdate.cs
@@ -11,7 +11,7 @@
         EAttribute Attribute { get; }
 
         /// <summary>
-        /// The amount to update the attribute to.
+        /// The signed delta to apply to the attribute's allocated points (negative to refund).
         /// </summary>
         int Amount { get; }
     }


### PR DESCRIPTION
## Summary

- `Game.Core/Players/IAttributeUpdate.cs` documented `Amount` as "the amount to update the attribute **to**" (an absolute target), but `PlayerStatPoints.TryUpdateAttributes` treats it as a signed **delta** (`allocation.Amount += update.Amount`, with negatives allowed for refunds), and the frontend sends deltas as well.
- Since this interface backs an anti-cheat validation surface (stat point allocation), a wrong doc invites a wrong reimplementation. Updated the comment to describe the actual delta semantics.

## Test plan

- [x] `dotnet build Game.Core/Game.Core.csproj` succeeds
- Doc-comment-only change, no behavior change — no new tests required.

Closes #2008


---
_Generated by [Claude Code](https://claude.ai/code/session_01G9MycVe3HY1vSnTF4nWV1H)_