### PR TITLE
Deduplicate more integration-test helpers: seed/login, presence-TTL, dead-letter fixtures

### DIFF
--- a/Game.Api.Tests/Integration/AdminDeadLettersControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminDeadLettersControllerTests.cs
@@ -1,5 +1,6 @@
 using Game.Abstractions.Contracts.Admin;
 using Game.Abstractions.Infrastructure;
+using Game.Api;
 using Game.Api.Models.Common;
 using Game.Api.Models.Progress;
 using Game.Api.Sockets.Commands;
@@ -122,7 +123,7 @@ namespace Game.Api.Tests.Integration
         {
             await SeedSocketDeadLettersAsync(
                 "not-json",
-                SocketEnvelope(playerId: 42, new ChallengeCompletedInfo(new ChallengeCompletedModel { ChallengeId = 1 })));
+                SocketDeadLetterEnvelope(playerId: 42, new ChallengeCompletedInfo(new ChallengeCompletedModel { ChallengeId = 1 })));
 
             using var client = AdminClient();
             var response = await client.GetAsync("/api/AdminTools/GetSocketCommandDeadLetters", CancellationToken);
@@ -144,7 +145,7 @@ namespace Game.Api.Tests.Integration
         [Fact]
         public async Task GetSocketCommandDeadLetters_ClassifiesASessionLifecycleCommandAsNotReplayable()
         {
-            await SeedSocketDeadLettersAsync(SocketEnvelope(playerId: 42, new SocketReplacedInfo()));
+            await SeedSocketDeadLettersAsync(SocketDeadLetterEnvelope(playerId: 42, new SocketReplacedInfo()));
 
             using var client = AdminClient();
             var response = await client.GetAsync("/api/AdminTools/GetSocketCommandDeadLetters", CancellationToken);
@@ -164,9 +165,9 @@ namespace Game.Api.Tests.Integration
             using var scope = CreateScope();
             var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
             var socketId = Guid.NewGuid().ToString();
-            await cache.Set($"{PlayerSocketPresencePrefix}_601", socketId, TimeSpan.FromMinutes(1));
+            await cache.Set(PresenceKey(601), socketId, TimeSpan.FromMinutes(1));
 
-            var entry = SocketEnvelope(601, new ChallengeCompletedInfo(new ChallengeCompletedModel { ChallengeId = 1 }));
+            var entry = SocketDeadLetterEnvelope(601, new ChallengeCompletedInfo(new ChallengeCompletedModel { ChallengeId = 1 }));
             await SeedSocketDeadLettersAsync(entry);
 
             using var client = AdminClient();
@@ -181,7 +182,7 @@ namespace Game.Api.Tests.Integration
 
             Assert.Equal(0, await SocketDeadLetterDepthAsync());
             var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
-            Assert.Single(await pubsub.GetQueue($"SocketQueue_{socketId}").PeekAsync(10));
+            Assert.Single(await pubsub.GetQueue(SocketQueueName(socketId)).PeekAsync(10));
         }
 
         private HttpClient AdminClient()
@@ -215,24 +216,11 @@ namespace Game.Api.Tests.Integration
         private static string Envelope(string type, string payloadJson)
             => new { type, payload = payloadJson }.Serialize();
 
-        private const string SocketCommandDeadLetterQueue = "SocketCommandDeadLetterQueue";
-        private const string PlayerSocketPresencePrefix = "PlayerSocket";
-
-        private async Task SeedSocketDeadLettersAsync(params string[] messages)
-        {
-            using var scope = CreateScope();
-            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
-            await pubsub.GetQueue(SocketCommandDeadLetterQueue).AddRangeToQueueAsync(messages);
-        }
-
         private async Task<long> SocketDeadLetterDepthAsync()
         {
             using var scope = CreateScope();
             var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
-            return await pubsub.GetQueue(SocketCommandDeadLetterQueue).GetLengthAsync();
+            return await pubsub.GetQueue(Constants.PUBSUB_SOCKET_DEAD_LETTER_QUEUE).GetLengthAsync();
         }
-
-        private static string SocketEnvelope(int playerId, SocketCommandInfo command)
-            => new SocketCommandDeadLetterEnvelope { PlayerId = playerId, Command = command }.Serialize();
     }
 }

--- a/Game.Api.Tests/Integration/ApiIntegrationTestBase.cs
+++ b/Game.Api.Tests/Integration/ApiIntegrationTestBase.cs
@@ -1,13 +1,18 @@
 using Game.Abstractions.DataAccess;
+using Game.Abstractions.Infrastructure;
+using Game.Api;
 using Game.Api.Models.Auth;
 using Game.Api.Models.Common;
 using Game.Api.Models.Player;
 using Game.Api.Services;
+using Game.Api.Sockets.Commands;
+using Game.Core;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
 using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -150,5 +155,61 @@ namespace Game.Api.Tests.Integration
         /// reference rows directly so the caches (which no longer lazily refill) serve the seeded data.
         /// </summary>
         protected Task ReloadReferenceCachesAsync() => ReferenceCacheReloader.ReloadAllAsync(Factory.Services);
+
+        /// <summary>
+        /// Seeds a user with a player (and a linked skill so the aggregate loads), without establishing a
+        /// session in Redis. Returns the userId (for WebSocket/token auth) and playerId.
+        /// </summary>
+        protected async Task<(int UserId, int PlayerId)> SeedAsync(string username = "testuser", string password = "testpass")
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context, username, password);
+            var skill = await TestDataSeeder.CreateSkillAsync(context);
+            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
+            // The caches no longer lazily refill, so reload them to resolve the player's linked skill on load.
+            await ReloadReferenceCachesAsync();
+
+            return (user.Id, player.Id);
+        }
+
+        /// <summary>
+        /// Seeds test data (see <see cref="SeedAsync"/>), logs in via the real HTTP endpoint (creating the
+        /// session in Redis), and returns the userId (for WebSocket/token auth) and playerId.
+        /// </summary>
+        protected async Task<(int UserId, int PlayerId)> SeedAndLoginAsync(string username = "testuser", string password = "testpass")
+        {
+            var seeded = await SeedAsync(username, password);
+            await LoginAsync(username, password);
+            return seeded;
+        }
+
+        /// <summary>The player's socket-presence cache key.</summary>
+        protected static string PresenceKey(int playerId) => $"{Constants.CACHE_PLAYER_SOCKET_PREFIX}_{playerId}";
+
+        /// <summary>Reads the live TTL on the player's socket-presence key directly from Redis.</summary>
+        protected async Task<TimeSpan?> GetPresenceTtlAsync(int playerId)
+        {
+            await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(Containers.CacheConnectionString);
+            return await multiplexer.GetDatabase().KeyTimeToLiveAsync(PresenceKey(playerId));
+        }
+
+        /// <summary>A live socket's own pub/sub queue name.</summary>
+        protected static string SocketQueueName(string socketId) => $"{Constants.PUBSUB_SOCKET_QUEUE_PREFIX}_{socketId}";
+
+        /// <summary>Wraps a server-initiated command as the socket-command dead-letter envelope shape
+        /// <see cref="Game.Api.Services.Admin.SocketCommandDeadLetters"/> replays, for tests seeding the
+        /// socket dead-letter queue directly.</summary>
+        protected static string SocketDeadLetterEnvelope(int playerId, SocketCommandInfo command) =>
+            new SocketCommandDeadLetterEnvelope { PlayerId = playerId, Command = command }.Serialize();
+
+        /// <summary>Pushes raw messages directly onto the socket-command dead-letter queue.</summary>
+        protected async Task SeedSocketDeadLettersAsync(params string[] messages)
+        {
+            using var scope = CreateScope();
+            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
+            await pubsub.GetQueue(Constants.PUBSUB_SOCKET_DEAD_LETTER_QUEUE).AddRangeToQueueAsync(messages);
+        }
     }
 }

--- a/Game.Api.Tests/Integration/LoginControllerTests.cs
+++ b/Game.Api.Tests/Integration/LoginControllerTests.cs
@@ -36,14 +36,7 @@ namespace Game.Api.Tests.Integration
         public async Task Login_ValidCredentials_ReturnsPlayerSummariesAndTokens()
         {
             // Arrange
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, "loginuser", "loginpass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            // The caches no longer lazily refill, so reload them to resolve the player's linked skill on load.
-            await ReloadReferenceCachesAsync();
+            var (_, playerId) = await SeedAsync("loginuser", "loginpass");
 
             var creds = new { Username = "loginuser", Password = "loginpass" };
 
@@ -59,8 +52,8 @@ namespace Game.Api.Tests.Integration
             Assert.NotNull(result.Data);
             // Login lists the account's characters (no player is bound until SelectPlayer).
             var summary = Assert.Single(result.Data.PlayerSummaries);
-            Assert.Equal(player.Id, summary.Id);
-            Assert.Equal(player.Name, summary.Name);
+            Assert.Equal(playerId, summary.Id);
+            Assert.Equal("TestPlayer", summary.Name);
 
             // Both tokens are issued in the response body (no auth cookie).
             Assert.False(response.Headers.Contains("Set-Cookie"));
@@ -72,14 +65,7 @@ namespace Game.Api.Tests.Integration
         public async Task Login_IssuedAccessToken_AuthenticatesProtectedEndpoint()
         {
             // Arrange
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, "beareruser", "bearerpass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            // The caches no longer lazily refill, so reload them to resolve the player's linked skill on load.
-            await ReloadReferenceCachesAsync();
+            await SeedAsync("beareruser", "bearerpass");
 
             var (authClient, _) = await LoginAndBuildClientAsync("beareruser", "bearerpass");
 
@@ -90,7 +76,7 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<ApiResponse<Models.Player.PlayerData>>(CancellationToken);
             Assert.NotNull(result?.Data);
-            Assert.Equal(player.Name, result.Data.Name);
+            Assert.Equal("TestPlayer", result.Data.Name);
             authClient.Dispose();
         }
 
@@ -113,14 +99,7 @@ namespace Game.Api.Tests.Integration
         public async Task Login_WrongPassword_ReturnsError()
         {
             // Arrange — a real user whose stored hash won't match the supplied password.
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, "wrongpassuser", "correctpass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            // The caches no longer lazily refill, so reload them to resolve the player's linked skill on load.
-            await ReloadReferenceCachesAsync();
+            await SeedAsync("wrongpassuser", "correctpass");
 
             var creds = new { Username = "wrongpassuser", Password = "wrongpass" };
 
@@ -141,16 +120,16 @@ namespace Game.Api.Tests.Integration
         {
             // A banned account with otherwise-correct credentials is rejected in the auth path: no tokens
             // are issued and no session is established.
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, "bannedlogin", "bannedpass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            await ReloadReferenceCachesAsync();
+            var (userId, _) = await SeedAsync("bannedlogin", "bannedpass");
 
-            user.BannedAt = DateTime.UtcNow;
-            await context.SaveChangesAsync(CancellationToken);
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                var user = await context.Users.FindAsync([userId], CancellationToken);
+                Assert.NotNull(user);
+                user.BannedAt = DateTime.UtcNow;
+                await context.SaveChangesAsync(CancellationToken);
+            }
 
             var creds = new { Username = "bannedlogin", Password = "bannedpass" };
 
@@ -165,35 +144,31 @@ namespace Game.Api.Tests.Integration
             Assert.Null(result.Data);
 
             // No session is established for the rejected login.
-            var sessionStore = scope.ServiceProvider.GetRequiredService<ISessionStore>();
-            Assert.Null(await sessionStore.GetSession(user.Id));
+            using var verifyScope = CreateScope();
+            var sessionStore = verifyScope.ServiceProvider.GetRequiredService<ISessionStore>();
+            Assert.Null(await sessionStore.GetSession(userId));
         }
 
         [Fact]
         public async Task SelectPlayer_OwnedCharacter_BindsSessionAndRotatesTokenIntoGameReadyState()
         {
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, "selectuser", "selectpass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            await ReloadReferenceCachesAsync();
+            var (userId, playerId) = await SeedAsync("selectuser", "selectpass");
 
             var login = await LoginAsync("selectuser", "selectpass");
             var summary = Assert.Single(login.PlayerSummaries);
 
             // Selecting binds the session and returns the loaded player plus a rotated, game-ready token.
             var select = await SelectPlayerAsync(login.Tokens, summary.Id);
-            Assert.Equal(player.Id, select.Player.Id);
-            Assert.Equal(player.Name, select.Player.Name);
+            Assert.Equal(playerId, select.Player.Id);
+            Assert.Equal("TestPlayer", select.Player.Name);
             Assert.NotEqual(login.Tokens.RefreshToken, select.Tokens.RefreshToken);
 
             // The cached session is now established for the selected character.
+            using var scope = CreateScope();
             var sessionStore = scope.ServiceProvider.GetRequiredService<ISessionStore>();
-            var session = await sessionStore.GetSession(user.Id);
+            var session = await sessionStore.GetSession(userId);
             Assert.NotNull(session);
-            Assert.Equal(player.Id, session.PlayerId);
+            Assert.Equal(playerId, session.PlayerId);
 
             // The rotated access token authenticates Status and resolves the selected player from its claim.
             using var authClient = Factory.CreateClient();
@@ -201,7 +176,7 @@ namespace Game.Api.Tests.Integration
             var statusResponse = await authClient.GetAsync("/api/Login/Status", CancellationToken);
             Assert.Equal(HttpStatusCode.OK, statusResponse.StatusCode);
             var status = await statusResponse.Content.ReadFromJsonAsync<ApiResponse<Models.Player.PlayerData>>(CancellationToken);
-            Assert.Equal(player.Id, status?.Data?.Id);
+            Assert.Equal(playerId, status?.Data?.Id);
         }
 
         [Fact]
@@ -927,7 +902,7 @@ namespace Game.Api.Tests.Integration
             // A valid token with no cached session (evicted, aged out under the sliding TTL, or never
             // established on this instance) must not be reported as "not logged in" (#693). The session is
             // rehydrated from the user's player binding instead.
-            var (client, user, player) = await SeedUserWithTokenButNoSessionAsync("evictedstatus");
+            var (client, userId, _) = await SeedUserWithTokenButNoSessionAsync("evictedstatus");
 
             var response = await client.GetAsync("/api/Login/Status", CancellationToken);
 
@@ -935,11 +910,11 @@ namespace Game.Api.Tests.Integration
             var result = await response.Content.ReadFromJsonAsync<ApiResponse<Models.Player.PlayerData>>(CancellationToken);
             Assert.NotNull(result?.Data);
             Assert.Null(result.ErrorMessage);
-            Assert.Equal(player.Name, result.Data.Name);
+            Assert.Equal("TestPlayer", result.Data.Name);
 
             // Rehydration is in-memory only: the request resolves the player without ever writing the session
             // cache, since player-state writes belong on the socket, not this concurrent HTTP path (#937).
-            await AssertSessionNotEstablishedAsync(user.Id);
+            await AssertSessionNotEstablishedAsync(userId);
             client.Dispose();
         }
 
@@ -948,7 +923,7 @@ namespace Game.Api.Tests.Integration
         {
             // The pre-game active-session takeover warning is the user-visible breakage from #693: an evicted
             // session must rehydrate and report the (absent) active socket, not "not logged in".
-            var (client, user, _) = await SeedUserWithTokenButNoSessionAsync("evictedactive");
+            var (client, userId, _) = await SeedUserWithTokenButNoSessionAsync("evictedactive");
 
             var response = await client.GetAsync("/api/Login/ActiveSession", CancellationToken);
 
@@ -959,7 +934,7 @@ namespace Game.Api.Tests.Integration
             Assert.False(result.Data.Active);
 
             // Rehydration is in-memory only — the presence check resolves the player without writing the cache (#937).
-            await AssertSessionNotEstablishedAsync(user.Id);
+            await AssertSessionNotEstablishedAsync(userId);
             client.Dispose();
         }
 
@@ -969,7 +944,7 @@ namespace Game.Api.Tests.Integration
             // The redundant per-request session read is gone (#755): an authenticated endpoint that never
             // reads player state (here DeviceInfo) must not load or rehydrate the session cache, even for a
             // user who has a resolvable player. Only the socket handshake and Status/ActiveSession do.
-            var (client, user, _) = await SeedUserWithTokenButNoSessionAsync("nosessionread");
+            var (client, userId, _) = await SeedUserWithTokenButNoSessionAsync("nosessionread");
             client.DefaultRequestHeaders.TryAddWithoutValidation(ClientHints.DeviceFingerprintHeader, "fp-nosession");
 
             var response = await client.PostAsJsonAsync("/api/Login/DeviceInfo",
@@ -978,7 +953,7 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Confirm the session was never established — the cache stays empty for this user.
-            await AssertSessionNotEstablishedAsync(user.Id);
+            await AssertSessionNotEstablishedAsync(userId);
             client.Dispose();
         }
 
@@ -987,25 +962,22 @@ namespace Game.Api.Tests.Integration
         /// carrying a valid bearer token for that user but with no session ever established in the cache —
         /// the "valid token, evicted/absent session" state.
         /// </summary>
-        private async Task<(HttpClient Client, User User, Player Player)>
+        private async Task<(HttpClient Client, int UserId, int PlayerId)>
             SeedUserWithTokenButNoSessionAsync(string username)
         {
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, username, "pass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            await ReloadReferenceCachesAsync();
+            var (userId, playerId) = await SeedAsync(username, "pass");
 
-            var sessionStore = scope.ServiceProvider.GetRequiredService<ISessionStore>();
-            Assert.Null(await sessionStore.GetSession(user.Id));
+            using (var scope = CreateScope())
+            {
+                var sessionStore = scope.ServiceProvider.GetRequiredService<ISessionStore>();
+                Assert.Null(await sessionStore.GetSession(userId));
+            }
 
             var client = Factory.CreateClient();
             // A post-selection token (carrying the selected-player claim) with no cached session — the
             // "valid token, evicted/absent session" state that must rehydrate from the claim.
-            TestAuthHelper.AddAuthHeader(client, user.Id, player.Id);
-            return (client, user, player);
+            TestAuthHelper.AddAuthHeader(client, userId, playerId);
+            return (client, userId, playerId);
         }
 
         // Confirms a session was never written to the cache: rehydration (and any non-session endpoint) resolves
@@ -1023,14 +995,7 @@ namespace Game.Api.Tests.Integration
         public async Task ActiveSession_NoOpenSocket_ReturnsFalse()
         {
             // Arrange — a logged-in user who has not opened a game connection.
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, "nosocketuser", "nosocketpass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            // The caches no longer lazily refill, so reload them to resolve the player's linked skill on load.
-            await ReloadReferenceCachesAsync();
+            await SeedAsync("nosocketuser", "nosocketpass");
 
             var (authClient, _) = await LoginAndBuildClientAsync("nosocketuser", "nosocketpass");
 
@@ -1047,20 +1012,13 @@ namespace Game.Api.Tests.Integration
         public async Task ActiveSession_WithOpenSocket_ReturnsTrue()
         {
             // Arrange — a logged-in user with a live websocket connection registered.
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, "livesocketuser", "livesocketpass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            // The caches no longer lazily refill, so reload them to resolve the player's linked skill on load.
-            await ReloadReferenceCachesAsync();
+            var (userId, _) = await SeedAsync("livesocketuser", "livesocketpass");
 
             var (authClient, _) = await LoginAndBuildClientAsync("livesocketuser", "livesocketpass");
 
             await using var socketClient = new TestSocketClient();
             var wsClient = Factory.Server.CreateWebSocketClient();
-            await socketClient.ConnectAsync(wsClient, user.Id);
+            await socketClient.ConnectAsync(wsClient, userId);
             // Round-trip a command so the connection is fully registered (the socket-presence key is set
             // before the command listener, so any response guarantees registration completed).
             await socketClient.SendCommandAsync<object>("GetStatisticTypes");
@@ -1085,18 +1043,11 @@ namespace Game.Api.Tests.Integration
         public async Task Refresh_ValidToken_RotatesAndReturnsNewTokens()
         {
             // Arrange
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, "refreshuser", "refreshpass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            // The caches no longer lazily refill, so reload them to resolve the player's linked skill on load.
-            await ReloadReferenceCachesAsync();
+            var (_, playerId) = await SeedAsync("refreshuser", "refreshpass");
 
             // Select a character so the refreshed token carries the selected player (and Status can load it).
             var login = await LoginAsync("refreshuser", "refreshpass");
-            var select = await SelectPlayerAsync(login.Tokens, player.Id);
+            var select = await SelectPlayerAsync(login.Tokens, playerId);
 
             // Act — exchange the refresh token for a new pair.
             var refreshResponse = await Client.PostAsJsonAsync("/api/Login/Refresh",
@@ -1121,14 +1072,7 @@ namespace Game.Api.Tests.Integration
         public async Task Refresh_SameTokenTwice_IsRejectedSecondTime()
         {
             // Arrange
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, "rotateuser", "rotatepass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            // The caches no longer lazily refill, so reload them to resolve the player's linked skill on load.
-            await ReloadReferenceCachesAsync();
+            await SeedAsync("rotateuser", "rotatepass");
 
             var login = await LoginAsync("rotateuser", "rotatepass");
 
@@ -1163,14 +1107,7 @@ namespace Game.Api.Tests.Integration
         public async Task Logout_Authenticated_RevokesRefreshTokenAndEndsSession()
         {
             // Arrange — a logged-in user carrying a valid access token.
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, "logoutuser", "logoutpass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            // The caches no longer lazily refill, so reload them to resolve the player's linked skill on load.
-            await ReloadReferenceCachesAsync();
+            var (userId, _) = await SeedAsync("logoutuser", "logoutpass");
 
             var (authClient, tokens) = await LoginAndBuildClientAsync("logoutuser", "logoutpass");
 
@@ -1184,8 +1121,9 @@ namespace Game.Api.Tests.Integration
             Assert.NotNull(result);
             Assert.Null(result.ErrorMessage);
 
+            using var scope = CreateScope();
             var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
-            var session = await cache.Get($"Session_{user.Id}");
+            var session = await cache.Get($"Session_{userId}");
             Assert.Null(session);
 
             // The revoked refresh token can no longer be exchanged for new tokens.
@@ -1201,18 +1139,12 @@ namespace Game.Api.Tests.Integration
             // The common logout path (#906): the 15-minute access token has already expired, so the client
             // logs out anonymously with just its refresh token. No request principal means no recorded
             // UserId, yet the cached session must still be evicted — derived from the consumed refresh token.
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, "expiredlogout", "logoutpass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            await ReloadReferenceCachesAsync();
+            var (userId, playerId) = await SeedAsync("expiredlogout", "logoutpass");
 
             // Selecting a character establishes the cached session; the refresh token outlives the access token.
             var login = await LoginAsync("expiredlogout", "logoutpass");
-            var select = await SelectPlayerAsync(login.Tokens, player.Id);
-            await AssertSessionPresentAsync(user.Id);
+            var select = await SelectPlayerAsync(login.Tokens, playerId);
+            await AssertSessionPresentAsync(userId);
 
             // Act — log out over the unauthenticated client (no bearer token, mimicking the expired access
             // token) carrying only the still-valid refresh token.
@@ -1221,7 +1153,7 @@ namespace Game.Api.Tests.Integration
 
             // Assert — logout succeeds and the session is evicted despite the absent access token.
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            await AssertSessionEvictedAsync(user.Id);
+            await AssertSessionEvictedAsync(userId);
 
             // The consumed refresh token can no longer be exchanged for new tokens.
             var refreshResponse = await Client.PostAsJsonAsync("/api/Login/Refresh",
@@ -1268,15 +1200,12 @@ namespace Game.Api.Tests.Integration
         public async Task Login_AdminUser_InjectsRoleIntoTokenAndGrantsAdminAccess()
         {
             // Arrange — a user granted the seeded Admin role.
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, "adminlogin", "adminpass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            // The caches no longer lazily refill, so reload them to resolve the player's linked skill on load.
-            await ReloadReferenceCachesAsync();
-            await TestDataSeeder.AssignRoleToUserAsync(context, user.Id, ERole.Admin);
+            var (userId, _) = await SeedAsync("adminlogin", "adminpass");
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                await TestDataSeeder.AssignRoleToUserAsync(context, userId, ERole.Admin);
+            }
 
             // Act — log in and reuse the issued access token against an admin endpoint.
             var (authClient, _) = await LoginAndBuildClientAsync("adminlogin", "adminpass");
@@ -1292,14 +1221,7 @@ namespace Game.Api.Tests.Integration
         public async Task Login_NonAdminUser_DoesNotGrantAdminAccess()
         {
             // Arrange — a user without any roles.
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, "plainlogin", "plainpass");
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            // The caches no longer lazily refill, so reload them to resolve the player's linked skill on load.
-            await ReloadReferenceCachesAsync();
+            await SeedAsync("plainlogin", "plainpass");
 
             // Act
             var (authClient, _) = await LoginAndBuildClientAsync("plainlogin", "plainpass");

--- a/Game.Api.Tests/Integration/SocketCommandDeadLettersIntegrationTests.cs
+++ b/Game.Api.Tests/Integration/SocketCommandDeadLettersIntegrationTests.cs
@@ -42,10 +42,10 @@ namespace Game.Api.Tests.Integration
         public async Task InspectAsync_ClassifiesEachEntry_AndDerivesCommandNameAndPlayerId()
         {
             using var scope = CreateScope();
-            await SeedDeadLettersAsync(scope,
+            await SeedSocketDeadLettersAsync(
                 "this-is-not-json",
-                Envelope(99, new SocketCommandInfo("MysteryCommand")),
-                Envelope(42, ChallengeCompletedEnvelope()));
+                SocketDeadLetterEnvelope(99, new SocketCommandInfo("MysteryCommand")),
+                SocketDeadLetterEnvelope(42, ChallengeCompletedEnvelope()));
 
             var deadLetters = scope.ServiceProvider.GetRequiredService<SocketCommandDeadLetters>();
             var inspection = await deadLetters.InspectAsync(50);
@@ -80,7 +80,7 @@ namespace Game.Api.Tests.Integration
             // SocketReplaced is server-initiated (a known command) but only ever meaningful at the moment it
             // was originally emitted — closing whatever socket happens to be live for the player later would
             // kick an innocent session, so it must classify distinctly from a genuinely Replayable entry.
-            await SeedDeadLettersAsync(scope, Envelope(42, new SocketReplacedInfo()));
+            await SeedSocketDeadLettersAsync(SocketDeadLetterEnvelope(42, new SocketReplacedInfo()));
 
             var deadLetters = scope.ServiceProvider.GetRequiredService<SocketCommandDeadLetters>();
             var inspection = await deadLetters.InspectAsync(50);
@@ -95,10 +95,10 @@ namespace Game.Api.Tests.Integration
         public async Task InspectAsync_RespectsMax_WhileStillReportingFullDepth()
         {
             using var scope = CreateScope();
-            await SeedDeadLettersAsync(scope,
-                Envelope(1, ChallengeCompletedEnvelope()),
-                Envelope(2, ChallengeCompletedEnvelope()),
-                Envelope(3, ChallengeCompletedEnvelope()));
+            await SeedSocketDeadLettersAsync(
+                SocketDeadLetterEnvelope(1, ChallengeCompletedEnvelope()),
+                SocketDeadLetterEnvelope(2, ChallengeCompletedEnvelope()),
+                SocketDeadLetterEnvelope(3, ChallengeCompletedEnvelope()));
 
             var deadLetters = scope.ServiceProvider.GetRequiredService<SocketCommandDeadLetters>();
             var inspection = await deadLetters.InspectAsync(2);
@@ -121,7 +121,9 @@ namespace Game.Api.Tests.Integration
             await cache.Set(PresenceKey(playerA), socketA, TimeSpan.FromMinutes(1));
             await cache.Set(PresenceKey(playerB), socketB, TimeSpan.FromMinutes(1));
 
-            await SeedDeadLettersAsync(scope, Envelope(playerA, ChallengeCompletedEnvelope()), Envelope(playerB, ChallengeCompletedEnvelope()));
+            await SeedSocketDeadLettersAsync(
+                SocketDeadLetterEnvelope(playerA, ChallengeCompletedEnvelope()),
+                SocketDeadLetterEnvelope(playerB, ChallengeCompletedEnvelope()));
 
             var deadLetters = scope.ServiceProvider.GetRequiredService<SocketCommandDeadLetters>();
             var result = await deadLetters.ReplayAllAsync();
@@ -145,9 +147,9 @@ namespace Game.Api.Tests.Integration
             var socketId = Guid.NewGuid().ToString();
             await cache.Set(PresenceKey(targetPlayer), socketId, TimeSpan.FromMinutes(1));
 
-            var keep = Envelope(202, ChallengeCompletedEnvelope());
-            var replay = Envelope(targetPlayer, ChallengeCompletedEnvelope());
-            await SeedDeadLettersAsync(scope, keep, replay);
+            var keep = SocketDeadLetterEnvelope(202, ChallengeCompletedEnvelope());
+            var replay = SocketDeadLetterEnvelope(targetPlayer, ChallengeCompletedEnvelope());
+            await SeedSocketDeadLettersAsync(keep, replay);
 
             var deadLetters = scope.ServiceProvider.GetRequiredService<SocketCommandDeadLetters>();
             var result = await deadLetters.ReplaySelectedAsync([replay]);
@@ -164,8 +166,8 @@ namespace Game.Api.Tests.Integration
         public async Task ReplaySelectedAsync_IgnoresPayloadsNotOnTheQueue_NeverInjectingThemOntoALiveSocket()
         {
             using var scope = CreateScope();
-            var real = Envelope(301, ChallengeCompletedEnvelope());
-            await SeedDeadLettersAsync(scope, real);
+            var real = SocketDeadLetterEnvelope(301, ChallengeCompletedEnvelope());
+            await SeedSocketDeadLettersAsync(real);
 
             var deadLetters = scope.ServiceProvider.GetRequiredService<SocketCommandDeadLetters>();
             // A fabricated payload that was never dead-lettered must be skipped, so replay can't be used to
@@ -186,8 +188,8 @@ namespace Game.Api.Tests.Integration
             var malformed = "not-json";
             // Well-formed and known, but the player has no live socket (no presence key seeded) — there is
             // nowhere to redeliver it, so it must stay on the dead-letter queue rather than being dropped.
-            var noLiveSocket = Envelope(401, ChallengeCompletedEnvelope());
-            await SeedDeadLettersAsync(scope, malformed, noLiveSocket);
+            var noLiveSocket = SocketDeadLetterEnvelope(401, ChallengeCompletedEnvelope());
+            await SeedSocketDeadLettersAsync(malformed, noLiveSocket);
 
             var deadLetters = scope.ServiceProvider.GetRequiredService<SocketCommandDeadLetters>();
             var result = await deadLetters.ReplayAllAsync();
@@ -213,8 +215,8 @@ namespace Game.Api.Tests.Integration
             // deploy). Replaying it would ship a command the client can't recognize and, unlike the player
             // write-behind queue, there is no re-processing round-trip that lets it come back — so it must
             // stay queued rather than being delivered and dropped.
-            var unknown = Envelope(playerId, new SocketCommandInfo("RetiredCommand"));
-            await SeedDeadLettersAsync(scope, unknown);
+            var unknown = SocketDeadLetterEnvelope(playerId, new SocketCommandInfo("RetiredCommand"));
+            await SeedSocketDeadLettersAsync(unknown);
 
             var deadLetters = scope.ServiceProvider.GetRequiredService<SocketCommandDeadLetters>();
             var result = await deadLetters.ReplayAllAsync();
@@ -239,8 +241,8 @@ namespace Game.Api.Tests.Integration
             // A dead-lettered SocketReplaced is only meaningful at the moment it was originally emitted —
             // replaying it later would force-close whatever socket is currently live for the player, which is
             // never correct. It must stay queued even though the player has a live socket right now.
-            var sessionLifecycle = Envelope(playerId, new SocketReplacedInfo());
-            await SeedDeadLettersAsync(scope, sessionLifecycle);
+            var sessionLifecycle = SocketDeadLetterEnvelope(playerId, new SocketReplacedInfo());
+            await SeedSocketDeadLettersAsync(sessionLifecycle);
 
             var deadLetters = scope.ServiceProvider.GetRequiredService<SocketCommandDeadLetters>();
             var result = await deadLetters.ReplayAllAsync();
@@ -260,7 +262,7 @@ namespace Game.Api.Tests.Integration
             // `required` only guarantees the "command" key is present, not that its value is non-null — a
             // payload like this deserializes without error but must still classify as Malformed rather than
             // NRE-ing out of InspectAsync.
-            await SeedDeadLettersAsync(scope, "{\"playerId\":5,\"command\":null}");
+            await SeedSocketDeadLettersAsync("{\"playerId\":5,\"command\":null}");
 
             var deadLetters = scope.ServiceProvider.GetRequiredService<SocketCommandDeadLetters>();
             var inspection = await deadLetters.InspectAsync(50);
@@ -271,20 +273,7 @@ namespace Game.Api.Tests.Integration
             Assert.Null(entry.PlayerId);
         }
 
-        private static async Task SeedDeadLettersAsync(IServiceScope scope, params string[] messages)
-        {
-            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
-            await pubsub.GetQueue(Constants.PUBSUB_SOCKET_DEAD_LETTER_QUEUE).AddRangeToQueueAsync(messages);
-        }
-
         /// <summary>A stand-in for a genuinely replayable server-initiated push in these tests.</summary>
         private static ChallengeCompletedInfo ChallengeCompletedEnvelope() => new(new ChallengeCompletedModel { ChallengeId = 1 });
-
-        private static string Envelope(int playerId, SocketCommandInfo command)
-            => new SocketCommandDeadLetterEnvelope { PlayerId = playerId, Command = command }.Serialize();
-
-        private static string PresenceKey(int playerId) => $"{Constants.CACHE_PLAYER_SOCKET_PREFIX}_{playerId}";
-
-        private static string SocketQueueName(string socketId) => $"{Constants.PUBSUB_SOCKET_QUEUE_PREFIX}_{socketId}";
     }
 }

--- a/Game.Api.Tests/Integration/SocketConnectionTests.cs
+++ b/Game.Api.Tests/Integration/SocketConnectionTests.cs
@@ -1,4 +1,3 @@
-using Game.Api;
 using Game.Api.Models.Common;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Fixtures;
@@ -6,7 +5,6 @@ using Game.TestInfrastructure.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
-using StackExchange.Redis;
 using System.Net;
 using System.Net.Http.Json;
 using System.Net.WebSockets;
@@ -21,39 +19,6 @@ namespace Game.Api.Tests.Integration
         public SocketConnectionTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper) : base(containers, testOutputHelper) { }
 
         /// <summary>
-        /// Seeds a user with a player (and a linked skill so the aggregate loads), without establishing a
-        /// session in Redis. Returns the userId (for WebSocket auth) and playerId.
-        /// </summary>
-        private async Task<(int UserId, int PlayerId)> SeedAsync(string username = "socketuser", string password = "socketpass")
-        {
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, username, password);
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            // The caches no longer lazily refill, so reload them to resolve the player's linked skill on load.
-            await ReloadReferenceCachesAsync();
-
-            return (user.Id, player.Id);
-        }
-
-        /// <summary>
-        /// Seeds test data, logs in via HTTP (creating the session in Redis), and returns the userId (for
-        /// WebSocket auth) and playerId.
-        /// </summary>
-        private async Task<(int UserId, int PlayerId)> SeedAndLoginAsync(string username = "socketuser", string password = "socketpass")
-        {
-            var seeded = await SeedAsync(username, password);
-
-            var loginResponse = await Client.PostAsJsonAsync("/api/Login",
-                new { Username = username, Password = password });
-            Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
-
-            return seeded;
-        }
-
-        /// <summary>
         /// Seeds a user with no player, so an authenticated handshake for it resolves no player to load.
         /// Returns the userId (for WebSocket auth).
         /// </summary>
@@ -63,13 +28,6 @@ namespace Game.Api.Tests.Integration
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
             var user = await TestDataSeeder.CreateUserAsync(context, username, password);
             return user.Id;
-        }
-
-        /// <summary>Reads the live TTL on the player's socket-presence key directly from Redis.</summary>
-        private async Task<TimeSpan?> GetPresenceTtlAsync(int playerId)
-        {
-            await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(Containers.CacheConnectionString);
-            return await multiplexer.GetDatabase().KeyTimeToLiveAsync($"{Constants.CACHE_PLAYER_SOCKET_PREFIX}_{playerId}");
         }
 
         [Fact]

--- a/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
+++ b/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
@@ -1,14 +1,11 @@
 using Game.Abstractions.Infrastructure;
-using Game.Api;
 using Game.Api.Services;
 using Game.Api.Sockets.Commands;
-using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using StackExchange.Redis;
 using System.Net.WebSockets;
 using Xunit;
 
@@ -351,25 +348,6 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(playerId, warning.Properties.Single(p => p.Key == "PlayerId").Value);
         }
 
-        /// <summary>
-        /// Seeds a user with a player and a linked skill, then logs in (creating the Redis session the
-        /// WebSocket handshake authenticates against), returning the ids needed for socket auth.
-        /// </summary>
-        private async Task<(int UserId, int PlayerId)> SeedAndLoginAsync(string username = "socketmgruser", string password = "socketmgrpass")
-        {
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, username, password);
-            var skill = await TestDataSeeder.CreateSkillAsync(context);
-            var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
-            await TestDataSeeder.LinkSkillToPlayerAsync(context, player.Id, skill.Id);
-            // The caches no longer lazily refill, so reload them to resolve the player's linked skill on load.
-            await ReloadReferenceCachesAsync();
-
-            await LoginAsync(username, password);
-            return (user.Id, player.Id);
-        }
-
         private async Task<bool> HasActiveSocketAsync(int playerId)
         {
             using var scope = CreateScope();
@@ -384,19 +362,8 @@ namespace Game.Api.Tests.Integration
             return await cache.Get(PresenceKey(playerId));
         }
 
-        private async Task<TimeSpan?> GetPresenceTtlAsync(int playerId)
-        {
-            await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(Containers.CacheConnectionString);
-            return await multiplexer.GetDatabase().KeyTimeToLiveAsync(PresenceKey(playerId));
-        }
-
         /// <summary>Polls the condition until it holds or a short timeout elapses; returns whether it held.</summary>
         private static Task<bool> WaitUntilAsync(Func<Task<bool>> condition, int timeoutMs = 5000) =>
             PollingHelper.PollUntilAsync(condition, held => held, timeoutMs);
-
-        private static string PresenceKey(int playerId)
-        {
-            return $"{Constants.CACHE_PLAYER_SOCKET_PREFIX}_{playerId}";
-        }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up split out of #1949 (per that issue's comment widening scope). Extracts three groups of duplicated integration-test helpers into `ApiIntegrationTestBase` (the shared base every affected test class already extends):

- **`SeedAsync`/`SeedAndLoginAsync`** (create user → skill → player → link → reload[, login]) — was re-implemented in `SocketConnectionTests`, `SocketManagerServiceTests`, and inlined ~15 times across `LoginControllerTests`.
- **`PresenceKey`/`GetPresenceTtlAsync`** — was duplicated in `SocketConnectionTests` and `SocketManagerServiceTests`.
- **`SocketDeadLetterEnvelope`/`SocketQueueName`/`SeedSocketDeadLettersAsync`** — was duplicated between `AdminDeadLettersControllerTests` and `SocketCommandDeadLettersIntegrationTests` (the socket-command dead-letter queue helpers; `AdminDeadLettersControllerTests`' separate player-update dead-letter helpers, which mirror the *internal* `Game.DataAccess.Constants` queue names, are untouched — they're not shared with any other file).

`LoginControllerTests` had ~15 near-identical inline seed blocks; only the ones with no further need for the tracked `User`/`Player` entities (or where the continued need was a simple id-keyed follow-up like banning a user or assigning a role) were migrated to the shared helper. The bespoke multi-player/multi-zone/custom-class scenarios (`SwitchPlayer_*`, `CreatePlayer_*`, etc.) were left as-is since they don't match the pattern being deduplicated.

Test-suite maintainability only — no production-code or behavior change.

## Test plan

- [x] `dotnet build Game.sln` — 0 errors, 0 warnings.
- [x] `dotnet test Game.Api.Tests -- --filter-class "*LoginControllerTests"` — 46/46 passed.
- [x] `dotnet test Game.Api.Tests -- --filter-class "*SocketConnectionTests" --filter-class "*SocketManagerServiceTests" --filter-class "*AdminDeadLettersControllerTests" --filter-class "*SocketCommandDeadLettersIntegrationTests"` — 40/40 passed.
- [x] Full `dotnet test Game.sln` run.

Closes #2023


---
_Generated by [Claude Code](https://claude.ai/code/session_01LYe2UM9v68H8FJ2qiaDfjd)_