### PR TITLE
Reject blank, control, and zero-width usernames on account creation

### DIFF
--- a/Game.Api.Tests/Integration/AuthControllerTests.cs
+++ b/Game.Api.Tests/Integration/AuthControllerTests.cs
@@ -208,6 +208,43 @@ namespace Game.Api.Tests.Integration
             Assert.Contains(nameof(CreateAccountRequest.Username), problem.Errors.Keys);
         }
 
+        [Theory]
+        [InlineData(" ")] // whitespace-only
+        [InlineData("bad\tname")] // embedded control character
+        public async Task CreateAccount_InvalidUsername_ReturnsError(string username)
+        {
+            var creds = new { Username = username, Password = "newpass" };
+
+            var response = await Client.PostAsJsonAsync("/api/Auth/CreateAccount", creds, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.NotNull(result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task CreateAccount_SurroundingWhitespace_IsTrimmedAndCollidesWithExistingUsername()
+        {
+            // Arrange — an existing account, then a signup for a whitespace-padded variant of the same name.
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                await TestDataSeeder.CreateUserAsync(context, "padded", "pass");
+            }
+
+            var creds = new { Username = "  padded  ", Password = "newpass" };
+
+            var response = await Client.PostAsJsonAsync("/api/Auth/CreateAccount", creds, CancellationToken);
+
+            // Normalizing before the uniqueness check means the padded variant collides with the existing
+            // account rather than creating a visually-confusable duplicate.
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.NotNull(result.ErrorMessage);
+        }
+
         [Fact]
         public async Task CreateAccount_ConcurrentDuplicate_ReturnsCleanErrorNotServerError()
         {

--- a/Game.Api/Controllers/AuthController.cs
+++ b/Game.Api/Controllers/AuthController.cs
@@ -5,6 +5,7 @@ using Game.Api.Models.Player;
 using Game.Api.Services;
 using Game.Api.RateLimiting;
 using Game.Application.Services;
+using Game.Core.Identity;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
@@ -88,6 +89,8 @@ namespace Game.Api.Controllers
             {
                 CreateAccountStatus.Success => ApiResponse.Success(),
                 CreateAccountStatus.UsernameTaken => ApiResponse.Error("There is already an account with this username."),
+                CreateAccountStatus.InvalidUsername =>
+                    ApiResponse.Error($"Username must be {UsernamePolicy.MinLength}-{UsernamePolicy.MaxLength} characters and contain no control or zero-width characters."),
                 _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
             };
         }

--- a/Game.Application.Tests/Services/AccountServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/AccountServiceIntegrationTests.cs
@@ -175,6 +175,57 @@ namespace Game.Application.Tests.Services
             Assert.Equal(starterSkills, battleSkillIds.Where(id => starterSkills.Contains(id)));
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("bad\tname")]
+        [InlineData("waaaaaaaaaaaaaaaaaaaytoolong")]
+        public async Task CreateAccount_InvalidUsername_ReturnsInvalidUsernameAndCreatesNothing(string username)
+        {
+            using var scope = CreateScope();
+            var accountService = CreateAccountService(scope.ServiceProvider);
+
+            var status = await accountService.CreateAccount(username, "pass");
+
+            Assert.Equal(CreateAccountStatus.InvalidUsername, status);
+
+            using var verifyScope = CreateScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
+            Assert.Equal(0, await verifyContext.Users.CountAsync(user => user.Username == username, CancellationToken));
+        }
+
+        [Fact]
+        public async Task CreateAccount_SurroundingWhitespace_IsTrimmedBeforePersisting()
+        {
+            using var scope = CreateScope();
+            var accountService = CreateAccountService(scope.ServiceProvider);
+
+            var status = await accountService.CreateAccount("  trimmed  ", "pass");
+            Assert.Equal(CreateAccountStatus.Success, status);
+
+            using var verifyScope = CreateScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
+            var createdUser = await verifyContext.Users
+                .FirstOrDefaultAsync(user => user.Username == "trimmed", CancellationToken);
+            Assert.NotNull(createdUser);
+        }
+
+        [Fact]
+        public async Task CreateAccount_WhitespaceVariantOfExistingUsername_ReturnsUsernameTaken()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            await TestDataSeeder.CreateUserAsync(context, "spoofable", "pass");
+
+            var accountService = CreateAccountService(scope.ServiceProvider);
+
+            // Normalizing before the uniqueness check closes the confusable-account gap: a whitespace-padded
+            // variant of an existing username collides with it rather than creating a distinct, spoofable row.
+            var status = await accountService.CreateAccount("  spoofable  ", "newpass");
+
+            Assert.Equal(CreateAccountStatus.UsernameTaken, status);
+        }
+
         [Fact]
         public async Task CreateAccount_DuplicateUsername_ReturnsUsernameTaken()
         {

--- a/Game.Application/Services/AccountResults.cs
+++ b/Game.Application/Services/AccountResults.cs
@@ -11,6 +11,9 @@ namespace Game.Application.Services
     {
         Success,
         UsernameTaken,
+
+        /// <summary>The supplied username failed validation (blank, too long, or control/zero-width characters).</summary>
+        InvalidUsername,
     }
 
     /// <summary>

--- a/Game.Application/Services/AccountService.cs
+++ b/Game.Application/Services/AccountService.cs
@@ -3,6 +3,7 @@ using Game.Abstractions.Contracts.Identity;
 using Game.Abstractions.DataAccess;
 using Game.Application.Auth;
 using Game.Core.Classes;
+using Game.Core.Identity;
 using Game.Core.Players;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -43,23 +44,29 @@ namespace Game.Application.Services
         private readonly ILogger<AccountService> _logger = logger;
 
         /// <summary>
-        /// Creates a new account: validates the username is available, hashes the password, and hands the
-        /// credential material to the Identity context for persistence. The account is created with
-        /// <b>no</b> character — a freshly signed-up account creates its first character on the select
-        /// screen through the same class picker as any additional one (issue #1256), so signup needs no
-        /// class. The up-front check is a fast path; the data tier's active-username uniqueness guard is
-        /// the authority, so a username claimed concurrently (past the check) is still reported as taken.
+        /// Creates a new account: validates and normalizes the username, checks it is available, hashes the
+        /// password, and hands the credential material to the Identity context for persistence. The account
+        /// is created with <b>no</b> character — a freshly signed-up account creates its first character on
+        /// the select screen through the same class picker as any additional one (issue #1256), so signup
+        /// needs no class. The up-front availability check is a fast path; the data tier's active-username
+        /// uniqueness guard is the authority, so a username claimed concurrently (past the check) is still
+        /// reported as taken.
         /// </summary>
         public async Task<CreateAccountStatus> CreateAccount(string username, string password, CancellationToken cancellationToken = default)
         {
-            if (await _users.CheckIfUsernameExists(username, cancellationToken))
+            if (!UsernamePolicy.TryNormalize(username, out var normalized))
+            {
+                return CreateAccountStatus.InvalidUsername;
+            }
+
+            if (await _users.CheckIfUsernameExists(normalized, cancellationToken))
             {
                 return CreateAccountStatus.UsernameTaken;
             }
 
             var account = new NewAccount
             {
-                Username = username,
+                Username = normalized,
                 PassHash = _passwordHasher.Hash(password),
             };
 

--- a/Game.Core.Tests/Identity/UsernamePolicyTests.cs
+++ b/Game.Core.Tests/Identity/UsernamePolicyTests.cs
@@ -1,0 +1,82 @@
+using Game.Core.Identity;
+using Xunit;
+
+namespace Game.Core.Tests.Identity
+{
+    public class UsernamePolicyTests
+    {
+        [Theory]
+        [InlineData("admin")]
+        [InlineData("A")] // minimum length
+        [InlineData("Player_123")]
+        [InlineData("12345678901234567890")] // exactly the 20-char max
+        public void TryNormalize_ValidUsername_ReturnsTrueWithSameValue(string username)
+        {
+            var valid = UsernamePolicy.TryNormalize(username, out var normalized);
+
+            Assert.True(valid);
+            Assert.Equal(username, normalized);
+        }
+
+        [Theory]
+        [InlineData("  admin  ", "admin")]
+        [InlineData("\tadmin\n", "admin")]
+        [InlineData("   A   ", "A")]
+        public void TryNormalize_SurroundingWhitespace_IsTrimmed(string username, string expected)
+        {
+            var valid = UsernamePolicy.TryNormalize(username, out var normalized);
+
+            Assert.True(valid);
+            Assert.Equal(expected, normalized);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")] // whitespace-only trims to empty
+        [InlineData("\t\n")]
+        public void TryNormalize_BlankUsername_ReturnsFalse(string? username)
+        {
+            var valid = UsernamePolicy.TryNormalize(username, out var normalized);
+
+            Assert.False(valid);
+            Assert.Null(normalized);
+        }
+
+        [Theory]
+        [InlineData("123456789012345678901")] // 21 chars — one over the max
+        [InlineData("this-username-is-definitely-too-long")]
+        public void TryNormalize_TooLong_ReturnsFalse(string username)
+        {
+            var valid = UsernamePolicy.TryNormalize(username, out var normalized);
+
+            Assert.False(valid);
+            Assert.Null(normalized);
+        }
+
+        [Theory]
+        [InlineData("bad\tname")] // embedded tab
+        [InlineData("bad\nname")] // embedded newline
+        [InlineData("bad\0name")] // embedded null
+        public void TryNormalize_ContainsControlCharacters_ReturnsFalse(string username)
+        {
+            var valid = UsernamePolicy.TryNormalize(username, out var normalized);
+
+            Assert.False(valid);
+            Assert.Null(normalized);
+        }
+
+        [Theory]
+        [InlineData("bad\u200Bname")] // zero width space
+        [InlineData("bad\u200Cname")] // zero width non-joiner
+        [InlineData("bad\u200Dname")] // zero width joiner
+        [InlineData("bad\uFEFFname")] // zero width no-break space / BOM
+        public void TryNormalize_ContainsZeroWidthCharacters_ReturnsFalse(string username)
+        {
+            var valid = UsernamePolicy.TryNormalize(username, out var normalized);
+
+            Assert.False(valid);
+            Assert.Null(normalized);
+        }
+    }
+}

--- a/Game.Core/Identity/UsernamePolicy.cs
+++ b/Game.Core/Identity/UsernamePolicy.cs
@@ -1,18 +1,60 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
 namespace Game.Core.Identity
 {
     /// <summary>
-    /// Length bounds for a user's login username. <see cref="MaxLength"/> mirrors the persisted
+    /// Validation rules for a login username. <see cref="MaxLength"/> mirrors the persisted
     /// <c>User.Username</c> column (see <see cref="Game.Core.Players.PlayerName"/> for the equivalent
     /// player-name rule) so a valid username always fits storage. Named <c>UsernamePolicy</c> rather than
     /// <c>Username</c> so it doesn't collide with the <c>Username</c> property on the request models that
-    /// reference it.
+    /// reference it. This is the domain answer to "is this an acceptable username?", enforced server-side
+    /// as anti-cheat regardless of any client-side check — it guards the admin roster, ban/archive surface,
+    /// and logs against confusable/spoofed entries (e.g. an account visually identical to an admin's).
     /// </summary>
     public static class UsernamePolicy
     {
-        /// <summary>The shortest a username may be.</summary>
+        /// <summary>The shortest a (trimmed) username may be.</summary>
         public const int MinLength = 1;
 
-        /// <summary>The longest a username may be — mirrors the persisted <c>User.Username</c> column.</summary>
+        /// <summary>The longest a (trimmed) username may be — mirrors the persisted <c>User.Username</c> column.</summary>
         public const int MaxLength = 20;
+
+        /// <summary>
+        /// Validates and normalizes a caller-supplied username: trims surrounding whitespace, then accepts
+        /// it only when the trimmed value is within [<see cref="MinLength"/>, <see cref="MaxLength"/>] and
+        /// free of control and zero-width characters (which could otherwise render a username visually
+        /// identical to another). Returns the normalized username via <paramref name="normalized"/> when valid.
+        /// </summary>
+        public static bool TryNormalize(string? username, [NotNullWhen(true)] out string? normalized)
+        {
+            normalized = null;
+            if (username is null)
+            {
+                return false;
+            }
+
+            var trimmed = username.Trim();
+            if (trimmed.Length < MinLength || trimmed.Length > MaxLength)
+            {
+                return false;
+            }
+
+            if (trimmed.Any(IsDisallowedCharacter))
+            {
+                return false;
+            }
+
+            normalized = trimmed;
+            return true;
+        }
+
+        // Control characters (e.g. tab, null) and the Unicode "Format" category (e.g. zero-width space,
+        // zero-width joiner/non-joiner, the zero-width no-break space/BOM) are both invisible and can make
+        // two usernames render identically while being distinct strings.
+        private static bool IsDisallowedCharacter(char c)
+        {
+            return char.IsControl(c) || char.GetUnicodeCategory(c) == UnicodeCategory.Format;
+        }
     }
 }


### PR DESCRIPTION
## Summary

`UsernamePolicy` previously bounded only length; `AccountService.CreateAccount` passed the raw username straight through with no trim, charset, or blank/control-character rule — unlike `PlayerName`, which already has a proper domain rule for character names. This let `" "`, `"admin"`/`" admin"`, and control-character usernames all persist as distinct, loggable-in accounts, enabling confusable/spoofed entries in the admin user roster.

- Added `UsernamePolicy.TryNormalize` (mirrors `PlayerName.TryNormalize`): trims surrounding whitespace, then rejects blank, too-long, control-character, and zero-width/Unicode-`Format`-category values (e.g. zero-width space/joiner/non-joiner, the zero-width no-break space/BOM) — invisible characters that could otherwise make two usernames render identically.
- Wired it into `AccountService.CreateAccount` before the uniqueness check, so a whitespace-padded or invisible-character variant of an existing username now collides with it instead of creating a distinct spoofable row.
- Added `CreateAccountStatus.InvalidUsername`, mapped in `AuthController.CreateAccount`'s exhaustive switch (compiler-enforced completeness catches any future status left unmapped).

No frontend changes needed — the signup form's client-side regex (`UI/src/routes/login/login-validation.ts`) already restricts usernames to `[a-zA-Z][a-zA-Z0-9_-]{2,19}`; this closes the server-side hole for anyone bypassing the client (verified end-to-end in the issue).

Existing rows are unaffected (pre-release, no grandfathering needed).

Closes #2095

## Test plan

- [x] `Game.Core.Tests` (`UsernamePolicyTests`) — trim, blank/whitespace-only, too-long, control-character, and zero-width-character cases. Full suite: 1396 passed.
- [x] `Game.Application.Tests` (`AccountServiceIntegrationTests`) — invalid usernames rejected and persist nothing; whitespace trimmed before persisting; a whitespace-padded variant of an existing username returns `UsernameTaken`. Full suite: 1011 passed.
- [x] `Game.Api.Tests` (`AuthControllerTests`) — `/api/Auth/CreateAccount` returns a clean 400 for whitespace-only/control-character usernames, and for a padded variant of an existing username. Full suite: 831 passed.
- [x] `dotnet build` — 0 warnings, 0 errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L13sUAgjWdzJQz3CnKVFXt)_