### PR TITLE
Battle-parity suite hygiene: mirror cooldownRecovery fact, pin replay-to-offset equivalence, fix stale comments

### DIFF
--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -1404,7 +1404,11 @@ namespace Game.Core.Tests.Battle
             Assert.Equal(offset, partial.TotalMs);
 
             // Continuing on the SAME (already-mutated) battlers, unbounded, must reach the identical
-            // conclusion a straight, uninterrupted run reaches from a fresh pair.
+            // conclusion a straight, uninterrupted run reaches from a fresh pair. Simulate() re-seeds its own
+            // Mulberry32 every call rather than resuming the prior stream, so this only holds because
+            // cooldownRecovery has no CriticalChance/DodgeChance/ParryChance on either battler — every draw is
+            // outcome-insensitive. Repointing this test at a scenario with a live crit/dodge/parry chance would
+            // make the re-seeded continuation diverge from a true resume.
             var continuation = splitSim.Simulate();
             var straight = new BattleSimulator(
                 Scenarios["cooldownRecovery"].Player(), Scenarios["cooldownRecovery"].Enemy(), ParitySeed).Simulate();

--- a/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
+++ b/Game.Core.Tests/Battle/BattleSimulatorParityTests.cs
@@ -576,8 +576,8 @@ namespace Game.Core.Tests.Battle
                     ExpectedTotalMs: 2000),
 
                 // Draw-order alignment over a multi-skill exchange: two player skills (two crit draws) and two
-                // enemy skills (two dodge draws, one each now that Block's second draw is gone) fire on the same
-                // ticks. CriticalDamage folds in the #799 base (1.5 + 0.5 = 2 multiplier). Neither side has
+                // enemy skills (three draws each — parry, dodge, counter-crit, per #1457 — six total) fire on the
+                // same ticks. CriticalDamage folds in the #799 base (1.5 + 0.5 = 2 multiplier). Neither side has
                 // Toughness. The player crits both hits (10×2=20, 15×2=30 → 50/tick); the enemy's two hits land
                 // in full (12 + 14 = 26/tick — no Block). The 100-HP enemy dies on the player's tick-20 volley →
                 // 800ms (before its own tick-20 attack), so the player only takes the tick-10 volley and ends at 74 HP.
@@ -911,7 +911,7 @@ namespace Game.Core.Tests.Battle
 
                 // A granted skill carrying an EFFECT works exactly as a selected one would: the item grants a
                 // skill whose self +10 Strength buff stacks each fire, ramping its own damage. Str×1.0 raw (no
-                // Toughness) deals 10,20,30,40,50 (Str climbing 10→50); cumulative 10,30,60,100,150 drops the
+                // Toughness) deals 10,20,30,40,50 (Str climbing 10→60); cumulative 10,30,60,100,150 drops the
                 // 150-HP enemy on fire 5 at tick 50 → 2000ms — proving granted skills wrap into a full BattleSkill.
                 ["grantedSkillWithEffects"] = new ParityScenario(
                     Player: () => MakeBattlerWithGrants(
@@ -1355,6 +1355,63 @@ namespace Game.Core.Tests.Battle
             // the enemy's Toughness 30) land at ticks 20..120 → 4800ms.
             Assert.Equal(4800, result.TotalMs);
             Assert.True(result.TotalMs < 5760, "Double-counted stats should end the battle sooner.");
+        }
+
+        /// <summary>
+        /// Pins down the <c>cooldownRecovery</c> scenario's derived stats so a divergence in the
+        /// CDR/CooldownBonus/CooldownBonusMultiplier composition is reported directly rather than only
+        /// surfacing as a different battle outcome. Mirrors the frontend "resolves the cooldownRecovery
+        /// derived stats to the expected values" expectation.
+        /// </summary>
+        [Fact]
+        public void Parity_CooldownRecovery_ResolvesDerivedStats()
+        {
+            var player = Scenarios["cooldownRecovery"].Player();
+            var enemy = Scenarios["cooldownRecovery"].Enemy();
+
+            Assert.Equal(900, player.GetAttributeValue(EAttribute.MaxHealth));
+            Assert.Equal(60, player.GetAttributeValue(EAttribute.Toughness)); // 2·Endurance(30)
+            // CDR is severed from the core attributes (#1426): it stays the base 1, and cadence rides the
+            // committed CooldownBonus (0.25, authored) × CooldownBonusMultiplier (1 + 0.002·Agi20 = 1.04) → cdMult 1.26.
+            Assert.Equal(1.0, player.GetAttributeValue(EAttribute.CooldownRecovery), 10);
+            Assert.Equal(0.25, player.GetAttributeValue(EAttribute.CooldownBonus), 10);
+            Assert.Equal(1.04, player.GetAttributeValue(EAttribute.CooldownBonusMultiplier), 10);
+            Assert.Equal(1.26, player.GetCooldownMultiplier(), 10);
+
+            Assert.Equal(400, enemy.GetAttributeValue(EAttribute.MaxHealth));
+            Assert.Equal(30, enemy.GetAttributeValue(EAttribute.Toughness)); // 2·Endurance(15)
+        }
+
+        /// <summary>
+        /// Pins the frontend's <c>replayToOffset</c> boundary (#1595/#1596/#1597 — battle-engine.ts:229-244)
+        /// against this simulator's own tick loop: simulating the <c>cooldownRecovery</c> scenario to a mid-battle
+        /// offset, then continuing on the same (already-mutated) battlers for the remainder, must land on the
+        /// exact same outcome and total elapsed time as one uninterrupted <see cref="BattleSimulator.Simulate"/>
+        /// call. Guards the loop's boundary arithmetic (<c>totalMs &lt;= limit</c>, the <c>totalMs - msPerTick</c>
+        /// exit) against a future refactor silently shifting where a resumed replay picks up. Mirrors the
+        /// frontend "replays to an offset then continues to the same conclusion" expectation.
+        /// </summary>
+        [Fact]
+        public void Parity_RunToOffsetThenContinue_MatchesUninterruptedRun()
+        {
+            const int offset = 2400; // mid-battle: cooldownRecovery concludes at 5760ms.
+
+            var splitSim = new BattleSimulator(
+                Scenarios["cooldownRecovery"].Player(), Scenarios["cooldownRecovery"].Enemy(), ParitySeed);
+            var partial = splitSim.Simulate(offset);
+            Assert.False(partial.Victory);
+            Assert.False(partial.PlayerDied);
+            Assert.Equal(offset, partial.TotalMs);
+
+            // Continuing on the SAME (already-mutated) battlers, unbounded, must reach the identical
+            // conclusion a straight, uninterrupted run reaches from a fresh pair.
+            var continuation = splitSim.Simulate();
+            var straight = new BattleSimulator(
+                Scenarios["cooldownRecovery"].Player(), Scenarios["cooldownRecovery"].Enemy(), ParitySeed).Simulate();
+
+            Assert.Equal(straight.Victory, continuation.Victory);
+            Assert.Equal(straight.PlayerDied, continuation.PlayerDied);
+            Assert.Equal(straight.TotalMs, offset + continuation.TotalMs);
         }
 
         /// <summary>

--- a/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
+++ b/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
@@ -798,8 +798,8 @@ const scenarios: ParityScenario[] = [
 		expected: { victory: true, playerDied: false, totalMs: 2000 }
 	},
 
-	// Draw-order alignment over a multi-skill exchange: two player skills (two crit draws) and two enemy
-	// skills (two dodge draws, one each now that Block's second draw is gone) fire on the same ticks.
+	// Draw-order alignment over a multi-skill exchange: two player skills (two crit draws) and two enemy skills
+	// (three draws each — parry, dodge, counter-crit, per #1457 — six total) fire on the same ticks.
 	// CriticalDamage folds in the #799 base (1.5 + 0.5 = 2 multiplier). Neither side has Toughness. The player
 	// crits both hits (10×2=20, 15×2=30 → 50/tick); the enemy's two hits land in full (12 + 14 = 26/tick — no
 	// Block). The 100-HP enemy dies on the player's tick-20 volley → 800ms (before its own tick-20 attack), so
@@ -1701,6 +1701,35 @@ describe('Battle simulation parity with backend', () => {
 
 		expect(enemy.attributes.getValue(EAttribute.MaxHealth)).toBe(400);
 		expect(enemy.attributes.getValue(EAttribute.Toughness)).toBe(30); // 2·Endurance(15)
+	});
+
+	// Pins the production replayToOffset boundary (#1595/#1596/#1597 — battle-engine.ts:229-244) against this
+	// simulator's own tick loop: simulating to a mid-battle offset, then continuing on the same (already-mutated)
+	// battlers for the remainder, must land on the exact same outcome and total elapsed time as one uninterrupted
+	// `simulate()` call. Guards the loop's boundary arithmetic (`totalMs <= maxMs`, the `totalMs - tickSize` exit)
+	// against a future refactor silently shifting where a resumed replay picks up. Mirrors the backend
+	// `Parity_RunToOffsetThenContinue_MatchesUninterruptedRun` expectation.
+	it('replays to an offset then continues to the same conclusion as an uninterrupted run', () => {
+		const offset = 2400; // mid-battle: cooldownRecovery concludes at 5760ms.
+		const scenario = scenarios.find((s) => s.name === 'cooldownRecovery');
+		if (!scenario) {
+			throw new Error('cooldownRecovery scenario is missing from the matrix');
+		}
+
+		const splitSim = new BattleSimulator(scenario.player(), scenario.enemy(), PARITY_SEED);
+		const partial = splitSim.simulate(offset);
+		expect(partial.victory).toBe(false);
+		expect(partial.playerDied).toBe(false);
+		expect(partial.totalMs).toBe(offset);
+
+		// Continuing on the SAME (already-mutated) battlers, unbounded, must reach the identical conclusion a
+		// straight, uninterrupted run reaches from a fresh pair.
+		const continuation = splitSim.simulate();
+		const straight = new BattleSimulator(scenario.player(), scenario.enemy(), PARITY_SEED).simulate();
+
+		expect(continuation.victory).toBe(straight.victory);
+		expect(continuation.playerDied).toBe(straight.playerDied);
+		expect(offset + continuation.totalMs).toBe(straight.totalMs);
 	});
 
 	it('composes the equippedItemWithMods stat + item + mod attributes to the expected values', () => {

--- a/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
+++ b/UI/src/tests/lib/battle/battle-simulation-parity.test.ts
@@ -1723,7 +1723,11 @@ describe('Battle simulation parity with backend', () => {
 		expect(partial.totalMs).toBe(offset);
 
 		// Continuing on the SAME (already-mutated) battlers, unbounded, must reach the identical conclusion a
-		// straight, uninterrupted run reaches from a fresh pair.
+		// straight, uninterrupted run reaches from a fresh pair. simulate() re-seeds its own Mulberry32 every
+		// call rather than resuming the prior stream, so this only holds because cooldownRecovery has no
+		// CriticalChance/DodgeChance/ParryChance on either battler — every draw is outcome-insensitive.
+		// Repointing this test at a scenario with a live crit/dodge/parry chance would make the re-seeded
+		// continuation diverge from a true resume.
 		const continuation = splitSim.simulate();
 		const straight = new BattleSimulator(scenario.player(), scenario.enemy(), PARITY_SEED).simulate();
 


### PR DESCRIPTION
## Summary

Three battle-parity test-suite hygiene fixes from the July 2026 health review (#2063), batched in one PR since each is small and independent:

1. **Mirrored the FE-only `cooldownRecovery` derived-stats fact.** The frontend suite pinned `cooldownRecovery`'s MaxHealth/Toughness/CDR/CooldownBonus/CooldownBonusMultiplier/`cdMultiplier` values, but the backend had no matching `[Fact]` — added `Parity_CooldownRecovery_ResolvesDerivedStats` mirroring it exactly, closing the gap in the row-for-row audit trail CLAUDE.md mandates for battle logic.

2. **Added a mirrored `replayToOffset` boundary pin on both sides.** Neither suite had a test asserting that simulating to a mid-battle offset and then continuing on the same battlers reaches the identical outcome/`totalMs` as one uninterrupted run. Added `Parity_RunToOffsetThenContinue_MatchesUninterruptedRun` (backend) and its frontend twin, both built on the existing deterministic `cooldownRecovery` scenario (0% crit/dodge/parry, so the RNG stream restart on the continuation call doesn't affect the outcome) — splitting `Simulate(offset)` then `Simulate()` again on the same simulator instance and comparing against a fresh, uninterrupted `Simulate()`. This guards the tick loop's boundary arithmetic (`totalMs <= limit`, the `totalMs - tickSize` exit) against a future refactor silently shifting the resume point by a tick.

3. **Fixed two stale comments** (present identically in both suites):
   - `drawOrderMultiSkill`: said "two dodge draws, one each now that Block's second draw is gone" — the rule since #1457 is **three** unconditional draws per enemy fire (parry, dodge, counter-crit), so two enemy skills firing is six draws, not two.
   - `grantedSkillWithEffects`: backend said "Str climbing 10→50" where the frontend's "10→60" (reflecting Strength after all five +10 stacks apply) is correct.

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings/errors
- [x] `dotnet test Game.Core.Tests` — 1376 passed, 0 failed (includes the two new Facts)
- [x] `npx vitest run src/tests/lib/battle/battle-simulation-parity.test.ts` — 74 passed (includes the new test)
- [x] `npm run test:unit:ci` (full UI suite) — 3791 passed, 0 failed
- [x] `npm run lint` — clean (ESLint + svelte-check, 0 errors/warnings)

Closes #2063


---
_Generated by [Claude Code](https://claude.ai/code/session_01QW8uEw4Nem6t6TMwAKbT5K)_