### PR TITLE
Fix Device.cs doc comment's false BrowserInfo stability claim

### DIFF
--- a/Game.Infrastructure/Entities/Device.cs
+++ b/Game.Infrastructure/Entities/Device.cs
@@ -2,9 +2,15 @@ namespace Game.Infrastructure.Entities
 {
     /// <summary>
     /// A distinct device, deduplicated by its client-computed <see cref="DeviceFingerprintHash"/> (the most
-    /// device-unique signal available). Each device belongs to one <see cref="Entities.BrowserInfo"/>
-    /// (user-agent) profile — the fingerprint incorporates the user-agent, so the mapping is stable. The
-    /// capabilities are reported by the frontend after login, since they are not present on a regular request.
+    /// device-unique signal available). Each device is linked to the <see cref="Entities.BrowserInfo"/>
+    /// (user-agent) profile seen when the device was first created; the link is set once and never
+    /// revisited afterward. The fingerprint itself deliberately excludes the raw user-agent string (using a
+    /// coarse, update-stable platform token instead, so a browser auto-update doesn't rotate the
+    /// fingerprint), so a browser upgrade — or a switch to a different browser reporting the same coarse
+    /// platform/hardware/locale signals — can leave a device pointing at a stale <see cref="BrowserInfo"/>.
+    /// This is fine because the link is presentation/telemetry data only, never used for authorization or
+    /// gameplay decisions. The capabilities are reported by the frontend after login, since they are not
+    /// present on a regular request.
     /// </summary>
     public class Device
     {


### PR DESCRIPTION
## Summary

`Device.cs`'s doc comment claimed "the fingerprint incorporates the user-agent, so the mapping is stable" between a `Device` and its `BrowserInfo`. That's not true of the actual fingerprint inputs (`UI/src/lib/api/device-fingerprint.ts`): the fingerprint deliberately uses a coarse, update-stable platform token instead of the raw `User-Agent` string, specifically so a browser auto-update doesn't rotate the fingerprint. Since `Device.BrowserInfoId` is set once at device creation (`UserLogins.CreateDevice` → `GetOrCreateBrowserInfo`) and never repointed afterward, a browser upgrade — or even a browser switch reporting the same coarse platform/hardware/locale signals — can leave a device's stored `BrowserInfo` link stale relative to its actual current browser.

## How it addresses the issue

Per the issue's own impact assessment, this is documentation/design-nit level: `BrowserInfo` is presentation/telemetry data only (admin visibility), never used in authorization or gameplay decisions. Given that low impact, I went with the doc-only fix (correct the comment to describe the real, weaker guarantee) rather than having `RecordConnection` repoint `BrowserInfoId` on every connection — that would add an extra query/write on every authenticated request purely to keep a cosmetic admin field current, which isn't worth the cost for telemetry data.

Updated the `Device` class XML doc comment to describe the actual behavior: the `BrowserInfo` link is set once and can drift, and that's fine because nothing security- or gameplay-relevant depends on it staying current.

## Test plan

- [x] `dotnet build Game.Infrastructure/Game.Infrastructure.csproj` — succeeds, 0 warnings/errors
- No behavior change (doc-comment only), so no new tests are needed.

Closes #2150


---
_Generated by [Claude Code](https://claude.ai/code/session_01LkhA7xgrKzd2fQGkVzyWxa)_