### PR TITLE
Reject Multiplicative skill effects on DoT-accumulator attributes

### DIFF
--- a/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
+++ b/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
@@ -712,6 +712,53 @@ namespace Game.Application.Tests.Content
             AssertHasFinding(graph, "ProficiencyPath", ContentGraphSeverity.Error, "Proficiency", 0);
         }
 
+        // --- Skill effects (DoT-accumulator modifier shape) -------------------------------------------
+
+        [Fact]
+        public void Skill_MultiplicativeEffectOnDotAccumulator_IsError()
+        {
+            var graph = HealthyGraph() with
+            {
+                Skills = HealthyGraph().Skills.Append(Skill(6, ESkillAcquisition.Player, effects:
+                [
+                    new Contracts.SkillEffect
+                    {
+                        Target = ESkillEffectTarget.Opponent,
+                        AttributeId = EAttribute.PoisonDamagePerSecond,
+                        ModifierTypeId = EModifierType.Multiplicative,
+                        Amount = 2m,
+                        DurationMs = 3000,
+                        ScalingAttributeId = EAttribute.Strength,
+                        ScalingAmount = 0,
+                    },
+                ])).ToList(),
+            };
+            AssertHasFinding(graph, "SkillEffectDotModifier", ContentGraphSeverity.Error, "Skill", 6);
+        }
+
+        [Fact]
+        public void Skill_AdditiveEffectOnDotAccumulator_ProducesNoFinding()
+        {
+            var graph = HealthyGraph() with
+            {
+                Skills = HealthyGraph().Skills.Append(Skill(6, ESkillAcquisition.Player, effects:
+                [
+                    new Contracts.SkillEffect
+                    {
+                        Target = ESkillEffectTarget.Opponent,
+                        AttributeId = EAttribute.PoisonDamagePerSecond,
+                        ModifierTypeId = EModifierType.Additive,
+                        Amount = 2m,
+                        DurationMs = 3000,
+                        ScalingAttributeId = EAttribute.Strength,
+                        ScalingAmount = 0,
+                    },
+                ])).ToList(),
+            };
+            var findings = _checker.Check(graph);
+            Assert.DoesNotContain(findings, f => f.Check == "SkillEffectDotModifier");
+        }
+
         // --- Skill recipes ----------------------------------------------------------------------------
 
         [Fact]
@@ -1271,7 +1318,8 @@ namespace Game.Application.Tests.Content
             DateTime? retiredAt = null,
             EDamageType primaryType = EDamageType.Physical,
             (EAttribute attributeId, decimal multiplier)[]? damageMultipliers = null,
-            (EAttribute attributeId, decimal scalingAmount)[]? effectScaling = null) => new()
+            (EAttribute attributeId, decimal scalingAmount)[]? effectScaling = null,
+            IReadOnlyList<Contracts.SkillEffect>? effects = null) => new()
             {
                 Id = id,
                 Name = $"Skill {id}",
@@ -1279,7 +1327,7 @@ namespace Game.Application.Tests.Content
                 DamageMultipliers = (damageMultipliers ?? [])
                 .Select(m => new Contracts.AttributeMultiplier { AttributeId = m.attributeId, Multiplier = m.multiplier })
                 .ToList(),
-                Effects = (effectScaling ?? [])
+                Effects = effects ?? (effectScaling ?? [])
                 .Select(e => new Contracts.SkillEffect
                 {
                     Target = ESkillEffectTarget.Self,

--- a/Game.Application.Tests/DataAccess/AdminSkillsIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminSkillsIntegrationTests.cs
@@ -356,6 +356,79 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SetEffects_MultiplicativeOnDotAccumulator_ReturnsFailureWithoutPersisting()
+        {
+            int skillId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                skillId = (await TestDataSeeder.CreateSkillAsync(context)).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // A Multiplicative effect on a DoT-accumulator attribute would double-apply the caster's
+            // amplification (#2169) — rejected regardless of any other otherwise-valid changes in the batch.
+            var data = new SetSkillEffectsData
+            {
+                Id = skillId,
+                Changes =
+                [
+                    new Change<Contracts.SkillEffect>
+                    {
+                        ChangeType = EChangeType.Add,
+                        Item = NewEffect(EAttribute.PoisonDamagePerSecond, amount: 2m,
+                            modifierType: EModifierType.Multiplicative),
+                    },
+                ],
+            };
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminSkills>();
+                var result = admin.SetEffects(data);
+                Assert.False(result.Succeeded);
+                Assert.Equal("A skill effect targeting a DoT-accumulator attribute must be Additive.", result.ErrorMessage);
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                Assert.Empty(await context.SkillEffects.Where(e => e.SkillId == skillId).ToListAsync(CancellationToken));
+            }
+        }
+
+        [Fact]
+        public async Task SetEffects_AdditiveOnDotAccumulator_Succeeds()
+        {
+            int skillId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                skillId = (await TestDataSeeder.CreateSkillAsync(context)).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            // The Additive shape is the documented amp-freeze rule (spike #1320 Area C) — the guard must not
+            // over-reject it.
+            var data = new SetSkillEffectsData
+            {
+                Id = skillId,
+                Changes =
+                [
+                    new Change<Contracts.SkillEffect>
+                    {
+                        ChangeType = EChangeType.Add,
+                        Item = NewEffect(EAttribute.PoisonDamagePerSecond, amount: 30m),
+                    },
+                ],
+            };
+
+            using var writeScope = CreateScope();
+            var admin = writeScope.ServiceProvider.GetRequiredService<IAdminSkills>();
+            Assert.True(admin.SetEffects(data).Succeeded);
+        }
+
+        [Fact]
         public async Task SetMultipliers_AddOfAlreadyPresentMultiplier_Upserts()
         {
             int skillId;
@@ -521,14 +594,15 @@ namespace Game.Application.Tests.DataAccess
 
         private static Contracts.SkillEffect NewEffect(
             EAttribute attribute, decimal amount, int id = 0,
-            EAttribute scalingAttribute = EAttribute.Strength, decimal scalingAmount = 0m)
+            EAttribute scalingAttribute = EAttribute.Strength, decimal scalingAmount = 0m,
+            EModifierType modifierType = EModifierType.Additive)
         {
             return new Contracts.SkillEffect
             {
                 Id = id,
                 Target = ESkillEffectTarget.Self,
                 AttributeId = attribute,
-                ModifierTypeId = EModifierType.Additive,
+                ModifierTypeId = modifierType,
                 Amount = amount,
                 DurationMs = 1000,
                 ScalingAttributeId = scalingAttribute,

--- a/Game.Application/Content/ProgressionGraphChecker.cs
+++ b/Game.Application/Content/ProgressionGraphChecker.cs
@@ -614,8 +614,6 @@ namespace Game.Application.Content
                 }
             }
 
-            // --- Skill recipes ----------------------------------------------------------------------------
-
             // --- Skill effects (DoT-accumulator modifier shape) -------------------------------------------
 
             /// <summary>
@@ -641,6 +639,8 @@ namespace Game.Application.Content
                     }
                 }
             }
+
+            // --- Skill recipes ----------------------------------------------------------------------------
 
             private void CheckSkillRecipes()
             {

--- a/Game.Application/Content/ProgressionGraphChecker.cs
+++ b/Game.Application/Content/ProgressionGraphChecker.cs
@@ -85,6 +85,7 @@ namespace Game.Application.Content
                 CheckItems();
                 CheckItemMods();
                 CheckProficiencies();
+                CheckSkillEffects();
                 CheckSkillRecipes();
                 CheckOrphanSkills();
                 CheckRecipeInputOwnability();
@@ -614,6 +615,32 @@ namespace Game.Application.Content
             }
 
             // --- Skill recipes ----------------------------------------------------------------------------
+
+            // --- Skill effects (DoT-accumulator modifier shape) -------------------------------------------
+
+            /// <summary>
+            /// A DoT-accumulator effect's magnitude is frozen with the caster's typed amplification at apply
+            /// time (spike #1320 Area C, <see cref="BattleContext.ApplySkillEffect"/>). That's correct for an
+            /// Additive effect, but a Multiplicative one would compound the amplification a second time when
+            /// it folds into the stack (#2169). The admin save path already rejects this combination
+            /// (<c>AdminSkills.SetEffects</c>), so this is a defense-in-depth backstop rather than a reachable
+            /// gap — matching the same-path-prerequisite pattern.
+            /// </summary>
+            private void CheckSkillEffects()
+            {
+                foreach (var skill in Live(_graph.Skills, s => s.RetiredAt))
+                {
+                    foreach (var effect in skill.Effects)
+                    {
+                        if (effect.ModifierTypeId == EModifierType.Multiplicative
+                            && DamageTypes.DotTypeForAccumulator(effect.AttributeId) is not null)
+                        {
+                            Error("SkillEffectDotModifier", "Skill", skill.Id,
+                                $"has a Multiplicative effect on DoT-accumulator attribute {effect.AttributeId}, which would double-apply the caster's amplification.");
+                        }
+                    }
+                }
+            }
 
             private void CheckSkillRecipes()
             {

--- a/Game.DataAccess/Repositories/Admin/AdminSkills.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminSkills.cs
@@ -1,6 +1,7 @@
 using Game.Abstractions.Contracts.Admin;
 using Game.Abstractions.DataAccess.Admin;
 using Game.Core;
+using Game.Core.Attributes;
 using Contracts = Game.Abstractions.Contracts;
 using Entities = Game.Infrastructure.Entities;
 
@@ -144,6 +145,19 @@ namespace Game.DataAccess.Repositories.Admin
             if (skill is null)
             {
                 return AdminSaveResult.NotFound("Skill");
+            }
+
+            // Anti-tamper (#2169): a DoT-accumulator effect's magnitude is frozen with the caster's typed
+            // amplification at apply time (spike #1320 Area C). For an Additive effect that's the correct
+            // per-second rate; for a Multiplicative one the amplified value would compound a second time when
+            // it folds into the stack's combined multiplicative modifier. Reject the combination up front
+            // rather than teaching the engine/rating model multiplicative-DoT semantics.
+            if (data.Changes.Any(c => c.ChangeType != EChangeType.Delete
+                && c.Item.ModifierTypeId == EModifierType.Multiplicative
+                && DamageTypes.DotTypeForAccumulator(c.Item.AttributeId) is not null))
+            {
+                return AdminSaveResult.Failure(
+                    "A skill effect targeting a DoT-accumulator attribute must be Additive.");
             }
 
             // Precompute the current effect-id set once so each Edit/Delete membership guard is an O(1)


### PR DESCRIPTION
## Summary

`BattleContext.ApplySkillEffect` freezes the caster's typed amplification into the resolved magnitude of any effect targeting a DoT-accumulator attribute (`Game.Core/Battle/BattleContext.cs:77-81`), regardless of `ModifierType`. For an **Additive** effect this is the documented amp-freeze rule (spike #1320 Area C) — correct. For a **Multiplicative** effect the frozen amount is a *ratio* that then compounds into the stack's combined multiplicative modifier, so the caster's amplification is applied twice. Nothing blocked authoring one, though no seeded content currently does.

Per the issue's suggested direction, this fixes it with **authoring-validation** rather than teaching the engine/rating model multiplicative-DoT semantics:

- **`AdminSkills.SetEffects`** (`Game.DataAccess/Repositories/Admin/AdminSkills.cs`): rejects a save containing a Multiplicative effect on a DoT-accumulator attribute (`DamageTypes.DotTypeForAccumulator`), matching the existing anti-tamper guard pattern used for skill damage portions.
- **`ProgressionGraphChecker`** (`Game.Application/Content/ProgressionGraphChecker.cs`): adds a matching `SkillEffectDotModifier` Error check as a defense-in-depth backstop (the admin save path already rejects the combination before it can be persisted, so Content Health can't observe a live instance today — same pattern as the same-path prerequisite guard in #2128/#2144).

I confirmed no seeded content (`content/skills.json`) currently authors this combination, so the new lint check introduces no findings against the live content graph.

## Scope note

The issue's body also flags two adjacent inconsistencies as context (not requested as part of this fix):
- `CombatRating.OffenseRate`'s DoT closed form reads `effect.Amount` as an additive DPS magnitude regardless of `ModifierType` — moot once Multiplicative-on-accumulator can no longer be authored.
- No engine/rating-model changes were made — the fix is purely at the authoring boundary, per the issue's suggested direction.

## Test plan

- [x] `Game.Application.Tests/DataAccess/AdminSkillsIntegrationTests.cs` — new integration tests pin the guard: a Multiplicative DoT-accumulator effect is rejected without persisting, and an Additive one still succeeds (guard doesn't over-reject).
- [x] `Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs` — new unit tests pin the lint rule: Multiplicative-on-accumulator is an Error, Additive-on-accumulator produces no finding.
- [x] `dotnet build` — full solution builds clean.
- [x] `dotnet test --no-build --no-restore` — full suite green (1398 + 68 + 1036 + 833 tests, 0 failures).

Closes #2169


---
_Generated by [Claude Code](https://claude.ai/code/session_01KJshFp9ys3fZw78CL7cnRW)_