### PR TITLE
Hoist EnforceCodeStyleInBuild solution-wide

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <!-- Overflow checking only in Debug: it's a dev/test-time bug detector (e.g. Game.Core's battle/XP math),

--- a/Game.DataAccess/Game.DataAccess.csproj
+++ b/Game.DataAccess/Game.DataAccess.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
-  </PropertyGroup>
-
   <ItemGroup>
     <InternalsVisibleTo Include="Game.Application.Tests" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

`Game.DataAccess.csproj` was the only project with `EnforceCodeStyleInBuild` set (a stranding flagged by #2054/PR #2117). This decides between hoisting it solution-wide, dropping it, or leaving it project-scoped with a documenting comment.

## Investigation

Followed the issue's suggested approach: temporarily enabled `EnforceCodeStyleInBuild` in `Directory.Build.props` and ran a clean, `--no-incremental` build of the whole solution in both Debug and Release.

- **Result: 0 style violations** across all 12 projects in both configurations.
- Confirmed the analyzer is actually wired up (not silently skipped) by temporarily injecting a braces violation into `Game.Core` and rebuilding — it correctly surfaced as `warning IDE0011`.

Zero violations is well below the "a handful, fix and hoist" threshold the issue describes, so this hoists it rather than dropping it or leaving it stranded.

## Changes

- `Directory.Build.props`: added `<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>` to the shared `PropertyGroup`.
- `Game.DataAccess/Game.DataAccess.csproj`: removed the now-redundant per-project setting.

## Test plan

- [x] `dotnet build Game.sln -c Debug --no-incremental` — 0 warnings, 0 errors (all 12 projects)
- [x] `dotnet build Game.sln -c Release --no-incremental` — 0 warnings, 0 errors (all 12 projects)
- [x] Confirmed the analyzer actually fires (temporary injected violation surfaced as `IDE0011`)
- [x] Full backend test suite: `Game.Core.Tests` (1396), `Game.Infrastructure.Tests` (68), `Game.Application.Tests` (1015), `Game.Api.Tests` (831) — all passing, no regressions

Closes #2118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01888Uj8oWwYREKh8WrhudTe

---
_Generated by [Claude Code](https://claude.ai/code/session_01888Uj8oWwYREKh8WrhudTe)_