### PR TITLE
Exclude tiers of retired paths from the gateway prerequisite picker

### DIFF
--- a/Game.Application.Tests/DataAccess/AdminProficienciesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminProficienciesIntegrationTests.cs
@@ -632,6 +632,38 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SetPrerequisites_PrerequisiteOnRetiredPath_ReturnsFailure()
+        {
+            int gatedId, prerequisiteId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var gatedPath = await SeedPathAsync(seedScope);
+                gatedId = (await SeedProficiencyAsync(seedScope, gatedPath.Id, name: "Fire I")).Id;
+
+                var frozenPath = await SeedPathAsync(seedScope);
+                prerequisiteId = (await SeedProficiencyAsync(seedScope, frozenPath.Id, name: "Frost I")).Id;
+                frozenPath.RetiredAt = DateTime.UtcNow;
+                await context.SaveChangesAsync(CancellationToken);
+            }
+            await ReloadReferenceCachesAsync();
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminProficiencies>();
+
+            // A tier on a retired path is frozen — it never accrues, so a gateway prerequisiting it can
+            // never open. Reject at save time as anti-tamper, mirroring the frontend picker exclusion.
+            var result = admin.SetPrerequisites([new SetProficiencyPrerequisitesData
+            {
+                Id = gatedId,
+                PrerequisiteIds = [prerequisiteId],
+            }]);
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("retired path", result.ErrorMessage);
+        }
+
+        [Fact]
         public async Task SetPrerequisites_WouldFormACycle_ReturnsFailure()
         {
             int gatedId, prerequisiteId;

--- a/Game.DataAccess/Repositories/Admin/AdminProficiencies.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminProficiencies.cs
@@ -253,6 +253,12 @@ namespace Game.DataAccess.Repositories.Admin
                     return AdminSaveResult.Failure(
                         $"Prerequisite proficiency {prerequisiteId} is on the same path as proficiency {proficiency.Id} — gateways must be cross-path.");
                 }
+
+                if (_proficiencies.LookupPath(prerequisite.PathId) is { RetiredAt: not null })
+                {
+                    return AdminSaveResult.Failure(
+                        $"Prerequisite proficiency {prerequisiteId} is on a retired path — its tiers can never accrue, so this gateway can never open.");
+                }
             }
 
             return null;

--- a/UI/src/routes/admin/workbench/progression/GatewaysEditor.svelte
+++ b/UI/src/routes/admin/workbench/progression/GatewaysEditor.svelte
@@ -61,10 +61,17 @@ let addPick = $state(ADD_PLACEHOLDER);
  */
 const prereqName = (id: number) => store.profs.find((p) => p.id === id)?.name || `#${id}`;
 
+// A tier on a retired path is frozen (never accrues, can never max), so picking it as a prerequisite
+// would author a gateway that can never open — excluded the same as a directly-retired tier (#2176).
+const isPathRetired = (pathId: number) => store.paths.find((path) => path.id === pathId)?.retiredAt != null;
+
 const addOptions = $derived([
 	{ value: ADD_PLACEHOLDER, text: '+ Add prerequisite…' },
 	...store.profs
-		.filter((p) => p.pathId !== tier.pathId && !p.retiredAt && !tier.prerequisiteIds.includes(p.id))
+		.filter(
+			(p) =>
+				p.pathId !== tier.pathId && !p.retiredAt && !isPathRetired(p.pathId) && !tier.prerequisiteIds.includes(p.id)
+		)
 		.map((p) => ({ value: p.id, text: p.name || 'Unnamed tier' }))
 ]);
 

--- a/UI/src/tests/routes/admin/workbench/progression/GatewaysEditor.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/GatewaysEditor.test.ts
@@ -3,7 +3,8 @@ import { render, cleanup, screen } from '@testing-library/svelte';
 
 import GatewaysEditor from '$routes/admin/workbench/progression/GatewaysEditor.svelte';
 import type { ProgressionStore } from '$routes/admin/workbench/progression/progression-store.svelte';
-import type { WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+import type { WorkbenchPath, WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+import { EActivityKey } from '$lib/api';
 
 afterEach(cleanup);
 
@@ -27,11 +28,21 @@ const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency =>
 	...over
 });
 
+const path = (over: Partial<WorkbenchPath> = {}): WorkbenchPath => ({
+	id: 0,
+	name: 'Fire',
+	description: '',
+	activityKey: EActivityKey.Fire,
+	designerNotes: '',
+	...over
+});
+
 // A fake store exposing exactly what GatewaysEditor reads/calls — mirrors TierDetail.test.ts's
 // fake-store pattern rather than driving the real ProgressionStore through a socket-backed load().
-const makeStore = (profs: WorkbenchProficiency[]) =>
+const makeStore = (profs: WorkbenchProficiency[], paths: WorkbenchPath[] = []) =>
 	({
 		profs,
+		paths,
 		addPrerequisite: vi.fn(),
 		removePrerequisite: vi.fn()
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -68,5 +79,27 @@ describe('GatewaysEditor — cross-path-only prerequisite picker (#2128)', () =>
 		expect(optionTexts).toContain('Wind I');
 		expect(optionTexts).not.toContain('Frost I');
 		expect(optionTexts).not.toContain('Frost II');
+	});
+});
+
+describe('GatewaysEditor — excludes tiers of a retired path (#2176)', () => {
+	it('omits a tier whose own record is live but whose owning path is retired', async () => {
+		const gated = tier({ id: 0, pathId: 0, name: 'Fire I' });
+		const frozenTier = tier({ id: 1, pathId: 1, name: 'Frost I' });
+		const openTier = tier({ id: 2, pathId: 2, name: 'Wind I' });
+		const paths = [
+			path({ id: 0, name: 'Fire' }),
+			path({ id: 1, name: 'Frost', retiredAt: '2026-01-01T00:00:00Z' }),
+			path({ id: 2, name: 'Wind' })
+		];
+		const store = makeStore([gated, frozenTier, openTier], paths);
+
+		render(GatewaysEditor, { store, tier: gated });
+
+		const select = screen.getByRole('combobox', { name: 'Add prerequisite' }) as HTMLSelectElement;
+		const optionTexts = Array.from(select.options).map((o) => o.text);
+
+		expect(optionTexts).toContain('Wind I');
+		expect(optionTexts).not.toContain('Frost I');
 	});
 });

--- a/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
@@ -51,6 +51,7 @@ const makeStore = (drilledTier: WorkbenchProficiency, overrides: Record<string, 
 	({
 		drilledTier,
 		profs: [drilledTier],
+		paths: [],
 		tierTab: 'identity',
 		selectedPath: { name: 'Fire Path' },
 		selectedLevel: 1,


### PR DESCRIPTION
## Summary

`GatewaysEditor.svelte`'s `addOptions` filtered out a directly-retired tier from the "Add prerequisite" picker, but never checked whether the *candidate tier's owning path* was retired. A tier on a retired path is frozen — it never accrues and can never max — so picking it as a prerequisite authors a gateway that can never open. Content Health immediately flags this as an Error, but the save silently succeeds, leaving the author with no in-the-moment warning (violating the documented picker rule in `frontend-admin.md`: retired records are "a hard block, not a warning" in authoring pickers).

This is the exact analogue of the same-path gap fixed in #2128, in the direction #2128 didn't cover (owning-path retirement rather than same-path).

## Changes

- **Frontend** (`GatewaysEditor.svelte`): `addOptions` now also excludes any tier whose owning path — looked up live off `store.paths`, not the last-saved snapshot, so a path retired earlier in the same session is respected — is retired.
- **Backend** (`AdminProficiencies.ValidatePrerequisiteIds`): added the same rejection at save time as anti-tamper (a tampered admin client can't bypass the frontend check), mirroring the existing same-path guard from #2128.

## Test plan

- [x] Added `SetPrerequisites_PrerequisiteOnRetiredPath_ReturnsFailure` (`Game.Application.Tests/DataAccess/AdminProficienciesIntegrationTests.cs`) — asserts the backend rejects a prerequisite on a retired path.
- [x] Added a new test to `GatewaysEditor.test.ts` (`#2176`) asserting a tier on a retired path is omitted from the picker even though the tier record itself isn't retired.
- [x] Updated the fake stores in `GatewaysEditor.test.ts`/`TierDetail.test.ts` to include `paths` now that the component reads it.
- [x] `dotnet build Game.sln` — succeeds, no warnings.
- [x] `dotnet test Game.sln` (full suite) — 3343/3343 passing.
- [x] `npm run lint` (UI) — clean.
- [x] `npm run test:unit:ci` (UI) — 3807/3807 passing.

Closes #2176


---
_Generated by [Claude Code](https://claude.ai/code/session_01UVq4kVSUaUtMo67Jjj2iFH)_