### PR TITLE
Skip zero-valued entries when attributing a kill's damage type

### DIFF
--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -429,6 +429,42 @@ namespace Game.Core.Tests.Progress
         }
 
         [Fact]
+        public void RecordBattleCompleted_Victory_AllZeroTypedDamage_RecordsNoKillByDamageType()
+        {
+            // A fire-immune enemy killed entirely by untyped reflection: every fire portion books 0, so there is
+            // no positive-damage entry to credit a kill to (#2170).
+            var progress = MakeProgress();
+            var stats = new BattleStats { TypedDamageDealt = { [EDamageType.Fire] = 0.0 } };
+
+            progress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000, stats,
+                isBossBattle: false, zoneId: 0);
+
+            Assert.False(progress.TryGetStatisticValue(EStatisticType.KillsByDamageType, (int)EDamageTypeKey.Fire, out _));
+            Assert.False(progress.TryGetStatisticValue(EStatisticType.KillsByDamageType, (int)EDamageTypeKey.Elemental, out _));
+        }
+
+        [Fact]
+        public void RecordBattleCompleted_Victory_ZeroValuedEntryIgnored_CreditsThePositiveMajorityInstead()
+        {
+            // A minority-but-positive type should still win over a larger zero-valued (immune) entry.
+            var progress = MakeProgress();
+            var stats = new BattleStats
+            {
+                TypedDamageDealt =
+                {
+                    [EDamageType.Fire] = 0.0,
+                    [EDamageType.Physical] = 5.0,
+                },
+            };
+
+            progress.RecordBattleCompleted(MakeEnemy(), victory: true, playerDied: false, totalMs: 1000, stats,
+                isBossBattle: false, zoneId: 0);
+
+            Assert.Equal(1m, progress.GetStatisticValue(EStatisticType.KillsByDamageType, (int)EDamageTypeKey.Physical));
+            Assert.False(progress.TryGetStatisticValue(EStatisticType.KillsByDamageType, (int)EDamageTypeKey.Fire, out _));
+        }
+
+        [Fact]
         public void RecordBattleCompleted_Victory_NoTypedDamageDealt_RecordsNoKillByDamageType()
         {
             // Defensive branch: a victory with an empty offense book (shouldn't happen in practice, since a

--- a/Game.Core/Progress/PlayerProgress.cs
+++ b/Game.Core/Progress/PlayerProgress.cs
@@ -295,16 +295,20 @@ namespace Game.Core.Progress
         /// battle-parity surface. Ties break on the lower <see cref="EDamageType"/> ordinal, for determinism.
         /// Rolled up through <see cref="DamageTypes.Applies"/> like proficiency training, so a Burn-majority
         /// kill books Burn, Fire, Elemental, and Dot alike (backing both "kill with fire magic" and "kill with
-        /// a weapon type" challenges — weapon leaves are damage-type leaves).
+        /// a weapon type" challenges — weapon leaves are damage-type leaves). Zero-valued entries (a portion
+        /// booked at 0 for full resistance/immunity) are excluded before the majority pick, so a kill made
+        /// entirely of untyped damage (e.g. reflection) against a type the player merely swung with — and dealt
+        /// no damage of — books no kill rather than crediting that type.
         /// </summary>
         private void RecordKillByDamageType(BattleStats stats)
         {
-            if (stats.TypedDamageDealt.Count == 0)
+            var positiveDamageDealt = stats.TypedDamageDealt.Where(kv => kv.Value > 0).ToList();
+            if (positiveDamageDealt.Count == 0)
             {
                 return;
             }
 
-            var majorityType = stats.TypedDamageDealt
+            var majorityType = positiveDamageDealt
                 .OrderByDescending(kv => kv.Value)
                 .ThenBy(kv => (int)kv.Key)
                 .First().Key;


### PR DESCRIPTION
## Summary

`PlayerProgress.RecordKillByDamageType` (`Game.Core/Progress/PlayerProgress.cs`) picked the majority entry of `BattleStats.TypedDamageDealt` guarding only the empty-dictionary case. Since `AddTypedDamageDealt` books every damage portion — including portions floored at 0 for full resistance/immunity (#1482/#2101) — a kill dealt entirely through untyped means (e.g. Retribution reflection) against an enemy the player merely *swung* a typed attack at, but dealt zero damage of, would still credit that type via a `{Type: 0}`-only dictionary.

**Concrete failure scenario (from the issue):** an enemy authored with `FireResistance = 1` (full immunity) is killed by a Retribution tank's reflection damage (untyped, never booked into `TypedDamageDealt`). The dictionary contains only `{Fire: 0}`, so the kill was credited to `Fire`/`Elemental` — wrongly progressing "kill with fire magic" challenges against a fire-immune enemy the player dealt zero fire damage to.

## Fix

Filter `TypedDamageDealt` to entries with `Value > 0` before picking the majority type, and skip attribution entirely when no entry is positive (a genuinely typeless kill) — matching the issue's suggested two-line fix. Updated the method's doc comment to note the invariant, since it's non-obvious from the code alone.

## Test plan

- [x] `Game.Core.Tests/Progress/PlayerProgressTests.cs` — added two tests: an all-zero `TypedDamageDealt` records no kill-by-damage-type row, and a zero-valued entry is correctly skipped in favor of a smaller-but-positive entry.
- [x] `dotnet build` — full solution builds clean.
- [x] `dotnet test --no-build --no-restore` — full suite green (1400 + 68 + 1032 + 833 tests, 0 failures).

This is server-only statistics/challenge-tracking logic with no battle-parity surface (per the method's existing doc comment), so no frontend changes are needed.

Closes #2170


---
_Generated by [Claude Code](https://claude.ai/code/session_01K7eQ9qyCkryVZg8918PWiY)_