### PR TITLE
Workbench a11y: add accessible names to table-cell selects/inputs and two bare selects

### DIFF
--- a/UI/src/routes/admin/workbench/components/ChipsSection.svelte
+++ b/UI/src/routes/admin/workbench/components/ChipsSection.svelte
@@ -27,6 +27,7 @@
 		<div class="fld add-select">
 			<select
 				class="sel"
+				aria-label={section.addLabel}
 				value=""
 				onchange={(e) => {
 					const { value } = e.currentTarget;

--- a/UI/src/routes/admin/workbench/components/TableCell.svelte
+++ b/UI/src/routes/admin/workbench/components/TableCell.svelte
@@ -1,7 +1,13 @@
 {#if col.type === 'select'}
 	<td style:min-width="{col.min ?? 160}px">
 		<div class="fld">
-			<select class="sel" class:dirty value={row[col.key] as number} onchange={(e) => onChange(+e.currentTarget.value)}>
+			<select
+				class="sel"
+				class:dirty
+				aria-label={col.label}
+				value={row[col.key] as number}
+				onchange={(e) => onChange(+e.currentTarget.value)}
+			>
 				{#each col.options?.(row[col.key] as number, row) ?? [] as option (option.value)}
 					<option value={option.value} disabled={taken.has(option.value) && option.value !== row[col.key]}>
 						{option.text}
@@ -31,6 +37,7 @@
 				value={(row[col.key] as number) ?? 0}
 				allowNegative={col.allowNegative}
 				commitOnBlur={identity}
+				ariaLabel={col.label}
 				onChange={(n) => onChange(n)}
 			/>
 			{#if dirty}<DirtyDot />{/if}

--- a/UI/src/routes/admin/workbench/components/challenge/ChallengeConditionSection.svelte
+++ b/UI/src/routes/admin/workbench/components/challenge/ChallengeConditionSection.svelte
@@ -11,6 +11,7 @@
 				<select
 					class="sel"
 					class:dirty={typeDirty}
+					aria-label="Objective Type"
 					value={challenge.challengeTypeId}
 					onchange={(e) =>
 						store.patch(challenge.id, (d) =>

--- a/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
@@ -97,6 +97,13 @@ describe('ChipsSection', () => {
 		expect(addSelect.querySelectorAll('option')).toHaveLength(3);
 	});
 
+	it('carries the add-label as an accessible name for the add select', () => {
+		const { store, record, baseline } = setup([1]);
+		const { container } = renderChips(store, record, baseline);
+		const addSelect = container.querySelector('.add-select select') as HTMLSelectElement;
+		expect(addSelect.getAttribute('aria-label')).toBe('Add skill…');
+	});
+
 	it('adds a chip when an option is chosen', async () => {
 		const { store, record, baseline } = setup([1]);
 		const { container } = renderChips(store, record, baseline);

--- a/UI/src/tests/routes/admin/workbench/TableCell.test.ts
+++ b/UI/src/tests/routes/admin/workbench/TableCell.test.ts
@@ -137,6 +137,21 @@ describe('TableCell — select type', () => {
 		expect(container.querySelector('select')!.classList.contains('dirty')).toBe(true);
 	});
 
+	it('carries the column label as an accessible name (the visible label is a presentational span)', () => {
+		const { container } = render(TableCell, {
+			props: {
+				col: makeSelectCol(),
+				row: { zoneId: 1 },
+				idx: 0,
+				rows: [{ zoneId: 1 }],
+				record: {},
+				dirty: false,
+				onChange: vi.fn()
+			}
+		});
+		expect(container.querySelector('select')!.getAttribute('aria-label')).toBe('Zone');
+	});
+
 	it('calls onChange with the numeric value when the selection changes', async () => {
 		const onChange = vi.fn();
 		const { container } = render(TableCell, {
@@ -172,6 +187,21 @@ describe('TableCell — number type', () => {
 		const input = container.querySelector('input') as HTMLInputElement;
 		expect(input).toBeTruthy();
 		expect(input.getAttribute('inputmode')).toBe('decimal');
+	});
+
+	it('carries the column label as an accessible name (the visible label is a presentational span)', () => {
+		const { container } = render(TableCell, {
+			props: {
+				col: makeNumberCol(),
+				row: { weight: 10 },
+				idx: 0,
+				rows: [{ weight: 10 }],
+				record: {},
+				dirty: false,
+				onChange: vi.fn()
+			}
+		});
+		expect(container.querySelector('input')!.getAttribute('aria-label')).toBe('Weight');
 	});
 
 	it('commits on every keystroke when this is not the identity column', async () => {

--- a/UI/src/tests/routes/admin/workbench/challenge/ChallengeConditionSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ChallengeConditionSection.test.ts
@@ -78,6 +78,13 @@ describe('ChallengeConditionSection', () => {
 		expect(select.value).toBe(String(EChallengeType.EnemiesKilled));
 	});
 
+	it('carries an accessible name for the objective-type select (the visible label is a bare span)', () => {
+		const { store, record, baseline } = setup();
+		const { container } = render(ChallengeConditionSection, { props: { record, baseline, store } });
+		const select = container.querySelector('.type-select select') as HTMLSelectElement;
+		expect(select.getAttribute('aria-label')).toBe('Objective Type');
+	});
+
 	it('renders the plain-language objective preview', () => {
 		const { store, record, baseline } = setup();
 		render(ChallengeConditionSection, { props: { record, baseline, store } });


### PR DESCRIPTION
## Summary

`NumInput.svelte`'s own prop doc establishes the convention: the visible field labels in the Workbench are presentational `<span>`s, not associated `<label>`s, so `aria-label`/`ariaLabel` is the designed naming mechanism. `TableCell` already followed it for the text and attribute columns but missed two of its own branches, and two other Workbench selects had the same gap:

- `TableCell.svelte` — the `select` column branch had no `aria-label`.
- `TableCell.svelte` — the `number` column's `NumInput` had no `ariaLabel`.
- `ChipsSection.svelte` — the add-`<select>`'s "＋ Add skill from pool…" text is an `<option>`, which doesn't name the `<select>` itself.
- `ChallengeConditionSection.svelte` — the objective-type `<select>`'s "Objective Type" label is a bare `<span>`.

Net effect: every numeric/select cell in the enemies/skills/items/zones/classes/lessons/recipes tables, plus these two selects, was announced as an unnamed control to assistive tech.

## Changes

- `TableCell.svelte`: pass `aria-label={col.label}` on the select branch and `ariaLabel={col.label}` on the `NumInput` in the number branch — matching the existing text/attribute column pattern.
- `ChipsSection.svelte`: `aria-label={section.addLabel}` on the add-select.
- `ChallengeConditionSection.svelte`: `aria-label="Objective Type"` on the objective-type select.
- Added regression assertions to each component's existing test file (`TableCell.test.ts`, `ChipsSection.test.ts`, `ChallengeConditionSection.test.ts`) checking the `aria-label` is present and correct.

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings (eslint + svelte-check)
- [x] `npx vitest run` on the three touched test files — 39/39 passing
- [x] `npm run test:unit:ci` (full suite) — 304 files / 3811 tests passing

Closes #2177


---
_Generated by [Claude Code](https://claude.ai/code/session_013bogAtdmNZdHDVBXLiCP1e)_