### PR TITLE
Convert non-reactive hot-path engine internals to #-private

### DIFF
--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -101,8 +101,9 @@ export class BattleEngine {
 	public running = false;
 
 	/** The seeded battle RNG, re-created from each enemy's seed in {@link reset} so the live battle draws the
-	 *  crit/parry/dodge rolls from the same stream the backend replays. Seeded to 0 until the first reset. */
-	private rng = new Mulberry32(0);
+	 *  crit/parry/dodge rolls from the same stream the backend replays. Seeded to 0 until the first reset.
+	 *  `#`-private so `statify` leaves it non-reactive — it's a hot-path internal read only imperatively. */
+	#rng = new Mulberry32(0);
 
 	private logicalUnhook?: Action;
 	private renderUnhook?: Action;
@@ -112,8 +113,10 @@ export class BattleEngine {
 	private finishLoading?: Action;
 
 	/** Reused per-tick sink the shared battleStep populates with this tick's newly-applied effects and
-	 *  DoT/HoT amounts, so the engine can turn them into combat-log lines (frontend-only). */
-	private readonly stepLog: BattleStepLog = {
+	 *  DoT/HoT amounts, so the engine can turn them into combat-log lines (frontend-only). `#`-private so
+	 *  `statify` leaves it non-reactive — it's a reused sink written on every 40ms tick, and deep-proxying
+	 *  it would re-add the per-tick allocation cost it exists to avoid. */
+	readonly #stepLog: BattleStepLog = {
 		appliedEffects: [],
 		enemyDotDamage: 0,
 		playerDotDamage: 0,
@@ -123,22 +126,24 @@ export class BattleEngine {
 
 	/** Over-time damage/heal accumulated since the last flush. DoT/HoT applies every 40ms tick (25/s),
 	 *  so per-tick logging would flood the feed — instead each channel is summed and emitted as a single
-	 *  line per ~1s window (and once more at battle end for the final partial second). */
-	private readonly effectDamage = { enemyDot: 0, playerDot: 0, enemyHot: 0, playerHot: 0 };
-	private effectDamageElapsedMs = 0;
+	 *  line per ~1s window (and once more at battle end for the final partial second). `#`-private for the
+	 *  same reason as {@link #stepLog} above — a per-tick-written internal, never read reactively. */
+	readonly #effectDamage = { enemyDot: 0, playerDot: 0, enemyHot: 0, playerHot: 0 };
+	#effectDamageElapsedMs = 0;
 
 	/** The inputs of the last *full* player attribute derive — the equipment stats, attribute
 	 *  distribution, loadout, and level. An idle farm re-spawns with all four unchanged, so the
 	 *  per-enemy reset can re-arm the existing player battler instead of rebuilding the whole attribute
 	 *  graph (and every Skill) from scratch on each cooldown (#811). The arrays are compared by
 	 *  reference — every producer reassigns rather than mutates in place, so a reference match means the
-	 *  inputs are unchanged. */
-	private lastEquipmentStats?: IBattlerAttribute[];
-	private lastPlayerAttributes?: IBattlerAttribute[];
-	private lastSelectedSkills?: number[];
-	private lastPlayerLevel?: number;
-	private lastLockedBaseModifiers?: AttributeModifier[];
-	private lastProficiencyModifiers?: AttributeModifier[];
+	 *  inputs are unchanged. `#`-private so `statify` leaves them non-reactive — they're read only
+	 *  imperatively inside {@link resetPlayer}. */
+	#lastEquipmentStats?: IBattlerAttribute[];
+	#lastPlayerAttributes?: IBattlerAttribute[];
+	#lastSelectedSkills?: number[];
+	#lastPlayerLevel?: number;
+	#lastLockedBaseModifiers?: AttributeModifier[];
+	#lastProficiencyModifiers?: AttributeModifier[];
 
 	public start() {
 		if (!this.running) {
@@ -201,7 +206,7 @@ export class BattleEngine {
 		this.timeElapsed = 0;
 		// Seed the battle RNG from the enemy instance's seed (the same value the backend simulates against),
 		// so the crit/dodge/block draws stay in lockstep with the anti-cheat replay.
-		this.rng = new Mulberry32(enemyInstance.seed);
+		this.#rng = new Mulberry32(enemyInstance.seed);
 		this.flushEffectDamage();
 		this.resetPlayer();
 		this.enemy.reset({ ...enemyInstance, ...enemyData[enemyInstance.id] });
@@ -230,7 +235,7 @@ export class BattleEngine {
 		const cappedOffsetMs = Math.min(offsetMs, DEFAULT_MAX_BATTLE_MS);
 		let totalMs = tickSize;
 		for (; totalMs <= cappedOffsetMs; totalMs += tickSize) {
-			battleStep(this.player, this.enemy, tickSize, this.rng);
+			battleStep(this.player, this.enemy, tickSize, this.#rng);
 			if (this.enemy.isDead || this.player.isDead) {
 				break;
 			}
@@ -260,12 +265,12 @@ export class BattleEngine {
 		// farm re-arms the existing battler instead of rebuilding it (#811).
 		const lockedBaseModifiers = playerManager.battleLockedBaseModifiers;
 		if (
-			equipmentStats === this.lastEquipmentStats &&
-			attributes === this.lastPlayerAttributes &&
-			selectedSkills === this.lastSelectedSkills &&
-			level === this.lastPlayerLevel &&
-			lockedBaseModifiers === this.lastLockedBaseModifiers &&
-			proficiencyModifiers === this.lastProficiencyModifiers
+			equipmentStats === this.#lastEquipmentStats &&
+			attributes === this.#lastPlayerAttributes &&
+			selectedSkills === this.#lastSelectedSkills &&
+			level === this.#lastPlayerLevel &&
+			lockedBaseModifiers === this.#lastLockedBaseModifiers &&
+			proficiencyModifiers === this.#lastProficiencyModifiers
 		) {
 			this.player.reset();
 			return;
@@ -294,12 +299,12 @@ export class BattleEngine {
 		// (#1933) — re-snapshot now so a passive that raises MaxHealth doesn't leave the battler under-full,
 		// matching the backend's Battler ctor which snapshots CurrentHealth after the passive is composed in.
 		this.player.currentHealth = this.player.attributes.getValue(EAttribute.MaxHealth);
-		this.lastEquipmentStats = equipmentStats;
-		this.lastPlayerAttributes = attributes;
-		this.lastSelectedSkills = selectedSkills;
-		this.lastPlayerLevel = level;
-		this.lastLockedBaseModifiers = lockedBaseModifiers;
-		this.lastProficiencyModifiers = proficiencyModifiers;
+		this.#lastEquipmentStats = equipmentStats;
+		this.#lastPlayerAttributes = attributes;
+		this.#lastSelectedSkills = selectedSkills;
+		this.#lastPlayerLevel = level;
+		this.#lastLockedBaseModifiers = lockedBaseModifiers;
+		this.#lastProficiencyModifiers = proficiencyModifiers;
 	}
 
 	public getOpponent(battler: Battler) {
@@ -369,7 +374,7 @@ export class BattleEngine {
 		// loop must declare the draw on the same tick the headless BattleSimulator caps at (battle parity).
 		if (this.stage === Active) {
 			this.timeElapsed += timeDelta;
-			const activations = battleStep(this.player, this.enemy, timeDelta, this.rng, this.stepLog);
+			const activations = battleStep(this.player, this.enemy, timeDelta, this.#rng, this.#stepLog);
 			const damageLogEnabled = playerManager.logTypeEnabled(ELogType.Damage);
 			for (const { skill, damage, byPlayer, crit, dodged, parried, counter, reflected } of activations) {
 				const outcome = damageLogOutcome(byPlayer, crit, dodged, parried, counter);
@@ -451,7 +456,7 @@ export class BattleEngine {
 		if (!playerManager.logTypeEnabled(ELogType.SkillEffect)) {
 			return;
 		}
-		for (const { effect, onPlayer, amount } of this.stepLog.appliedEffects) {
+		for (const { effect, onPlayer, amount } of this.#stepLog.appliedEffects) {
 			const name = attributeName(effect.attributeId, staticData.attributes);
 			const isHarmful = attributeIsHarmful(effect.attributeId, staticData.attributes);
 			logMessage(ELogType.SkillEffect, effectLogMessage(effect, name, isHarmful, onPlayer, this.enemy.name, amount));
@@ -461,12 +466,12 @@ export class BattleEngine {
 	/** Adds this tick's DoT/HoT to the running per-channel totals, flushing a summary line once the
 	 *  accumulation window reaches a second. */
 	private accumulateEffectDamage(timeDelta: number) {
-		this.effectDamage.enemyDot += this.stepLog.enemyDotDamage;
-		this.effectDamage.playerDot += this.stepLog.playerDotDamage;
-		this.effectDamage.enemyHot += this.stepLog.enemyHotHeal;
-		this.effectDamage.playerHot += this.stepLog.playerHotHeal;
-		this.effectDamageElapsedMs += timeDelta;
-		if (this.effectDamageElapsedMs >= 1000) {
+		this.#effectDamage.enemyDot += this.#stepLog.enemyDotDamage;
+		this.#effectDamage.playerDot += this.#stepLog.playerDotDamage;
+		this.#effectDamage.enemyHot += this.#stepLog.enemyHotHeal;
+		this.#effectDamage.playerHot += this.#stepLog.playerHotHeal;
+		this.#effectDamageElapsedMs += timeDelta;
+		if (this.#effectDamageElapsedMs >= 1000) {
 			this.flushEffectDamage();
 		}
 	}
@@ -474,7 +479,7 @@ export class BattleEngine {
 	/** Emits one combat-log line per non-zero over-time channel accumulated since the last flush, then
 	 *  resets the window — so the player sees DoT/HoT totals without a line every 40ms tick. */
 	private flushEffectDamage() {
-		const { enemyDot, playerDot, enemyHot, playerHot } = this.effectDamage;
+		const { enemyDot, playerDot, enemyHot, playerHot } = this.#effectDamage;
 		if (enemyDot > 0) {
 			logMessage(ELogType.SkillEffect, `${this.enemy.name} took ${formatNum(enemyDot)} damage over time.`);
 		}
@@ -491,11 +496,11 @@ export class BattleEngine {
 	}
 
 	private resetEffectDamage() {
-		this.effectDamage.enemyDot = 0;
-		this.effectDamage.playerDot = 0;
-		this.effectDamage.enemyHot = 0;
-		this.effectDamage.playerHot = 0;
-		this.effectDamageElapsedMs = 0;
+		this.#effectDamage.enemyDot = 0;
+		this.#effectDamage.playerDot = 0;
+		this.#effectDamage.enemyHot = 0;
+		this.#effectDamage.playerHot = 0;
+		this.#effectDamageElapsedMs = 0;
 	}
 
 	private renderUpdate(renderDelta: number) {

--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -71,45 +71,48 @@ export class EnemyManager {
 	 *  incomplete to complete). Drives the Zone-Cleared overlay's "Next zone unlocked" line. */
 	public bossUnlockedNextZone = false;
 
-	private battleStageUnhook?: Action;
+	/** All fields below are non-reactive hot-path internals — never read by a `$derived`/template — so
+	 *  they're `#`-private, matching the {@link PlayerManager} convention, keeping `statify` from
+	 *  deep-proxying them. */
+	#battleStageUnhook?: Action;
 	/** Guards the challenge/retreat transitions so a resolving stage change for the battle being
 	 *  swapped out is not mistaken for an outcome of the new one. Stays set across a supersession (a
 	 *  press that takes over an in-flight transition) — only the transition that ends up current clears it. */
-	private transitioning = false;
+	#transitioning = false;
 	/** Bumped whenever a new transition supersedes an in-flight one. A running transition captures this at
 	 *  its start and, after each await, abandons (without applying its result) once it no longer matches — so
 	 *  a superseded challenge/retreat can't clobber the transition that took over, and the superseded one's
 	 *  finally won't release the `transitioning` guard the new transition still holds. */
-	private transitionGeneration = 0;
+	#transitionGeneration = 0;
 	/** Re-entrancy guard for getNewEnemy: overlapping stage handlers must not both spawn-and-notify an
 	 *  enemy (a double-spawn the backend replay would flag as cheating). */
-	private fetchingEnemy = false;
+	#fetchingEnemy = false;
 	/** Bumped whenever the active enemy-fetch loop is superseded (a stop, or a transition taking over).
 	 *  The running getNewEnemy captures this value and exits once it no longer matches, so a stale loop
 	 *  under a sustained outage can't keep spinning — nor later clobber the new fight with an enemy
 	 *  nobody is waiting for. */
-	private fetchGeneration = 0;
+	#fetchGeneration = 0;
 	/** The generation the in-flight fetch loop captured at its start. Lets a fresh getNewEnemy tell a
 	 *  genuine re-entrant duplicate (same generation — the running loop will still spawn, so drop) apart
 	 *  from a superseded loop (older generation — it will abandon without spawning, so wait it out then
 	 *  fetch fresh rather than be dropped by the re-entrancy guard). */
-	private fetchingGeneration = 0;
+	#fetchingGeneration = 0;
 	/** The in-flight fetch loop, so a superseding caller (e.g. a failing boss-challenge falling back to
 	 *  the idle loop) can await its teardown before fetching afresh — keeping a single fetch in flight. */
-	private inFlightFetch?: Promise<void>;
+	#inFlightFetch?: Promise<void>;
 	/** Resolver that short-circuits an in-flight retry backoff so a stop / superseding transition need
 	 *  not wait out the full delay before the loop re-checks whether it should still be running. */
-	private cancelBackoff?: () => void;
+	#cancelBackoff?: () => void;
 	/** The last `AutoChallengeBoss` value synced to the backend, so {@link syncAutoChallengeBoss} drops
 	 *  redundant re-syncs (e.g. a returnToIdle when the persisted mode is already idle). `undefined` until
 	 *  the first sync, so the first authoritative state is always sent. */
-	private lastSyncedAutoChallengeBoss?: boolean;
+	#lastSyncedAutoChallengeBoss?: boolean;
 	/** Whether the fight loop has not yet sent a `NewEnemy` request since {@link start}. Re-armed by every
 	 *  `start()` and consumed by the first `runFetchLoop` dispatch, regardless of whether that `start()` was
 	 *  handed an `activeBattle` — a fresh `battleEngine` has no history for whatever battle the server may
 	 *  still be holding (e.g. a sub-5-minute reconnect the welcome-back gate didn't resume directly), so its
 	 *  untouched `timeElapsed` of 0 must not be reported as a genuine "never fought" claim (#1883). */
-	private isFirstFetch = true;
+	#isFirstFetch = true;
 
 	/**
 	 * Starts the fight loop. `activeBattle` is the server-handed-back battle a `GetOfflineProgress` summary
@@ -125,8 +128,8 @@ export class EnemyManager {
 	public start(activeBattle?: IEnemyInstance) {
 		if (!this.started) {
 			this.started = true;
-			this.isFirstFetch = true;
-			this.battleStageUnhook = onBattleStageChanged((stage) => this.watchBattleStage(stage));
+			this.#isFirstFetch = true;
+			this.#battleStageUnhook = onBattleStageChanged((stage) => this.watchBattleStage(stage));
 			if (activeBattle) {
 				this.mode = activeBattle.isBossBattle ? 'boss' : 'idle';
 				this.currentEnemy = activeBattle;
@@ -140,7 +143,7 @@ export class EnemyManager {
 	public stop() {
 		if (this.started) {
 			this.started = false;
-			this.battleStageUnhook?.();
+			this.#battleStageUnhook?.();
 			// Cut short an in-flight retry backoff so a getNewEnemy parked under a sustained outage exits
 			// at once on the cleared `started` flag rather than after the full backoff window.
 			this.interruptFetch();
@@ -207,37 +210,37 @@ export class EnemyManager {
 	 * (#1690), mirroring the unconditional discard `ChallengeBoss` already applies server-side.
 	 */
 	public async getNewEnemy(prepared?: PreparedBattle, forceAbandon = false): Promise<void> {
-		const generation = this.fetchGeneration;
+		const generation = this.#fetchGeneration;
 		// Looped (not a one-shot if): a fetch already running when we arrive is checked again after each
 		// wait. Two same-generation callers can both queue behind an older, superseded fetch — the first
 		// to resume starts a fresh fetch (synchronously re-arming fetchingEnemy/fetchingGeneration before
 		// its first await), and looping back here is what lets the second recognize that new fetch as its
 		// own genuine re-entrant duplicate instead of racing it into a double spawn.
-		while (this.fetchingEnemy) {
+		while (this.#fetchingEnemy) {
 			// A fetch is already running. If it captured this same generation it's a genuine re-entrant
 			// duplicate — overlapping stage handlers (e.g. an idle victory racing an Idle/Defeated change)
 			// each request-and-notify a spawn, and a double-spawn has anti-cheat consequences (the backend
 			// replays what the client reports). Drop it; the running fetch still spawns one.
-			if (this.fetchingGeneration === generation) {
+			if (this.#fetchingGeneration === generation) {
 				return;
 			}
 			// Otherwise this call's generation is newer, so the running fetch has been superseded (a
 			// transition bumped the generation) and will abandon without spawning. Wait for it to tear
 			// down, then loop back and re-check rather than assuming the guard is now clear.
-			await this.inFlightFetch;
+			await this.#inFlightFetch;
 			// The wait can overlap a stop or a further supersession; bail if either landed meanwhile.
-			if (!this.started || generation !== this.fetchGeneration) {
+			if (!this.started || generation !== this.#fetchGeneration) {
 				return;
 			}
 		}
 		const run = this.runFetchLoop(generation, prepared, forceAbandon);
-		this.inFlightFetch = run;
+		this.#inFlightFetch = run;
 		await run;
 	}
 
 	private async runFetchLoop(generation: number, prepared?: PreparedBattle, forceAbandon = false): Promise<void> {
-		this.fetchingEnemy = true;
-		this.fetchingGeneration = generation;
+		this.#fetchingEnemy = true;
+		this.#fetchingGeneration = generation;
 		try {
 			// The no-combat Home sanctuary never spawns enemies, so halt the loop rather than sending NewEnemy:
 			// the backend refuses a battle zone-change into Home and would answer with a real-zone enemy, which
@@ -253,7 +256,7 @@ export class EnemyManager {
 			// lands between capture and present (bumping the generation) skips it — so the prefetched idle
 			// enemy can't double-spawn or clobber the fight the supersession moved to. Used only while still
 			// valid (same zone, unchanged player battle-state); otherwise fall through to a fresh fetch.
-			if (prepared && this.started && generation === this.fetchGeneration && this.preparedStillValid(prepared)) {
+			if (prepared && this.started && generation === this.#fetchGeneration && this.preparedStillValid(prepared)) {
 				this.currentEnemy = prepared.enemy;
 				notifyNewEnemyLoaded(this.currentEnemy);
 				return;
@@ -268,8 +271,8 @@ export class EnemyManager {
 			// literal 0 would falsely claim "never fought," discarding it with no outcome instead of letting the
 			// backend's wall-clock fallback settle or hand it back (#1883). A plain fetch after that (e.g. an
 			// idle loss/draw) reports the elapsed time the client genuinely did fight.
-			const isFirstFetch = this.isFirstFetch;
-			this.isFirstFetch = false;
+			const isFirstFetch = this.#isFirstFetch;
+			this.#isFirstFetch = false;
 			const clientBattleMs = prepared ? 0 : isFirstFetch ? undefined : battleEngine.timeElapsed;
 
 			// Retry iteratively rather than via self-recursion: each attempt returns to a flat stack
@@ -277,7 +280,7 @@ export class EnemyManager {
 			// as `stop()` flips `started` or a transition supersedes this fetch (bumping the generation);
 			// because the retry backoff is cancellable, either takes effect immediately rather than after
 			// the full delay — so the controls don't feel frozen while a backoff is parked.
-			while (this.started && generation === this.fetchGeneration) {
+			while (this.started && generation === this.#fetchGeneration) {
 				const result = await apiSocket.sendSocketCommand('NewEnemy', {
 					newZoneId: playerManager.currentZone,
 					clientBattleMs,
@@ -287,7 +290,7 @@ export class EnemyManager {
 				// transition that lands while parked on the await above (not on the cancellable backoff)
 				// would otherwise still apply this response. Re-check before applying so a successful
 				// NewEnemy can't clobber the fight the supersession already moved on to.
-				if (!this.started || generation !== this.fetchGeneration) {
+				if (!this.started || generation !== this.#fetchGeneration) {
 					return;
 				}
 				if (result.data?.enemyInstance) {
@@ -311,7 +314,7 @@ export class EnemyManager {
 						await battleEngine.startLoading(result.data.cooldown);
 						// The awaited cooldown can overlap a stop / superseding transition; re-check before
 						// presenting so a resolved wait can't clobber the fight the supersession moved on to.
-						if (!this.started || generation !== this.fetchGeneration) {
+						if (!this.started || generation !== this.#fetchGeneration) {
 							return;
 						}
 					}
@@ -331,7 +334,7 @@ export class EnemyManager {
 				await this.backoff(result.data?.cooldown || NEW_ENEMY_RETRY_DELAY_MS);
 			}
 		} finally {
-			this.fetchingEnemy = false;
+			this.#fetchingEnemy = false;
 		}
 	}
 
@@ -351,12 +354,12 @@ export class EnemyManager {
 				settled = true;
 				// Only clear the shared handle if it still points at this backoff — a later backoff may
 				// have already replaced it (e.g. the real timer firing after an early cancel).
-				if (this.cancelBackoff === finish) {
-					this.cancelBackoff = undefined;
+				if (this.#cancelBackoff === finish) {
+					this.#cancelBackoff = undefined;
 				}
 				resolve();
 			};
-			this.cancelBackoff = finish;
+			this.#cancelBackoff = finish;
 			delay(ms).then(finish);
 		});
 	}
@@ -365,8 +368,8 @@ export class EnemyManager {
 	 *  bumped generation no longer matches) and its retry backoff is cut short so the supersession takes
 	 *  effect immediately rather than after the parked delay. */
 	private interruptFetch() {
-		this.fetchGeneration++;
-		this.cancelBackoff?.();
+		this.#fetchGeneration++;
+		this.#cancelBackoff?.();
 	}
 
 	/** Begins a control transition (challenge/retreat), superseding any in-flight one: it holds the
@@ -374,17 +377,17 @@ export class EnemyManager {
 	 *  result), and cuts short any parked enemy-fetch backoff so the takeover is immediate. Returns the new
 	 *  generation for the caller to re-check after each await. */
 	private beginTransition(): number {
-		this.transitioning = true;
+		this.#transitioning = true;
 		this.interruptFetch();
-		return ++this.transitionGeneration;
+		return ++this.#transitionGeneration;
 	}
 
 	/** Ends a control transition, releasing the guard — but only if this transition is still the current
 	 *  one. A superseded transition leaving its finally must not clear the flag the transition that took
 	 *  over still holds. */
 	private endTransition(generation: number) {
-		if (generation === this.transitionGeneration) {
-			this.transitioning = false;
+		if (generation === this.#transitionGeneration) {
+			this.#transitioning = false;
 		}
 	}
 
@@ -394,7 +397,7 @@ export class EnemyManager {
 	 * failure falls back to the idle loop.
 	 */
 	public async challengeBoss() {
-		if (this.transitioning && this.mode === 'boss') {
+		if (this.#transitioning && this.mode === 'boss') {
 			// A challenge is already in flight heading to the same destination (boss). Pressing again is
 			// redundant — re-sending ChallengeBoss would make the backend abandon and re-spawn the boss — so
 			// let the in-flight transition continue rather than start a second.
@@ -418,7 +421,7 @@ export class EnemyManager {
 			});
 			// A stop, or a later press superseding this challenge, landed while ChallengeBoss was in flight;
 			// abandon so its result can't clobber the transition that took over (mirrors getNewEnemy's guard).
-			if (!this.started || generation !== this.transitionGeneration) {
+			if (!this.started || generation !== this.#transitionGeneration) {
 				return;
 			}
 			if (result.data?.enemyInstance) {
@@ -430,7 +433,7 @@ export class EnemyManager {
 					await battleEngine.startLoading(result.data.cooldown);
 					// The awaited cooldown can overlap a stop / superseding transition; re-check before
 					// presenting so a resolved wait can't clobber the fight the supersession moved on to.
-					if (!this.started || generation !== this.transitionGeneration) {
+					if (!this.started || generation !== this.#transitionGeneration) {
 						return;
 					}
 				}
@@ -458,7 +461,7 @@ export class EnemyManager {
 	 * so a still-active fight ends immediately instead of being handed back and resumed under boss mode.
 	 */
 	public async retreatFromBoss() {
-		if (this.transitioning) {
+		if (this.#transitioning) {
 			if (this.mode === 'idle') {
 				// A transition heading to the same destination (idle) is already in flight — a retreat, or a
 				// failing challenge's idle fallback. Pressing again is redundant, so let it continue.
@@ -501,7 +504,7 @@ export class EnemyManager {
 	 */
 	public reconcilePersistedMode(autoChallengeBoss: boolean) {
 		this.autoFight = autoChallengeBoss;
-		this.lastSyncedAutoChallengeBoss = autoChallengeBoss;
+		this.#lastSyncedAutoChallengeBoss = autoChallengeBoss;
 	}
 
 	private returnToIdle(sync = true) {
@@ -530,10 +533,10 @@ export class EnemyManager {
 	 * login is the welcome-back gate's job (#1043).
 	 */
 	private syncAutoChallengeBoss(enabled: boolean) {
-		if (enabled === this.lastSyncedAutoChallengeBoss) {
+		if (enabled === this.#lastSyncedAutoChallengeBoss) {
 			return;
 		}
-		this.lastSyncedAutoChallengeBoss = enabled;
+		this.#lastSyncedAutoChallengeBoss = enabled;
 		void apiSocket.sendSocketCommand('SetAutoChallengeBoss', enabled);
 	}
 
@@ -541,7 +544,7 @@ export class EnemyManager {
 	 *  has transitioned us away. A boss-victory resolution re-checks this after each await so a transition
 	 *  landing mid-resolution abandons it instead of clobbering the new state. */
 	private get bossLoopActive(): boolean {
-		return this.started && this.mode === 'boss' && !this.transitioning;
+		return this.started && this.mode === 'boss' && !this.#transitioning;
 	}
 
 	/** Whether `generation` (a {@link transitionGeneration} snapshot) is still current — false once a stop
@@ -549,12 +552,12 @@ export class EnemyManager {
 	 *  on. Unlike {@link bossLoopActive}, this doesn't require `mode === 'boss'`: boss-loss resolution leaves
 	 *  boss mode itself partway through (via returnToIdle), so it re-checks this after each await instead. */
 	private transitionCurrent(generation: number): boolean {
-		return this.started && generation === this.transitionGeneration;
+		return this.started && generation === this.#transitionGeneration;
 	}
 
 	private async watchBattleStage(stage: BattleStage) {
 		// While swapping the active battle, ignore the outgoing battle's resolving stage changes.
-		if (this.transitioning) {
+		if (this.#transitioning) {
 			return;
 		}
 		if (this.mode === 'boss') {
@@ -579,7 +582,7 @@ export class EnemyManager {
 		// The awaited claim/cooldown above can overlap a boss challenge or retreat that hands the loop
 		// off (and resolves the cooldown early via reset); if we've since left idle mode or a transition
 		// is mid-flight, don't spawn an idle enemy over the new fight.
-		if (this.transitioning || this.mode !== 'idle') {
+		if (this.#transitioning || this.mode !== 'idle') {
 			return;
 		}
 
@@ -688,7 +691,7 @@ export class EnemyManager {
 		// bumps it (via beginTransition), and its result can resolve the parked startLoading below early
 		// (finishLoading) — so this resolution must not then hand a stale prepared idle battle to a fresh
 		// getNewEnemy call and clobber the fight the supersession already started (#1696).
-		const generation = this.transitionGeneration;
+		const generation = this.#transitionGeneration;
 		// Record the loss explicitly (turning auto-fight off) and drop back to the boss-available
 		// state — the normal idle farm loop — honoring the post-loss cooldown. Report the duration the
 		// client simulated alongside the claim, mirroring claimVictory's diagnostic-only clientTotalMs.

--- a/UI/src/lib/engine/player/inventory-manager.ts
+++ b/UI/src/lib/engine/player/inventory-manager.ts
@@ -83,21 +83,23 @@ export class InventoryManager {
 	 */
 	private grantedSkillIdsCache: number[] = [];
 
-	/** Serializes the optimistic mutations so rollback baselines never interleave (see {@link serialize}). */
-	private queue = new SerializedQueue();
+	/** Serializes the optimistic mutations so rollback baselines never interleave (see {@link serialize}).
+	 *  `#`-private so `statify` leaves it non-reactive — it's a hot-path internal read only imperatively. */
+	#queue = new SerializedQueue();
 
 	/**
-	 * Bumped on every {@link initialize}. `initialize()` runs outside the {@link queue} (a mid-session
+	 * Bumped on every {@link initialize}. `initialize()` runs outside the {@link #queue} (a mid-session
 	 * resync can't wait behind an in-flight mutation's persist), so a mutation that started optimistically
 	 * applying before a resync — then has its persist fail afterward — must not roll back: its snapshot
 	 * predates the resync's fresh item instances, and restoring it would splice orphaned pre-resync objects
 	 * back into live state (#1808). Each mutation captures the generation at snapshot time and checks it
-	 * via {@link rollbackIfCurrent} before invoking its rollback.
+	 * via {@link rollbackIfCurrent} before invoking its rollback. `#`-private for the same reason as
+	 * {@link #queue} above.
 	 */
-	private generation = 0;
+	#generation = 0;
 
 	public initialize() {
-		this.generation++;
+		this.#generation++;
 		const unlockedItems: Map<number, Item> = new Map();
 		const unlockedMods: Set<number> = new Set();
 		const equippedSlots: (Item | undefined)[] = new Array(6).fill(undefined);
@@ -207,7 +209,7 @@ export class InventoryManager {
 
 			// Apply optimistically (instant UI), then persist; a failed persist rolls the change back so
 			// the authoritative state can never diverge from what was actually saved.
-			const startGeneration = this.generation;
+			const startGeneration = this.#generation;
 			const affected = [item, this.equippedSlots[slotId]].filter((it): it is Item => it != null);
 			const rollback = combineSnapshots(
 				snapshotFields(this, 'equippedSlots'),
@@ -242,7 +244,7 @@ export class InventoryManager {
 				return false;
 			}
 
-			const startGeneration = this.generation;
+			const startGeneration = this.#generation;
 			const rollback = combineSnapshots(
 				snapshotFields(this, 'equippedSlots'),
 				snapshotFields(item, 'equipped', 'equipmentSlotId')
@@ -283,7 +285,7 @@ export class InventoryManager {
 				return false;
 			}
 
-			const startGeneration = this.generation;
+			const startGeneration = this.#generation;
 			const rollback = snapshotFields(item, 'appliedMods', 'totalAttributes');
 			item.appliedMods = [...item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId), mod];
 			this.refreshItemAttributes(item);
@@ -311,7 +313,7 @@ export class InventoryManager {
 				return false;
 			}
 
-			const startGeneration = this.generation;
+			const startGeneration = this.#generation;
 			const rollback = snapshotFields(item, 'appliedMods', 'totalAttributes');
 			item.appliedMods = item.appliedMods.filter((m) => m.itemModSlotId !== itemModSlotId);
 			this.refreshItemAttributes(item);
@@ -395,18 +397,18 @@ export class InventoryManager {
 	 * which is better UX than dropping the second one.
 	 */
 	private serialize<T>(operation: () => Promise<T>): Promise<T> {
-		return this.queue.run(operation);
+		return this.#queue.run(operation);
 	}
 
 	/**
 	 * Invokes `rollback` only if no {@link initialize} resync has happened since `startGeneration` was
-	 * captured. `initialize()` runs outside the {@link queue}, so a mid-flight mutation's persist can fail
+	 * captured. `initialize()` runs outside the {@link #queue}, so a mid-flight mutation's persist can fail
 	 * after a resync has already rebuilt `unlockedItems`/`equippedSlots` with fresh objects; rolling back at
 	 * that point would restore the stale pre-resync snapshot — reintroducing orphaned item references the
 	 * resync just replaced (#1808). When the generation has moved on, the resync's own state is left as-is.
 	 */
 	private rollbackIfCurrent(startGeneration: number, rollback: RestoreSnapshot, after: () => void) {
-		if (this.generation !== startGeneration) {
+		if (this.#generation !== startGeneration) {
 			return;
 		}
 		rollback();

--- a/UI/src/tests/lib/common/statify.svelte.test.ts
+++ b/UI/src/tests/lib/common/statify.svelte.test.ts
@@ -12,6 +12,20 @@ class Outer {
 	items: Inner[] = [new Inner()];
 }
 
+class WithPrivateField {
+	// `for...in` (which `statify` walks) never enumerates `#`-private fields, unlike a TS `private` field
+	// (a plain enumerable property at runtime) — the escape hatch a hot-path internal opts into.
+	#hidden = 0;
+
+	bumpHidden() {
+		this.#hidden++;
+	}
+
+	get hidden() {
+		return this.#hidden;
+	}
+}
+
 // Reads the `__statifyPerformed` idempotency marker the utility stamps on every processed object.
 const wasStatified = (obj: unknown) => (obj as { __statifyPerformed?: boolean }).__statifyPerformed === true;
 
@@ -103,5 +117,29 @@ describe('statify', () => {
 
 		// The setter routes a class-typed assignment back through statify.
 		expect(wasStatified(replacement)).toBe(true);
+	});
+
+	it('leaves `#`-private fields non-reactive, unlike a same-shaped public field', () => {
+		const instance = statify(new WithPrivateField());
+
+		// No `$state` accessor was defined for `#hidden` — a `$derived` reading it through the public
+		// getter never re-runs on a mutation, since statify never saw the field to begin with.
+		let observed = -1;
+		const cleanup = $effect.root(() => {
+			const derivedHidden = $derived(instance.hidden);
+			$effect(() => {
+				observed = derivedHidden;
+			});
+		});
+
+		flushSync();
+		expect(observed).toBe(0);
+
+		instance.bumpHidden();
+		flushSync();
+		expect(observed).toBe(0);
+		expect(instance.hidden).toBe(1);
+
+		cleanup();
 	});
 });


### PR DESCRIPTION
## Summary

`statify` (`$lib/common/statify.svelte.ts`) enumerates plain properties via `for...in`, so TS-`private` fields (plain enumerable props at runtime) get deep-proxied into `$state`; only `#`-private fields escape. `PlayerManager` already follows this convention deliberately for `#lockedBaseCache`, but three other statified managers didn't:

- **`BattleEngine`** (`battle-engine.ts`): `rng`, `stepLog`, `effectDamage`/`effectDamageElapsedMs`, and the `last*` change-detection fields (`lastEquipmentStats`, `lastPlayerAttributes`, `lastSelectedSkills`, `lastPlayerLevel`, `lastLockedBaseModifiers`, `lastProficiencyModifiers`). `stepLog`/`effectDamage` in particular are documented as a "reused per-tick sink" written on every 40ms tick (and up to ~3,000 ticks synchronously in `replayToOffset`) specifically to avoid per-tick allocation cost — the proxying was silently re-adding that cost.
- **`EnemyManager`** (`enemy-manager.ts`): the transition/fetch generation counters, re-entrancy/backoff guards, and related internals (`transitioning`, `transitionGeneration`, `fetchingEnemy`, `fetchGeneration`, `fetchingGeneration`, `inFlightFetch`, `cancelBackoff`, `lastSyncedAutoChallengeBoss`, `isFirstFetch`, `battleStageUnhook`).
- **`InventoryManager`** (`inventory-manager.ts`): `queue` and `generation` only — its `equipmentStatsCache`/`grantedSkillIdsCache` are left as TS-`private` and stay reactive on purpose, since screens derive from `equipmentStats`.

All are mechanical renames (`private field` → `#field`), no behavior change. Verified none of these field names are referenced outside their owning class (only a couple of unrelated matches in `loom-game.ts`, a different class, and a comment in a test file that names the concept, not the symbol).

Also adds a regression test to `statify.svelte.test.ts` pinning the exact contract this issue relies on: a `#`-private field is never wrapped by `statify`, while a same-shaped public field is.

Closes #2059

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings
- [x] `npx vitest run` on the affected engine/statify test files — all passing
- [x] `npm run test:unit:ci` (full frontend suite) — 299 files / 3765 tests passing (was 3764; added one new statify regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7DXWmrF3ewj6XZs4D6RqD

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7DXWmrF3ewj6XZs4D6RqD)_