### PR TITLE
Game.Core contract nits: name CombatRating's execute constant; fix RecordBattleCompleted's delta contract

### DIFF
--- a/Game.Application/Services/OfflineProgressService.cs
+++ b/Game.Application/Services/OfflineProgressService.cs
@@ -314,11 +314,10 @@ namespace Game.Application.Services
             var victoryExpRewards = new List<int>();
             var proficiencyGains = new ProficiencyGainAccumulator();
             // Union the statistic rows touched across every battle, so the end-of-window challenge evaluation
-            // sees every moved statistic. RecordBattleCompleted currently returns the progress aggregate's
-            // cumulative dirty set (it is loaded once for the whole window), but unioning each call's result
-            // explicitly keeps this correct even if that method were ever changed to return only the per-battle
-            // delta — a mixed-outcome window can touch a tracked statistic in a non-final battle (e.g. a kill
-            // challenge crossed by early wins before a closing loss), and the union captures it regardless.
+            // sees every moved statistic. RecordBattleCompleted returns only this call's own per-battle delta
+            // (the progress aggregate is loaded once for the whole window), so a mixed-outcome window still
+            // needs the explicit union to keep a statistic touched by a non-final battle (e.g. a kill challenge
+            // crossed by early wins before a closing loss) in scope for the end-of-window evaluation.
             var touchedStatistics = new HashSet<(EStatisticType Type, int? EntityId)>();
             foreach (var battle in result.Battles)
             {

--- a/Game.Core.Tests/Progress/PlayerProgressTests.cs
+++ b/Game.Core.Tests/Progress/PlayerProgressTests.cs
@@ -1184,6 +1184,27 @@ namespace Game.Core.Tests.Progress
         }
 
         [Fact]
+        public void RecordBattleCompleted_SecondCallOnSameAggregate_ReturnsOnlyThatCallsOwnDelta()
+        {
+            // The offline path reuses one aggregate across a whole away window without AcceptChanges between
+            // battles (#2209), so the touched set returned by each call must be that battle's own delta —
+            // not the aggregate's whole dirty set accumulated since load.
+            var progress = MakeProgress();
+            var enemy = MakeEnemy(id: 5);
+
+            var firstTouched = progress.RecordBattleCompleted(enemy, victory: true, playerDied: false,
+                totalMs: 1000, new BattleStats { CriticalHits = 2 }, isBossBattle: false, zoneId: 0);
+            var secondTouched = progress.RecordBattleCompleted(enemy, victory: true, playerDied: false,
+                totalMs: 1000, new BattleStats(), isBossBattle: false, zoneId: 0);
+
+            // CriticalHits was touched by the first, crit-having battle and stays dirty (unsaved) into the
+            // second call, but the second, crit-less battle never touched it and must not re-report it.
+            Assert.Contains((EStatisticType.CriticalHits, (int?)null), firstTouched);
+            Assert.Contains(progress.DirtyStatistics, s => s.Type == EStatisticType.CriticalHits);
+            Assert.DoesNotContain((EStatisticType.CriticalHits, (int?)null), secondTouched);
+        }
+
+        [Fact]
         public void EvaluateChallenges_MarksNewAndChangedChallengesDirty_ButNotSkippedCompletedOnes()
         {
             var progressed = MakeChallenge(id: 0, EChallengeType.EnemiesKilled, goal: 5);

--- a/Game.Core/Battle/CombatRating.cs
+++ b/Game.Core/Battle/CombatRating.cs
@@ -250,7 +250,7 @@ namespace Game.Core.Battle
             // only pipeline that applies the Cull execute multiplier, so an authored enemy ExecuteBonus is never
             // priced as a capability that cannot fire (the same asymmetry as critExpectation above).
             var executeExpectation = isPlayer
-                ? 1.0 + effectiveCaster.GetAttributeValue(ExecuteBonus) * 0.5
+                ? 1.0 + effectiveCaster.GetAttributeValue(ExecuteBonus) * ServerGameConstants.RefMissingHealthFraction
                 : 1.0;
 
             return afterMitigation * critExpectation * executeExpectation;

--- a/Game.Core/Progress/PlayerProgress.cs
+++ b/Game.Core/Progress/PlayerProgress.cs
@@ -19,6 +19,13 @@ namespace Game.Core.Progress
         private readonly HashSet<int> _dirtyChallenges = [];
         private readonly HashSet<int> _dirtyProficiencies = [];
 
+        // The (statistic type, entity) keys written by the most recent RecordBattleCompleted call — reset at
+        // that call's start and populated alongside _dirtyStatistics by the Increment/SetMax/SetMin write
+        // paths, so it always reflects this battle's real delta rather than _dirtyStatistics' whole
+        // aggregate-lifetime accumulation (which the offline path's single reused aggregate can carry across
+        // many battles between AcceptChanges calls).
+        private readonly HashSet<(EStatisticType Type, int? EntityId)> _touchedThisBattle = [];
+
         public Player Player { get; }
         public IEnumerable<PlayerStatistic> Statistics => _statistics.Values;
         public IEnumerable<PlayerChallenge> ChallengeProgress => _challenges.Values;
@@ -46,14 +53,16 @@ namespace Game.Core.Progress
         }
 
         /// <summary>
-        /// Records the outcome of a completed battle and returns the (statistic type, entity) keys it
-        /// touched. On a freshly loaded aggregate (one is built per battle) those keys are exactly this
-        /// battle's mutated statistics, so the caller can scope challenge evaluation to the challenges that
-        /// track them (see <see cref="ChallengeIndex.RelevantTo"/>) instead of re-scanning the whole catalog.
+        /// Records the outcome of a completed battle and returns the (statistic type, entity) keys this call
+        /// touched — this battle's mutated statistics, so the caller can scope challenge evaluation to the
+        /// challenges that track them (see <see cref="ChallengeIndex.RelevantTo"/>) instead of re-scanning the
+        /// whole catalog.
         /// </summary>
         public IReadOnlyCollection<(EStatisticType Type, int? EntityId)> RecordBattleCompleted(
             Enemy enemy, bool victory, bool playerDied, int totalMs, BattleStats stats, bool isBossBattle, int zoneId)
         {
+            _touchedThisBattle.Clear();
+
             // PlayerDamageDealt/PlayerDamageTaken stay signed in BattleStats (parity-critical, health
             // reconciliation) and can go negative under authored absorption (resistance > 1 heals instead of
             // damaging). Floored here, at the Sum-aggregated lifetime-statistic seam, so an absorption-heavy
@@ -139,9 +148,7 @@ namespace Game.Core.Progress
                 Record(EStatisticType.HighestSingleAttackDamage, skillId, (decimal)Math.Round(skillStats.HighestSingleAttack, 3));
             }
 
-            // The mutated rows are exactly the statistics this battle touched (the aggregate was freshly
-            // loaded), so they double as the relevance scope for challenge evaluation.
-            return [.. _dirtyStatistics];
+            return [.. _touchedThisBattle];
         }
 
         public List<CompletedChallenge> EvaluateChallenges(IEnumerable<Challenge> challenges, DateTime timestamp)
@@ -358,6 +365,7 @@ namespace Game.Core.Progress
             var stat = GetOrCreate(type, entityId, out _);
             stat.Value += amount;
             _dirtyStatistics.Add((type, entityId));
+            _touchedThisBattle.Add((type, entityId));
         }
 
         private void SetMax(EStatisticType type, int? entityId, decimal value)
@@ -378,6 +386,7 @@ namespace Game.Core.Progress
             {
                 stat.Value = value;
                 _dirtyStatistics.Add((type, entityId));
+                _touchedThisBattle.Add((type, entityId));
             }
         }
 
@@ -392,6 +401,7 @@ namespace Game.Core.Progress
             {
                 stat.Value = value;
                 _dirtyStatistics.Add((type, entityId));
+                _touchedThisBattle.Add((type, entityId));
             }
         }
 

--- a/Game.Core/ServerGameConstants.cs
+++ b/Game.Core/ServerGameConstants.cs
@@ -120,6 +120,15 @@ namespace Game.Core
         public const double RefFightDuration = 30.0;
 
         /// <summary>
+        /// The average missing-health fraction the combat rating assumes over the reference fight when pricing
+        /// <see cref="EAttribute.ExecuteBonus"/> (<c>1 + ExecuteBonus × RefMissingHealthFraction</c>,
+        /// <see cref="Battle.CombatRating"/>) — the same half-horizon logic as <see cref="RefFightDuration"/>/2:
+        /// health depletes from full to empty over the reference fight, so its time-average missing fraction is
+        /// one half. A strawman value, open to future retuning.
+        /// </summary>
+        public const double RefMissingHealthFraction = 0.5;
+
+        /// <summary>
         /// Upper clamp on the avoidance (parry+dodge) and resistance credit <see cref="Battle.CombatRating"/>'s
         /// survivability term prices — both are authored-only, uncapped enablers that the shared-expiry effect
         /// ramp can push toward 1, and <c>(1 - credit)</c> sits in survivability's denominator, so an uncapped


### PR DESCRIPTION
## Summary

Two small, unrelated contract cleanups in the domain tier, as described in #2209:

1. **`CombatRating`'s execute pricing hardcoded an inline `0.5`.** `Game.Core/Battle/CombatRating.cs`'s `executeExpectation` term used a bare `0.5` for the reference average missing-health fraction. Every sibling reference-profile assumption (`RefToughness`, `RefDps`, `RefAttackRate`, `RefFightDuration`, `MaxMitigationCredit`) is a named, documented `ServerGameConstants` member the calibration-report workflow (#1533) can find and re-tune against — this one wasn't. Promoted it to `ServerGameConstants.RefMissingHealthFraction`, documented with the same half-horizon reasoning as `RefFightDuration`.

2. **`PlayerProgress.RecordBattleCompleted`'s doc contract promised a per-battle delta but returned the cumulative dirty set.** The doc comment said the returned keys are "exactly this battle's mutated statistics," but the implementation returned `[.. _dirtyStatistics]` — the whole aggregate-lifetime dirty set. That's only true while the aggregate is freshly loaded per battle; the offline path (`OfflineProgressService.ApplyOfflineRewards`) reuses one aggregate across an entire away window without calling `AcceptChanges` between battles, so each call was re-returning and re-copying the whole window's accumulated key set instead of just the keys it touched. The call site already carried a defensive comment acknowledging the mismatch.

   Fixed by tracking a dedicated `_touchedThisBattle` set, cleared at the start of each `RecordBattleCompleted` call and populated alongside `_dirtyStatistics` by the `Increment`/`SetMax`/`SetMin` write paths, so the return value is always this call's own delta. Updated the `OfflineProgressService` comment accordingly — the union of per-call deltas is still needed (a mixed-outcome window can touch a stat in a non-final battle), but it's no longer hedging against the method one day meaning what its doc comment already claimed.

## Test plan

- [x] Added `PlayerProgressTests.RecordBattleCompleted_SecondCallOnSameAggregate_ReturnsOnlyThatCallsOwnDelta` — reuses one aggregate across two `RecordBattleCompleted` calls (mirroring the offline path) and asserts a statistic touched only by the first call is absent from the second call's returned delta, even though it's still dirty.
- [x] `dotnet build` — clean.
- [x] `dotnet test --no-build --no-restore` — full suite green (Game.Core.Tests 1416, Game.Infrastructure.Tests 68, Game.Application.Tests 1036, Game.Api.Tests 835 — all passed).
- Frontend untouched by this change (both fixes are server-only domain code), so `npm run lint`/`npm run test:unit:ci` were not re-run.

Closes #2209


---
_Generated by [Claude Code](https://claude.ai/code/session_015CVXtRUReovxnM6RSVaK33)_