### PR TITLE
Centralize the 401 error envelope in the JWT bearer challenge; drop 7 dead per-action guards

### DIFF
--- a/Game.Api.Tests/Integration/AuthControllerTests.cs
+++ b/Game.Api.Tests/Integration/AuthControllerTests.cs
@@ -268,6 +268,10 @@ namespace Game.Api.Tests.Integration
             var response = await Client.GetAsync("/api/Auth/Status", CancellationToken);
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            // The bearer challenge writes the project's standard ApiResponse envelope rather than the
+            // JWT bearer handler's default empty body.
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result?.ErrorMessage);
         }
 
         [Fact]
@@ -299,6 +303,8 @@ namespace Game.Api.Tests.Integration
             var response = await Client.GetAsync("/api/Auth/ActiveSession", CancellationToken);
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result?.ErrorMessage);
         }
 
         [Fact]

--- a/Game.Api.Tests/Integration/PlayersControllerTests.cs
+++ b/Game.Api.Tests/Integration/PlayersControllerTests.cs
@@ -197,6 +197,10 @@ namespace Game.Api.Tests.Integration
                 new { PlayerId = 1, RefreshToken = "irrelevant" }, CancellationToken);
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            // The bearer challenge writes the project's standard ApiResponse envelope rather than the
+            // JWT bearer handler's default empty body.
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result?.ErrorMessage);
         }
 
         [Fact]
@@ -206,6 +210,8 @@ namespace Game.Api.Tests.Integration
                 new { PlayerId = 1, RefreshToken = "irrelevant" }, CancellationToken);
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result?.ErrorMessage);
         }
 
         [Fact]
@@ -506,6 +512,8 @@ namespace Game.Api.Tests.Integration
         {
             var response = await Client.GetAsync("/api/Players", CancellationToken);
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result?.ErrorMessage);
         }
 
         // Switches the bound character through the real SwitchPlayer endpoint and returns the deserialized
@@ -592,6 +600,8 @@ namespace Game.Api.Tests.Integration
             var response = await Client.PostAsJsonAsync("/api/Players/CreatePlayer", new { Name = "Nobody" }, CancellationToken);
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result?.ErrorMessage);
         }
 
         [Fact]
@@ -713,6 +723,8 @@ namespace Game.Api.Tests.Integration
             // No bearer token — a pre-authentication request never reaches the creatable-class payload.
             var response = await Client.GetAsync("/api/Players/CharacterCreationData", CancellationToken);
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result?.ErrorMessage);
         }
     }
 }

--- a/Game.Api/Controllers/AuthController.cs
+++ b/Game.Api/Controllers/AuthController.cs
@@ -111,11 +111,6 @@ namespace Game.Api.Controllers
         [HttpGet]
         public async Task<ApiResponse<PlayerData>> Status()
         {
-            if (!_sessionService.Authenticated)
-            {
-                return ApiResponse.Error("Not logged in", ApiErrorCategory.Unauthorized);
-            }
-
             // Load (or rehydrate) the session so the selected player id resolves; the HTTP pipeline no
             // longer reads the session cache per request.
             await _sessionInitializer.EnsureSessionLoaded(HttpContext.RequestAborted);
@@ -139,11 +134,6 @@ namespace Game.Api.Controllers
         [HttpGet]
         public async Task<ApiResponse<ActiveSessionResult>> ActiveSession()
         {
-            if (!_sessionService.Authenticated)
-            {
-                return ApiResponse.Error("Not logged in", ApiErrorCategory.Unauthorized);
-            }
-
             // Load (or rehydrate) the session so the selected player id resolves for the presence check;
             // the HTTP pipeline no longer reads the session cache per request.
             await _sessionInitializer.EnsureSessionLoaded(HttpContext.RequestAborted);

--- a/Game.Api/Controllers/PlayersController.cs
+++ b/Game.Api/Controllers/PlayersController.cs
@@ -34,11 +34,6 @@ namespace Game.Api.Controllers
         [HttpPost]
         public async Task<ApiResponse<SelectPlayerResult>> SelectPlayer([FromBody] SelectPlayerRequest request)
         {
-            if (!_sessionService.Authenticated)
-            {
-                return ApiResponse.Error("Not logged in", ApiErrorCategory.Unauthorized);
-            }
-
             var outcome = await _characterSelectionService.SelectPlayer(
                 _sessionService.UserId, request.PlayerId, request.RefreshToken, HttpContext.RequestAborted);
             if (!outcome.Success)
@@ -57,11 +52,6 @@ namespace Game.Api.Controllers
         [HttpPost]
         public async Task<ApiResponse<SelectPlayerResult>> SwitchPlayer([FromBody] SelectPlayerRequest request)
         {
-            if (!_sessionService.Authenticated)
-            {
-                return ApiResponse.Error("Not logged in", ApiErrorCategory.Unauthorized);
-            }
-
             var outcome = await _characterSelectionService.SwitchPlayer(
                 _sessionService.UserId, request.PlayerId, request.RefreshToken, HttpContext.RequestAborted);
             if (!outcome.Success)
@@ -81,11 +71,6 @@ namespace Game.Api.Controllers
         [HttpPost]
         public async Task<ApiResponse<PlayerSummary>> CreatePlayer([FromBody] CreatePlayerRequest request)
         {
-            if (!_sessionService.Authenticated)
-            {
-                return ApiResponse.Error("Not logged in", ApiErrorCategory.Unauthorized);
-            }
-
             var result = await _accountService.CreatePlayer(_sessionService.UserId, request.Name, request.ClassId, HttpContext.RequestAborted);
             if (!result.Success)
             {
@@ -104,11 +89,6 @@ namespace Game.Api.Controllers
         [HttpGet("/api/[controller]")]
         public async Task<ApiEnumerableResponse<PlayerSummary>> Players()
         {
-            if (!_sessionService.Authenticated)
-            {
-                return ApiResponse.Error("Not logged in", ApiErrorCategory.Unauthorized);
-            }
-
             var players = await _accountService.GetPlayers(_sessionService.UserId, HttpContext.RequestAborted);
             return ApiResponse.Success(players);
         }
@@ -123,11 +103,6 @@ namespace Game.Api.Controllers
         [HttpGet]
         public ApiEnumerableResponse<CreatableClass> CharacterCreationData()
         {
-            if (!_sessionService.Authenticated)
-            {
-                return ApiResponse.Error("Not logged in", ApiErrorCategory.Unauthorized);
-            }
-
             return ApiResponse.Success(_accountService.GetCreatableClasses());
         }
 

--- a/Game.Api/Startup.cs
+++ b/Game.Api/Startup.cs
@@ -8,6 +8,7 @@ using Game.Api.Events;
 using Game.Api.Filters;
 using Game.Api.Forwarding;
 using Game.Api.Middleware;
+using Game.Api.Models.Common;
 using Game.Api.RateLimiting;
 using Game.Api.Services;
 using Game.Api.Services.Admin;
@@ -353,6 +354,17 @@ namespace Game.Api
                             }
 
                             return Task.CompletedTask;
+                        },
+                        // A missing/invalid/expired token otherwise gets the bearer handler's default empty-body
+                        // 401, unlike every other failure response's { errorMessage } ApiResponse envelope
+                        // (mirrors the auth rate limiter's OnRejected, which fixes the same gap for 429s).
+                        OnChallenge = async context =>
+                        {
+                            context.HandleResponse();
+                            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                            await context.Response.WriteAsJsonAsync(
+                                ApiResponse.Error("Not logged in", ApiErrorCategory.Unauthorized),
+                                context.HttpContext.RequestAborted);
                         }
                     };
                 });


### PR DESCRIPTION
## Summary

Closes #2131.

- The global fallback authorization policy (`RequireAuthenticatedUser`, `Startup.cs`) already rejects any unauthenticated request to a non-`[AllowAnonymous]` endpoint at the authorization middleware, before the action runs. Past that point, `SessionService.Authenticated` can only be false if the validated token lacks an integer `sub` claim — which `JwtTokenService.CreateAccessToken` always sets. So the seven per-action `if (!_sessionService.Authenticated)` guards in `AuthController` (`Status`, `ActiveSession`) and `PlayersController` (`SelectPlayer`, `SwitchPlayer`, `CreatePlayer`, `Players`, `CharacterCreationData`) were dead code — removed.
- The real behavioral gap those guards were papering over: a genuinely unauthenticated caller received the JWT bearer handler's default **empty-body 401** instead of the project's consistent `{ errorMessage }` `ApiResponse` envelope every other failure response uses. Fixed by writing the envelope from the bearer's `OnChallenge` event in `Startup.cs`, mirroring the existing pattern in the auth rate limiter's `OnRejected` handler (which does the same for 429s).
- This doesn't touch the `/socket` endpoint's 401 handling, which already writes the envelope via a separate `SocketInterceptorMiddleware` that runs before the authorization middleware, nor 403 (`AdminRoleAuthorizationFilter`), which was already unaffected by this gap.

## Test plan

- [x] `dotnet build Game.sln` — succeeds with 0 warnings/errors.
- [x] Updated the six existing `*_Unauthenticated_Returns401` / `*_WithoutAuthentication_IsRejected` integration tests (`AuthControllerTests`, `PlayersControllerTests`) to also assert the response body now carries a populated `ErrorMessage`, proving the envelope is written.
- [x] Full backend suite: `dotnet test Game.sln --no-build --no-restore` — 3329 tests, 0 failures (`Game.Core.Tests`, `Game.Infrastructure.Tests`, `Game.Application.Tests`, `Game.Api.Tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Da4f1uCbutT6Y4sqwmqMgd)_