### PR TITLE
Extract shared ToEntity helper in admin repos to prevent add/edit field drift

### DIFF
--- a/Game.DataAccess/Repositories/Admin/AdminChallenges.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminChallenges.cs
@@ -52,36 +52,35 @@ namespace Game.DataAccess.Repositories.Admin
             }
 
             return ChangeSetProcessor.Apply(changes,
-                add: item => _entityStore.Insert(new Entities.Challenge
+                add: item => _entityStore.Insert(ToEntity(item)),
+                edit: item =>
                 {
-                    Name = item.Name,
-                    Description = item.Description,
-                    ChallengeTypeId = (int)item.ChallengeTypeId,
-                    TargetEntityId = item.TargetEntityId,
-                    ProgressGoal = item.ProgressGoal,
-                    RewardItemId = item.RewardItemId,
-                    RewardItemModId = item.RewardItemModId,
-                    DesignerNotes = item.DesignerNotes,
-                }),
-                edit: item => _entityStore.Update(new Entities.Challenge
-                {
-                    Id = item.Id,
-                    Name = item.Name,
-                    Description = item.Description,
-                    ChallengeTypeId = (int)item.ChallengeTypeId,
-                    TargetEntityId = item.TargetEntityId,
-                    ProgressGoal = item.ProgressGoal,
-                    RewardItemId = item.RewardItemId,
-                    RewardItemModId = item.RewardItemModId,
-                    DesignerNotes = item.DesignerNotes,
-                    RetiredAt = item.RetiredAt,
-                }),
+                    var entity = ToEntity(item);
+                    entity.Id = item.Id;
+                    entity.RetiredAt = item.RetiredAt;
+                    _entityStore.Update(entity);
+                },
                 key: item => item.Id,
                 resourceName: "challenge",
                 // An edit must target an existing challenge; a missing id is a not-found rejection (matching the
                 // relationship setters), not an EF 0-row update that throws. Challenges are zero-based-id
                 // reference data, so existence is the shared in-range index check.
                 editExists: item => _challenges.ValidateChallengeId(item.Id));
+        }
+
+        private static Entities.Challenge ToEntity(Contracts.Challenge item)
+        {
+            return new Entities.Challenge
+            {
+                Name = item.Name,
+                Description = item.Description,
+                ChallengeTypeId = (int)item.ChallengeTypeId,
+                TargetEntityId = item.TargetEntityId,
+                ProgressGoal = item.ProgressGoal,
+                RewardItemId = item.RewardItemId,
+                RewardItemModId = item.RewardItemModId,
+                DesignerNotes = item.DesignerNotes,
+            };
         }
 
         /// <summary>

--- a/Game.DataAccess/Repositories/Admin/AdminClasses.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminClasses.cs
@@ -27,35 +27,33 @@ namespace Game.DataAccess.Repositories.Admin
         public AdminSaveResult SaveClasses(IReadOnlyList<Change<Contracts.Class>> changes)
         {
             return ChangeSetProcessor.Apply(changes,
-                add: item => _entityStore.Insert(new Entities.Class
+                add: item => _entityStore.Insert(ToEntity(item)),
+                edit: item =>
                 {
-                    Name = item.Name,
-                    Description = item.Description,
-                    Word = item.Word,
-                    PassiveAttributeId = (int)item.PassiveAttributeId,
-                    PassiveAmount = item.PassiveAmount,
-                    PassiveScalingAttributeId = (int?)item.PassiveScalingAttributeId,
-                    PassiveScalingAmount = item.PassiveScalingAmount,
-                    PassiveModifierType = (int)item.PassiveModifierType,
-                    DesignerNotes = item.DesignerNotes,
-                }),
-                edit: item => _entityStore.Update(new Entities.Class
-                {
-                    Id = item.Id,
-                    Name = item.Name,
-                    Description = item.Description,
-                    Word = item.Word,
-                    PassiveAttributeId = (int)item.PassiveAttributeId,
-                    PassiveAmount = item.PassiveAmount,
-                    PassiveScalingAttributeId = (int?)item.PassiveScalingAttributeId,
-                    PassiveScalingAmount = item.PassiveScalingAmount,
-                    PassiveModifierType = (int)item.PassiveModifierType,
-                    DesignerNotes = item.DesignerNotes,
-                    RetiredAt = item.RetiredAt,
-                }),
+                    var entity = ToEntity(item);
+                    entity.Id = item.Id;
+                    entity.RetiredAt = item.RetiredAt;
+                    _entityStore.Update(entity);
+                },
                 key: item => item.Id,
                 resourceName: "class",
                 editExists: item => _classes.LookupClass(item.Id) is not null);
+        }
+
+        private static Entities.Class ToEntity(Contracts.Class item)
+        {
+            return new Entities.Class
+            {
+                Name = item.Name,
+                Description = item.Description,
+                Word = item.Word,
+                PassiveAttributeId = (int)item.PassiveAttributeId,
+                PassiveAmount = item.PassiveAmount,
+                PassiveScalingAttributeId = (int?)item.PassiveScalingAttributeId,
+                PassiveScalingAmount = item.PassiveScalingAmount,
+                PassiveModifierType = (int)item.PassiveModifierType,
+                DesignerNotes = item.DesignerNotes,
+            };
         }
 
         public AdminSaveResult SetStarterSkills(SetClassStarterSkillsData data)

--- a/Game.DataAccess/Repositories/Admin/AdminEnemies.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminEnemies.cs
@@ -33,25 +33,29 @@ namespace Game.DataAccess.Repositories.Admin
             }
 
             return ChangeSetProcessor.Apply(changes,
-                add: item => _entityStore.Insert(new Entities.Enemy
+                add: item => _entityStore.Insert(ToEntity(item)),
+                edit: item =>
                 {
-                    Name = item.Name,
-                    IsBoss = item.IsBoss,
-                    DesignerNotes = item.DesignerNotes,
-                }),
-                edit: item => _entityStore.Update(new Entities.Enemy
-                {
-                    Id = item.Id,
-                    Name = item.Name,
-                    IsBoss = item.IsBoss,
-                    DesignerNotes = item.DesignerNotes,
-                    RetiredAt = item.RetiredAt,
-                }),
+                    var entity = ToEntity(item);
+                    entity.Id = item.Id;
+                    entity.RetiredAt = item.RetiredAt;
+                    _entityStore.Update(entity);
+                },
                 key: item => item.Id,
                 resourceName: "enemy",
                 // An edit must target an existing enemy; a missing id is a not-found rejection (matching the
                 // relationship setters), validated up front by the processor before anything is staged.
                 editExists: item => _enemies.GetEnemy(item.Id) is not null);
+        }
+
+        private static Entities.Enemy ToEntity(Contracts.Enemy item)
+        {
+            return new Entities.Enemy
+            {
+                Name = item.Name,
+                IsBoss = item.IsBoss,
+                DesignerNotes = item.DesignerNotes,
+            };
         }
 
         public AdminSaveResult SetAttributeDistributions(SetEnemyAttributeDistributions data)

--- a/Game.DataAccess/Repositories/Admin/AdminItemMods.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminItemMods.cs
@@ -31,31 +31,33 @@ namespace Game.DataAccess.Repositories.Admin
             }
 
             return ChangeSetProcessor.Apply(changes,
-                add: item => _entityStore.Insert(new Entities.ItemMod
-                {
-                    Name = item.Name,
-                    Description = item.Description,
-                    ItemModTypeId = (int)item.ItemModTypeId,
-                    RarityId = (int)item.RarityId,
-                    DesignerNotes = item.DesignerNotes,
-                }),
+                add: item => _entityStore.Insert(ToEntity(item)),
                 // Build a fresh, navigation-free entity rather than mutating the cached one, whose loaded
                 // graph would otherwise be dragged into the change tracker.
-                edit: item => _entityStore.Update(new Entities.ItemMod
+                edit: item =>
                 {
-                    Id = item.Id,
-                    Name = item.Name,
-                    Description = item.Description,
-                    ItemModTypeId = (int)item.ItemModTypeId,
-                    RarityId = (int)item.RarityId,
-                    DesignerNotes = item.DesignerNotes,
-                    RetiredAt = item.RetiredAt,
-                }),
+                    var entity = ToEntity(item);
+                    entity.Id = item.Id;
+                    entity.RetiredAt = item.RetiredAt;
+                    _entityStore.Update(entity);
+                },
                 key: item => item.Id,
                 resourceName: "item mod",
                 // An edit must target an existing item mod; a missing id is a not-found rejection (matching the
                 // relationship setters), validated up front by the processor before anything is staged.
                 editExists: item => _itemMods.LookupItemMod(item.Id) is not null);
+        }
+
+        private static Entities.ItemMod ToEntity(Contracts.ItemMod item)
+        {
+            return new Entities.ItemMod
+            {
+                Name = item.Name,
+                Description = item.Description,
+                ItemModTypeId = (int)item.ItemModTypeId,
+                RarityId = (int)item.RarityId,
+                DesignerNotes = item.DesignerNotes,
+            };
         }
 
         public AdminSaveResult SetAttributes(AddEditAttributesData data)

--- a/Game.DataAccess/Repositories/Admin/AdminItems.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminItems.cs
@@ -68,41 +68,38 @@ namespace Game.DataAccess.Repositories.Admin
             }
 
             return ChangeSetProcessor.Apply(changes,
-                add: item => _entityStore.Insert(new Entities.Item
-                {
-                    Name = item.Name,
-                    Description = item.Description,
-                    ItemCategoryId = (int)item.ItemCategoryId,
-                    RarityId = (int)item.RarityId,
-                    IconPath = item.IconPath,
-                    GrantedSkillId = item.GrantedSkillId,
-                    WeaponType = (int?)item.WeaponType,
-                    RequiredProficiencyId = item.RequiredProficiencyId,
-                    RequiredProficiencyLevel = item.RequiredProficiencyId is null ? 0 : item.RequiredProficiencyLevel,
-                    DesignerNotes = item.DesignerNotes,
-                }),
+                add: item => _entityStore.Insert(ToEntity(item)),
                 // Build a fresh, navigation-free entity rather than mutating the cached one, whose loaded
                 // graph would otherwise be dragged into the change tracker.
-                edit: item => _entityStore.Update(new Entities.Item
+                edit: item =>
                 {
-                    Id = item.Id,
-                    Name = item.Name,
-                    Description = item.Description,
-                    ItemCategoryId = (int)item.ItemCategoryId,
-                    RarityId = (int)item.RarityId,
-                    IconPath = item.IconPath,
-                    GrantedSkillId = item.GrantedSkillId,
-                    WeaponType = (int?)item.WeaponType,
-                    RequiredProficiencyId = item.RequiredProficiencyId,
-                    RequiredProficiencyLevel = item.RequiredProficiencyId is null ? 0 : item.RequiredProficiencyLevel,
-                    DesignerNotes = item.DesignerNotes,
-                    RetiredAt = item.RetiredAt,
-                }),
+                    var entity = ToEntity(item);
+                    entity.Id = item.Id;
+                    entity.RetiredAt = item.RetiredAt;
+                    _entityStore.Update(entity);
+                },
                 key: item => item.Id,
                 resourceName: "item",
                 // An edit must target an existing item; a missing id is a not-found rejection (matching the
                 // relationship setters), validated up front by the processor before anything is staged.
                 editExists: item => _items.LookupItem(item.Id) is not null);
+        }
+
+        private static Entities.Item ToEntity(Contracts.Item item)
+        {
+            return new Entities.Item
+            {
+                Name = item.Name,
+                Description = item.Description,
+                ItemCategoryId = (int)item.ItemCategoryId,
+                RarityId = (int)item.RarityId,
+                IconPath = item.IconPath,
+                GrantedSkillId = item.GrantedSkillId,
+                WeaponType = (int?)item.WeaponType,
+                RequiredProficiencyId = item.RequiredProficiencyId,
+                RequiredProficiencyLevel = item.RequiredProficiencyId is null ? 0 : item.RequiredProficiencyLevel,
+                DesignerNotes = item.DesignerNotes,
+            };
         }
 
         /// <summary>

--- a/Game.DataAccess/Repositories/Admin/AdminLessons.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminLessons.cs
@@ -29,31 +29,31 @@ namespace Game.DataAccess.Repositories.Admin
             }
 
             return ChangeSetProcessor.Apply(changes,
-                add: item => _entityStore.Insert(new Entities.Lesson
+                add: item => _entityStore.Insert(ToEntity(item)),
+                edit: item =>
                 {
-                    Key = item.Key,
-                    Name = item.Name,
-                    TriggerType = (int)item.TriggerType,
-                    ScreenKey = item.ScreenKey,
-                    TriggerMechanicEvent = item.TriggerMechanicEvent is EMechanicEvent mechanicEvent ? (int)mechanicEvent : null,
-                    Ordinal = item.Ordinal,
-                    DesignerNotes = item.DesignerNotes,
-                }),
-                edit: item => _entityStore.Update(new Entities.Lesson
-                {
-                    Id = item.Id,
-                    Key = item.Key,
-                    Name = item.Name,
-                    TriggerType = (int)item.TriggerType,
-                    ScreenKey = item.ScreenKey,
-                    TriggerMechanicEvent = item.TriggerMechanicEvent is EMechanicEvent mechanicEvent ? (int)mechanicEvent : null,
-                    Ordinal = item.Ordinal,
-                    DesignerNotes = item.DesignerNotes,
-                    RetiredAt = item.RetiredAt,
-                }),
+                    var entity = ToEntity(item);
+                    entity.Id = item.Id;
+                    entity.RetiredAt = item.RetiredAt;
+                    _entityStore.Update(entity);
+                },
                 key: item => item.Id,
                 resourceName: "lesson",
                 editExists: item => _lessons.LookupLesson(item.Id) is not null);
+        }
+
+        private static Entities.Lesson ToEntity(Contracts.Lesson item)
+        {
+            return new Entities.Lesson
+            {
+                Key = item.Key,
+                Name = item.Name,
+                TriggerType = (int)item.TriggerType,
+                ScreenKey = item.ScreenKey,
+                TriggerMechanicEvent = item.TriggerMechanicEvent is EMechanicEvent mechanicEvent ? (int)mechanicEvent : null,
+                Ordinal = item.Ordinal,
+                DesignerNotes = item.DesignerNotes,
+            };
         }
 
         public AdminSaveResult SetSteps(SetLessonStepsData data)

--- a/Game.DataAccess/Repositories/Admin/AdminPaths.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminPaths.cs
@@ -30,25 +30,28 @@ namespace Game.DataAccess.Repositories.Admin
             }
 
             return ChangeSetProcessor.Apply(changes,
-                add: item => _entityStore.Insert(new Entities.Path
+                add: item => _entityStore.Insert(ToEntity(item)),
+                edit: item =>
                 {
-                    Name = item.Name,
-                    Description = item.Description,
-                    ActivityKey = (int)item.ActivityKey,
-                    DesignerNotes = item.DesignerNotes,
-                }),
-                edit: item => _entityStore.Update(new Entities.Path
-                {
-                    Id = item.Id,
-                    Name = item.Name,
-                    Description = item.Description,
-                    ActivityKey = (int)item.ActivityKey,
-                    DesignerNotes = item.DesignerNotes,
-                    RetiredAt = item.RetiredAt,
-                }),
+                    var entity = ToEntity(item);
+                    entity.Id = item.Id;
+                    entity.RetiredAt = item.RetiredAt;
+                    _entityStore.Update(entity);
+                },
                 key: item => item.Id,
                 resourceName: "path",
                 editExists: item => _proficiencies.LookupPath(item.Id) is not null);
+        }
+
+        private static Entities.Path ToEntity(Contracts.Path item)
+        {
+            return new Entities.Path
+            {
+                Name = item.Name,
+                Description = item.Description,
+                ActivityKey = (int)item.ActivityKey,
+                DesignerNotes = item.DesignerNotes,
+            };
         }
 
         /// <summary>

--- a/Game.DataAccess/Repositories/Admin/AdminProficiencies.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminProficiencies.cs
@@ -50,41 +50,36 @@ namespace Game.DataAccess.Repositories.Admin
             }
 
             return ChangeSetProcessor.Apply(changes,
-                add: item => _entityStore.Insert(new Entities.Proficiency
+                add: item => _entityStore.Insert(ToEntity(item)),
+                edit: item =>
                 {
-                    Name = item.Name,
-                    Description = item.Description,
-                    IconPath = item.IconPath,
-                    Word = item.Word,
-                    Pronunciation = item.Pronunciation,
-                    Translation = item.Translation,
-                    PathId = item.PathId,
-                    PathOrdinal = item.PathOrdinal,
-                    MaxLevel = item.MaxLevel,
-                    BaseXp = item.BaseXp,
-                    XpGrowth = item.XpGrowth,
-                    DesignerNotes = item.DesignerNotes,
-                }),
-                edit: item => _entityStore.Update(new Entities.Proficiency
-                {
-                    Id = item.Id,
-                    Name = item.Name,
-                    Description = item.Description,
-                    IconPath = item.IconPath,
-                    Word = item.Word,
-                    Pronunciation = item.Pronunciation,
-                    Translation = item.Translation,
-                    PathId = item.PathId,
-                    PathOrdinal = item.PathOrdinal,
-                    MaxLevel = item.MaxLevel,
-                    BaseXp = item.BaseXp,
-                    XpGrowth = item.XpGrowth,
-                    DesignerNotes = item.DesignerNotes,
-                    RetiredAt = item.RetiredAt,
-                }),
+                    var entity = ToEntity(item);
+                    entity.Id = item.Id;
+                    entity.RetiredAt = item.RetiredAt;
+                    _entityStore.Update(entity);
+                },
                 key: item => item.Id,
                 resourceName: "proficiency",
                 editExists: item => _proficiencies.LookupProficiency(item.Id) is not null);
+        }
+
+        private static Entities.Proficiency ToEntity(Contracts.Proficiency item)
+        {
+            return new Entities.Proficiency
+            {
+                Name = item.Name,
+                Description = item.Description,
+                IconPath = item.IconPath,
+                Word = item.Word,
+                Pronunciation = item.Pronunciation,
+                Translation = item.Translation,
+                PathId = item.PathId,
+                PathOrdinal = item.PathOrdinal,
+                MaxLevel = item.MaxLevel,
+                BaseXp = item.BaseXp,
+                XpGrowth = item.XpGrowth,
+                DesignerNotes = item.DesignerNotes,
+            };
         }
 
         public AdminSaveResult SetModifiers(SetProficiencyModifiersData data)

--- a/Game.DataAccess/Repositories/Admin/AdminSkillRecipes.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminSkillRecipes.cs
@@ -52,21 +52,26 @@ namespace Game.DataAccess.Repositories.Admin
             }
 
             return ChangeSetProcessor.Apply(changes,
-                add: item => _entityStore.Insert(new Entities.SkillRecipe
+                add: item => _entityStore.Insert(ToEntity(item)),
+                edit: item =>
                 {
-                    ResultSkillId = item.ResultSkillId,
-                    DesignerNotes = item.DesignerNotes,
-                }),
-                edit: item => _entityStore.Update(new Entities.SkillRecipe
-                {
-                    Id = item.Id,
-                    ResultSkillId = item.ResultSkillId,
-                    DesignerNotes = item.DesignerNotes,
-                    RetiredAt = item.RetiredAt,
-                }),
+                    var entity = ToEntity(item);
+                    entity.Id = item.Id;
+                    entity.RetiredAt = item.RetiredAt;
+                    _entityStore.Update(entity);
+                },
                 key: item => item.Id,
                 resourceName: "skill recipe",
                 editExists: item => _recipes.LookupSkillRecipe(item.Id) is not null);
+        }
+
+        private static Entities.SkillRecipe ToEntity(Contracts.SkillRecipe item)
+        {
+            return new Entities.SkillRecipe
+            {
+                ResultSkillId = item.ResultSkillId,
+                DesignerNotes = item.DesignerNotes,
+            };
         }
 
         public AdminSaveResult SetInputs(SetSkillRecipeInputsData data)

--- a/Game.DataAccess/Repositories/Admin/AdminSkills.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminSkills.cs
@@ -26,43 +26,38 @@ namespace Game.DataAccess.Repositories.Admin
             }
 
             return ChangeSetProcessor.Apply(changes,
-                add: item => _entityStore.Insert(new Entities.Skill
+                add: item => _entityStore.Insert(ToEntity(item)),
+                edit: item =>
                 {
-                    Name = item.Name,
-                    BaseDamage = item.BaseDamage,
-                    CriticalChance = item.CriticalChance,
-                    CooldownMs = item.CooldownMs,
-                    Description = item.Description,
-                    IconPath = item.IconPath,
-                    RarityId = (int)item.RarityId,
-                    Word = item.Word,
-                    Pronunciation = item.Pronunciation,
-                    Translation = item.Translation,
-                    Acquisition = (int)item.Acquisition,
-                    DesignerNotes = item.DesignerNotes,
-                }),
-                edit: item => _entityStore.Update(new Entities.Skill
-                {
-                    Id = item.Id,
-                    Name = item.Name,
-                    BaseDamage = item.BaseDamage,
-                    CriticalChance = item.CriticalChance,
-                    CooldownMs = item.CooldownMs,
-                    Description = item.Description,
-                    IconPath = item.IconPath,
-                    RarityId = (int)item.RarityId,
-                    Word = item.Word,
-                    Pronunciation = item.Pronunciation,
-                    Translation = item.Translation,
-                    Acquisition = (int)item.Acquisition,
-                    DesignerNotes = item.DesignerNotes,
-                    RetiredAt = item.RetiredAt,
-                }),
+                    var entity = ToEntity(item);
+                    entity.Id = item.Id;
+                    entity.RetiredAt = item.RetiredAt;
+                    _entityStore.Update(entity);
+                },
                 key: item => item.Id,
                 resourceName: "skill",
                 // An edit must target an existing skill; a missing id is a not-found rejection (matching the
                 // relationship setters), validated up front by the processor before anything is staged.
                 editExists: item => _skills.LookupSkill(item.Id) is not null);
+        }
+
+        private static Entities.Skill ToEntity(Contracts.Skill item)
+        {
+            return new Entities.Skill
+            {
+                Name = item.Name,
+                BaseDamage = item.BaseDamage,
+                CriticalChance = item.CriticalChance,
+                CooldownMs = item.CooldownMs,
+                Description = item.Description,
+                IconPath = item.IconPath,
+                RarityId = (int)item.RarityId,
+                Word = item.Word,
+                Pronunciation = item.Pronunciation,
+                Translation = item.Translation,
+                Acquisition = (int)item.Acquisition,
+                DesignerNotes = item.DesignerNotes,
+            };
         }
 
         public AdminSaveResult SetMultipliers(AddEditAttributesData data)
@@ -157,35 +152,16 @@ namespace Game.DataAccess.Repositories.Admin
             var existingEffectIds = skill.SkillEffects.Select(se => se.Id).ToHashSet();
 
             return ChangeSetProcessor.Apply(data.Changes,
-                add: effect => _entityStore.Insert(new Entities.SkillEffect
-                {
-                    SkillId = skill.Id,
-                    Target = (int)effect.Target,
-                    AttributeId = (int)effect.AttributeId,
-                    ModifierType = (int)effect.ModifierTypeId,
-                    Amount = effect.Amount,
-                    DurationMs = effect.DurationMs,
-                    ScalingAttributeId = (int)effect.ScalingAttributeId,
-                    ScalingAmount = effect.ScalingAmount,
-                }),
+                add: effect => _entityStore.Insert(ToEffectEntity(skill.Id, effect)),
                 // Build fresh, navigation-free entities so cached back-references don't drag
                 // the whole graph into the change tracker.
                 edit: effect =>
                 {
                     if (existingEffectIds.Contains(effect.Id))
                     {
-                        _entityStore.Update(new Entities.SkillEffect
-                        {
-                            Id = effect.Id,
-                            SkillId = skill.Id,
-                            Target = (int)effect.Target,
-                            AttributeId = (int)effect.AttributeId,
-                            ModifierType = (int)effect.ModifierTypeId,
-                            Amount = effect.Amount,
-                            DurationMs = effect.DurationMs,
-                            ScalingAttributeId = (int)effect.ScalingAttributeId,
-                            ScalingAmount = effect.ScalingAmount,
-                        });
+                        var entity = ToEffectEntity(skill.Id, effect);
+                        entity.Id = effect.Id;
+                        _entityStore.Update(entity);
                     }
                 },
                 delete: effect =>
@@ -200,6 +176,21 @@ namespace Game.DataAccess.Repositories.Admin
                 },
                 key: effect => effect.Id,
                 resourceName: "skill effect");
+        }
+
+        private static Entities.SkillEffect ToEffectEntity(int skillId, Contracts.SkillEffect effect)
+        {
+            return new Entities.SkillEffect
+            {
+                SkillId = skillId,
+                Target = (int)effect.Target,
+                AttributeId = (int)effect.AttributeId,
+                ModifierType = (int)effect.ModifierTypeId,
+                Amount = effect.Amount,
+                DurationMs = effect.DurationMs,
+                ScalingAttributeId = (int)effect.ScalingAttributeId,
+                ScalingAmount = effect.ScalingAmount,
+            };
         }
     }
 }

--- a/Game.DataAccess/Repositories/Admin/AdminTags.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminTags.cs
@@ -27,20 +27,25 @@ namespace Game.DataAccess.Repositories.Admin
             // front as a graceful business failure rather than 500-ing (Add ids are store-generated sentinels,
             // so they are excluded from the guard). An otherwise well-formed tag write never rejects.
             return ChangeSetProcessor.Apply(changes,
-                add: item => _entityStore.Insert(new Entities.Tag
+                add: item => _entityStore.Insert(ToEntity(item)),
+                edit: item =>
                 {
-                    Name = item.Name,
-                    TagCategoryId = item.TagCategoryId,
-                }),
-                edit: item => _entityStore.Update(new Entities.Tag
-                {
-                    Id = item.Id,
-                    Name = item.Name,
-                    TagCategoryId = item.TagCategoryId,
-                }),
+                    var entity = ToEntity(item);
+                    entity.Id = item.Id;
+                    _entityStore.Update(entity);
+                },
                 delete: item => _entityStore.DeleteByKey<Entities.Tag>(item.Id),
                 key: item => item.Id,
                 resourceName: "tag");
+        }
+
+        private static Entities.Tag ToEntity(Contracts.Tag item)
+        {
+            return new Entities.Tag
+            {
+                Name = item.Name,
+                TagCategoryId = item.TagCategoryId,
+            };
         }
     }
 }

--- a/Game.DataAccess/Repositories/Admin/AdminZones.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminZones.cs
@@ -80,39 +80,36 @@ namespace Game.DataAccess.Repositories.Admin
             }
 
             return ChangeSetProcessor.Apply(changes,
-                add: item => _entityStore.Insert(new Entities.Zone
+                add: item => _entityStore.Insert(ToEntity(item)),
+                edit: item =>
                 {
-                    Name = item.Name,
-                    Description = item.Description,
-                    LevelMin = item.LevelMin,
-                    LevelMax = item.LevelMax,
-                    Order = item.Order,
-                    BossEnemyId = item.BossEnemyId,
-                    BossLevel = item.BossLevel,
-                    UnlockChallengeId = item.UnlockChallengeId,
-                    IsHome = item.IsHome,
-                    DesignerNotes = item.DesignerNotes,
-                }),
-                edit: item => _entityStore.Update(new Entities.Zone
-                {
-                    Id = item.Id,
-                    Name = item.Name,
-                    Description = item.Description,
-                    LevelMin = item.LevelMin,
-                    LevelMax = item.LevelMax,
-                    Order = item.Order,
-                    BossEnemyId = item.BossEnemyId,
-                    BossLevel = item.BossLevel,
-                    UnlockChallengeId = item.UnlockChallengeId,
-                    IsHome = item.IsHome,
-                    DesignerNotes = item.DesignerNotes,
-                    RetiredAt = item.RetiredAt,
-                }),
+                    var entity = ToEntity(item);
+                    entity.Id = item.Id;
+                    entity.RetiredAt = item.RetiredAt;
+                    _entityStore.Update(entity);
+                },
                 key: item => item.Id,
                 resourceName: "zone",
                 // An edit must target an existing zone; a missing id is a not-found rejection (matching the
                 // relationship setters), validated up front by the processor before anything is staged.
                 editExists: item => _zones.LookupZone(item.Id) is not null);
+        }
+
+        private static Entities.Zone ToEntity(Contracts.Zone item)
+        {
+            return new Entities.Zone
+            {
+                Name = item.Name,
+                Description = item.Description,
+                LevelMin = item.LevelMin,
+                LevelMax = item.LevelMax,
+                Order = item.Order,
+                BossEnemyId = item.BossEnemyId,
+                BossLevel = item.BossLevel,
+                UnlockChallengeId = item.UnlockChallengeId,
+                IsHome = item.IsHome,
+                DesignerNotes = item.DesignerNotes,
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Every admin `Save*` repository (`Game.DataAccess/Repositories/Admin`) built near-identical 10–14-property entity constructions in both its `add:` and `edit:` `ChangeSetProcessor.Apply` lambdas, differing only in `Id`/`RetiredAt`. Since the entity scalar columns aren't `required` members (only string columns are), a field mapped in `add:` but forgotten in `edit:` (or vice versa) compiles cleanly and silently persists a default — exactly the drift the `required`-members convention on `PlayerCacheModel` exists to prevent.

This extracts a private `ToEntity(contract)` per repo, used by both lambdas, with `edit:` setting `entity.Id = item.Id;` (and `entity.RetiredAt = item.RetiredAt;` where the entity carries retirement) afterward — halving the field lists and making add/edit drift structurally impossible. This mirrors the pattern already used by several child-collection setters in the same files (e.g. `AdminProficiencies.ToModifierEntity`, `AdminClasses.ToDistributionEntity`).

Applied to all 12 admin repos named in the issue — `AdminItems`, `AdminSkills`, `AdminProficiencies`, `AdminZones`, `AdminChallenges`, `AdminClasses`, `AdminEnemies`, `AdminLessons`, `AdminPaths`, `AdminItemMods`, `AdminTags`, `AdminSkillRecipes` — plus `AdminSkills.SetEffects`, a child-collection setter that had the same add/edit duplication for `SkillEffect`.

Deliberately per-repo, no new shared framework, matching the issue's suggested fix. Mechanical refactor — no behavior change.

## Test plan

- [x] `dotnet build Game.sln` — clean, 0 warnings/errors
- [x] `dotnet test Game.sln --no-build --no-restore` — full suite green (Game.Core.Tests 1371, Game.Infrastructure.Tests 66, Game.Application.Tests 992, Game.Api.Tests 823 — 3252 total, 0 failures)

No new tests: this is a pure mapping-shape refactor with identical persisted output, already covered by each repo's existing add/edit test coverage.

Closes #2051

---
_Generated by [Claude Code](https://claude.ai/code/session_01BREDZhU7RZF2go1r9Dtu61)_