### PR TITLE
Fix fire-and-forget Lua scripts wedging into silent NOSCRIPT after cache clear

### DIFF
--- a/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
@@ -224,6 +224,32 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task HashSetAndForget_AfterScriptCacheIsFlushedMidRun_StillTakesEffect()
+        {
+            // Mirrors a Redis restart, failover, or manual SCRIPT FLUSH clearing the server-side script cache
+            // mid-process (#2126). HashSetAndForget is fire-and-forget, so it gets no reply to inspect for
+            // NOSCRIPT — this only survives the flush if it never trusted an assumed-cached script in the first
+            // place, which is exactly the fix: it always sends the full script text.
+            var key = $"redis-hash-{Guid.NewGuid()}";
+            using var scope = CreateScope();
+            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+
+            // Exercise the script at least once first, matching a long-lived process that already warmed it
+            // before its Redis connection loses the script cache.
+            cache.HashSetAndForget(key, new Dictionary<string, string> { ["a"] = "1" }, TimeSpan.FromSeconds(30));
+            await WaitForHashFieldCountAsync(cache, key, 1);
+
+            await FlushScriptCacheAsync();
+
+            cache.HashSetAndForget(key, new Dictionary<string, string> { ["b"] = "2" }, TimeSpan.FromSeconds(30));
+
+            var fields = await PollingHelper.PollUntilAsync(() => cache.HashGetAllIfExists(key), f => f?.ContainsKey("b") == true);
+
+            Assert.NotNull(fields);
+            Assert.Equal("2", fields["b"]);
+        }
+
+        [Fact]
         public async Task HashSetIfExistsAndForget_OnAMissingKey_DoesNotCreateIt()
         {
             var key = $"redis-hash-{Guid.NewGuid()}";
@@ -340,6 +366,14 @@ namespace Game.Application.Tests.DataAccess
         {
             await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(Containers.CacheConnectionString);
             return await multiplexer.GetDatabase().KeyTimeToLiveAsync(key);
+        }
+
+        private async Task FlushScriptCacheAsync()
+        {
+            var options = ConfigurationOptions.Parse(Containers.CacheConnectionString);
+            options.AllowAdmin = true;
+            await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(options);
+            await multiplexer.GetServers().First().ScriptFlushAsync();
         }
     }
 }

--- a/Game.Infrastructure.Tests/PreparedScriptTests.cs
+++ b/Game.Infrastructure.Tests/PreparedScriptTests.cs
@@ -12,7 +12,7 @@ namespace Game.Infrastructure.Tests
     /// server has genuinely never cached. <see cref="PreparedScript.Evaluate"/> (the fire-and-forget-capable sync
     /// path) has no such state to pin — it always sends the full script text (#2126) — so it isn't covered here;
     /// its NOSCRIPT-survival behaviour is covered by the integration suite instead
-    /// (RedisServiceIntegrationTests.HashSetAndForget_AfterScriptCacheIsFlushed_StillTakesEffect).
+    /// (RedisServiceIntegrationTests.HashSetAndForget_AfterScriptCacheIsFlushedMidRun_StillTakesEffect).
     /// <para>
     /// Uses the same dead-endpoint technique as the sibling <see cref="RedisPubSubPublishFailureTests"/>: a
     /// multiplexer pointed at an unreachable endpoint (<c>abortConnect=false</c>) connects lazily and then throws

--- a/Game.Infrastructure.Tests/PreparedScriptTests.cs
+++ b/Game.Infrastructure.Tests/PreparedScriptTests.cs
@@ -5,13 +5,14 @@ using Xunit;
 namespace Game.Infrastructure.Tests
 {
     /// <summary>
-    /// Unit tests for <see cref="PreparedScript"/>, the helper that lets <c>RedisService</c>/<c>RedisQueue</c>
-    /// send a Lua script's hash instead of its full text on every call after the first (#2056). The behaviour
-    /// that matters and is otherwise only exercised indirectly through a live Redis: a cold call that fails
-    /// before it reaches the server must not mark the script warmed, or every later call would jump straight to
-    /// an <c>EVALSHA</c> the server has genuinely never cached — pinned for both <see cref="PreparedScript.EvaluateAsync"/>
-    /// and <see cref="PreparedScript.Evaluate"/>, since the latter blocks its own cold call rather than sharing
-    /// the former's fallback logic.
+    /// Unit tests for <see cref="PreparedScript"/>, the helper that lets an awaited caller send a Lua script's
+    /// hash instead of its full text on every call after the first (#2056). The behaviour that matters and is
+    /// otherwise only exercised indirectly through a live Redis: a cold call that fails before it reaches the
+    /// server must not mark the script warmed, or every later call would jump straight to an <c>EVALSHA</c> the
+    /// server has genuinely never cached. <see cref="PreparedScript.Evaluate"/> (the fire-and-forget-capable sync
+    /// path) has no such state to pin — it always sends the full script text (#2126) — so it isn't covered here;
+    /// its NOSCRIPT-survival behaviour is covered by the integration suite instead
+    /// (RedisServiceIntegrationTests.HashSetAndForget_AfterScriptCacheIsFlushed_StillTakesEffect).
     /// <para>
     /// Uses the same dead-endpoint technique as the sibling <see cref="RedisPubSubPublishFailureTests"/>: a
     /// multiplexer pointed at an unreachable endpoint (<c>abortConnect=false</c>) connects lazily and then throws
@@ -36,21 +37,6 @@ namespace Game.Infrastructure.Tests
 
             // A failed cold call means Redis never actually cached this script; if it had wrongly been marked
             // warmed anyway, every later call would send only the hash and get NOSCRIPT forever.
-            Assert.False(script.IsWarmedForTesting);
-        }
-
-        [Fact]
-        public async Task Evaluate_WhenTheColdCallFails_LeavesTheScriptUnwarmed()
-        {
-            // Evaluate's cold branch strips a caller's FireAndForget flag and blocks for a confirmed reply, so
-            // this is pinned separately from EvaluateAsync's version of the same invariant: a dropped cold send
-            // must not wedge the script into the hash-only path.
-            await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(DeadEndpoint);
-            var db = multiplexer.GetDatabase();
-            var script = new PreparedScript("return 1");
-
-            Assert.Throws<RedisConnectionException>(() => script.Evaluate(db, [], [], CommandFlags.FireAndForget));
-
             Assert.False(script.IsWarmedForTesting);
         }
 

--- a/Game.Infrastructure/Redis/PreparedScript.cs
+++ b/Game.Infrastructure/Redis/PreparedScript.cs
@@ -11,17 +11,24 @@ namespace Game.Infrastructure.Redis
     /// fixed named-parameter model can't express), so this talks to <see cref="IDatabase"/> directly rather than
     /// through that helper.
     /// <para>
-    /// The very first call this process makes for a given script sends the full text — an <c>EVAL</c>, which as a
-    /// side effect caches the script on the server under its hash — so a cold script cache never causes a
-    /// <c>NOSCRIPT</c> failure; every call after that sends the hash. That cold call is always a confirmed,
-    /// blocking round trip (a caller's <see cref="CommandFlags.FireAndForget"/> is ignored just for it), because
-    /// a dropped fire-and-forget cold send would still flip the warm flag and then wedge every later
-    /// <c>EVALSHA</c> into <c>NOSCRIPT</c> for the rest of the process — a materially worse failure than the
-    /// single lost op a normal fire-and-forget command risks. <see cref="EvaluateAsync"/> additionally falls back
-    /// to a full-text resend if the server reports <c>NOSCRIPT</c> on an already-warmed script (a manual
-    /// <c>SCRIPT FLUSH</c> or a Redis restart that lost its script cache), so an awaited caller also self-heals
-    /// after warm-up; <see cref="Evaluate"/> has no response to inspect for that once warmed, matching the
-    /// no-delivery-guarantee every other fire-and-forget call in this tier already accepts for a single op.
+    /// <see cref="EvaluateAsync"/> is the only method that trusts the server-side script cache: the first call for
+    /// a given script sends the full text (an <c>EVAL</c>, which as a side effect caches it under its hash), every
+    /// call after that sends just the hash, and a <c>NOSCRIPT</c> reply (a manual <c>SCRIPT FLUSH</c>, or a Redis
+    /// restart/failover that lost its script cache) falls back to a full-text resend — so an awaited caller
+    /// self-heals from a cleared cache no matter the cause.
+    /// </para>
+    /// <para>
+    /// <see cref="Evaluate"/> (the fire-and-forget-capable sync path) passes <see cref="CommandFlags.NoScriptCache"/>
+    /// on every call (#2126). This isn't just skipping our own <c>_hash</c>/<c>_warmed</c> bookkeeping — without
+    /// it, StackExchange.Redis' own <c>ScriptEvalMessage</c> transparently substitutes <c>EVALSHA</c> for any
+    /// script text it has seen succeed before (a *per-connection* cache, independent of this class), and its
+    /// <c>NOSCRIPT</c> self-heal only runs inside the reply processor — which a <see cref="CommandFlags.FireAndForget"/>
+    /// command never reaches, since the reply is discarded before it gets there. So once that library-level cache
+    /// believes the script is known, a fire-and-forget call silently wedges into <c>NOSCRIPT</c> for the rest of
+    /// the process the moment the server-side cache is cleared (restart, failover, <c>SCRIPT FLUSH</c>) — and
+    /// <c>NoScriptCache</c> is the only way to opt a call out of that library behaviour, forcing a literal
+    /// <c>EVAL</c> every time. These scripts are ~100-300 bytes, so the bytes an <c>EVALSHA</c> would save isn't
+    /// worth that failure mode.
     /// </para>
     /// <para>
     /// <see cref="Cache.Redis.RedisService"/>/<see cref="PubSub.Redis.RedisQueue"/> are resolved transient
@@ -79,18 +86,10 @@ namespace Game.Infrastructure.Redis
 
         public RedisResult Evaluate(IDatabase db, RedisKey[] keys, RedisValue[] values, CommandFlags flags = CommandFlags.None)
         {
-            if (!_warmed)
-            {
-                // The cold call ignores a FireAndForget flag and blocks for a confirmed reply, so _warmed only
-                // flips once the script is genuinely cached server-side — see the class doc for why a dropped
-                // fire-and-forget cold send would be worse than the single-op loss this flag normally risks.
-                // One blocking round trip, once per process, on a path that is otherwise off the hot loop.
-                var coldResult = db.ScriptEvaluate(_script, keys, values, flags & ~CommandFlags.FireAndForget);
-                _warmed = true;
-                return coldResult;
-            }
-
-            return db.ScriptEvaluate(_hash, keys, values, flags);
+            // NoScriptCache forces a literal EVAL and opts out of StackExchange.Redis' own transparent
+            // EVALSHA-once-known cache — see the class doc for why this path can't safely trust either that or
+            // our own _warmed the way EvaluateAsync does.
+            return db.ScriptEvaluate(_script, keys, values, flags | CommandFlags.NoScriptCache);
         }
     }
 }


### PR DESCRIPTION
## Summary

- `PreparedScript.Evaluate` (the sync, fire-and-forget-capable path used by `ReclaimAndForget`, `HashSetAndForget`, and `HashSetIfExistsAndForget`) had no way to self-heal from a `NOSCRIPT` reply the way the awaited `EvaluateAsync` path does, because StackExchange.Redis discards the reply for a `CommandFlags.FireAndForget` command before any retry logic can run.
- Simply always sending the full script text turned out **not** to be enough on its own: StackExchange.Redis maintains its own transparent, per-connection "once seen, always send the hash" cache (`ScriptEvalMessage.GetMessages`) that silently substitutes `EVALSHA` regardless of what our code passes, and its own `NOSCRIPT` self-heal only fires from inside the reply processor — which a fire-and-forget command never reaches. I verified this against a live Redis container before landing the fix; a naive "just send `_script`" version still silently dropped the write after a `SCRIPT FLUSH`.
- The real fix is `CommandFlags.NoScriptCache`, a documented StackExchange.Redis flag that forces a literal `EVAL` and opts the call out of that library-level cache entirely. `PreparedScript.Evaluate` now always ORs this flag in.
- Updated `PreparedScript`'s class doc to explain the two code paths' very different cache-trust guarantees, and removed the now-obsolete unit test that pinned `Evaluate`'s old warmed-state behavior (that method no longer touches `_warmed` at all).

## How this addresses #2126

Closes #2126. The issue listed three triggers for the server losing its script cache — a Redis restart, a failover, or a manual `SCRIPT FLUSH` — and all three are now covered uniformly, since the fix never depends on the script being cached server-side in the first place, rather than trying to detect and recover from the loss after the fact.

## Test plan

- [x] Added `RedisServiceIntegrationTests.HashSetAndForget_AfterScriptCacheIsFlushedMidRun_StillTakesEffect`, which flushes the Redis script cache mid-test (via an `AllowAdmin` connection) and asserts a subsequent `HashSetAndForget` call still lands — this is the integration test the issue asked for.
- [x] `dotnet build` — clean.
- [x] `dotnet test` (full solution, against the local Postgres/Redis containers) — 3,261 passed, 0 failed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01HFKEi44US8wiThVrhFjpZ7)_