### PR TITLE
Memoize ProgressionStore per-record status to stop full-catalogue re-diffs

### DIFF
--- a/UI/src/routes/admin/workbench/progression/progression-helpers.ts
+++ b/UI/src/routes/admin/workbench/progression/progression-helpers.ts
@@ -1,7 +1,6 @@
 import type { IProficiencyLevelModifier, IProficiencyLevelReward } from '$lib/api';
 import { EActivityKey, EAttribute, EModifierType } from '$lib/api';
 import { activityKeyDisplay, type ActivityKeyKind } from '$lib/common';
-import { canonicalEqual } from '../save-helpers';
 import type { SelectOption } from '../entities/types';
 import type { WorkbenchPath, WorkbenchProficiency } from './types';
 
@@ -220,30 +219,3 @@ export const profIdentityDto = (prof: WorkbenchProficiency) => ({
 	prerequisiteIds: [] as number[],
 	retiredAt: prof.retiredAt
 });
-
-// ── Diffing & new-id resolution (shared shape with the generic save pipeline) ──
-
-export interface CatalogueDiff<T> {
-	added: T[];
-	modified: { record: T; baseline: T }[];
-}
-
-/**
- * Split a catalogue against its baseline into added (no baseline) and modified (differs from baseline
- * in any way — identity or child collection). Retire is an edit, so there is no delete set; never-saved
- * records that are dropped simply never appear in `current`.
- */
-export const diffCatalogue = <T extends { id: number }>(current: T[], baseline: T[]): CatalogueDiff<T> => {
-	const baseMap = new Map(baseline.map((record) => [record.id, record]));
-	const added: T[] = [];
-	const modified: { record: T; baseline: T }[] = [];
-	for (const record of current) {
-		const base = baseMap.get(record.id);
-		if (!base) {
-			added.push(record);
-		} else if (!canonicalEqual(record, base)) {
-			modified.push({ record, baseline: base });
-		}
-	}
-	return { added, modified };
-};

--- a/UI/src/routes/admin/workbench/progression/progression-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/progression/progression-store.svelte.ts
@@ -14,7 +14,6 @@ import { childChanged, canonicalEqual, resolveId, resolveNewIds } from '../save-
 import { firstFree } from '../entities/helpers';
 import {
 	blankModifier,
-	diffCatalogue,
 	newPath,
 	newProficiency,
 	pathIdentityDto,
@@ -109,8 +108,68 @@ export class ProgressionStore {
 		}
 		return map;
 	});
-	private pathDiff = $derived(diffCatalogue(this.paths, this.basePaths));
-	private profDiff = $derived(diffCatalogue(this.profs, this.baseProfs));
+
+	/**
+	 * Per-record status, memoised per record object (mirroring EntityStore.recordStates): a patch
+	 * replaces only the one record it touched, so every other record is a same-reference cache hit
+	 * instead of a re-canonicalized comparison against its baseline. No epoch invalidation is needed
+	 * here (unlike EntityStore) — this store has no soft-delete side channel that can flip a status
+	 * without also replacing the record's reference.
+	 */
+	private pathStateCache = new WeakMap<WorkbenchPath, RecordStatus>();
+	private profStateCache = new WeakMap<WorkbenchProficiency, RecordStatus>();
+
+	private pathStatuses = $derived.by<Record<number, RecordStatus>>(() => {
+		const map: Record<number, RecordStatus> = {};
+		for (const path of this.paths) {
+			let status = this.pathStateCache.get(path);
+			if (status === undefined) {
+				const baseline = this.basePathMap[path.id];
+				status = !baseline ? 'added' : canonicalEqual(path, baseline) ? 'clean' : 'modified';
+				this.pathStateCache.set(path, status);
+			}
+			map[path.id] = status;
+		}
+		return map;
+	});
+	private profStatuses = $derived.by<Record<number, RecordStatus>>(() => {
+		const map: Record<number, RecordStatus> = {};
+		for (const prof of this.profs) {
+			let status = this.profStateCache.get(prof);
+			if (status === undefined) {
+				const baseline = this.baseProfMap[prof.id];
+				status = !baseline ? 'added' : canonicalEqual(prof, baseline) ? 'clean' : 'modified';
+				this.profStateCache.set(prof, status);
+			}
+			map[prof.id] = status;
+		}
+		return map;
+	});
+
+	private pathDiff = $derived.by(() => {
+		const added: WorkbenchPath[] = [];
+		const modified: { record: WorkbenchPath; baseline: WorkbenchPath }[] = [];
+		for (const path of this.paths) {
+			if (this.pathStatuses[path.id] === 'added') {
+				added.push(path);
+			} else if (this.pathStatuses[path.id] === 'modified') {
+				modified.push({ record: path, baseline: this.basePathMap[path.id] });
+			}
+		}
+		return { added, modified };
+	});
+	private profDiff = $derived.by(() => {
+		const added: WorkbenchProficiency[] = [];
+		const modified: { record: WorkbenchProficiency; baseline: WorkbenchProficiency }[] = [];
+		for (const prof of this.profs) {
+			if (this.profStatuses[prof.id] === 'added') {
+				added.push(prof);
+			} else if (this.profStatuses[prof.id] === 'modified') {
+				modified.push({ record: prof, baseline: this.baseProfMap[prof.id] });
+			}
+		}
+		return { added, modified };
+	});
 
 	counts = $derived({
 		added: this.pathDiff.added.length + this.profDiff.added.length,
@@ -121,20 +180,14 @@ export class ProgressionStore {
 		return this.counts.added + this.counts.modified;
 	}
 
+	/** Always called with a record from {@link paths}, which {@link pathStatuses} covers exhaustively. */
 	pathStatus(path: WorkbenchPath): RecordStatus {
-		const baseline = this.basePathMap[path.id];
-		if (!baseline) {
-			return 'added';
-		}
-		return canonicalEqual(path, baseline) ? 'clean' : 'modified';
+		return this.pathStatuses[path.id];
 	}
 
+	/** Always called with a record from {@link profs}, which {@link profStatuses} covers exhaustively. */
 	profStatus(prof: WorkbenchProficiency): RecordStatus {
-		const baseline = this.baseProfMap[prof.id];
-		if (!baseline) {
-			return 'added';
-		}
-		return canonicalEqual(prof, baseline) ? 'clean' : 'modified';
+		return this.profStatuses[prof.id];
 	}
 
 	isRetired(record: { retiredAt?: string | null }): boolean {
@@ -407,8 +460,8 @@ export class ProgressionStore {
 		let committed = false;
 		try {
 			const baseProfMap = this.baseProfMap;
-			const pathDiff = diffCatalogue(this.paths, this.basePaths);
-			const profDiff = diffCatalogue(this.profs, this.baseProfs);
+			const pathDiff = this.pathDiff;
+			const profDiff = this.profDiff;
 
 			// 1. Cross-path prerequisite changes that touch only already-persisted tiers need no id remap,
 			// so — only when this save is also retiring a path — they're posted immediately, before path

--- a/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
@@ -4,7 +4,6 @@ import {
 	activityKeyGroups,
 	cumulativeXp,
 	decipherThresholds,
-	diffCatalogue,
 	hasTierCollision,
 	isMilestoneLevel,
 	modifiersAtLevel,
@@ -149,21 +148,6 @@ describe('validation', () => {
 			levelRewards: [{ level: 9, rewardSkillId: 1 }]
 		});
 		expect(proficiencyWarnings(ranged)).toContain('Reward level 9 out of range');
-	});
-});
-
-describe('diffCatalogue', () => {
-	it('splits into added (no baseline) and modified (differs)', () => {
-		const a = { id: 1, name: 'A' };
-		const b = { id: 2, name: 'B' };
-		const current = [
-			{ id: 1, name: 'A2' }, // modified
-			{ id: -1, name: 'New' }, // added
-			b // unchanged
-		];
-		const diff = diffCatalogue(current, [a, b]);
-		expect(diff.added.map((r) => r.id)).toEqual([-1]);
-		expect(diff.modified.map((m) => m.record.id)).toEqual([1]);
 	});
 });
 

--- a/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
  * exercised end to end rather than mocked into a tautology.
  */
 
-const { postMock, fetchMock, staticDataMock, toastErrorMock, referenceMock } = vi.hoisted(() => ({
+const { postMock, fetchMock, staticDataMock, toastErrorMock, referenceMock, canonicalEqualMock } = vi.hoisted(() => ({
 	postMock: vi.fn(),
 	fetchMock: vi.fn(),
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -18,7 +18,8 @@ const { postMock, fetchMock, staticDataMock, toastErrorMock, referenceMock } = v
 			{ value: 0, text: 'a0' },
 			{ value: 1, text: 'a1' }
 		]
-	}
+	},
+	canonicalEqualMock: vi.fn()
 }));
 
 vi.mock('$lib/api', async (importOriginal) => {
@@ -27,6 +28,18 @@ vi.mock('$lib/api', async (importOriginal) => {
 });
 vi.mock('$stores', () => ({ staticData: staticDataMock, toastError: toastErrorMock }));
 vi.mock('$routes/admin/workbench/reference.svelte', () => ({ reference: referenceMock }));
+// Spies through to the real implementation — only observes call counts, so status/diff results are unaffected.
+vi.mock('$routes/admin/workbench/save-helpers', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	const real = actual.canonicalEqual as (a: unknown, b: unknown) => boolean;
+	return {
+		...actual,
+		canonicalEqual: (a: unknown, b: unknown) => {
+			canonicalEqualMock(a, b);
+			return real(a, b);
+		}
+	};
+});
 
 import { EActivityKey, EChangeType } from '$lib/api';
 import { ProgressionStore } from '$routes/admin/workbench/progression/progression-store.svelte';
@@ -245,6 +258,29 @@ describe('local editing', () => {
 		store.patchPath(0, (d) => (d.name = 'Inferno'));
 		expect(store.counts.modified).toBe(1);
 		expect(store.totalChanges).toBe(1);
+	});
+
+	it('patching one path only re-diffs that record, not the whole catalogue (per-record memoization)', async () => {
+		serverPaths = [
+			{ id: 0, name: 'Fire', description: 'fire path', activityKey: EActivityKey.Physical, retiredAt: null },
+			{ id: 1, name: 'Water', description: 'water path', activityKey: EActivityKey.Physical, retiredAt: null }
+		];
+		serverProfs = [fullTier({ id: 0, pathId: 0, pathOrdinal: 0, name: 'Fire T0' })];
+		const store = new ProgressionStore();
+		await store.load();
+
+		// Reading status once seeds the memo for both paths.
+		expect(store.pathStatus(reqPath(store, 0))).toBe('clean');
+		expect(store.pathStatus(reqPath(store, 1))).toBe('clean');
+		canonicalEqualMock.mockClear();
+
+		store.patchPath(0, (d) => (d.name = 'Inferno'));
+		expect(store.pathStatus(reqPath(store, 0))).toBe('modified');
+		expect(store.pathStatus(reqPath(store, 1))).toBe('clean');
+
+		// Only path 0's (new object reference) status was recomputed; path 1's untouched reference hit the cache.
+		expect(canonicalEqualMock).toHaveBeenCalledTimes(1);
+		expect(canonicalEqualMock).toHaveBeenCalledWith(reqPath(store, 0), store.pathBaseline(0));
 	});
 
 	it('addPath adds a path plus its first tier', async () => {


### PR DESCRIPTION
## Summary

- `ProgressionStore.pathDiff`/`profDiff` ran `canonicalEqual` (canonicalize + double `JSON.stringify`) against baseline for **every** record in the catalogue on any single-record patch, and `pathStatus`/`profStatus` repeated that same work per row read (`ProgressionList.svelte`'s per-row `status:` binding). This is the exact pattern #2085 eliminated for the generic Workbench `EntityStore` via per-record `WeakMap` memoization — `ProgressionStore` predates that fix and never picked it up.
- Adopted the same per-record memoization: `patchPath`/`patchProf` only ever replace the one record they touch with a new object reference, so every other record's status is now a same-reference cache hit in a `WeakMap` instead of a re-canonicalized comparison against its baseline. `pathDiff`/`profDiff` (used by `counts`) are now derived from these memoized statuses instead of independently re-diffing the whole catalogue.
- Unlike `EntityStore`, no epoch-based cache invalidation was needed — `ProgressionStore` has no soft-delete side channel that can flip a record's status without also replacing its object reference (retire is an ordinary field patch, `removePath`/`removeTier` just filter the record out).
- `diffCatalogue`/`CatalogueDiff` (`progression-helpers.ts`) became dead code once their only call site was replaced — removed them along with their direct unit test, per CLAUDE.md's dead-code guideline.

## Test plan

- [x] Added a unit test asserting that patching one path only triggers one `canonicalEqual` call (for the patched record), while an untouched sibling record hits the cache — verifying the memoization actually works, not just that statuses stay correct.
- [x] `npx vitest run` — full UI suite: 306 files / 3819 tests passing.
- [x] `npx eslint .` — clean.
- [x] `npx svelte-check` — 0 errors / 0 warnings.

Closes #2137


---
_Generated by [Claude Code](https://claude.ai/code/session_01CAwcww79USVg3cHFvi3m6G)_