### PR TITLE
Reject same-path proficiency prerequisites at all three authoring layers

### DIFF
--- a/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
+++ b/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
@@ -687,6 +687,22 @@ namespace Game.Application.Tests.Content
         }
 
         [Fact]
+        public void Proficiency_PrerequisiteOnOwnPath_IsError()
+        {
+            // Gateways are cross-path only; a same-path prerequisite deadlocks the path against its own
+            // implicit tier ordering (tier N+1 requires tier N maxed), regardless of retirement state.
+            var graph = HealthyGraph() with
+            {
+                Proficiencies =
+                [
+                    Proficiency(0, pathId: 0, maxLevel: 10, rewards: [(5, 5)], prerequisiteIds: [1]),
+                    Proficiency(1, pathId: 0, maxLevel: 10),
+                ],
+            };
+            AssertHasFinding(graph, "ProficiencyPrerequisite", ContentGraphSeverity.Error, "Proficiency", 0);
+        }
+
+        [Fact]
         public void Proficiency_OnMissingPath_IsError()
         {
             var graph = HealthyGraph() with

--- a/Game.Application.Tests/DataAccess/AdminProficienciesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminProficienciesIntegrationTests.cs
@@ -605,6 +605,33 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SetPrerequisites_PrerequisiteOnSamePath_ReturnsFailure()
+        {
+            int gatedId, prerequisiteId;
+            using (var seedScope = CreateScope())
+            {
+                var path = await SeedPathAsync(seedScope);
+                gatedId = (await SeedProficiencyAsync(seedScope, path.Id, pathOrdinal: 0)).Id;
+                prerequisiteId = (await SeedProficiencyAsync(seedScope, path.Id, pathOrdinal: 1)).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminProficiencies>();
+
+            // Gating tier 0 on tier 1 of the same path would deadlock the path — tier 1 can't accrue until
+            // tier 0 opens, but tier 0 never opens because tier 1 (which needs tier 0) can never be maxed.
+            var result = admin.SetPrerequisites([new SetProficiencyPrerequisitesData
+            {
+                Id = gatedId,
+                PrerequisiteIds = [prerequisiteId],
+            }]);
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("same path", result.ErrorMessage);
+        }
+
+        [Fact]
         public async Task SetPrerequisites_WouldFormACycle_ReturnsFailure()
         {
             int gatedId, prerequisiteId;

--- a/Game.Application/Content/ProgressionGraphChecker.cs
+++ b/Game.Application/Content/ProgressionGraphChecker.cs
@@ -602,6 +602,13 @@ namespace Game.Application.Content
                         {
                             Error("ProficiencyPrerequisite", "Proficiency", proficiency.Id, $"has prerequisite proficiency {prerequisiteId}, which is retired/frozen, so this tier can never open.");
                         }
+
+                        // Gateways are cross-path only; a same-path prerequisite deadlocks the path against its
+                        // own implicit tier ordering (tier N+1 requires tier N maxed) regardless of ordinal.
+                        if (onLivePath && prerequisite.PathId == proficiency.PathId)
+                        {
+                            Error("ProficiencyPrerequisite", "Proficiency", proficiency.Id, $"has prerequisite proficiency {prerequisiteId}, which is on its own path {proficiency.PathId} — gateways must be cross-path, so this tier can never open.");
+                        }
                     }
                 }
             }

--- a/Game.DataAccess/Repositories/Admin/AdminProficiencies.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminProficiencies.cs
@@ -188,7 +188,7 @@ namespace Game.DataAccess.Repositories.Admin
                     return ChangeSetProcessor.DuplicateFailure<SetProficiencyPrerequisitesData>("proficiency prerequisite");
                 }
 
-                if (ValidatePrerequisiteIds(proficiency.Id, change.PrerequisiteIds) is { } idRejection)
+                if (ValidatePrerequisiteIds(proficiency, change.PrerequisiteIds) is { } idRejection)
                 {
                     return idRejection;
                 }
@@ -230,19 +230,28 @@ namespace Game.DataAccess.Repositories.Admin
         }
 
         /// <summary>Returns a rejection if any id in <paramref name="prerequisiteIds"/> is
-        /// <paramref name="proficiencyId"/> itself or does not exist, else null.</summary>
-        private AdminSaveResult? ValidatePrerequisiteIds(int proficiencyId, IReadOnlyList<int> prerequisiteIds)
+        /// <paramref name="proficiency"/> itself, does not exist, or is on <paramref name="proficiency"/>'s own
+        /// path — gateways are cross-path only (a same-path prerequisite deadlocks the path against its own
+        /// implicit tier ordering, where tier N+1 requires tier N maxed) — else null.</summary>
+        private AdminSaveResult? ValidatePrerequisiteIds(Entities.Proficiency proficiency, IReadOnlyList<int> prerequisiteIds)
         {
             foreach (var prerequisiteId in prerequisiteIds)
             {
-                if (prerequisiteId == proficiencyId)
+                if (prerequisiteId == proficiency.Id)
                 {
                     return AdminSaveResult.Failure("A proficiency cannot be its own prerequisite.");
                 }
 
-                if (_proficiencies.LookupProficiency(prerequisiteId) is null)
+                var prerequisite = _proficiencies.LookupProficiency(prerequisiteId);
+                if (prerequisite is null)
                 {
                     return AdminSaveResult.Failure($"Prerequisite proficiency {prerequisiteId} does not exist.");
+                }
+
+                if (prerequisite.PathId == proficiency.PathId)
+                {
+                    return AdminSaveResult.Failure(
+                        $"Prerequisite proficiency {prerequisiteId} is on the same path as proficiency {proficiency.Id} — gateways must be cross-path.");
                 }
             }
 

--- a/UI/src/routes/admin/workbench/progression/GatewaysEditor.svelte
+++ b/UI/src/routes/admin/workbench/progression/GatewaysEditor.svelte
@@ -64,7 +64,7 @@ const prereqName = (id: number) => store.profs.find((p) => p.id === id)?.name ||
 const addOptions = $derived([
 	{ value: ADD_PLACEHOLDER, text: '+ Add prerequisite…' },
 	...store.profs
-		.filter((p) => p.id !== tier.id && !p.retiredAt && !tier.prerequisiteIds.includes(p.id))
+		.filter((p) => p.pathId !== tier.pathId && !p.retiredAt && !tier.prerequisiteIds.includes(p.id))
 		.map((p) => ({ value: p.id, text: p.name || 'Unnamed tier' }))
 ]);
 

--- a/UI/src/tests/routes/admin/workbench/progression/GatewaysEditor.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/GatewaysEditor.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/svelte';
+
+import GatewaysEditor from '$routes/admin/workbench/progression/GatewaysEditor.svelte';
+import type { ProgressionStore } from '$routes/admin/workbench/progression/progression-store.svelte';
+import type { WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+
+afterEach(cleanup);
+
+const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency => ({
+	id: 0,
+	name: 'Blades',
+	description: '',
+	iconPath: '',
+	word: '',
+	pronunciation: '',
+	translation: '',
+	pathId: 0,
+	pathOrdinal: 0,
+	maxLevel: 10,
+	baseXp: 100,
+	xpGrowth: 1.4,
+	designerNotes: '',
+	levelModifiers: [],
+	levelRewards: [],
+	prerequisiteIds: [],
+	...over
+});
+
+// A fake store exposing exactly what GatewaysEditor reads/calls — mirrors TierDetail.test.ts's
+// fake-store pattern rather than driving the real ProgressionStore through a socket-backed load().
+const makeStore = (profs: WorkbenchProficiency[]) =>
+	({
+		profs,
+		addPrerequisite: vi.fn(),
+		removePrerequisite: vi.fn()
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	}) as any as ProgressionStore;
+
+describe('GatewaysEditor — cross-path-only prerequisite picker (#2128)', () => {
+	it('excludes tiers of the gated tier\'s own path from the "Add prerequisite" options', async () => {
+		const gated = tier({ id: 0, pathId: 0, name: 'Fire I' });
+		const sibling = tier({ id: 1, pathId: 0, pathOrdinal: 1, name: 'Fire II' });
+		const crossPathTier = tier({ id: 2, pathId: 1, name: 'Frost I' });
+		const store = makeStore([gated, sibling, crossPathTier]);
+
+		render(GatewaysEditor, { store, tier: gated });
+
+		const select = screen.getByRole('combobox', { name: 'Add prerequisite' }) as HTMLSelectElement;
+		const optionTexts = Array.from(select.options).map((o) => o.text);
+
+		expect(optionTexts).toContain('Frost I');
+		expect(optionTexts).not.toContain('Fire II');
+	});
+
+	it('still excludes an already-added cross-path prerequisite and a retired cross-path tier', async () => {
+		const gated = tier({ id: 0, pathId: 0, prerequisiteIds: [2] });
+		const alreadyAdded = tier({ id: 2, pathId: 1, name: 'Frost I' });
+		const retiredCrossPath = tier({ id: 3, pathId: 1, name: 'Frost II', retiredAt: '2026-01-01T00:00:00Z' });
+		const openCrossPath = tier({ id: 4, pathId: 2, name: 'Wind I' });
+		const store = makeStore([gated, alreadyAdded, retiredCrossPath, openCrossPath]);
+
+		render(GatewaysEditor, { store, tier: gated });
+
+		const select = screen.getByRole('combobox', { name: 'Add prerequisite' }) as HTMLSelectElement;
+		const optionTexts = Array.from(select.options).map((o) => o.text);
+
+		expect(optionTexts).toContain('Wind I');
+		expect(optionTexts).not.toContain('Frost I');
+		expect(optionTexts).not.toContain('Frost II');
+	});
+});

--- a/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
@@ -244,8 +244,10 @@ describe('TierDetail — tab bodies', () => {
 	});
 
 	it('lists an existing prerequisite chip, removes it, and adds a new one', async () => {
-		const basics = tier({ id: 3, name: 'Basics', prerequisiteIds: [] });
-		const advanced = tier({ id: 7, name: 'Advanced', prerequisiteIds: [] });
+		// Gateways are cross-path only (#2128), so the prerequisite candidates live on a different
+		// path than the gated tier's own (pathId 0, the tier() default).
+		const basics = tier({ id: 3, pathId: 1, name: 'Basics', prerequisiteIds: [] });
+		const advanced = tier({ id: 7, pathId: 1, name: 'Advanced', prerequisiteIds: [] });
 		const gatedTier = tier({ prerequisiteIds: [3] });
 		const store = makeStore(gatedTier, { profs: [gatedTier, basics, advanced], tierTab: 'gateways' });
 		render(TierDetail, { props: { store } });
@@ -261,7 +263,8 @@ describe('TierDetail — tab bodies', () => {
 	it('offers an unsaved tier (negative id, never in staticData) as a prerequisite option (#1997)', async () => {
 		// id -1 is the first id ProgressionStore.nextId hands out to a brand-new tier — deliberately
 		// chosen here to also pin that it doesn't collide with the picker's own placeholder value.
-		const draftTier = tier({ id: -1, name: 'Brand New Tier', prerequisiteIds: [] });
+		// Cross-path (#2128) so it isn't excluded as a same-path candidate.
+		const draftTier = tier({ id: -1, pathId: 1, name: 'Brand New Tier', prerequisiteIds: [] });
 		const gatedTier = tier({ prerequisiteIds: [] });
 		const store = makeStore(gatedTier, { profs: [gatedTier, draftTier], tierTab: 'gateways' });
 		render(TierDetail, { props: { store } });


### PR DESCRIPTION
## Summary

Gateways are documented everywhere as **cross-path** (editor copy, store section header, `pathReferences` counts only `p.pathId !== id` edges), but nothing actually enforced it. Gating tier 0 of a path on a later tier of that *same* path saved fine, passed lint, and permanently deadlocked the path: tier 0 becomes a gateway that accrues nothing until tier 2 is maxed, but tier 2 can't be reached without tier 0 opening first.

This fixes the gap at all three layers the issue calls out, backend as the source of truth:

- **`AdminProficiencies.ValidatePrerequisiteIds`** (`Game.DataAccess/Repositories/Admin/AdminProficiencies.cs`) now rejects a prerequisite whose `PathId` matches the gated tier's own — anti-tamper, since a tampered admin client can't bypass a frontend-only filter.
- **`ProgressionGraphChecker.CheckProficiencies`** (`Game.Application/Content/ProgressionGraphChecker.cs`) gains an `Error` finding for the same case, alongside the existing retired/frozen-prerequisite check, so Content Health catches it too (e.g. against a seed/migration mistake).
- **`GatewaysEditor.addOptions`** (`UI/src/routes/admin/workbench/progression/GatewaysEditor.svelte`) filters the "Add prerequisite" picker to `p.pathId !== tier.pathId` so the Workbench never offers an invalid option in the first place.

## Scope note

The issue's fix section also suggested (marked "ideally") extending cycle detection to model the *implicit* within-path tier ordering (tier N+1 requires tier N maxed), so a cross-path prerequisite cycle composed with that implicit chain would also be caught. That's a materially larger change — it needs a shared graph-cycle utility reachable from both `Game.DataAccess` (admin save + build-time cache backstop) and `Game.Application` (Content Health), which today can't see each other's `internal` types. I split that out as **#2144** rather than scope-creep this PR; the same-path ban here does not subsume it (the composed-cycle scenario in #2144 never involves a same-path edge).

## Test plan

- [x] Backend: `Game.Application.Tests/DataAccess/AdminProficienciesIntegrationTests.cs` — new `SetPrerequisites_PrerequisiteOnSamePath_ReturnsFailure` integration test seeding two tiers on one path and asserting the save is rejected.
- [x] Backend: `Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs` — new `Proficiency_PrerequisiteOnOwnPath_IsError` unit test.
- [x] Frontend: new `UI/src/tests/routes/admin/workbench/progression/GatewaysEditor.test.ts` — asserts the picker excludes same-path tiers while still offering cross-path ones, and still respects the existing already-added/retired exclusions.
- [x] Frontend: updated two `TierDetail.test.ts` fixtures that previously modeled an (now-invalid) same-path prerequisite to use cross-path tiers instead.
- [x] `dotnet build` — clean.
- [x] `dotnet test --no-build --no-restore` — full solution green (Core/Infrastructure/Application/Api test projects).
- [x] `npm run lint` — clean (eslint + svelte-check, 0 errors/warnings).
- [x] `npm run test:unit:ci` — full suite green (302 files / 3778 tests).

Closes #2128


---
_Generated by [Claude Code](https://claude.ai/code/session_01GFDgZ5UfE2fs31amgZTjj4)_