### PR TITLE
Clear the tutorial-tour store on stopGame teardown (#2092)

### DIFF
--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -32,7 +32,8 @@ import {
 	toastSuccess,
 	navigation,
 	clearToasts,
-	clearModals
+	clearModals,
+	tutorialTour
 } from '$stores';
 import {
 	apiSocket,
@@ -368,6 +369,9 @@ const stopGame = () => {
 	clearToasts();
 	clearModals();
 	navigation.reset();
+	// A coach-mark tour left open must not leak into the next character's session and mark its
+	// lesson read on the wrong character (#2092).
+	tutorialTour.clear();
 	// SocketReplaced routes back to login client-side (no reload), so the socket singleton survives. Tear
 	// it down explicitly, otherwise the keepalive ping would silently reconnect and fight the session that
 	// just took over.

--- a/UI/src/tests/lib/engine/engine.test.ts
+++ b/UI/src/tests/lib/engine/engine.test.ts
@@ -50,8 +50,11 @@ const {
 }));
 vi.mock('$stores', async () => {
 	const modal = await vi.importActual<typeof import('$stores/modal.svelte')>('$stores/modal.svelte');
+	const tutorialTourModule =
+		await vi.importActual<typeof import('$stores/tutorial-tour.svelte')>('$stores/tutorial-tour.svelte');
 	return {
 		...modal,
+		...tutorialTourModule,
 		staticData: staticDataStub,
 		statistics: statisticsStub,
 		playerChallenges: playerChallengesStub,
@@ -162,10 +165,12 @@ import {
 	inventoryManager
 } from '$lib/engine/engine';
 import { activeModal, clearModals, confirmActiveModal, showModal } from '$stores/modal.svelte';
+import { tutorialTour } from '$stores/tutorial-tour.svelte';
 import { createHook } from '$lib/common/hooks';
 import { onDestroy } from 'svelte';
 import {
 	EItemCategory,
+	ELessonTriggerType,
 	ELogType,
 	ERarity,
 	type IApiSocketResponse,
@@ -185,6 +190,7 @@ let hidden = false;
 beforeEach(() => {
 	vi.clearAllMocks();
 	clearModals();
+	tutorialTour.clear();
 	hidden = false;
 	Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
 	staticDataStub.loaded = true;
@@ -224,6 +230,7 @@ beforeEach(() => {
 
 afterEach(() => {
 	clearModals();
+	tutorialTour.clear();
 	// vi.unstubAllGlobals doesn't undo a defineProperty, so drop the own-property override of
 	// document.hidden and let it fall back to the jsdom prototype getter.
 	delete (document as unknown as Record<string, unknown>).hidden;
@@ -387,6 +394,24 @@ describe('startGame', () => {
 		void handleSocketReplaced();
 
 		expect(navigation.reset).toHaveBeenCalledTimes(1);
+	});
+
+	it('stopGame clears an open coach-mark tour so it cannot leak onto the next character (#2092)', () => {
+		startGame();
+		tutorialTour.play({
+			id: 1,
+			key: 'lesson-key',
+			name: 'Lesson Name',
+			triggerType: ELessonTriggerType.ScreenVisit,
+			screenKey: 'fight',
+			ordinal: 0,
+			designerNotes: '',
+			steps: [{ ordinal: 0, text: 'Step text' }]
+		});
+
+		void handleSocketReplaced();
+
+		expect(tutorialTour.activeLesson).toBeNull();
 	});
 
 	it("unhooks the previous call's listeners before re-registering, so a remount cannot leak them (#1807)", () => {


### PR DESCRIPTION
## Summary

`stopGame` (`UI/src/lib/engine/engine.ts`) clears the other module-level UI stores on a `SocketReplaced` teardown — toasts, modals, the navigation intent — but never touched `tutorialTour` (`UI/src/stores/tutorial-tour.svelte.ts`), the store backing the coach-mark tour overlay. Since `SocketReplaced` routes back to login **client-side** (no reload), module-level singletons survive the takeover.

## Failure scenario (from the issue)

1. A coach-mark tour is open when `SocketReplaced` lands (or the takeover lands while parked on `/admin` mid-tour).
2. `stopGame` runs, the user is routed to login client-side.
3. The user logs in as a **different character** → `/game` mounts and `TourPlayer` immediately reopens with the previous character's lesson still active.
4. Dismissing it calls `closeTutorialTour` → `playerManager.markLessonRead(lesson.id)`, permanently marking a lesson read for a character that never saw it.

## Fix

- `stopGame` now calls `tutorialTour.clear()` alongside the other UI-store resets.
- Extended `engine.test.ts`'s `stopGame` teardown suite (mirroring the existing toast/modal/navigation-intent assertions) with a test that opens a tour via `tutorialTour.play(...)` and asserts `handleSocketReplaced` clears `tutorialTour.activeLesson`.
- The `$stores` mock in `engine.test.ts` now also spreads the real `tutorial-tour.svelte` module (previously only the real `modal.svelte` module was spread in), so the store's actual state is exercised rather than silently resolving to `undefined`.

## Test plan

- [x] `npx vitest run src/tests/lib/engine/engine.test.ts` — 55/55 passing, including the new teardown test.
- [x] `npm run test:unit:ci` — full frontend suite, 299 files / 3759 tests passing.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- No backend changes.

Closes #2092


---
_Generated by [Claude Code](https://claude.ai/code/session_01MR4Hcc8oU77RE7KLWJLyXY)_