### PR TITLE
Pass the per-command cancellation token to the socket UoW commit

### DIFF
--- a/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandExecutionTests.cs
@@ -379,6 +379,32 @@ namespace Game.Api.Tests.Unit
             Assert.False(session.PlayerNeedsReload);
         }
 
+        [Fact]
+        public async Task ExecuteCommand_Succeeds_CommitsUnderThePerCommandCancellationToken()
+        {
+            // #2174: the unit-of-work commit must observe the same per-command budget as ExecuteAsync — a
+            // flush that itself wedges past the timeout must be cancellable rather than riding out Npgsql's
+            // own command timeout, mirroring CommitFilter's HTTP-side behavior (which passes RequestAborted).
+            var unitOfWork = new CapturingUnitOfWork();
+            using var provider = new ServiceCollection()
+                .AddScoped<IUnitOfWork>(_ => unitOfWork)
+                .BuildServiceProvider();
+
+            var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
+            var session = new SessionService(new NoOpSessionStore());
+            await session.CreateSession(userId: 1, playerId: 1);
+            var context = new SocketContext(socket, playerId: 1, session, isAdmin: false, _loggerFactory.CreateLogger<SocketContext>());
+            var handler = new SocketHandler(context, new StubCommandFactory(_ => null), provider.GetRequiredService<IServiceScopeFactory>(),
+                _loggerFactory.CreateLogger<SocketHandler>(), () => { });
+
+            await handler.ExecuteCommand(new SocketCommandInfo("Ok") { Id = "c1" });
+
+            // A token backed by a real CancellationTokenSource reports CanBeCanceled; the prior default-token
+            // call (CancellationToken.None) would not, so this fails without the fix.
+            Assert.NotNull(unitOfWork.ReceivedToken);
+            Assert.True(unitOfWork.ReceivedToken!.Value.CanBeCanceled);
+        }
+
         private (FakeWebSocket Socket, SocketHandler Handler) CreateHandler(Func<string, Exception?> throwOn, Func<string, Exception?>? throwOnCreate = null, Func<string, bool>? selfDelivering = null)
         {
             var socket = new FakeWebSocket(sendDuration: TimeSpan.Zero);
@@ -489,6 +515,17 @@ namespace Game.Api.Tests.Unit
         private sealed class NoOpUnitOfWork : IUnitOfWork
         {
             public Task CommitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+
+        private sealed class CapturingUnitOfWork : IUnitOfWork
+        {
+            public CancellationToken? ReceivedToken { get; private set; }
+
+            public Task CommitAsync(CancellationToken cancellationToken = default)
+            {
+                ReceivedToken = cancellationToken;
+                return Task.CompletedTask;
+            }
         }
 
         /// <summary>Returns each of <paramref name="responses"/> in order on successive <see cref="GetPlayer"/>

--- a/Game.Api/Sockets/SocketHandler.cs
+++ b/Game.Api/Sockets/SocketHandler.cs
@@ -202,9 +202,11 @@ namespace Game.Api.Sockets
                     // mid read-modify-write of the shared cached Player, and releasing would let the next
                     // command race it (the lost-update class the per-socket command lock prevents — see
                     // docs/backend.md). Hand the lock to a continuation that releases it once the abandoned
-                    // task finally settles. The abandoned command still commits its write (so it isn't lost),
-                    // but its now-late response is dropped: RunCommand never sends — this method owns the single
-                    // send — so the client never receives a second response for the same id.
+                    // task finally settles. The abandoned task's own commit runs under this same (already
+                    // cancelled) token, so a flush that is itself the wedge point unwinds promptly rather than
+                    // riding out Npgsql's own command timeout; its now-late response is dropped regardless:
+                    // RunCommand never sends — this method owns the single send — so the client never receives
+                    // a second response for the same id.
                     _logger.LogWarning("Socket command timed out after {Timeout} and was abandoned: {CommandInfo} on socket: {Id}", _commandTimeout, commandInfo, Id);
                     await SendErrorAsync(commandInfo, "Command timed out.");
                     ReleaseCommandLockWhenSettled(commandTask, cts, commandInfo);
@@ -269,11 +271,13 @@ namespace Game.Api.Sockets
             }
         }
 
-        // Executes the command and commits its unit of work, returning the response (and whether the command
-        // already delivered it itself — ISelfDeliveringCommand) for the caller to send. It deliberately does
-        // not send when not self-delivering: RunCommandUnderLock owns the single send so that a command
-        // abandoned on timeout (whose task runs on here in the background) commits its write but never emits a
-        // second, late response for an id the client already saw time out.
+        // Executes the command and commits its unit of work — under the same per-command token as
+        // ExecuteAsync, so a flush that wedges past the budget unwinds instead of riding out Npgsql's own
+        // command timeout — returning the response (and whether the command already delivered it itself —
+        // ISelfDeliveringCommand) for the caller to send. It deliberately does not send when not
+        // self-delivering: RunCommandUnderLock owns the single send so that a command abandoned on timeout
+        // (whose task runs on here in the background) never emits a second, late response for an id the
+        // client already saw time out.
         private async Task<(ApiSocketResponse Response, bool SelfDelivered)> RunCommand(SocketCommandInfo commandInfo, CancellationToken cancellationToken)
         {
             using var scope = _scopeFactory.CreateScope();
@@ -301,7 +305,7 @@ namespace Game.Api.Sockets
             // JsonException/ArgumentNullException a command's DI construction happened to throw.
             var command = _commandFactory.CreateCommand(commandInfo, scope);
             var response = await command.ExecuteAsync(_context, cancellationToken);
-            await scope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            await scope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync(cancellationToken);
             return (response, command is ISelfDeliveringCommand);
         }
 


### PR DESCRIPTION
## Summary

`SocketHandler.RunCommand` calls `command.ExecuteAsync(_context, cancellationToken)` with the per-command budget token, but then called `IUnitOfWork.CommitAsync()` with no token at all. This deviates from the documented contract (`backend-sockets.md`: the per-command token "is plumbed down through the application services and the data tier… so a wedged command unwinds promptly and releases the lock") and from the HTTP twin, `CommitFilter`, which passes `RequestAborted`.

**Failure scenario:** a command whose EF flush wedges can't be cut off at the per-command budget — the timed-out command's lock-handoff continuation (`ReleaseCommandLockWhenSettled`) keeps the player's entire command stream blocked until Npgsql's own ~30s command timeout unwinds it instead. The one hop the budget couldn't cancel was exactly the last one before lock release.

## Changes

- `Game.Api/Sockets/SocketHandler.cs`: pass `cancellationToken` into `CommitAsync`, mirroring `CommitFilter`.
- Updated two adjacent comments in the same method that asserted an abandoned command's commit *always* lands — that's no longer universally true post-fix: if the flush itself is the wedge point, it now unwinds under the same (already-cancelled) token instead of riding out Npgsql's own timeout.

## Investigation note

Before applying the literal one-line fix, I checked it against `Game.Api.Tests/Integration/SocketCommandTimeoutTests.cs`, which has an existing test explicitly asserting "the abandoned command still commits its write." Passing an already-cancelled token to a real `SaveChangesAsync` could in principle short-circuit that guarantee for a command with pending EF changes. I ran that integration test suite before and after the fix (real Postgres, via `ApiIntegrationTestBase`) — it passes identically both ways, because that test's stub command performs no EF mutations (nothing to save), so the risk doesn't materialize there. The comment updates above make the actual (narrower) guarantee explicit for future readers instead of leaving the stale absolute claim in place.

## Test plan

- [x] Added `ExecuteCommand_Succeeds_CommitsUnderThePerCommandCancellationToken` (`Game.Api.Tests/Unit/SocketCommandExecutionTests.cs`) — a `CapturingUnitOfWork` fake pins that `CommitAsync` now receives a real, cancellable token instead of `CancellationToken.None`.
- [x] `dotnet build Game.sln` — succeeds, no warnings.
- [x] `dotnet test Game.Api.Tests` (full suite) — 834/834 passing.
- [x] `dotnet test Game.Api.Tests -- --filter-class "*SocketCommandExecutionTests"` and `*SocketCommandTimeoutTests*` — passing (see follow-up note below).

## Follow-up filed

While verifying, I found `SocketCommandTimeoutTests.CooperativelyCancellingCommand_TimesOut_AndReleasesLockSoNextCommandRuns` fails reproducibly when that test class is run in isolation (5/5 runs, both before and after this change — pre-existing, unrelated flakiness, likely cold-start latency against the 200ms test budget) but passes cleanly as part of the full suite. Filed as #2184.

Closes #2174


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kyp72jxSgNa23g85MRUY9N)_