### PR TITLE
Detect prerequisite cycles composed with implicit within-path tier ordering

### DIFF
--- a/Game.Application.Tests/DataAccess/AdminProficienciesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminProficienciesIntegrationTests.cs
@@ -699,6 +699,49 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SetPrerequisites_CrossPathCycleComposedWithImplicitTierOrdering_ReturnsFailure()
+        {
+            // The #2144 scenario: Path A tier 0 already gates on Path B tier 2 (a cross-path edge, allowed on
+            // its own). Path B tier 0 -> Path A tier 0 is also cross-path on its own — but Path B's implicit
+            // within-path chain (tier 2 needs tier 1 needs tier 0) composes the two authored edges into
+            // A0 -> B2 -> B1 -> B0 -> A0, a cycle invisible to a check over the authored edges alone.
+            int a0Id, b0Id;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var pathA = await SeedPathAsync(seedScope);
+                var a0 = await SeedProficiencyAsync(seedScope, pathA.Id, pathOrdinal: 0, name: "A0");
+                a0Id = a0.Id;
+
+                var pathB = await SeedPathAsync(seedScope);
+                var b0 = await SeedProficiencyAsync(seedScope, pathB.Id, pathOrdinal: 0, name: "B0");
+                await SeedProficiencyAsync(seedScope, pathB.Id, pathOrdinal: 1, name: "B1");
+                var b2 = await SeedProficiencyAsync(seedScope, pathB.Id, pathOrdinal: 2, name: "B2");
+                b0Id = b0.Id;
+
+                context.Set<Entities.ProficiencyPrerequisite>().Add(new Entities.ProficiencyPrerequisite
+                {
+                    ProficiencyId = a0Id,
+                    PrerequisiteProficiencyId = b2.Id,
+                });
+                await context.SaveChangesAsync(CancellationToken);
+            }
+            await ReloadReferenceCachesAsync();
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminProficiencies>();
+
+            var result = admin.SetPrerequisites([new SetProficiencyPrerequisitesData
+            {
+                Id = b0Id,
+                PrerequisiteIds = [a0Id],
+            }]);
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("cycle", result.ErrorMessage);
+        }
+
+        [Fact]
         public async Task SetPrerequisites_BatchNamesTheSameProficiencyTwice_ReturnsFailure()
         {
             int proficiencyId, otherId;

--- a/Game.Application.Tests/DataAccess/ProficiencyPrerequisiteGraphTests.cs
+++ b/Game.Application.Tests/DataAccess/ProficiencyPrerequisiteGraphTests.cs
@@ -55,7 +55,61 @@ namespace Game.Application.Tests.DataAccess
             Assert.False(ProficiencyPrerequisiteGraph.TryFindCycle(graph, out _));
         }
 
+        [Fact]
+        public void BuildGraph_WithinPathTierChain_AddsNoCycleOnItsOwn()
+        {
+            // Three tiers of one path (ordinals 0, 1, 2) and no authored prerequisites: the implicit
+            // tier-N+1-needs-tier-N chain is a straight line, not a cycle.
+            var tiers = Tiers((0, path: 0, ordinal: 0), (1, path: 0, ordinal: 1), (2, path: 0, ordinal: 2));
+            var graph = ProficiencyPrerequisiteGraph.BuildGraph(tiers, Graph());
+            Assert.False(ProficiencyPrerequisiteGraph.TryFindCycle(graph, out _));
+        }
+
+        [Fact]
+        public void BuildGraph_AuthoredEdgeBackToAnEarlierTierOnTheSamePath_IsDetected()
+        {
+            // Tier 0 of a path authoring a prerequisite on tier 1 of the same path deadlocks against the
+            // implicit tier-1-needs-tier-0 edge — a same-path cycle composed from one authored + one implicit edge.
+            var tiers = Tiers((0, path: 0, ordinal: 0), (1, path: 0, ordinal: 1));
+            var graph = ProficiencyPrerequisiteGraph.BuildGraph(tiers, Graph((0, [1])));
+            Assert.True(ProficiencyPrerequisiteGraph.TryFindCycle(graph, out _));
+        }
+
+        [Fact]
+        public void BuildGraph_CrossPathEdgesComposedWithImplicitTierOrdering_IsDetected()
+        {
+            // The #2144 scenario: Path A tier 0 (id 0) gates on Path B tier 2 (id 3); Path B tier 0 (id 1)
+            // gates on Path A tier 0 (id 0). Neither authored edge revisits its own path, so a check over the
+            // authored edges alone sees no cycle. But Path B's implicit chain (id 3 needs id 2 needs id 1)
+            // composes with the two authored edges into 0 -> 3 -> 2 -> 1 -> 0.
+            var tiers = Tiers(
+                (0, path: 0, ordinal: 0), // Path A tier 0
+                (1, path: 1, ordinal: 0), // Path B tier 0
+                (2, path: 1, ordinal: 1), // Path B tier 1
+                (3, path: 1, ordinal: 2)); // Path B tier 2
+            var authored = Graph((0, [3]), (1, [0]));
+            Assert.False(ProficiencyPrerequisiteGraph.TryFindCycle(authored, out _));
+
+            var graph = ProficiencyPrerequisiteGraph.BuildGraph(tiers, authored);
+            Assert.True(ProficiencyPrerequisiteGraph.TryFindCycle(graph, out var cycle));
+            Assert.Equal(cycle[0], cycle[^1]);
+        }
+
+        [Fact]
+        public void BuildGraph_TiersOnDifferentPaths_AddNoImplicitEdgeBetweenThem()
+        {
+            // Two single-tier paths (ordinal 0 each) never chain to one another regardless of id order.
+            var tiers = Tiers((5, path: 0, ordinal: 0), (2, path: 1, ordinal: 0));
+            var graph = ProficiencyPrerequisiteGraph.BuildGraph(tiers, Graph());
+            Assert.False(ProficiencyPrerequisiteGraph.TryFindCycle(graph, out _));
+            Assert.False(graph.ContainsKey(5));
+            Assert.False(graph.ContainsKey(2));
+        }
+
         private static Dictionary<int, IReadOnlyList<int>> Graph(params (int Node, int[] Edges)[] edges) =>
             edges.ToDictionary(e => e.Node, e => (IReadOnlyList<int>)e.Edges);
+
+        private static List<(int Id, int PathId, int PathOrdinal)> Tiers(params (int Id, int path, int ordinal)[] tiers) =>
+            tiers.Select(t => (t.Id, t.path, t.ordinal)).ToList();
     }
 }

--- a/Game.DataAccess/Repositories/Admin/AdminProficiencies.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminProficiencies.cs
@@ -409,17 +409,23 @@ namespace Game.DataAccess.Repositories.Admin
         /// <summary>Returns a rejection if overriding each proficiency named in
         /// <paramref name="desiredByProficiencyId"/> with its desired prerequisite set would introduce a cycle
         /// in the prerequisite graph, else null. The prospective graph keeps every other proficiency's
-        /// existing edges and overrides only the named nodes'.</summary>
+        /// existing edges and overrides only the named nodes', and is checked together with the implicit
+        /// within-path tier ordering (see <see cref="ProficiencyPrerequisiteGraph"/>) so a cross-path edge
+        /// composed with that ordering is caught too, not just a cycle made entirely of authored edges.</summary>
         private AdminSaveResult? FindPrerequisiteCycle(IReadOnlyDictionary<int, IReadOnlyList<int>> desiredByProficiencyId)
         {
-            var graph = _proficiencies.AllProficiencyEntities().ToDictionary(
+            var allProficiencies = _proficiencies.AllProficiencyEntities();
+
+            var prerequisites = allProficiencies.ToDictionary(
                 p => p.Id,
                 p => (IReadOnlyList<int>)p.Prerequisites.Select(pr => pr.PrerequisiteProficiencyId).ToList());
             foreach (var (proficiencyId, desiredPrerequisiteIds) in desiredByProficiencyId)
             {
-                graph[proficiencyId] = desiredPrerequisiteIds;
+                prerequisites[proficiencyId] = desiredPrerequisiteIds;
             }
 
+            var tiers = allProficiencies.Select(p => (p.Id, p.PathId, p.PathOrdinal)).ToList();
+            var graph = ProficiencyPrerequisiteGraph.BuildGraph(tiers, prerequisites);
             if (ProficiencyPrerequisiteGraph.TryFindCycle(graph, out var cycle))
             {
                 return AdminSaveResult.Failure(

--- a/Game.DataAccess/Repositories/Caching/ProficienciesCacheHolder.cs
+++ b/Game.DataAccess/Repositories/Caching/ProficienciesCacheHolder.cs
@@ -60,13 +60,16 @@ namespace Game.DataAccess.Repositories.Caching
                 .Select(path => path.Id)
                 .ToHashSet();
 
-            // Build-time invariant: the authored prerequisite graph must be acyclic, since a cycle would
-            // soft-lock every node on it under the "open once prerequisites are maxed" rule. The admin save
-            // rejects a cycle before it commits; this is the backstop against a seed/migration mistake (it
-            // fails the build-then-swap, keeping the prior good snapshot or surfacing as a boot failure).
-            var prerequisiteGraph = entities.ToDictionary(
+            // Build-time invariant: the authored prerequisite graph, combined with the implicit within-path tier
+            // ordering, must be acyclic, since a cycle would soft-lock every node on it under the "open once
+            // prerequisites are maxed" rule. The admin save rejects a cycle before it commits; this is the
+            // backstop against a seed/migration mistake (it fails the build-then-swap, keeping the prior good
+            // snapshot or surfacing as a boot failure).
+            var prerequisites = entities.ToDictionary(
                 p => p.Id,
                 p => (IReadOnlyList<int>)p.Prerequisites.Select(pr => pr.PrerequisiteProficiencyId).ToList());
+            var tiers = entities.Select(p => (p.Id, p.PathId, p.PathOrdinal)).ToList();
+            var prerequisiteGraph = ProficiencyPrerequisiteGraph.BuildGraph(tiers, prerequisites);
             if (ProficiencyPrerequisiteGraph.TryFindCycle(prerequisiteGraph, out var cycle))
             {
                 throw new InvalidOperationException(

--- a/Game.DataAccess/Repositories/Caching/ProficiencyPrerequisiteGraph.cs
+++ b/Game.DataAccess/Repositories/Caching/ProficiencyPrerequisiteGraph.cs
@@ -6,11 +6,40 @@ namespace Game.DataAccess.Repositories.Caching
     /// would soft-lock every node on it under the "open once prerequisites are maxed" rule, so it is rejected
     /// both at admin-authoring time (a clean failure before the write commits) and as a build-time invariant on
     /// the cache snapshot (the backstop against a seed/migration mistake, mirroring the zero-based contiguity
-    /// assertion). Within-path order is implicit in the tier ordinals and inherently acyclic, so only the
-    /// authored prerequisite edges are checked here.
+    /// assertion). Within-path order is implicit in the tier ordinals (tier N+1 requires tier N maxed) and
+    /// inherently acyclic on its own, but a cross-path authored edge composed with that implicit chain can still
+    /// close a cycle the authored edges alone never show — so <see cref="BuildGraph"/> folds each path's
+    /// consecutive-tier edges into the same graph the authored prerequisites use before it is checked.
     /// </summary>
     internal static class ProficiencyPrerequisiteGraph
     {
+        /// <summary>
+        /// Builds the combined prerequisite graph: <paramref name="prerequisites"/>'s authored edges plus one
+        /// implicit edge per path from each tier to the tier immediately below it (ordered by
+        /// <c>PathOrdinal</c>). <paramref name="tiers"/> must list every proficiency (id, path id, path
+        /// ordinal) the graph should account for, regardless of whether it carries authored prerequisites.
+        /// </summary>
+        public static IReadOnlyDictionary<int, IReadOnlyList<int>> BuildGraph(
+            IReadOnlyList<(int Id, int PathId, int PathOrdinal)> tiers,
+            IReadOnlyDictionary<int, IReadOnlyList<int>> prerequisites)
+        {
+            var graph = prerequisites.ToDictionary(kv => kv.Key, kv => (IReadOnlyList<int>)[.. kv.Value]);
+
+            foreach (var path in tiers.GroupBy(t => t.PathId))
+            {
+                var ordered = path.OrderBy(t => t.PathOrdinal).ToList();
+                for (var i = 1; i < ordered.Count; i++)
+                {
+                    var currentId = ordered[i].Id;
+                    var previousId = ordered[i - 1].Id;
+                    var edges = graph.TryGetValue(currentId, out var existing) ? existing : [];
+                    graph[currentId] = [.. edges, previousId];
+                }
+            }
+
+            return graph;
+        }
+
         /// <summary>
         /// Finds a cycle in the prerequisite graph if one exists. <paramref name="prerequisites"/> maps each
         /// proficiency id to the ids it depends on; an absent node is treated as having no prerequisites.


### PR DESCRIPTION
## Summary

`ProficiencyPrerequisiteGraph.TryFindCycle` only ever walked the *authored* prerequisite edges. That misses cycles formed by composing a cross-path authored edge with a path's **implicit** within-path tier ordering (tier N+1 requires tier N maxed) — e.g. Path A tier 0 gates on Path B tier 2, and Path B tier 0 gates on Path A tier 0. Neither edge revisits its own path, so the authored-edges-only check sees no cycle, but Path B's implicit chain (tier 2 needs tier 1 needs tier 0) composes them into `A0 -> B2 -> B1 -> B0 -> A0` — every node on that cycle silently deadlocks, same failure mode #2128 fixed for the direct same-path case.

- Added `ProficiencyPrerequisiteGraph.BuildGraph(tiers, prerequisites)`, which folds one implicit edge per path (each tier -> the tier immediately below it, ordered by `PathOrdinal`) into the authored-edges dictionary before cycle detection runs.
- Wired it into both places cycle detection already ran:
  - `AdminProficiencies.FindPrerequisiteCycle` — admin save-time rejection.
  - `ProficienciesCacheHolder.BuildSnapshotAsync` — the build-time backstop against a seed/migration mistake.

## Scope note

The issue's suggested direction also mentioned extending `ProgressionGraphChecker` (Content Health) for parity. I left that out of this PR:

- Content Health can never actually *observe* a live cycle today, since the admin save path already rejects one before it's persisted — adding it there would be defense-in-depth/consistency, not closing a reachable gap.
- `ProficiencyPrerequisiteGraph`/`DirectedGraphCycleDetector` are `internal` to `Game.DataAccess`, while `ProgressionGraphChecker` lives in `Game.Application` (which doesn't reference `Game.DataAccess` per the onion-architecture isolation in `docs/backend.md`). Doing this properly needs a short design pass on where the shared cycle-detection utility should live (the issue suggests `Game.Core`, since acyclicity is arguably a domain invariant) rather than duplicating the algorithm across layers.

Happy to pick that up as a follow-up if it's wanted — flagging it here rather than guessing at the right home for the shared logic.

## Test plan

- [x] `dotnet build` — clean, 0 warnings/errors.
- [x] `dotnet test` (full solution) — 3350/3350 passing.
- [x] New unit tests in `ProficiencyPrerequisiteGraphTests` cover: a within-path tier chain alone (no cycle), a same-path authored+implicit composed cycle, the issue's exact cross-path + implicit composed cycle scenario (asserting the authored-edges-only graph shows no cycle while the combined graph does), and that tiers on different paths never chain together.
- [x] New integration test in `AdminProficienciesIntegrationTests` (`SetPrerequisites_CrossPathCycleComposedWithImplicitTierOrdering_ReturnsFailure`) reproduces the issue's scenario end-to-end through `AdminProficiencies.SetPrerequisites` against a real database.

Closes #2144


---
_Generated by [Claude Code](https://claude.ai/code/session_017PKn4R8pPGMUAwyXTP91GY)_