### PR TITLE
Remove dead ICacheService.HashGetAllIfExists and IPubSubQueue.GetProcessingCountAsync surface

### DIFF
--- a/Game.Abstractions/Infrastructure/ICacheService.cs
+++ b/Game.Abstractions/Infrastructure/ICacheService.cs
@@ -60,15 +60,11 @@
         /// </summary>
         public void ReclaimAndForget(string key, string ownerValue, TimeSpan expiry);
         /// <summary>
-        /// Reads every field of the Redis hash at <paramref name="key"/> in one round trip, or
-        /// <see langword="null"/> if the key does not exist — letting a caller distinguish a genuine cache
-        /// miss from a hash that exists but happens to carry no fields.
-        /// </summary>
-        public Task<Dictionary<string, string>?> HashGetAllIfExists(string key, CancellationToken cancellationToken = default);
-        /// <summary>
-        /// Same as <see cref="HashGetAllIfExists"/>, but also resets the key's TTL to <paramref name="expiry"/>
-        /// in the same round trip on a hit (a no-op on a miss, like <see cref="GetAndRefreshExpiry"/>). Lets a
-        /// sliding-expiration hash read avoid the separate awaited HGETALL followed by a fire-and-forget expire.
+        /// Reads every field of the Redis hash at <paramref name="key"/> in one round trip, resetting its TTL
+        /// to <paramref name="expiry"/> in the same round trip on a hit (a no-op on a miss, like
+        /// <see cref="GetAndRefreshExpiry"/>). Returns <see langword="null"/> if the key does not exist —
+        /// letting a caller distinguish a genuine cache miss from a hash that exists but happens to carry no
+        /// fields.
         /// </summary>
         public Task<Dictionary<string, string>?> HashGetAllAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default);
         /// <summary>

--- a/Game.Abstractions/Infrastructure/IPubSubQueue.cs
+++ b/Game.Abstractions/Infrastructure/IPubSubQueue.cs
@@ -33,13 +33,6 @@
         public Task<long> GetLengthAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// The current number of items reserved via <see cref="ReserveNextAsync"/> but not yet acknowledged —
-        /// the size of the side processing list. Lets a caller detect items stranded there (so they can be
-        /// reclaimed opportunistically) without mutating anything, unlike <see cref="ReclaimProcessingAsync"/>.
-        /// </summary>
-        public Task<long> GetProcessingCountAsync(CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Returns up to <paramref name="count"/> items from the head of the queue (oldest first) WITHOUT
         /// removing them — a non-destructive read. Lets a dead-letter queue be inspected without the
         /// at-most-once exposure a destructive pop would reintroduce. A non-positive count returns an empty list.

--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -370,7 +370,6 @@ namespace Game.Api.Tests.Unit
             public Task AcknowledgeAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> ReclaimProcessingAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> GetLengthAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task<long> GetProcessingCountAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<IReadOnlyList<string>> PeekProcessingAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -397,7 +396,6 @@ namespace Game.Api.Tests.Unit
             public Task AcknowledgeAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> ReclaimProcessingAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> GetLengthAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task<long> GetProcessingCountAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<IReadOnlyList<string>> PeekProcessingAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -449,7 +447,6 @@ namespace Game.Api.Tests.Unit
             public Task<long> ReclaimProcessingAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             // The escalation path reads the depth right after adding, to log it alongside the escalation.
             public Task<long> GetLengthAsync(CancellationToken cancellationToken = default) => Task.FromResult((long)Added.Count);
-            public Task<long> GetProcessingCountAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<IReadOnlyList<string>> PeekProcessingAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -480,7 +477,6 @@ namespace Game.Api.Tests.Unit
             public void DeleteAndForget(string key) => throw new NotSupportedException();
             public Task CompareAndDelete(string key, string deleteIfValue, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void ReclaimAndForget(string key, string ownerValue, TimeSpan expiry) => throw new NotSupportedException();
-            public Task<Dictionary<string, string>?> HashGetAllIfExists(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<Dictionary<string, string>?> HashGetAllAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void HashSetAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry) => throw new NotSupportedException();
             public void HashSetIfExistsAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry) => throw new NotSupportedException();
@@ -551,7 +547,6 @@ namespace Game.Api.Tests.Unit
             public void SetAndForget<T>(string key, T value, TimeSpan expiry) => throw new NotSupportedException();
             public void DeleteAndForget(string key) => throw new NotSupportedException();
             public void ReclaimAndForget(string key, string ownerValue, TimeSpan expiry) => throw new NotSupportedException();
-            public Task<Dictionary<string, string>?> HashGetAllIfExists(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<Dictionary<string, string>?> HashGetAllAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void HashSetAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry) => throw new NotSupportedException();
             public void HashSetIfExistsAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry) => throw new NotSupportedException();
@@ -605,7 +600,6 @@ namespace Game.Api.Tests.Unit
             public void DeleteAndForget(string key) => throw new NotSupportedException();
             public Task CompareAndDelete(string key, string deleteIfValue, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void ReclaimAndForget(string key, string ownerValue, TimeSpan expiry) => throw new NotSupportedException();
-            public Task<Dictionary<string, string>?> HashGetAllIfExists(string key, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<Dictionary<string, string>?> HashGetAllAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public void HashSetAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry) => throw new NotSupportedException();
             public void HashSetIfExistsAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry) => throw new NotSupportedException();

--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -157,7 +157,7 @@ namespace Game.Application.Tests.DataAccess
             // Nothing was dead-lettered — the item stays reserved on the processing list for the reclaim to
             // pick back up once the database recovers, rather than requiring a manual replay.
             Assert.Empty(await DrainDeadLetterQueue(pubsub));
-            Assert.Equal(1, await queue.GetProcessingCountAsync());
+            Assert.Single(await queue.PeekProcessingAsync(10));
         }
 
         public static IEnumerable<object[]> GenuinePerWriteFailures()
@@ -201,7 +201,7 @@ namespace Game.Application.Tests.DataAccess
             Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error && e.Message.Contains("dead-lettering"));
             var deadLettered = await DrainDeadLetterQueue(pubsub);
             Assert.Single(deadLettered);
-            Assert.Equal(0, await queue.GetProcessingCountAsync());
+            Assert.Empty(await queue.PeekProcessingAsync(10));
         }
 
         [Fact]
@@ -1125,7 +1125,7 @@ namespace Game.Application.Tests.DataAccess
             // restart against it rather than reclaiming a fresh item.
             await synchronizer.ProcessQueue(queue);
             Assert.DoesNotContain(logger.Entries, e => e.Message.Contains("stranded"));
-            Assert.Equal(1, await queue.GetProcessingCountAsync());
+            Assert.Single(await queue.PeekProcessingAsync(10));
 
             // Only once "stranded-b" has itself dwelled at the head past the grace period does it reclaim.
             timeProvider.Advance(TimeSpan.FromSeconds(31));
@@ -1133,7 +1133,7 @@ namespace Game.Application.Tests.DataAccess
 
             Assert.Contains(logger.Entries, e => e.Level == LogLevel.Information && e.Message.Contains("stranded"));
             Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
-            Assert.Equal(0, await queue.GetProcessingCountAsync());
+            Assert.Empty(await queue.PeekProcessingAsync(10));
         }
 
         [Fact]
@@ -1235,7 +1235,7 @@ namespace Game.Application.Tests.DataAccess
             // cooperatively into the reserve/reclaim ops, so it could abort the reclaim/apply before it lands
             // rather than waiting for it.
             await synchronizer.StartAsync(CancellationToken.None);
-            await PollingHelper.PollUntilAsync(() => queue.GetProcessingCountAsync(), count => count == 0);
+            await PollingHelper.PollUntilAsync(() => queue.PeekProcessingAsync(1), items => items.Count == 0);
 
             Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
             Assert.Empty(await DrainDeadLetterQueue(realPubSub));
@@ -1566,7 +1566,7 @@ namespace Game.Application.Tests.DataAccess
 
             // Both of player A's items stay reserved on the processing list for the reclaim: the equip because
             // its acknowledge faulted, the unequip because it chained onto the dead lane and never applied.
-            Assert.Equal(2, await queue.GetProcessingCountAsync());
+            Assert.Equal(2, (await queue.PeekProcessingAsync(10)).Count);
 
             using var verifyScope = CreateScope();
             var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
@@ -1751,14 +1751,6 @@ namespace Game.Application.Tests.DataAccess
                 }
             }
 
-            public Task<long> GetProcessingCountAsync(CancellationToken cancellationToken = default)
-            {
-                lock (_gate)
-                {
-                    return Task.FromResult((long)_processing.Count);
-                }
-            }
-
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default)
             {
                 lock (_gate)
@@ -1894,14 +1886,6 @@ namespace Game.Application.Tests.DataAccess
                 }
             }
 
-            public Task<long> GetProcessingCountAsync(CancellationToken cancellationToken = default)
-            {
-                lock (_gate)
-                {
-                    return Task.FromResult((long)_processing.Count);
-                }
-            }
-
             // The drained-queue assertion uses GetNextAsync to confirm nothing is left waiting.
             public Task<string?> GetNextAsync(CancellationToken cancellationToken = default)
             {
@@ -1997,14 +1981,6 @@ namespace Game.Application.Tests.DataAccess
                 lock (_gate)
                 {
                     return Task.FromResult((long)_items.Count);
-                }
-            }
-
-            public Task<long> GetProcessingCountAsync(CancellationToken cancellationToken = default)
-            {
-                lock (_gate)
-                {
-                    return Task.FromResult((long)_processing.Count);
                 }
             }
 
@@ -2176,7 +2152,6 @@ namespace Game.Application.Tests.DataAccess
 
             public Task<long> ReclaimProcessingAsync(CancellationToken cancellationToken = default) => Task.FromResult(0L);
             public Task<long> GetLengthAsync(CancellationToken cancellationToken = default) => Task.FromResult((long)_items.Count);
-            public Task<long> GetProcessingCountAsync(CancellationToken cancellationToken = default) => Task.FromResult((long)_processing.Count);
             public Task<string?> GetNextAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>(_items.Count > 0 ? _items.Dequeue() : null);
 
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -2211,7 +2186,6 @@ namespace Game.Application.Tests.DataAccess
 
             public Task<long> ReclaimProcessingAsync(CancellationToken cancellationToken = default) => inner.ReclaimProcessingAsync(cancellationToken);
             public Task<long> GetLengthAsync(CancellationToken cancellationToken = default) => inner.GetLengthAsync(cancellationToken);
-            public Task<long> GetProcessingCountAsync(CancellationToken cancellationToken = default) => inner.GetProcessingCountAsync(cancellationToken);
             public Task<string?> GetNextAsync(CancellationToken cancellationToken = default) => inner.GetNextAsync(cancellationToken);
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default) => inner.PeekAsync(count, cancellationToken);
             public Task<IReadOnlyList<string>> PeekProcessingAsync(long count, CancellationToken cancellationToken = default) => inner.PeekProcessingAsync(count, cancellationToken);
@@ -2292,14 +2266,6 @@ namespace Game.Application.Tests.DataAccess
                 }
             }
 
-            public Task<long> GetProcessingCountAsync(CancellationToken cancellationToken = default)
-            {
-                lock (_gate)
-                {
-                    return Task.FromResult((long)_processing.Count);
-                }
-            }
-
             public Task<string?> GetNextAsync(CancellationToken cancellationToken = default)
             {
                 lock (_gate)
@@ -2345,7 +2311,6 @@ namespace Game.Application.Tests.DataAccess
             public Task<long> ReclaimProcessingAsync(CancellationToken cancellationToken = default) => Task.FromResult(0L);
             public Task AcknowledgeAsync(string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<long> GetLengthAsync(CancellationToken cancellationToken = default) => Task.FromResult(0L);
-            public Task<long> GetProcessingCountAsync(CancellationToken cancellationToken = default) => Task.FromResult(0L);
             public Task<string?> GetNextAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
 
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/Game.Application.Tests/DataAccess/RedisQueueIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisQueueIntegrationTests.cs
@@ -225,7 +225,6 @@ namespace Game.Application.Tests.DataAccess
             // first and leaves it in place.
             Assert.Equal(["a"], await queue.PeekProcessingAsync(1));
             Assert.Equal(["a", "b"], await queue.PeekProcessingAsync(10));
-            Assert.Equal(2, await queue.GetProcessingCountAsync());
         }
 
         [Fact]
@@ -240,7 +239,7 @@ namespace Game.Application.Tests.DataAccess
 
             Assert.Empty(await queue.PeekProcessingAsync(0));
             Assert.Empty(await queue.PeekProcessingAsync(-5));
-            Assert.Equal(1, await queue.GetProcessingCountAsync());
+            Assert.Equal(["a"], await queue.PeekProcessingAsync(10));
         }
 
         [Fact]
@@ -259,7 +258,6 @@ namespace Game.Application.Tests.DataAccess
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queue.ReserveNextAsync(AlreadyCancelled()));
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queue.ReclaimProcessingAsync(AlreadyCancelled()));
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queue.GetLengthAsync(AlreadyCancelled()));
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queue.GetProcessingCountAsync(AlreadyCancelled()));
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queue.PeekAsync(1, AlreadyCancelled()));
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queue.PeekProcessingAsync(1, AlreadyCancelled()));
 
@@ -272,31 +270,6 @@ namespace Game.Application.Tests.DataAccess
             var cts = new CancellationTokenSource();
             cts.Cancel();
             return cts.Token;
-        }
-
-        [Fact]
-        public async Task GetProcessingCountAsync_ReflectsReservedButNotYetAcknowledgedItems()
-        {
-            using var scope = CreateScope();
-            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
-            var queue = pubsub.GetQueue($"redis-queue-test-{Guid.NewGuid()}");
-
-            await queue.AddRangeToQueueAsync(["a", "b"]);
-            Assert.Equal(0, await queue.GetProcessingCountAsync());
-
-            // Reserving parks the item on the processing list without acknowledging it.
-            Assert.Equal("a", await queue.ReserveNextAsync());
-            Assert.Equal(1, await queue.GetProcessingCountAsync());
-
-            Assert.Equal("b", await queue.ReserveNextAsync());
-            Assert.Equal(2, await queue.GetProcessingCountAsync());
-
-            // Acknowledging removes it from the processing list for good.
-            await queue.AcknowledgeAsync("a");
-            Assert.Equal(1, await queue.GetProcessingCountAsync());
-
-            await queue.AcknowledgeAsync("b");
-            Assert.Equal(0, await queue.GetProcessingCountAsync());
         }
 
         [Fact]

--- a/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
@@ -140,17 +140,7 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
-        public async Task HashGetAllIfExists_OnAMissingKey_ReturnsNull()
-        {
-            var key = $"redis-hash-{Guid.NewGuid()}";
-            using var scope = CreateScope();
-            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
-
-            Assert.Null(await cache.HashGetAllIfExists(key));
-        }
-
-        [Fact]
-        public async Task HashSetAndForget_ThenHashGetAllIfExists_RoundTripsFieldsAndSetsTtl()
+        public async Task HashSetAndForget_ThenReadBack_RoundTripsFieldsAndSetsTtl()
         {
             var key = $"redis-hash-{Guid.NewGuid()}";
             using var scope = CreateScope();
@@ -158,7 +148,7 @@ namespace Game.Application.Tests.DataAccess
 
             cache.HashSetAndForget(key, new Dictionary<string, string> { ["a"] = "1", ["b"] = "2" }, TimeSpan.FromSeconds(30));
 
-            var fields = await PollingHelper.PollUntilAsync(() => cache.HashGetAllIfExists(key), f => f is not null);
+            var fields = await PollingHelper.PollUntilAsync(() => ReadHashAsync(key), f => f is not null);
 
             Assert.NotNull(fields);
             Assert.Equal(2, fields.Count);
@@ -178,13 +168,13 @@ namespace Game.Application.Tests.DataAccess
             var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
 
             cache.HashSetAndForget(key, new Dictionary<string, string> { ["a"] = "1", ["b"] = "2" }, TimeSpan.FromSeconds(2));
-            await WaitForHashFieldCountAsync(cache, key, 2);
+            await WaitForHashFieldCountAsync(key, 2);
 
             // Only "a" is named this time — "b" must survive untouched and the TTL must be refreshed well
             // past the 2s seed ceiling.
             cache.HashSetAndForget(key, new Dictionary<string, string> { ["a"] = "9" }, TimeSpan.FromSeconds(30));
 
-            var fields = await PollingHelper.PollUntilAsync(() => cache.HashGetAllIfExists(key), f => f?.GetValueOrDefault("a") == "9");
+            var fields = await PollingHelper.PollUntilAsync(() => ReadHashAsync(key), f => f?.GetValueOrDefault("a") == "9");
 
             Assert.NotNull(fields);
             Assert.Equal("9", fields["a"]);
@@ -193,21 +183,6 @@ namespace Game.Application.Tests.DataAccess
             var ttl = await ReadTtlAsync(key);
             Assert.NotNull(ttl);
             Assert.True(ttl > TimeSpan.FromSeconds(10), $"Expected the TTL to be refreshed past the 2s seed but was {ttl}.");
-        }
-
-        [Fact]
-        public async Task HashGetAllIfExists_OnAKeyHoldingANonHashValue_TreatsItAsAMissAndClearsIt()
-        {
-            // Mirrors a key still holding a prior string-blob representation after a cache-shape change
-            // (#1635 moved player progress from a serialized string to a Redis hash) — HGETALL would otherwise
-            // error every read forever instead of self-healing on the next write.
-            var key = $"redis-hash-{Guid.NewGuid()}";
-            using var scope = CreateScope();
-            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
-            await cache.Set(key, "a-stale-string-blob", TimeSpan.FromSeconds(30));
-
-            Assert.Null(await cache.HashGetAllIfExists(key));
-            Assert.Null(await cache.Get(key));
         }
 
         [Fact]
@@ -220,7 +195,7 @@ namespace Game.Application.Tests.DataAccess
             cache.HashSetAndForget(key, new Dictionary<string, string>(), TimeSpan.FromSeconds(30));
 
             await Task.Delay(200);
-            Assert.Null(await cache.HashGetAllIfExists(key));
+            Assert.Null(await ReadHashAsync(key));
         }
 
         [Fact]
@@ -237,13 +212,13 @@ namespace Game.Application.Tests.DataAccess
             // Exercise the script at least once first, matching a long-lived process that already warmed it
             // before its Redis connection loses the script cache.
             cache.HashSetAndForget(key, new Dictionary<string, string> { ["a"] = "1" }, TimeSpan.FromSeconds(30));
-            await WaitForHashFieldCountAsync(cache, key, 1);
+            await WaitForHashFieldCountAsync(key, 1);
 
             await FlushScriptCacheAsync();
 
             cache.HashSetAndForget(key, new Dictionary<string, string> { ["b"] = "2" }, TimeSpan.FromSeconds(30));
 
-            var fields = await PollingHelper.PollUntilAsync(() => cache.HashGetAllIfExists(key), f => f?.ContainsKey("b") == true);
+            var fields = await PollingHelper.PollUntilAsync(() => ReadHashAsync(key), f => f?.ContainsKey("b") == true);
 
             Assert.NotNull(fields);
             Assert.Equal("2", fields["b"]);
@@ -259,7 +234,7 @@ namespace Game.Application.Tests.DataAccess
             cache.HashSetIfExistsAndForget(key, new Dictionary<string, string> { ["a"] = "1" }, TimeSpan.FromSeconds(30));
 
             await Task.Delay(200);
-            Assert.Null(await cache.HashGetAllIfExists(key));
+            Assert.Null(await ReadHashAsync(key));
         }
 
         [Fact]
@@ -270,11 +245,11 @@ namespace Game.Application.Tests.DataAccess
             var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
 
             cache.HashSetAndForget(key, new Dictionary<string, string> { ["a"] = "1", ["b"] = "2" }, TimeSpan.FromSeconds(2));
-            await WaitForHashFieldCountAsync(cache, key, 2);
+            await WaitForHashFieldCountAsync(key, 2);
 
             cache.HashSetIfExistsAndForget(key, new Dictionary<string, string> { ["a"] = "9" }, TimeSpan.FromSeconds(30));
 
-            var fields = await PollingHelper.PollUntilAsync(() => cache.HashGetAllIfExists(key), f => f?.GetValueOrDefault("a") == "9");
+            var fields = await PollingHelper.PollUntilAsync(() => ReadHashAsync(key), f => f?.GetValueOrDefault("a") == "9");
 
             Assert.NotNull(fields);
             Assert.Equal("9", fields["a"]);
@@ -295,7 +270,7 @@ namespace Game.Application.Tests.DataAccess
             var fields = await cache.HashGetAllAndRefreshExpiry(key, TimeSpan.FromSeconds(30));
 
             Assert.Null(fields);
-            Assert.Null(await cache.HashGetAllIfExists(key));
+            Assert.Null(await ReadHashAsync(key));
         }
 
         [Fact]
@@ -305,7 +280,7 @@ namespace Game.Application.Tests.DataAccess
             using var scope = CreateScope();
             var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
             cache.HashSetAndForget(key, new Dictionary<string, string> { ["a"] = "1", ["b"] = "2" }, TimeSpan.FromSeconds(2));
-            await WaitForHashFieldCountAsync(cache, key, 2);
+            await WaitForHashFieldCountAsync(key, 2);
 
             var fields = await cache.HashGetAllAndRefreshExpiry(key, TimeSpan.FromSeconds(30));
 
@@ -324,7 +299,9 @@ namespace Game.Application.Tests.DataAccess
         [Fact]
         public async Task HashGetAllAndRefreshExpiry_OnAKeyHoldingANonHashValue_TreatsItAsAMissAndClearsIt()
         {
-            // Mirrors HashGetAllIfExists's same self-heal for a stale non-hash representation (#1635).
+            // Mirrors a key still holding a prior string-blob representation after a cache-shape change
+            // (#1635 moved player progress from a serialized string to a Redis hash) — HGETALL would otherwise
+            // error every read forever instead of self-healing on the next write.
             var key = $"redis-hash-getex-{Guid.NewGuid()}";
             using var scope = CreateScope();
             var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
@@ -344,12 +321,12 @@ namespace Game.Application.Tests.DataAccess
             cache.HashSetIfExistsAndForget(key, new Dictionary<string, string>(), TimeSpan.FromSeconds(30));
 
             await Task.Delay(200);
-            Assert.Null(await cache.HashGetAllIfExists(key));
+            Assert.Null(await ReadHashAsync(key));
         }
 
-        private static async Task WaitForHashFieldCountAsync(ICacheService cache, string key, int count, int timeoutMs = 5000)
+        private async Task WaitForHashFieldCountAsync(string key, int count, int timeoutMs = 5000)
         {
-            var fields = await PollingHelper.PollUntilAsync(() => cache.HashGetAllIfExists(key), f => f?.Count == count, timeoutMs);
+            var fields = await PollingHelper.PollUntilAsync(() => ReadHashAsync(key), f => f?.Count == count, timeoutMs);
             if (fields?.Count != count)
             {
                 Assert.Fail($"Expected hash '{key}' to have {count} fields within the timeout.");
@@ -366,6 +343,22 @@ namespace Game.Application.Tests.DataAccess
         {
             await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(Containers.CacheConnectionString);
             return await multiplexer.GetDatabase().KeyTimeToLiveAsync(key);
+        }
+
+        // A side-effect-free raw HGETALL, independent of ICacheService's own hash-read methods, so tests that
+        // merely verify state written by HashSetAndForget/HashSetIfExistsAndForget don't accidentally exercise
+        // (or mask a bug in) HashGetAllAndRefreshExpiry's own TTL-refreshing side effect.
+        private async Task<Dictionary<string, string>?> ReadHashAsync(string key)
+        {
+            await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(Containers.CacheConnectionString);
+            var db = multiplexer.GetDatabase();
+            if (!await db.KeyExistsAsync(key))
+            {
+                return null;
+            }
+
+            var entries = await db.HashGetAllAsync(key);
+            return entries.ToDictionary(e => (string)e.Name!, e => (string)e.Value!);
         }
 
         private async Task FlushScriptCacheAsync()

--- a/Game.DataAccess/Repositories/PlayerRepository.cs
+++ b/Game.DataAccess/Repositories/PlayerRepository.cs
@@ -78,7 +78,7 @@ namespace Game.DataAccess.Repositories
             {
                 // A blob that no longer deserializes (e.g. a shape change to PlayerCacheModel's required
                 // members) is corruption, not data - Postgres remains the durable copy, so this self-heals
-                // the same way HashGetAllIfExists treats a wrong-representation key: delete it and fall
+                // the same way HashGetAllAndRefreshExpiry treats a wrong-representation key: delete it and fall
                 // through to the DB reload below instead of locking the player out for the rest of the TTL (#1924).
                 _logger.LogError(ex, "Cached player {PlayerId} at key '{Key}' failed to deserialize; deleting the key and reloading from the database.", playerId, playerKey);
                 await _cache.Delete(playerKey, cancellationToken);

--- a/Game.Infrastructure/Cache/Redis/RedisService.cs
+++ b/Game.Infrastructure/Cache/Redis/RedisService.cs
@@ -138,26 +138,6 @@ namespace Game.Infrastructure.Cache.Redis
             Redis.KeyDelete(key, CommandFlags.FireAndForget);
         }
 
-        private static readonly PreparedScript HashGetAllIfExistsScript = new(
-            "local t = redis.call('type', KEYS[1]).ok "
-            + "if t == 'none' then return false end "
-            + "if t ~= 'hash' then redis.call('del', KEYS[1]) return false end "
-            + "return redis.call('hgetall', KEYS[1])");
-
-        public async Task<Dictionary<string, string>?> HashGetAllIfExists(string key, CancellationToken cancellationToken = default)
-        {
-            // TYPE-then-HGETALL in one script (rather than two round trips) so a hot per-battle read pays only
-            // one — and so the two checks can't race a concurrent expiry/eviction between them. Lua false
-            // comes back over RESP as a null reply, which is how a missing key is told apart from one whose
-            // hash happens to have no fields. A key still holding an older, non-hash representation (e.g. a
-            // caller that repurposed a string-valued key into a hash-valued one) is treated the same as a miss
-            // and cleared, so a stale value self-heals via the normal miss-then-reload path on next write
-            // rather than erroring every future read.
-            var result = await RedisCommandBudget.Read(HashGetAllIfExistsScript.EvaluateAsync(Redis, [key], []), cancellationToken);
-
-            return MapHashResult(result);
-        }
-
         private static readonly PreparedScript HashGetAllAndRefreshExpiryScript = new(
             "local t = redis.call('type', KEYS[1]).ok "
             + "if t == 'none' then return false end "
@@ -168,20 +148,25 @@ namespace Game.Infrastructure.Cache.Redis
 
         public async Task<Dictionary<string, string>?> HashGetAllAndRefreshExpiry(string key, TimeSpan expiry, CancellationToken cancellationToken = default)
         {
-            // Same TYPE-then-HGETALL script as HashGetAllIfExists, plus a PEXPIRE on the hit path so a
-            // sliding-expiration hash read pays one round trip instead of an awaited HGETALL followed by a
-            // fire-and-forget expire (mirroring GetAndRefreshExpiry's GETEX win for string keys, which GETEX
-            // itself can't serve here since it only applies to strings). The PEXPIRE makes this a write, so it
-            // routes through ObserveWrite like GetAndRefreshExpiry rather than the plain-read path
-            // HashGetAllIfExists uses.
+            // TYPE-then-HGETALL in one script (rather than two round trips) so a hot per-battle read pays only
+            // one — and so the two checks can't race a concurrent expiry/eviction between them — plus a
+            // PEXPIRE on the hit path so a sliding-expiration hash read pays one round trip instead of a
+            // separate awaited HGETALL followed by a fire-and-forget expire (mirroring GetAndRefreshExpiry's
+            // GETEX win for string keys, which GETEX itself can't serve here since it only applies to strings).
+            // Lua false comes back over RESP as a null reply, which is how a missing key is told apart from one
+            // whose hash happens to have no fields. A key still holding an older, non-hash representation (e.g.
+            // a caller that repurposed a string-valued key into a hash-valued one) is treated the same as a
+            // miss and cleared, so a stale value self-heals via the normal miss-then-reload path on next write
+            // rather than erroring every future read. The PEXPIRE makes this a write, so it routes through
+            // ObserveWrite rather than the plain-read path.
             var result = await ObserveWrite(HashGetAllAndRefreshExpiryScript.EvaluateAsync(Redis, [key], [(RedisValue)(long)expiry.TotalMilliseconds]), cancellationToken);
 
             return MapHashResult(result);
         }
 
-        // Shared by HashGetAllIfExists and HashGetAllAndRefreshExpiry: both scripts return either a Lua false
-        // (told apart from an empty hash by RedisResult.IsNull) or the flat HGETALL reply, so the
-        // flat-array-to-dictionary conversion — and the null-forgiving indexing it requires — lives in one place.
+        // The script above returns either a Lua false (told apart from an empty hash by RedisResult.IsNull)
+        // or the flat HGETALL reply, so the flat-array-to-dictionary conversion — and the null-forgiving
+        // indexing it requires — lives in one place.
         private static Dictionary<string, string>? MapHashResult(RedisResult result)
         {
             if (result.IsNull)

--- a/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
@@ -112,11 +112,6 @@ namespace Game.Infrastructure.PubSub.Redis
             return RedisCommandBudget.Read(_redis.ListLengthAsync(QueueName), cancellationToken);
         }
 
-        public Task<long> GetProcessingCountAsync(CancellationToken cancellationToken = default)
-        {
-            return RedisCommandBudget.Read(_redis.ListLengthAsync(ProcessingQueueName), cancellationToken);
-        }
-
         public async Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default)
         {
             if (count <= 0)


### PR DESCRIPTION
## Summary

Per CLAUDE.md's dead-code guideline, removes two interface members that were superseded surface kept alive only by their own tests:

- **`ICacheService.HashGetAllIfExists`** (`Game.Abstractions/Infrastructure/ICacheService.cs`, impl + Lua script in `Game.Infrastructure/Cache/Redis/RedisService.cs`) — the only non-test production reference was a comment in `PlayerRepository.cs`. `PlayerProgressRepository` reads exclusively through `HashGetAllAndRefreshExpiry`, its #2019 fold-TTL-into-read successor.
- **`IPubSubQueue.GetProcessingCountAsync`** (`Game.Abstractions/Infrastructure/IPubSubQueue.cs`, impl `Game.Infrastructure/PubSub/Redis/RedisQueue.cs`) — called only from tests; the synchronizer's stranded-item detection moved to `PeekProcessingAsync` head-identity tracking (#1702).

Re-confirmed no production callers had appeared for either member before removing.

## Changes

- Removed both interface members, their Redis implementations (including `HashGetAllIfExistsScript`), and the `RedisService`/`PlayerRepository` comments that referenced them (reworded onto `HashGetAllAndRefreshExpiry`, which keeps the shared TYPE-then-HGETALL script).
- Removed the direct tests pinning each removed member's own behavior (redundant with `HashGetAllAndRefreshExpiry`'s equivalent coverage, or with `GetProcessingCountAsync`'s reserve/acknowledge round trip already covered by `ReserveNextAsync_ParksItemOffTheQueueUntilAcknowledged`).
- For tests that used a removed method only as a verification/polling helper (not testing the removed method itself), swapped in:
  - `IPubSubQueue.PeekProcessingAsync` (already on the interface) for processing-list size checks.
  - A new side-effect-free raw-Redis `ReadHashAsync` helper in `RedisServiceIntegrationTests` for hash-content checks — deliberately not routed through `HashGetAllAndRefreshExpiry`, since that method's own TTL-refresh side effect would otherwise mask a real regression in the TTL behavior some of these tests assert on.
- Removed the fake-implementation burden in test doubles: the `throw new NotSupportedException()` stubs in `SocketCommandProcessorTests`, and the real in-memory implementations across the several `IPubSubQueue` test fakes in `DataProviderSynchronizerTests` (`InMemoryPubSubQueue`, `ConcurrencyTrackingQueue`, `ConcurrentAcknowledgeTrackingQueue`, `GatedDrainQueue`, `FaultingAcknowledgeQueue`, `MultiGatedAcknowledgeQueue`, `WedgedReserveQueue`).

No behavior change to any surviving code path.

## Test plan

- [x] `dotnet build` (full solution) — 0 warnings, 0 errors
- [x] `dotnet test --no-build --no-restore` (full suite, all 4 test projects against the real Postgres/Redis containers) — 3,347/3,347 passed
- [x] Repo-wide grep confirms no remaining references to either removed member (production or test)

Closes #2173


---
_Generated by [Claude Code](https://claude.ai/code/session_01EqANs1c4QF1y5nseNGxcYY)_