### PR TITLE
Distinguish pre-selection Status/ActiveSession state from a real 404 (#2132)

### DIFF
--- a/Game.Api.Tests/Integration/AuthControllerTests.cs
+++ b/Game.Api.Tests/Integration/AuthControllerTests.cs
@@ -275,18 +275,39 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
-        public async Task Status_AuthenticatedButPlayerNotLoadable_Returns404WithError()
+        public async Task Status_PreSelectionToken_ReturnsNoPlayerSelectedNotOpaque404()
         {
-            // A still-valid token whose player can't be loaded (archived/deleted between requests; here a user
-            // with no player at all) must return a structured error, not a 500 — mirroring how Login surfaces a
-            // missing player. Rehydration finds no player, so the session's selected id stays unresolved and the
-            // player load comes back null. The missing-resource semantics surface as 404, not a blanket 400.
+            // A pre-selection token (post-Login, pre-SelectPlayer) is a normal, documented flow state
+            // (docs/backend-auth.md) — every character-select screen refresh carries one. Status must
+            // surface it as its own distinguishable category, not the same 404 a genuinely unloadable
+            // player gets (see the test below).
             using var scope = CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
             var user = await TestDataSeeder.CreateUserAsync(context, "playerlessstatus", "pass");
 
             var client = Factory.CreateClient();
             TestAuthHelper.AddAuthHeader(client, user.Id);
+
+            var response = await client.GetAsync("/api/Auth/Status", CancellationToken);
+
+            Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse<Models.Player.PlayerData>>(CancellationToken);
+            Assert.Null(result?.Data);
+            Assert.NotNull(result?.ErrorMessage);
+            client.Dispose();
+        }
+
+        [Fact]
+        public async Task Status_PostSelectionTokenButPlayerGone_Returns404WithError()
+        {
+            // A post-selection token naming a player that can't be loaded (archived/deleted between
+            // requests) is a genuine missing-resource failure, distinct from the pre-selection state
+            // above — it must still surface as 404, not a 500. A token minted for a player id that was
+            // never persisted stands in for "since deleted" without tearing down FK-linked rows.
+            var (userId, _) = await SeedAsync("playergonestatus", "pass");
+
+            var client = Factory.CreateClient();
+            TestAuthHelper.AddAuthHeader(client, userId, playerId: 999_999_999);
 
             var response = await client.GetAsync("/api/Auth/Status", CancellationToken);
 

--- a/Game.Api.Tests/Unit/ErrorStatusFilterTests.cs
+++ b/Game.Api.Tests/Unit/ErrorStatusFilterTests.cs
@@ -58,6 +58,14 @@ namespace Game.Api.Tests.Unit
         }
 
         [Fact]
+        public void RewritesTo409_WhenErrorCategoryIsNoPlayerSelected()
+        {
+            var result = new ObjectResult(ApiResponse.Error("No character selected.", ApiErrorCategory.NoPlayerSelected));
+
+            Assert.Equal(StatusCodes.Status409Conflict, RunFilter(result));
+        }
+
+        [Fact]
         public void RewritesTo400_WhenErrorCategoryIsBadRequest()
         {
             var result = new ObjectResult(ApiResponse.Error("Invalid input", ApiErrorCategory.BadRequest));

--- a/Game.Api/Controllers/AuthController.cs
+++ b/Game.Api/Controllers/AuthController.cs
@@ -115,6 +115,14 @@ namespace Game.Api.Controllers
             // longer reads the session cache per request.
             await _sessionInitializer.EnsureSessionLoaded(HttpContext.RequestAborted);
 
+            // A pre-selection token (post-Login, pre-SelectPlayer) is a normal, expected flow state, not a
+            // missing-resource failure — distinguish it from a genuinely unloadable player so callers don't
+            // have to infer "no character chosen yet" from an opaque 404.
+            if (_sessionService.TokenSelectedPlayerId is null)
+            {
+                return ApiResponse.Error("No character selected.", ApiErrorCategory.NoPlayerSelected);
+            }
+
             // A still-valid token whose player can't be loaded (deleted/archived between requests) is a
             // graceful error, not a 500 — mirroring the structured ApiResponse.Error its sibling endpoints use.
             var player = await _playerService.LoadPlayer(_sessionService.SelectedPlayerId, HttpContext.RequestAborted);

--- a/Game.Api/Enums.cs
+++ b/Game.Api/Enums.cs
@@ -24,6 +24,10 @@
         /// <summary>The requested resource does not exist — maps to 404 Not Found.</summary>
         NotFound = 2,
         /// <summary>The caller is being throttled/backed off — maps to 429 Too Many Requests.</summary>
-        TooManyRequests = 3
+        TooManyRequests = 3,
+        /// <summary>The caller is authenticated but has not yet selected a character (a pre-selection
+        /// token, post-Login/pre-SelectPlayer) — maps to 409 Conflict. Distinct from
+        /// <see cref="NotFound"/> because it is an expected flow state, not a missing-resource failure.</summary>
+        NoPlayerSelected = 4
     }
 }

--- a/Game.Api/Filters/ErrorStatusFilter.cs
+++ b/Game.Api/Filters/ErrorStatusFilter.cs
@@ -37,6 +37,7 @@ namespace Game.Api.Filters
                 ApiErrorCategory.Unauthorized => StatusCodes.Status401Unauthorized,
                 ApiErrorCategory.NotFound => StatusCodes.Status404NotFound,
                 ApiErrorCategory.TooManyRequests => StatusCodes.Status429TooManyRequests,
+                ApiErrorCategory.NoPlayerSelected => StatusCodes.Status409Conflict,
                 _ => StatusCodes.Status400BadRequest,
             };
         }

--- a/Game.Api/Services/SessionInitializer.cs
+++ b/Game.Api/Services/SessionInitializer.cs
@@ -30,7 +30,10 @@ namespace Game.Api.Services
         {
             if (_sessionService.TokenSelectedPlayerId is not int selectedPlayerId)
             {
-                _logger.LogWarning(
+                // A pre-selection token (post-Login, pre-SelectPlayer) is a normal, documented flow state
+                // (docs/backend-auth.md), not a warning-worthy condition — every character-select screen
+                // refresh would otherwise log a warning for expected behavior.
+                _logger.LogDebug(
                     "Authenticated user {UserId} has a valid token with no selected player; session not established.",
                     _sessionService.UserId);
                 return;


### PR DESCRIPTION
## Summary

- `SessionInitializer.EnsureSessionLoaded` logged a `LogWarning` on every request that hit `Status`/`ActiveSession` with a valid **pre-selection** token (post-`Login`, pre-`SelectPlayer`) — a normal, documented flow state (`docs/backend-auth.md`), not a warning-worthy condition. Every character-select-screen refresh produced a server warning. Downgraded to `LogDebug`.
- `AuthController.Status` collapsed that same pre-selection state into the generic `"Player data not found"` 404 that a genuinely unloadable player (deleted/archived between requests) also produces, making the two indistinguishable to any caller. Added `ApiErrorCategory.NoPlayerSelected` (mapped to `409 Conflict` in `ErrorStatusFilter`) so `Status` now returns a distinct, graceful response for "no character selected yet" instead of an opaque 404.
- `ActiveSession` already degrades gracefully for this state (`HasActiveSocket(0)` just reports `Active: false`), so it needed only the shared log-level fix.

## Why not also change frontend routing

I looked at whether the frontend's `resumeSession` should treat this new status differently (e.g. route a refresh on `/select` to stay put instead of bouncing to `/`). It shouldn't: `/select/+page.svelte`'s own `onMount` already documents that a refresh/direct deep-link with no in-memory character-summary handoff *must* return to login, since there's no endpoint to re-fetch the account's character list outside of `Login` itself. So today's "any Status failure → login" frontend behavior is already correct for this case; no frontend change was needed.

## Test plan

- Replaced the existing (mislabeled) `Status_AuthenticatedButPlayerNotLoadable_Returns404WithError` test — it was actually exercising the pre-selection-token path via `TestAuthHelper.AddAuthHeader(client, user.Id)` (no player claim), not a genuinely deleted player — with `Status_PreSelectionToken_ReturnsNoPlayerSelectedNotOpaque404`, asserting `409 Conflict`.
- Added `Status_PostSelectionTokenButPlayerGone_Returns404WithError`, which now actually covers the "post-selection token naming a player that can't load" case (a token minted for a never-persisted player id), asserting `404 NotFound` is preserved for that genuine failure.
- Added `ErrorStatusFilterTests.RewritesTo409_WhenErrorCategoryIsNoPlayerSelected`.
- `dotnet build`: succeeds, 0 warnings/errors.
- `dotnet test Game.Api.Tests`: 833/833 passing.

Closes #2132


---
_Generated by [Claude Code](https://claude.ai/code/session_01ABjMUFj2GJpom6VqswjiwS)_