### PR TITLE
Fix e2e suite hygiene: empty-credentials test, game-flow timeout, signup duplication

### DIFF
--- a/UI/e2e-tests/game-flow.test.ts
+++ b/UI/e2e-tests/game-flow.test.ts
@@ -21,7 +21,7 @@ test.describe('Game flow', () => {
 		await expect(enterButton).toBeEnabled({ timeout: 10000 });
 
 		await enterButton.click();
-		await expect(page).toHaveURL('/game', { timeout: 5000 });
+		await expect(page).toHaveURL('/game', { timeout: 10000 });
 	});
 
 	test('game page renders sidebar and battle screen', async ({ page }) => {
@@ -34,7 +34,7 @@ test.describe('Game flow', () => {
 		await expect(enterButton).toBeEnabled({ timeout: 10000 });
 		await enterButton.click();
 
-		await expect(page).toHaveURL('/game', { timeout: 5000 });
+		await expect(page).toHaveURL('/game', { timeout: 10000 });
 
 		await expect(page.getByTestId('sidebar')).toBeVisible();
 		await expect(page.getByTestId('sidebar-item-fight')).toBeVisible();
@@ -52,7 +52,7 @@ test.describe('Game flow', () => {
 		await expect(enterButton).toBeEnabled({ timeout: 10000 });
 		await enterButton.click();
 
-		await expect(page).toHaveURL('/game', { timeout: 5000 });
+		await expect(page).toHaveURL('/game', { timeout: 10000 });
 
 		// The fight screen is the default. The seeded second zone (Ashen Wastes) is gated behind
 		// clearing the starter zone, which a brand-new player has not done, so the forward arrow is

--- a/UI/e2e-tests/helpers.ts
+++ b/UI/e2e-tests/helpers.ts
@@ -81,7 +81,12 @@ export async function createFirstCharacter(page: Page, name = 'Hero') {
 	await expect(page.getByTestId('player-card')).toHaveCount(1, { timeout: 10000 });
 }
 
-export async function createAccountAndLogin(page: Page, prefix = 'e') {
+/**
+ * Sign up a new account from the login screen and submit, landing on the (empty) character-select
+ * screen. Split out from {@link createAccountAndLogin} so tests that need to stop at that screen
+ * (rather than create a character and enter the game) don't duplicate the signup block.
+ */
+export async function signUp(page: Page, prefix = 'e') {
 	await page.goto('/');
 	await waitForLoginReady(page);
 
@@ -93,6 +98,12 @@ export async function createAccountAndLogin(page: Page, prefix = 'e') {
 	await page.getByTestId('password-input').fill(TEST_PASSWORD);
 	await page.getByTestId('confirm-input').fill(TEST_PASSWORD);
 	await page.getByTestId('submit-button').click();
+
+	return username;
+}
+
+export async function createAccountAndLogin(page: Page, prefix = 'e') {
+	const username = await signUp(page, prefix);
 
 	// Signup lands on the select screen with no characters; create the first one, then enter as it.
 	await createFirstCharacter(page);

--- a/UI/e2e-tests/login.test.ts
+++ b/UI/e2e-tests/login.test.ts
@@ -36,7 +36,19 @@ test.describe('Login page', () => {
 
 		await expect(page.getByTestId('submit-button')).toBeDisabled();
 
-		await page.waitForTimeout(500);
+		const authRequests: string[] = [];
+		page.on('request', (request) => {
+			if (request.url().includes('/api/Auth')) {
+				authRequests.push(request.url());
+			}
+		});
+
+		// A disabled submit button alone doesn't prove the form can't be submitted — attempt the
+		// implicit Enter-key submission and confirm it's actually blocked, not just untried.
+		await page.getByTestId('password-input').press('Enter');
+		await page.waitForLoadState('networkidle');
+
+		expect(authRequests).toHaveLength(0);
 		await expect(page).toHaveURL('/');
 	});
 });

--- a/UI/e2e-tests/select.test.ts
+++ b/UI/e2e-tests/select.test.ts
@@ -1,24 +1,12 @@
 import { expect, test } from '@playwright/test';
-import { createFirstCharacter, selectFirstCharacter, shortUsername, TEST_PASSWORD, waitForLoginReady } from './helpers';
+import { createFirstCharacter, selectFirstCharacter, signUp } from './helpers';
 
 // The character-select screen sits between login and the loading screen. Signup creates the account
 // only (#1256), so a freshly signed-up account lands here with no characters and creates its first one
 // through the class picker — the single class-selection surface — before entering the game.
 test.describe('Character select', () => {
-	const signUp = async (page: import('@playwright/test').Page) => {
-		await page.goto('/');
-		await waitForLoginReady(page);
-
-		await page.getByTestId('mode-toggle').click();
-		const username = shortUsername('sel');
-		await page.getByTestId('username-input').fill(username);
-		await page.getByTestId('password-input').fill(TEST_PASSWORD);
-		await page.getByTestId('confirm-input').fill(TEST_PASSWORD);
-		await page.getByTestId('submit-button').click();
-	};
-
 	test('signup lands on the empty select screen with the create form open', async ({ page }) => {
-		await signUp(page);
+		await signUp(page, 'sel');
 
 		await expect(page).toHaveURL('/select', { timeout: 10000 });
 		await expect(page.getByTestId('select-heading')).toBeVisible();
@@ -28,7 +16,7 @@ test.describe('Character select', () => {
 	});
 
 	test('creates the first character and enters as it', async ({ page }) => {
-		await signUp(page);
+		await signUp(page, 'sel');
 
 		await createFirstCharacter(page);
 


### PR DESCRIPTION
## Summary

Three small, unrelated Playwright hygiene fixes from #2134:

1. **`login.test.ts` — the empty-credentials test couldn't actually catch the regression it names.** It asserted the submit button was disabled, then did a blind `waitForTimeout(500)` + URL check — it never attempted a submission, so the assertion would pass even if the form submitted on Enter with empty fields. It's rewritten to press Enter in a field and assert neither a `/api/Auth` request nor a navigation occurs, replacing the arbitrary sleep with a deterministic `waitForLoadState('networkidle')`.
2. **`game-flow.test.ts` kept the 5s `/game` navigation budget that `helpers.ts` already widened to 10s** (with a comment explaining the navigation routinely exceeds 5s on WebKit/Firefox under parallel load). The three direct-navigation assertions in this file hit the exact same navigation and are updated to the same 10s budget.
3. **`select.test.ts` duplicated the signup block of `createAccountAndLogin` line-for-line.** Extracted a `signUp()` helper in `helpers.ts` (shared by `createAccountAndLogin` and `select.test.ts`) so the next timing fix to that flow lands in one place instead of two.

## Test plan

- [x] `npm run lint` (ESLint + `svelte-check`) — clean
- [x] `npm run test:unit:ci` — 3806/3806 passing
- [ ] `npm run test:e2e` — not run locally; this sandbox's backing services (`.claude/hooks/session-start.sh`) are provisioned only for the dotnet integration-test suites (Testcontainers-reuse Postgres/Redis on fixed ports), not a full dev API + frontend stack, so there's no local way to drive the Playwright suite here. The changes are scoped to test files only (no application code touched); reasoned through each new assertion against the Playwright API (`page.on('request')`, `.press('Enter')`, `waitForLoadState('networkidle')`) and existing suite conventions.

Closes #2134


---
_Generated by [Claude Code](https://claude.ai/code/session_01YDaoqBGNtnp1TgC1etXh7g)_