### PR TITLE
Resolve codegen repo root via CodeGenPaths.FindRepositoryRoot in Startup

### DIFF
--- a/Game.Api/Startup.cs
+++ b/Game.Api/Startup.cs
@@ -202,8 +202,7 @@ namespace Game.Api
             {
                 // Regenerate the frontend's TypeScript API client from the running API's types. This
                 // writes into the UI source tree, so it is strictly a local-development concern.
-                var rootFolder = (Directory.GetParent(app.Environment.ContentRootPath)
-                    ?? throw new InvalidOperationException($"Could not resolve parent directory of '{app.Environment.ContentRootPath}'.")).FullName;
+                var rootFolder = CodeGenPaths.FindRepositoryRoot(app.Environment.ContentRootPath);
                 var targetDir = CodeGenPaths.ResolveTargetDirectory(rootFolder);
                 var codeGen = app.Services.GetRequiredService<ApiCodeGenerator>();
                 codeGen.GenerateCode(typeof(Startup).Assembly, new CodeGenOptions { TargetDirectory = targetDir, NewLine = "\n" });


### PR DESCRIPTION
## Summary

Closes #2055.

`Game.Api/Startup.cs` computed the dev-time codegen output root as
`Directory.GetParent(app.Environment.ContentRootPath)`, while `CodeGenCommand`
(the standalone `dotnet run --project Game.Api -- codegen` entry point) used
`CodeGenPaths.FindRepositoryRoot()`, which walks up from a starting directory
until it finds `Game.sln`. `CodeGenPaths`' doc comment claims both paths are
"centralized so … compute the frontend target directory the same way," which
was false — they only happened to agree because `dotnet run`'s default
`ContentRootPath` is `Game.Api/`, whose parent is the repo root.

With any other content root (published output, `--contentRoot`), the old
`Startup.cs` logic would write the generated TypeScript client into the wrong
directory or throw, silently contradicting the shared-path invariant the
comment promises.

## Fix

`Startup.cs` now calls `CodeGenPaths.FindRepositoryRoot(app.Environment.ContentRootPath)`,
matching `CodeGenCommand`'s approach and making the two paths agree for any
content root, not just the `dotnet run` default.

## Test plan

- [x] `dotnet build Game.sln` (Debug) — clean, 0 warnings/errors
- [x] `dotnet test Game.sln --no-build --no-restore` — all 3,258 tests pass across Game.Core.Tests, Game.Application.Tests, Game.Api.Tests, Game.Infrastructure.Tests
- [x] Existing `CodeGenPathsTests` already cover `FindRepositoryRoot`'s walk-up-to-`Game.sln` behavior; no behavior change to that method, only which caller uses it

---
_Generated by [Claude Code](https://claude.ai/code/session_014DhVPYd2HK92GWxXadPywS)_