### PR TITLE
Memoize idle-mode enemy combat rating in the offline loop

### DIFF
--- a/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
@@ -495,6 +495,57 @@ namespace Game.Core.Tests.Battle.Offline
             Assert.All(result.Battles, battle => Assert.Equal(0, battle.Result.Stats.PlayerRating));
         }
 
+        // ── Idle enemy rating memo (#2130) ───────────────────────────────────
+
+        [Fact]
+        public void Simulate_IdleMode_MemoizedEnemyRatingMatchesAFreshComputation_AcrossRepeatedEncounters()
+        {
+            // WeakEnemy's one-skill pool is well within GameConstants.MaxSelectedSkills, so
+            // Enemy.SelectBattleSkills always fields its whole (stationary) pool and RateIdleEnemy's memo
+            // applies. Pin that every victory against the same (id, level) still reports exactly the rating a
+            // fresh CombatRating.Rate computation would, whether served from the memo or not.
+            var scenario = StrongPlayerWinScenario();
+            var freshEnemy = WeakEnemy(level: 1);
+            var expectedRating = CombatRating.Rate(
+                new Battler(new AttributeCollection(freshEnemy.GetAttributeModifiers()), freshEnemy.AvailableSkills, freshEnemy.Level),
+                isPlayer: false);
+
+            var result = _simulator.Simulate(IdleParameters(ManyStepsBudget(), scenario));
+
+            var wins = result.Battles.Where(b => b.Result.Victory).ToList();
+            Assert.True(wins.Count > 1);
+            Assert.All(wins, battle => Assert.Equal(expectedRating, battle.EnemyRating, precision: 9));
+        }
+
+        [Fact]
+        public void Simulate_IdleMode_OversizedSkillPoolEnemy_PricesEachVictoryByItsOwnActuallySelectedLoadout()
+        {
+            // A pool larger than GameConstants.MaxSelectedSkills makes Enemy.SelectBattleSkills draw a
+            // genuinely random subset per encounter, so the enemy's rating is not pure in (id, level) alone —
+            // RateIdleEnemy must not memo-serve a stale rating from an earlier encounter's different draw.
+            // VariedSkillPoolEnemy's 8 skills carry distinct damage, so a different draw genuinely re-prices
+            // the enemy; pin that every victory's EnemyRating matches a fresh rating of that battle's own
+            // recorded loadout rather than the first one seen.
+            var scenario = new Scenario
+            {
+                Zone = MakeZone(levelMin: 1, levelMax: 1),
+                Snapshot = PlayerSnapshot(strength: 100, endurance: 100),
+                ResolveEnemy = VariedSkillPoolEnemy,
+            };
+
+            var result = _simulator.Simulate(IdleParameters(ManyStepsBudget(), scenario));
+
+            var wins = result.Battles.Where(b => b.Result.Victory).ToList();
+            Assert.True(wins.Count > 1);
+            var distinctRatings = wins.Select(b => b.EnemyRating).Distinct().Count();
+            Assert.True(distinctRatings > 1, "The random per-encounter loadout never varied the enemy rating — the fixture doesn't exercise the case.");
+            Assert.All(wins, battle =>
+            {
+                var expected = CombatRating.Rate(battle.Enemy.ToBattler(), isPlayer: false);
+                Assert.Equal(expected, battle.EnemyRating, precision: 9);
+            });
+        }
+
         // ── Cancellation ─────────────────────────────────────────────────────
 
         [Fact]
@@ -1239,6 +1290,27 @@ namespace Game.Core.Tests.Battle.Offline
 
         private static Enemy WeakEnemy(int level, int skillCount = 1) =>
             MakeEnemy(level, strength: 5, endurance: 5, skillCount: skillCount);
+
+        /// <summary>
+        /// An enemy whose 8-skill pool exceeds <see cref="GameConstants.MaxSelectedSkills"/>, each skill
+        /// carrying distinct damage — so <see cref="Enemy.SelectBattleSkills"/>'s random per-encounter subset
+        /// genuinely changes the fielded loadout's combat rating, not just its skill ids.
+        /// </summary>
+        private static Enemy VariedSkillPoolEnemy(int level) => new()
+        {
+            Id = EnemyId,
+            Name = "Varied Pool Enemy",
+            IsBoss = false,
+            Level = level,
+            AttributeDistributions =
+            [
+                new AttributeDistribution { AttributeId = Strength, BaseAmount = 5, AmountPerLevel = 0 },
+                new AttributeDistribution { AttributeId = Endurance, BaseAmount = 5, AmountPerLevel = 0 },
+            ],
+            AvailableSkills = Enumerable.Range(0, 8)
+                .Select(id => EnemyAttackSkill(id, baseDamage: 5 + id * 40, cooldownMs: 1500))
+                .ToList(),
+        };
 
         private static Enemy StrongEnemy(int level, int skillCount = 1) =>
             MakeEnemy(level, strength: 200, endurance: 200, skillCount: skillCount);

--- a/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
+++ b/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
@@ -80,6 +80,11 @@ namespace Game.Core.Battle.Offline
             // in Idle mode, where each battle's random encounter genuinely differs.
             double? bossEnemyRating = null;
 
+            // Idle mode's per-(template, level) rating memo (#2130): a zone's random encounters are drawn from
+            // a small, bounded-level spawn table, so the same enemy id/level pair recurs across many victories
+            // in one run. Populated and consulted by RateIdleEnemy below.
+            var idleEnemyRatingMemo = new Dictionary<(int Id, int Level), double>();
+
             // Tracks whether any battle has produced progress (a win or a loss). A run that is nothing but
             // draws is a stalemate the player can neither win nor lose; the cutoff below stops it early.
             var madeProgress = false;
@@ -112,9 +117,9 @@ namespace Game.Core.Battle.Offline
                 if (result.Victory)
                 {
                     // The enemy rating reuses the memoized boss rating in Boss mode (populating it on the first
-                    // victory) and is re-derived per victory in Idle mode, where each random encounter genuinely
-                    // differs. Kept as an explicit local — not folded into the DefeatRewards call — so the
-                    // bossEnemyRating cache write-back stays visible rather than buried in a ternary argument.
+                    // victory) and RateIdleEnemy's per-(id, level) memo in Idle mode (#2130). Kept as an
+                    // explicit local — not folded into the DefeatRewards call — so the bossEnemyRating cache
+                    // write-back stays visible rather than buried in a ternary argument.
                     double enemyRating;
                     if (parameters.Mode == OfflineLoopMode.Boss)
                     {
@@ -122,7 +127,7 @@ namespace Game.Core.Battle.Offline
                     }
                     else
                     {
-                        enemyRating = CombatRating.Rate(enemy.ToBattler(), isPlayer: false);
+                        enemyRating = RateIdleEnemy(enemy, idleEnemyRatingMemo);
                     }
 
                     rewards = new DefeatRewards(playerRating, enemyRating);
@@ -269,6 +274,37 @@ namespace Game.Core.Battle.Offline
                 _ => throw new ArgumentOutOfRangeException(
                     nameof(parameters), parameters.Mode, $"Unhandled offline loop mode {parameters.Mode}."),
             };
+        }
+
+        /// <summary>
+        /// Idle mode's per-victory enemy rating (#2130), memoized by (template id, level): a zone's random
+        /// encounters are drawn from a small, bounded-level spawn table, so the same pair recurs across many
+        /// victories in one run, and <see cref="CombatRating.Rate"/> is a pure function of the assembled
+        /// battler — which for a given template and level depends only on which skills got fielded.
+        /// <para>
+        /// That is safe to key on (id, level) alone only when <see cref="Enemy.AvailableSkills"/> fits within
+        /// <see cref="GameConstants.MaxSelectedSkills"/>: <see cref="Enemy.SelectBattleSkills"/> then always
+        /// fields the whole pool (shuffled, but <see cref="CombatRating.Rate"/> sums over skills order-
+        /// independently) and the rating is genuinely stationary. A larger pool draws a genuinely random
+        /// subset per encounter, so the rating is <b>not</b> pure in (id, level) alone — that case falls back
+        /// to a fresh computation every time, matching pre-#2130 behavior.
+        /// </para>
+        /// </summary>
+        private static double RateIdleEnemy(Enemy enemy, Dictionary<(int Id, int Level), double> ratingMemo)
+        {
+            if (enemy.AvailableSkills.Count > GameConstants.MaxSelectedSkills)
+            {
+                return CombatRating.Rate(enemy.ToBattler(), isPlayer: false);
+            }
+
+            var key = (enemy.Id, enemy.Level);
+            if (!ratingMemo.TryGetValue(key, out var rating))
+            {
+                rating = CombatRating.Rate(enemy.ToBattler(), isPlayer: false);
+                ratingMemo[key] = rating;
+            }
+
+            return rating;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

`OfflineProgressSimulator` calls `CombatRating.Rate(enemy.ToBattler(), …)` for every idle-mode victory, even though idle encounters are drawn from a small, bounded-level per-zone spawn table — so a 10-hour away window can recompute the same enemy's rating from scratch thousands of times, each materializing three full `AttributeCollection`s and walking the whole `EAttribute` enum.

`OfflineProgressSimulator.RateIdleEnemy` now memoizes the rating by `(enemy id, level)`, mirroring the existing `bossEnemyRating` memo Boss mode already had.

## Note on the issue's premise

The issue described the rating as "a pure function of (template, level)." That's not quite right in general: `Enemy.SelectBattleSkills` (used for every idle encounter) draws a genuinely random subset of up to `GameConstants.MaxSelectedSkills` (4) skills whenever an enemy's pool exceeds that cap — confirmed by the existing `EnemyTests`/`BattleFactoryTests` coverage, which explicitly exercise 6–8 skill pools. For such an enemy, two encounters can field different loadouts and therefore different ratings, so a naive `(id, level)`-only memo would silently misprice every encounter after the first with a stale value from an earlier random draw.

Today's authored content never hits this (`content/enemies.json`'s largest `skillPool` is 2), but nothing enforces that invariant, so I didn't want to bake in a fix that's only correct by coincidence of current content. `RateIdleEnemy` only memoizes when `Enemy.AvailableSkills.Count <= GameConstants.MaxSelectedSkills` — the case where `SelectBattleSkills` always fields the whole (stationary) pool, just shuffled, which doesn't affect `CombatRating.Rate`'s skill-order-independent sum. An oversized pool falls back to a fresh per-encounter computation, exactly matching pre-fix behavior.

## Scope note: the issue's second suggestion

The issue also suggested that since `CombatRating.Rate` doesn't mutate its battler, the rating battler and the simulation battler "need not be built separately." I looked into this and it's **not safe as stated**: `CombatRating.Rate` itself doesn't mutate, but `BattleSimulator.Simulate()` does — it applies/expires timed effects via `Battler.AddModifier`/`RemoveModifier`, which changes what `GetAttributeValue` (and therefore `Rate`) would report afterward. Reusing the *already-simulated* battler for a post-battle rating call would read post-fight transient state, not the enemy's assembled combat power. Merging the two builds safely would require computing the rating unconditionally *before* simulating (not just on a win), which is a real behavior change I didn't want to bundle into this fix — especially since the memo already eliminates the redundant computation this issue was primarily about. I left that as-is; happy to open a follow-up if it's worth pursuing separately, but I don't think it's worth much once the memo is in place.

## Test plan

- [x] Added `Simulate_IdleMode_MemoizedEnemyRatingMatchesAFreshComputation_AcrossRepeatedEncounters`: pins that a memoized rating still equals a fresh `CombatRating.Rate` computation for a stationary (small) skill pool.
- [x] Added `Simulate_IdleMode_OversizedSkillPoolEnemy_PricesEachVictoryByItsOwnActuallySelectedLoadout`: pins that an enemy with a pool larger than `MaxSelectedSkills` still gets a fresh, per-encounter-correct rating (verified this test actually catches the bug by temporarily removing the safety guard locally — it failed as expected, then passed again once restored).
- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] Full backend suite: `Game.Core.Tests` (1398), `Game.Infrastructure.Tests` (68), `Game.Application.Tests` (1026), `Game.Api.Tests` (831) — all passing, no regressions.

Closes #2130

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CrnZ7d1sAkVzGcrdSkYQh2)_