### PR TITLE
Dedupe post-#2124 scss residue: detail-pane block and ops-console chrome

### DIFF
--- a/UI/src/routes/admin/ops/ContentHealthConsole.svelte
+++ b/UI/src/routes/admin/ops/ContentHealthConsole.svelte
@@ -1,5 +1,5 @@
-<div class="ch-console" data-testid="content-health-console">
-	<div class="ch-head">
+<div class="ops-console" data-testid="content-health-console">
+	<div class="head">
 		<div class="eyebrow">Admin Console · Ops</div>
 		<div class="title-row">
 			<h1 class="title" data-testid="ch-title">Content Health</h1>
@@ -30,21 +30,21 @@
 		</p>
 	</div>
 
-	<div class="ch-toolbar">
+	<div class="toolbar">
 		<button type="button" class="btn" data-testid="ch-refresh" disabled={health.loading} onclick={refresh}>
 			Refresh
 		</button>
 	</div>
 
 	{#if health.error}
-		<div class="ch-error" role="alert" data-testid="ch-error">{health.error}</div>
+		<div class="error-panel" role="alert" data-testid="ch-error">{health.error}</div>
 	{/if}
 
-	<div class="ch-body">
+	<div class="body">
 		{#if !health.loaded && health.loading}
 			<Loading loading={true} delay={150} />
 		{:else if health.isHealthy}
-			<div class="ch-empty" data-testid="ch-healthy">
+			<div class="empty-state" data-testid="ch-healthy">
 				<div class="glyph">
 					<svg
 						width="26"
@@ -97,6 +97,7 @@ import { onMount } from 'svelte';
 import Loading from '$components/Loading.svelte';
 import { toastError } from '$stores';
 import { staticData } from '$stores';
+import './ops-console.scss';
 import { ContentHealthState, entityDisplayName, severityMeta, type EntityNameSources } from './content-health.svelte';
 
 const health = new ContentHealthState();
@@ -124,48 +125,7 @@ const refresh = async () => {
 </script>
 
 <style lang="scss">
-.ch-console {
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	min-height: 0;
-	font-family: var(--sans);
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-}
-
-.ch-head {
-	padding: 20px 32px 16px;
-	border-bottom: 1px solid var(--border-subtle);
-}
-.eyebrow {
-	font-family: var(--mono);
-	font-size: 10px;
-	letter-spacing: 2px;
-	text-transform: uppercase;
-	color: color-mix(in srgb, var(--accent) 70%, transparent);
-	margin-bottom: 6px;
-}
-.title-row {
-	display: flex;
-	align-items: baseline;
-	gap: 14px;
-	flex-wrap: wrap;
-}
-.title {
-	margin: 0;
-	font-size: 22px;
-	font-weight: 500;
-	letter-spacing: -0.2px;
-}
 .summary {
-	display: inline-flex;
-	align-items: center;
-	gap: 14px;
-	font-family: var(--mono);
-	font-size: 11.5px;
-	color: var(--text-tertiary);
-
 	.err {
 		color: var(--error);
 	}
@@ -177,69 +137,7 @@ const refresh = async () => {
 	}
 }
 .blurb {
-	margin: 12px 0 0;
 	max-width: 820px;
-	font-size: 12.5px;
-	line-height: 1.55;
-	color: var(--text-tertiary);
-
-	em {
-		font-style: normal;
-		color: var(--text-secondary);
-	}
-}
-
-.ch-toolbar {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	padding: 14px 32px;
-	border-bottom: 1px solid var(--border-subtle);
-}
-.btn {
-	display: inline-flex;
-	align-items: center;
-	gap: 7px;
-	background: transparent;
-	border: 1px solid var(--border-light);
-	color: var(--text-secondary);
-	font-family: var(--mono);
-	font-size: 11.5px;
-	letter-spacing: 0.6px;
-	text-transform: uppercase;
-	padding: 8px 15px;
-	border-radius: 3px;
-	cursor: pointer;
-	transition: all 0.14s ease;
-	white-space: nowrap;
-
-	&:hover:not(:disabled) {
-		border-color: color-mix(in srgb, var(--white) 32%, transparent);
-		box-shadow: 0 0 10px color-mix(in srgb, var(--accent) 40%, transparent);
-	}
-	&:disabled {
-		color: var(--text-muted);
-		border-color: var(--border-subtle);
-		cursor: not-allowed;
-		box-shadow: none;
-	}
-}
-
-.ch-error {
-	margin: 14px 32px 0;
-	padding: 11px 14px;
-	border: 1px solid color-mix(in srgb, var(--error) 45%, transparent);
-	background: color-mix(in srgb, var(--error) 10%, transparent);
-	border-radius: 4px;
-	color: var(--error);
-	font-size: 12.5px;
-}
-
-.ch-body {
-	flex: 1;
-	min-height: 0;
-	overflow: auto;
-	padding: 12px 32px 28px;
 }
 
 .ch-groups {
@@ -334,32 +232,9 @@ const refresh = async () => {
 	line-height: 1.5;
 }
 
-.ch-empty {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	text-align: center;
-	padding: 60px 20px;
-	color: var(--text-muted);
-	gap: 12px;
-
-	.glyph {
-		width: 56px;
-		height: 56px;
-		border-radius: 10px;
-		border: 1px dashed var(--border-light);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		color: var(--accent);
-	}
-	.et {
-		font-size: 14px;
-		color: var(--text-tertiary);
-	}
-	.es {
-		font-size: 12px;
-	}
+// The healthy-graph checkmark reads as a positive confirmation, not a neutral empty state,
+// so its glyph keeps the accent color instead of the shared .empty-state's muted default.
+.empty-state .glyph {
+	color: var(--accent);
 }
 </style>

--- a/UI/src/routes/admin/ops/DeadLetterConsole.svelte
+++ b/UI/src/routes/admin/ops/DeadLetterConsole.svelte
@@ -1,5 +1,5 @@
-<div class="dl-console" data-testid="dead-letter-console">
-	<div class="dl-head">
+<div class="ops-console" data-testid="dead-letter-console">
+	<div class="head">
 		<div class="eyebrow">Admin Console · Ops</div>
 		<div class="title-row">
 			<h1 class="title" data-testid="dl-title">{title}</h1>
@@ -27,7 +27,7 @@
 		</p>
 	</div>
 
-	<div class="dl-toolbar">
+	<div class="toolbar">
 		<button
 			type="button"
 			class="btn"
@@ -59,14 +59,14 @@
 	</div>
 
 	{#if queue.error}
-		<div class="dl-error" role="alert" data-testid="dl-error">{queue.error}</div>
+		<div class="error-panel" role="alert" data-testid="dl-error">{queue.error}</div>
 	{/if}
 
-	<div class="dl-body">
+	<div class="body">
 		{#if !queue.loaded && queue.loading}
 			<Loading loading={true} delay={150} />
 		{:else if queue.loaded && queue.entries.length === 0}
-			<div class="dl-empty" data-testid="dl-empty">
+			<div class="empty-state" data-testid="dl-empty">
 				<div class="glyph">
 					<svg
 						width="26"
@@ -135,6 +135,7 @@
 import { onMount, untrack } from 'svelte';
 import Loading from '$components/Loading.svelte';
 import { confirmModal, toastError, toastSuccess } from '$stores';
+import './ops-console.scss';
 import DeadLetterRow from './DeadLetterRow.svelte';
 import { DeadLetterConsoleState, type DeadLetterQueueVariant } from './dead-letters.svelte';
 
@@ -233,131 +234,16 @@ const replayAll = async () => {
 </script>
 
 <style lang="scss">
-.dl-console {
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	min-height: 0;
-	font-family: var(--sans);
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-}
-
-.dl-head {
-	padding: 20px 32px 16px;
-	border-bottom: 1px solid var(--border-subtle);
-}
-.eyebrow {
-	font-family: var(--mono);
-	font-size: 10px;
-	letter-spacing: 2px;
-	text-transform: uppercase;
-	color: color-mix(in srgb, var(--accent) 70%, transparent);
-	margin-bottom: 6px;
-}
-.title-row {
-	display: flex;
-	align-items: baseline;
-	gap: 14px;
-	flex-wrap: wrap;
-}
-.title {
-	margin: 0;
-	font-size: 22px;
-	font-weight: 500;
-	letter-spacing: -0.2px;
+.blurb {
+	max-width: 760px;
 }
 .summary {
-	display: inline-flex;
-	align-items: center;
-	gap: 14px;
-	font-family: var(--mono);
-	font-size: 11.5px;
-	color: var(--text-tertiary);
-
 	.sel {
 		color: var(--accent);
 	}
 	.more {
 		color: var(--text-muted);
 	}
-}
-.blurb {
-	margin: 12px 0 0;
-	max-width: 760px;
-	font-size: 12.5px;
-	line-height: 1.55;
-	color: var(--text-tertiary);
-
-	em {
-		font-style: normal;
-		color: var(--text-secondary);
-	}
-}
-
-.dl-toolbar {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	padding: 14px 32px;
-	border-bottom: 1px solid var(--border-subtle);
-
-	.spacer {
-		flex: 1;
-	}
-}
-.btn {
-	display: inline-flex;
-	align-items: center;
-	gap: 7px;
-	background: transparent;
-	border: 1px solid var(--border-light);
-	color: var(--text-secondary);
-	font-family: var(--mono);
-	font-size: 11.5px;
-	letter-spacing: 0.6px;
-	text-transform: uppercase;
-	padding: 8px 15px;
-	border-radius: 3px;
-	cursor: pointer;
-	transition: all 0.14s ease;
-	white-space: nowrap;
-
-	&:hover:not(:disabled) {
-		border-color: color-mix(in srgb, var(--white) 32%, transparent);
-		box-shadow: 0 0 10px color-mix(in srgb, var(--accent) 40%, transparent);
-	}
-	&.primary {
-		background: color-mix(in srgb, var(--accent) 12%, transparent);
-		border-color: var(--accent);
-		color: var(--accent-light);
-	}
-	&.primary:hover:not(:disabled) {
-		box-shadow: 0 0 12px color-mix(in srgb, var(--accent) 50%, transparent);
-	}
-	&:disabled {
-		color: var(--text-muted);
-		border-color: var(--border-subtle);
-		cursor: not-allowed;
-		box-shadow: none;
-	}
-}
-
-.dl-error {
-	margin: 14px 32px 0;
-	padding: 11px 14px;
-	border: 1px solid color-mix(in srgb, var(--error) 45%, transparent);
-	background: color-mix(in srgb, var(--error) 10%, transparent);
-	border-radius: 4px;
-	color: var(--error);
-	font-size: 12.5px;
-}
-
-.dl-body {
-	flex: 1;
-	min-height: 0;
-	overflow: auto;
-	padding: 12px 32px 28px;
 }
 
 .dl-table {
@@ -400,35 +286,6 @@ const replayAll = async () => {
 	strong {
 		color: var(--text-secondary);
 		font-weight: 500;
-	}
-}
-
-.dl-empty {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	text-align: center;
-	padding: 60px 20px;
-	color: var(--text-muted);
-	gap: 12px;
-
-	.glyph {
-		width: 56px;
-		height: 56px;
-		border-radius: 10px;
-		border: 1px dashed var(--border-light);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		color: var(--text-tertiary);
-	}
-	.et {
-		font-size: 14px;
-		color: var(--text-tertiary);
-	}
-	.es {
-		font-size: 12px;
 	}
 }
 </style>

--- a/UI/src/routes/admin/ops/ops-console.scss
+++ b/UI/src/routes/admin/ops/ops-console.scss
@@ -1,0 +1,154 @@
+/* ════════════════════════════════════════════════════════════════════════
+   Shared chrome for the admin ops consoles (Dead Letters, Content Health).
+   Namespaced under `.ops-console` so it can be imported globally without
+   leaking. Content specific to one console (e.g. table markup, per-console
+   summary badges) stays in that component's own scoped styles.
+   ════════════════════════════════════════════════════════════════════════ */
+.ops-console {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+	font-family: var(--sans);
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+
+	.head {
+		padding: 20px 32px 16px;
+		border-bottom: 1px solid var(--border-subtle);
+	}
+	.eyebrow {
+		font-family: var(--mono);
+		font-size: 10px;
+		letter-spacing: 2px;
+		text-transform: uppercase;
+		color: color-mix(in srgb, var(--accent) 70%, transparent);
+		margin-bottom: 6px;
+	}
+	.title-row {
+		display: flex;
+		align-items: baseline;
+		gap: 14px;
+		flex-wrap: wrap;
+	}
+	.title {
+		margin: 0;
+		font-size: 22px;
+		font-weight: 500;
+		letter-spacing: -0.2px;
+	}
+	.summary {
+		display: inline-flex;
+		align-items: center;
+		gap: 14px;
+		font-family: var(--mono);
+		font-size: 11.5px;
+		color: var(--text-tertiary);
+	}
+	// max-width is set per-console below, since it tracks each blurb's own copy length.
+	.blurb {
+		margin: 12px 0 0;
+		font-size: 12.5px;
+		line-height: 1.55;
+		color: var(--text-tertiary);
+
+		em {
+			font-style: normal;
+			color: var(--text-secondary);
+		}
+	}
+
+	.toolbar {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 14px 32px;
+		border-bottom: 1px solid var(--border-subtle);
+
+		.spacer {
+			flex: 1;
+		}
+	}
+	.btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 7px;
+		background: transparent;
+		border: 1px solid var(--border-light);
+		color: var(--text-secondary);
+		font-family: var(--mono);
+		font-size: 11.5px;
+		letter-spacing: 0.6px;
+		text-transform: uppercase;
+		padding: 8px 15px;
+		border-radius: 3px;
+		cursor: pointer;
+		transition: all 0.14s ease;
+		white-space: nowrap;
+
+		&:hover:not(:disabled) {
+			border-color: color-mix(in srgb, var(--white) 32%, transparent);
+			box-shadow: 0 0 10px color-mix(in srgb, var(--accent) 40%, transparent);
+		}
+		&.primary {
+			background: color-mix(in srgb, var(--accent) 12%, transparent);
+			border-color: var(--accent);
+			color: var(--accent-light);
+		}
+		&.primary:hover:not(:disabled) {
+			box-shadow: 0 0 12px color-mix(in srgb, var(--accent) 50%, transparent);
+		}
+		&:disabled {
+			color: var(--text-muted);
+			border-color: var(--border-subtle);
+			cursor: not-allowed;
+			box-shadow: none;
+		}
+	}
+
+	.error-panel {
+		margin: 14px 32px 0;
+		padding: 11px 14px;
+		border: 1px solid color-mix(in srgb, var(--error) 45%, transparent);
+		background: color-mix(in srgb, var(--error) 10%, transparent);
+		border-radius: 4px;
+		color: var(--error);
+		font-size: 12.5px;
+	}
+
+	.body {
+		flex: 1;
+		min-height: 0;
+		overflow: auto;
+		padding: 12px 32px 28px;
+	}
+
+	.empty-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		text-align: center;
+		padding: 60px 20px;
+		color: var(--text-muted);
+		gap: 12px;
+
+		.glyph {
+			width: 56px;
+			height: 56px;
+			border-radius: 10px;
+			border: 1px dashed var(--border-light);
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			color: var(--text-tertiary);
+		}
+		.et {
+			font-size: 14px;
+			color: var(--text-tertiary);
+		}
+		.es {
+			font-size: 12px;
+		}
+	}
+}

--- a/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
+++ b/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
@@ -163,17 +163,4 @@ const sectionDirty = (section: EntityConfig<Identified>['sections'][number]): bo
 .empty-fill {
 	height: 100%;
 }
-.detail-body {
-	flex: 1;
-	overflow-y: auto;
-	padding: 24px 32px;
-}
-.body-inner {
-	max-width: 1020px;
-
-	&.locked {
-		opacity: 0.5;
-		pointer-events: none;
-	}
-}
 </style>

--- a/UI/src/routes/admin/workbench/progression/PathDetail.svelte
+++ b/UI/src/routes/admin/workbench/progression/PathDetail.svelte
@@ -19,8 +19,8 @@
 		onRemove={() => store.removePath(path.id)}
 	/>
 
-	<div class="detail-body" class:locked={store.isRetired(path) || store.saving}>
-		<div class="body-inner">
+	<div class="detail-body">
+		<div class="body-inner" class:locked={store.isRetired(path) || store.saving}>
 			{#if store.pathTab === 'identity'}
 				<div class="sec-title">Identity<span class="sub">— the path-level record</span><span class="ln"></span></div>
 				<div class="row gap16">
@@ -114,43 +114,6 @@ const tiersDirty = $derived(!!baseline && tiers.some((t) => store.profStatus(t) 
 </script>
 
 <style lang="scss">
-.detail-body {
-	flex: 1;
-	overflow-y: auto;
-	padding: 24px 32px;
-
-	&.locked {
-		opacity: 0.55;
-		pointer-events: none;
-	}
-}
-.body-inner {
-	max-width: 1020px;
-}
-.sec-title {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	font-family: var(--mono);
-	font-size: 10px;
-	letter-spacing: 1.8px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-	margin: 0 0 18px;
-
-	.sub {
-		text-transform: none;
-		letter-spacing: 0;
-		font-family: var(--sans);
-		font-size: 12px;
-		white-space: nowrap;
-	}
-	.ln {
-		flex: 1;
-		height: 1px;
-		background: var(--border-subtle);
-	}
-}
 .row {
 	display: flex;
 }

--- a/UI/src/routes/admin/workbench/progression/TierDetail.svelte
+++ b/UI/src/routes/admin/workbench/progression/TierDetail.svelte
@@ -35,8 +35,8 @@
 		{/snippet}
 	</DetailHeader>
 
-	<div class="detail-body" class:locked={store.isRetired(tier) || store.saving}>
-		<div class="body-inner">
+	<div class="detail-body">
+		<div class="body-inner" class:locked={store.isRetired(tier) || store.saving}>
 			{#if store.tierTab === 'identity'}
 				<div class="sec-title">
 					Identity · Conlang<span class="sub">— name and words of power</span><span class="ln"></span>
@@ -138,42 +138,5 @@ const milestonesDirty = $derived(
 }
 .crumb-sep {
 	color: var(--text-muted);
-}
-.detail-body {
-	flex: 1;
-	overflow-y: auto;
-	padding: 24px 32px;
-
-	&.locked {
-		opacity: 0.55;
-		pointer-events: none;
-	}
-}
-.body-inner {
-	max-width: 1020px;
-}
-.sec-title {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	font-family: var(--mono);
-	font-size: 10px;
-	letter-spacing: 1.8px;
-	text-transform: uppercase;
-	color: var(--text-muted);
-	margin: 0 0 18px;
-
-	.sub {
-		text-transform: none;
-		letter-spacing: 0;
-		font-family: var(--sans);
-		font-size: 12px;
-		white-space: nowrap;
-	}
-	.ln {
-		flex: 1;
-		height: 1px;
-		background: var(--border-subtle);
-	}
 }
 </style>

--- a/UI/src/routes/admin/workbench/workbench.scss
+++ b/UI/src/routes/admin/workbench/workbench.scss
@@ -617,6 +617,21 @@
 		}
 	}
 
+	/* detail pane body — the scrollable content area under a DetailHeader */
+	.detail-body {
+		flex: 1;
+		overflow-y: auto;
+		padding: 24px 32px;
+	}
+	.body-inner {
+		max-width: 1020px;
+
+		&.locked {
+			opacity: 0.5;
+			pointer-events: none;
+		}
+	}
+
 	/* header row actions */
 	.hdr-action {
 		display: inline-flex;


### PR DESCRIPTION
## Summary

Two scss duplication clusters left after #2124's shared-chrome extraction, as described in #2138.

**1. Detail-pane block** (`.detail-body`/`.body-inner`/`.sec-title`)

`PathDetail.svelte` and `TierDetail.svelte` carried locally-defined `.detail-body`/`.body-inner`/`.sec-title` blocks, near-identical to `WorkbenchDetail.svelte`'s (only a locked-opacity value and which element the `locked` class was toggled on differed). `workbench.scss` already carried an identical `.sec-title` — so `PathDetail`/`TierDetail`'s local copy was pure redundant drift (their local margin-bottom had also silently drifted to 18px vs the shared 12px).

- Moved `.detail-body`/`.body-inner` into `workbench.scss`, canonicalized on `WorkbenchDetail`'s values (0.5 lock opacity, `locked` toggled on `.body-inner`) since the progression editor originally copied its chrome from `WorkbenchDetail` (per #2124's PR description).
- Removed the now-fully-redundant local `.detail-body`/`.body-inner`/`.sec-title` blocks from all three components.
- Updated `PathDetail`/`TierDetail`'s markup to toggle `locked` on `.body-inner`, matching `WorkbenchDetail`'s pattern.

**2. Ops-console chrome**

`DeadLetterConsole.svelte` and `ContentHealthConsole.svelte` each re-declared ~100 lines of identical visual system (eyebrow/title-row/summary/blurb/toolbar/`.btn`/error-panel/empty-state).

- Extracted a new `ops-console.scss` partial (mirroring the existing `workbench.scss` pattern: a namespaced `.ops-console` scope imported as global CSS) covering the shared chrome.
- Updated both consoles' markup to use the shared class names, keeping only genuinely console-specific bits local (summary's state-color spans, blurb `max-width` — the two consoles' copy differs in length so their `max-width` legitimately differs, and Content Health's healthy-state checkmark keeps its accent-colored glyph instead of the shared muted default).

No functional or user-facing behavior changes intended — this is pure scss/markup consolidation. The two numeric value drifts found during consolidation (18px vs 12px section-title margin, 0.55 vs 0.5 lock opacity) are now unified on the values already used by the generic `WorkbenchDetail`/`workbench.scss` (the copied-from original), a negligible cosmetic delta.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors/warnings
- [x] `npm run test:unit:ci` — 306 test files / 3819 tests pass
- [ ] Manual visual pass in a browser was not performed (no backend/auth stack running in this environment) — the CSS moves were verified rule-by-rule for equivalence against the original scoped styles, and the removed component tests all still assert via `data-testid`, not CSS class names, so none needed updating.

Closes #2138


---
_Generated by [Claude Code](https://claude.ai/code/session_01TNbDG4Hso6FWAFmjaY58nu)_