### PR TITLE
Fix UI lint/format to ignore generated test outputs; make npm test terminate

### DIFF
--- a/UI/.prettierignore
+++ b/UI/.prettierignore
@@ -9,6 +9,12 @@ src/lib/api/types
 # Images
 **/*.png
 
+# Generated test/coverage outputs
+coverage
+playwright-report
+test-results
+unit-test-results.json
+
 # Other
 .gitignore
 .npmrc

--- a/UI/eslint.config.js
+++ b/UI/eslint.config.js
@@ -35,6 +35,15 @@ export default [
 	},
 	prettierConfig,
 	{
-		ignores: ['build/', '.svelte-kit/', 'dist/', 'node_modules/']
+		ignores: [
+			'build/',
+			'.svelte-kit/',
+			'dist/',
+			'node_modules/',
+			'coverage/',
+			'playwright-report/',
+			'test-results/',
+			'unit-test-results.json'
+		]
 	}
 ];

--- a/UI/package.json
+++ b/UI/package.json
@@ -9,7 +9,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
-		"test": "npm run test:e2e && npm run test:unit",
+		"test": "npm run test:unit:ci && npm run test:e2e",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "eslint . && npm run check",


### PR DESCRIPTION
## Summary

Two local-developer-experience gaps in the UI toolchain config (CI was unaffected, which is why these went unnoticed):

1. **ESLint and Prettier didn't ignore generated test/coverage outputs.** `UI/eslint.config.js` only ignored `build/`, `.svelte-kit/`, `dist/`, `node_modules/`; `.prettierignore` had the same gap. After a local coverage run, `npm run lint` would lint istanbul's generated HTML-report JS and fail on `prettier/prettier`, and `npm run format` would rewrite `coverage/`, `playwright-report/`, `test-results/`, and `unit-test-results.json`. Added those to both ignore lists.
2. **`npm test` never terminated locally.** The aggregate script was `"test:e2e && npm run test:unit"` with `"test:unit": "vitest"` — bare `vitest` is watch-mode outside CI, so it ran the slow, backend-dependent e2e suite first and then hung in watch mode. Changed it to `"test:unit:ci && npm run test:e2e"` — the CI-mode unit suite (fast, non-interactive) runs first, then e2e, and the whole thing now actually terminates.

`test:unit` itself is left untouched (still bare `vitest`), since that's the intended interactive watch-mode entry point for local dev.

## How this addresses the issue

Reproduced both problems locally before fixing:
- Ran `npm run test:unit:coverage` to generate a real `coverage/` directory, then confirmed `npm run lint` failed on the generated files before the fix and passes cleanly after.
- Confirmed `prettier --write .` no longer touches files under `coverage/` after the `.prettierignore` update (verified via file mtimes and diffing the prettier output).
- Confirmed the full unit suite (304 files / 3806 tests) still passes under the new `test:unit:ci` invocation.

## Test plan

- [x] `npm run lint` passes with a `coverage/` directory present (previously failed)
- [x] `prettier --write .` leaves `coverage/`, `playwright-report/`, `test-results/`, `unit-test-results.json` untouched
- [x] `npm run test:unit:ci` — 304 test files / 3806 tests pass
- [x] Reviewed diff — only the three toolchain-config files changed, no source changes

Closes #2135


---
_Generated by [Claude Code](https://claude.ai/code/session_01BWYhyLESEY1dQBQW6UoUEF)_