### PR TITLE
Game.Core micro-cleanups: avoidable null-forgiving operators; split Invalidate() out of SetCachedValue

### DIFF
--- a/Game.Core/Attributes/AttributeCollection.cs
+++ b/Game.Core/Attributes/AttributeCollection.cs
@@ -37,7 +37,7 @@ namespace Game.Core.Attributes
         public void AddModifier(AttributeModifier modifier)
         {
             AddModifierWithoutCacheInvalidation(modifier);
-            GetOrCreateNode((int)modifier.Attribute).SetCachedValue(null);
+            GetOrCreateNode((int)modifier.Attribute).Invalidate();
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Game.Core.Attributes
                 UnhookDerivedLink(node, modifier.DerivedSource);
             }
 
-            node.SetCachedValue(null);
+            node.Invalidate();
             return true;
         }
 

--- a/Game.Core/Attributes/AttributeCollectionNode.cs
+++ b/Game.Core/Attributes/AttributeCollectionNode.cs
@@ -39,9 +39,19 @@ namespace Game.Core.Attributes
             return DerivedNodes ??= [];
         }
 
-        public void SetCachedValue(double? value)
+        // Caches a freshly computed value without cascading invalidation — every dependent is
+        // already invalid at this point (a cached dependent always implies cached sources), so
+        // walking DerivedNodes here would be a redundant no-op.
+        public void SetCachedValue(double value)
         {
             CachedValue = value;
+        }
+
+        // Clears this node's cached value and cascades to every derived node whose cache
+        // depended on it. Call this whenever a modifier is added or removed.
+        public void Invalidate()
+        {
+            CachedValue = null;
             if (DerivedNodes is null)
             {
                 return;
@@ -51,7 +61,7 @@ namespace Game.Core.Attributes
             {
                 if (derivedNode.CachedValue is not null)
                 {
-                    derivedNode.SetCachedValue(null);
+                    derivedNode.Invalidate();
                 }
             }
         }

--- a/Game.Core/Collections/SortedLinkedList.cs
+++ b/Game.Core/Collections/SortedLinkedList.cs
@@ -96,6 +96,9 @@ namespace Game.Core.Collections
                 _head = head;
             }
 
+            // Undefined before the first MoveNext or after it returns false, matching the BCL
+            // enumerator contract (e.g. List<T>.Enumerator) — the ! here is deliberate, not an
+            // oversight, for the same reason the BCL's own enumerators use it.
             public readonly T Current => _current!.Value;
 
             readonly object IEnumerator.Current => Current!;

--- a/Game.Core/Proficiencies/Proficiency.cs
+++ b/Game.Core/Proficiencies/Proficiency.cs
@@ -109,8 +109,9 @@ namespace Game.Core.Proficiencies
         /// is exactly the bonus-only set.
         /// </summary>
         public IReadOnlyList<int> RewardSkillsCrossed(int fromLevel, int toLevel) =>
-            [.. Levels.Where(l => l.Level > fromLevel && l.Level <= toLevel && l.RewardSkillId is not null)
-                .Select(l => l.RewardSkillId!.Value)];
+            [.. Levels.Where(l => l.Level > fromLevel && l.Level <= toLevel)
+                .Select(l => l.RewardSkillId)
+                .OfType<int>()];
 
         /// <summary>True once a player has reached this proficiency's <see cref="MaxLevel"/>.</summary>
         public bool IsMaxed(int level) => level >= MaxLevel;


### PR DESCRIPTION
## Summary

Three small clarity/guideline items in `Game.Core`, bundled per the issue:

1. **`Proficiency.RewardSkillsCrossed`** (`Game.Core/Proficiencies/Proficiency.cs`) — replaced the `l.RewardSkillId!.Value` null-forgiving unwrap with `.Select(l => l.RewardSkillId).OfType<int>()`, which filters out the `null` entries and unwraps the survivors without a manual `!`.
2. **`SortedLinkedList<T>.Enumerator`** (`Game.Core/Collections/SortedLinkedList.cs`) — left `_current!.Value` / `Current!` as-is (the conventional BCL enumerator pattern — `Current` is undefined before the first `MoveNext`/after it returns `false`), but added a short comment so the guideline exception reads as deliberate rather than an oversight, matching the style of `AttributeCollectionNode`'s existing comparer comment.
3. **`AttributeCollectionNode.SetCachedValue`** (`Game.Core/Attributes/AttributeCollectionNode.cs`) — split into two methods:
   - `SetCachedValue(double value)` — just caches a freshly computed value, no cascade.
   - `Invalidate()` — clears the cached value and cascades invalidation to derived nodes (the old combined behavior).

   `AttributeCollection.GetAttributeValue`'s cache-fill path (a freshly computed value, where every dependent is already invalid by construction) now calls `SetCachedValue`, dropping the redundant `DerivedNodes` walk on that mid-battle recompute path. `AddModifier`/`RemoveModifier` now call `Invalidate()` explicitly where they previously called `SetCachedValue(null)`.

No behavior change for items 1 and 3 (item 3 is behavior-preserving plus a micro-perf win on the recompute path); item 2 is comment-only.

## Test plan

- [x] `dotnet build` (full solution) — 0 warnings, 0 errors
- [x] `dotnet test` (full solution: `Game.Core.Tests`, `Game.Infrastructure.Tests`, `Game.Application.Tests`, `Game.Api.Tests`) — 3345/3345 passing

Closes #2139


---
_Generated by [Claude Code](https://claude.ai/code/session_012akpyqZNvk98aDRwbPSFP1)_