### PR TITLE
Reflect the admin shell's active tool in the URL

### DIFF
--- a/UI/src/routes/admin/+page.svelte
+++ b/UI/src/routes/admin/+page.svelte
@@ -51,6 +51,7 @@
 import { onMount } from 'svelte';
 import { beforeNavigate, goto } from '$app/navigation';
 import { resolve } from '$app/paths';
+import { page } from '$app/state';
 import { Loading } from '$components';
 import AdminLoadError from './AdminLoadError.svelte';
 import AdminSidebar from './AdminSidebar.svelte';
@@ -73,7 +74,17 @@ import { ensureAdminAccess } from './admin-access';
 import { confirmDiscard, createPopStateDiscardGuard, guardBeforeUnload } from './discard-guard';
 import { toastError } from '$stores';
 
-let active = $state('enemies');
+/** Nav key for the default landing tool; omitted from the URL to keep a bare `/admin` link canonical. */
+const DEFAULT_TOOL_KEY = 'enemies';
+const knownToolKeys = new Set(adminTools.map((tool) => tool.key));
+
+// The active tool is derived from the `tool` query param rather than held as its own local state, so
+// there's a single source of truth: a refresh or a shared deep link (e.g. `/admin?tool=paths`) lands on
+// the right tool, and switching tools (below) just writes the URL rather than two things to keep in sync.
+const active = $derived.by(() => {
+	const key = page.url.searchParams.get('tool');
+	return key && knownToolKeys.has(key) ? key : DEFAULT_TOOL_KEY;
+});
 let sidebarPinned = $state(false);
 // Gates rendering until the client-side admin-role check passes. Starts false so the server render
 // (no token available) shows nothing, and a non-admin who deep-links here is redirected before the
@@ -111,7 +122,12 @@ const handleNavigate = async (key: string) => {
 		return;
 	}
 	if (await confirmDiscard(workbenchDirty.total)) {
-		active = key;
+		// Reflects the tool switch in the URL (query param, not a new history entry — Back/Forward
+		// still exits /admin entirely, guarded by the popstate handler below) so the tool is
+		// deep-linkable and survives a refresh. The default tool omits the param, keeping a bare
+		// `/admin` link canonical.
+		const href = key === DEFAULT_TOOL_KEY ? resolve('/admin') : resolve(`/admin?tool=${key}`);
+		await goto(href, { replaceState: true, keepFocus: true, noScroll: true });
 	}
 };
 

--- a/UI/src/tests/routes/admin/admin-tool-param-resolve.test.ts
+++ b/UI/src/tests/routes/admin/admin-tool-param-resolve.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { resolve } from '$app/paths';
+
+/*
+ * `+page.svelte`'s tool switch is the only `resolve(...)` call site in the codebase that passes a
+ * query string rather than a bare pathname (every other call site is `resolve('/admin')`,
+ * `resolve('/game')`, …). `admin-tool-param.test.ts` mocks `resolve` as an identity function, so it
+ * never exercises the real implementation — pinned here instead, against the real (unmocked)
+ * `$app/paths` module: `resolve_route` only substitutes bracketed `[param]` segments, so a literal
+ * `?query` suffix rides through a plain pathname segment unchanged (#2219 review).
+ */
+describe('resolve() with an appended query string', () => {
+	it('passes the query string through unchanged', () => {
+		expect(resolve('/admin?tool=items')).toBe('/admin?tool=items');
+	});
+
+	it('resolves a bare pathname unchanged', () => {
+		expect(resolve('/admin')).toBe('/admin');
+	});
+});

--- a/UI/src/tests/routes/admin/admin-tool-param.test.ts
+++ b/UI/src/tests/routes/admin/admin-tool-param.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { SvelteURL } from 'svelte/reactivity';
+import AdminSidebarStub from './page/AdminSidebarStub.svelte';
+import WorkbenchStub from './page/WorkbenchStub.svelte';
+import DeadLetterConsoleStub from './page/DeadLetterConsoleStub.svelte';
+import ContentHealthConsoleStub from './page/ContentHealthConsoleStub.svelte';
+import ProgressionStub from './page/ProgressionStub.svelte';
+
+/*
+ * #2208: the active admin tool is derived from the `tool` query param instead of being held as its
+ * own local state — so a refresh or a shared deep link (e.g. `/admin?tool=paths`) lands on the right
+ * tool, and switching tools just writes the URL. This suite pins: deriving the initial tool from the
+ * URL (including an unrecognized key falling back to the default), and that a tool switch writes the
+ * param via a `replaceState` `goto` — no new history entry — omitting the param for the default tool.
+ *
+ * The URL mock must be reactive (a `SvelteURL`, matching layout.svelte.test.ts's pattern) since
+ * `active` is `$derived` off `page.url.searchParams`.
+ */
+
+const { goto, page } = vi.hoisted(() => ({
+	goto: vi.fn(() => Promise.resolve()),
+	page: { url: new URL('http://localhost/admin') as URL }
+}));
+
+vi.mock('$app/navigation', () => ({ goto, beforeNavigate: vi.fn() }));
+vi.mock('$app/paths', () => ({ resolve: (path: string) => path }));
+vi.mock('$app/state', () => ({ page }));
+vi.mock('$stores', () => ({ staticData: {}, toastError: vi.fn(), dangerModal: vi.fn() }));
+vi.mock('$routes/admin/admin-access', () => ({ ensureAdminAccess: vi.fn(() => true) }));
+vi.mock('$routes/admin/workbench/reference.svelte', () => ({
+	reference: { loaded: true, load: vi.fn(async () => {}) }
+}));
+vi.mock('$routes/admin/workbench/entities', () => ({
+	entityByKey: (key: string) =>
+		(
+			({
+				enemies: { key: 'enemies', label: 'Enemies' },
+				items: { key: 'items', label: 'Items' }
+			}) as Record<string, { key: string; label: string }>
+		)[key],
+	groupLabelFor: () => 'Group'
+}));
+vi.mock('$routes/admin/workbench/nav', () => ({
+	adminGroups: [],
+	adminTools: [
+		{ key: 'enemies', label: 'Enemies', group: 'combat', glyph: 'sword' },
+		{ key: 'items', label: 'Items', group: 'items', glyph: 'sword' },
+		{ key: 'paths', label: 'Paths', group: 'progression', glyph: 'rune' }
+	],
+	CONTENT_HEALTH_TOOL_KEY: 'content-health',
+	DEAD_LETTERS_TOOL_KEY: 'dead-letters',
+	PROGRESSION_TOOL_KEY: 'paths',
+	SOCKET_DEAD_LETTERS_TOOL_KEY: 'socket-dead-letters'
+}));
+vi.mock('$routes/admin/AdminSidebar.svelte', () => ({ default: AdminSidebarStub }));
+vi.mock('$routes/admin/workbench/Workbench.svelte', () => ({ default: WorkbenchStub }));
+vi.mock('$routes/admin/ops/DeadLetterConsole.svelte', () => ({ default: DeadLetterConsoleStub }));
+vi.mock('$routes/admin/ops/ContentHealthConsole.svelte', () => ({ default: ContentHealthConsoleStub }));
+vi.mock('$routes/admin/workbench/progression/Progression.svelte', () => ({ default: ProgressionStub }));
+
+import AdminPage from '$routes/admin/+page.svelte';
+
+beforeEach(() => {
+	goto.mockClear();
+	page.url = new SvelteURL('http://localhost/admin');
+});
+
+afterEach(cleanup);
+
+describe('Admin page — tool deep-linking (#2208)', () => {
+	it('lands on the tool named by the `tool` query param on mount', async () => {
+		page.url = new SvelteURL('http://localhost/admin?tool=items');
+
+		render(AdminPage);
+
+		await waitFor(() => expect(screen.getByTestId('workbench-stub').textContent).toBe('Items'));
+	});
+
+	it('falls back to the default tool for an unrecognized key', async () => {
+		page.url = new SvelteURL('http://localhost/admin?tool=bogus');
+
+		render(AdminPage);
+
+		await waitFor(() => expect(screen.getByTestId('workbench-stub').textContent).toBe('Enemies'));
+	});
+
+	it('lands on a non-entity tool (e.g. Progression) named by the query param', async () => {
+		page.url = new SvelteURL('http://localhost/admin?tool=paths');
+
+		render(AdminPage);
+
+		await waitFor(() => expect(screen.getByTestId('progression-stub')).toBeTruthy());
+	});
+
+	it('writes the tool to the URL via a replaceState navigation when switching tools', async () => {
+		render(AdminPage);
+		await waitFor(() => expect(screen.getByTestId('workbench-stub').textContent).toBe('Enemies'));
+
+		await fireEvent.click(screen.getByTestId('nav-items'));
+
+		await waitFor(() =>
+			expect(goto).toHaveBeenCalledWith('/admin?tool=items', {
+				replaceState: true,
+				keepFocus: true,
+				noScroll: true
+			})
+		);
+	});
+
+	it('omits the query param entirely when switching back to the default tool', async () => {
+		page.url = new SvelteURL('http://localhost/admin?tool=items');
+		render(AdminPage);
+		await waitFor(() => expect(screen.getByTestId('workbench-stub').textContent).toBe('Items'));
+
+		await fireEvent.click(screen.getByTestId('nav-enemies'));
+
+		await waitFor(() =>
+			expect(goto).toHaveBeenCalledWith('/admin', {
+				replaceState: true,
+				keepFocus: true,
+				noScroll: true
+			})
+		);
+	});
+});

--- a/UI/src/tests/routes/admin/page/AdminSidebarStub.svelte
+++ b/UI/src/tests/routes/admin/page/AdminSidebarStub.svelte
@@ -1,8 +1,14 @@
-<!-- Test stub for AdminSidebar: not exercised by the reference-load tests (the default 'enemies'
-     tool never needs a nav switch), so it renders nothing but still accepts the bindable `pinned`
-     prop the real page wires up. -->
-<div data-testid="admin-sidebar-stub" data-pinned={pinned}></div>
+<!-- Test stub for AdminSidebar: renders a nav button per tool (invoking onNavigate) so tests can drive
+     tool switches, plus the bindable `pinned` prop the real page wires up. Renders no buttons when
+     `tools` is empty (the reference-load suite's setup), so it's inert there. -->
+<div data-testid="admin-sidebar-stub" data-pinned={pinned} data-active={active}>
+	{#each tools as tool (tool.key)}
+		<button type="button" data-testid={`nav-${tool.key}`} onclick={() => onNavigate(tool.key)}>
+			{tool.label}
+		</button>
+	{/each}
+</div>
 
 <script lang="ts">
-let { pinned = $bindable(false) } = $props();
+let { tools = [], active = '', onNavigate = () => {}, pinned = $bindable(false) } = $props();
 </script>


### PR DESCRIPTION
## Summary

The active admin tool (`UI/src/routes/admin/+page.svelte`) lived only in local component state (`let active = $state('enemies')`), so:

- a page refresh mid-session always reset to the Enemies workbench, and
- an admin couldn't link a collaborator to a specific tool (e.g. Content Health or the Progression editor).

This PR makes the `tool` query param the single source of truth for the active tool:

- `active` is now `$derived` off `page.url.searchParams.get('tool')` (falling back to `enemies` for a missing or unrecognized key) instead of being held as its own `$state` — so there's one source of truth rather than two to keep in sync.
- `handleNavigate` writes the new tool to the URL via a `replaceState` `goto()` (reusing the existing `confirmDiscard` unsaved-edits guard) instead of just reassigning local state. `replaceState` keeps today's Back/Forward semantics unchanged — a tool switch still doesn't push a history entry, so the existing popstate discard-guard (`discard-guard.ts`) needed no changes.
- The default tool (`enemies`) omits the `tool` param entirely, so a bare `/admin` link stays canonical.

## Test plan

- [x] Added `UI/src/tests/routes/admin/admin-tool-param.test.ts`: lands on the tool named by `?tool=`, falls back to the default for an unrecognized key, lands on a non-entity tool (Progression) via the param, and switching tools calls `goto` with the expected `replaceState` href (including omitting the param for the default tool).
- [x] Extended the shared `AdminSidebarStub` test stub to render a clickable nav button per tool (invoking `onNavigate`) so tool-switch tests can drive it without pulling in the real sidebar.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — 3833/3833 passing.
- Backend untouched by this change, so `dotnet build`/`dotnet test` were not re-run.

Closes #2208


---
_Generated by [Claude Code](https://claude.ai/code/session_01UVjrmbyqNHXcFq435pg2Fe)_