### PR TITLE
Override live paths (not just proficiencies) in path retire-confirm (#2099)

### DIFF
--- a/UI/src/routes/admin/workbench/progression/PathDetail.svelte
+++ b/UI/src/routes/admin/workbench/progression/PathDetail.svelte
@@ -68,7 +68,7 @@
 {/if}
 
 <script lang="ts">
-import { referenceSourcesFromStatic, retireWithConfirm } from '../retire-confirm';
+import { denseByLiveId, referenceSourcesFromStatic, retireWithConfirm } from '../retire-confirm';
 import type { ProgressionStore, PathTab } from './progression-store.svelte';
 import { activityKeyGroups, hasTierCollision, pathWarnings } from './progression-helpers';
 import type { WorkbenchPath } from './types';
@@ -87,6 +87,12 @@ const { store }: Props = $props();
  * Retire a path, first surfacing any live gateway one of its tiers would soft-lock — the same
  * check the backend guard (`AdminPaths.FindRetiredPathGatingLiveGateway`) rejects the save on.
  * Previously bypassed the confirm entirely (#1863), unlike every other retire path.
+ *
+ * Overrides both `proficiencies` and `paths` with this session's live (unsaved-edits-included)
+ * copies — `pathReferences` reads `store.paths`' own `retiredAt` to decide whether a gating path
+ * is still live (#2099), not just `store.profs` for the tiers themselves. `paths` needs the
+ * dense-by-id rebuild since `addPath` prepends unsaved paths with negative ids, unlike `profs`
+ * which `pathReferences`/`proficiencyReferences` only ever `.filter()`, never index by id.
  */
 const onRetire = (rec: WorkbenchPath) =>
 	retireWithConfirm({
@@ -94,7 +100,7 @@ const onRetire = (rec: WorkbenchPath) =>
 		id: rec.id,
 		name: rec.name || 'Unnamed path',
 		title: 'Retire path?',
-		sources: referenceSourcesFromStatic({ proficiencies: store.profs }),
+		sources: referenceSourcesFromStatic({ proficiencies: store.profs, paths: denseByLiveId(store.paths) }),
 		onConfirmed: () => store.retirePath(rec.id, true)
 	});
 

--- a/UI/src/routes/admin/workbench/retire-confirm.ts
+++ b/UI/src/routes/admin/workbench/retire-confirm.ts
@@ -39,12 +39,13 @@ const SELF_REFERENCING_KEYS = new Set(['enemies', 'skills']);
 /**
  * Rebuilds a zero-based-id-indexed array from a store's live `items`, honouring the Id-as-index
  * invariant `references.ts`'s self-referential lookups rely on (`docs/backend.md` → _Reference
- * Data_). `EntityStore.addItem` prepends new records with negative ids, shifting every saved
- * record's array position, so indexing the live array directly would resolve the wrong record. A
- * never-saved (negative-id) record is dropped: only an already-saved record can be a retire target
- * or a referencing recipe's result, so none is looked up by id here.
+ * Data_). A store that prepends new records with negative ids (`EntityStore.addItem`,
+ * `ProgressionStore.addPath`) shifts every saved record's array position, so indexing the live
+ * array directly would resolve the wrong record. A never-saved (negative-id) record is dropped:
+ * only an already-saved record can be a retire target or a referencing recipe's result, so none
+ * is looked up by id here.
  */
-function denseByLiveId<T extends { id: number }>(live: T[]): T[] {
+export function denseByLiveId<T extends { id: number }>(live: T[]): T[] {
 	const dense: T[] = [];
 	for (const record of live) {
 		if (record.id >= 0) {

--- a/UI/src/tests/routes/admin/workbench/progression/PathDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/PathDetail.test.ts
@@ -13,7 +13,8 @@ const { staticData, dangerModal } = vi.hoisted(() => ({
 		classes: [] as unknown[],
 		skillRecipes: [] as unknown[],
 		proficiencies: [] as unknown[],
-		skills: [] as unknown[]
+		skills: [] as unknown[],
+		paths: [] as unknown[]
 	},
 	dangerModal: vi.fn()
 }));
@@ -58,6 +59,7 @@ const makeStore = (selectedPath: WorkbenchPath, overrides: Record<string, unknow
 	({
 		selectedPath,
 		profs: [],
+		paths: [],
 		currentTiers: [],
 		pathTab: 'identity',
 		saving: false,
@@ -82,6 +84,7 @@ beforeEach(() => {
 	staticData.skillRecipes = [];
 	staticData.proficiencies = [];
 	staticData.skills = [];
+	staticData.paths = [];
 });
 afterEach(cleanup);
 
@@ -140,5 +143,58 @@ describe('PathDetail — retire confirm dialog (#1863)', () => {
 		expect(screen.queryByText('Retire')).toBeNull();
 		await fireEvent.click(screen.getByText('Reinstate'));
 		expect(store.retirePath).toHaveBeenCalledWith(5, false);
+	});
+});
+
+describe('PathDetail — retire confirm honours this session’s live paths, not just staticData (#2099)', () => {
+	it('does not warn when the gating tier lives on a path retired only in this session (staticData still shows it live)', async () => {
+		// Path 9 ("Runeforging's" path) is retired live this session but not yet saved — staticData
+		// (last-saved) still shows it live, so a naive staticData-only check would wrongly warn.
+		const gatingTier = tier({ id: 6, name: 'Runeforging', pathId: 9, prerequisiteIds: [0] });
+		staticData.paths = [path({ id: 9, name: 'Elemental Path', activityKey: EActivityKey.Fire })];
+		const liveRetiredGatingPath = path({ id: 9, name: 'Elemental Path', retiredAt: '2026-07-17T00:00:00Z' });
+		const store = makeStore(path(), { profs: [tier(), gatingTier], paths: [liveRetiredGatingPath] });
+		render(PathDetail, { props: { store } });
+
+		await fireEvent.click(screen.getByText('Retire'));
+
+		expect(dangerModal).not.toHaveBeenCalled();
+		expect(store.retirePath).toHaveBeenCalledWith(5, true);
+	});
+
+	it('warns when the gating tier lives on a path reinstated only in this session (staticData still shows it retired)', async () => {
+		// Inverse: staticData (last-saved) shows path 9 retired, but this session reinstated it live —
+		// a naive staticData-only check would wrongly skip the warning the backend guard would still enforce.
+		dangerModal.mockResolvedValue(true);
+		const gatingTier = tier({ id: 6, name: 'Runeforging', pathId: 9, prerequisiteIds: [0] });
+		staticData.paths = [path({ id: 9, name: 'Elemental Path', retiredAt: '2026-07-01T00:00:00Z' })];
+		const liveReinstatedGatingPath = path({ id: 9, name: 'Elemental Path', retiredAt: undefined });
+		const store = makeStore(path(), { profs: [tier(), gatingTier], paths: [liveReinstatedGatingPath] });
+		render(PathDetail, { props: { store } });
+
+		await fireEvent.click(screen.getByText('Retire'));
+
+		expect(dangerModal).toHaveBeenCalledOnce();
+		const body = dangerModal.mock.calls[0][0].body as string;
+		expect(body).toContain('Runeforging');
+		await waitFor(() => expect(store.retirePath).toHaveBeenCalledWith(5, true));
+	});
+
+	it('rebuilds a dense-by-id paths array so an unsaved new path prepended this session does not shift the gating path’s index', async () => {
+		// ProgressionStore.addPath prepends new paths with negative ids (mirroring EntityStore.addItem),
+		// so passing store.paths through unindexed would misalign paths[9] once a new path exists.
+		const gatingTier = tier({ id: 6, name: 'Runeforging', pathId: 9, prerequisiteIds: [0] });
+		const unsavedNewPath = path({ id: -1, name: 'Draft Path' });
+		const liveRetiredGatingPath = path({ id: 9, name: 'Elemental Path', retiredAt: '2026-07-17T00:00:00Z' });
+		const store = makeStore(path(), {
+			profs: [tier(), gatingTier],
+			paths: [unsavedNewPath, liveRetiredGatingPath]
+		});
+		render(PathDetail, { props: { store } });
+
+		await fireEvent.click(screen.getByText('Retire'));
+
+		expect(dangerModal).not.toHaveBeenCalled();
+		expect(store.retirePath).toHaveBeenCalledWith(5, true);
 	});
 });


### PR DESCRIPTION
## Summary

`PathDetail.svelte`'s `onRetire` built the retire-confirm reference sources with only `{ proficiencies: store.profs }` as the live override. But `pathReferences` (in `references.ts`) also reads a gating path's *own* `retiredAt` via `paths[p.pathId]?.retiredAt` — and that slot was left on `staticData.paths`, the last-saved catalogue. So:

- Retiring path B in-session (unsaved), then retiring path A whose tier gates a B gateway → the confirm still showed the strong "re-point first" warning, even though #2031 exists to suppress exactly this case once B is (about to be) retired.
- The inverse — reinstating B in-session, then retiring A — silently skipped the warning, even though the backend guard would still reject the save.

## Fix

Pass `paths: denseByLiveId(store.paths)` alongside the existing `proficiencies: store.profs` override in `PathDetail`'s `onRetire`.

The dense-by-id rebuild matters here specifically for `paths`: `ProgressionStore.addPath` prepends unsaved new paths with negative ids, so passing `store.paths` straight through would misalign the array-index lookup `pathReferences` relies on (`paths[p.pathId]`) — the exact problem `denseByLiveId` already solves for `ownCatalogueOverride`'s enemies/skills case, just newly needed here since `paths` is now indexed rather than only ever `.filter()`-ed. `profs` doesn't need the same treatment — `pathReferences`/`proficiencyReferences` only ever `.filter()` over proficiencies, never index them by id. `denseByLiveId` is now exported from `retire-confirm.ts` for this reuse.

## Test plan

- [x] Added a unit test for each scenario from the issue (path retired live suppresses the warning; path reinstated live surfaces it) to `PathDetail.test.ts`.
- [x] Added a third test covering the dense-by-id rebuild itself (an unsaved new path with a negative id prepended to `store.paths` no longer shifts the gating path's index).
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — full suite, 3762/3762 passing.

Closes #2099


---
_Generated by [Claude Code](https://claude.ai/code/session_019HJeDxknDLdJBkemPtYiC2)_