### PR TITLE
Bump SocketCommandTimeoutTests' ShortTimeout to avoid cold-start flake

### DIFF
--- a/Game.Api.Tests/Integration/SocketCommandTimeoutTests.cs
+++ b/Game.Api.Tests/Integration/SocketCommandTimeoutTests.cs
@@ -22,7 +22,12 @@ namespace Game.Api.Tests.Integration
     [Collection("Integration")]
     public class SocketCommandTimeoutTests : ApiIntegrationTestBase
     {
-        private static readonly TimeSpan ShortTimeout = TimeSpan.FromMilliseconds(200);
+        // Long enough that a cold JIT/connection-pool run (e.g. this class run in isolation, with no prior
+        // test in the process having warmed the EF/Npgsql code paths the `Next`/`Coop` commands' own
+        // scope-creation and SaveChangesAsync round trip through) doesn't spuriously blow the budget itself —
+        // short enough that the deliberately-wedged `Hung`/`Coop` commands above still reliably time out well
+        // within WaitTimeout (#2184).
+        private static readonly TimeSpan ShortTimeout = TimeSpan.FromMilliseconds(750);
         private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);
 
         public SocketCommandTimeoutTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)

--- a/Game.Api.Tests/Integration/SocketCommandTimeoutTests.cs
+++ b/Game.Api.Tests/Integration/SocketCommandTimeoutTests.cs
@@ -25,7 +25,7 @@ namespace Game.Api.Tests.Integration
         // Long enough that a cold JIT/connection-pool run (e.g. this class run in isolation, with no prior
         // test in the process having warmed the EF/Npgsql code paths the `Next`/`Coop` commands' own
         // scope-creation and SaveChangesAsync round trip through) doesn't spuriously blow the budget itself —
-        // short enough that the deliberately-wedged `Hung`/`Coop` commands above still reliably time out well
+        // short enough that the deliberately-wedged `Hung`/`Coop` commands below still reliably time out well
         // within WaitTimeout (#2184).
         private static readonly TimeSpan ShortTimeout = TimeSpan.FromMilliseconds(750);
         private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);


### PR DESCRIPTION
## Summary

`SocketCommandTimeoutTests.CooperativelyCancellingCommand_TimesOut_AndReleasesLockSoNextCommandRuns` uses a 200ms `ShortTimeout` budget for both the deliberately-wedged `Coop` command and a trivial follow-up `Next` command. When this test class runs in isolation (no prior test in the process having JIT/connection-pool warmed the EF/Npgsql code paths that `RunCommand`'s scope creation and `IUnitOfWork.CommitAsync` round trip through), the `Next` command's own cold-start latency could exceed the 200ms budget, causing it to spuriously time out even though its body is a no-op. This reproduced reliably (5/5) in isolation while passing in the full suite (where those code paths are already warm from hundreds of prior tests).

## Changes

- `Game.Api.Tests/Integration/SocketCommandTimeoutTests.cs`: bumped `ShortTimeout` from 200ms to 750ms, giving cold-start headroom while staying comfortably inside `WaitTimeout` (5s) — the deliberately-wedged `Hung`/`Coop` commands (parked on a `TaskCompletionSource` that's never released until the test explicitly signals it) still reliably time out and exercise the same behavior regardless of the exact budget value.

No production code changed — this is a test-only timing fix.

## Test plan

- [x] `dotnet build` (full solution) — 0 warnings, 0 errors
- [x] `dotnet test -- --filter-class "*SocketCommandTimeoutTests"` run in isolation, twice — 6/6 passed both times (previously reproduced the "Next" timeout failure per the issue report)
- [x] `dotnet test --no-build --no-restore` (full suite, all 4 test projects against the real Postgres/Redis containers) — all green (835/835 in `Game.Api.Tests`)

Closes #2184

---
_Generated by [Claude Code](https://claude.ai/code/session_013MdmBiwwyNxp785bLtv5kA)_