### PR TITLE
Stabilize SynthesisView.proficiencyLevels' reference across xp-only pushes

### DIFF
--- a/UI/src/routes/game/screens/synthesis/synthesis-view.svelte.ts
+++ b/UI/src/routes/game/screens/synthesis/synthesis-view.svelte.ts
@@ -37,9 +37,27 @@ export class SynthesisView {
 	// eslint-disable-next-line svelte/prefer-svelte-reactivity
 	readonly ownedSkillIds = $derived(new Set(playerManager.unlockedSkills.map((s) => s.skillId)));
 
-	/** The player's current level per proficiency (a missing proficiency counts as level 0 in gating). */
-	// eslint-disable-next-line svelte/prefer-svelte-reactivity
-	readonly proficiencyLevels = $derived(new Map(playerProficiencies.all.map((p) => [p.proficiencyId, p.level])));
+	/** Previous {@link proficiencyLevels} value, for the reference-stability check below. Plain (not
+	 *  `$state`) so writing it mid-derivation isn't a reactive mutation. */
+	#previousLevels: Map<number, number> | undefined;
+
+	/** The player's current level per proficiency (a missing proficiency counts as level 0 in gating).
+	 *  Keeps the previous Map's identity when every level is unchanged: `playerProficiencies.all`
+	 *  reassigns its array wholesale on every `ProficiencyXpGained` push (deliberately, for by-reference
+	 *  change detection elsewhere) even when xp moved but no level did, and this is the value {@link
+	 *  recipes} and {@link graph} key their own recomputation on — without this, the whole recipe list
+	 *  and graph layout would re-derive on every battle victory for no visible change. */
+	readonly proficiencyLevels = $derived.by(() => {
+		const all = playerProficiencies.all;
+		const previous = this.#previousLevels;
+		if (previous && previous.size === all.length && all.every((p) => previous.get(p.proficiencyId) === p.level)) {
+			return previous;
+		}
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const next = new Map(all.map((p) => [p.proficiencyId, p.level]));
+		this.#previousLevels = next;
+		return next;
+	});
 
 	/** The discovered recipes with their reveal/gating state — recomputed as owned skills, proficiency
 	 *  levels, and reference data change. */

--- a/UI/src/tests/routes/game/screens/synthesis/synthesis-view-proficiency-stability.test.ts
+++ b/UI/src/tests/routes/game/screens/synthesis/synthesis-view-proficiency-stability.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/* Unlike synthesis-view.test.ts, this file deliberately does NOT mock $stores: proficiencyLevels'
+   reference-stability fix (#2136) only exercises Svelte's derived-chain memoization when its
+   `playerProficiencies.all` dependency is a real `$state`-backed signal — a plain mock object's
+   property mutation isn't tracked, so it could never expose a regression here. playerManager and
+   apiSocket are still mocked; neither is exercised. */
+const { mockPlayerManager } = vi.hoisted(() => ({
+	mockPlayerManager: { unlockedSkills: [] as { skillId: number; selected: boolean; order?: number }[] }
+}));
+vi.mock('$lib/engine', () => ({ playerManager: mockPlayerManager }));
+vi.mock('$lib/api', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return { ...actual, apiSocket: { sendSocketCommand: vi.fn() } };
+});
+
+import { playerProficiencies, staticData } from '$stores';
+import type { IProficiencyXpResultModel } from '$lib/api';
+import { SynthesisView } from '$routes/game/screens/synthesis/synthesis-view.svelte';
+
+const xpResult = (proficiencyId: number, newLevel: number, newXp: number): IProficiencyXpResultModel => ({
+	proficiencyId,
+	xpGained: 10,
+	newLevel,
+	newXp,
+	milestonesCrossed: [],
+	grantedSkillIds: []
+});
+
+beforeEach(() => {
+	mockPlayerManager.unlockedSkills = [];
+	playerProficiencies.reset();
+	staticData.reset();
+	staticData.skillRecipes = [];
+	staticData.skills = [];
+	staticData.proficiencies = [];
+});
+
+describe('SynthesisView.proficiencyLevels — reference stability', () => {
+	it('keeps the same Map reference across a push that only moves xp, not level', () => {
+		playerProficiencies.applyXpGained({ proficiencies: [xpResult(0, 3, 10)], opened: [] });
+		const view = new SynthesisView();
+
+		const before = view.proficiencyLevels;
+		expect(before.get(0)).toBe(3);
+
+		// A same-level push still reassigns playerProficiencies.all wholesale (by design).
+		playerProficiencies.applyXpGained({ proficiencies: [xpResult(0, 3, 45)], opened: [] });
+
+		expect(view.proficiencyLevels).toBe(before);
+	});
+
+	it('returns a new Map when a level actually changes', () => {
+		playerProficiencies.applyXpGained({ proficiencies: [xpResult(0, 3, 10)], opened: [] });
+		const view = new SynthesisView();
+		const before = view.proficiencyLevels;
+
+		playerProficiencies.applyXpGained({ proficiencies: [xpResult(0, 4, 0)], opened: [] });
+
+		expect(view.proficiencyLevels).not.toBe(before);
+		expect(view.proficiencyLevels.get(0)).toBe(4);
+	});
+
+	it('returns a new Map when a proficiency is newly opened', () => {
+		const view = new SynthesisView();
+		const before = view.proficiencyLevels;
+		expect(before.size).toBe(0);
+
+		playerProficiencies.applyXpGained({ proficiencies: [], opened: [{ proficiencyId: 2 }] });
+
+		expect(view.proficiencyLevels).not.toBe(before);
+		expect(view.proficiencyLevels.get(2)).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

- `playerProficiencies.all` reassigns its array wholesale on every `ProficiencyXpGained` push (one per battle victory) — deliberate, for by-reference change detection elsewhere (proficiencies store docs).
- `SynthesisView.proficiencyLevels` (`UI/src/routes/game/screens/synthesis/synthesis-view.svelte.ts`) built a fresh `Map` from that array on every derivation, even when no proficiency **level** actually changed (the common case — only xp moved).
- Because `recipes` (→ `buildSynthesis`) and `graph` (→ `layoutSynthesisGraph`) key their own `$derived` recomputation on `proficiencyLevels`' reference identity, this re-ran the whole recipe pipeline and full graph layout (longest-path layering + barycenter sort) on every battle victory while the Synthesis screen was open — pure wasted work, per #2136.

## Fix

`proficiencyLevels` now memoizes against a plain (non-reactive, `#`-private) cache field: it returns the previous `Map` reference when every proficiency's level is unchanged, and only builds a new one when a level actually moved (or a proficiency newly opens). This mirrors the existing per-record `WeakMap` memoization pattern in `entity-store.svelte.ts`'s `recordStates` (writing to a non-reactive field mid-`$derived` is the established way to avoid an illegal `$state` mutation during derivation in this codebase — see `player-manager.ts`'s `#lockedBaseCache` for another instance).

Since Svelte 5's `$derived` chain only propagates invalidation when a dependency's *value* actually changes (not just when it's recomputed), keeping the same `Map` reference here means `recipes`/`graph` skip their own re-derivation entirely when only xp moved.

## Test plan

- Added `UI/src/tests/routes/game/screens/synthesis/synthesis-view-proficiency-stability.test.ts`, which — unlike the existing `synthesis-view.test.ts` — deliberately does **not** mock `$stores`, since the reference-stability bug only manifests through real `$state`-backed reactivity (a plain mocked object's property mutation isn't tracked by Svelte, so it could never expose this regression). Verified this test fails on the pre-fix code (via `git stash`) and passes after the fix.
  - Same-level push → `proficiencyLevels` keeps the same `Map` reference.
  - Level-up push → `proficiencyLevels` returns a new `Map` with the updated level.
  - Newly-opened proficiency → `proficiencyLevels` returns a new `Map` including it at level 0.
- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — 306 files / 3819 tests passed

Closes #2136


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vr4MFo5WqP95T8rsieJpAk)_