### PR TITLE
Unify Workbench and progression list-row primitives

### DIFF
--- a/UI/src/routes/admin/workbench/components/ListRow.svelte
+++ b/UI/src/routes/admin/workbench/components/ListRow.svelte
@@ -1,0 +1,154 @@
+<button
+	type="button"
+	class="list-row"
+	data-testid={testId}
+	class:selected
+	class:deleted={status === 'deleted'}
+	class:retired
+	onclick={onSelect}
+>
+	<div
+		class="row-edge"
+		class:added={status === 'added'}
+		class:modified={status === 'modified'}
+		class:removed={status === 'deleted'}
+	></div>
+	{#if leading}{@render leading()}{/if}
+	<div class="row-body">
+		<div class="row-top">
+			<span class="row-name" class:blank={!name}>{name || blank}</span>
+			{#if badge}
+				<span class="rare-tag" style:color={badgeColor ?? 'var(--text-secondary)'}>{badge}</span>
+			{/if}
+			{#if status === 'added'}<span class="spill added">new</span>{/if}
+			{#if status === 'modified'}<span class="spill modified">edited</span>{/if}
+			{#if retired}<span class="spill retired">retired</span>{/if}
+			<div class="spacer"></div>
+			{#if status !== 'deleted' && warnings.length > 0}
+				<WarnTriangle title={warnings.join(' · ')} />
+			{/if}
+		</div>
+		<span class="meta">{@render meta()}</span>
+	</div>
+</button>
+
+<script lang="ts">
+import type { Snippet } from 'svelte';
+import WarnTriangle from './WarnTriangle.svelte';
+
+/** A record's change status, driving the edge accent and the added/modified spill badge. */
+export type ListRowStatus = 'clean' | 'added' | 'modified' | 'deleted';
+
+interface Props {
+	/** `data-testid` on the row button — each tool picks its own (e.g. `workbench-row`). */
+	testId?: string;
+	selected: boolean;
+	status: ListRowStatus;
+	retired?: boolean;
+	name: string;
+	blank: string;
+	badge?: string | null;
+	badgeColor?: string;
+	warnings?: string[];
+	onSelect: () => void;
+	/** Leading content ahead of the row body — e.g. progression's tier ordinal circle. */
+	leading?: Snippet;
+	meta: Snippet;
+}
+
+const {
+	testId,
+	selected,
+	status,
+	retired = false,
+	name,
+	blank,
+	badge,
+	badgeColor,
+	warnings = [],
+	onSelect,
+	leading,
+	meta
+}: Props = $props();
+</script>
+
+<style lang="scss">
+.list-row {
+	width: 100%;
+	text-align: left;
+	background: transparent;
+	border: none;
+	border-bottom: 1px solid var(--border-subtle);
+	padding: 10px 14px 10px 0;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+
+	&:hover {
+		background: color-mix(in srgb, var(--white) 3%, transparent);
+	}
+	&.selected {
+		background: color-mix(in srgb, var(--accent) 8%, transparent);
+	}
+	&.deleted {
+		opacity: 0.45;
+	}
+	// Retired records stay in the catalogue (still resolvable by id), just dimmed — distinct
+	// from the stronger fade + strikethrough of a pending hard-delete.
+	&.retired:not(.deleted) {
+		opacity: 0.6;
+	}
+	// Cascade the row's own change-state onto the name text rather than threading a second
+	// selected/struck prop down to every caller.
+	&.selected .row-name {
+		color: var(--text-primary);
+		font-weight: 500;
+	}
+	&.deleted .row-name {
+		text-decoration: line-through;
+	}
+}
+.row-edge {
+	width: 3px;
+	height: 34px;
+	flex-shrink: 0;
+	border-radius: 2px;
+	background: transparent;
+
+	&.added {
+		background: var(--change-added);
+		box-shadow: 0 0 7px var(--change-added);
+	}
+	&.modified {
+		background: var(--change-modified);
+		box-shadow: 0 0 7px var(--change-modified);
+	}
+	&.removed {
+		background: var(--change-removed);
+		box-shadow: 0 0 7px var(--change-removed);
+	}
+}
+.row-body {
+	flex: 1;
+	min-width: 0;
+}
+.row-top {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 4px;
+}
+.row-name {
+	font-size: 13.5px;
+	color: var(--text-secondary);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+
+	&.blank {
+		color: var(--text-muted);
+		font-style: italic;
+	}
+}
+</style>

--- a/UI/src/routes/admin/workbench/components/WorkbenchList.svelte
+++ b/UI/src/routes/admin/workbench/components/WorkbenchList.svelte
@@ -22,60 +22,27 @@
 	<div class="list-scroll">
 		{#each filtered as record (record.id)}
 			{@const state = store.stateOf(record)}
-			{@const status = state.status}
-			{@const warns = state.warnings}
-			{@const title = displayName(record)}
-			{@const badge = entity.listBadge?.(record)}
-			{@const edge =
-				status === 'added'
-					? 'var(--change-added)'
-					: status === 'modified'
-						? 'var(--change-modified)'
-						: status === 'deleted'
-							? 'var(--change-removed)'
-							: 'transparent'}
 			{@const retired = (entity.retireable ?? false) && store.isRetired(record)}
-			<button
-				type="button"
-				class="list-row"
-				data-testid="workbench-row"
-				class:selected={record.id === selectedId}
-				class:deleted={status === 'deleted'}
-				class:retired
-				onclick={() => onSelect(record.id)}
+			<ListRow
+				testId="workbench-row"
+				selected={record.id === selectedId}
+				status={state.status}
+				{retired}
+				name={displayName(record)}
+				blank={entity.blankName}
+				badge={entity.listBadge?.(record)}
+				badgeColor={entity.badgeColor?.(record)}
+				warnings={state.warnings}
+				onSelect={() => onSelect(record.id)}
 			>
-				<div
-					class="row-edge"
-					style:width="3px"
-					style:height="34px"
-					style:background={edge}
-					style:box-shadow={edge === 'transparent' ? 'none' : `0 0 7px ${edge}`}
-				></div>
-				<div class="row-body">
-					<div class="row-top">
-						<span class="row-name" class:selected={record.id === selectedId} class:struck={status === 'deleted'}>
-							{#if title}{title}{:else}<span class="blank">{entity.blankName}</span>{/if}
-						</span>
-						{#if badge}
-							<span class="rare-tag" style:color={entity.badgeColor?.(record) ?? 'var(--text-secondary)'}>{badge}</span>
-						{/if}
-						{#if status === 'added'}<span class="spill added">new</span>{/if}
-						{#if status === 'modified'}<span class="spill modified">edited</span>{/if}
-						{#if retired}<span class="spill retired">retired</span>{/if}
-						<div class="spacer"></div>
-						{#if status !== 'deleted' && warns.length > 0}
-							<WarnTriangle title={warns.join(' · ')} />
-						{/if}
-					</div>
-					<span class="meta">
-						{#each entity.meta(record) as [label, value] (label)}
-							<span
-								>{#if label}<b>{value}</b> {label}{:else}<b class="bare">{value}</b>{/if}</span
-							>
-						{/each}
-					</span>
-				</div>
-			</button>
+				{#snippet meta()}
+					{#each entity.meta(record) as [label, value] (label)}
+						<span
+							>{#if label}<b>{value}</b> {label}{:else}<b class="bare">{value}</b>{/if}</span
+						>
+					{/each}
+				{/snippet}
+			</ListRow>
 		{/each}
 	</div>
 </div>
@@ -84,7 +51,7 @@
 import type { EntityConfig, Identified } from '../entities/types';
 import type { EntityStore } from '../entity-store.svelte';
 import WorkbenchIcon from '../WorkbenchIcon.svelte';
-import WarnTriangle from './WarnTriangle.svelte';
+import ListRow from './ListRow.svelte';
 
 interface Props {
 	entity: EntityConfig<Identified>;
@@ -116,63 +83,9 @@ const liveCount = $derived(store.items.filter((it) => store.stateOf(it).status !
 		font-weight: 500;
 	}
 }
-.list-row {
-	width: 100%;
-	text-align: left;
-	background: transparent;
-	border: none;
-	border-bottom: 1px solid var(--border-subtle);
-	padding: 10px 14px 10px 0;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	gap: 10px;
-
-	&:hover {
-		background: color-mix(in srgb, var(--white) 2%, transparent);
-	}
-	&.selected {
-		background: color-mix(in srgb, var(--accent) 8%, transparent);
-	}
-	&.deleted {
-		opacity: 0.45;
-	}
-	// Retired records stay in the catalogue (still resolvable by id), just dimmed — distinct
-	// from the stronger fade + strikethrough of a pending hard-delete.
-	&.retired:not(.deleted) {
-		opacity: 0.6;
-	}
-}
-.row-body {
-	flex: 1;
-	min-width: 0;
-}
-.row-top {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	margin-bottom: 4px;
-}
-.row-name {
-	font-size: 13.5px;
-	color: var(--text-secondary);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-
-	&.selected {
-		color: var(--text-primary);
-		font-weight: 500;
-	}
-	&.struck {
-		text-decoration: line-through;
-	}
-	.blank {
-		color: var(--text-muted);
-		font-style: italic;
-	}
-}
-.meta .bare {
+// `.meta`'s wrapper is rendered by ListRow, so scope directly off `.bare` rather than an
+// ancestor combinator that Svelte's per-component CSS scoping can't see across.
+.bare {
 	color: var(--text-tertiary);
 }
 </style>

--- a/UI/src/routes/admin/workbench/components/WorkbenchList.svelte
+++ b/UI/src/routes/admin/workbench/components/WorkbenchList.svelte
@@ -83,9 +83,4 @@ const liveCount = $derived(store.items.filter((it) => store.stateOf(it).status !
 		font-weight: 500;
 	}
 }
-// `.meta`'s wrapper is rendered by ListRow, so scope directly off `.bare` rather than an
-// ancestor combinator that Svelte's per-component CSS scoping can't see across.
-.bare {
-	color: var(--text-tertiary);
-}
 </style>

--- a/UI/src/routes/admin/workbench/progression/ProgressionList.svelte
+++ b/UI/src/routes/admin/workbench/progression/ProgressionList.svelte
@@ -23,31 +23,25 @@
 
 	<div class="list-scroll">
 		{#each rows as row (row.id)}
-			<button
-				type="button"
-				class="row"
-				class:selected={row.id === selectedId}
-				onclick={() => (drilled ? store.drillTier(row.id) : store.selectPath(row.id))}
+			<ListRow
+				testId="progression-row"
+				selected={row.id === selectedId}
+				status={row.status}
+				retired={row.retired}
+				name={row.name}
+				blank={row.blank}
+				warnings={row.warnings}
+				onSelect={() => (drilled ? store.drillTier(row.id) : store.selectPath(row.id))}
 			>
-				<span class="edge" class:added={row.status === 'added'} class:modified={row.status === 'modified'}></span>
-				{#if drilled}
-					<span class="ord" class:sel={row.id === selectedId}>{row.ordinal}</span>
-				{/if}
-				<span class="row-main">
-					<span class="row-name-line">
-						<span class="row-name" class:blank={!row.name}>{row.name || row.blank}</span>
-						{#if row.status === 'added'}<span class="spill added">new</span>{/if}
-						{#if row.status === 'modified'}<span class="spill modified">edited</span>{/if}
-						{#if row.retired}<span class="spill retired">retired</span>{/if}
-						{#if row.warn}<span class="spacer"></span><WorkbenchIcon
-								kind="warn"
-								size={11}
-								stroke="var(--warning)"
-							/>{/if}
-					</span>
-					<span class="row-meta">{row.meta}</span>
-				</span>
-			</button>
+				{#snippet leading()}
+					{#if drilled}
+						<span class="ord" class:sel={row.id === selectedId}>{row.ordinal}</span>
+					{/if}
+				{/snippet}
+				{#snippet meta()}
+					{row.meta}
+				{/snippet}
+			</ListRow>
 		{/each}
 		{#if rows.length === 0}
 			<div class="list-empty">{query ? 'No matches' : drilled ? 'No tiers yet' : 'No paths yet'}</div>
@@ -60,6 +54,7 @@ import WorkbenchIcon from '../WorkbenchIcon.svelte';
 import { activityKeyLabel } from '$lib/common';
 import type { ProgressionStore } from './progression-store.svelte';
 import { hasTierCollision, pathWarnings, proficiencyWarnings, tiersOfPath } from './progression-helpers';
+import ListRow, { type ListRowStatus } from '../components/ListRow.svelte';
 
 interface Props {
 	store: ProgressionStore;
@@ -77,9 +72,9 @@ interface Row {
 	name: string;
 	blank: string;
 	meta: string;
-	status: 'added' | 'modified' | 'clean';
+	status: ListRowStatus;
 	retired: boolean;
-	warn: boolean;
+	warnings: string[];
 	ordinal: number;
 }
 
@@ -96,7 +91,7 @@ const rows = $derived.by<Row[]>(() => {
 				meta: `cap ${t.maxLevel} · ${t.levelRewards.length} ${t.levelRewards.length === 1 ? 'milestone' : 'milestones'}`,
 				status: store.profStatus(t),
 				retired: store.isRetired(t),
-				warn: proficiencyWarnings(t).length > 0,
+				warnings: proficiencyWarnings(t),
 				ordinal: t.pathOrdinal
 			}));
 	}
@@ -104,6 +99,7 @@ const rows = $derived.by<Row[]>(() => {
 		.filter((p) => matches(p.name))
 		.map((p) => {
 			const tiers = tiersOfPath(store.profs, p.id);
+			const warnings = pathWarnings(p);
 			return {
 				id: p.id,
 				name: p.name,
@@ -111,7 +107,7 @@ const rows = $derived.by<Row[]>(() => {
 				meta: `${tiers.length} ${tiers.length === 1 ? 'tier' : 'tiers'} · ${activityKeyLabel(p.activityKey)}`,
 				status: store.pathStatus(p),
 				retired: store.isRetired(p),
-				warn: pathWarnings(p).length > 0 || hasTierCollision(tiers),
+				warnings: hasTierCollision(tiers) ? [...warnings, 'Tiers have colliding order'] : warnings,
 				ordinal: 0
 			};
 		});
@@ -164,40 +160,6 @@ const rows = $derived.by<Row[]>(() => {
 	border-radius: 3px;
 	cursor: pointer;
 }
-.row {
-	width: 100%;
-	text-align: left;
-	background: transparent;
-	border: none;
-	border-bottom: 1px solid var(--border-subtle);
-	padding: 10px 14px 10px 0;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	gap: 10px;
-
-	&:hover {
-		background: color-mix(in srgb, var(--white) 4%, transparent);
-	}
-	&.selected {
-		background: color-mix(in srgb, var(--accent) 8%, transparent);
-	}
-}
-.edge {
-	width: 3px;
-	height: 34px;
-	flex-shrink: 0;
-	background: transparent;
-
-	&.added {
-		background: var(--change-added);
-		box-shadow: 0 0 7px var(--change-added);
-	}
-	&.modified {
-		background: var(--change-modified);
-		box-shadow: 0 0 7px var(--change-modified);
-	}
-}
 .ord {
 	width: 24px;
 	height: 24px;
@@ -217,38 +179,6 @@ const rows = $derived.by<Row[]>(() => {
 		border-color: var(--accent);
 		color: var(--accent-light);
 	}
-}
-.row-main {
-	flex: 1;
-	min-width: 0;
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-}
-.row-name-line {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-}
-.row-name {
-	font-size: 13.5px;
-	color: var(--text-secondary);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-
-	&.blank {
-		color: var(--text-muted);
-	}
-}
-.row.selected .row-name {
-	color: var(--text-primary);
-	font-weight: 500;
-}
-.row-meta {
-	font-family: var(--mono);
-	font-size: 11px;
-	color: var(--text-tertiary);
 }
 .list-empty {
 	padding: 24px 16px;

--- a/UI/src/routes/admin/workbench/workbench.scss
+++ b/UI/src/routes/admin/workbench/workbench.scss
@@ -395,6 +395,11 @@
 			color: var(--text-secondary);
 			font-weight: 500;
 		}
+		// A label-less meta value (WorkbenchList's `[label, value]` pairs with an empty label)
+		// stays muted rather than picking up the labelled-value emphasis above.
+		.bare {
+			color: var(--text-tertiary);
+		}
 	}
 	.count-badge {
 		font-family: var(--mono);

--- a/UI/src/tests/routes/admin/workbench/components/ListRow.test.ts
+++ b/UI/src/tests/routes/admin/workbench/components/ListRow.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+
+import ListRow from '$routes/admin/workbench/components/ListRow.svelte';
+
+const meta = createRawSnippet(() => ({ render: () => '<span>meta</span>' }));
+
+const baseProps = {
+	testId: 'row',
+	selected: false,
+	status: 'clean' as const,
+	name: 'Fire',
+	blank: 'Unnamed',
+	onSelect: vi.fn(),
+	meta
+};
+
+afterEach(cleanup);
+
+describe('ListRow', () => {
+	it('shows the "new" spill and added edge accent for an added record', () => {
+		const { container } = render(ListRow, { props: { ...baseProps, status: 'added' } });
+		expect(screen.getByText('new')).toBeTruthy();
+		expect(container.querySelector('.row-edge')?.classList.contains('added')).toBe(true);
+	});
+
+	it('shows the "edited" spill and modified edge accent for a modified record', () => {
+		const { container } = render(ListRow, { props: { ...baseProps, status: 'modified' } });
+		expect(screen.getByText('edited')).toBeTruthy();
+		expect(container.querySelector('.row-edge')?.classList.contains('modified')).toBe(true);
+	});
+
+	it('dims and strikes a deleted record, with no spill or warnings shown', () => {
+		const { container } = render(ListRow, {
+			props: { ...baseProps, status: 'deleted', warnings: ['Missing name'] }
+		});
+		expect(container.querySelector('.list-row')?.classList.contains('deleted')).toBe(true);
+		expect(screen.queryByText('new')).toBeNull();
+		expect(screen.queryByText('edited')).toBeNull();
+		// A deleted record's warnings are moot — the row is going away — so the triangle stays hidden.
+		expect(container.querySelector('.warn-tri')).toBeNull();
+	});
+
+	it('renders a WarnTriangle with the joined warnings as its tooltip title for a non-deleted record', () => {
+		const { container } = render(ListRow, {
+			props: { ...baseProps, warnings: ['Missing name', 'Missing icon'] }
+		});
+		const warn = container.querySelector('.warn-tri');
+		expect(warn?.getAttribute('title')).toBe('Missing name · Missing icon');
+	});
+
+	it('shows the retired spill and dims the row when retired', () => {
+		const { container } = render(ListRow, { props: { ...baseProps, retired: true } });
+		expect(screen.getByText('retired')).toBeTruthy();
+		expect(container.querySelector('.list-row')?.classList.contains('retired')).toBe(true);
+	});
+
+	it('falls back to the blank placeholder when name is empty', () => {
+		const { container } = render(ListRow, { props: { ...baseProps, name: '' } });
+		const row = container.querySelector('.row-name');
+		expect(row?.textContent).toBe('Unnamed');
+		expect(row?.classList.contains('blank')).toBe(true);
+	});
+
+	it('renders leading content ahead of the row body when provided', () => {
+		const leading = createRawSnippet(() => ({ render: () => '<span data-testid="ordinal">0</span>' }));
+		const { getByTestId } = render(ListRow, { props: { ...baseProps, leading } });
+		expect(getByTestId('ordinal')).toBeTruthy();
+	});
+
+	it('renders the provided meta snippet', () => {
+		const { container } = render(ListRow, { props: baseProps });
+		expect(container.querySelector('.meta')?.textContent).toBe('meta');
+	});
+});


### PR DESCRIPTION
## Summary

Follow-up to #2060 (PR #2124), which deduplicated the Workbench/progression save bar, detail header, and list-pane skeleton/spill/search styling but deliberately left the two list-**row** primitives separate. This closes that gap: `WorkbenchList.svelte`'s `.list-row` and `ProgressionList.svelte`'s `.row` re-implemented the same button shell, edge-accent coloring, name/badge/spill layout, and meta line, 1:1.

Closes #2125

## Approach

Extracted a new shared `components/ListRow.svelte`:

- Owns the row shell (button, hover/selected states, dimmed deleted/retired opacity), the change-state edge accent (added/modified/deleted, driven by a single `status` prop instead of each caller computing its own inline style or CSS class), the name text (with a `blank`-placeholder modifier), the badge/spill/warning-triangle row, and the meta line.
- Exposes a `leading` snippet slot for content ahead of the row body — the one genuinely different affordance between the two tools: progression's tier-ordinal circle (and, transitively, the back-button/drill-down state that lives one level up in `ProgressionList` itself, untouched).
- `WorkbenchList` and `ProgressionList` now only supply their per-record data (name, status, warnings, badge, meta) and a `meta` snippet for their differently-shaped meta line (label/value pairs vs. a single formatted string).

One behavioral tightening while unifying: progression's list row previously showed a bare warning icon with no message on hover, while the Workbench row already used the tooltip-bearing `WarnTriangle` (`warns.join(' · ')`). Both now use `WarnTriangle` uniformly, and I added a `'Tiers have colliding order'` message to a path's computed warnings for the tier-collision case (`hasTierCollision`) that previously only flipped a boolean with no accompanying text — so the tooltip is now always meaningful, not just present.

This is presentation-only: no store/data-model changes, and the retained `data-testid="workbench-row"` (and every class the existing `WorkbenchList.test.ts` asserts on: `selected`, `retired`, `.spill.retired`, `.blank`) are unchanged.

## Test plan

- [x] `npx vitest run` — full UI suite: 303 files / 3798 tests passing, including `WorkbenchList.test.ts` (10/10) unmodified.
- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors/warnings.
- [x] `npm run build` (vite build) — production build succeeds, including the new component's SCSS.
- [x] Manual verification against a real backend: stood up the Postgres/Redis/API stack (`docker compose` + `dotnet run` + the e2e admin-role fixture) and ran the existing Playwright `admin.test.ts` suite (3/3 passing) plus ad-hoc screenshots of both the flat Workbench list (Enemies, with a `BOSS` badge) and the drilled progression tier list (ordinal circles, `new`/warning-triangle badges) to confirm the shared row renders correctly in both shapes.


---
_Generated by [Claude Code](https://claude.ai/code/session_011nLwN2tTeDD7be1EWBPxoM)_