### PR TITLE
Share a ConnectionMultiplexer across RedisServiceIntegrationTests read helpers

### DIFF
--- a/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs
@@ -19,7 +19,19 @@ namespace Game.Application.Tests.DataAccess
     [Collection("Integration")]
     public class RedisServiceIntegrationTests : ApplicationIntegrationTestBase
     {
+        private ConnectionMultiplexer? _readMultiplexer;
+
         public RedisServiceIntegrationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper) : base(containers, testOutputHelper) { }
+
+        public override async ValueTask DisposeAsync()
+        {
+            if (_readMultiplexer is not null)
+            {
+                await _readMultiplexer.DisposeAsync();
+            }
+
+            await base.DisposeAsync();
+        }
 
         [Fact]
         public async Task SetWithExpiry_WithNullValue_DeletesTheKey()
@@ -341,7 +353,7 @@ namespace Game.Application.Tests.DataAccess
 
         private async Task<TimeSpan?> ReadTtlAsync(string key)
         {
-            await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(Containers.CacheConnectionString);
+            var multiplexer = await GetReadMultiplexerAsync();
             return await multiplexer.GetDatabase().KeyTimeToLiveAsync(key);
         }
 
@@ -350,7 +362,7 @@ namespace Game.Application.Tests.DataAccess
         // (or mask a bug in) HashGetAllAndRefreshExpiry's own TTL-refreshing side effect.
         private async Task<Dictionary<string, string>?> ReadHashAsync(string key)
         {
-            await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(Containers.CacheConnectionString);
+            var multiplexer = await GetReadMultiplexerAsync();
             var db = multiplexer.GetDatabase();
             if (!await db.KeyExistsAsync(key))
             {
@@ -359,6 +371,18 @@ namespace Game.Application.Tests.DataAccess
 
             var entries = await db.HashGetAllAsync(key);
             return entries.ToDictionary(e => (string)e.Name!, e => (string)e.Value!);
+        }
+
+        // Shared across ReadTtlAsync/ReadHashAsync (frequently called inside PollUntilAsync loops) so a
+        // slow-settling assertion reuses one connection instead of churning through a fresh one per call.
+        private async Task<ConnectionMultiplexer> GetReadMultiplexerAsync()
+        {
+            if (_readMultiplexer is null)
+            {
+                _readMultiplexer = await ConnectionMultiplexer.ConnectAsync(Containers.CacheConnectionString);
+            }
+
+            return _readMultiplexer;
         }
 
         private async Task FlushScriptCacheAsync()

--- a/Game.TestInfrastructure/Base/ApplicationIntegrationTestBase.cs
+++ b/Game.TestInfrastructure/Base/ApplicationIntegrationTestBase.cs
@@ -63,7 +63,7 @@ namespace Game.TestInfrastructure.Base
             await CleanupAsync();
         }
 
-        public async ValueTask DisposeAsync()
+        public virtual async ValueTask DisposeAsync()
         {
             if (_rootProvider is not null)
             {


### PR DESCRIPTION
## Summary

`RedisServiceIntegrationTests`' raw-Redis read helpers (`ReadTtlAsync`, `ReadHashAsync`) each opened a fresh `ConnectionMultiplexer` per call. Both are invoked repeatedly inside `PollUntilAsync` poll loops, so a slow-settling assertion churned through several full Redis connections in a single test.

## Changes

- `Game.Application.Tests/DataAccess/RedisServiceIntegrationTests.cs`: added a `GetReadMultiplexerAsync()` helper that lazily creates and caches one `ConnectionMultiplexer` per test instance, and routed `ReadTtlAsync`/`ReadHashAsync` through it instead of connecting per call. The cached connection is disposed alongside the rest of the fixture.
- `Game.TestInfrastructure/Base/ApplicationIntegrationTestBase.cs`: made `DisposeAsync()` `virtual` so `RedisServiceIntegrationTests` can override it to dispose the cached multiplexer before calling `base.DisposeAsync()`. No other derived integration test class currently overrides it, so this is non-breaking for the rest of the suite.

`FlushScriptCacheAsync` (a one-off `AllowAdmin` connection used once, not inside a poll loop) is left as-is — it's outside the scope of the churn this issue describes.

Test-only change; no production behavior affected.

## Duplicate issue note

#2201 and #2202 were filed seconds apart and describe the exact same fix (same helpers, same root cause, same suggested change) — both are closed by this PR.

## Test plan

- [x] `dotnet build` (full solution) — 0 warnings, 0 errors
- [x] `dotnet test Game.Application.Tests --no-build --no-restore -- --filter-class "*RedisServiceIntegrationTests"` — 17/17 passed
- [x] `dotnet test --no-build --no-restore` (full suite, all 4 test projects against the real Postgres/Redis containers) — all green (3350/3350)

Closes #2201
Closes #2202

---
_Generated by [Claude Code](https://claude.ai/code/session_012vNz1VVqjTJPrLD4WcBsgR)_