### PR TITLE
Floor avoided/counter damage tallies at 0 under authored absorption (#2091)

### DIFF
--- a/Game.Core.Tests/Battle/BattleContextTests.cs
+++ b/Game.Core.Tests/Battle/BattleContextTests.cs
@@ -371,6 +371,23 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(0, context.Stats.DamageDodged, 0.001);
         }
 
+        [Fact]
+        public void DamageTarget_PlayerDodge_AbsorptionResistance_FloorsAvoidedDamageAtZero()
+        {
+            // FireResistance 2.0 drives ComputeNetDamage negative (a would-be heal) — an absorbed hit avoided
+            // no real damage, so the dodged tally floors at 0 instead of decrementing the lifetime
+            // DamageDodged statistic (#2091).
+            var player = MakeBattlerWith((DodgeChance, 1), (FireResistance, 2.0));
+            var enemy = MakeBattlerWith((Endurance, 0));
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+            context.SwapActiveAndTargetBattlers();
+
+            context.DamageTarget(20, Single(EDamageType.Fire), 0);
+
+            Assert.Equal(1, context.Stats.AttacksDodged);
+            Assert.Equal(0, context.Stats.DamageDodged, 0.001);
+        }
+
         // ── DamageTarget: RNG draw order ─────────────────────────────────────
 
         [Fact]
@@ -885,6 +902,22 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(1, context.Stats.AttacksDodged);
             Assert.Equal(40, context.Stats.DamageDodged, 0.001);
             Assert.Empty(context.Stats.TypedDamageExposure); // a dodge records no exposure
+        }
+
+        [Fact]
+        public void DamageTarget_MultiPortion_DodgeWithAbsorption_FloorsEachPortionIndividually()
+        {
+            // Physical avoided = 5 (no resistance); Fire avoided would be 95 × (1 − 2) = −95 (absorbed, FireResistance
+            // 2.0). Flooring EACH portion at 0 before summing gives 5 + 0 = 5; flooring only the summed total
+            // would instead give max(0, 5 − 95) = 0 — the two disagree, proving the floor is per portion (#2091).
+            var player = MakeBattlerWith((DodgeChance, 1), (FireResistance, 2.0));
+            var enemy = MakeBattlerWith((Endurance, 0));
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+            context.SwapActiveAndTargetBattlers();
+
+            context.DamageTarget(100, Portions((EDamageType.Physical, 5), (EDamageType.Fire, 95)), 0);
+
+            Assert.Equal(5, context.Stats.DamageDodged, 0.001);
         }
 
         [Fact]
@@ -1828,6 +1861,45 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(1, context.Stats.AttacksParried);
             Assert.Equal(15, context.Stats.DamageParried, 0.001);
             Assert.Equal(0, context.Stats.PlayerDamageTaken, 0.001);
+            Assert.Equal(0, context.Stats.PlayerCounterDamageDealt, 0.001);
+        }
+
+        [Fact]
+        public void DamageTarget_PlayerParry_AbsorptionResistance_FloorsAvoidedDamageAtZero()
+        {
+            // FireResistance 2.0 drives ComputeNetDamage negative (a would-be heal) — an absorbed hit avoided
+            // no real damage, so the parried tally floors at 0 instead of decrementing the lifetime
+            // DamageParried statistic (#2091).
+            var player = MakeBattlerWith((ParryChance, 1), (FireResistance, 2.0));
+            var enemy = MakeBattlerWith((Endurance, 0));
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+            context.SwapActiveAndTargetBattlers();
+
+            context.DamageTarget(20, Single(EDamageType.Fire), 0);
+
+            Assert.Equal(1, context.Stats.AttacksParried);
+            Assert.Equal(0, context.Stats.DamageParried, 0.001);
+        }
+
+        [Fact]
+        public void DamageTarget_ParryCounter_AbsorbedByTheEnemy_BooksNoNegativeCounterDamage()
+        {
+            // The enemy absorbs (FireResistance 2.0) the riposte, which would otherwise heal it back toward
+            // MaxHealth. A prior physical hit first brings the enemy below MaxHealth so the absorption heal
+            // has room to actually apply (TakeDamage's absorption branch only returns a negative net when
+            // CapHealToRoom's room is positive, mirroring DamageTarget_ResistanceAboveOne_HealsTheTarget). An
+            // absorbed counter avoided no real damage either, so it floors at 0 rather than going negative
+            // (#2091) — the sanity assertion on the enemy's health confirms the absorption genuinely happened.
+            var counter = MakeCounterSkill(20, damageType: EDamageType.Fire);
+            var player = MakeBattlerWithCounter(counter, (ParryChance, 1));
+            var enemy = MakeBattlerWith((Endurance, 0), (FireResistance, 2.0)); // MaxHealth 50, Toughness 0
+            var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
+            context.DamageTarget(30, Single(EDamageType.Physical), 0); // 50 → 20 health, opens 30 of heal room
+            context.SwapActiveAndTargetBattlers();
+
+            context.DamageTarget(20, Single(EDamageType.Physical), 0); // parried; the Fire riposte is absorbed
+
+            Assert.Equal(40, enemy.CurrentHealth, 0.001); // 20 + min(20, 30 room) — absorption genuinely healed it
             Assert.Equal(0, context.Stats.PlayerCounterDamageDealt, 0.001);
         }
 

--- a/Game.Core/Battle/BattleContext.cs
+++ b/Game.Core/Battle/BattleContext.cs
@@ -218,7 +218,7 @@ namespace Game.Core.Battle
                 // scaled by the active battler's CriticalChanceMultiplier (base 1, so an uncommitted skill still
                 // crits at its own authored rate and further investment scales it). A single crit multiplies
                 // every portion (× 1.0 when it misses is exact, so a non-crit is unchanged).
-                totalNet = ResolvePlayerHit(rawDamage, portions, totalWeight, baseCriticalChance, _rng.Next());
+                totalNet = ResolvePlayerHit(rawDamage, portions, totalWeight, baseCriticalChance, _rng.Next(), out _);
             }
             else
             {
@@ -236,12 +236,14 @@ namespace Game.Core.Battle
                 {
                     // A parry negates the whole hit exactly like a dodge — the avoided damage is each portion's
                     // net (resistance then the Toughness curve) computed without mutating health, and no exposure
-                    // is recorded — and then ripostes with the defender's counter skill.
+                    // is recorded — and then ripostes with the defender's counter skill. A portion an authored
+                    // absorption (resistance > 1) would have healed avoided no damage, so it is floored at 0
+                    // rather than decrementing the tally (#2091).
                     Stats.AttacksParried++;
                     for (var i = 0; i < portions.Count; i++)
                     {
                         var dealt = AmplifiedPortion(rawDamage, totalWeight, portions[i]);
-                        Stats.DamageParried += _targetBattler.ComputeNetDamage(dealt, portions[i].Type);
+                        Stats.DamageParried += Math.Max(0, _targetBattler.ComputeNetDamage(dealt, portions[i].Type));
                     }
 
                     FireParryCounter(counterCritDraw);
@@ -250,12 +252,13 @@ namespace Game.Core.Battle
                 {
                     // A dodge zeroes the whole hit; the avoided damage is the sum of each portion's net (resistance
                     // then the Toughness curve), computed without mutating health. A dodge evaded the hit
-                    // entirely, so no exposure is recorded (it trains evasion instead).
+                    // entirely, so no exposure is recorded (it trains evasion instead). Floored per portion at 0
+                    // for the same absorption reason as the parry tally above (#2091).
                     Stats.AttacksDodged++;
                     for (var i = 0; i < portions.Count; i++)
                     {
                         var dealt = AmplifiedPortion(rawDamage, totalWeight, portions[i]);
-                        Stats.DamageDodged += _targetBattler.ComputeNetDamage(dealt, portions[i].Type);
+                        Stats.DamageDodged += Math.Max(0, _targetBattler.ComputeNetDamage(dealt, portions[i].Type));
                     }
                 }
                 else
@@ -290,9 +293,16 @@ namespace Game.Core.Battle
         /// with its crit draw supplied by the caller (the enemy fire's third unconditional draw) rather than
         /// drawn here. Requires the player to be the active battler.
         /// </summary>
+        /// <param name="totalNetFloored">
+        /// The same per-portion nets as the return value, but each portion floored at 0 before summing (#2091)
+        /// — unlike <paramref name="rawDamage"/>'s uncapped return, an absorbed (healed) portion contributes
+        /// nothing rather than pulling the total negative, while a killing portion's overkill is still kept (it
+        /// deliberately does <b>not</b> apply <see cref="Battler.HealthRemoved"/>'s health cap, unlike the typed
+        /// offense book). Consumed by <see cref="FireParryCounter"/> for <see cref="BattleStats.PlayerCounterDamageDealt"/>.
+        /// </param>
         private double ResolvePlayerHit(
             double rawDamage, IReadOnlyList<SkillDamagePortion> portions, double totalWeight,
-            double baseCriticalChance, double critDraw)
+            double baseCriticalChance, double critDraw, out double totalNetFloored)
         {
             var isCrit = critDraw < baseCriticalChance * _activeBattler.GetAttributeValue(CriticalChanceMultiplier);
             var critMultiplier = isCrit ? _activeBattler.GetAttributeValue(CriticalDamage) : 1.0;
@@ -317,6 +327,7 @@ namespace Game.Core.Battle
 
             var totalNet = 0.0;
             var totalBooked = 0.0;
+            var netFloored = 0.0;
             for (var i = 0; i < portions.Count; i++)
             {
                 var type = portions[i].Type;
@@ -330,6 +341,7 @@ namespace Game.Core.Battle
                 var booked = Battler.HealthRemoved(net, healthBefore);
                 Stats.AddTypedDamageDealt(type, booked);
                 totalNet += net;
+                netFloored += Math.Max(0, net);
 
                 // Every overlay tally books a share claim on the damage this portion actually landed (#1481):
                 // the booked (health-capped) net × φ(its own investment) — one uniform shape with no
@@ -392,6 +404,7 @@ namespace Game.Core.Battle
                 Stats.HighestPlayerAttack = totalNet;
             }
 
+            totalNetFloored = netFloored;
             return totalNet;
         }
 
@@ -407,7 +420,9 @@ namespace Game.Core.Battle
         /// <paramref name="counterCritDraw"/> (the enemy fire's third unconditional draw), so a defender with
         /// no resolvable counter skill (which parries without a riposte) leaves the stream identical. The
         /// counter's net is additionally booked as <see cref="BattleStats.PlayerCounterDamageDealt"/> — the
-        /// Riposte training signal, a direct tally like Retribution's.
+        /// Riposte training signal, a direct tally like Retribution's — with each portion floored at 0 so an
+        /// enemy that absorbs (resistance > 1) one portion of the riposte contributes nothing for it rather
+        /// than pulling the tally negative (#2091).
         /// </summary>
         private void FireParryCounter(double counterCritDraw)
         {
@@ -427,8 +442,9 @@ namespace Game.Core.Battle
             }
 
             var counterNet = ResolvePlayerHit(
-                raw, counterPortions, totalWeight, counterSkill.CriticalChance, counterCritDraw);
-            Stats.PlayerCounterDamageDealt += counterNet;
+                raw, counterPortions, totalWeight, counterSkill.CriticalChance, counterCritDraw,
+                out var counterNetFloored);
+            Stats.PlayerCounterDamageDealt += counterNetFloored;
             // The enemy's deterministic reflection applies to the counter like any direct hit it takes (the
             // counter is a genuine attack, subject to the target's defenses — unlike reflection itself, which
             // never chains: reflected damage is not routed through this pipeline).

--- a/Game.Core/Battle/BattleContext.cs
+++ b/Game.Core/Battle/BattleContext.cs
@@ -236,9 +236,9 @@ namespace Game.Core.Battle
                 {
                     // A parry negates the whole hit exactly like a dodge — the avoided damage is each portion's
                     // net (resistance then the Toughness curve) computed without mutating health, and no exposure
-                    // is recorded — and then ripostes with the defender's counter skill. A portion an authored
-                    // absorption (resistance > 1) would have healed avoided no damage, so it is floored at 0
-                    // rather than decrementing the tally (#2091).
+                    // is recorded — and then ripostes with the defender's counter skill. A portion that an
+                    // authored absorption (resistance > 1) would have healed avoided no real damage, so it is
+                    // floored at 0 rather than decrementing the tally (#2091).
                     Stats.AttacksParried++;
                     for (var i = 0; i < portions.Count; i++)
                     {
@@ -294,11 +294,11 @@ namespace Game.Core.Battle
         /// drawn here. Requires the player to be the active battler.
         /// </summary>
         /// <param name="totalNetFloored">
-        /// The same per-portion nets as the return value, but each portion floored at 0 before summing (#2091)
-        /// — unlike <paramref name="rawDamage"/>'s uncapped return, an absorbed (healed) portion contributes
-        /// nothing rather than pulling the total negative, while a killing portion's overkill is still kept (it
-        /// deliberately does <b>not</b> apply <see cref="Battler.HealthRemoved"/>'s health cap, unlike the typed
-        /// offense book). Consumed by <see cref="FireParryCounter"/> for <see cref="BattleStats.PlayerCounterDamageDealt"/>.
+        /// The same per-portion nets as the (uncapped) return value, but each portion floored at 0 before
+        /// summing (#2091) — an absorbed (healed) portion contributes nothing rather than pulling the total
+        /// negative, while a killing portion's overkill is still kept (it deliberately does <b>not</b> apply
+        /// <see cref="Battler.HealthRemoved"/>'s health cap, unlike the typed offense book). Consumed by
+        /// <see cref="FireParryCounter"/> for <see cref="BattleStats.PlayerCounterDamageDealt"/>.
         /// </param>
         private double ResolvePlayerHit(
             double rawDamage, IReadOnlyList<SkillDamagePortion> portions, double totalWeight,


### PR DESCRIPTION
## Summary

`ComputeNetDamage` deliberately returns a **negative** net when a damage type's summed resistance exceeds 1 (authored absorption — a supported mechanic). Three battle-stat tallies in `BattleContext.cs` consumed that value without guarding its sign:

- `Stats.DamageParried` (parry-avoided-damage loop)
- `Stats.DamageDodged` (dodge-avoided-damage loop)
- `Stats.PlayerCounterDamageDealt` (the parry riposte's booked damage)

At battle completion these feed `PlayerProgress.Record(...)` with **Sum** aggregation, so an absorbed dodge/parry/counter would silently **decrement** the player's lifetime `DamageDodged`/`DamageParried` statistics, recompute an "AtLeast" challenge's progress downward, and (within a mixed-type battle) offset the Evasion/Riposte proficiency training totals for other, non-absorbed hits in the same battle (`ProficiencyAccrual`'s `amount > 0` guard only checks the aggregated battle total, not per-hit sign).

This mirrors the policy the sibling overlay tallies (Hex, Sunder, Momentum, Cull, Crit) already enforce per #1927/#1482 — "an absorbed portion trains nothing" — which these three tallies hadn't adopted.

## Fix

Floor each portion's avoided/countered net at **0** before booking, rather than letting a negative (absorption) portion pull the running total down:

- `DamageTarget`'s parry and dodge loops now wrap `ComputeNetDamage(...)` in `Math.Max(0, ...)` per portion.
- `ResolvePlayerHit` (the shared player-fire pipeline the parry riposte routes through) now also returns a `totalNetFloored` out-value — the same per-portion nets as its normal return, but each floored at 0 before summing. It deliberately does **not** apply the offense book's health-removed overkill cap, so a counter that kills the enemy still books its full gross damage (unchanged from today), while an absorbed portion contributes nothing instead of going negative.
- `FireParryCounter` books `PlayerCounterDamageDealt` from that floored value instead of the raw (potentially negative) total.

The flooring happens per-portion (not on the summed total), so a multi-type hit where one portion is absorbed and another isn't still credits the non-absorbed portion in full — covered by a dedicated test.

## Scope note

This is content-gated today — no authored enemy or gear currently carries resistance above 1 — but the mechanic is explicitly supported, so the fix lands ahead of that content per the issue's own framing.

While implementing this I found a related but architecturally distinct gap: the offense book (`TypedDamageDealt`, fed by a *different* clamp — `Battler.HealthRemoved`'s overkill cap) can also go negative under enemy-side absorption, reaching `ProficiencyAccrual`'s activity folding (no sign guard there either) and the kill-by-damage-type majority-type pick. That needs its own design pass (whether the floor belongs in `HealthRemoved` itself, which has other callers), so I filed it separately as #2101 rather than folding it into this PR.

## Test plan

- [x] Added `BattleContextTests`: dodge/parry/counter each get a dedicated absorption-floors-at-zero test, plus a multi-portion test proving the floor applies **per portion** (not to the summed total — a case where the two approaches would disagree).
- [x] Verified the new tests fail against the pre-fix code (4 failures) and pass after the fix (all green).
- [x] `dotnet build Game.sln` — 0 errors, 0 warnings.
- [x] `dotnet test Game.sln` — full suite green (Core 1371, Infrastructure 66, Application 991, Api 821).
- [x] No frontend changes — these are server-only progression/statistics tallies (dodge/parry/riposte rolls aren't part of the frontend's battle simulation), not part of the tick-by-tick frontend/backend parity surface.

Closes #2091

---
_Generated by [Claude Code](https://claude.ai/code/session_019XoMuuntnUKYVqiShyLnAY)_