### PR TITLE
Cap CombatRating's DoT term duration at the shared ramp horizon

### DIFF
--- a/Game.Core.Tests/Battle/CombatRatingTests.cs
+++ b/Game.Core.Tests/Battle/CombatRatingTests.cs
@@ -142,21 +142,28 @@ namespace Game.Core.Tests.Battle
         [Fact]
         public void Rate_DoTEffect_ContributesOffenseEvenWithZeroBaseDamage()
         {
-            var dotEffect = new SkillEffect
-            {
-                Id = 1,
-                Target = ESkillEffectTarget.Opponent,
-                AttributeId = BleedDamagePerSecond,
-                ModifierType = EModifierType.Additive,
-                Amount = 10,
-                DurationMs = 5000,
-                ScalingAttributeId = Strength,
-                ScalingAmount = 0,
-            };
+            var dotEffect = MakeDotEffect(amount: 10, durationMs: 5000);
             var noDot = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 0)]);
             var withDot = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 0, effects: [dotEffect])]);
 
             Assert.True(CombatRating.Rate(withDot, isPlayer: true) > CombatRating.Rate(noDot, isPlayer: true));
+        }
+
+        [Fact]
+        public void Rate_DoTEffectDurationBeyondRampHorizon_RatesTheSameAsExactlyAtTheHorizon()
+        {
+            // A DoT accumulator rides the same shared-expiry stacking machinery as a Self-targeted effect
+            // (Battler.ApplyEffect), so once duration clears FoldedEffectMagnitude's RefFightDuration/2 ramp
+            // horizon, further duration must not move the rating at all — pins that the DoT term's duration is
+            // truly capped rather than left to grow unboundedly for a duration exceeding its skill's cooldown.
+            var atHorizon = MakeSkill(cooldownMs: 1000, baseDamage: 0, effects:
+                [MakeDotEffect(amount: 10, durationMs: (int)(ServerGameConstants.RefFightDuration * 1000 / 2))]);
+            var wayPastHorizon = MakeSkill(cooldownMs: 1000, baseDamage: 0, effects:
+                [MakeDotEffect(amount: 10, durationMs: 1_000_000)]);
+
+            Assert.Equal(
+                CombatRating.Rate(MakeBattlerWithSkills([], [atHorizon]), isPlayer: true),
+                CombatRating.Rate(MakeBattlerWithSkills([], [wayPastHorizon]), isPlayer: true), 6);
         }
 
         [Fact]
@@ -181,17 +188,7 @@ namespace Game.Core.Tests.Battle
             // A DoT effect's ScalingAttributeId is a core attribute in general (mirroring how the live engine
             // scales an effect's magnitude off the caster) — pins that the DoT term reads it correctly rather
             // than zeroing it.
-            var dotEffect = new SkillEffect
-            {
-                Id = 1,
-                Target = ESkillEffectTarget.Opponent,
-                AttributeId = BleedDamagePerSecond,
-                ModifierType = EModifierType.Additive,
-                Amount = 0,
-                DurationMs = 5000,
-                ScalingAttributeId = Strength,
-                ScalingAmount = 1.0,
-            };
+            var dotEffect = MakeDotEffect(amount: 0, durationMs: 5000, scalingAmount: 1.0);
             var skill = MakeSkill(cooldownMs: 1000, baseDamage: 0, effects: [dotEffect]);
             var weak = MakeBattlerWithSkills([], [skill]);
             var strong = MakeBattlerWithSkills([(Strength, 50)], [skill]);
@@ -344,6 +341,19 @@ namespace Game.Core.Tests.Battle
 
             return new Battler(new AttributeCollection(modifiers), skills, 1, counterSkill);
         }
+
+        private static SkillEffect MakeDotEffect(
+            double amount, int durationMs, EAttribute scalingAttribute = Strength, double scalingAmount = 0) => new()
+            {
+                Id = 1,
+                Target = ESkillEffectTarget.Opponent,
+                AttributeId = BleedDamagePerSecond,
+                ModifierType = EModifierType.Additive,
+                Amount = amount,
+                DurationMs = durationMs,
+                ScalingAttributeId = scalingAttribute,
+                ScalingAmount = scalingAmount,
+            };
 
         private static Skill MakeSkill(
             int cooldownMs, double baseDamage, double criticalChance = 0,

--- a/Game.Core/Battle/CombatRating.cs
+++ b/Game.Core/Battle/CombatRating.cs
@@ -185,14 +185,21 @@ namespace Game.Core.Battle
                         continue;
                     }
 
-                    // The exact DoT steady-state closed form (spike #1526 Decision 1): magnitude × frozen
-                    // amplification × duration ÷ effective cooldown. DoT bypasses the reference Toughness
-                    // (its real property), so no mitigation term applies here. The scaling attribute is read
-                    // off the original battler, not effectiveCaster — mirroring FoldedEffectMagnitude's "the
-                    // caster's ORIGINAL attribute" rule, so the two DoT-adjacent reads agree.
+                    // The DoT steady-state closed form (spike #1526 Decision 1): magnitude × frozen
+                    // amplification × duration ÷ effective cooldown — capped the same way
+                    // FoldedEffectMagnitude caps a Self-targeted effect's uptime, since a DoT accumulator
+                    // rides the same shared-expiry stacking machinery (Battler.ApplyEffect: magnitudes sum,
+                    // expiry resets on every re-application) as any other effect. Duration ≤ cooldown is the
+                    // exact steady state (d/cd); a duration exceeding its skill's cooldown instead ramps for
+                    // as long as the skill cycles, whose average over the reference fight is the same
+                    // RefFightDuration/(2·cd) horizon FoldedEffectMagnitude derives. DoT bypasses the
+                    // reference Toughness (its real property), so no mitigation term applies here. The
+                    // scaling attribute is read off the original battler, not effectiveCaster — mirroring
+                    // FoldedEffectMagnitude's "the caster's ORIGINAL attribute" rule, so the two DoT-adjacent
+                    // reads agree.
                     var magnitude = effect.Amount + battler.GetAttributeValue(effect.ScalingAttributeId) * effect.ScalingAmount;
                     var ampedMagnitude = effectiveCaster.AmplifyDamage(magnitude, dotType);
-                    var durationSec = effect.DurationMs / 1000.0;
+                    var durationSec = Math.Min(effect.DurationMs / 1000.0, ServerGameConstants.RefFightDuration / 2.0);
                     total += ampedMagnitude * durationSec / effectiveCooldownSec;
                 }
             }


### PR DESCRIPTION
## Summary

`CombatRating`'s opponent-DoT term priced an effect as `ampedMagnitude × durationSec / effectiveCooldownSec`, uncapped (`Game.Core/Battle/CombatRating.cs`). But a DoT accumulator rides the same `ApplyEffect` stacking machinery as every other effect (magnitudes sum, expiry resets on every re-application), so a bleed/DoT whose `DurationMs` exceeds its skill's effective cooldown refreshes the shared expiry every cast and **ramps** for as long as the skill cycles. The "exact steady-state `magnitude × d/cd`" closed form (spike #1526 Decision 1) is only exact for `d ≤ cd`.

`FoldedEffectMagnitude` in the same file already models this ramp for Self-targeted attribute buffs/debuffs (`min(DurationMs, RefFightDuration/2) ÷ effectiveCooldownMs`) — the opponent-DoT term didn't apply the same cap.

## Fix

Cap the DoT term's duration the same way `FoldedEffectMagnitude` does: `min(durationSec, RefFightDuration / 2) / effectiveCooldownSec`.

No authored content currently ships a DoT skill (`content/skills.json` has 4 seeded skills, none with effects), so this has zero effect on today's rating output — it's a correctness fix ahead of when DoT skills get authored, so XP bounties/proficiency accrual price ramping-DoT content correctly from day one instead of needing a retroactive calibration pass.

## Changes

- `Game.Core/Battle/CombatRating.cs` — cap the DoT term's `durationSec` at `RefFightDuration / 2`, matching `FoldedEffectMagnitude`'s ramp horizon; updated the term's comment to explain why.
- `Game.Core.Tests/Battle/CombatRatingTests.cs`:
  - New test `Rate_DoTEffectDurationBeyondRampHorizon_RatesTheSameAsExactlyAtTheHorizon`, which fails on the old (uncapped) code and passes with the fix.
  - Extracted a `MakeDotEffect` helper and refactored the two existing DoT tests to use it (DRY).

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings
- [x] `dotnet test` (full solution, using the session's Postgres/Redis containers) — 3345/3345 passing, 0 failures
- [x] Verified the new test fails against the pre-fix code (manually reverted the source change, confirmed the test catches the regression, then restored the fix)
- [x] Confirmed no seeded content is affected (no DoT skills currently authored) — this is a forward-looking correctness fix, not a content-migrating change

Closes #2049

---
_Generated by [Claude Code](https://claude.ai/code/session_01CA8RiqT6xWReNjC383mRk2)_