### PR TITLE
Data-tier consistency: Zones routes through ReferenceSnapshotExtensions; challenge resolution fails loudly on orphaned refs

### DIFF
--- a/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerProgressRepositoryIntegrationTests.cs
@@ -8,6 +8,7 @@ using Game.Core.Players;
 using Game.Core.Progress;
 using Game.Core.TestInfrastructure.Builders;
 using Game.DataAccess;
+using Game.DataAccess.Mapping;
 using Game.DataAccess.Repositories;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Base;
@@ -540,6 +541,35 @@ namespace Game.Application.Tests.DataAccess
                 var kills = Assert.Single(stats, s => s.Type == EStatisticType.EnemiesKilled && s.EntityId == null);
                 Assert.Equal(5m, kills.Value);
             }
+        }
+
+        [Fact]
+        public async Task GetChallenges_OrphanedChallengeReference_ThrowsDiagnosableException()
+        {
+            var playerId = await SeedPlayerAsync();
+
+            using var multiplexer = await ConnectRedisAsync();
+            var redis = multiplexer.GetDatabase();
+            var hashKey = $"Progress_{playerId}";
+
+            // A challenge id with no matching reference-cache entry stands in for a content-data mistake (a
+            // migration/seed that removed a referenced challenge) — the same class of defect the player-load
+            // missing-reference policy (docs/backend.md → Reference Data) guards against for items/mods/skills.
+            // Written straight to the cache hash (the field-name format `ToCoreChallenge` reads) rather than
+            // through Save, since Save can only ever persist a challenge already resolved from the live catalog.
+            var orphaned = new CachedPlayerChallenge { ChallengeId = 999999, Progress = 1m, Completed = false, CompletedAt = null };
+            await redis.HashSetAsync(hashKey, "C_999999", orphaned.Serialize());
+
+            using var scope = CreateScope();
+            var repo = scope.ServiceProvider.GetRequiredService<IPlayerProgressRepository>();
+
+            var ex = await Assert.ThrowsAsync<OrphanedReferenceException>(() => repo.GetChallenges(playerId));
+
+            // The message names the player, the catalog, and the missing id so the mistake is diagnosable from logs.
+            Assert.Contains($"Player {playerId}", ex.Message);
+            Assert.Contains("challenge", ex.Message);
+            Assert.Contains("999999", ex.Message);
+            Assert.NotNull(ex.InnerException);
         }
 
         [Fact]

--- a/Game.DataAccess/Mapping/OrphanedReferenceException.cs
+++ b/Game.DataAccess/Mapping/OrphanedReferenceException.cs
@@ -14,5 +14,24 @@ namespace Game.DataAccess.Mapping
             $"Player {playerId} owns a {catalogName} reference with Id {missingId} that no longer resolves against " +
             $"the {catalogName} catalog (a content-data mistake — a referenced id was removed). Player-owned " +
             "references must stay resolvable: top-level reference records are retired, never deleted.",
-            innerException);
+            innerException)
+    {
+        /// <summary>
+        /// Resolves a player-owned reference against its catalog, rethrowing a catalog miss (a resolver's
+        /// documented <see cref="ArgumentOutOfRangeException"/>) as a loud, diagnosable
+        /// <see cref="OrphanedReferenceException"/> naming the player, catalog, and missing id. Any other
+        /// failure propagates unwrapped so the orphaned-reference diagnosis stays truthful.
+        /// </summary>
+        public static T ResolveOrThrow<T>(Func<int, T> resolve, int referenceId, int playerId, string catalogName)
+        {
+            try
+            {
+                return resolve(referenceId);
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                throw new OrphanedReferenceException(playerId, catalogName, referenceId, ex);
+            }
+        }
+    }
 }

--- a/Game.DataAccess/Mapping/PlayerCacheMapper.cs
+++ b/Game.DataAccess/Mapping/PlayerCacheMapper.cs
@@ -106,7 +106,7 @@ namespace Game.DataAccess.Mapping
             var unlockedItems = new List<UnlockedItemSlot>();
             foreach (var ui in model.UnlockedItems)
             {
-                var coreItem = ResolveOrThrow(items.GetItem, ui.ItemId, model.Id, "item");
+                var coreItem = OrphanedReferenceException.ResolveOrThrow(items.GetItem, ui.ItemId, model.Id, "item");
                 var appliedMods = new List<AppliedModSlot>();
 
                 if (appliedModsByItem.TryGetValue(ui.ItemId, out var mods))
@@ -117,7 +117,7 @@ namespace Game.DataAccess.Mapping
                         {
                             ItemModId = am.ItemModId,
                             ItemModSlotId = am.ItemModSlotId,
-                            ItemMod = ResolveOrThrow(itemMods.GetItemMod, am.ItemModId, model.Id, "item mod"),
+                            ItemMod = OrphanedReferenceException.ResolveOrThrow(itemMods.GetItemMod, am.ItemModId, model.Id, "item mod"),
                         });
                     }
                 }
@@ -150,7 +150,7 @@ namespace Game.DataAccess.Mapping
             // BattleSnapshot.SkillIds and sent to the client, so it must be deterministic to preserve battle
             // parity — including for legacy rows that default to Order = 0 (SkillId is the deterministic tie-break).
             var skillsById = model.Skills
-                .ToDictionary(ps => ps.SkillId, ps => ResolveOrThrow(skills.GetSkill, ps.SkillId, model.Id, "skill"));
+                .ToDictionary(ps => ps.SkillId, ps => OrphanedReferenceException.ResolveOrThrow(skills.GetSkill, ps.SkillId, model.Id, "skill"));
 
             var playerSkills = skillsById.Values.ToList();
 
@@ -184,26 +184,6 @@ namespace Game.DataAccess.Mapping
                 LogPreferences = model.LogPreferences,
                 Lessons = model.Lessons,
             };
-        }
-
-        /// <summary>
-        /// Resolves an owned reference (item / item mod / skill) against its catalog, rethrowing a catalog miss as a
-        /// loud, diagnosable <see cref="OrphanedReferenceException"/> that names the player, catalog, and missing
-        /// id. We never silently drop the player-owned row; instead the aggregate fails loudly so a content-data
-        /// mistake (a removed referenced id) is obvious from logs rather than surfacing as an opaque load failure.
-        /// </summary>
-        private static T ResolveOrThrow<T>(Func<int, T> resolve, int referenceId, int playerId, string catalogName)
-        {
-            try
-            {
-                return resolve(referenceId);
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                // Only a catalog miss (GetById's documented out-of-range contract) is an orphaned reference;
-                // any other failure propagates unwrapped so the orphaned-reference diagnosis stays truthful.
-                throw new OrphanedReferenceException(playerId, catalogName, referenceId, ex);
-            }
         }
     }
 }

--- a/Game.DataAccess/Repositories/PlayerProgressRepository.cs
+++ b/Game.DataAccess/Repositories/PlayerProgressRepository.cs
@@ -5,6 +5,7 @@ using Game.Core;
 using Game.Core.Events;
 using Game.Core.Players;
 using Game.Core.Progress;
+using Game.DataAccess.Mapping;
 using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -59,7 +60,7 @@ namespace Game.DataAccess.Repositories
             return new PlayerProgress(
                 player,
                 cached.Statistics.Select(ToCoreStatistic),
-                cached.Challenges.Select(ToCoreChallenge),
+                cached.Challenges.Select(c => ToCoreChallenge(c, player.Id)),
                 cached.Proficiencies.Select(ToCoreProficiency));
         }
 
@@ -72,7 +73,7 @@ namespace Game.DataAccess.Repositories
         public async Task<List<CoreChallenge>> GetChallenges(int playerId, CancellationToken cancellationToken = default)
         {
             var cached = await GetCachedProgress(playerId, cancellationToken);
-            return cached.Challenges.Select(ToCoreChallenge).ToList();
+            return cached.Challenges.Select(c => ToCoreChallenge(c, playerId)).ToList();
         }
 
         public async Task<HashSet<int>> GetCompletedChallengeIds(int playerId, CancellationToken cancellationToken = default)
@@ -269,8 +270,12 @@ namespace Game.DataAccess.Repositories
             Value = cached.Value,
         };
 
-        private CoreChallenge ToCoreChallenge(CachedPlayerChallenge cached) =>
-            new(_challenges.GetChallenge(cached.ChallengeId), cached.Progress, cached.Completed, cached.CompletedAt);
+        private CoreChallenge ToCoreChallenge(CachedPlayerChallenge cached, int playerId) =>
+            new(
+                OrphanedReferenceException.ResolveOrThrow(_challenges.GetChallenge, cached.ChallengeId, playerId, "challenge"),
+                cached.Progress,
+                cached.Completed,
+                cached.CompletedAt);
 
         private static CoreProficiency ToCoreProficiency(CachedPlayerProficiency cached) => new()
         {

--- a/Game.DataAccess/Repositories/Zones.cs
+++ b/Game.DataAccess/Repositories/Zones.cs
@@ -8,8 +8,8 @@ namespace Game.DataAccess.Repositories
 {
     internal class Zones(ZonesCacheHolder holder) : IZones, IZoneEntityCache
     {
-        // A single volatile read of the current snapshot; capturing it once per call keeps the bounds check
-        // and the index reading the same list, so a build-then-swap mid-call can never tear.
+        // Read the immutable snapshot once per logical operation (docs/backend.md → Reference-data snapshot
+        // read-once idiom) so a build-then-swap between reads can't mix an old and a new snapshot in one call.
         private ZoneSnapshot Snapshot => holder.Current;
 
         // The snapshot instance changes on every build-then-swap, so it doubles as the content-version key.
@@ -25,16 +25,12 @@ namespace Game.DataAccess.Repositories
             // Hands back the snapshot's shared, pre-materialized domain model rather than mapping a fresh
             // CoreZone per call — this is the per-battle setup hot path and the model is immutable, so the
             // shared instance is safe (docs/backend.md → Reference Data).
-            var snapshot = Snapshot;
-            return IsValidZoneId(snapshot.Entities, zoneId)
-                ? snapshot.CoreZones[zoneId]
-                : throw new ArgumentOutOfRangeException(nameof(zoneId));
+            return Snapshot.CoreZones.GetById(zoneId, "zone");
         }
 
         public Zone? LookupZone(int zoneId)
         {
-            var entities = Snapshot.Entities;
-            return IsValidZoneId(entities, zoneId) ? entities[zoneId] : null;
+            return Snapshot.Entities.Lookup(zoneId);
         }
 
         public IReadOnlyList<Zone> AllZones()
@@ -44,18 +40,12 @@ namespace Game.DataAccess.Repositories
 
         public bool IsZoneRetired(int zoneId)
         {
-            var entities = Snapshot.Entities;
-            return IsValidZoneId(entities, zoneId)
-                ? entities[zoneId].RetiredAt is not null
-                : throw new ArgumentOutOfRangeException(nameof(zoneId));
+            return Snapshot.Entities.GetById(zoneId, "zone").RetiredAt is not null;
         }
 
         public bool IsHomeZone(int zoneId)
         {
-            var entities = Snapshot.Entities;
-            return IsValidZoneId(entities, zoneId)
-                ? entities[zoneId].IsHome
-                : throw new ArgumentOutOfRangeException(nameof(zoneId));
+            return Snapshot.Entities.GetById(zoneId, "zone").IsHome;
         }
 
         public bool ValidateZoneId(int zoneId)


### PR DESCRIPTION
## Summary

Closes #2053. Two small, batchable data-tier consistency gaps found in the July 2026 health review:

1. **`Zones` hand-rolled bounds checks.** `GetDomainZone`/`IsZoneRetired`/`IsHomeZone` (`Game.DataAccess/Repositories/Zones.cs`) did their own `zoneId >= 0 && zoneId < entities.Count` check and threw a bare `ArgumentOutOfRangeException(nameof(zoneId))` on failure, unlike every sibling reference repo (`Items`, `Challenges`, `Enemies`, …), which routes through `ReferenceSnapshotExtensions.GetById`/`Lookup`. Those extensions exist specifically so a bad id "fails meaningfully rather than throwing a bare `ArgumentOutOfRangeException` from the raw indexer" (per their own doc comment) — `Zones` just wasn't using them. Now `GetDomainZone` reads `Snapshot.CoreZones.GetById(zoneId, "zone")`, `LookupZone` reads `Snapshot.Entities.Lookup(zoneId)`, and `IsZoneRetired`/`IsHomeZone` route through `Snapshot.Entities.GetById(zoneId, "zone")`. `ValidateZoneId` (which legitimately needs a non-throwing bounds check) keeps its own `IsValidZoneId` helper.

2. **`PlayerProgressRepository.ToCoreChallenge` bypassed the orphaned-reference policy.** It resolved `_challenges.GetChallenge(cached.ChallengeId)` raw, so an orphaned player-owned challenge (a migration/seed mistake that removed a referenced challenge id) surfaced as `GetById`'s generic "No challenge exists with Id X" error — naming only the id — instead of the `OrphanedReferenceException` (player id + catalog + missing id) that the player-load loud-fail-fast policy (`docs/backend.md` → Reference Data) prescribes, and that `PlayerCacheMapper.ResolveOrThrow` already implements for items/mods/skills.

   Rather than duplicate that try/catch-and-wrap logic in a second place, I extracted `PlayerCacheMapper`'s private `ResolveOrThrow` onto `OrphanedReferenceException` itself as a reusable static helper (`OrphanedReferenceException.ResolveOrThrow<T>(...)`). `PlayerCacheMapper`'s three call sites (item/item mod/skill resolution) and `PlayerProgressRepository.ToCoreChallenge` now both call the same helper, so the diagnostic-wrapping behavior lives in one place.

## Test plan

- [x] Existing `ZonesIntegrationTests` (bounds-check + not-found behavior for `GetDomainZone`/`IsZoneRetired`/`IsHomeZone`/`LookupZone`) — unchanged behavior, still green (all still expect `ArgumentOutOfRangeException`, which `GetById` also throws).
- [x] Existing `PlayerCacheMapperTests` (orphaned item/item-mod/skill reference tests) — unchanged behavior after the `ResolveOrThrow` extraction, still green.
- [x] Added `PlayerProgressRepositoryIntegrationTests.GetChallenges_OrphanedChallengeReference_ThrowsDiagnosableException` — writes a `CachedPlayerChallenge` row referencing a non-existent challenge id straight into the Redis progress cache, then asserts `GetChallenges` throws `OrphanedReferenceException` naming the player, "challenge", and the missing id.
- [x] Full backend suite: `dotnet build` clean, `dotnet test Game.sln` — **3258/3258 passing** (Game.Core.Tests 1371, Game.Infrastructure.Tests 66, Game.Application.Tests 998 including the new test, Game.Api.Tests 823).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkswNykRauBGXcLosowSva

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkswNykRauBGXcLosowSva)_