### PR TITLE
Cross-reference the PlayerName/UsernamePolicy char-rejection divergence

### DIFF
--- a/Game.Core/Identity/UsernamePolicy.cs
+++ b/Game.Core/Identity/UsernamePolicy.cs
@@ -25,6 +25,10 @@ namespace Game.Core.Identity
         /// it only when the trimmed value is within [<see cref="MinLength"/>, <see cref="MaxLength"/>] and
         /// free of control and zero-width characters (which could otherwise render a username visually
         /// identical to another). Returns the normalized username via <paramref name="normalized"/> when valid.
+        /// Stricter than <see cref="Game.Core.Players.PlayerName.TryNormalize"/> deliberately: usernames
+        /// surface in the admin roster, ban/archive surface, and logs, where a confusable duplicate is a
+        /// real spoofing concern that character names don't share. Not an oversight; keep in sync only if
+        /// that changes.
         /// </summary>
         public static bool TryNormalize(string? username, [NotNullWhen(true)] out string? normalized)
         {

--- a/Game.Core/Players/PlayerName.cs
+++ b/Game.Core/Players/PlayerName.cs
@@ -21,6 +21,10 @@ namespace Game.Core.Players
         /// Validates and normalizes a player-supplied name: trims surrounding whitespace, then accepts it
         /// only when the trimmed value is within [<see cref="MinLength"/>, <see cref="MaxLength"/>] and free
         /// of control characters. Returns the normalized name via <paramref name="normalized"/> when valid.
+        /// Deliberately does <b>not</b> reject zero-width/Unicode "Format"-category characters the way
+        /// <see cref="Game.Core.Identity.UsernamePolicy.TryNormalize"/> does — character names are
+        /// non-unique with no admin/competitive surface, so a visually-confusable duplicate isn't a
+        /// spoofing risk the way it is for logins. Not an oversight; keep in sync only if that changes.
         /// </summary>
         public static bool TryNormalize(string? name, [NotNullWhen(true)] out string? normalized)
         {


### PR DESCRIPTION
## Summary

`PlayerName.TryNormalize` (`Game.Core/Players/PlayerName.cs`) and `UsernamePolicy.TryNormalize` (`Game.Core/Identity/UsernamePolicy.cs`) are sibling "normalize this player-supplied identifier" rules that reject different sets of invisible characters:

- `PlayerName` rejects only control characters.
- `UsernamePolicy` additionally rejects Unicode `Format`-category characters (zero-width space, ZWJ/ZWNJ, BOM, etc.).

Both #2155 and #2156 flagged this as a maintenance trap — the divergence is intentional, but nothing recorded *why*, so the next person to touch either rule has no signal that it isn't an oversight.

## Decision: document, don't unify

I went with option 2 from both issues (document the difference) rather than unifying the two rules:

- Character names (`PlayerName`) are non-unique and the game currently has **no social/competitive surface** where they're compared to each other — no chat, guilds, trading, or leaderboards exist in the design docs (`docs/game-design.md`). A visually-confusable duplicate character name has no exploitable effect today.
- Usernames (`UsernamePolicy`) surface in the admin roster, ban/archive tooling, and logs, where a confusable duplicate is a real spoofing concern (e.g. an account rendering identically to an admin's).

Since there's no current mechanism where character-name confusability is a risk, extending `PlayerName` to match would be speculative hardening rather than fixing a real gap — so I documented the intentional asymmetry on both types instead of adding a shared predicate.

## Changes

- `PlayerName.TryNormalize`: doc comment now explains it deliberately omits the zero-width/Format-category check, cross-referencing `UsernamePolicy` and why.
- `UsernamePolicy.TryNormalize`: doc comment now explains why it's stricter, cross-referencing `PlayerName`.

No behavior change — this is a documentation-only fix for both issues.

## Test plan

- [x] `dotnet build` (full solution) — succeeds, 0 warnings/errors
- [x] `dotnet test Game.Core.Tests` filtered to `PlayerNameTests` / `UsernamePolicyTests` — 38/38 passed
- No new tests needed since behavior is unchanged.

Closes #2155
Closes #2156


---
_Generated by [Claude Code](https://claude.ai/code/session_01KWxb7hbAnxPi93yp8DWxPi)_