### PR TITLE
Render a level-0 slot in the Milestones editor for on-open modifiers

### DIFF
--- a/UI/src/routes/admin/workbench/progression/MilestonesEditor.svelte
+++ b/UI/src/routes/admin/workbench/progression/MilestonesEditor.svelte
@@ -67,17 +67,19 @@
 		{/each}
 		<button type="button" class="link-add" onclick={() => store.addModifier(tier.id, sel)}>+ Add modifier</button>
 
-		<div class="field-label mt">
-			Reward skill <span class="muted">(optional — granted on reaching this level)</span>
-		</div>
-		<div class="reward">
-			<ProgSelect
-				ariaLabel="Reward skill"
-				value={reward?.rewardSkillId ?? NO_SKILL}
-				options={rewardOptions}
-				onChange={(v) => store.setReward(tier.id, sel, v)}
-			/>
-		</div>
+		{#if sel > 0}
+			<div class="field-label mt">
+				Reward skill <span class="muted">(optional — granted on reaching this level)</span>
+			</div>
+			<div class="reward">
+				<ProgSelect
+					ariaLabel="Reward skill"
+					value={reward?.rewardSkillId ?? NO_SKILL}
+					options={rewardOptions}
+					onChange={(v) => store.setReward(tier.id, sel, v)}
+				/>
+			</div>
+		{/if}
 
 		<div class="payout-foot">
 			<button type="button" class="link-danger" onclick={() => store.removePayout(tier.id, sel)}
@@ -86,7 +88,11 @@
 		</div>
 	{:else}
 		<div class="empty-payout">
-			<div class="ep-text">No payout at level {sel} — players just gain the level.</div>
+			<div class="ep-text">
+				{sel === 0
+					? 'No on-open bonus — players start this tier with nothing.'
+					: `No payout at level ${sel} — players just gain the level.`}
+			</div>
 			<button
 				type="button"
 				class="btn-add"
@@ -115,7 +121,7 @@ interface Props {
 const { store, tier }: Props = $props();
 
 const maxLevel = $derived(Math.max(1, Math.floor(tier.maxLevel) || 1));
-const sel = $derived(Math.min(Math.max(1, store.selectedLevel), maxLevel));
+const sel = $derived(Math.min(Math.max(0, store.selectedLevel), maxLevel));
 const reward = $derived(rewardAtLevel(tier, sel));
 const selMods = $derived(modifiersAtLevel(tier, sel));
 const hasPayout = $derived(selMods.length > 0 || reward !== undefined);
@@ -136,7 +142,7 @@ const attrOptionsFor = (current: number) =>
 
 const levelNodes = $derived.by(() => {
 	const nodes: { level: number; kind: 'empty' | 'bonus' | 'milestone' }[] = [];
-	for (let level = 1; level <= maxLevel; level++) {
+	for (let level = 0; level <= maxLevel; level++) {
 		const hasReward = isMilestoneLevel(tier, level);
 		const hasMod = modifiersAtLevel(tier, level).length > 0;
 		nodes.push({ level, kind: hasReward ? 'milestone' : hasMod ? 'bonus' : 'empty' });

--- a/UI/src/tests/routes/admin/workbench/progression/MilestonesEditor.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/MilestonesEditor.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
+import { EAttribute, EModifierType } from '$lib/api';
+
+// MilestonesEditor's Reward-skill select reads staticData.skills via the reference module —
+// mirrors TierDetail.test.ts's hoisted staticData mock.
+const { staticData } = vi.hoisted(() => ({
+	staticData: { skills: [] as unknown[] }
+}));
+vi.mock('$stores', () => ({ staticData }));
+
+import MilestonesEditor from '$routes/admin/workbench/progression/MilestonesEditor.svelte';
+import type { ProgressionStore } from '$routes/admin/workbench/progression/progression-store.svelte';
+import type { WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+
+const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency => ({
+	id: 5,
+	name: 'Blades',
+	description: '',
+	iconPath: '',
+	word: '',
+	pronunciation: '',
+	translation: '',
+	pathId: 0,
+	pathOrdinal: 0,
+	maxLevel: 10,
+	baseXp: 100,
+	xpGrowth: 1.4,
+	designerNotes: '',
+	levelModifiers: [],
+	levelRewards: [],
+	prerequisiteIds: [],
+	...over
+});
+
+// A fake store exposing exactly what MilestonesEditor reads/calls — mirrors GatewaysEditor.test.ts's
+// fake-store pattern rather than driving the real ProgressionStore through a socket-backed load().
+const makeStore = (selectedLevel: number, overrides: Record<string, unknown> = {}) =>
+	({
+		selectedLevel,
+		selectLevel: vi.fn(),
+		updateModifier: vi.fn(),
+		removeModifier: vi.fn(),
+		addModifier: vi.fn(),
+		setReward: vi.fn(),
+		addPayout: vi.fn(),
+		removePayout: vi.fn(),
+		...overrides
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	}) as any as ProgressionStore;
+
+beforeEach(() => {
+	staticData.skills = [];
+});
+afterEach(cleanup);
+
+describe('MilestonesEditor — level 0 (on-open) payouts (#2178)', () => {
+	it('renders a level-0 node in the timeline, selectable like any other level', async () => {
+		const store = makeStore(1);
+		render(MilestonesEditor, { store, tier: tier() });
+
+		const zero = screen.getByRole('button', { name: 'Level 0' });
+		expect(zero).toBeTruthy();
+
+		await fireEvent.click(zero);
+		expect(store.selectLevel).toHaveBeenCalledWith(0);
+	});
+
+	it('shows the on-open empty state (not the "gain the level" copy) when level 0 has no payout', () => {
+		const store = makeStore(0);
+		render(MilestonesEditor, { store, tier: tier() });
+
+		expect(screen.getByText(/players start this tier with nothing/)).toBeTruthy();
+		expect(screen.queryByText(/players just gain the level/)).toBeNull();
+	});
+
+	it('lets an author add a modifier at level 0 and clears it via "Add a payout here"', async () => {
+		const store = makeStore(0);
+		render(MilestonesEditor, { store, tier: tier() });
+
+		await fireEvent.click(screen.getByTestId('progression-add-payout'));
+		expect(store.addPayout).toHaveBeenCalledWith(5, 0);
+	});
+
+	it('displays an existing level-0 modifier and omits the reward-skill field entirely', () => {
+		const payoutTier = tier({
+			levelModifiers: [
+				{ level: 0, attributeId: EAttribute.Strength, modifierTypeId: EModifierType.Additive, amount: 5 }
+			]
+		});
+		const store = makeStore(0);
+		render(MilestonesEditor, { store, tier: payoutTier });
+
+		expect(screen.getByText('Attribute modifiers')).toBeTruthy();
+		// Level 0 rewards can never fire (AdminProficiencies.SetRewards rejects level < 1), so the
+		// editor must not offer authoring one here.
+		expect(screen.queryByText(/Reward skill/)).toBeNull();
+		expect(screen.queryByLabelText('Reward skill')).toBeNull();
+	});
+
+	it('shows the reward-skill field once a level above 0 is selected', () => {
+		const store = makeStore(1);
+		render(MilestonesEditor, {
+			store,
+			tier: tier({
+				levelModifiers: [
+					{ level: 1, attributeId: EAttribute.Strength, modifierTypeId: EModifierType.Additive, amount: 5 }
+				]
+			})
+		});
+
+		expect(screen.getByText(/Reward skill/)).toBeTruthy();
+	});
+});


### PR DESCRIPTION
## Summary

`AdminProficiencies.SetModifiers` explicitly allows a level-0 attribute modifier — the "on-open" bonus honored by `Proficiency.ModifiersForLevel`'s `l.Level <= level` rule (a payout authored at the just-opened state). But `MilestonesEditor`'s timeline and selectable level range started at 1 (`Math.max(1, Math.floor(tier.maxLevel) || 1)` / `Math.max(1, store.selectedLevel)`), so a level-0 modifier — valid, persistable backend data — could never be displayed, edited, or removed in the Workbench once authored (e.g. via seed/import or a future authoring path).

`payoutLevels()` (the Milestones tab's payout count) was already correct — it counts every level present in `levelModifiers`/`levelRewards` regardless of value — so the count vs. visible-slots mismatch the issue called out is now resolved by making the visible slots match.

## Changes

- `MilestonesEditor.svelte`: the level timeline now renders `0..maxLevel` (was `1..maxLevel`), and the selected-level clamp allows 0.
- The "Reward skill" field is now hidden while level 0 is selected. Unlike modifiers, level-0 **rewards** remain rejected server-side (`AdminProficiencies.SetRewards` requires `minLevel: 1` — a milestone reward is granted by crossing a level, and level 0 is never crossed), so surfacing that field at level 0 would let an author fill in a value the backend rejects on save. This mirrors the existing backend asymmetry rather than introducing a new one.
- The empty-payout copy at level 0 now reads "No on-open bonus — players start this tier with nothing." instead of the level-1+ "players just gain the level" wording, since level 0 isn't reached by leveling up.

## Test plan

- [x] Added `MilestonesEditor.test.ts` covering: level-0 timeline node renders and is selectable, the on-open empty-state copy, adding a payout at level 0, an existing level-0 modifier displays with the reward field omitted, and the reward field reappears at level 1+.
- [x] `npm run test:unit:ci` — full frontend suite green (3816/3816).
- [x] `npm run lint` — clean (eslint + svelte-check).
- Backend is unchanged (it already permitted level-0 modifiers correctly); no backend test changes needed.

Closes #2178


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnQetaXoF8AtyPDbLrM69U)_