### PR TITLE
Fix zone editor's retired-enemy spawn accounting

### DIFF
--- a/UI/src/routes/admin/workbench/components/TableCell.svelte
+++ b/UI/src/routes/admin/workbench/components/TableCell.svelte
@@ -97,7 +97,9 @@ const taken = $derived(
 );
 
 // Share columns: denominator is the sibling-row sum unless the column overrides it
-// (an enemy's spawn share competes against all enemies in the zone).
+// (an enemy's spawn share competes against all enemies in the zone). The numerator is the
+// row's own weight unless the column overrides it (a row that never actually counts, e.g. a
+// retired enemy's spawn, reports 0 so its displayed share matches runtime truth).
 const pct = $derived.by(() => {
 	if (col.type !== 'share') {
 		return 0;
@@ -106,7 +108,8 @@ const pct = $derived.by(() => {
 	const total = col.shareTotal
 		? col.shareTotal(row, rows, record)
 		: rows.reduce((sum, r) => sum + (Number(r[weightKey]) || 0), 0) || 1;
-	return total > 0 ? Math.round(((Number(row[weightKey]) || 0) / total) * 100) : 0;
+	const value = col.shareValue ? col.shareValue(row, rows, record) : Number(row[weightKey]) || 0;
+	return total > 0 ? Math.round((value / total) * 100) : 0;
 });
 </script>
 

--- a/UI/src/routes/admin/workbench/entities/types.ts
+++ b/UI/src/routes/admin/workbench/entities/types.ts
@@ -101,6 +101,13 @@ export interface ColumnConfig {
 	 * rows; an enemy's spawn share instead competes against all enemies in the zone.
 	 */
 	shareTotal?: (row: TableRow, rows: TableRow[], record: unknown) => number;
+	/**
+	 * Share columns: override the numerator. Defaults to the row's own `weightKey` value;
+	 * a row whose weight never actually counts (e.g. a retired enemy's spawn) can report 0
+	 * here so its displayed share matches runtime truth instead of dividing its raw weight
+	 * into a denominator that has already excluded it.
+	 */
+	shareValue?: (row: TableRow, rows: TableRow[], record: unknown) => number;
 }
 
 interface BaseSection<T> {

--- a/UI/src/routes/admin/workbench/entities/zone.ts
+++ b/UI/src/routes/admin/workbench/entities/zone.ts
@@ -10,6 +10,14 @@ export interface WorkbenchZone extends IZone {
 	zoneEnemies: IZoneEnemy[];
 }
 
+/**
+ * Whether an enemy id resolves to a live (non-retired) enemy — the runtime spawn table
+ * (`EnemiesCacheHolder.BuildZoneEnemyTables`) and the `EmptyCombatZone` lint both drop a
+ * retired enemy's spawns entirely, so anything computing "will this actually spawn" must
+ * agree.
+ */
+const isLiveEnemy = (enemyId: number): boolean => !staticData.enemies?.[enemyId]?.retiredAt;
+
 const refresh = async (): Promise<WorkbenchZone[]> => {
 	const [zones, enemies] = await Promise.all([fetchSocketData('GetZones'), fetchSocketData('GetEnemies')]);
 	staticData.zones = zones;
@@ -20,6 +28,11 @@ const refresh = async (): Promise<WorkbenchZone[]> => {
 		bossEnemyId: zone.bossEnemyId ?? -1,
 		// Likewise normalise the optional unlock-gate FK to the "None" sentinel (-1).
 		unlockChallengeId: zone.unlockChallengeId ?? -1,
+		// Includes a retired enemy's spawn row: it stays visible/editable (its own enemy
+		// picker shows "· retired") and, critically, must round-trip verbatim on save since
+		// SetZoneEnemies fully reconciles the zone's spawn table against whatever is posted —
+		// filtering it out here would delete the row from the database on the next unrelated
+		// save. Consumers that need "will this actually spawn" semantics use isLiveEnemy.
 		zoneEnemies: enemies.flatMap((enemy) => {
 			const spawn = enemy.spawns.find((s) => s.zoneId === zone.id);
 			return spawn ? [{ enemyId: enemy.id, weight: spawn.weight }] : [];
@@ -135,7 +148,9 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 			glyph: 'skull',
 			desc: 'Enemies that spawn here & their weights',
 			count: (z) => z.zoneEnemies.length,
-			warn: (z) => (z.isHome || z.zoneEnemies.length ? null : 'No enemies spawn here'),
+			// A retired enemy's row doesn't count toward "does something spawn here" — it never
+			// rolls at runtime (mirrors the backend's EmptyCombatZone lint).
+			warn: (z) => (z.isHome || z.zoneEnemies.some((ze) => isLiveEnemy(ze.enemyId)) ? null : 'No enemies spawn here'),
 			kind: 'table',
 			itemsKey: 'zoneEnemies',
 			rowKey: 'enemyId',
@@ -153,7 +168,17 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 			columns: [
 				{ key: 'enemyId', label: 'Enemy', type: 'select', options: reference.enemyOptions, min: 220, unique: true },
 				{ key: 'weight', label: 'Weight', type: 'number', align: 'r', width: 100 },
-				{ key: '__share', label: 'Spawn share', type: 'share', width: 150, weightKey: 'weight' }
+				{
+					key: '__share',
+					label: 'Spawn share',
+					type: 'share',
+					width: 150,
+					weightKey: 'weight',
+					// Excludes a retired sibling's weight from the denominator — it never rolls,
+					// so counting it would understate every live enemy's real share.
+					shareTotal: (_row, rows) =>
+						rows.reduce((sum, r) => (isLiveEnemy(r.enemyId as number) ? sum + (Number(r.weight) || 0) : sum), 0) || 1
+				}
 			]
 		}
 	],

--- a/UI/src/routes/admin/workbench/entities/zone.ts
+++ b/UI/src/routes/admin/workbench/entities/zone.ts
@@ -177,7 +177,11 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 					// Excludes a retired sibling's weight from the denominator — it never rolls,
 					// so counting it would understate every live enemy's real share.
 					shareTotal: (_row, rows) =>
-						rows.reduce((sum, r) => (isLiveEnemy(r.enemyId as number) ? sum + (Number(r.weight) || 0) : sum), 0) || 1
+						rows.reduce((sum, r) => (isLiveEnemy(r.enemyId as number) ? sum + (Number(r.weight) || 0) : sum), 0) || 1,
+					// A retired enemy's own row never rolls either, so its displayed share is 0 —
+					// otherwise dividing its raw weight into a denominator that already excludes it
+					// could show a share over 100%.
+					shareValue: (row) => (isLiveEnemy(row.enemyId as number) ? Number(row.weight) || 0 : 0)
 				}
 			]
 		}

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -329,14 +329,16 @@ class WorkbenchReference {
 
 	/**
 	 * Total spawn weight competing in a zone: this row's weight plus every OTHER
-	 * enemy's weight in the same zone (so an enemy's share reflects zone competition,
-	 * not its own zone list).
+	 * LIVE enemy's weight in the same zone (so an enemy's share reflects zone competition,
+	 * not its own zone list). A retired competitor is excluded — the runtime spawn table
+	 * (`EnemiesCacheHolder.BuildZoneEnemyTables`) drops it too, so its weight is not real
+	 * competition.
 	 */
 	enemySpawnShareTotal = (row: TableRow, _rows: TableRow[], record: unknown): number => {
 		const enemyId = (record as { id: number }).id;
 		let sum = Number(row.weight) || 0;
 		for (const enemy of staticData.enemies ?? []) {
-			if (enemy.id === enemyId) {
+			if (enemy.id === enemyId || enemy.retiredAt) {
 				continue;
 			}
 			const spawn = enemy.spawns?.find((s) => s.zoneId === row.zoneId);

--- a/UI/src/tests/routes/admin/workbench/TableCell.test.ts
+++ b/UI/src/tests/routes/admin/workbench/TableCell.test.ts
@@ -408,4 +408,36 @@ describe('TableCell — share type', () => {
 		});
 		expect(container.querySelector('.share-pct')!.textContent).toBe('0%');
 	});
+
+	it("a shareTotal override that already excludes the row's own weight can push the share over 100% (#2214 nit)", () => {
+		// shareTotal alone controls only the denominator; a row whose raw weight (5) exceeds a
+		// denominator that has excluded it (3, from a sibling) divides out to more than 100%.
+		const { container } = render(TableCell, {
+			props: {
+				col: makeShareCol({ shareTotal: () => 3 }),
+				row: { weight: 5 },
+				idx: 0,
+				rows: [{ weight: 5 }, { weight: 3 }],
+				record: {},
+				dirty: false,
+				onChange: vi.fn()
+			}
+		});
+		expect(container.querySelector('.share-pct')!.textContent).toBe('167%');
+	});
+
+	it('shareValue overrides the numerator so a row that never counts reports 0% regardless of its raw weight', () => {
+		const { container } = render(TableCell, {
+			props: {
+				col: makeShareCol({ shareTotal: () => 3, shareValue: () => 0 }),
+				row: { weight: 5 },
+				idx: 0,
+				rows: [{ weight: 5 }, { weight: 3 }],
+				record: {},
+				dirty: false,
+				onChange: vi.fn()
+			}
+		});
+		expect(container.querySelector('.share-pct')!.textContent).toBe('0%');
+	});
 });

--- a/UI/src/tests/routes/admin/workbench/entities/zone.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/zone.test.ts
@@ -176,10 +176,12 @@ describe('zoneEntity', () => {
 	describe('zoneEnemies section warn/share (#2206)', () => {
 		const zoneEnemiesSection = zoneEntity.sections.find((s) => s.key === 'zoneEnemies');
 		const enemiesWarn = zoneEnemiesSection?.warn;
-		const shareTotal =
+		const shareColumn =
 			zoneEnemiesSection && 'columns' in zoneEnemiesSection
-				? zoneEnemiesSection.columns.find((c) => c.key === '__share')?.shareTotal
+				? zoneEnemiesSection.columns.find((c) => c.key === '__share')
 				: undefined;
+		const shareTotal = shareColumn?.shareTotal;
+		const shareValue = shareColumn?.shareValue;
 
 		beforeEach(() => {
 			staticData.enemies = [
@@ -216,6 +218,22 @@ describe('zoneEntity', () => {
 		it('share total falls back to 1 when every spawn row is retired', () => {
 			const rows = [{ enemyId: 1, weight: 5 }];
 			expect(shareTotal?.(rows[0], rows, undefined)).toBe(1);
+		});
+
+		it("share value reports 0 for a retired enemy's own row, so it can't render over 100% (#2214 nit)", () => {
+			const rows = [
+				{ enemyId: 1, weight: 5 },
+				{ enemyId: 0, weight: 3 }
+			];
+			expect(shareValue?.(rows[0], rows, undefined)).toBe(0);
+		});
+
+		it("share value passes through a live enemy's own weight unchanged", () => {
+			const rows = [
+				{ enemyId: 1, weight: 5 },
+				{ enemyId: 0, weight: 3 }
+			];
+			expect(shareValue?.(rows[1], rows, undefined)).toBe(3);
 		});
 	});
 

--- a/UI/src/tests/routes/admin/workbench/entities/zone.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/zone.test.ts
@@ -173,6 +173,52 @@ describe('zoneEntity', () => {
 		]);
 	});
 
+	describe('zoneEnemies section warn/share (#2206)', () => {
+		const zoneEnemiesSection = zoneEntity.sections.find((s) => s.key === 'zoneEnemies');
+		const enemiesWarn = zoneEnemiesSection?.warn;
+		const shareTotal =
+			zoneEnemiesSection && 'columns' in zoneEnemiesSection
+				? zoneEnemiesSection.columns.find((c) => c.key === '__share')?.shareTotal
+				: undefined;
+
+		beforeEach(() => {
+			staticData.enemies = [
+				{ id: 0, name: 'Bat', isBoss: false, spawns: [] },
+				{ id: 1, name: 'Warden', isBoss: true, retiredAt: '2026-01-01T00:00:00Z', spawns: [] }
+			];
+		});
+
+		it('flags a zone whose only spawn rows belong to a retired enemy', () => {
+			const z = { ...zoneEntity.newItem(1), zoneEnemies: [{ enemyId: 1, weight: 5 }] };
+			expect(enemiesWarn?.(z)).toBe('No enemies spawn here');
+		});
+
+		it('passes once a live enemy also spawns there', () => {
+			const z = {
+				...zoneEntity.newItem(1),
+				zoneEnemies: [
+					{ enemyId: 1, weight: 5 },
+					{ enemyId: 0, weight: 3 }
+				]
+			};
+			expect(enemiesWarn?.(z)).toBeNull();
+		});
+
+		it("share total excludes a retired sibling's weight from the denominator", () => {
+			const rows = [
+				{ enemyId: 1, weight: 5 },
+				{ enemyId: 0, weight: 3 }
+			];
+			// Only the live row's weight (3) counts — the retired sibling's 5 is dropped.
+			expect(shareTotal?.(rows[1], rows, undefined)).toBe(3);
+		});
+
+		it('share total falls back to 1 when every spawn row is retired', () => {
+			const rows = [{ enemyId: 1, weight: 5 }];
+			expect(shareTotal?.(rows[0], rows, undefined)).toBe(1);
+		});
+	});
+
 	describe('identity section warn (#1996)', () => {
 		const identityWarn = zoneEntity.sections.find((s) => s.key === 'identity')?.warn;
 

--- a/UI/src/tests/routes/admin/workbench/reference.test.ts
+++ b/UI/src/tests/routes/admin/workbench/reference.test.ts
@@ -475,4 +475,11 @@ describe('enemySpawnShareTotal', () => {
 		const total = reference.enemySpawnShareTotal({ zoneId: 99, weight: 0 }, [], { id: 2 });
 		expect(total).toBe(1);
 	});
+
+	it('excludes a retired competitor — it never rolls, so its weight is not real competition', () => {
+		// Zone 0 without retirement: Goblin (30) + Cave Bat (5) + Catacomb Lich (15) = 50 (see above).
+		staticData.enemies[0].retiredAt = '2026-01-01T00:00:00Z'; // Cave Bat
+		const total = reference.enemySpawnShareTotal({ zoneId: 0, weight: 30 }, [], { id: 2 });
+		expect(total).toBe(45);
+	});
 });


### PR DESCRIPTION
## Summary

The Workbench zone editor treated a retired enemy's spawn rows as live, disagreeing with the runtime in three places:

- **`zone.ts`'s "No enemies spawn here" warning** — computed off the raw `zoneEnemies` row count, so a zone whose only spawn rows belonged to retired enemies showed no warning, even though the backend's `EmptyCombatZone` lint flags exactly that zone and the runtime relocates players out of it.
- **The zone's own "Spawn share" column** — defaulted to summing every sibling row's weight (including retired enemies'), overstating the denominator.
- **The enemy editor's "Spawn share" column** (`reference.svelte.ts`'s `enemySpawnShareTotal`) — summed every *other* enemy's weight in the zone with no retired filter, understating a live enemy's real share whenever a retired competitor's rows persisted.

All three now agree with the runtime spawn table (`EnemiesCacheHolder.BuildZoneEnemyTables`), which excludes retired enemies entirely.

## Design note (deviation from the issue's literal suggestion)

The issue's suggested fix was "filter `retiredAt` in all three spots," naming `zone.ts:23-27` (the `zoneEnemies` array itself) as one of them. I deliberately **did not** filter that array at the source: it's the exact payload `childSavers` posts to `AdminTools/SetZoneEnemies`, and that endpoint fully reconciles the zone's spawn table against whatever is sent (`ChildCollectionReconciler.Reconcile`). Filtering retired rows out of the in-memory array would silently **delete** a retired enemy's `ZoneEnemy` row from the database the next time an admin saved an unrelated change to that zone (e.g. tweaking another enemy's weight) — a destructive side effect and a violation of the Workbench's own "never silently drop a reference" convention (`docs/frontend-admin.md`).

Instead, the array stays intact (so it round-trips safely on save), and the three *derived* computations (the warning and both share denominators) now explicitly skip retired enemies.

I also did not implement the issue's hedged ("probably") suggestion to add a visible "retired" affordance to the zone's spawn table rows — it's already there for free: the row's own `enemyId` select uses `reference.enemyOptions`, which keeps a retired *current* value visible with a "· retired" suffix (the same convention used by every other retireable picker in the Workbench).

## Changes

- `UI/src/routes/admin/workbench/entities/zone.ts` — added an `isLiveEnemy` helper; the "no enemies spawn here" warning and the zone's own spawn-share column now exclude retired enemies.
- `UI/src/routes/admin/workbench/reference.svelte.ts` — `enemySpawnShareTotal` now excludes retired competitors from the sum.
- Unit tests added/updated in both corresponding test files covering the warning, both share-total computations, and the "everything retired" fallback-to-1 case.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — full suite green (3824 tests)
- [x] New tests cover: warning suppressed only when a live spawn exists, zone-share-total excludes retired siblings, enemy-share-total excludes retired competitors, share-total falls back to 1 when every row is retired

Closes #2206


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sziy3g5dWEw9WfhJvKW97P)_