### PR TITLE
Send hot-path Redis Lua scripts as EVALSHA instead of full text (#2056)

### DIFF
--- a/Game.Infrastructure.Tests/PreparedScriptTests.cs
+++ b/Game.Infrastructure.Tests/PreparedScriptTests.cs
@@ -9,7 +9,9 @@ namespace Game.Infrastructure.Tests
     /// send a Lua script's hash instead of its full text on every call after the first (#2056). The behaviour
     /// that matters and is otherwise only exercised indirectly through a live Redis: a cold call that fails
     /// before it reaches the server must not mark the script warmed, or every later call would jump straight to
-    /// an <c>EVALSHA</c> the server has genuinely never cached.
+    /// an <c>EVALSHA</c> the server has genuinely never cached — pinned for both <see cref="PreparedScript.EvaluateAsync"/>
+    /// and <see cref="PreparedScript.Evaluate"/>, since the latter blocks its own cold call rather than sharing
+    /// the former's fallback logic.
     /// <para>
     /// Uses the same dead-endpoint technique as the sibling <see cref="RedisPubSubPublishFailureTests"/>: a
     /// multiplexer pointed at an unreachable endpoint (<c>abortConnect=false</c>) connects lazily and then throws
@@ -38,15 +40,32 @@ namespace Game.Infrastructure.Tests
         }
 
         [Fact]
-        public async Task EvaluateAsync_WhenAlreadyWarmed_SendsTheHashRatherThanRewarming()
+        public async Task Evaluate_WhenTheColdCallFails_LeavesTheScriptUnwarmed()
+        {
+            // Evaluate's cold branch strips a caller's FireAndForget flag and blocks for a confirmed reply, so
+            // this is pinned separately from EvaluateAsync's version of the same invariant: a dropped cold send
+            // must not wedge the script into the hash-only path.
+            await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(DeadEndpoint);
+            var db = multiplexer.GetDatabase();
+            var script = new PreparedScript("return 1");
+
+            Assert.Throws<RedisConnectionException>(() => script.Evaluate(db, [], [], CommandFlags.FireAndForget));
+
+            Assert.False(script.IsWarmedForTesting);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_WhenAlreadyWarmed_StaysWarmedAfterAFailedCall()
         {
             await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(DeadEndpoint);
             var db = multiplexer.GetDatabase();
             var script = PreparedScript.CreateAlreadyWarmedForTesting("return 1");
 
-            // Still fails against a dead endpoint either way, but this pins that a warmed script never revisits
-            // the cold (full-text) branch — CreateAlreadyWarmedForTesting's contract that the seam actually
-            // starts in the warmed state.
+            // A dead endpoint can't distinguish the hash branch from the full-text one — both throw the same
+            // RedisConnectionException before anything reaches a server — so this doesn't pin which command form
+            // was sent (that needs a genuine NOSCRIPT reply, covered by the Redis integration suites instead).
+            // What it does pin: CreateAlreadyWarmedForTesting actually starts warmed, and a failure afterward
+            // doesn't flip it back to cold.
             Assert.True(script.IsWarmedForTesting);
             await Assert.ThrowsAsync<RedisConnectionException>(() => script.EvaluateAsync(db, [], []));
             Assert.True(script.IsWarmedForTesting);

--- a/Game.Infrastructure.Tests/PreparedScriptTests.cs
+++ b/Game.Infrastructure.Tests/PreparedScriptTests.cs
@@ -1,0 +1,55 @@
+using Game.Infrastructure.Redis;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Game.Infrastructure.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="PreparedScript"/>, the helper that lets <c>RedisService</c>/<c>RedisQueue</c>
+    /// send a Lua script's hash instead of its full text on every call after the first (#2056). The behaviour
+    /// that matters and is otherwise only exercised indirectly through a live Redis: a cold call that fails
+    /// before it reaches the server must not mark the script warmed, or every later call would jump straight to
+    /// an <c>EVALSHA</c> the server has genuinely never cached.
+    /// <para>
+    /// Uses the same dead-endpoint technique as the sibling <see cref="RedisPubSubPublishFailureTests"/>: a
+    /// multiplexer pointed at an unreachable endpoint (<c>abortConnect=false</c>) connects lazily and then throws
+    /// a real <see cref="RedisConnectionException"/> from the awaited command — no mocking, no Redis server
+    /// required. The NOSCRIPT-triggered fallback itself needs a genuine server reply and is covered by the
+    /// existing Redis integration suite exercising these scripts end to end (RedisServiceIntegrationTests,
+    /// RedisQueueIntegrationTests) rather than duplicated here.
+    /// </para>
+    /// </summary>
+    public class PreparedScriptTests
+    {
+        private const string DeadEndpoint = "127.0.0.1:1,abortConnect=false,connectTimeout=500,connectRetry=0";
+
+        [Fact]
+        public async Task EvaluateAsync_WhenTheColdCallFails_LeavesTheScriptUnwarmed()
+        {
+            await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(DeadEndpoint);
+            var db = multiplexer.GetDatabase();
+            var script = new PreparedScript("return 1");
+
+            await Assert.ThrowsAsync<RedisConnectionException>(() => script.EvaluateAsync(db, [], []));
+
+            // A failed cold call means Redis never actually cached this script; if it had wrongly been marked
+            // warmed anyway, every later call would send only the hash and get NOSCRIPT forever.
+            Assert.False(script.IsWarmedForTesting);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_WhenAlreadyWarmed_SendsTheHashRatherThanRewarming()
+        {
+            await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(DeadEndpoint);
+            var db = multiplexer.GetDatabase();
+            var script = PreparedScript.CreateAlreadyWarmedForTesting("return 1");
+
+            // Still fails against a dead endpoint either way, but this pins that a warmed script never revisits
+            // the cold (full-text) branch — CreateAlreadyWarmedForTesting's contract that the seam actually
+            // starts in the warmed state.
+            Assert.True(script.IsWarmedForTesting);
+            await Assert.ThrowsAsync<RedisConnectionException>(() => script.EvaluateAsync(db, [], []));
+            Assert.True(script.IsWarmedForTesting);
+        }
+    }
+}

--- a/Game.Infrastructure/Cache/Redis/RedisService.cs
+++ b/Game.Infrastructure/Cache/Redis/RedisService.cs
@@ -87,10 +87,16 @@ namespace Game.Infrastructure.Cache.Redis
             SetAndForget(key, value?.Serialize(), expiry);
         }
 
+        private static readonly PreparedScript CompareAndDeleteScript = new(
+            "if redis.call('get', KEYS[1]) == ARGV[1] then redis.call('del', KEYS[1]) end");
+
         public async Task CompareAndDelete(string key, string deleteIfValue, CancellationToken cancellationToken = default)
         {
-            await ObserveWrite(Redis.ScriptEvaluateAsync("if redis.call('get', KEYS[1]) == ARGV[1] then redis.call('del', KEYS[1]) end", [key], [deleteIfValue]), cancellationToken);
+            await ObserveWrite(CompareAndDeleteScript.EvaluateAsync(Redis, [key], [deleteIfValue]), cancellationToken);
         }
+
+        private static readonly PreparedScript ReclaimAndForgetScript = new(
+            "if redis.call('exists', KEYS[1]) == 0 then redis.call('set', KEYS[1], ARGV[1], 'PX', ARGV[2]) else redis.call('pexpire', KEYS[1], ARGV[2]) end");
 
         public void ReclaimAndForget(string key, string ownerValue, TimeSpan expiry)
         {
@@ -99,11 +105,15 @@ namespace Game.Infrastructure.Cache.Redis
             // just extend the TTL of whatever is already there, mirroring ExpireAndForget's existing
             // don't-care-who-asked refresh so a stale caller still can't overwrite a newer claim's value.
             // CommandFlags.FireAndForget keeps it off the hot inbound-message path the same way ExpireAndForget is.
-            Redis.ScriptEvaluate(
-                "if redis.call('exists', KEYS[1]) == 0 then redis.call('set', KEYS[1], ARGV[1], 'PX', ARGV[2]) else redis.call('pexpire', KEYS[1], ARGV[2]) end",
-                [key], [(RedisValue)ownerValue, (RedisValue)(long)expiry.TotalMilliseconds],
+            ReclaimAndForgetScript.Evaluate(
+                Redis, [key], [(RedisValue)ownerValue, (RedisValue)(long)expiry.TotalMilliseconds],
                 flags: CommandFlags.FireAndForget);
         }
+
+        private static readonly PreparedScript CompareAndSetIfAbsentScript = new(
+            "if redis.call('exists', KEYS[1]) == 1 then return 0 end redis.call('set', KEYS[1], ARGV[1], 'PX', ARGV[2]) return 1");
+        private static readonly PreparedScript CompareAndSetScript = new(
+            "if redis.call('get', KEYS[1]) ~= ARGV[3] then return 0 end redis.call('set', KEYS[1], ARGV[1], 'PX', ARGV[2]) return 1");
 
         public async Task<bool> CompareAndSet(string key, string? expectedValue, string newValue, TimeSpan expiry, CancellationToken cancellationToken = default)
         {
@@ -113,12 +123,8 @@ namespace Game.Infrastructure.Cache.Redis
             // value is unchanged. The TTL is written alongside the value so the key never lingers without one.
             var expiryMs = (long)expiry.TotalMilliseconds;
             var result = expectedValue is null
-                ? await ObserveWrite(Redis.ScriptEvaluateAsync(
-                    "if redis.call('exists', KEYS[1]) == 1 then return 0 end redis.call('set', KEYS[1], ARGV[1], 'PX', ARGV[2]) return 1",
-                    [key], [(RedisValue)newValue, (RedisValue)expiryMs]), cancellationToken)
-                : await ObserveWrite(Redis.ScriptEvaluateAsync(
-                    "if redis.call('get', KEYS[1]) ~= ARGV[3] then return 0 end redis.call('set', KEYS[1], ARGV[1], 'PX', ARGV[2]) return 1",
-                    [key], [(RedisValue)newValue, (RedisValue)expiryMs, (RedisValue)expectedValue]), cancellationToken);
+                ? await ObserveWrite(CompareAndSetIfAbsentScript.EvaluateAsync(Redis, [key], [(RedisValue)newValue, (RedisValue)expiryMs]), cancellationToken)
+                : await ObserveWrite(CompareAndSetScript.EvaluateAsync(Redis, [key], [(RedisValue)newValue, (RedisValue)expiryMs, (RedisValue)expectedValue]), cancellationToken);
             return (long)result == 1;
         }
 
@@ -132,6 +138,12 @@ namespace Game.Infrastructure.Cache.Redis
             Redis.KeyDelete(key, CommandFlags.FireAndForget);
         }
 
+        private static readonly PreparedScript HashGetAllIfExistsScript = new(
+            "local t = redis.call('type', KEYS[1]).ok "
+            + "if t == 'none' then return false end "
+            + "if t ~= 'hash' then redis.call('del', KEYS[1]) return false end "
+            + "return redis.call('hgetall', KEYS[1])");
+
         public async Task<Dictionary<string, string>?> HashGetAllIfExists(string key, CancellationToken cancellationToken = default)
         {
             // TYPE-then-HGETALL in one script (rather than two round trips) so a hot per-battle read pays only
@@ -141,15 +153,18 @@ namespace Game.Infrastructure.Cache.Redis
             // caller that repurposed a string-valued key into a hash-valued one) is treated the same as a miss
             // and cleared, so a stale value self-heals via the normal miss-then-reload path on next write
             // rather than erroring every future read.
-            var result = await RedisCommandBudget.Read(Redis.ScriptEvaluateAsync(
-                "local t = redis.call('type', KEYS[1]).ok "
-                + "if t == 'none' then return false end "
-                + "if t ~= 'hash' then redis.call('del', KEYS[1]) return false end "
-                + "return redis.call('hgetall', KEYS[1])",
-                [key]), cancellationToken);
+            var result = await RedisCommandBudget.Read(HashGetAllIfExistsScript.EvaluateAsync(Redis, [key], []), cancellationToken);
 
             return MapHashResult(result);
         }
+
+        private static readonly PreparedScript HashGetAllAndRefreshExpiryScript = new(
+            "local t = redis.call('type', KEYS[1]).ok "
+            + "if t == 'none' then return false end "
+            + "if t ~= 'hash' then redis.call('del', KEYS[1]) return false end "
+            + "local result = redis.call('hgetall', KEYS[1]) "
+            + "redis.call('pexpire', KEYS[1], ARGV[1]) "
+            + "return result");
 
         public async Task<Dictionary<string, string>?> HashGetAllAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default)
         {
@@ -159,14 +174,7 @@ namespace Game.Infrastructure.Cache.Redis
             // itself can't serve here since it only applies to strings). The PEXPIRE makes this a write, so it
             // routes through ObserveWrite like GetAndRefreshExpiry rather than the plain-read path
             // HashGetAllIfExists uses.
-            var result = await ObserveWrite(Redis.ScriptEvaluateAsync(
-                "local t = redis.call('type', KEYS[1]).ok "
-                + "if t == 'none' then return false end "
-                + "if t ~= 'hash' then redis.call('del', KEYS[1]) return false end "
-                + "local result = redis.call('hgetall', KEYS[1]) "
-                + "redis.call('pexpire', KEYS[1], ARGV[1]) "
-                + "return result",
-                [key], [(RedisValue)(long)expiry.TotalMilliseconds]), cancellationToken);
+            var result = await ObserveWrite(HashGetAllAndRefreshExpiryScript.EvaluateAsync(Redis, [key], [(RedisValue)(long)expiry.TotalMilliseconds]), cancellationToken);
 
             return MapHashResult(result);
         }
@@ -191,6 +199,9 @@ namespace Game.Infrastructure.Cache.Redis
             return fields;
         }
 
+        private static readonly PreparedScript HashSetAndForgetScript = new(
+            "for i = 2, #ARGV, 2 do redis.call('hset', KEYS[1], ARGV[i], ARGV[i + 1]) end redis.call('pexpire', KEYS[1], ARGV[1])");
+
         public void HashSetAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry)
         {
             if (fields.Count == 0)
@@ -201,10 +212,14 @@ namespace Game.Infrastructure.Cache.Redis
             // Bundles every field write and the TTL reset into one atomic script (mirroring CompareAndSet/
             // ReclaimAndForget) so the hash is never left holding freshly-written fields without its expiry
             // refreshed.
-            Redis.ScriptEvaluate(
-                "for i = 2, #ARGV, 2 do redis.call('hset', KEYS[1], ARGV[i], ARGV[i + 1]) end redis.call('pexpire', KEYS[1], ARGV[1])",
-                [key], BuildHashArgv(fields, expiry), flags: CommandFlags.FireAndForget);
+            HashSetAndForgetScript.Evaluate(Redis, [key], BuildHashArgv(fields, expiry), flags: CommandFlags.FireAndForget);
         }
+
+        private static readonly PreparedScript HashSetIfExistsAndForgetScript = new(
+            "if redis.call('exists', KEYS[1]) == 1 then "
+            + "for i = 2, #ARGV, 2 do redis.call('hset', KEYS[1], ARGV[i], ARGV[i + 1]) end "
+            + "redis.call('pexpire', KEYS[1], ARGV[1]) "
+            + "end");
 
         public void HashSetIfExistsAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry)
         {
@@ -217,12 +232,7 @@ namespace Game.Infrastructure.Cache.Redis
             // under memory pressure, an operator delete) is never resurrected from a caller's partial field
             // view — resurrecting it would recreate the hash holding only these fields, silently shadowing
             // every other row the caller didn't touch this call.
-            Redis.ScriptEvaluate(
-                "if redis.call('exists', KEYS[1]) == 1 then "
-                + "for i = 2, #ARGV, 2 do redis.call('hset', KEYS[1], ARGV[i], ARGV[i + 1]) end "
-                + "redis.call('pexpire', KEYS[1], ARGV[1]) "
-                + "end",
-                [key], BuildHashArgv(fields, expiry), flags: CommandFlags.FireAndForget);
+            HashSetIfExistsAndForgetScript.Evaluate(Redis, [key], BuildHashArgv(fields, expiry), flags: CommandFlags.FireAndForget);
         }
 
         // Shared argv layout for both hash-set scripts above: [expiry-ms, then field/value pairs].

--- a/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
@@ -83,10 +83,10 @@ namespace Game.Infrastructure.PubSub.Redis
         // count moved. A single Lua script replaces the previous O(N) sequential ListMove round-trips on the
         // crash-recovery path (#954); it is atomic, so readers never see a half-reclaimed state, and on a bounded
         // in-flight processing list the script stays short.
-        private const string ReclaimScript =
+        private static readonly PreparedScript ReclaimScript = new(
             "local n = 0 " +
             "while redis.call('lmove', KEYS[1], KEYS[2], 'RIGHT', 'LEFT') do n = n + 1 end " +
-            "return n";
+            "return n");
 
         public async Task<long> ReclaimProcessingAsync(CancellationToken cancellationToken = default)
         {
@@ -95,7 +95,7 @@ namespace Game.Infrastructure.PubSub.Redis
             cancellationToken.ThrowIfCancellationRequested();
 
             var result = await ObserveWrite(
-                _redis.ScriptEvaluateAsync(ReclaimScript, [ProcessingQueueName, QueueName]),
+                ReclaimScript.EvaluateAsync(_redis, [ProcessingQueueName, QueueName], []),
                 cancellationToken);
             var reclaimed = (long)result;
 

--- a/Game.Infrastructure/Redis/PreparedScript.cs
+++ b/Game.Infrastructure/Redis/PreparedScript.cs
@@ -1,0 +1,89 @@
+using System.Security.Cryptography;
+using System.Text;
+using StackExchange.Redis;
+
+namespace Game.Infrastructure.Redis
+{
+    /// <summary>
+    /// Wraps a Lua script's source text with its SHA1 hash so repeat calls send the 20-byte <c>EVALSHA</c> hash
+    /// instead of retransmitting the full script body on every hot-path call (#2056). The scripts stay raw
+    /// <c>KEYS[n]</c>/<c>ARGV[n]</c> text (some build a variable-length <c>ARGV</c>, which <c>LuaScript.Prepare</c>'s
+    /// fixed named-parameter model can't express), so this talks to <see cref="IDatabase"/> directly rather than
+    /// through that helper.
+    /// <para>
+    /// The very first call this process makes for a given script sends the full text — an <c>EVAL</c>, which as a
+    /// side effect caches the script on the server under its hash — so a cold script cache never causes a
+    /// <c>NOSCRIPT</c> failure; every call after that sends the hash. <see cref="EvaluateAsync"/> additionally
+    /// falls back to a full-text resend if the server reports <c>NOSCRIPT</c> after the script was already warmed
+    /// (a manual <c>SCRIPT FLUSH</c> or a Redis restart that lost its script cache), so an awaited caller
+    /// self-heals. <see cref="Evaluate"/> (fire-and-forget) has no response to inspect for that — the same
+    /// no-delivery-guarantee every other <see cref="CommandFlags.FireAndForget"/> call in this tier already
+    /// accepts.
+    /// </para>
+    /// <para>
+    /// <see cref="Cache.Redis.RedisService"/>/<see cref="PubSub.Redis.RedisQueue"/> are resolved transient
+    /// (constructed per DI scope), so each script is prepared once as a <c>static readonly</c> field on its
+    /// owning class — the hash and warm state are shared process-wide rather than recomputed or re-sent per
+    /// instance.
+    /// </para>
+    /// </summary>
+    internal sealed class PreparedScript
+    {
+        private readonly string _script;
+        private readonly byte[] _hash;
+        private volatile bool _warmed;
+
+        public PreparedScript(string script)
+        {
+            _script = script;
+            _hash = SHA1.HashData(Encoding.UTF8.GetBytes(script));
+        }
+
+        // Test-only seams (mirroring RedisMultiplexerFactory.ResetForTesting): CreateAlreadyWarmedForTesting lets
+        // a test force the hash-only path on a script Redis has never actually loaded, to pin the NOSCRIPT
+        // self-heal without a process-wide SCRIPT FLUSH that would disturb every other script this process
+        // already warmed; IsWarmedForTesting exposes the state a test needs to assert on since a failed call
+        // can't be told apart from a successful one by exception shape alone.
+        internal static PreparedScript CreateAlreadyWarmedForTesting(string script)
+        {
+            var prepared = new PreparedScript(script)
+            {
+                _warmed = true
+            };
+            return prepared;
+        }
+
+        internal bool IsWarmedForTesting => _warmed;
+
+        public async Task<RedisResult> EvaluateAsync(IDatabaseAsync db, RedisKey[] keys, RedisValue[] values, CommandFlags flags = CommandFlags.None)
+        {
+            if (!_warmed)
+            {
+                var coldResult = await db.ScriptEvaluateAsync(_script, keys, values, flags);
+                _warmed = true;
+                return coldResult;
+            }
+
+            try
+            {
+                return await db.ScriptEvaluateAsync(_hash, keys, values, flags);
+            }
+            catch (RedisServerException ex) when (ex.Message.StartsWith("NOSCRIPT", StringComparison.Ordinal))
+            {
+                return await db.ScriptEvaluateAsync(_script, keys, values, flags);
+            }
+        }
+
+        public RedisResult Evaluate(IDatabase db, RedisKey[] keys, RedisValue[] values, CommandFlags flags = CommandFlags.None)
+        {
+            if (!_warmed)
+            {
+                var coldResult = db.ScriptEvaluate(_script, keys, values, flags);
+                _warmed = true;
+                return coldResult;
+            }
+
+            return db.ScriptEvaluate(_hash, keys, values, flags);
+        }
+    }
+}

--- a/Game.Infrastructure/Redis/PreparedScript.cs
+++ b/Game.Infrastructure/Redis/PreparedScript.cs
@@ -13,12 +13,15 @@ namespace Game.Infrastructure.Redis
     /// <para>
     /// The very first call this process makes for a given script sends the full text — an <c>EVAL</c>, which as a
     /// side effect caches the script on the server under its hash — so a cold script cache never causes a
-    /// <c>NOSCRIPT</c> failure; every call after that sends the hash. <see cref="EvaluateAsync"/> additionally
-    /// falls back to a full-text resend if the server reports <c>NOSCRIPT</c> after the script was already warmed
-    /// (a manual <c>SCRIPT FLUSH</c> or a Redis restart that lost its script cache), so an awaited caller
-    /// self-heals. <see cref="Evaluate"/> (fire-and-forget) has no response to inspect for that — the same
-    /// no-delivery-guarantee every other <see cref="CommandFlags.FireAndForget"/> call in this tier already
-    /// accepts.
+    /// <c>NOSCRIPT</c> failure; every call after that sends the hash. That cold call is always a confirmed,
+    /// blocking round trip (a caller's <see cref="CommandFlags.FireAndForget"/> is ignored just for it), because
+    /// a dropped fire-and-forget cold send would still flip the warm flag and then wedge every later
+    /// <c>EVALSHA</c> into <c>NOSCRIPT</c> for the rest of the process — a materially worse failure than the
+    /// single lost op a normal fire-and-forget command risks. <see cref="EvaluateAsync"/> additionally falls back
+    /// to a full-text resend if the server reports <c>NOSCRIPT</c> on an already-warmed script (a manual
+    /// <c>SCRIPT FLUSH</c> or a Redis restart that lost its script cache), so an awaited caller also self-heals
+    /// after warm-up; <see cref="Evaluate"/> has no response to inspect for that once warmed, matching the
+    /// no-delivery-guarantee every other fire-and-forget call in this tier already accepts for a single op.
     /// </para>
     /// <para>
     /// <see cref="Cache.Redis.RedisService"/>/<see cref="PubSub.Redis.RedisQueue"/> are resolved transient
@@ -78,7 +81,11 @@ namespace Game.Infrastructure.Redis
         {
             if (!_warmed)
             {
-                var coldResult = db.ScriptEvaluate(_script, keys, values, flags);
+                // The cold call ignores a FireAndForget flag and blocks for a confirmed reply, so _warmed only
+                // flips once the script is genuinely cached server-side — see the class doc for why a dropped
+                // fire-and-forget cold send would be worse than the single-op loss this flag normally risks.
+                // One blocking round trip, once per process, on a path that is otherwise off the hot loop.
+                var coldResult = db.ScriptEvaluate(_script, keys, values, flags & ~CommandFlags.FireAndForget);
                 _warmed = true;
                 return coldResult;
             }


### PR DESCRIPTION
## Summary

`RedisService`/`RedisQueue` sent every Lua script's full source text on every `ScriptEvaluate(Async)` call — `IDatabase.ScriptEvaluate(string, ...)` always issues a raw `EVAL`, with no automatic `EVALSHA`. This hits the hottest Redis paths: `GetSet`/`CompareAndSet`, `ReclaimAndForget` (every inbound socket message), the hash-get/hash-set scripts (per battle completion), and `RedisQueue.ReclaimProcessingAsync`.

- Added `PreparedScript` (`Game.Infrastructure/Redis/PreparedScript.cs`): wraps a script's source text with its SHA1 hash. The scripts stay raw `KEYS[n]`/`ARGV[n]` text — `LuaScript.Prepare`'s fixed named-parameter model can't express the variable-length `ARGV` the hash-set scripts build, so this talks to `IDatabase` directly instead.
  - The first call this process makes for a given script sends the full text (an `EVAL`, which as a side effect caches the script on the server), so a cold script cache never causes a `NOSCRIPT` failure on startup.
  - Every call after that sends only the hash (`EVALSHA`).
  - The awaited path (`EvaluateAsync`) additionally falls back to a full-text resend if the server ever reports `NOSCRIPT` after the script was already warmed (a manual `SCRIPT FLUSH` or a Redis restart that lost its script cache), so it self-heals. The fire-and-forget path (`Evaluate`) has no response to inspect for that — the same no-delivery-guarantee every other `CommandFlags.FireAndForget` call in this tier already accepts.
  - `RedisService`/`RedisQueue` are resolved **transient** (constructed per DI scope), so each script is prepared once as a `static readonly` field on its owning class — the hash and warm state are shared process-wide rather than recomputed or re-sent per instance.
- Converted every `ScriptEvaluate`/`ScriptEvaluateAsync` call site in `RedisService.cs` and `RedisQueue.cs` to go through a `PreparedScript`.

I manually validated the hash format and the NOSCRIPT/fallback behavior against a live Redis instance before wiring this in (a computed `SHA1` hash matches exactly what `ScriptEvaluate(byte[] hash, ...)` expects, a pre-load `EVALSHA` genuinely returns `NOSCRIPT`, and it succeeds after the script is loaded).

Not a correctness fix — this is purely a byte-savings optimization, per the issue.

## Test plan

- [x] `dotnet build Game.sln` — clean, 0 warnings/errors
- [x] New unit tests in `Game.Infrastructure.Tests/PreparedScriptTests.cs` pin the one genuinely regression-prone piece of logic — a failed cold call must not mark the script warmed (or every later call would jump straight to an `EVALSHA` the server never actually cached) — using the project's existing dead-endpoint technique (no live Redis, no mocking).
- [x] Full existing Redis integration suites (`RedisServiceIntegrationTests`, `RedisQueueIntegrationTests`) pass unchanged against the real Redis container, exercising every converted script end to end.
- [x] `Game.Infrastructure.Tests` (68 tests), `Game.Application.Tests` (998 tests), `Game.Api.Tests` (823 tests), `Game.Core.Tests` (1371 tests) all pass.

Closes #2056

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y98qiKza3cxfNGo4AnS2Ec)_