### PR TITLE
Distinguish no-player-selected from player-not-found in the socket handshake

### DIFF
--- a/Game.Api.Tests/Integration/SocketConnectionTests.cs
+++ b/Game.Api.Tests/Integration/SocketConnectionTests.cs
@@ -1,10 +1,8 @@
 using Game.Api.Models.Common;
-using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Net.Http.Json;
 using System.Net.WebSockets;
@@ -17,18 +15,6 @@ namespace Game.Api.Tests.Integration
     public class SocketConnectionTests : ApiIntegrationTestBase
     {
         public SocketConnectionTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper) : base(containers, testOutputHelper) { }
-
-        /// <summary>
-        /// Seeds a user with no player, so an authenticated handshake for it resolves no player to load.
-        /// Returns the userId (for WebSocket auth).
-        /// </summary>
-        private async Task<int> SeedUserWithoutPlayerAsync(string username = "socketnoplayer", string password = "socketpass")
-        {
-            using var scope = CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
-            var user = await TestDataSeeder.CreateUserAsync(context, username, password);
-            return user.Id;
-        }
 
         [Fact]
         public async Task Connect_Authenticated_Succeeds()
@@ -92,10 +78,12 @@ namespace Game.Api.Tests.Integration
             // The player-load short-circuit sits after the WebSocket-upgrade check, so — unlike the 401/400
             // cases — it can't be reached with a plain GET (that stops at the 400 branch). The request is
             // driven through the pipeline presenting as a WebSocket upgrade (a stubbed feature), but the
-            // socket is never accepted: the authenticated user has no player, so the handshake loads none and
+            // socket is never accepted: a post-selection token naming a player that can't be loaded
+            // (archived/deleted between requests, mirrored here by a token minted for a never-persisted id)
+            // is a genuine missing-resource failure, distinct from the pre-selection case below — it
             // short-circuits to 404 with the { errorMessage } envelope still written to the (un-upgraded) body.
-            var userId = await SeedUserWithoutPlayerAsync();
-            var token = TestAuthHelper.CreateAccessToken(userId);
+            var (userId, _) = await SeedAsync();
+            var token = TestAuthHelper.CreateAccessToken(userId, playerId: 999_999_999);
 
             var context = await Factory.Server.SendAsync(ctx =>
             {
@@ -107,6 +95,33 @@ namespace Game.Api.Tests.Integration
 
             Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
             // The response body stream isn't seekable, so deserialize straight from its start.
+            var body = await JsonSerializer.DeserializeAsync<ApiResponse>(
+                context.Response.Body,
+                new JsonSerializerOptions(JsonSerializerDefaults.Web),
+                CancellationToken);
+            Assert.NotNull(body);
+            Assert.False(string.IsNullOrWhiteSpace(body.ErrorMessage));
+        }
+
+        [Fact]
+        public async Task Socket_AuthenticatedNoPlayerSelected_ReturnsNoPlayerSelectedNotOpaque404()
+        {
+            // A pre-selection token (post-Login, pre-SelectPlayer) is a normal, documented flow state
+            // (docs/backend-auth.md) — a well-behaved client never opens a socket in this state, but the
+            // handshake must still reject it as its own distinguishable category (mirroring
+            // AuthController.Status), not the generic 404 a genuinely unloadable player gets.
+            var (userId, _) = await SeedAsync();
+            var token = TestAuthHelper.CreateAccessToken(userId);
+
+            var context = await Factory.Server.SendAsync(ctx =>
+            {
+                ctx.Request.Method = HttpMethods.Get;
+                ctx.Request.Path = "/socket";
+                ctx.Request.QueryString = new QueryString($"?access_token={token}");
+                ctx.Features.Set<IHttpWebSocketFeature>(new StubWebSocketFeature());
+            }, CancellationToken);
+
+            Assert.Equal(StatusCodes.Status409Conflict, context.Response.StatusCode);
             var body = await JsonSerializer.DeserializeAsync<ApiResponse>(
                 context.Response.Body,
                 new JsonSerializerOptions(JsonSerializerDefaults.Web),

--- a/Game.Api/Middleware/SocketInterceptorMiddleware.cs
+++ b/Game.Api/Middleware/SocketInterceptorMiddleware.cs
@@ -31,27 +31,48 @@ namespace Game.Api.Middleware
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
                 await context.Response.WriteAsJsonAsync(ApiResponse.Error("The /socket endpoint requires a WebSocket upgrade request."), context.RequestAborted);
             }
-            else if (!await TryLoadPlayer(sessionService, sessionInitializer, scopeFactory, context.RequestAborted))
-            {
-                // An authenticated session whose player can't be loaded can't play, so fail before upgrading
-                // the socket rather than erroring on the first command. The socket isn't upgraded yet, so a
-                // body can still be written: return the project's { errorMessage } envelope (a 404 — the
-                // player resource is absent, not a server fault; a genuine load error throws and is shaped by
-                // ExceptionHandlingMiddleware) rather than a bare 500.
-                context.Response.StatusCode = StatusCodes.Status404NotFound;
-                await context.Response.WriteAsJsonAsync(ApiResponse.Error("Player could not be loaded."), context.RequestAborted);
-            }
             else
             {
-                // Read from the handshake's validated ClaimsPrincipal (the same source
-                // AdminRoleAuthorizationFilter reads for HTTP admin endpoints), not the volatile session
-                // cache, so it derives from the token alone.
-                var isAdmin = context.User.IsInRole(nameof(ERole.Admin));
-                using var webSocket = await context.WebSockets.AcceptWebSocketAsync();
-                var socketContext = await socketManager.RegisterSocket(webSocket, sessionService, isAdmin);
-                await socketContext.WaitSocketClosed();
-                await socketManager.UnRegisterSocket(socketContext);
+                var loadResult = await TryLoadPlayer(sessionService, sessionInitializer, scopeFactory, context.RequestAborted);
+                if (loadResult == PlayerLoadResult.NoPlayerSelected)
+                {
+                    // A pre-selection token (post-Login, pre-SelectPlayer) can never resolve a loadable
+                    // player, so reject on the token's missing selected-player claim with the same category
+                    // AuthController.Status uses, rather than let a well-behaved-client-can't-hit-this state
+                    // fall through to the generic "player not found" 404 below.
+                    context.Response.StatusCode = StatusCodes.Status409Conflict;
+                    await context.Response.WriteAsJsonAsync(ApiResponse.Error("No character selected.", ApiErrorCategory.NoPlayerSelected), context.RequestAborted);
+                }
+                else if (loadResult == PlayerLoadResult.PlayerNotFound)
+                {
+                    // An authenticated session whose player can't be loaded can't play, so fail before upgrading
+                    // the socket rather than erroring on the first command. The socket isn't upgraded yet, so a
+                    // body can still be written: return the project's { errorMessage } envelope (a 404 — the
+                    // player resource is absent, not a server fault; a genuine load error throws and is shaped by
+                    // ExceptionHandlingMiddleware) rather than a bare 500.
+                    context.Response.StatusCode = StatusCodes.Status404NotFound;
+                    await context.Response.WriteAsJsonAsync(ApiResponse.Error("Player could not be loaded."), context.RequestAborted);
+                }
+                else
+                {
+                    // Read from the handshake's validated ClaimsPrincipal (the same source
+                    // AdminRoleAuthorizationFilter reads for HTTP admin endpoints), not the volatile session
+                    // cache, so it derives from the token alone.
+                    var isAdmin = context.User.IsInRole(nameof(ERole.Admin));
+                    using var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+                    var socketContext = await socketManager.RegisterSocket(webSocket, sessionService, isAdmin);
+                    await socketContext.WaitSocketClosed();
+                    await socketManager.UnRegisterSocket(socketContext);
+                }
             }
+        }
+
+        /// <summary>Whether (and why not) the handshake was able to load a player aggregate for the session.</summary>
+        private enum PlayerLoadResult
+        {
+            Loaded,
+            NoPlayerSelected,
+            PlayerNotFound
         }
 
         /// <summary>
@@ -60,22 +81,28 @@ namespace Game.Api.Middleware
         /// it happens — then loads the player aggregate up front so socket commands read it synchronously for
         /// the connection's lifetime (the connection never re-reads the cache per command). The aggregate load
         /// runs in a disposable scope so its <c>GameContext</c> is not held open for the whole connection.
-        /// Returns false when the authenticated player has no loadable aggregate.
+        /// Rejects a pre-selection token before any load I/O, since <see cref="SessionService.SelectedPlayerId"/>
+        /// can never resolve a real player while it's unbound (player identity starts at 1).
         /// </summary>
-        private static async Task<bool> TryLoadPlayer(SessionService sessionService, SessionInitializer sessionInitializer, IServiceScopeFactory scopeFactory, CancellationToken cancellationToken)
+        private static async Task<PlayerLoadResult> TryLoadPlayer(SessionService sessionService, SessionInitializer sessionInitializer, IServiceScopeFactory scopeFactory, CancellationToken cancellationToken)
         {
             await sessionInitializer.EnsureSessionLoaded(cancellationToken);
+
+            if (sessionService.TokenSelectedPlayerId is null)
+            {
+                return PlayerLoadResult.NoPlayerSelected;
+            }
 
             using var scope = scopeFactory.CreateScope();
             var player = await scope.ServiceProvider.GetRequiredService<PlayerService>()
                 .LoadPlayer(sessionService.SelectedPlayerId, cancellationToken);
             if (player is null)
             {
-                return false;
+                return PlayerLoadResult.PlayerNotFound;
             }
 
             sessionService.SetPlayer(player);
-            return true;
+            return PlayerLoadResult.Loaded;
         }
     }
 


### PR DESCRIPTION
## Summary

`SocketInterceptorMiddleware.TryLoadPlayer` (`Game.Api/Middleware/SocketInterceptorMiddleware.cs`) collapsed two different failure states into the same generic 404:

- A **pre-selection token** (no `player_id` claim) — a normal flow state (`EnsureSessionLoaded` deliberately leaves the session unbound for it) — left `SelectedPlayerId` at `0`, so the handshake still called `PlayerService.LoadPlayer(0)`: a real cache-miss + DB round trip for an id that can never exist (player identity starts at 1).
- A **genuinely unloadable player** (post-selection token naming a deleted/archived player).

`AuthController.Status` already distinguishes these two states via `ApiErrorCategory.NoPlayerSelected` (409), added in #2166. This PR brings the socket handshake into parity, per #2175.

## Changes

- `SocketInterceptorMiddleware.TryLoadPlayer` now returns a `PlayerLoadResult` enum (`Loaded` / `NoPlayerSelected` / `PlayerNotFound`) instead of a `bool`. It checks `SessionService.TokenSelectedPlayerId` immediately after `EnsureSessionLoaded` and short-circuits to `NoPlayerSelected` before any `LoadPlayer` I/O.
- `SocketInterceptorMiddleware.InvokeAsync` branches on the result: `NoPlayerSelected` → 409 with `ApiErrorCategory.NoPlayerSelected` and the same `"No character selected."` message `AuthController.Status` uses; `PlayerNotFound` → unchanged 404 `"Player could not be loaded."`; `Loaded` → proceeds to accept the WebSocket as before.
- Fixed `SocketConnectionTests.Socket_AuthenticatedButPlayerNotLoadable_ReturnsErrorEnvelope`, which (pre-existing) used a pre-selection token to represent "player not loadable" — that scenario is now correctly a 409, so the test was updated to use a post-selection token naming a never-persisted player id (mirroring `AuthControllerTests.Status_PostSelectionTokenButPlayerGone_Returns404WithError`) to exercise the genuine 404 path. Removed the now-unused `SeedUserWithoutPlayerAsync` helper.
- Added `Socket_AuthenticatedNoPlayerSelected_ReturnsNoPlayerSelectedNotOpaque404` covering the new 409 path.

No architecture-level documentation change: `docs/backend.md`/`docs/backend-auth.md` already describe the general rehydration/pre-selection-token behavior without pinning the socket handshake's specific status code, so this is an implementation-level fix within existing documented behavior.

## Test plan

- [x] `dotnet build` (full solution) — 0 warnings, 0 errors
- [x] `dotnet test` per project (`Game.Core.Tests`, `Game.Application.Tests`, `Game.Infrastructure.Tests`, `Game.Api.Tests`) — all green, `Game.Api.Tests` 835/835 passed against the real Postgres/Redis containers

Closes #2175


---
_Generated by [Claude Code](https://claude.ai/code/session_01QPCTQ2zhoNNeeQbX6yzKrh)_