### PR TITLE
Fold PlayerProgressRepository's hash read + TTL slide into one round trip

### DIFF
--- a/Game.Abstractions/Infrastructure/ICacheService.cs
+++ b/Game.Abstractions/Infrastructure/ICacheService.cs
@@ -75,6 +75,12 @@
         /// </summary>
         public Task<Dictionary<string, string>?> HashGetAllIfExists(string key, CancellationToken cancellationToken = default);
         /// <summary>
+        /// Same as <see cref="HashGetAllIfExists"/>, but also resets the key's TTL to <paramref name="expiry"/>
+        /// in the same round trip on a hit (a no-op on a miss, like <see cref="GetAndRefreshExpiry"/>). Lets a
+        /// sliding-expiration hash read avoid the separate awaited HGETALL followed by a fire-and-forget expire.
+        /// </summary>
+        public Task<Dictionary<string, string>?> HashGetAllAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default);
+        /// <summary>
         /// Atomically writes <paramref name="fields"/> into the Redis hash at <paramref name="key"/> (adding
         /// or overwriting each named field; existing fields not named in <paramref name="fields"/> are left
         /// untouched) and resets the key's TTL to <paramref name="expiry"/>, without awaiting the result

--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -439,6 +439,7 @@ namespace Game.Api.Tests.Unit
             public Task<bool> CompareAndSet(string key, string? expectedValue, string newValue, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void ReclaimAndForget(string key, string ownerValue, TimeSpan expiry) => throw new NotSupportedException();
             public Task<Dictionary<string, string>?> HashGetAllIfExists(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task<Dictionary<string, string>?> HashGetAllAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void HashSetAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry) => throw new NotSupportedException();
             public void HashSetIfExistsAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry) => throw new NotSupportedException();
         }
@@ -510,6 +511,7 @@ namespace Game.Api.Tests.Unit
             public Task<bool> CompareAndSet(string key, string? expectedValue, string newValue, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void ReclaimAndForget(string key, string ownerValue, TimeSpan expiry) => throw new NotSupportedException();
             public Task<Dictionary<string, string>?> HashGetAllIfExists(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task<Dictionary<string, string>?> HashGetAllAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void HashSetAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry) => throw new NotSupportedException();
             public void HashSetIfExistsAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry) => throw new NotSupportedException();
         }

--- a/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
@@ -302,6 +302,55 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task HashGetAllAndRefreshExpiry_OnAMissingKey_ReturnsNullAndDoesNotCreateTheKey()
+        {
+            var key = $"redis-hash-getex-{Guid.NewGuid()}";
+            using var scope = CreateScope();
+            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+
+            var fields = await cache.HashGetAllAndRefreshExpiry(key, TimeSpan.FromSeconds(30));
+
+            Assert.Null(fields);
+            Assert.Null(await cache.HashGetAllIfExists(key));
+        }
+
+        [Fact]
+        public async Task HashGetAllAndRefreshExpiry_OnAnExistingHash_ReturnsFieldsAndRefreshesTtlInOneRoundTrip()
+        {
+            var key = $"redis-hash-getex-{Guid.NewGuid()}";
+            using var scope = CreateScope();
+            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+            cache.HashSetAndForget(key, new Dictionary<string, string> { ["a"] = "1", ["b"] = "2" }, TimeSpan.FromSeconds(2));
+            await WaitForHashFieldCountAsync(cache, key, 2);
+
+            var fields = await cache.HashGetAllAndRefreshExpiry(key, TimeSpan.FromSeconds(30));
+
+            Assert.NotNull(fields);
+            Assert.Equal(2, fields.Count);
+            Assert.Equal("1", fields["a"]);
+            Assert.Equal("2", fields["b"]);
+
+            // The TTL is refreshed well past the 2s seed ceiling, in the same round trip as the read rather
+            // than a separate awaited HGETALL followed by a fire-and-forget expire.
+            var ttl = await ReadTtlAsync(key);
+            Assert.NotNull(ttl);
+            Assert.True(ttl > TimeSpan.FromSeconds(10), $"Expected the TTL to be refreshed past the 2s seed but was {ttl}.");
+        }
+
+        [Fact]
+        public async Task HashGetAllAndRefreshExpiry_OnAKeyHoldingANonHashValue_TreatsItAsAMissAndClearsIt()
+        {
+            // Mirrors HashGetAllIfExists's same self-heal for a stale non-hash representation (#1635).
+            var key = $"redis-hash-getex-{Guid.NewGuid()}";
+            using var scope = CreateScope();
+            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+            await cache.Set(key, "a-stale-string-blob", TimeSpan.FromSeconds(30));
+
+            Assert.Null(await cache.HashGetAllAndRefreshExpiry(key, TimeSpan.FromSeconds(30)));
+            Assert.Null(await cache.Get(key));
+        }
+
+        [Fact]
         public async Task HashSetIfExistsAndForget_WithNoFields_IsANoOp()
         {
             var key = $"redis-hash-{Guid.NewGuid()}";

--- a/Game.DataAccess/Repositories/PlayerProgressRepository.cs
+++ b/Game.DataAccess/Repositories/PlayerProgressRepository.cs
@@ -183,16 +183,15 @@ namespace Game.DataAccess.Repositories
             }
 
             var key = ProgressKey(playerId);
-            var raw = await _cache.HashGetAllIfExists(key, cancellationToken);
+            // Sliding expiration: a hit refreshes the idle TTL so an active player never ages out, folded into
+            // the same round trip as the read (#2019) rather than a separate fire-and-forget expire.
+            var raw = await _cache.HashGetAllAndRefreshExpiry(key, ProgressCacheTtl, cancellationToken);
             CachedPlayerProgress? progress = null;
             if (raw is not null)
             {
                 try
                 {
                     progress = FromHashFields(raw);
-
-                    // Sliding expiration: a cache hit refreshes the idle TTL so an active player never ages out.
-                    _cache.ExpireAndForget(key, ProgressCacheTtl);
                 }
                 catch (JsonException ex)
                 {

--- a/Game.Infrastructure/Cache/Redis/RedisService.cs
+++ b/Game.Infrastructure/Cache/Redis/RedisService.cs
@@ -162,19 +162,7 @@ namespace Game.Infrastructure.Cache.Redis
                 + "return redis.call('hgetall', KEYS[1])",
                 [key]), cancellationToken);
 
-            if (result.IsNull)
-            {
-                return null;
-            }
-
-            var flat = (RedisValue[])result!;
-            var fields = new Dictionary<string, string>(flat.Length / 2);
-            for (var i = 0; i < flat.Length; i += 2)
-            {
-                fields[flat[i]!] = flat[i + 1]!;
-            }
-
-            return fields;
+            return MapHashResult(result);
         }
 
         public async Task<Dictionary<string, string>?> HashGetAllAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default)
@@ -194,6 +182,14 @@ namespace Game.Infrastructure.Cache.Redis
                 + "return result",
                 [key], [(RedisValue)(long)expiry.TotalMilliseconds]), cancellationToken);
 
+            return MapHashResult(result);
+        }
+
+        // Shared by HashGetAllIfExists and HashGetAllAndRefreshExpiry: both scripts return either a Lua false
+        // (told apart from an empty hash by RedisResult.IsNull) or the flat HGETALL reply, so the
+        // flat-array-to-dictionary conversion — and the null-forgiving indexing it requires — lives in one place.
+        private static Dictionary<string, string>? MapHashResult(RedisResult result)
+        {
             if (result.IsNull)
             {
                 return null;

--- a/Game.Infrastructure/Cache/Redis/RedisService.cs
+++ b/Game.Infrastructure/Cache/Redis/RedisService.cs
@@ -177,6 +177,38 @@ namespace Game.Infrastructure.Cache.Redis
             return fields;
         }
 
+        public async Task<Dictionary<string, string>?> HashGetAllAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default)
+        {
+            // Same TYPE-then-HGETALL script as HashGetAllIfExists, plus a PEXPIRE on the hit path so a
+            // sliding-expiration hash read pays one round trip instead of an awaited HGETALL followed by a
+            // fire-and-forget expire (mirroring GetAndRefreshExpiry's GETEX win for string keys, which GETEX
+            // itself can't serve here since it only applies to strings). The PEXPIRE makes this a write, so it
+            // routes through ObserveWrite like GetAndRefreshExpiry rather than the plain-read path
+            // HashGetAllIfExists uses.
+            var result = await ObserveWrite(Redis.ScriptEvaluateAsync(
+                "local t = redis.call('type', KEYS[1]).ok "
+                + "if t == 'none' then return false end "
+                + "if t ~= 'hash' then redis.call('del', KEYS[1]) return false end "
+                + "local result = redis.call('hgetall', KEYS[1]) "
+                + "redis.call('pexpire', KEYS[1], ARGV[1]) "
+                + "return result",
+                [key], [(RedisValue)(long)expiry.TotalMilliseconds]), cancellationToken);
+
+            if (result.IsNull)
+            {
+                return null;
+            }
+
+            var flat = (RedisValue[])result!;
+            var fields = new Dictionary<string, string>(flat.Length / 2);
+            for (var i = 0; i < flat.Length; i += 2)
+            {
+                fields[flat[i]!] = flat[i + 1]!;
+            }
+
+            return fields;
+        }
+
         public void HashSetAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry)
         {
             if (fields.Count == 0)


### PR DESCRIPTION
## Summary

Follow-up from #1925 / #2018, which collapsed the sliding-TTL `Get` + fire-and-forget `ExpireAndForget` pattern into a single Redis `GETEX` round trip for string keys (`PlayerRepository.GetPlayer`, `SessionStore.GetSession`). `PlayerProgressRepository.GetCachedProgress` has the same read-then-slide shape, but its key is a Redis **hash**, so `GETEX` doesn't apply — this was deliberately left out of that PR and tracked here as #2019.

- Added `ICacheService.HashGetAllAndRefreshExpiry`, implemented in `RedisService` as a single Lua script that does `TYPE`/`HGETALL` + `PEXPIRE` atomically — mirroring the existing `HashGetAllIfExists` script's shape (including its wrong-representation self-heal: a non-hash key is deleted and treated as a miss) with the TTL refresh folded into the same round trip.
- Swapped `PlayerProgressRepository.GetCachedProgress`'s `HashGetAllIfExists` + `ExpireAndForget` pair for the new primitive, halving Redis command volume on the per-battle cached-progress read path.
- `HashGetAllIfExists` itself is untouched and still used elsewhere (`PlayerRepository`), so it stays.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test --no-build --no-restore` — full suite green (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests all passed)
- [x] Added integration coverage for the new primitive in `RedisServiceIntegrationTests`: hit refreshes TTL + returns fields in one round trip, miss returns null and creates no key, and the non-hash self-heal behavior — matching the `GetAndRefreshExpiry` tests added in #2018.
- [x] Updated the two hand-rolled `ICacheService` test doubles (`SocketCommandProcessorTests`) to implement the new interface member.

Closes #2019


---
_Generated by [Claude Code](https://claude.ai/code/session_014r89iMjpsNibzDjTdL8Ljt)_