### PR TITLE
Clamp challenge progress readouts to the goal

### DIFF
--- a/UI/src/lib/common/challenge-type.ts
+++ b/UI/src/lib/common/challenge-type.ts
@@ -36,3 +36,11 @@ export const challengeTypeColor = (id: EChallengeType): string =>
  */
 export const challengeTypeName = (id: EChallengeType, challengeTypes?: IChallengeType[]): string =>
 	challengeTypes?.find((t) => t.id === id)?.name ?? normalizeText(EChallengeType[id] ?? '');
+
+/**
+ * Clamp an accumulating challenge's raw progress to its goal for display. Stored progress can
+ * transiently exceed the goal in the window before a `ChallengeCompleted` push lands; every
+ * progress readout (Challenges screen, Codex dossier) should route through this so they can't
+ * diverge on how they handle it.
+ */
+export const clampChallengeProgress = (progress: number, goal: number): number => Math.min(progress, goal);

--- a/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
+++ b/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
@@ -13,6 +13,7 @@ import { Item } from '$lib/battle';
 import {
 	challengeTypeColor,
 	challengeTypeName,
+	clampChallengeProgress,
 	damageTypeKeyName,
 	rarityGlow,
 	rarityLevel,
@@ -173,7 +174,15 @@ export function progressInfo(ch: IChallenge, comparison: EChallengeGoalCompariso
 		return { atMost: true, percent, value: 0, goal: ch.progressGoal, best, target: ch.progressGoal, hasData };
 	}
 	const percent = Math.min(100, (progress / Math.max(1, ch.progressGoal)) * 100);
-	return { atMost: false, percent, value: progress, goal: ch.progressGoal, best: 0, target: 0, hasData: true };
+	return {
+		atMost: false,
+		percent,
+		value: clampChallengeProgress(progress, ch.progressGoal),
+		goal: ch.progressGoal,
+		best: 0,
+		target: 0,
+		hasData: true
+	};
 }
 
 /* ─── View-model assembly ────────────────────────────────────────────── */

--- a/UI/src/routes/game/screens/codex/enemies-tab-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/enemies-tab-view.svelte.ts
@@ -4,7 +4,13 @@
    orchestrator and the cross-tab concerns (active tab, stats fetch, cross-links). */
 
 import { EEntityType, type IEnemy } from '$lib/api';
-import { type EnemyAttributes, challengeTypeColor, challengeTypeName, enemyAttributesAtLevel } from '$lib/common';
+import {
+	type EnemyAttributes,
+	challengeTypeColor,
+	challengeTypeName,
+	clampChallengeProgress,
+	enemyAttributesAtLevel
+} from '$lib/common';
 import { playerChallenges, staticData } from '$stores';
 import {
 	type EnemyFilter,
@@ -260,8 +266,9 @@ export class EnemiesTabView {
 					const pc = progressById.get(c.id);
 					const progress = pc?.progress ?? 0;
 					const completed = pc?.completed ?? false;
+					const clampedProgress = clampChallengeProgress(progress, c.progressGoal);
 					const progressText =
-						c.progressGoal === 1 ? (completed ? 'done' : 'sealed') : `${Math.round(progress)}/${c.progressGoal}`;
+						c.progressGoal === 1 ? (completed ? 'done' : 'sealed') : `${Math.round(clampedProgress)}/${c.progressGoal}`;
 					return {
 						id: c.id,
 						name: c.name,

--- a/UI/src/tests/lib/common/challenge-type.test.ts
+++ b/UI/src/tests/lib/common/challenge-type.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { EChallengeType, type IChallengeType } from '$lib/api';
-import { challengeTypeColor, challengeTypeName } from '$lib/common';
+import { challengeTypeColor, challengeTypeName, clampChallengeProgress } from '$lib/common';
 
 describe('challengeTypeColor', () => {
 	it('maps each type to its themeable --challenge-* accent variable', () => {
@@ -19,5 +19,17 @@ describe('challengeTypeName', () => {
 	it('falls back to the normalized enum name when the type is absent or no set is given', () => {
 		expect(challengeTypeName(EChallengeType.TimeTrial, types)).toBe('Time Trial');
 		expect(challengeTypeName(EChallengeType.BossesDefeated)).toBe('Bosses Defeated');
+	});
+});
+
+describe('clampChallengeProgress', () => {
+	it('passes through progress at or under the goal', () => {
+		expect(clampChallengeProgress(0, 10)).toBe(0);
+		expect(clampChallengeProgress(7, 10)).toBe(7);
+		expect(clampChallengeProgress(10, 10)).toBe(10);
+	});
+
+	it('clamps progress that overshoots the goal', () => {
+		expect(clampChallengeProgress(12, 10)).toBe(10);
 	});
 });

--- a/UI/src/tests/routes/game/screens/challenges/challenges-view.svelte.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/challenges-view.svelte.test.ts
@@ -169,6 +169,11 @@ describe('progressInfo', () => {
 		expect(progressInfo(ch, EChallengeGoalComparison.AtLeast, 80).percent).toBe(100);
 	});
 
+	it('clamps an over-goal value to the goal (transient race before the ChallengeCompleted push lands)', () => {
+		const ch = challenge({ id: 2, name: 'x', challengeTypeId: EChallengeType.EnemiesKilled, progressGoal: 10 });
+		expect(progressInfo(ch, EChallengeGoalComparison.AtLeast, 12)).toMatchObject({ value: 10, goal: 10 });
+	});
+
 	it('treats an atMost goal as best-vs-target proximity, with 0 meaning "no data"', () => {
 		const ch = challenge({ id: 9, name: 'x', challengeTypeId: EChallengeType.TimeTrial, progressGoal: 60 });
 		// no qualifying value yet

--- a/UI/src/tests/routes/game/screens/codex/codex-view.svelte.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/codex-view.svelte.test.ts
@@ -430,6 +430,13 @@ describe('CodexView dossier projections', () => {
 		expect(view.enemiesTab.challenges[0].progressText).toBe('sealed');
 	});
 
+	it('clamps progress text to the goal when stored progress races ahead of the completion push', () => {
+		playerChallenges.all = [{ challengeId: 0, progress: 112, completed: false }];
+		const view = new CodexView();
+		view.enemiesTab.selectEnemy(0);
+		expect(view.enemiesTab.challenges[0].progressText).toBe('100/100');
+	});
+
 	it('hides a retired enemy-scoped challenge unless it was already completed', () => {
 		staticData.challenges = [
 			...staticData.challenges,


### PR DESCRIPTION
## Summary

- The Codex enemy dossier rendered a challenge's stored progress unclamped (`${Math.round(progress)}/${goal}`), so an over-goal value in the window before a `ChallengeCompleted` push lands could read e.g. `12/10`.
- Added a shared `clampChallengeProgress(progress, goal)` helper in `$lib/common/challenge-type.ts` (already the shared home for other cross-screen challenge display helpers).
- Routed both the Codex dossier's progress text and the Challenges screen's `progressInfo().value` (used by `ProgressReadout`) through it, so the two surfaces can't diverge on this again.

**Note on scope vs. the issue as filed:** the issue described this as the Codex dossier being unclamped "unlike the Challenges screen," pointing at `ProgressBar.svelte:35`. That line only clamps the *bar-fill percentage* (0–100%) — the Challenges screen's own text readout (`ProgressReadout.svelte`'s `{value} / {goal}`) had the identical latent bug, since `progressInfo()` returned the raw, unclamped `progress` as `value`. Rather than fix only the Codex side and leave the Challenges screen with the same bug, I clamped at the shared source so both readouts are correct.

## How this addresses the issue

Closes #2140

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npx vitest run` — full suite passes (302 files / 3786 tests)
- [x] Added unit tests: `clampChallengeProgress` (challenge-type.test.ts), an over-goal case for `progressInfo` (challenges-view.svelte.test.ts), and an over-goal case for the Codex dossier's `progressText` (codex-view.svelte.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rs9JWTKSid5kpT9ikqVJ1h

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rs9JWTKSid5kpT9ikqVJ1h)_