### PR TITLE
Cancel RenderEngine's pending rAF handle in stop() (#2047)

### DIFF
--- a/UI/src/lib/engine/render-engine.ts
+++ b/UI/src/lib/engine/render-engine.ts
@@ -11,6 +11,7 @@ export class RenderEngine {
 	public tickRate = 0;
 
 	private running = false;
+	private rafHandle?: number;
 	private countTick = getEventCounter((t) => (this.tickRate = Math.round(t)));
 
 	public start() {
@@ -25,6 +26,12 @@ export class RenderEngine {
 
 	public stop() {
 		this.running = false;
+		// Cancel the pending frame so a start() within the same frame can't leave the old callback
+		// running alongside the new loop (mirrors LogicalEngine.stop clearing its tickSource handle).
+		if (this.rafHandle !== undefined) {
+			window.cancelAnimationFrame(this.rafHandle);
+			this.rafHandle = undefined;
+		}
 	}
 
 	//use performance.now instead of animation frame timestamp, because frame stamp is before some amount of processing.
@@ -32,7 +39,7 @@ export class RenderEngine {
 	private renderLoop() {
 		if (this.running) {
 			this.update();
-			window.requestAnimationFrame(() => this.renderLoop());
+			this.rafHandle = window.requestAnimationFrame(() => this.renderLoop());
 		}
 	}
 

--- a/UI/src/tests/lib/engine/render-engine.test.ts
+++ b/UI/src/tests/lib/engine/render-engine.test.ts
@@ -9,10 +9,15 @@ const logicEngineStub = vi.hoisted(() => ({ time: 0 }));
 vi.mock('$lib/engine/engine', () => ({ logicEngine: logicEngineStub }));
 
 const rafCallbacks: (() => void)[] = [];
+const cancelledHandles: number[] = [];
+let rafHandleCounter = 0;
 vi.stubGlobal('window', {
 	requestAnimationFrame: vi.fn((cb: () => void) => {
 		rafCallbacks.push(cb);
-		return rafCallbacks.length;
+		return ++rafHandleCounter;
+	}),
+	cancelAnimationFrame: vi.fn((handle: number) => {
+		cancelledHandles.push(handle);
 	})
 });
 
@@ -27,6 +32,8 @@ describe('RenderEngine', () => {
 
 	beforeEach(() => {
 		rafCallbacks.length = 0;
+		cancelledHandles.length = 0;
+		rafHandleCounter = 0;
 		logicEngineStub.time = 0;
 		performanceNow = 0;
 		renderUpdates = [];
@@ -58,6 +65,23 @@ describe('RenderEngine', () => {
 			engine.stop();
 			rafCallbacks.shift()?.(); // renderLoop checks running → false, schedules nothing
 			expect(rafCallbacks.length).toBe(0);
+		});
+
+		it('stop cancels the pending RAF callback (regression: stop→start within one frame doubling the loop)', () => {
+			// Without cancelling, a start() before this stale callback fires would leave it alive
+			// alongside the new loop — running is true again by then, so it would reschedule itself
+			// forever, doubling every onRenderUpdate notification from then on.
+			engine.start();
+			engine.stop();
+			expect(cancelledHandles).toEqual([1]);
+		});
+
+		it('cancels the latest handle, not a stale one, after several frames have run', () => {
+			engine.start(); // handle 1
+			rafCallbacks.shift()?.(); // handle 2
+			rafCallbacks.shift()?.(); // handle 3
+			engine.stop();
+			expect(cancelledHandles).toEqual([3]);
 		});
 
 		it('can be restarted after stop', () => {


### PR DESCRIPTION
## Summary

`RenderEngine.stop()` (`UI/src/lib/engine/render-engine.ts`) only flipped the `running` flag and never cancelled the already-queued `requestAnimationFrame` callback. If `start()` ran again within the same frame (or before that callback fired), the stale callback would find `running === true` by the time it fired and reschedule itself — producing a second, independent rAF chain that runs forever alongside the new one, each firing `notifyRenderUpdate` every frame.

`LogicalEngine` already guards the equivalent hazard by holding a `tickSource` handle and cancelling it in `stop()`; `RenderEngine` only had the boolean.

Latent today (current `stopEngines` → `startGame` cycles are separated by awaited network calls), but a one-line-away trap for any future synchronous restart, as noted in the issue.

## Changes

- Hold the rAF handle returned by `requestAnimationFrame` and `cancelAnimationFrame` it in `stop()`, mirroring `LogicalEngine.stop`'s handling of its `tickSource`.
- Added regression tests in `render-engine.test.ts`:
  - `stop()` cancels the pending RAF handle.
  - The correct (latest) handle is cancelled after several frames have run, not a stale one.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npx vitest run` — full suite, 299 files / 3764 tests passed
- [x] New tests specifically cover the stop→start-within-one-frame double-loop regression described in the issue

Closes #2047


---
_Generated by [Claude Code](https://claude.ai/code/session_01NEaoMj5dkEGJYyjae17AAJ)_