### PR TITLE
Reject AdminTags.SaveTags edits/deletes of a missing tag id

### DIFF
--- a/Game.Abstractions/DataAccess/Admin/IAdminTags.cs
+++ b/Game.Abstractions/DataAccess/Admin/IAdminTags.cs
@@ -10,8 +10,8 @@ namespace Game.Abstractions.DataAccess.Admin
     public interface IAdminTags
     {
         /// <summary>Applies an identity-level Add/Edit/Delete change set to the tag catalogue. Tags carry
-        /// their own identity and keep the hard-delete lifecycle, so this never rejects — it succeeds to
-        /// share the unified <see cref="AdminSaveResult"/> contract every admin write reports through.</summary>
-        AdminSaveResult SaveTags(IReadOnlyList<Change<Tag>> changes);
+        /// their own identity and keep the hard-delete lifecycle. An Edit or Delete naming an id that no
+        /// longer exists is rejected as a not-found failure rather than staged.</summary>
+        Task<AdminSaveResult> SaveTags(IReadOnlyList<Change<Tag>> changes, CancellationToken cancellationToken = default);
     }
 }

--- a/Game.Api/Controllers/Admin/AdminTagsController.cs
+++ b/Game.Api/Controllers/Admin/AdminTagsController.cs
@@ -21,9 +21,9 @@ namespace Game.Api.Controllers.Admin
         private readonly IAdminTags _adminTags = adminTags;
 
         [HttpPost]
-        public ApiResponse AddEditTags([FromBody] List<Change<Tag>> changes)
+        public async Task<ApiResponse> AddEditTags([FromBody] List<Change<Tag>> changes)
         {
-            return _adminTags.SaveTags(changes);
+            return await _adminTags.SaveTags(changes, HttpContext.RequestAborted);
         }
     }
 }

--- a/Game.Application.Tests/DataAccess/AdminTagsIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminTagsIntegrationTests.cs
@@ -1,6 +1,7 @@
 using Game.Abstractions.Contracts.Admin;
 using Game.Abstractions.DataAccess;
 using Game.Abstractions.DataAccess.Admin;
+using Game.Core;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
@@ -48,7 +49,7 @@ namespace Game.Application.Tests.DataAccess
                 using (var writeScope = CreateScope())
                 {
                     var admin = writeScope.ServiceProvider.GetRequiredService<IAdminTags>();
-                    Assert.True(admin.SaveTags([Delete(tag)]).Succeeded);
+                    Assert.True((await admin.SaveTags([Delete(tag)])).Succeeded);
                     await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
                 }
             }
@@ -81,7 +82,7 @@ namespace Game.Application.Tests.DataAccess
                 using (var writeScope = CreateScope())
                 {
                     var admin = writeScope.ServiceProvider.GetRequiredService<IAdminTags>();
-                    Assert.True(admin.SaveTags([Delete(tag)]).Succeeded);
+                    Assert.True((await admin.SaveTags([Delete(tag)])).Succeeded);
                     await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
                 }
             }
@@ -113,7 +114,7 @@ namespace Game.Application.Tests.DataAccess
                 using (var writeScope = CreateScope())
                 {
                     var admin = writeScope.ServiceProvider.GetRequiredService<IAdminTags>();
-                    Assert.True(admin.SaveTags([Delete(doomed)]).Succeeded);
+                    Assert.True((await admin.SaveTags([Delete(doomed)])).Succeeded);
                     await writeScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
                 }
             }
@@ -123,6 +124,66 @@ namespace Game.Application.Tests.DataAccess
                 var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
                 Assert.False(await context.Tags.AnyAsync(t => t.Id == doomedId, CancellationToken));
                 Assert.True(await context.Tags.AnyAsync(t => t.Id == keptId, CancellationToken));
+            }
+        }
+
+        [Fact]
+        public async Task SaveTags_EditMissingId_ReturnsNotFoundAndLeavesRowUntouched()
+        {
+            int missingId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var tag = await TestDataSeeder.CreateTagAsync(context, "Ephemeral");
+                missingId = tag.Id;
+                // Remove it directly (bypassing the admin write) so the id is genuinely absent, mirroring a
+                // stale admin client naming an id a concurrent delete already removed.
+                context.Tags.Remove(tag);
+                await context.SaveChangesAsync(CancellationToken);
+            }
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminTags>();
+                var edit = new Change<Contracts.Tag>
+                {
+                    ChangeType = EChangeType.Edit,
+                    Item = new Contracts.Tag { Id = missingId, Name = "Ghost", TagCategoryId = (int)ETagCategory.Accessory },
+                };
+
+                var result = await admin.SaveTags([edit]);
+
+                Assert.False(result.Succeeded);
+                Assert.Equal("Tag not found.", result.ErrorMessage);
+            }
+        }
+
+        [Fact]
+        public async Task SaveTags_DeleteMissingId_ReturnsNotFound()
+        {
+            int missingId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var tag = await TestDataSeeder.CreateTagAsync(context, "Ephemeral");
+                missingId = tag.Id;
+                context.Tags.Remove(tag);
+                await context.SaveChangesAsync(CancellationToken);
+            }
+
+            using (var writeScope = CreateScope())
+            {
+                var admin = writeScope.ServiceProvider.GetRequiredService<IAdminTags>();
+                var delete = new Change<Contracts.Tag>
+                {
+                    ChangeType = EChangeType.Delete,
+                    Item = new Contracts.Tag { Id = missingId, Name = "Ghost", TagCategoryId = (int)ETagCategory.Accessory },
+                };
+
+                var result = await admin.SaveTags([delete]);
+
+                Assert.False(result.Succeeded);
+                Assert.Equal("Tag not found.", result.ErrorMessage);
             }
         }
     }

--- a/Game.Application.Tests/DataAccess/AdminTagsTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminTagsTests.cs
@@ -1,4 +1,5 @@
 using Game.Abstractions.Contracts.Admin;
+using Game.DataAccess.Repositories;
 using Game.DataAccess.Repositories.Admin;
 using Xunit;
 using Contracts = Game.Abstractions.Contracts;
@@ -13,16 +14,28 @@ namespace Game.Application.Tests.DataAccess
     /// </summary>
     public class AdminTagsTests
     {
+        // Reports back exactly the ids supplied at construction as "existing" — a database-free stand-in for
+        // the existence check SaveTags now performs against Edit/Delete ids (#2210).
+        private sealed class FakeTagAssignmentQueries(params int[] existingIds) : ITagAssignmentQueries
+        {
+            public IAsyncEnumerable<int> GetExistingTagIds(IReadOnlyCollection<int> tagIds) =>
+                tagIds.Where(existingIds.Contains).ToAsyncEnumerable();
+
+            public IAsyncEnumerable<int> GetTagIdsForItem(int itemId) => throw new NotSupportedException();
+
+            public IAsyncEnumerable<int> GetTagIdsForItemMod(int itemModId) => throw new NotSupportedException();
+        }
+
         private static Change<Contracts.Tag> Change(EChangeType type, int id, string name = "Tag", int categoryId = 0) =>
             new() { ChangeType = type, Item = new Contracts.Tag { Id = id, Name = name, TagCategoryId = categoryId } };
 
         [Fact]
-        public void SaveTags_Add_InsertsTagWithNameAndCategory()
+        public async Task SaveTags_Add_InsertsTagWithNameAndCategory()
         {
             var store = new RecordingEntityStore();
-            var adminTags = new AdminTags(store);
+            var adminTags = new AdminTags(store, new FakeTagAssignmentQueries());
 
-            var result = adminTags.SaveTags([Change(EChangeType.Add, id: 0, name: "Fire", categoryId: 3)]);
+            var result = await adminTags.SaveTags([Change(EChangeType.Add, id: 0, name: "Fire", categoryId: 3)]);
 
             Assert.True(result.Succeeded);
             var inserted = Assert.IsType<Entities.Tag>(Assert.Single(store.Inserted));
@@ -33,12 +46,12 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
-        public void SaveTags_Edit_UpdatesTagByIdWithNewValues()
+        public async Task SaveTags_Edit_UpdatesTagByIdWithNewValues()
         {
             var store = new RecordingEntityStore();
-            var adminTags = new AdminTags(store);
+            var adminTags = new AdminTags(store, new FakeTagAssignmentQueries(7));
 
-            var result = adminTags.SaveTags([Change(EChangeType.Edit, id: 7, name: "Ice", categoryId: 2)]);
+            var result = await adminTags.SaveTags([Change(EChangeType.Edit, id: 7, name: "Ice", categoryId: 2)]);
 
             Assert.True(result.Succeeded);
             var updated = Assert.IsType<Entities.Tag>(Assert.Single(store.Updated));
@@ -50,12 +63,12 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
-        public void SaveTags_Delete_DeletesByKeyWithoutFabricatingName()
+        public async Task SaveTags_Delete_DeletesByKeyWithoutFabricatingName()
         {
             var store = new RecordingEntityStore();
-            var adminTags = new AdminTags(store);
+            var adminTags = new AdminTags(store, new FakeTagAssignmentQueries(42));
 
-            var result = adminTags.SaveTags([Change(EChangeType.Delete, id: 42)]);
+            var result = await adminTags.SaveTags([Change(EChangeType.Delete, id: 42)]);
 
             Assert.True(result.Succeeded);
             var (entityType, keyValues) = Assert.Single(store.DeletedByKey);
@@ -68,14 +81,14 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
-        public void SaveTags_AddWithUndefinedCategory_ReturnsFailureWithoutStaging()
+        public async Task SaveTags_AddWithUndefinedCategory_ReturnsFailureWithoutStaging()
         {
             var store = new RecordingEntityStore();
-            var adminTags = new AdminTags(store);
+            var adminTags = new AdminTags(store, new FakeTagAssignmentQueries());
 
             // TagCategoryId 0 has no backing ETagCategory member (the enum starts at 1); without the up-front
             // guard this would 500 on the FK at commit instead of rejecting gracefully.
-            var result = adminTags.SaveTags([Change(EChangeType.Add, id: 0, name: "Fire", categoryId: 0)]);
+            var result = await adminTags.SaveTags([Change(EChangeType.Add, id: 0, name: "Fire", categoryId: 0)]);
 
             Assert.False(result.Succeeded);
             Assert.Equal("0 is not a valid tag category.", result.ErrorMessage);
@@ -83,12 +96,12 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
-        public void SaveTags_EditWithUndefinedCategory_ReturnsFailureWithoutStaging()
+        public async Task SaveTags_EditWithUndefinedCategory_ReturnsFailureWithoutStaging()
         {
             var store = new RecordingEntityStore();
-            var adminTags = new AdminTags(store);
+            var adminTags = new AdminTags(store, new FakeTagAssignmentQueries(7));
 
-            var result = adminTags.SaveTags([Change(EChangeType.Edit, id: 7, name: "Ice", categoryId: 99)]);
+            var result = await adminTags.SaveTags([Change(EChangeType.Edit, id: 7, name: "Ice", categoryId: 99)]);
 
             Assert.False(result.Succeeded);
             Assert.Equal("99 is not a valid tag category.", result.ErrorMessage);
@@ -96,16 +109,42 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
-        public void SaveTags_DeleteWithUndefinedCategoryPayload_Succeeds()
+        public async Task SaveTags_DeleteWithUndefinedCategoryPayload_Succeeds()
         {
             var store = new RecordingEntityStore();
-            var adminTags = new AdminTags(store);
+            var adminTags = new AdminTags(store, new FakeTagAssignmentQueries(42));
 
             // Deletes carry no meaningful category payload (the field just defaults to 0), so the reference
             // guard skips them like every other change-type it's applied to.
-            var result = adminTags.SaveTags([Change(EChangeType.Delete, id: 42)]);
+            var result = await adminTags.SaveTags([Change(EChangeType.Delete, id: 42)]);
 
             Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task SaveTags_EditMissingId_ReturnsNotFoundWithoutStaging()
+        {
+            var store = new RecordingEntityStore();
+            var adminTags = new AdminTags(store, new FakeTagAssignmentQueries());
+
+            var result = await adminTags.SaveTags([Change(EChangeType.Edit, id: 7, name: "Ice", categoryId: 2)]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Tag not found.", result.ErrorMessage);
+            Assert.Empty(store.Updated);
+        }
+
+        [Fact]
+        public async Task SaveTags_DeleteMissingId_ReturnsNotFoundWithoutStaging()
+        {
+            var store = new RecordingEntityStore();
+            var adminTags = new AdminTags(store, new FakeTagAssignmentQueries());
+
+            var result = await adminTags.SaveTags([Change(EChangeType.Delete, id: 42)]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Tag not found.", result.ErrorMessage);
+            Assert.Empty(store.DeletedByKey);
         }
     }
 }

--- a/Game.DataAccess/Repositories/Admin/AdminTags.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminTags.cs
@@ -9,11 +9,12 @@ namespace Game.DataAccess.Repositories.Admin
     /// <summary>
     /// Content Authoring persistence for tags. Builds fresh, navigation-free entities for every write.
     /// </summary>
-    internal class AdminTags(IEntityStore entityStore) : IAdminTags
+    internal class AdminTags(IEntityStore entityStore, ITagAssignmentQueries tagAssignmentQueries) : IAdminTags
     {
         private readonly IEntityStore _entityStore = entityStore;
+        private readonly ITagAssignmentQueries _tagAssignmentQueries = tagAssignmentQueries;
 
-        public AdminSaveResult SaveTags(IReadOnlyList<Change<Contracts.Tag>> changes)
+        public async Task<AdminSaveResult> SaveTags(IReadOnlyList<Change<Contracts.Tag>> changes, CancellationToken cancellationToken = default)
         {
             // A tag's category is a FK into the enum-seeded TagCategories table, so an unmapped value (a
             // missing/0 payload) would 500 on the FK at commit — reject it up front as a clean failure.
@@ -22,10 +23,26 @@ namespace Game.DataAccess.Repositories.Admin
                 return categoryRejection;
             }
 
+            // Tags have no in-memory cache to check membership against (unlike the zero-based reference sets'
+            // editExists), so an Edit/Delete naming an id that no longer exists (a stale admin client — a second
+            // tab, a double-clicked delete) is checked against the database up front. Without this, the resulting
+            // 0-row UPDATE/DELETE throws DbUpdateConcurrencyException out of the deferred commit instead of a
+            // clean not-found rejection.
+            var targetedIds = changes.Where(c => c.ChangeType != EChangeType.Add).Select(c => c.Item.Id).ToHashSet();
+            if (targetedIds.Count > 0)
+            {
+                var existingIds = await _tagAssignmentQueries.GetExistingTagIds(targetedIds)
+                    .ToHashSetAsync(cancellationToken: cancellationToken);
+                if (targetedIds.Any(id => !existingIds.Contains(id)))
+                {
+                    return AdminSaveResult.NotFound("Tag");
+                }
+            }
+
             // Tags carry their own identity and have no owner to miss, but they support a real delete, so a
             // duplicate Edit/Delete of one tag would double-track it in EF — reject such a malformed batch up
             // front as a graceful business failure rather than 500-ing (Add ids are store-generated sentinels,
-            // so they are excluded from the guard). An otherwise well-formed tag write never rejects.
+            // so they are excluded from the guard).
             return ChangeSetProcessor.Apply(changes,
                 add: item => _entityStore.Insert(ToEntity(item)),
                 edit: item =>


### PR DESCRIPTION
## Summary

`AdminTags.SaveTags` was the only identity-level admin save that omitted the missing-id guard every sibling repo has (`AdminSkills.cs:42`, `AdminChallenges.cs:68`, `AdminEnemies.cs:48`, etc.). Tags are the one hard-deletable reference set, so a stale admin client (a second tab, a second admin, a double-clicked delete) could legitimately name an id that no longer exists. That produced a 0-row `UPDATE`/`DELETE` that threw `DbUpdateConcurrencyException` out of the deferred `CommitFilter.SaveChangesAsync` — an opaque 500 **after** the action had already returned `AdminSaveResult.Success` — contradicting the documented standard in `docs/backend-admin.md` that a missing identity should be a clean not-found rejection, not an EF 0-row throw.

## Fix

Tags have no in-memory reference cache to check membership against (unlike the zero-based reference sets' `editExists` cache lookup), so `SaveTags` now:

- Collects the ids named by any Edit/Delete change.
- Validates them against the database via the existing `ITagAssignmentQueries.GetExistingTagIds` query, up front, before staging anything.
- Returns `AdminSaveResult.NotFound("Tag")` if any targeted id doesn't exist.

Because the guard needs a database round-trip, `SaveTags` (and `IAdminTags.SaveTags`) become async, following the same `Task<AdminSaveResult>` shape the other admin relationship setters (e.g. `AdminItems.SetTags`) already use. The controller action follows suit, using `HttpContext.RequestAborted` like its siblings.

## Testing

- Unit tests (`AdminTagsTests.cs`) — added a fake `ITagAssignmentQueries` (mirrors the existing `RecordingEntityStore` fake pattern) so the pure entity-mapping/staging tests stay database-free, plus two new tests covering the Edit/Delete not-found rejection.
- Integration tests (`AdminTagsIntegrationTests.cs`) — added two tests that seed a tag, delete it directly (bypassing the admin write) to guarantee a genuinely absent id, then assert the admin `SaveTags` call rejects with `"Tag not found."` for both Edit and Delete.
- `dotnet build` — clean, 0 warnings/errors.
- Full `dotnet test` — all 3354 tests pass (1415 Core, 68 Infrastructure, 1036 Application, 835 Api).

Closes #2210


---
_Generated by [Claude Code](https://claude.ai/code/session_01SNFQmeYaHjb9bdPWHzqP8R)_