### PR TITLE
Redraw battle seed on collision with LastCreditedBattleSeed

### DIFF
--- a/Game.Application.Tests/Services/CreateBattleSeedTests.cs
+++ b/Game.Application.Tests/Services/CreateBattleSeedTests.cs
@@ -27,5 +27,44 @@ namespace Game.Application.Tests.Services
             Assert.True(seeds.Distinct().Count() > 1,
                 "Expected the seed generator to produce varied values from a non-time entropy source.");
         }
+
+        // #2112: a fresh seed equal to the player's LastCreditedBattleSeed must never be handed out, since
+        // BattleAlreadyCredited would then treat the brand-new battle as a stale re-presentation of the
+        // already-credited one. The real CSPRNG can't be made to collide on demand (2^-32), so this pins the
+        // public entry point's exclude plumbing statistically, and DrawSeed below pins the redraw loop itself
+        // deterministically via a stubbed generator.
+        [Fact]
+        public void CreateBattleSeed_NeverEqualsProvidedExclude()
+        {
+            var exclude = BattleService.CreateBattleSeed();
+
+            var seeds = Enumerable.Range(0, 1000)
+                .Select(_ => BattleService.CreateBattleSeed(exclude))
+                .ToList();
+
+            Assert.DoesNotContain(exclude, seeds);
+        }
+
+        [Fact]
+        public void DrawSeed_RedrawsUntilPastTheExcludedValue()
+        {
+            var draws = new Queue<uint>([5u, 5u, 5u, 7u]);
+
+            var result = BattleService.DrawSeed(draws.Dequeue, exclude: 5u);
+
+            Assert.Equal(7u, result);
+            Assert.Empty(draws);
+        }
+
+        [Fact]
+        public void DrawSeed_NullExclude_ReturnsFirstDrawUnconditionally()
+        {
+            var draws = new Queue<uint>([5u, 7u]);
+
+            var result = BattleService.DrawSeed(draws.Dequeue, exclude: null);
+
+            Assert.Equal(5u, result);
+            Assert.Equal(7u, draws.Peek());
+        }
     }
 }

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -119,7 +119,7 @@ namespace Game.Application.Services
             // (see PrepareNextIdleBattle) — and, for the abandon case, is what makes the cooldown just applied
             // actually pace the replacement battle instead of being immediately bypassed (#1851).
             var battleStartTime = scheduledStartTime ?? abandonedOutcomeCooldown ?? DateTime.UtcNow;
-            var seed = CreateBattleSeed();
+            var seed = CreateBattleSeed(player.LastCreditedBattleSeed);
 
             var enemy = _battleFactory.CreateBattleEnemy(
                 zone,
@@ -233,7 +233,7 @@ namespace Game.Application.Services
             // only battle duration per kill instead of duration + cooldown (#1920).
             var utcNow = DateTime.UtcNow;
             var battleStartTime = state.IsOnCooldown(utcNow) ? state.EnemyCooldown : utcNow;
-            var seed = CreateBattleSeed();
+            var seed = CreateBattleSeed(player.LastCreditedBattleSeed);
 
             var enemy = _battleFactory.CreateBossEnemy(zone, _zoneResolution.BossEnemyResolver(zone));
 
@@ -653,8 +653,27 @@ namespace Game.Application.Services
         // (DateTime.Ticks) is monotonic and low-entropy in its low 32 bits — correlated and predictable between
         // battles — which makes it unsuitable as the shared starting point for the parity-identical crit/dodge
         // RNG (#178). The seed is server-generated and transmitted to the client as-is, so changing the source
-        // does not affect how it is consumed. Shared by both start paths.
-        internal static uint CreateBattleSeed() => BitConverter.ToUInt32(RandomNumberGenerator.GetBytes(sizeof(uint)));
+        // does not affect how it is consumed. Shared by both start paths (and the offline simulator's
+        // SeedSource, threaded from OfflineProgressService).
+        //
+        // exclude redraws away from the player's own LastCreditedBattleSeed (#2112): BattleAlreadyCredited
+        // matches on seed alone, so a freshly drawn seed that happens to equal the last-credited one would make
+        // this brand-new battle indistinguishable from a stale re-presentation of the already-credited one and
+        // wrongly reject its eventual claim. null for a caller with no player context (none today).
+        internal static uint CreateBattleSeed(uint? exclude = null) =>
+            DrawSeed(() => BitConverter.ToUInt32(RandomNumberGenerator.GetBytes(sizeof(uint))), exclude);
+
+        // Extracted so the redraw-on-collision loop can be pinned by a unit test with a stubbed draw — the
+        // real 2^-32 collision this guards against cannot be triggered through the actual CSPRNG.
+        internal static uint DrawSeed(Func<uint> draw, uint? exclude)
+        {
+            uint seed;
+            do
+            {
+                seed = draw();
+            } while (seed == exclude);
+            return seed;
+        }
 
         /// <summary>
         /// Rates the player's current live capability (<see cref="CombatRating.Rate"/>, spike #1526 Decision 7)

--- a/Game.Application/Services/OfflineProgressService.cs
+++ b/Game.Application/Services/OfflineProgressService.cs
@@ -259,7 +259,12 @@ namespace Game.Application.Services
                 PathsForActivityKey = _proficiencies.PathsForActivityKey,
                 DependentsOf = _proficiencies.DependentsOf,
                 ResolveClass = ResolveClass,
-                SeedSource = BattleService.CreateBattleSeed,
+                // Excludes the player's own LastCreditedBattleSeed (#2112), same as the live start paths: this
+                // value never changes across the offline pass (mid-window credits land on the PlayerProgress
+                // aggregate, not Player), so excluding it once per draw is sufficient — a collision with any
+                // other in-window battle's seed is harmless since only a seed matching the persisted credited
+                // value could ever be misread as already-credited by a later live claim.
+                SeedSource = () => BattleService.CreateBattleSeed(player.LastCreditedBattleSeed),
                 StalemateCutoffBattles = StalemateCutoffBattles,
             };
         }


### PR DESCRIPTION
## Summary

`BattleAlreadyCredited` (`Game.Application/Services/BattleService.cs`) matches an in-progress battle against the idempotency backstop purely by `state.BattleSeed == player.LastCreditedBattleSeed`. `CreateBattleSeed` drew a fresh cryptographic `uint` with no exclusion, so a 2⁻³² chance the newly-drawn seed for a player's *next* battle collided with their own `LastCreditedBattleSeed` would make `EndBattleVictory`/`EndBattleLoss`/the abandon path treat that brand-new, legitimately-fought battle as a stale re-presentation of the already-credited one and wrongly reject/void its claim.

Closes #2112.

## Approach

Of the issue's two suggested directions, this implements the seed-generation fix (re-roll on collision) rather than widening `BattleAlreadyCredited` to also compare enemy id — the enemy-id approach would need a new persisted `LastCreditedEnemyId`-shaped field (migration, entity, domain event, cache mapper — the same plumbing `LastCreditedBattleSeed` itself needed in #1874), whereas redrawing at the point of generation closes the root cause with no new schema.

- `BattleService.CreateBattleSeed` now takes an optional `exclude` parameter and redraws until the result differs from it, via an extracted `DrawSeed(Func<uint> draw, uint? exclude)` helper — pulled out so the redraw loop can be pinned by a unit test with a stubbed generator (the real 2⁻³² collision can't be triggered through the actual CSPRNG).
- `StartBattle` and `StartBossBattle` now call `CreateBattleSeed(player.LastCreditedBattleSeed)`.
- `OfflineProgressService`'s `SeedSource` delegate (handed to the pure-domain `OfflineProgressSimulator`) now closes over `player.LastCreditedBattleSeed` too. That value is stable for the whole offline pass — mid-window credits land on the `PlayerProgress` aggregate, not `Player` — so excluding it once per draw is sufficient; a collision between two in-window battle seeds is harmless since only a seed matching the *persisted* credited value could ever be misread as already-credited by a later live claim.

## Test plan

- [x] `CreateBattleSeed_NeverEqualsProvidedExclude` — statistical pin on the public entry point (1000 draws against a fixed exclude).
- [x] `DrawSeed_RedrawsUntilPastTheExcludedValue` / `DrawSeed_NullExclude_ReturnsFirstDrawUnconditionally` — deterministic pins on the redraw loop via a stubbed draw source.
- [x] `dotnet build Game.sln` — 0 warnings, 0 errors.
- [x] `dotnet test Game.sln` — full suite green (Game.Core.Tests 1396, Game.Infrastructure.Tests 68, Game.Application.Tests 1015, Game.Api.Tests 831 — 3310 total, 0 failures).

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZUHC45MsX9awHa2j9DZau)_