### PR TITLE
Dedupe Workbench attribute-table sections and save-flash plumbing

### DIFF
--- a/UI/src/lib/common/index.ts
+++ b/UI/src/lib/common/index.ts
@@ -20,3 +20,4 @@ export * from './hooks';
 export * from './event-measuring';
 export * from './serialized-queue';
 export * from './statify.svelte';
+export * from './save-flash.svelte';

--- a/UI/src/lib/common/save-flash.svelte.ts
+++ b/UI/src/lib/common/save-flash.svelte.ts
@@ -1,0 +1,31 @@
+/** Brief "saved" confirmation flash with a self-owned timer lifecycle — the pattern duplicated
+ *  across the Attributes/Options draft-edit view-models before being extracted here. A consumer
+ *  calls {@link flash} after a successful save and must call {@link dispose} on teardown to clear
+ *  a pending timer. */
+export class SaveFlash {
+	active = $state(false);
+
+	#timer: ReturnType<typeof setTimeout> | undefined;
+
+	constructor(private readonly durationMs = 1900) {}
+
+	flash(): void {
+		this.active = true;
+		if (this.#timer) {
+			clearTimeout(this.#timer);
+		}
+		this.#timer = setTimeout(() => {
+			this.active = false;
+		}, this.durationMs);
+	}
+
+	reset(): void {
+		this.active = false;
+	}
+
+	dispose(): void {
+		if (this.#timer) {
+			clearTimeout(this.#timer);
+		}
+	}
+}

--- a/UI/src/routes/admin/workbench/entities/attribute-table-sections.ts
+++ b/UI/src/routes/admin/workbench/entities/attribute-table-sections.ts
@@ -1,0 +1,107 @@
+import { reference } from '../reference.svelte';
+import { firstFree } from './helpers';
+import { fieldsOf, type Identified, type TableSectionConfig } from './types';
+
+interface AttributeDistributionRow {
+	attributeId: number;
+	baseAmount: number;
+	amountPerLevel: number;
+}
+
+interface AttributeBonusRow {
+	attributeId: number;
+	amount: number;
+}
+
+/**
+ * Shared "stat distribution per level" table — identical shape for Enemies and Classes
+ * (attributeId + baseAmount + amountPerLevel, one row per attribute); only the collection
+ * key, section key, description and empty-state copy vary per entity.
+ */
+export const attributeDistributionSection = <T extends Identified>(config: {
+	key: string;
+	itemsKey: keyof T & string;
+	desc: string;
+	emptySub: string;
+}): TableSectionConfig<T> => {
+	const rowsOf = (rec: T) => fieldsOf(rec)[config.itemsKey] as AttributeDistributionRow[];
+	return {
+		key: config.key,
+		label: 'Attributes',
+		glyph: 'bars',
+		desc: config.desc,
+		count: (rec) => rowsOf(rec).length,
+		warn: (rec) => (rowsOf(rec).length ? null : 'No attribute distribution'),
+		kind: 'table',
+		itemsKey: config.itemsKey,
+		rowKey: 'attributeId',
+		addLabel: 'Add attribute',
+		emptyIcon: 'bars',
+		emptyTitle: 'No attributes set',
+		emptySub: config.emptySub,
+		newRow: (rec) => ({
+			attributeId: firstFree(
+				rowsOf(rec).map((a) => a.attributeId),
+				reference.attributeOptions()
+			),
+			baseAmount: 0,
+			amountPerLevel: 0
+		}),
+		columns: [
+			{
+				key: 'attributeId',
+				label: 'Attribute',
+				type: 'attribute',
+				options: reference.attributeOptions,
+				min: 190,
+				unique: true
+			},
+			{ key: 'baseAmount', label: 'Base', type: 'number', align: 'r', width: 110, allowNegative: true },
+			{ key: 'amountPerLevel', label: 'Per Level', type: 'number', align: 'r', width: 110, allowNegative: true }
+		]
+	};
+};
+
+/**
+ * Shared "flat stat bonus" table — identical shape for Items and Item Mods (attributeId +
+ * amount, one row per attribute); only the collection key and empty-state copy vary.
+ */
+export const attributeBonusSection = <T extends Identified>(config: {
+	itemsKey: keyof T & string;
+	emptySub: string;
+}): TableSectionConfig<T> => {
+	const rowsOf = (rec: T) => fieldsOf(rec)[config.itemsKey] as AttributeBonusRow[];
+	return {
+		key: 'attributes',
+		label: 'Attributes',
+		glyph: 'bars',
+		desc: 'Flat stat bonuses granted',
+		count: (rec) => rowsOf(rec).length,
+		warn: (rec) => (rowsOf(rec).length ? null : 'No attributes'),
+		kind: 'table',
+		itemsKey: config.itemsKey,
+		rowKey: 'attributeId',
+		addLabel: 'Add bonus',
+		emptyIcon: 'bars',
+		emptyTitle: 'No attribute bonuses',
+		emptySub: config.emptySub,
+		newRow: (rec) => ({
+			attributeId: firstFree(
+				rowsOf(rec).map((a) => a.attributeId),
+				reference.attributeOptions()
+			),
+			amount: 1
+		}),
+		columns: [
+			{
+				key: 'attributeId',
+				label: 'Attribute',
+				type: 'attribute',
+				options: reference.attributeOptions,
+				min: 200,
+				unique: true
+			},
+			{ key: 'amount', label: 'Amount', type: 'number', align: 'r', width: 120, allowNegative: true }
+		]
+	};
+};

--- a/UI/src/routes/admin/workbench/entities/class.ts
+++ b/UI/src/routes/admin/workbench/entities/class.ts
@@ -11,6 +11,7 @@ import { hasFlag } from '$lib/common';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import { childChanged, guardedSave, persistEntity } from '../save-helpers';
+import { attributeDistributionSection } from './attribute-table-sections';
 import { firstFree } from './helpers';
 import { chipsSection, type EntityConfig } from './types';
 
@@ -204,41 +205,12 @@ export const classEntity: EntityConfig<WorkbenchClass> = {
 				}
 			]
 		},
-		{
+		attributeDistributionSection<WorkbenchClass>({
 			key: 'attributes',
-			label: 'Attributes',
-			glyph: 'bars',
-			desc: 'Locked-base stat distribution per level',
-			count: (c) => c.attributeDistributions.length,
-			warn: (c) => (c.attributeDistributions.length ? null : 'No attribute distribution'),
-			kind: 'table',
 			itemsKey: 'attributeDistributions',
-			rowKey: 'attributeId',
-			addLabel: 'Add attribute',
-			emptyIcon: 'bars',
-			emptyTitle: 'No attributes set',
-			emptySub: 'This class has no stat distribution yet.',
-			newRow: (c) => ({
-				attributeId: firstFree(
-					c.attributeDistributions.map((a) => a.attributeId),
-					reference.attributeOptions()
-				),
-				baseAmount: 0,
-				amountPerLevel: 0
-			}),
-			columns: [
-				{
-					key: 'attributeId',
-					label: 'Attribute',
-					type: 'attribute',
-					options: reference.attributeOptions,
-					min: 190,
-					unique: true
-				},
-				{ key: 'baseAmount', label: 'Base', type: 'number', align: 'r', width: 110, allowNegative: true },
-				{ key: 'amountPerLevel', label: 'Per Level', type: 'number', align: 'r', width: 110, allowNegative: true }
-			]
-		}
+			desc: 'Locked-base stat distribution per level',
+			emptySub: 'This class has no stat distribution yet.'
+		})
 	],
 	refresh,
 	persist: (diff) =>

--- a/UI/src/routes/admin/workbench/entities/enemy.ts
+++ b/UI/src/routes/admin/workbench/entities/enemy.ts
@@ -3,6 +3,7 @@ import { hasFlag } from '$lib/common';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import { childChanged, guardedSave, persistEntity } from '../save-helpers';
+import { attributeDistributionSection } from './attribute-table-sections';
 import { firstFree } from './helpers';
 import { chipsSection, type EntityConfig } from './types';
 
@@ -85,41 +86,12 @@ export const enemyEntity: EntityConfig<WorkbenchEnemy> = {
 				}
 			]
 		},
-		{
+		attributeDistributionSection<WorkbenchEnemy>({
 			key: 'attrs',
-			label: 'Attributes',
-			glyph: 'bars',
-			desc: 'Stat distribution per level',
-			count: (e) => e.attributeDistribution.length,
-			warn: (e) => (e.attributeDistribution.length ? null : 'No attribute distribution'),
-			kind: 'table',
 			itemsKey: 'attributeDistribution',
-			rowKey: 'attributeId',
-			addLabel: 'Add attribute',
-			emptyIcon: 'bars',
-			emptyTitle: 'No attributes set',
-			emptySub: 'This enemy has no stat distribution yet.',
-			newRow: (e) => ({
-				attributeId: firstFree(
-					e.attributeDistribution.map((a) => a.attributeId),
-					reference.attributeOptions()
-				),
-				baseAmount: 0,
-				amountPerLevel: 0
-			}),
-			columns: [
-				{
-					key: 'attributeId',
-					label: 'Attribute',
-					type: 'attribute',
-					options: reference.attributeOptions,
-					min: 190,
-					unique: true
-				},
-				{ key: 'baseAmount', label: 'Base', type: 'number', align: 'r', width: 110, allowNegative: true },
-				{ key: 'amountPerLevel', label: 'Per Level', type: 'number', align: 'r', width: 110, allowNegative: true }
-			]
-		},
+			desc: 'Stat distribution per level',
+			emptySub: 'This enemy has no stat distribution yet.'
+		}),
 		chipsSection<WorkbenchEnemy>()({
 			key: 'skills',
 			label: 'Skills',

--- a/UI/src/routes/admin/workbench/entities/item-mod.ts
+++ b/UI/src/routes/admin/workbench/entities/item-mod.ts
@@ -2,7 +2,7 @@ import { ApiRequest, EItemModType, ERarity, fetchSocketData, type IItemMod } fro
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import { attributeChanges, childChanged, guardedSave, persistEntity } from '../save-helpers';
-import { firstFree } from './helpers';
+import { attributeBonusSection } from './attribute-table-sections';
 import { tagsSection } from './tags-section';
 import type { EntityConfig } from './types';
 
@@ -73,39 +73,10 @@ export const itemModEntity: EntityConfig<IItemMod> = {
 				}
 			]
 		},
-		{
-			key: 'attributes',
-			label: 'Attributes',
-			glyph: 'bars',
-			desc: 'Flat stat bonuses granted',
-			count: (m) => m.attributes.length,
-			warn: (m) => (m.attributes.length ? null : 'No attributes'),
-			kind: 'table',
+		attributeBonusSection<IItemMod>({
 			itemsKey: 'attributes',
-			rowKey: 'attributeId',
-			addLabel: 'Add bonus',
-			emptyIcon: 'bars',
-			emptyTitle: 'No attribute bonuses',
-			emptySub: 'This mod grants no stats.',
-			newRow: (m) => ({
-				attributeId: firstFree(
-					m.attributes.map((a) => a.attributeId),
-					reference.attributeOptions()
-				),
-				amount: 1
-			}),
-			columns: [
-				{
-					key: 'attributeId',
-					label: 'Attribute',
-					type: 'attribute',
-					options: reference.attributeOptions,
-					min: 200,
-					unique: true
-				},
-				{ key: 'amount', label: 'Amount', type: 'number', align: 'r', width: 120, allowNegative: true }
-			]
-		},
+			emptySub: 'This mod grants no stats.'
+		}),
 		tagsSection<IItemMod>()
 	],
 	refresh,

--- a/UI/src/routes/admin/workbench/entities/item.ts
+++ b/UI/src/routes/admin/workbench/entities/item.ts
@@ -2,7 +2,7 @@ import { ApiRequest, EItemCategory, ERarity, fetchSocketData, type IItem } from 
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import { attributeChanges, childChanged, guardedSave, modSlotChanges, persistEntity } from '../save-helpers';
-import { firstFree } from './helpers';
+import { attributeBonusSection } from './attribute-table-sections';
 import { tagsSection } from './tags-section';
 import type { EntityConfig } from './types';
 
@@ -137,39 +137,10 @@ export const itemEntity: EntityConfig<WorkbenchItem> = {
 				}
 			]
 		},
-		{
-			key: 'attributes',
-			label: 'Attributes',
-			glyph: 'bars',
-			desc: 'Flat stat bonuses granted',
-			count: (it) => it.attributes.length,
-			warn: (it) => (it.attributes.length ? null : 'No attributes'),
-			kind: 'table',
+		attributeBonusSection<WorkbenchItem>({
 			itemsKey: 'attributes',
-			rowKey: 'attributeId',
-			addLabel: 'Add bonus',
-			emptyIcon: 'bars',
-			emptyTitle: 'No attribute bonuses',
-			emptySub: 'This item grants no stats.',
-			newRow: (it) => ({
-				attributeId: firstFree(
-					it.attributes.map((a) => a.attributeId),
-					reference.attributeOptions()
-				),
-				amount: 1
-			}),
-			columns: [
-				{
-					key: 'attributeId',
-					label: 'Attribute',
-					type: 'attribute',
-					options: reference.attributeOptions,
-					min: 200,
-					unique: true
-				},
-				{ key: 'amount', label: 'Amount', type: 'number', align: 'r', width: 120, allowNegative: true }
-			]
-		},
+			emptySub: 'This item grants no stats.'
+		}),
 		{
 			key: 'modSlots',
 			label: 'Mod Slots',

--- a/UI/src/routes/admin/workbench/entity-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/entity-store.svelte.ts
@@ -1,4 +1,5 @@
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
+import { SaveFlash } from '$lib/common';
 import { toastError } from '$stores';
 import { canonicalEqual, PersistFailedError } from './save-helpers';
 import { entityWarnings } from './validation';
@@ -27,19 +28,28 @@ export class EntityStore<T extends Identified> {
 	items = $state<T[]>([]);
 	private base = $state<T[]>([]);
 	private deleted = new SvelteSet<number>();
-	saved = $state(false);
+	#saveFlash = new SaveFlash();
 	saving = $state(false);
 	/** Maps a just-saved record's local (negative) id to its persisted id, so a caller tracking a
 	 *  selection by id (the Workbench detail pane) can follow a newly-added record across a save
 	 *  instead of losing it to the "record no longer found" fallback. Replaced wholesale each save. */
 	lastIdMap = $state<SvelteMap<number, number>>(new SvelteMap());
 	private nextId = -1;
-	#flashTimer: ReturnType<typeof setTimeout> | undefined;
 
 	constructor(config: EntityConfig<T>, seed: T[]) {
 		this.config = config;
 		this.items = seed.map(clone);
 		this.base = seed.map(clone);
+	}
+
+	/** Brief "Changes saved" confirmation flash; writable so a mutator can clear it directly
+	 *  (see {@link patch}/{@link removeItem}/etc.) without going through {@link save}. */
+	get saved(): boolean {
+		return this.#saveFlash.active;
+	}
+
+	set saved(value: boolean) {
+		this.#saveFlash.active = value;
 	}
 
 	private baseMap = $derived.by(() => {
@@ -248,7 +258,7 @@ export class EntityStore<T extends Identified> {
 			this.items = records.map(clone);
 			this.base = records.map(clone);
 			this.deleted.clear();
-			this.flashSaved();
+			this.#saveFlash.flash();
 		} catch (ex) {
 			// A *partial* failure (the identity Add/Edit batch or an earlier child saver committed,
 			// then a later step threw) leaves our baseline behind the server: the persisted adds are
@@ -277,22 +287,7 @@ export class EntityStore<T extends Identified> {
 		this.saved = false;
 	}
 
-	/** Briefly flash the "Changes saved" confirmation. The timer handle is owned so a
-	 *  re-arm clears the prior one and {@link dispose} can cancel a pending flash — a save
-	 *  that lands just before the Workbench unmounts must not write into a dead store. */
-	private flashSaved() {
-		this.saved = true;
-		if (this.#flashTimer) {
-			clearTimeout(this.#flashTimer);
-		}
-		this.#flashTimer = setTimeout(() => {
-			this.saved = false;
-		}, 1900);
-	}
-
 	dispose() {
-		if (this.#flashTimer) {
-			clearTimeout(this.#flashTimer);
-		}
+		this.#saveFlash.dispose();
 	}
 }

--- a/UI/src/routes/admin/workbench/progression/progression-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/progression/progression-store.svelte.ts
@@ -7,6 +7,7 @@ import {
 	type IProficiency,
 	type ISetProficiencyPrerequisitesData
 } from '$lib/api';
+import { SaveFlash } from '$lib/common';
 import { staticData, toastError } from '$stores';
 import { reference } from '../reference.svelte';
 import { childChanged, canonicalEqual, resolveId, resolveNewIds } from '../save-helpers';
@@ -46,7 +47,7 @@ export class ProgressionStore {
 
 	loaded = $state(false);
 	saving = $state(false);
-	saved = $state(false);
+	#saveFlash = new SaveFlash();
 	error = $state<string | null>(null);
 
 	// Selection / navigation.
@@ -57,7 +58,11 @@ export class ProgressionStore {
 	selectedLevel = $state(1);
 
 	private nextId = -1;
-	#flashTimer: ReturnType<typeof setTimeout> | undefined;
+
+	/** Brief "Changes saved" confirmation flash. */
+	get saved(): boolean {
+		return this.#saveFlash.active;
+	}
 
 	// ── Loading / seeding ──
 
@@ -209,7 +214,7 @@ export class ProgressionStore {
 			mutate(draft);
 			return draft;
 		});
-		this.saved = false;
+		this.#saveFlash.reset();
 	}
 
 	patchProf(id: number, mutate: (draft: WorkbenchProficiency) => void) {
@@ -224,7 +229,7 @@ export class ProgressionStore {
 			mutate(draft);
 			return draft;
 		});
-		this.saved = false;
+		this.#saveFlash.reset();
 	}
 
 	// ── Add / reorder / retire ──
@@ -240,7 +245,7 @@ export class ProgressionStore {
 		this.selectedPathId = pathId;
 		this.drilledTierId = null;
 		this.pathTab = 'identity';
-		this.saved = false;
+		this.#saveFlash.reset();
 	}
 
 	addTier(pathId: number): number {
@@ -251,7 +256,7 @@ export class ProgressionStore {
 		const ordinal = tiers.length ? Math.max(...tiers.map((t) => t.pathOrdinal)) + 1 : 0;
 		const id = this.nextId--;
 		this.profs = [newProficiency(id, pathId, ordinal), ...this.profs];
-		this.saved = false;
+		this.#saveFlash.reset();
 		return id;
 	}
 
@@ -271,7 +276,7 @@ export class ProgressionStore {
 			const match = renumbered.find((t) => t.id === prof.id);
 			return match ? { ...prof, pathOrdinal: match.pathOrdinal } : prof;
 		});
-		this.saved = false;
+		this.#saveFlash.reset();
 	}
 
 	retirePath(id: number, retired: boolean) {
@@ -297,7 +302,7 @@ export class ProgressionStore {
 			this.selectedPathId = this.paths[0]?.id ?? null;
 			this.drilledTierId = null;
 		}
-		this.saved = false;
+		this.#saveFlash.reset();
 	}
 
 	/** Remove a never-saved tier locally; leave the drill view if it was open. */
@@ -309,7 +314,7 @@ export class ProgressionStore {
 		if (this.drilledTierId === id) {
 			this.drilledTierId = null;
 		}
-		this.saved = false;
+		this.#saveFlash.reset();
 	}
 
 	resetPath(id: number) {
@@ -575,7 +580,7 @@ export class ProgressionStore {
 				this.drilledTierId = resolveId(this.drilledTierId, profIdMap);
 			}
 			await this.reseed();
-			this.flashSaved();
+			this.#saveFlash.flash();
 		} catch (ex) {
 			// Once anything has committed, our baseline is behind the server; re-seed so a retry can't
 			// re-Add already-persisted records. A pre-commit failure changed nothing, so keep the edits.
@@ -609,22 +614,10 @@ export class ProgressionStore {
 		this.paths = this.basePaths.map(clone);
 		this.profs = this.baseProfs.map(clone);
 		this.reconcileSelection();
-		this.saved = false;
-	}
-
-	private flashSaved() {
-		this.saved = true;
-		if (this.#flashTimer) {
-			clearTimeout(this.#flashTimer);
-		}
-		this.#flashTimer = setTimeout(() => {
-			this.saved = false;
-		}, 1900);
+		this.#saveFlash.reset();
 	}
 
 	dispose() {
-		if (this.#flashTimer) {
-			clearTimeout(this.#flashTimer);
-		}
+		this.#saveFlash.dispose();
 	}
 }

--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -31,7 +31,7 @@ import {
 	type ISkill
 } from '$lib/api';
 import { BattleAttributes, isSkillDormant } from '$lib/battle';
-import { attributeName } from '$lib/common';
+import { attributeName, SaveFlash } from '$lib/common';
 import { safeLocalStorage } from '$lib/common/local-storage';
 import { inventoryManager, playerManager } from '$lib/engine';
 import { staticData, toastError } from '$stores';
@@ -298,17 +298,20 @@ export class AttributesView {
 	 *  never matches, so deltas read as zero until the first edit stamps it. */
 	#pendingDeltasAttrs = $state<IBattlerAttribute[] | null>(null);
 	/** Brief "Attributes saved" confirmation flash. */
-	saved = $state(false);
+	#saveFlash = new SaveFlash();
 	/** True while a save request is in flight (guards against double-submit). */
 	saving = $state(false);
 	/** While a radar drag is active the scale is pinned to the value captured at
 	 *  gesture start (see {@link lockScale}); null when unpinned. */
 	#lockedHexMax = $state<number | null>(null);
 
-	#flashTimer: ReturnType<typeof setTimeout> | undefined;
-
 	constructor() {
 		this.mode = readStoredMode();
+	}
+
+	/** Brief "Attributes saved" confirmation flash. */
+	get saved(): boolean {
+		return this.#saveFlash.active;
 	}
 
 	/** Unspent pool (statPointsGained − statPointsUsed), derived live from the reactive
@@ -381,7 +384,7 @@ export class AttributesView {
 		next[i] += add;
 		this.#pendingDeltas = next;
 		this.#pendingDeltasAttrs = playerManager.attributes;
-		this.saved = false;
+		this.#saveFlash.reset();
 	}
 
 	dec(i: number, by = 1): void {
@@ -393,7 +396,7 @@ export class AttributesView {
 		next[i] -= sub;
 		this.#pendingDeltas = next;
 		this.#pendingDeltasAttrs = playerManager.attributes;
-		this.saved = false;
+		this.#saveFlash.reset();
 	}
 
 	/** Set the attribute at `i` directly to `target`, clamped to the available
@@ -430,7 +433,7 @@ export class AttributesView {
 	discard(): void {
 		this.#pendingDeltas = CORE_ATTRIBUTES.map(() => 0);
 		this.#pendingDeltasAttrs = playerManager.attributes;
-		this.saved = false;
+		this.#saveFlash.reset();
 	}
 
 	/** The minimal set of per-attribute deltas to persist — only the changed
@@ -495,23 +498,11 @@ export class AttributesView {
 		if (deltasStillValid) {
 			this.#pendingDeltas = this.#pendingDeltas.map((d, i) => d - sentDeltas[i]);
 		}
-		this.flashSaved();
-	}
-
-	private flashSaved(): void {
-		this.saved = true;
-		if (this.#flashTimer) {
-			clearTimeout(this.#flashTimer);
-		}
-		this.#flashTimer = setTimeout(() => {
-			this.saved = false;
-		}, 1900);
+		this.#saveFlash.flash();
 	}
 
 	dispose(): void {
-		if (this.#flashTimer) {
-			clearTimeout(this.#flashTimer);
-		}
+		this.#saveFlash.dispose();
 	}
 }
 

--- a/UI/src/routes/game/screens/options/options-view.svelte.ts
+++ b/UI/src/routes/game/screens/options/options-view.svelte.ts
@@ -9,6 +9,7 @@
 import { apiSocket, ELogType, type ILogPreference } from '$lib/api';
 import { playerManager } from '$lib/engine';
 import { logColors } from '$components';
+import { SaveFlash } from '$lib/common';
 import { toastError } from '$stores';
 import type { GlyphKind } from '$components';
 
@@ -155,11 +156,14 @@ export class OptionsView {
 	 *  `null` never matches, so overrides read as empty until the first toggle stamps it. */
 	#draftOverridesPrefs = $state<ILogPreference[] | null>(null);
 	/** Brief "Preferences saved" confirmation flash. */
-	saved = $state(false);
+	#saveFlash = new SaveFlash();
 	/** True while a save request is in flight (guards against double-submit). */
 	saving = $state(false);
 
-	#flashTimer: ReturnType<typeof setTimeout> | undefined;
+	/** Brief "Preferences saved" confirmation flash. */
+	get saved(): boolean {
+		return this.#saveFlash.active;
+	}
 
 	/** Last-persisted preferences, read live off the player manager (see the class doc). */
 	readonly baseline = $derived(readPlayerPrefs());
@@ -206,7 +210,7 @@ export class OptionsView {
 	setOne(id: ELogType, enabled: boolean): void {
 		this.#draftOverrides = { ...this.effectiveOverrides(), [id]: enabled };
 		this.#draftOverridesPrefs = playerManager.logPreferences;
-		this.saved = false;
+		this.#saveFlash.reset();
 	}
 
 	setMany(ids: ELogType[], enabled: boolean): void {
@@ -216,13 +220,13 @@ export class OptionsView {
 		}
 		this.#draftOverrides = next;
 		this.#draftOverridesPrefs = playerManager.logPreferences;
-		this.saved = false;
+		this.#saveFlash.reset();
 	}
 
 	discard(): void {
 		this.#draftOverrides = {};
 		this.#draftOverridesPrefs = playerManager.logPreferences;
-		this.saved = false;
+		this.#saveFlash.reset();
 	}
 
 	/** The minimal set of preferences to persist — only the changed ones.
@@ -275,23 +279,11 @@ export class OptionsView {
 			}
 		}
 		this.#draftOverrides = remaining;
-		this.flashSaved();
-	}
-
-	private flashSaved(): void {
-		this.saved = true;
-		if (this.#flashTimer) {
-			clearTimeout(this.#flashTimer);
-		}
-		this.#flashTimer = setTimeout(() => {
-			this.saved = false;
-		}, 1900);
+		this.#saveFlash.flash();
 	}
 
 	dispose(): void {
-		if (this.#flashTimer) {
-			clearTimeout(this.#flashTimer);
-		}
+		this.#saveFlash.dispose();
 	}
 }
 

--- a/UI/src/tests/lib/common/save-flash.test.ts
+++ b/UI/src/tests/lib/common/save-flash.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SaveFlash } from '$lib/common';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('SaveFlash', () => {
+	it('starts inactive', () => {
+		expect(new SaveFlash().active).toBe(false);
+	});
+
+	it('flash activates immediately and clears itself after the duration elapses', () => {
+		const flash = new SaveFlash(100);
+		flash.flash();
+		expect(flash.active).toBe(true);
+
+		vi.advanceTimersByTime(99);
+		expect(flash.active).toBe(true);
+
+		vi.advanceTimersByTime(1);
+		expect(flash.active).toBe(false);
+	});
+
+	it('a second flash before the first clears restarts the timer instead of stacking', () => {
+		const flash = new SaveFlash(100);
+		flash.flash();
+		vi.advanceTimersByTime(60);
+		flash.flash(); // restarts the 100ms window
+
+		vi.advanceTimersByTime(60);
+		expect(flash.active).toBe(true); // the original timer (would have fired at 100ms) didn't fire early
+
+		vi.advanceTimersByTime(40);
+		expect(flash.active).toBe(false);
+	});
+
+	it('reset clears the flag immediately without waiting for the timer', () => {
+		const flash = new SaveFlash(100);
+		flash.flash();
+		flash.reset();
+		expect(flash.active).toBe(false);
+
+		// The original timer firing afterward is a no-op against the already-clear flag.
+		vi.advanceTimersByTime(100);
+		expect(flash.active).toBe(false);
+	});
+
+	it('dispose cancels the pending auto-clear so it never fires after teardown', () => {
+		const flash = new SaveFlash(100);
+		flash.flash();
+		flash.dispose();
+
+		// Had the timer survived disposal, this would flip `active` back to false.
+		vi.advanceTimersByTime(100);
+		expect(flash.active).toBe(true);
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/entities/attribute-table-sections.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/attribute-table-sections.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+	attributeBonusSection,
+	attributeDistributionSection
+} from '$routes/admin/workbench/entities/attribute-table-sections';
+
+/* Shared factories behind enemy/class's "stat distribution per level" table and item/item-mod's
+   "flat stat bonus" table (#2061) — exercised against a minimal stand-in record rather than the
+   real entity shapes, since the factories are entity-agnostic. */
+
+interface Distributed {
+	id: number;
+	dist: { attributeId: number; baseAmount: number; amountPerLevel: number }[];
+}
+
+interface Bonused {
+	id: number;
+	bonuses: { attributeId: number; amount: number }[];
+}
+
+describe('attributeDistributionSection', () => {
+	const section = attributeDistributionSection<Distributed>({
+		key: 'attrs',
+		itemsKey: 'dist',
+		desc: 'Stat distribution per level',
+		emptySub: 'No distribution yet.'
+	});
+
+	it('carries the configured key/desc/empty copy and the fixed baseAmount/amountPerLevel columns', () => {
+		expect(section.key).toBe('attrs');
+		expect(section.itemsKey).toBe('dist');
+		expect(section.desc).toBe('Stat distribution per level');
+		expect(section.emptySub).toBe('No distribution yet.');
+		expect(section.columns.map((c) => c.key)).toEqual(['attributeId', 'baseAmount', 'amountPerLevel']);
+	});
+
+	it('counts and warns off the configured collection', () => {
+		const empty: Distributed = { id: 0, dist: [] };
+		const full: Distributed = { id: 0, dist: [{ attributeId: 0, baseAmount: 1, amountPerLevel: 0 }] };
+		expect(section.count?.(empty)).toBe(0);
+		expect(section.warn?.(empty)).toBe('No attribute distribution');
+		expect(section.count?.(full)).toBe(1);
+		expect(section.warn?.(full)).toBeNull();
+	});
+
+	it('newRow picks the first free attribute and zeroes both amounts', () => {
+		// Strength (id 0) is already taken, so the first free attribute (id 1) is chosen.
+		const rec: Distributed = { id: 0, dist: [{ attributeId: 0, baseAmount: 5, amountPerLevel: 2 }] };
+		expect(section.newRow(rec)).toEqual({ attributeId: 1, baseAmount: 0, amountPerLevel: 0 });
+	});
+});
+
+describe('attributeBonusSection', () => {
+	const section = attributeBonusSection<Bonused>({
+		itemsKey: 'bonuses',
+		emptySub: 'No bonuses yet.'
+	});
+
+	it('always uses the "attributes" section key and the fixed amount column', () => {
+		expect(section.key).toBe('attributes');
+		expect(section.itemsKey).toBe('bonuses');
+		expect(section.emptySub).toBe('No bonuses yet.');
+		expect(section.columns.map((c) => c.key)).toEqual(['attributeId', 'amount']);
+	});
+
+	it('counts and warns off the configured collection', () => {
+		const empty: Bonused = { id: 0, bonuses: [] };
+		const full: Bonused = { id: 0, bonuses: [{ attributeId: 0, amount: 3 }] };
+		expect(section.count?.(empty)).toBe(0);
+		expect(section.warn?.(empty)).toBe('No attributes');
+		expect(section.count?.(full)).toBe(1);
+		expect(section.warn?.(full)).toBeNull();
+	});
+
+	it('newRow picks the first free attribute with a default amount of 1', () => {
+		const rec: Bonused = { id: 0, bonuses: [{ attributeId: 0, amount: 5 }] };
+		expect(section.newRow(rec)).toEqual({ attributeId: 1, amount: 1 });
+	});
+});


### PR DESCRIPTION
## Summary

Two small, independent DRY extractions from the July 2026 health review (#2061):

1. **Duplicated Workbench attribute-table sections.** `entities/enemy.ts` (`attributeDistribution`) and `entities/class.ts` (`attributeDistributions`) defined identical "stat distribution per level" table sections (attributeId + baseAmount + amountPerLevel); `entities/item.ts` and `entities/item-mod.ts` defined identical "flat stat bonus" table sections (attributeId + amount). Extracted `attributeDistributionSection<T>()`/`attributeBonusSection<T>()` factories in a new `entities/attribute-table-sections.ts`, mirroring the existing `tagsSection` pattern (curried config, entity-agnostic via `fieldsOf`). All four entity configs now call the shared factory instead of hand-copying the section.

2. **Copy-pasted save-flash plumbing.** `attributes-view.svelte.ts` and `options-view.svelte.ts` each carried an identical `saved = $state(false)` + `#flashTimer` + `flashSaved()` (1900ms) + `dispose()` block. Extracted a `SaveFlash` reactive class (`$lib/common/save-flash.svelte.ts`) that owns the flag and the timer lifecycle; both view-models now delegate to it via a `saved` getter, preserving the existing public API.

   While implementing this, I found the **exact same duplicated pattern** in two more places — `EntityStore` and `ProgressionStore` (the Workbench's own save orchestration stores) — which weren't named in the issue. Since it's the same mechanical fix using the tool built for this PR, I folded those in too rather than leaving the dedup half-finished or filing a separate issue for an already-solved duplication. `EntityStore.saved` keeps a getter **and** setter (one existing test writes to it directly to arrange state), while the other three consumers only needed a getter.

## Test plan

- [x] `npm run test:unit:ci` — all 3776 tests pass, including new unit tests for `SaveFlash` and the `attribute-table-sections` factories
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings
- [x] `npm run build` — succeeds

Closes #2061


---
_Generated by [Claude Code](https://claude.ai/code/session_019d1ADCSFg2Ft8ggyRdhv5U)_