### PR TITLE
Floor the typed offense book at 0 under enemy-side absorption

### DIFF
--- a/Game.Core.Tests/Battle/BattleContextTests.cs
+++ b/Game.Core.Tests/Battle/BattleContextTests.cs
@@ -610,10 +610,11 @@ namespace Game.Core.Tests.Battle
         }
 
         [Fact]
-        public void DamageTarget_AbsorbedHit_BooksTheNegativeNetUnchanged()
+        public void DamageTarget_AbsorbedHit_FloorsTheTypedOffenseBookAtZero()
         {
-            // The #1482 cap trims only positive overkill: an absorbed hit's negative net (the capped heal
-            // TakeDamage reports) still books through to the typed book exactly as before.
+            // An absorbed hit's negative net (the capped heal TakeDamage reports) removed no real health, so
+            // the typed offense book floors it at 0 rather than booking a negative that would offset a
+            // sibling type's genuine training within the same battle (#2101).
             var player = MakeBattlerWith((Endurance, 0));
             var enemy = MakeBattlerWith((Endurance, 0), (FireResistance, 2.0)); // Toughness 0, MaxHealth 50
             var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
@@ -622,7 +623,7 @@ namespace Game.Core.Tests.Battle
             context.DamageTarget(20, Single(EDamageType.Fire), 0); // 20 × (1 − 2) = −20, absorbed
 
             Assert.Equal(30, TypedDealt(context, EDamageType.Physical), 0.001);
-            Assert.Equal(-20, TypedDealt(context, EDamageType.Fire), 0.001);
+            Assert.Equal(0, TypedDealt(context, EDamageType.Fire), 0.001);
         }
 
         [Fact]
@@ -964,6 +965,8 @@ namespace Game.Core.Tests.Battle
             // 100 against an enemy absorbing Fire (resistance 2.0) at full health: the Physical portion deals 20
             // (full 50 → 30, opening 20 room), then the Fire portion's −80 absorption heal is capped at that 20
             // room (back to 50). Net 20 + (−20) = 0 — the fixed Physical-first order is what lets the heal land.
+            // The Fire portion's typed offense-book booking floors at 0 (#2101): it removed no real health, so
+            // it trains nothing despite the health math showing the order-dependent heal.
             var player = MakeBattlerWith((Endurance, 0));
             var enemy = MakeBattlerWith((Endurance, 0), (FireResistance, 2.0)); // MaxHealth 50, Toughness 0
             var context = new BattleContext(player, enemy, timeDelta: 0, new Mulberry32(0));
@@ -973,7 +976,7 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(0, dealt, 0.001);
             Assert.Equal(50, enemy.CurrentHealth, 0.001); // 50 → 30 (Physical) → 50 (Fire heal capped at 20 room)
             Assert.Equal(20, TypedDealt(context, EDamageType.Physical), 0.001);
-            Assert.Equal(-20, TypedDealt(context, EDamageType.Fire), 0.001);
+            Assert.Equal(0, TypedDealt(context, EDamageType.Fire), 0.001);
         }
 
         [Fact]
@@ -1890,6 +1893,8 @@ namespace Game.Core.Tests.Battle
             // CapHealToRoom's room is positive, mirroring DamageTarget_ResistanceAboveOne_HealsTheTarget). An
             // absorbed counter avoided no real damage either, so it floors at 0 rather than going negative
             // (#2091) — the sanity assertion on the enemy's health confirms the absorption genuinely happened.
+            // The riposte fires through the same ResolvePlayerHit pipeline as a normal player fire, so its
+            // typed offense book booking floors at 0 too, for the same absorption reason (#2101).
             var counter = MakeCounterSkill(20, damageType: EDamageType.Fire);
             var player = MakeBattlerWithCounter(counter, (ParryChance, 1));
             var enemy = MakeBattlerWith((Endurance, 0), (FireResistance, 2.0)); // MaxHealth 50, Toughness 0
@@ -1901,6 +1906,7 @@ namespace Game.Core.Tests.Battle
 
             Assert.Equal(40, enemy.CurrentHealth, 0.001); // 20 + min(20, 30 room) — absorption genuinely healed it
             Assert.Equal(0, context.Stats.PlayerCounterDamageDealt, 0.001);
+            Assert.Equal(0, TypedDealt(context, EDamageType.Fire), 0.001);
         }
 
         [Fact]

--- a/Game.Core.Tests/Battle/BattleDamageOverTimeTests.cs
+++ b/Game.Core.Tests/Battle/BattleDamageOverTimeTests.cs
@@ -90,7 +90,8 @@ namespace Game.Core.Tests.Battle
             // A +2.0 BleedResistance would heal 80 (2000 × 40/1000 × (1 − 2) = −80), but the battler is already
             // at MaxHealth (no prior damage) so there's no room — capped at zero net effect, consistent with
             // TakeDamage's absorption cap and ApplyHealOverTime (no overheal/shield concept). Per-type booking
-            // still sees the uncapped tick.
+            // floors at 0 too — an absorbed tick removed no real health, so it books nothing (#2101) — even
+            // though the underlying tick is uncapped.
             var battler = MakeBattler(Stat(Strength, 0), Stat(BleedDamagePerSecond, 2000), Stat(BleedResistance, 2.0)); // MaxHealth 50
             var dealtByType = new Dictionary<EDamageType, double>();
 
@@ -98,7 +99,7 @@ namespace Game.Core.Tests.Battle
 
             Assert.Equal(0, dealt);
             Assert.Equal(50, battler.CurrentHealth);
-            Assert.Equal(-80, dealtByType[EDamageType.Bleed]); // per-type booking stays uncapped
+            Assert.Equal(0, dealtByType[EDamageType.Bleed]); // per-type booking floors the absorbed tick at 0
         }
 
         [Fact]
@@ -456,7 +457,9 @@ namespace Game.Core.Tests.Battle
         {
             // A Bleed absorption (resistance 2) heals 80 (uncapped, per the DoT absorption rule) before Burn
             // resolves in the fixed order, so the Burn tick's 100 comes out of genuinely restored health and
-            // books in full — the #1482 cap tracks the running health through the order, negatives included.
+            // books in full — the #1482 cap tracks the running (uncapped) health through the order. Bleed's own
+            // booking floors at 0 (#2101): it removed no real health, so it trains nothing despite restoring
+            // room for Burn.
             var battler = MakeBattler(
                 Stat(Strength, 0), Stat(BleedDamagePerSecond, 2000), Stat(BleedResistance, 2.0),
                 Stat(BurnDamagePerSecond, 2500));
@@ -464,9 +467,9 @@ namespace Game.Core.Tests.Battle
 
             battler.ApplyDamageOverTime(40, recordDamageDealt: (type, amount) => dealtByType[type] = amount);
 
-            Assert.Equal(-80, dealtByType[EDamageType.Bleed]); // the negative (heal) passes through unchanged
-            Assert.Equal(100, dealtByType[EDamageType.Burn]);  // fully booked — it removed real, restored health
-            Assert.Equal(30, battler.CurrentHealth);           // 50 + 80 − 100
+            Assert.Equal(0, dealtByType[EDamageType.Bleed]);  // the absorbed (healing) tick books nothing
+            Assert.Equal(100, dealtByType[EDamageType.Burn]); // fully booked — it removed real, restored health
+            Assert.Equal(30, battler.CurrentHealth);          // 50 + 80 − 100
         }
 
         [Fact]

--- a/Game.Core/Battle/BattleContext.cs
+++ b/Game.Core/Battle/BattleContext.cs
@@ -165,7 +165,8 @@ namespace Game.Core.Battle
         /// a parry additionally fires the defender's riposte (see <see cref="FireParryCounter"/>).</item>
         /// </list>
         /// The per-portion typed books (<see cref="BattleStats.AddTypedDamageDealt"/> per portion's net capped at
-        /// the health it actually removed — overkill books nothing, #1482 —
+        /// the health it actually removed and floored at 0 — overkill books nothing (#1482), an absorbed portion
+        /// books nothing rather than going negative (#2101) —
         /// <see cref="BattleStats.AddTypedDamageExposure"/> per portion's pre-resist dealt) are the cross-school
         /// proficiency signal; the whole-hit stats (<see cref="BattleStats.HighestPlayerAttack"/>,
         /// <see cref="BattleStats.CriticalDamageDealt"/>, and the per-skill total via the return) use
@@ -338,6 +339,9 @@ namespace Game.Core.Battle
                 // The typed offense book is capped at the health the portion actually removed (#1482): a
                 // killing swing's overkill tail — and every later portion of it — books nothing, while the
                 // whole-hit stats below keep the full net (feedback like HighestPlayerAttack includes overkill).
+                // It's also floored at 0: a portion the target's own resistance instead absorbed into a heal
+                // (resistance > 1) books nothing rather than a negative that would offset a sibling type's
+                // genuine training within the same battle (#2101).
                 var booked = Battler.HealthRemoved(net, healthBefore);
                 Stats.AddTypedDamageDealt(type, booked);
                 totalNet += net;

--- a/Game.Core/Battle/BattleStats.cs
+++ b/Game.Core/Battle/BattleStats.cs
@@ -162,7 +162,7 @@ namespace Game.Core.Battle
         public double PlayerRating { get; set; }
 
         /// <summary>Accumulates a direct hit's or DoT tick's booked <paramref name="amount"/> (already capped at
-        /// the health it removed by the caller — #1482) into the typed offense book.</summary>
+        /// the health it removed and floored at 0 by the caller — #1482/#2101) into the typed offense book.</summary>
         public void AddTypedDamageDealt(EDamageType type, double amount)
         {
             TypedDamageDealt.TryGetValue(type, out var existing);

--- a/Game.Core/Battle/Battler.cs
+++ b/Game.Core/Battle/Battler.cs
@@ -413,12 +413,15 @@ namespace Game.Core.Battle
         /// <summary>
         /// The share of a hit's <paramref name="damage"/> that removed live health, given the target's
         /// <paramref name="healthBefore"/> it landed: capped at the positive health remaining, so a killing
-        /// blow's overkill tail books nothing (#1482). A negative amount (an absorption heal) passes through
-        /// unchanged. A booking rule for the proficiency offense book only — the health math is never capped.
+        /// blow's overkill tail books nothing (#1482), and floored at 0, so a portion that instead healed the
+        /// target under authored absorption (resistance &gt; 1) books nothing rather than going negative and
+        /// offsetting a sibling type's genuine offense-book training (#2101). A booking rule for the
+        /// proficiency offense book only — the health math (both direct hits and DoT ticks) is never capped or
+        /// floored.
         /// </summary>
         public static double HealthRemoved(double damage, double healthBefore)
         {
-            return Math.Min(damage, Math.Max(0, healthBefore));
+            return Math.Clamp(damage, 0, Math.Max(0, healthBefore));
         }
 
         /// <summary>
@@ -468,10 +471,11 @@ namespace Game.Core.Battle
         /// <param name="recordDamageDealt">
         /// Optional per-type <b>post-mitigation</b> recorder for the proficiency offense book (spike #1338) —
         /// invoked with each DoT type and the tick damage <em>after</em> this battler's resistance, capped at
-        /// the health the tick actually removes (<see cref="HealthRemoved"/>, #1482) across the fixed
-        /// accumulator order, so a killing tick's overkill tail books nothing while the health math below stays
-        /// uncapped. Supplied when this battler is the victim of the player's DoT (the enemy), so the player's
-        /// DoT damage dealt is typed for the offense binding consistently with a direct hit's booked damage;
+        /// the health the tick actually removes and floored at 0 (<see cref="HealthRemoved"/>, #1482/#2101)
+        /// across the fixed accumulator order, so a killing tick's overkill tail — and a tick that instead
+        /// healed this battler under authored absorption — both book nothing, while the health math below
+        /// stays uncapped. Supplied when this battler is the victim of the player's DoT (the enemy), so the
+        /// player's DoT damage dealt is typed for the offense binding consistently with a direct hit's booked damage;
         /// <c>null</c> leaves the loop unchanged. Like <paramref name="recordExposure"/> it is a backend-only
         /// side channel that adds no parity surface.
         /// </param>


### PR DESCRIPTION
## Summary

`ResolvePlayerHit`'s per-portion loop (`Game.Core/Battle/BattleContext.cs`) books each portion's post-mitigation net into the typed offense book (`Stats.AddTypedDamageDealt`) via `Battler.HealthRemoved(net, healthBefore)`. `HealthRemoved` capped a killing blow's overkill tail at the health actually removed (#1482), but let a **negative** net — a portion the target's own absorption (resistance > 1) turned into a heal — pass straight through unchanged.

The same helper backs the DoT tick booking in `Battler.ApplyDamageOverTime`, so the identical gap existed on that path too (an absorbed DoT tick's negative `bookedTick` also fed the offense book via `recordDamageDealt`).

Two downstream consumers read `TypedDamageDealt` with no sign guard on the per-type entry:
- `ProficiencyAccrual.BuildActivities` → `FoldIntoActivityKeys` folds the raw (possibly negative) per-type quantity into the shared activity map with no floor — unlike the sibling `AddEvent` tallies just below it, which floor at `amount > 0`. Within a mixed multi-type battle this can silently offset a sibling type's genuine training total.
- `PlayerProgress.RecordKillByDamageType` picks the "majority-dealt" type via `OrderByDescending` to attribute a kill's `KillsByDamageType` credit — a negative entry could skew which type is picked.

This is content-gated today (no authored enemy currently carries resistance > 1) but the mechanic is explicitly supported, mirroring the same root cause #2091 fixed for the Dodge/Parry/Counter avoided-damage tallies.

## Fix

`Battler.HealthRemoved` now floors at 0 in addition to capping at the health removed: `Math.Clamp(damage, 0, Math.Max(0, healthBefore))`. Since this one static helper is the *only* thing feeding `TypedDamageDealt` — both the direct-hit path (`ResolvePlayerHit`, which the parry riposte also routes through) and the DoT tick path (`ApplyDamageOverTime`) — fixing it there closes the gap for every caller at once, rather than needing a separate guard at each call site or in the downstream consumers.

The health math itself is untouched (the doc comment already called this out as "a booking rule for the proficiency offense book only" — that invariant is preserved).

## Test plan

- [x] Updated three existing tests that pinned the old (negative) booking behavior to assert the new floor-at-0 behavior instead: `DamageTarget_AbsorbedHit_FloorsTheTypedOffenseBookAtZero` (renamed), `DamageTarget_MultiPortion_AbsorbingPortionCapsHealAtRoomInFixedOrder`, and two DoT tests in `BattleDamageOverTimeTests.cs`.
- [x] Extended `DamageTarget_ParryCounter_AbsorbedByTheEnemy_BooksNoNegativeCounterDamage` with an assertion that the riposte's typed offense-book entry also floors at 0 (same `ResolvePlayerHit` pipeline).
- [x] `dotnet build Game.sln` — 0 errors, 0 warnings.
- [x] `dotnet test Game.sln` — full suite green (Core 1371, Infrastructure 66, Application 989, Api 823).
- [x] No frontend changes — this is a server-only proficiency/statistics booking path (dodge/parry/riposte/offense-book tallies aren't part of the frontend's battle simulation), not part of the tick-by-tick frontend/backend parity surface, consistent with #2091/#2102's precedent.

Closes #2101


---
_Generated by [Claude Code](https://claude.ai/code/session_01AoDn4riF2mg4Qt9ADAJhw7)_