### PR TITLE
Floor Sum-aggregated lifetime damage statistics under authored absorption

### DIFF
--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -60,6 +60,71 @@ namespace Game.Core.Tests.Progress
         }
 
         [Fact]
+        public void RecordBattleCompleted_NegativeNetUnderAbsorption_FloorsDamageStatisticsAtZeroInsteadOfRecordingARow()
+        {
+            // An enemy with authored absorption (resistance > 1) can heal the player back more than the
+            // battle's real hits dealt/took, so the in-battle (signed, parity-critical) totals go negative.
+            // The lifetime Sum statistics must never regress from that — a floored-to-zero delta carries no
+            // information, so (like any other zero delta) it records no row at all (#2127).
+            var progress = MakeProgress();
+            var stats = new BattleStats
+            {
+                PlayerDamageDealt = -12.0,
+                PlayerDamageTaken = -3.0,
+                CriticalDamageDealt = -6.5,
+            };
+
+            progress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000, stats,
+                isBossBattle: false, zoneId: 0);
+
+            Assert.False(progress.TryGetStatisticValue(EStatisticType.DamageDealt, null, out _));
+            Assert.False(progress.TryGetStatisticValue(EStatisticType.DamageTaken, null, out _));
+            Assert.False(progress.TryGetStatisticValue(EStatisticType.CriticalDamageDealt, null, out _));
+        }
+
+        [Fact]
+        public void RecordBattleCompleted_NegativeNetUnderAbsorption_NeverRegressesAnExistingLifetimeTotal()
+        {
+            var progress = MakeProgress(statistics:
+            [
+                Stat(EStatisticType.DamageDealt, null, 100m),
+                Stat(EStatisticType.DamageTaken, null, 50m),
+                Stat(EStatisticType.CriticalDamageDealt, null, 20m),
+            ]);
+            var stats = new BattleStats
+            {
+                PlayerDamageDealt = -8.0,
+                PlayerDamageTaken = -4.0,
+                CriticalDamageDealt = -2.0,
+            };
+
+            progress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000, stats,
+                isBossBattle: false, zoneId: 0);
+
+            Assert.Equal(100m, progress.GetStatisticValue(EStatisticType.DamageDealt, null));
+            Assert.Equal(50m, progress.GetStatisticValue(EStatisticType.DamageTaken, null));
+            Assert.Equal(20m, progress.GetStatisticValue(EStatisticType.CriticalDamageDealt, null));
+            Assert.DoesNotContain(progress.DirtyStatistics, s => s.Type == EStatisticType.DamageDealt && s.EntityId == null);
+            Assert.DoesNotContain(progress.DirtyStatistics, s => s.Type == EStatisticType.DamageTaken && s.EntityId == null);
+            Assert.DoesNotContain(progress.DirtyStatistics, s => s.Type == EStatisticType.CriticalDamageDealt && s.EntityId == null);
+        }
+
+        [Fact]
+        public void RecordBattleCompleted_PerSkillNegativeNetUnderAbsorption_FloorsAtZeroInsteadOfRecordingARow()
+        {
+            var progress = MakeProgress();
+            var stats = new BattleStats
+            {
+                SkillStats = { [10] = new SkillStats { Uses = 1, TotalDamage = -9.0 } },
+            };
+
+            progress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000, stats,
+                isBossBattle: false, zoneId: 0);
+
+            Assert.False(progress.TryGetStatisticValue(EStatisticType.DamageDealt, 10, out _));
+        }
+
+        [Fact]
         public void RecordBattleCompleted_TracksEncountersGloballyAndPerEnemy()
         {
             var progress = MakeProgress();

--- a/Game.Core/Progress/PlayerProgress.cs
+++ b/Game.Core/Progress/PlayerProgress.cs
@@ -54,9 +54,14 @@ namespace Game.Core.Progress
         public IReadOnlyCollection<(EStatisticType Type, int? EntityId)> RecordBattleCompleted(
             Enemy enemy, bool victory, bool playerDied, int totalMs, BattleStats stats, bool isBossBattle, int zoneId)
         {
-            Record(EStatisticType.DamageDealt, null, (decimal)Math.Round(stats.PlayerDamageDealt, 3));
+            // PlayerDamageDealt/PlayerDamageTaken stay signed in BattleStats (parity-critical, health
+            // reconciliation) and can go negative under authored absorption (resistance > 1 heals instead of
+            // damaging). Floored here, at the Sum-aggregated lifetime-statistic seam, so an absorption-heavy
+            // battle's net can never regress the monotone lifetime totals or an in-flight challenge's progress
+            // (#2127) — mirroring how the sibling signed channels were floored (#2091, #2101).
+            Record(EStatisticType.DamageDealt, null, (decimal)Math.Round(Math.Max(0, stats.PlayerDamageDealt), 3));
             Record(EStatisticType.HighestSingleAttackDamage, null, (decimal)Math.Round(stats.HighestPlayerAttack, 3));
-            Record(EStatisticType.DamageTaken, null, (decimal)Math.Round(stats.PlayerDamageTaken, 3));
+            Record(EStatisticType.DamageTaken, null, (decimal)Math.Round(Math.Max(0, stats.PlayerDamageTaken), 3));
             Record(EStatisticType.DamageHealed, null, (decimal)Math.Round(stats.PlayerDamageHealed, 3));
             Record(EStatisticType.EnemiesEncountered, null, 1);
             Record(EStatisticType.EnemiesEncountered, enemy.Id, 1);
@@ -64,7 +69,7 @@ namespace Game.Core.Progress
             // Player-only crit/dodge/parry tallies — recorded globally only (no per-skill/per-enemy breakdown),
             // alongside the damage statistics they mirror.
             Record(EStatisticType.CriticalHits, null, stats.CriticalHits);
-            Record(EStatisticType.CriticalDamageDealt, null, (decimal)Math.Round(stats.CriticalDamageDealt, 3));
+            Record(EStatisticType.CriticalDamageDealt, null, (decimal)Math.Round(Math.Max(0, stats.CriticalDamageDealt), 3));
             Record(EStatisticType.AttacksDodged, null, stats.AttacksDodged);
             Record(EStatisticType.DamageDodged, null, (decimal)Math.Round(stats.DamageDodged, 3));
             Record(EStatisticType.AttacksParried, null, stats.AttacksParried);
@@ -130,7 +135,7 @@ namespace Game.Core.Progress
             foreach (var (skillId, skillStats) in stats.SkillStats)
             {
                 Record(EStatisticType.SkillsUsed, skillId, skillStats.Uses);
-                Record(EStatisticType.DamageDealt, skillId, (decimal)Math.Round(skillStats.TotalDamage, 3));
+                Record(EStatisticType.DamageDealt, skillId, (decimal)Math.Round(Math.Max(0, skillStats.TotalDamage), 3));
                 Record(EStatisticType.HighestSingleAttackDamage, skillId, (decimal)Math.Round(skillStats.HighestSingleAttack, 3));
             }
 


### PR DESCRIPTION
## Summary

- `Battler.TakeDamage` deliberately returns a negative net (a heal) when an enemy's authored absorption (summed type resistance > 1) exceeds the incoming hit, and `BattleContext` accumulates that signed net into `Stats.PlayerDamageDealt`, `Stats.PlayerDamageTaken`, `Stats.CriticalDamageDealt`, and per-skill `TotalDamage` — correctly, since those in-battle totals are parity-critical (health reconciliation, FE/BE parity) and must stay signed.
- `PlayerProgress.RecordBattleCompleted` then Sum-aggregated those signed per-battle deltas straight into the **monotone lifetime statistics**, so a battle against an absorption enemy could make lifetime `DamageDealt`/`CriticalDamageDealt`/`DamageTaken` (global and per-skill) go **down**, and visibly regress an in-flight `DamageDealt` challenge's progress (`PlayerChallenge.Update` re-derives `Progress = Math.Min(value, goal)` from that same statistic).
- This was the one unfloored channel left from the family of fixes that floored the sibling signed channels this quarter (avoided/counter tallies #2091/#2102, the typed offense book #2101/#2108, the exposure book).

## Fix

Floored the four vulnerable per-battle deltas at the **Sum-aggregated lifetime-statistic recording seam** (`PlayerProgress.RecordBattleCompleted`), not in the parity-critical `BattleContext`/`BattleStats` aggregates:

- `DamageDealt` (global, from `stats.PlayerDamageDealt`)
- `DamageTaken` (from `stats.PlayerDamageTaken`)
- `CriticalDamageDealt` (from `stats.CriticalDamageDealt`)
- `DamageDealt` (per-skill, from `skillStats.TotalDamage`)

A floored-to-zero delta reuses the existing "zero carries no information" skip in `Increment` (no row created/regressed), so no row/dirty-mark is emitted for a battle whose net damage was fully absorbed — same convention the zero-damage-skill test already pins.

`HighestSingleAttackDamage` (Max-aggregated) was left untouched: it already naturally floors, since it only overwrites on `value > stat.Value` and a fresh row starts implicitly comparable to 0 via the existing zero-write guard — a negative first value there is a separate, narrower edge case outside this issue's scope (Sum stats only), not something this PR silently papers over.

This is backend-only bookkeeping (post-battle statistics/challenge recording), not battle logic — the frontend has no equivalent lifetime-statistics recording path to mirror, since progress is server-authoritative.

## Test plan

- [x] Added `RecordBattleCompleted_NegativeNetUnderAbsorption_FloorsDamageStatisticsAtZeroInsteadOfRecordingARow` — a fresh aggregate, negative `PlayerDamageDealt`/`PlayerDamageTaken`/`CriticalDamageDealt` records no row.
- [x] Added `RecordBattleCompleted_NegativeNetUnderAbsorption_NeverRegressesAnExistingLifetimeTotal` — an existing lifetime total is untouched (and not marked dirty) by a battle with negative net.
- [x] Added `RecordBattleCompleted_PerSkillNegativeNetUnderAbsorption_FloorsAtZeroInsteadOfRecordingARow` — per-skill `DamageDealt` gets the same treatment.
- [x] `dotnet build` — clean, 0 warnings.
- [x] `dotnet test --no-build --no-restore` (full solution, against the local Postgres/Redis containers) — 3,264 passed, 0 failed.

Closes #2127

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFjJRsQJCqVtBFQLP9FLxM)_