### PR TITLE
Fix four keyboard/focus accessibility holes

### DIFF
--- a/UI/src/components/Popover.svelte
+++ b/UI/src/components/Popover.svelte
@@ -48,10 +48,24 @@ let shell = $state<HTMLElement | null>(null);
 
 // On open, move focus onto the first focusable inside the popover (or the shell itself if it has
 // none) so the trap has somewhere to anchor. Trap/Escape/scroll-lock/restore are owned by focusTrap.
+// Content can also swap while open (e.g. a loading placeholder replaced once an async fetch resolves);
+// if that unmounts the focused element, focus falls back to <body>, so a MutationObserver re-places it
+// onto the (possibly new) first focusable whenever a swap drops focus outside the shell.
 $effect(() => {
 	if (open && shell) {
-		const target = shell.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
-		(target ?? shell).focus();
+		const placeFocus = () => {
+			const target = shell?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+			(target ?? shell)?.focus();
+		};
+		placeFocus();
+
+		const observer = new MutationObserver(() => {
+			if (!shell?.contains(document.activeElement)) {
+				placeFocus();
+			}
+		});
+		observer.observe(shell, { childList: true, subtree: true });
+		return () => observer.disconnect();
 	}
 });
 </script>

--- a/UI/src/components/sidebar/CollapsibleRail.svelte
+++ b/UI/src/components/sidebar/CollapsibleRail.svelte
@@ -7,6 +7,8 @@
 	style:--rail-header-padding="{headerPadding}px"
 	onmouseenter={() => (hovering = true)}
 	onmouseleave={() => (hovering = false)}
+	onfocusin={() => (focused = true)}
+	onfocusout={() => (focused = false)}
 >
 	<!-- Header: brand wordmark + pin toggle -->
 	<div class="sidebar-header">
@@ -106,8 +108,9 @@ let {
 }: Props = $props();
 
 let hovering = $state(false);
+let focused = $state(false);
 
-const expanded = $derived(pinned || hovering);
+const expanded = $derived(pinned || hovering || focused);
 </script>
 
 <style lang="scss">

--- a/UI/src/routes/game/screens/card-game/loom-input.ts
+++ b/UI/src/routes/game/screens/card-game/loom-input.ts
@@ -28,10 +28,11 @@ export function runLoomLoop(view: CardGameView): () => void {
  *  pointer release/cancel anywhere ends a held Reflex (the button is press-and-hold, so the release can
  *  land off the button). Returns a teardown that removes every listener. */
 export function bindLoomInput(view: CardGameView): () => void {
-	// Hotkeys yield to focused sandbox sliders so they keep working.
+	// Hotkeys yield to focused sandbox sliders and buttons so they keep working (a focused button's own
+	// Space/Enter handling — e.g. the Reflex button's press-and-hold — takes precedence over the global one).
 	const onKeyDown = (e: KeyboardEvent) => {
 		const ae = document.activeElement;
-		if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA')) {
+		if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.tagName === 'BUTTON')) {
 			return;
 		}
 		if (e.code === 'Space') {

--- a/UI/src/routes/game/welcome-back/WelcomeBackGate.svelte
+++ b/UI/src/routes/game/welcome-back/WelcomeBackGate.svelte
@@ -43,7 +43,8 @@
 			</section>
 		{/if}
 
-		<button class="enter-btn" type="button" onclick={onEnter} data-testid="welcome-back-enter">
+		<!-- svelte-ignore a11y_autofocus -->
+		<button class="enter-btn" type="button" autofocus onclick={onEnter} data-testid="welcome-back-enter">
 			Enter the realm
 		</button>
 	</div>

--- a/UI/src/tests/components/Popover.test.ts
+++ b/UI/src/tests/components/Popover.test.ts
@@ -83,6 +83,25 @@ describe('Popover', () => {
 		outside.remove();
 	});
 
+	it('re-anchors focus onto the new content when the focused element unmounts (async loading -> ready swap)', async () => {
+		const loadingChildren = createRawSnippet(() => ({
+			render: () => '<div><button data-testid="cancel">cancel</button></div>'
+		}));
+		const readyChildren = createRawSnippet(() => ({
+			render: () => '<div><button data-testid="pick">pick</button></div>'
+		}));
+
+		const { getByTestId, rerender } = render(Popover, {
+			props: { open: true, onClose: vi.fn(), label: 'Switcher', children: loadingChildren }
+		});
+		await tick();
+		expect(document.activeElement).toBe(getByTestId('cancel'));
+
+		await rerender({ open: true, onClose: vi.fn(), label: 'Switcher', children: readyChildren });
+		await tick();
+		expect(document.activeElement).toBe(getByTestId('pick'));
+	});
+
 	it('locks body scroll while open and releases it on close', async () => {
 		const { rerender } = setup(true);
 		await tick();

--- a/UI/src/tests/components/nav-menu/NavSidebar.test.ts
+++ b/UI/src/tests/components/nav-menu/NavSidebar.test.ts
@@ -89,6 +89,21 @@ describe('NavSidebar', () => {
 		expect(pinButton.classList.contains('pinned')).toBe(true);
 	});
 
+	it('expands on keyboard focus so a Tab-only user can reach the pin button', async () => {
+		render(NavSidebar, { props: { screens, active: 'fight', onNavigate: vi.fn() } });
+
+		const sidebar = screen.getByTestId('sidebar');
+		expect(sidebar.classList.contains('expanded')).toBe(false);
+		expect(screen.queryByTestId('pin-button')).toBeNull();
+
+		await fireEvent.focusIn(screen.getByTestId('sidebar-item-fight'));
+		expect(sidebar.classList.contains('expanded')).toBe(true);
+		expect(screen.getByTestId('pin-button')).toBeTruthy();
+
+		await fireEvent.focusOut(screen.getByTestId('sidebar-item-fight'));
+		expect(sidebar.classList.contains('expanded')).toBe(false);
+	});
+
 	it('toggles the pinned state when the pin button is clicked', async () => {
 		render(NavSidebar, { props: { screens, active: 'fight', onNavigate: vi.fn(), pinned: true } });
 

--- a/UI/src/tests/routes/game/screens/card-game/loom-input.test.ts
+++ b/UI/src/tests/routes/game/screens/card-game/loom-input.test.ts
@@ -95,6 +95,22 @@ describe('bindLoomInput', () => {
 		unbind();
 	});
 
+	it('yields Space to a focused button so its own click/keydown handling still fires', () => {
+		const button = document.createElement('button');
+		document.body.appendChild(button);
+		button.focus();
+
+		const view = fakeView();
+		const unbind = bindLoomInput(view);
+
+		const event = new KeyboardEvent('keydown', { code: 'Space', cancelable: true });
+		window.dispatchEvent(event);
+		expect(view.setReflex).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
+
+		unbind();
+	});
+
 	it('does not cast once the duel is over', () => {
 		const view = fakeView(true);
 		const unbind = bindLoomInput(view);

--- a/UI/src/tests/routes/game/welcome-back/WelcomeBackGate.test.ts
+++ b/UI/src/tests/routes/game/welcome-back/WelcomeBackGate.test.ts
@@ -78,4 +78,10 @@ describe('WelcomeBackGate', () => {
 
 		expect(onEnter).toHaveBeenCalledTimes(1);
 	});
+
+	it('autofocuses the enter button on arrival so Enter dismisses the gate immediately', () => {
+		render(WelcomeBackGate, { props: { summary: summary(), onEnter: vi.fn() } });
+
+		expect(document.activeElement).toBe(screen.getByTestId('welcome-back-enter'));
+	});
 });


### PR DESCRIPTION
## Summary

Fixes the four bundled keyboard/focus defects from #2133:

1. **Sidebar rail unreachable by keyboard.** `CollapsibleRail.svelte`'s `expanded` state was driven only by hover. Added `onfocusin`/`onfocusout` handlers (mirroring the existing hover handlers) so tabbing into any nav item expands the rail — making the pin button reachable and nav labels visible while tabbing, instead of staying at `opacity: 0`.

2. **Card-game Space handler swallowed button activation.** The global `keydown` handler in `loom-input.ts` called `preventDefault()` and engaged Reflex whenever focus wasn't in an `INPUT`/`TEXTAREA`, so tabbing to the "↺ RESET" button and pressing Space triggered slow-time instead of the click. Added `BUTTON` to the focused-element bypass list — the Reflex button already has its own explicit Space/Enter handling, so this only changes behavior for buttons (like Reset) that rely on native activation.

3. **Welcome-back gate's only action wasn't focused on open.** `WelcomeBackGate.svelte` is a plain full-screen div with no initial focus, so Enter did nothing until the player tabbed to the button, despite the docs describing Enter-to-dismiss. Added `autofocus` to the primary button (same pattern already used in `TagSearch.svelte`/`RewardPicker.svelte`).

4. **Popover focus dropped on async content swap.** `Popover.svelte` placed initial focus once, keyed on `open`/`shell`. When a consumer (e.g. `CharacterSwitcher`) swaps its loading-state content for the ready state within the same open popover, the focused element unmounts and focus fell to `<body>` until the next Tab re-anchored it via the trap. Added a `MutationObserver` that re-places focus onto the (possibly new) first focusable whenever a content swap drops focus outside the shell.

## Test plan

- [x] Added a `NavSidebar` test asserting `focusin`/`focusout` expands/collapses the rail and exposes the pin button.
- [x] Added a `loom-input` test asserting a focused button's Space keydown is no longer intercepted (no `preventDefault`, no Reflex engaged).
- [x] Added a `WelcomeBackGate` test asserting the enter button is the active element on render.
- [x] Added a `Popover` test simulating a loading→ready content swap and asserting focus re-anchors onto the new content.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] Full frontend unit suite (`vitest run`) — 302 files / 3782 tests passing.

Closes #2133


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr2BM5Tsp6bxRuR3N92Y4q)_