### PR TITLE
Make createHook.notify re-entrancy-safe with a dispatch-depth counter

### DIFF
--- a/UI/src/lib/common/hooks.ts
+++ b/UI/src/lib/common/hooks.ts
@@ -8,7 +8,10 @@ interface HookTracker<T extends unknown[]> {
 }
 
 export const createHook = <T extends unknown[] = []>() => {
-	let dispatching = false;
+	// A depth counter (not a boolean) so a callback that synchronously re-notifies this same
+	// hook doesn't reset the in-progress-dispatch flag early: the outer walk's tombstone
+	// compaction must wait until every nested dispatch has also finished.
+	let dispatchDepth = 0;
 	let hasPendingRemovals = false;
 	const trackers: HookTracker<T>[] = [];
 
@@ -18,18 +21,21 @@ export const createHook = <T extends unknown[] = []>() => {
 		// the index walk isn't disturbed: an unhook only tombstones (`removed`) instead
 		// of splicing, and the snapshotted `count` excludes any subscriber a callback
 		// appends mid-dispatch — keeping it from firing on an event that predates it.
-		// Tombstones are compacted out once after dispatch; appends survive it.
-		dispatching = true;
-		const count = trackers.length;
-		for (let i = 0; i < count; i++) {
-			const tracker = trackers[i];
-			if (!tracker.removed) {
-				tracker.callback(...data, tracker.unhook);
+		// Tombstones are compacted out once after the outermost dispatch; appends survive it.
+		dispatchDepth++;
+		try {
+			const count = trackers.length;
+			for (let i = 0; i < count; i++) {
+				const tracker = trackers[i];
+				if (!tracker.removed) {
+					tracker.callback(...data, tracker.unhook);
+				}
 			}
+		} finally {
+			dispatchDepth--;
 		}
-		dispatching = false;
 
-		if (hasPendingRemovals) {
+		if (dispatchDepth === 0 && hasPendingRemovals) {
 			for (let i = trackers.length - 1; i >= 0; i--) {
 				if (trackers[i].removed) {
 					trackers.splice(i, 1);
@@ -57,7 +63,7 @@ export const createHook = <T extends unknown[] = []>() => {
 			}
 			tracker.removed = true;
 			// Defer the splice during dispatch so the in-progress index walk isn't disturbed.
-			if (dispatching) {
+			if (dispatchDepth > 0) {
 				hasPendingRemovals = true;
 			} else {
 				const index = trackers.indexOf(tracker);

--- a/UI/src/tests/lib/common/hooks.test.ts
+++ b/UI/src/tests/lib/common/hooks.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('svelte', async (importOriginal) => ({
+	...((await importOriginal()) as Record<string, unknown>),
+	onDestroy: vi.fn()
+}));
+
+import { createHook } from '$lib/common';
+
+describe('createHook', () => {
+	it('notifies subscribers in subscription order with the passed data', () => {
+		const hook = createHook<[number]>();
+		const calls: number[] = [];
+		hook.onNotified((n) => calls.push(n));
+		hook.onNotified((n) => calls.push(n * 10));
+
+		hook.notify(1);
+
+		expect(calls).toEqual([1, 10]);
+	});
+
+	it('a subscriber that unhooks itself is skipped for the rest of the current dispatch', () => {
+		const hook = createHook();
+		const calls: string[] = [];
+		hook.onNotified((unhook) => {
+			calls.push('a');
+			unhook();
+		});
+		hook.onNotified(() => calls.push('b'));
+
+		hook.notify();
+		expect(calls).toEqual(['a', 'b']);
+
+		calls.length = 0;
+		hook.notify();
+		expect(calls).toEqual(['b']); // the self-unhooked subscriber no longer fires
+	});
+
+	it('a subscriber added during dispatch does not fire until the next notify', () => {
+		const hook = createHook();
+		const calls: string[] = [];
+		hook.onNotified(() => {
+			calls.push('first');
+			hook.onNotified(() => calls.push('added-mid-dispatch'));
+		});
+
+		hook.notify();
+		expect(calls).toEqual(['first']);
+
+		hook.notify();
+		expect(calls).toEqual(['first', 'first', 'added-mid-dispatch']);
+	});
+
+	it('unhooking a subscriber ahead of the current walk index during dispatch excludes it from this pass', () => {
+		const hook = createHook();
+		const calls: string[] = [];
+		let unhookB: () => void = () => {};
+		hook.onNotified(() => {
+			calls.push('a');
+			unhookB();
+		});
+		hook.onNotified(() => calls.push('b'));
+		// Capture b's own unhook by re-subscribing and grabbing the returned function.
+		unhookB = hook.onNotified(() => calls.push('c'));
+
+		hook.notify();
+		expect(calls).toEqual(['a', 'b']); // c was tombstoned before its turn in this pass
+	});
+
+	it('a callback that synchronously re-notifies the same hook does not corrupt the outer dispatch (regression)', () => {
+		// Without a reentrancy-safe depth counter, the inner notify's epilogue would reset the
+		// dispatch flag to false while the outer walk is still mid-loop, letting a subsequent
+		// unhook splice immediately (shifting indices under the outer loop) instead of tombstoning.
+		const hook = createHook();
+		const calls: string[] = [];
+		let reentered = false;
+
+		hook.onNotified((unhook) => {
+			calls.push('outer-a');
+			if (!reentered) {
+				reentered = true;
+				hook.notify(); // synchronous same-hook re-entry
+			}
+			unhook(); // unhooks outer-a itself, mid-outer-walk
+		});
+		hook.onNotified(() => calls.push('outer-b'));
+
+		hook.notify();
+
+		// outer-a fires once for the outer call and once for the nested call; outer-b fires
+		// once for each pass that reaches it (the nested notify's pass, then the outer's own).
+		expect(calls).toEqual(['outer-a', 'outer-a', 'outer-b', 'outer-b']);
+
+		calls.length = 0;
+		hook.notify();
+		expect(calls).toEqual(['outer-b']); // outer-a's self-unhook took effect cleanly
+	});
+});


### PR DESCRIPTION
## Summary

Closes #2093.

`createHook.notify` (`UI/src/lib/common/hooks.ts`) used a boolean `dispatching` flag to defer unhook-during-dispatch splices (tombstone instead, compact after). If a callback synchronously called `notify` on the *same* hook, the inner call's epilogue reset `dispatching` to `false` while the outer walk was still mid-loop. A subsequent `unhook` during the outer walk would then splice immediately (instead of tombstoning) and shift indices out from under the in-progress `for` loop — silently skipping subscribers or, in the case exercised by the new test, reading past the truncated array.

This was flagged as latent (no current caller triggers a synchronous same-hook re-entry), but the hook is the substrate of the battle/tick pub-sub, so a future synchronous stage-change chain would corrupt dispatch silently.

## Fix

- Replaced the boolean `dispatching` flag with a `dispatchDepth` counter, incremented/decremented around the walk (via `try`/`finally`).
- Tombstone compaction and clearing `hasPendingRemovals` now only run once `dispatchDepth` returns to `0`, i.e. after the *outermost* dispatch completes — mirroring the shape of the #2047 `RenderEngine` stop→start fix (generation/handle-based reentrancy guard instead of a boolean).
- `unhook`'s defer-vs-splice check now reads `dispatchDepth > 0` instead of the old boolean.

## Test plan

- [x] Added `UI/src/tests/lib/common/hooks.test.ts` — no test file existed for this primitive before. Covers ordering, self-unhook mid-dispatch, unhook-ahead-of-walk-index, add-during-dispatch, and the nested-notify regression case (which reproduces the exact corruption described in the issue against the old boolean implementation).
- [x] `npx vitest run` — full UI unit suite: 303 files / 3798 tests passing.
- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors/warnings.


---
_Generated by [Claude Code](https://claude.ai/code/session_015UXww5eUBw3T1DjqbYn9nw)_