### PR TITLE
Clear staticData on logout so re-login re-checks reference-data versions

### DIFF
--- a/UI/src/lib/engine/engine.ts
+++ b/UI/src/lib/engine/engine.ts
@@ -362,6 +362,9 @@ const stopGame = () => {
 	statistics.reset();
 	playerChallenges.reset();
 	playerProficiencies.reset();
+	// Cleared so a subsequent login in the same tab re-checks content versions instead of reusing
+	// whatever reference data was in memory for the prior session (#2067).
+	staticData.reset();
 	resetLogs();
 	// Clear the other module-level UI stores stopEngines/the resets above don't touch, so a leftover toast,
 	// queued modal, or pending screen request can't leak into the next session (e.g. a "View" toast action

--- a/UI/src/stores/static-data.svelte.ts
+++ b/UI/src/stores/static-data.svelte.ts
@@ -137,5 +137,24 @@ export const staticData = {
 			skillRecipes,
 			lessons
 		].every((set) => set != null);
+	},
+	/** Clears every slot back to unloaded (e.g. on logout), so a subsequent login re-checks content
+	 *  versions instead of reusing whatever was in memory for the prior session. The local-storage
+	 *  cache (`reference-cache.ts`) makes the re-hydrate on next load nearly free when nothing changed. */
+	reset() {
+		zones = undefined;
+		enemies = undefined;
+		items = undefined;
+		skills = undefined;
+		itemMods = undefined;
+		attributes = undefined;
+		challenges = undefined;
+		challengeTypes = undefined;
+		statisticTypes = undefined;
+		proficiencies = undefined;
+		paths = undefined;
+		classes = undefined;
+		skillRecipes = undefined;
+		lessons = undefined;
 	}
 };

--- a/UI/src/tests/lib/engine/engine.test.ts
+++ b/UI/src/tests/lib/engine/engine.test.ts
@@ -22,8 +22,9 @@ const {
 	navigation,
 	clearToasts
 } = vi.hoisted(() => ({
-	staticDataStub: { loaded: true } as {
+	staticDataStub: { loaded: true, reset: vi.fn() } as {
 		loaded: boolean;
+		reset: () => void;
 		challenges?: ({ id: number; name: string; rewardItemId?: number } | undefined)[];
 		items?: ({ id: number; name: string; rarityId: number; itemCategoryId: number } | undefined)[];
 		itemMods?: unknown[];
@@ -394,6 +395,13 @@ describe('startGame', () => {
 		void handleSocketReplaced();
 
 		expect(navigation.reset).toHaveBeenCalledTimes(1);
+	});
+
+	it("stopGame clears the in-memory reference data so a subsequent login re-checks content versions instead of reusing the prior session's copy (#2067)", () => {
+		startGame();
+		void handleSocketReplaced();
+
+		expect(staticDataStub.reset).toHaveBeenCalledTimes(1);
 	});
 
 	it('stopGame clears an open coach-mark tour so it cannot leak onto the next character (#2092)', () => {

--- a/UI/src/tests/stores/static-data.test.ts
+++ b/UI/src/tests/stores/static-data.test.ts
@@ -77,4 +77,16 @@ describe('staticData store', () => {
 		staticData.skills = undefined;
 		expect(staticData.loaded).toBe(false);
 	});
+
+	it('reset() clears every slot back to unloaded', () => {
+		populateAll();
+		expect(staticData.loaded).toBe(true);
+
+		staticData.reset();
+
+		for (const slot of SLOTS) {
+			expect(staticData[slot]).toBeUndefined();
+		}
+		expect(staticData.loaded).toBe(false);
+	});
 });


### PR DESCRIPTION
## Summary

Closes #2067.

The loading screen's "same-session re-mount" short-circuit (`REFERENCE_DATA.every((source) => source.loaded())` in `reference-data.ts`, mirrored in `loading-view.svelte.ts`) is sound for its intended case, but `staticData` is a module singleton and `stopGame` never cleared it. A `SocketReplaced` logout is a client-side `goto`, not a page reload, so a subsequent login in the same tab reused whatever reference data was already in memory with **no version check at all** — content published between sessions stayed invisible until a hard refresh.

## Change

`stopGame()` (`UI/src/lib/engine/engine.ts`) now calls a new `staticData.reset()` (`UI/src/stores/static-data.svelte.ts`) that clears every reference-data slot back to `undefined`, alongside the existing `statistics`/`playerChallenges`/`playerProficiencies` resets it already ran on logout.

I went with this option (of the two the issue suggested) over dropping the pre-version-check short-circuit entirely, since clearing on logout only pays the version-check cost when it's actually needed (across a real re-login) and leaves the same-session re-mount fast-path untouched. The local-storage cache (`reference-cache.ts`) keeps the next load's re-hydrate cheap for any set whose version didn't change — the version check itself is one socket round trip.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npx vitest run` — 302 files / 3793 tests passing, including new coverage:
  - `static-data.test.ts`: `reset()` clears every slot back to unloaded.
  - `engine.test.ts`: `stopGame` calls `staticData.reset()` on `handleSocketReplaced`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSukRCjxeEAW5mQhYi2oeP)_