### PR TITLE
Adopt central package/build-property management

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <!-- Overflow checking only in Debug: it's a dev/test-time bug detector (e.g. Game.Core's battle/XP math),
+       not something worth paying the runtime cost for in Release. -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+  </PropertyGroup>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,27 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.0.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.12.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
+  </ItemGroup>
+
+</Project>

--- a/Game.Abstractions/Game.Abstractions.csproj
+++ b/Game.Abstractions/Game.Abstractions.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Game.Core\Game.Core.csproj" />
   </ItemGroup>

--- a/Game.Api.Tests/Game.Api.Tests.csproj
+++ b/Game.Api.Tests/Game.Api.Tests.csproj
@@ -1,10 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -12,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Game.Api/Dockerfile
+++ b/Game.Api/Dockerfile
@@ -15,11 +15,14 @@ WORKDIR /src
 
 # Restore from the project manifests *before* copying the rest of the source — the standard .NET
 # multi-stage layering. NuGet restore is the slow part of the build and its inputs are only the
-# .csproj files, so isolating it in its own layer lets Docker reuse the restored packages from its
-# local layer cache on incremental rebuilds (e.g. local dev) whenever the dependency graph is
-# unchanged, even when source files change. The set below is Game.Api's full restore graph (it
-# references Abstractions/Core/DataAccess/Application; DataAccess pulls in Infrastructure). Add a
-# line here if Game.Api gains a new project reference.
+# .csproj files (plus the repo-root Directory.Build.props/Directory.Packages.props that centrally
+# manage the TargetFramework and package versions referenced below), so isolating it in its own
+# layer lets Docker reuse the restored packages from its local layer cache on incremental rebuilds
+# (e.g. local dev) whenever the dependency graph is unchanged, even when source files change. The
+# .csproj set below is Game.Api's full restore graph (it references Abstractions/Core/DataAccess/
+# Application; DataAccess pulls in Infrastructure). Add a line here if Game.Api gains a new project
+# reference.
+COPY Directory.Build.props Directory.Packages.props ./
 COPY Game.Abstractions/Game.Abstractions.csproj Game.Abstractions/
 COPY Game.Core/Game.Core.csproj Game.Core/
 COPY Game.Infrastructure/Game.Infrastructure.csproj Game.Infrastructure/

--- a/Game.Api/Game.Api.csproj
+++ b/Game.Api/Game.Api.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>6324a056-d62e-4577-8793-e15f9e33e1a9</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DisableTransitiveProjectReferences>True</DisableTransitiveProjectReferences>
@@ -14,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Game.Application.Tests/Game.Application.Tests.csproj
+++ b/Game.Application.Tests/Game.Application.Tests.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -12,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Game.Application/Game.Application.csproj
+++ b/Game.Application/Game.Application.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.*" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
   <ItemGroup>
@@ -13,11 +13,5 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Game.Application.Tests" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
 
 </Project>

--- a/Game.Core.TestInfrastructure/Game.Core.TestInfrastructure.csproj
+++ b/Game.Core.TestInfrastructure/Game.Core.TestInfrastructure.csproj
@@ -1,11 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Game.Core\Game.Core.csproj" />
   </ItemGroup>

--- a/Game.Core.Tests/Game.Core.Tests.csproj
+++ b/Game.Core.Tests/Game.Core.Tests.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -12,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Game.Core/Battle/Mulberry32.cs
+++ b/Game.Core/Battle/Mulberry32.cs
@@ -22,10 +22,15 @@
         /// <returns></returns>
         public double Next()
         {
-            _seed += 0x6D2B79F5;
-            var t = (_seed ^ (_seed >> 15)) * (1 | _seed);
-            t = (t + ((t ^ (t >> 7)) * (61 | t))) ^ t;
-            return (t ^ (t >> 14)) / 4294967296.0;
+            // Mulberry32 deliberately relies on uint wraparound; unchecked keeps that intact
+            // regardless of the project's overflow-checking setting.
+            unchecked
+            {
+                _seed += 0x6D2B79F5;
+                var t = (_seed ^ (_seed >> 15)) * (1 | _seed);
+                t = (t + ((t ^ (t >> 7)) * (61 | t))) ^ t;
+                return (t ^ (t >> 14)) / 4294967296.0;
+            }
         }
     }
 }

--- a/Game.Core/Game.Core.csproj
+++ b/Game.Core/Game.Core.csproj
@@ -1,15 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <UserSecretsId>9d97d42c-27ce-4e53-ab21-ed63f4f4bec8</UserSecretsId>
-  </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 </Project>

--- a/Game.DataAccess/Game.DataAccess.csproj
+++ b/Game.DataAccess/Game.DataAccess.csproj
@@ -1,18 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/Game.Infrastructure.Tests/Game.Infrastructure.Tests.csproj
+++ b/Game.Infrastructure.Tests/Game.Infrastructure.Tests.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -12,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Game.Infrastructure/Game.Infrastructure.csproj
+++ b/Game.Infrastructure/Game.Infrastructure.csproj
@@ -1,27 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <InternalsVisibleTo Include="Game.TestInfrastructure" />
     <InternalsVisibleTo Include="Game.Infrastructure.Tests" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
-    <PackageReference Include="StackExchange.Redis" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="StackExchange.Redis" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Game.TestInfrastructure/Game.TestInfrastructure.csproj
+++ b/Game.TestInfrastructure/Game.TestInfrastructure.csproj
@@ -1,20 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <InternalsVisibleTo Include="Game.Application.Tests" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.12.0" />
-    <PackageReference Include="Testcontainers.Redis" Version="4.12.0" />
-    <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="Testcontainers.Redis" />
+    <PackageReference Include="xunit.v3.extensibility.core" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Closes #2054.

- **Adds `Directory.Packages.props`** (Central Package Management) covering all 17 distinct NuGet packages used across the 12 backend projects. This fixes the silently-drifting wildcard: `Game.Application.csproj` pinned `Microsoft.Extensions.Logging.Abstractions` at `10.*`, which every sibling project pinned at `10.0.9` — NuGet was unifying the whole graph upward past those pins (resolving to `10.0.10` at the time of the health review). The wildcard is now pinned to the concrete `10.0.9` used everywhere else.
- **Adds `Directory.Build.props`** with the `TargetFramework`/`Nullable`/`ImplicitUsings` triplet that was duplicated verbatim in all 12 `.csproj` files.
- **Removes the dead `UserSecretsId`** from `Game.Core.csproj` — a pure domain library with no reason to carry one (`Game.Api.csproj`, the actual host, keeps its own).
- **Fixes the stray `EFCore.Design` metadata**: kept its `PrivateAssets`/`IncludeAssets` on the local `PackageReference` (CPM only centralizes the version) in `Game.Infrastructure.csproj`.
- **Decides the `CheckForOverflowUnderflow` scope**: it was previously only set (for both Debug and Release) on `Game.DataAccess`, a project with essentially no arithmetic — not on `Game.Core`, where the battle/XP math actually lives. Hoisted it into `Directory.Build.props`, scoped to `Debug` builds only across the whole solution, so it's a dev/test-time bug detector without a Release runtime cost.
- **Fixed a latent bug this surfaced immediately**: `Mulberry32.Next()` (the battle RNG) deliberately relies on `uint` wraparound as part of the algorithm, and had never run under overflow checking before. Wrapped its arithmetic in an explicit `unchecked` block — this documents the intentional wraparound and makes it immune to the project's overflow-checking setting rather than relying on it happening to be off. Without this, every battle simulation throws `OverflowException` the instant Debug overflow checking is enabled solution-wide (found via the full test run: ~300 failures in `Game.Core.Tests`/`Game.Application.Tests`/`Game.Api.Tests`, all with the same root-cause stack trace).

### Left out of scope

The issue also flagged `Game.DataAccess.csproj` as the only project with `EnforceCodeStyleInBuild`. I left it as-is rather than hoisting it solution-wide — turning on build-time style enforcement everywhere is a separate, riskier decision that could surface a large number of new violations across projects that have never been checked against it. Happy to follow up as its own issue if that's wanted.

The cosmetic `Game.Application.csproj` `ItemGroup`-before-`PropertyGroup` ordering issue is resolved as a side effect: that project's `PropertyGroup` only ever held the now-centralized TFM/Nullable/ImplicitUsings, so it's removed entirely rather than reordered.

## Test plan

- [x] `dotnet build Game.sln` (Debug) — clean, 0 warnings/errors
- [x] `dotnet build Game.sln -c Release` — clean, 0 warnings/errors
- [x] `dotnet test Game.sln --no-build -c Debug` — all 3,258 tests pass (Game.Core.Tests, Game.Application.Tests, Game.Api.Tests, Game.Infrastructure.Tests), after the `Mulberry32` fix


---
_Generated by [Claude Code](https://claude.ai/code/session_0194SwL8qLgTi1nBk11ZUCv5)_