### PR TITLE
Bound ReferenceCacheSynchronizer.StopAsync to the host shutdown token

### DIFF
--- a/Game.Application.Tests/DataAccess/ReferenceCacheSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/ReferenceCacheSynchronizerTests.cs
@@ -9,6 +9,7 @@ using Game.TestInfrastructure.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Game.Application.Tests.DataAccess
@@ -108,6 +109,31 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task StopAsync_ReloadLoopWedged_GivesUpWhenTheShutdownDeadlineTrips()
+        {
+            // Models a reload stuck on a wedged Npgsql connection (#2172): it never completes, ignoring the
+            // stopping token entirely, so StopAsync must still honor the host's own shutdown deadline rather
+            // than block on it.
+            var wedgedCache = new WedgedReloadableCache();
+            var policy = new ReferenceCacheReloadPolicy(TimeSpan.FromMilliseconds(10), maxAttempts: 1, baseDelay: TimeSpan.Zero);
+            var reloader = new CoalescingReferenceCacheReloader([wedgedCache], policy, NullLogger<CoalescingReferenceCacheReloader>.Instance);
+            var synchronizer = new ReferenceCacheSynchronizer(new NoOpPubSubService(), reloader);
+
+            await synchronizer.StartAsync(CancellationToken);
+            reloader.NotifyChanged();
+
+            // Wait for the reload to actually be in flight so StopAsync races a real wedged awaiter, not an idle loop.
+            await wedgedCache.ReloadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            // Returns (does not throw, does not hang) once the deadline has tripped, even though the reload
+            // loop is still stuck awaiting a reload that will never complete.
+            await synchronizer.StopAsync(cts.Token).WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        [Fact]
         public async Task Dispose_WithoutStopAsync_DoesNotThrowAndIsIdempotent()
         {
             using var scope = CreateScope();
@@ -157,6 +183,29 @@ namespace Game.Application.Tests.DataAccess
 
                 await Task.Delay(25, CancellationToken);
             }
+        }
+
+        /// <summary>An <see cref="IReloadableReferenceCache"/> whose reload never completes, ignoring its cancellation
+        /// token entirely — a stand-in for a wedged Npgsql connection during a background sweep.</summary>
+        private sealed class WedgedReloadableCache : IReloadableReferenceCache
+        {
+            public TaskCompletionSource ReloadStarted { get; } = new();
+
+            private readonly TaskCompletionSource _neverCompletes = new();
+
+            public Task ReloadAsync(CancellationToken cancellationToken = default)
+            {
+                ReloadStarted.TrySetResult();
+                return _neverCompletes.Task;
+            }
+        }
+
+        /// <summary>An <see cref="IPubSubService"/> stub whose subscribe/unsubscribe are no-ops, for tests that never
+        /// need a live channel subscription.</summary>
+        private sealed class NoOpPubSubService : NotSupportedPubSubService
+        {
+            public override Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => Task.CompletedTask;
+            public override Task UnSubscribe(string id) => Task.CompletedTask;
         }
     }
 }

--- a/Game.DataAccess/ReferenceCacheSynchronizer.cs
+++ b/Game.DataAccess/ReferenceCacheSynchronizer.cs
@@ -44,7 +44,19 @@ namespace Game.DataAccess
         {
             await _pubsub.UnSubscribe(InstanceId);
             _stopping.Cancel();
-            await _reloadLoop;
+
+            // Honor the host's shutdown deadline: a wedged reload query (e.g. a stuck Npgsql connection) must not
+            // stall host shutdown past the deadline. If the token trips first, stop awaiting and let the loop
+            // finish (or die with the process) in the background — the same bounded give-up
+            // RedisConnectionLifetime.StopAsync applies to multiplexer disposal.
+            try
+            {
+                await _reloadLoop.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutdown deadline reached before the reload loop settled; unwinding is the deliberate give-up.
+            }
         }
 
         public async Task NotifyChangedAsync()


### PR DESCRIPTION
## Summary

`ReferenceCacheSynchronizer.StopAsync` awaited its background reload loop unbounded, never consulting the `cancellationToken` the host passes it. Since the loop's exit is gated on `Task.WhenAll` over every in-flight cache reload settling, a wedged Npgsql connection during a background sweep would stall host shutdown until the host's own ~30s deadline force-abandoned it.

Every sibling stop path in the codebase already bounds this exact scenario (`DataProviderSynchronizer._drainTimeout`, `RedisConnectionLifetime.StopAsync`'s `.WaitAsync(cancellationToken)`), so this brings `ReferenceCacheSynchronizer` in line with the established pattern rather than introducing a new one.

## Change

`Game.DataAccess/ReferenceCacheSynchronizer.cs`: `StopAsync` now awaits the reload loop via `.WaitAsync(cancellationToken)` and swallows the resulting `OperationCanceledException`, mirroring `RedisConnectionLifetime.StopAsync` — if the deadline trips first, shutdown proceeds and the loop is left to finish (or die with the process) in the background.

## Test plan

- [x] `dotnet build Game.sln` — clean build
- [x] `dotnet test Game.Application.Tests --no-build --no-restore` — all 1037 tests pass
- [x] Added `StopAsync_ReloadLoopWedged_GivesUpWhenTheShutdownDeadlineTrips`, which drives a reload that never completes (ignoring its own cancellation token, simulating a wedged Npgsql connection) and asserts `StopAsync` still returns promptly once an already-cancelled token is passed — bounded so a regression back to an unbounded await hangs the test rather than silently passing.

Closes #2172


---
_Generated by [Claude Code](https://claude.ai/code/session_01PtjWk5q5iJ1bZcy5FLiVk2)_