### PR TITLE
Cap CombatRating's avoidance/resistance credit to prevent survivability blowup

### DIFF
--- a/Game.Core.Tests/Battle/CombatRatingTests.cs
+++ b/Game.Core.Tests/Battle/CombatRatingTests.cs
@@ -55,6 +55,70 @@ namespace Game.Core.Tests.Battle
             Assert.True(CombatRating.Rate(tough, isPlayer: true) > CombatRating.Rate(weak, isPlayer: true));
         }
 
+        // ── Rate: survivability avoidance/resistance pole (#2171) ───────────────
+
+        [Fact]
+        public void Rate_ParryAtCertainty_DoesNotExplodeRating()
+        {
+            // ParryChance × ParryChanceMultiplier(base 1) = 1.0 drives raw `avoid` to exactly 1, the pole where
+            // the uncapped mitigation fraction hits its Epsilon floor. The capped credit must keep the rating
+            // finite and in the same order of magnitude as a merely-strong (not fully-certain) avoidance build.
+            var certainParry = MakeBattlerWithSkills([(ParryChance, 1.0)], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+            var strongParry = MakeBattlerWithSkills([(ParryChance, 0.5)], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+
+            var certainRate = CombatRating.Rate(certainParry, isPlayer: true);
+            var strongRate = CombatRating.Rate(strongParry, isPlayer: true);
+
+            Assert.False(double.IsNaN(certainRate));
+            Assert.False(double.IsInfinity(certainRate));
+            Assert.True(certainRate > strongRate);
+            Assert.True(certainRate < strongRate * 100);
+        }
+
+        [Fact]
+        public void Rate_DodgeBeyondCertainty_DoesNotExplodeRating()
+        {
+            // DodgeChance authored beyond what a chance can mean in-fight (2.0 × base-1 multiplier = 2.0) still
+            // must not push the capped avoidance credit above ServerGameConstants.MaxMitigationCredit.
+            var overCertainDodge = MakeBattlerWithSkills([(DodgeChance, 2.0)], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+
+            var rate = CombatRating.Rate(overCertainDodge, isPlayer: true);
+
+            Assert.False(double.IsNaN(rate));
+            Assert.False(double.IsInfinity(rate));
+        }
+
+        [Fact]
+        public void Rate_ParryBeyondCertainty_RatesTheSameAsExactlyAtTheCap()
+        {
+            // Once avoid clears MaxMitigationCredit, further ParryChance must not move the rating at all —
+            // pins that the credit is truly capped (not just softened) past the pole.
+            var atCap = MakeBattlerWithSkills([(ParryChance, 1.0)], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+            var wayPastCap = MakeBattlerWithSkills([(ParryChance, 50.0)], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+
+            Assert.Equal(
+                CombatRating.Rate(atCap, isPlayer: true),
+                CombatRating.Rate(wayPastCap, isPlayer: true), 6);
+        }
+
+        [Fact]
+        public void Rate_ResistanceBeyondCertainty_DoesNotExplodeRating()
+        {
+            // Stacking every resistance attribute that feeds RefIncomingTypeMix well past 100% average must not
+            // push the capped resist credit above MaxMitigationCredit either.
+            var battler = MakeBattlerWithSkills(
+                [
+                    (PhysicalResistance, 5.0), (FireResistance, 5.0), (WaterResistance, 5.0), (EarthResistance, 5.0),
+                    (WindResistance, 5.0), (BleedResistance, 5.0), (PoisonResistance, 5.0), (BurnResistance, 5.0),
+                ],
+                [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+
+            var rate = CombatRating.Rate(battler, isPlayer: true);
+
+            Assert.False(double.IsNaN(rate));
+            Assert.False(double.IsInfinity(rate));
+        }
+
         // ── Rate: offense ─────────────────────────────────────────────────────
 
         [Fact]

--- a/Game.Core/Battle/CombatRating.cs
+++ b/Game.Core/Battle/CombatRating.cs
@@ -274,7 +274,9 @@ namespace Game.Core.Battle
             var toughness = effectiveCaster.GetAttributeValue(Toughness);
             var toughnessReduction = toughness / (toughness + GameConstants.ToughnessMitigationConstant);
 
-            var mitigationFraction = (1 - avoid) * (1 - resist) * (1 - toughnessReduction);
+            var cappedAvoid = Math.Min(avoid, ServerGameConstants.MaxMitigationCredit);
+            var cappedResist = Math.Min(resist, ServerGameConstants.MaxMitigationCredit);
+            var mitigationFraction = (1 - cappedAvoid) * (1 - cappedResist) * (1 - toughnessReduction);
             return effectiveHealth / Math.Max(mitigationFraction, Epsilon);
         }
 

--- a/Game.Core/ServerGameConstants.cs
+++ b/Game.Core/ServerGameConstants.cs
@@ -118,5 +118,15 @@ namespace Game.Core
         /// (<c>min(duration, RefFightDuration / 2)</c>). ~30s per the spike (#1526).
         /// </summary>
         public const double RefFightDuration = 30.0;
+
+        /// <summary>
+        /// Upper clamp on the avoidance (parry+dodge) and resistance credit <see cref="Battle.CombatRating"/>'s
+        /// survivability term prices — both are authored-only, uncapped enablers that the shared-expiry effect
+        /// ramp can push toward 1, and <c>(1 - credit)</c> sits in survivability's denominator, so an uncapped
+        /// credit near 1 diverges the rating (#2171) even though the battle engine itself degrades gracefully at
+        /// chance ≥ 1. The engine's real counter to a near-100%-avoidance build is DoT, which this survivability
+        /// model doesn't price, so an uncapped credit would overstate what avoidance/resistance is actually worth.
+        /// </summary>
+        public const double MaxMitigationCredit = 0.95;
     }
 }


### PR DESCRIPTION
## Summary

`CombatRating.Survivability` (`Game.Core/Battle/CombatRating.cs`) computed `mitigationFraction = (1 - avoid) * (1 - resist) * (1 - toughnessReduction)` with `avoid` (parry+dodge) and `resist` (average incoming resistance) both **uncapped, authored-only** enablers. Since `avoid`/`resist` can be amplified by Luck/Agility-derived multipliers and stacked via the shared-expiry effect ramp, they can approach or exceed 1 — at which point `mitigationFraction` hits the `Epsilon = 1e-6` floor and `survivability` (and hence `PlayerRating`) blows up to `effectiveHealth × 10⁶`.

That runaway rating drives `DefeatRewards.DifficultyMultiplier = min(enemy/player, 1)² ≈ 0` and the proficiency denominator `max(playerRating, enemyRating)`, so a committed-avoidance (or heavy-resistance) build earns effectively **zero XP and zero proficiency** — permanently.

## Fix

- Added `ServerGameConstants.MaxMitigationCredit = 0.95` — the upper clamp on both the avoidance and resistance credit the survivability term prices.
- `CombatRating.Survivability` now clamps `avoid` and `resist` to this cap before computing `mitigationFraction`, so the pole is unreachable while normal (non-degenerate) builds are unaffected.

The battle engine itself already degrades gracefully at chance ≥ 1 (a draw simply always avoids) — this only fixes the *rating model's* divergence, matching the fix already applied to the DoT-term ramp pricing elsewhere in the same file.

## Test plan

- [x] Added unit tests in `Game.Core.Tests/Battle/CombatRatingTests.cs` pinning the boundary behavior: parry at exact certainty, dodge/resistance authored past certainty, and confirmation that the rating no longer moves once the credit clears the cap.
- [x] `dotnet build` — solution builds clean.
- [x] `dotnet test` (no-build) — full backend suite passes: 1404 (Core) + 68 (Infrastructure) + 1036 (Application, includes the combat-rating calibration suite) + 833 (Api) = 3341 tests, 0 failures. No calibration drift observed.
- [x] No frontend changes — combat rating is server-only with no frontend mirror (per `docs/backend.md`).

Closes #2171


---
_Generated by [Claude Code](https://claude.ai/code/session_019XbgafXWtX9LqcK2eK4rts)_