### PR TITLE
Fix CI backend path filter and NuGet cache key for CPM

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,6 +66,8 @@ jobs:
             - '.editorconfig'
             - 'global.json'
             - '.config/dotnet-tools.json'
+            - 'Directory.Build.props'
+            - 'Directory.Packages.props'
             - '.github/workflows/**'
             - 'UI/src/lib/api/types/**'
           frontend:
@@ -97,7 +99,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.nuget/packages
-        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props', '.config/dotnet-tools.json') }}
         restore-keys: |
           nuget-${{ runner.os }}-
 
@@ -176,7 +178,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.nuget/packages
-        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props', '.config/dotnet-tools.json') }}
         restore-keys: |
           nuget-${{ runner.os }}-
 


### PR DESCRIPTION
## Summary

Since the central package/build-property management (CPM) migration, `Directory.Build.props` and `Directory.Packages.props` own every NuGet version and core build property, but `.github/workflows/run-tests.yml` was never updated for the two places that matter:

- **Backend path filter (bug):** the `detect-changes` backend filter didn't list either props file, so a PR that only bumps a package version or flips a build property ran zero backend jobs (`verify-backend`, `test-backend`, `test-e2e` all skipped), and `all-checks-passed` treats skipped as green.
- **NuGet cache key (tech debt):** both restore caches keyed only on `hashFiles('**/*.csproj')`. Under CPM the csproj files carry version-less `PackageReference`s, so a package version bump left the cache key unchanged — `actions/cache` kept hitting the pre-bump cache and never saved an updated one, meaning bumped packages were re-downloaded on every run indefinitely.

## Changes

- Added `Directory.Build.props` and `Directory.Packages.props` to the `detect-changes` backend path filter.
- Extended both NuGet cache keys (`verify-backend`, `test-backend`) to also hash `Directory.Packages.props` and `.config/dotnet-tools.json` (the tools manifest `build/coverage.ps1` restores into the same package cache).

## Test plan

- [x] Verified the updated workflow file is valid YAML.
- [x] Manually confirmed `Directory.Build.props`, `Directory.Packages.props`, and `.config/dotnet-tools.json` exist at the repo root and are referenced correctly in the filter/cache-key paths.
- This is a CI-workflow-only change with no application code affected, so no backend/frontend build or test suite applies; correctness is verified by inspection of the filter and cache-key changes against the actual repo-root file layout.

Closes #2205

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_014126AN1DsqENHUt5iBgbun)_