### PR TITLE
Gate progression editor Save on out-of-range payout levels (#2222)

### DIFF
--- a/UI/src/routes/admin/workbench/SaveBar.svelte
+++ b/UI/src/routes/admin/workbench/SaveBar.svelte
@@ -42,8 +42,8 @@ interface Props {
 	modified: number;
 	deleted?: number;
 	/** True when a pending record carries a save-blocking warning — disables Save alongside the
-	 *  existing total/saving gates and surfaces why. Defaults to false for callers with no concept
-	 *  of blocking warnings (e.g. the progression editor's own advisory-only warnings). */
+	 *  existing total/saving gates and surfaces why. Defaults to false for a caller with no concept
+	 *  of blocking warnings at all. */
 	blocked?: boolean;
 	onDiscard: () => void;
 	onSave: () => void;

--- a/UI/src/routes/admin/workbench/progression/Progression.svelte
+++ b/UI/src/routes/admin/workbench/progression/Progression.svelte
@@ -69,6 +69,7 @@
 			saving={store.saving}
 			added={store.counts.added}
 			modified={store.counts.modified}
+			blocked={store.hasBlockingWarnings}
 			onDiscard={() => store.discard()}
 			onSave={() => store.save()}
 			saveTestId="progression-save"

--- a/UI/src/routes/admin/workbench/progression/TierDetail.svelte
+++ b/UI/src/routes/admin/workbench/progression/TierDetail.svelte
@@ -68,7 +68,7 @@
 import { childChanged } from '../save-helpers';
 import { referenceSourcesFromStatic, retireWithConfirm } from '../retire-confirm';
 import type { ProgressionStore, TierTab } from './progression-store.svelte';
-import { payoutLevels, proficiencyWarnings } from './progression-helpers';
+import { payoutLevels, proficiencyBlockingWarnings } from './progression-helpers';
 import DetailHeader from '../components/DetailHeader.svelte';
 import ConlangIdentity from './ConlangIdentity.svelte';
 import XpCurve from './XpCurve.svelte';
@@ -111,9 +111,7 @@ const identityWarn = $derived(
 			!tier.iconPath.trim())
 );
 const xpWarn = $derived(!!tier && (tier.maxLevel < 1 || !(tier.baseXp > 0) || !(tier.xpGrowth > 0)));
-const milestoneWarn = $derived(
-	!!tier && proficiencyWarnings(tier).some((w) => w.includes('level') && w.includes('out of range'))
-);
+const milestoneWarn = $derived(!!tier && proficiencyBlockingWarnings(tier).length > 0);
 const milestonesDirty = $derived(
 	!!baseline &&
 		(childChanged(tier?.levelModifiers, baseline.levelModifiers) ||

--- a/UI/src/routes/admin/workbench/progression/progression-helpers.ts
+++ b/UI/src/routes/admin/workbench/progression/progression-helpers.ts
@@ -157,6 +157,30 @@ export const pathWarnings = (path: WorkbenchPath): string[] => {
 	return warnings;
 };
 
+/**
+ * An out-of-range modifier/reward level, checked against the tier's own (about-to-be-saved) MaxLevel.
+ * This is the one proficiency condition the backend genuinely hard-rejects a save over — via
+ * AdminProficiencies.FindShrunkenMaxLevelViolation (the identity edit, against a still-persisted
+ * payout) or FindLevelOutOfRange (SetModifiers/SetRewards, against the tier's saved MaxLevel) — so it
+ * doubles as {@link proficiencyBlockingWarnings}, unlike the rest of {@link proficiencyWarnings}.
+ */
+const levelRangeWarnings = (prof: WorkbenchProficiency): string[] => {
+	const warnings: string[] = [];
+	for (const modifier of prof.levelModifiers) {
+		if (modifier.level < 0 || modifier.level > prof.maxLevel) {
+			warnings.push(`Modifier level ${modifier.level} out of range`);
+			break;
+		}
+	}
+	for (const reward of prof.levelRewards) {
+		if (reward.level < 1 || reward.level > prof.maxLevel) {
+			warnings.push(`Reward level ${reward.level} out of range`);
+			break;
+		}
+	}
+	return warnings;
+};
+
 export const proficiencyWarnings = (prof: WorkbenchProficiency): string[] => {
 	const warnings: string[] = [];
 	if (!prof.name.trim()) {
@@ -174,20 +198,16 @@ export const proficiencyWarnings = (prof: WorkbenchProficiency): string[] => {
 	if (!(prof.baseXp > 0) || !(prof.xpGrowth > 0)) {
 		warnings.push('XP curve must be positive');
 	}
-	for (const modifier of prof.levelModifiers) {
-		if (modifier.level < 0 || modifier.level > prof.maxLevel) {
-			warnings.push(`Modifier level ${modifier.level} out of range`);
-			break;
-		}
-	}
-	for (const reward of prof.levelRewards) {
-		if (reward.level < 1 || reward.level > prof.maxLevel) {
-			warnings.push(`Reward level ${reward.level} out of range`);
-			break;
-		}
-	}
-	return warnings;
+	return [...warnings, ...levelRangeWarnings(prof)];
 };
+
+/**
+ * The subset of {@link proficiencyWarnings} the backend is known to hard-reject a save over — see
+ * {@link levelRangeWarnings}. `MaxLevel < 1` and a non-positive XP curve stay advisory-only: neither
+ * `Contracts.Proficiency` nor `AdminProficiencies` rejects them, so gating Save on them would block a
+ * save the backend would actually accept.
+ */
+export const proficiencyBlockingWarnings = (prof: WorkbenchProficiency): string[] => levelRangeWarnings(prof);
 
 // ── Persisted DTOs (identity-level Add/Edit; child collections go through their own endpoints) ──
 

--- a/UI/src/routes/admin/workbench/progression/progression-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/progression/progression-store.svelte.ts
@@ -17,6 +17,7 @@ import {
 	newPath,
 	newProficiency,
 	pathIdentityDto,
+	proficiencyBlockingWarnings,
 	profIdentityDto,
 	renumberTiers,
 	tiersOfPath
@@ -179,6 +180,16 @@ export class ProgressionStore {
 	get totalChanges(): number {
 		return this.counts.added + this.counts.modified;
 	}
+
+	/** True while any not-yet-saved tier (added/modified) carries an out-of-range modifier/reward
+	 *  level — the one proficiency condition the backend genuinely hard-rejects (mirrors
+	 *  EntityStore.hasBlockingWarnings, #2217/#2222). Gates {@link save}. */
+	hasBlockingWarnings = $derived.by(() => {
+		return this.profs.some((prof) => {
+			const status = this.profStatuses[prof.id];
+			return (status === 'added' || status === 'modified') && proficiencyBlockingWarnings(prof).length > 0;
+		});
+	});
 
 	/** Always called with a record from {@link paths}, which {@link pathStatuses} covers exhaustively. */
 	pathStatus(path: WorkbenchPath): RecordStatus {
@@ -453,7 +464,7 @@ export class ProgressionStore {
 	// ── Save / discard ──
 
 	async save() {
-		if (this.totalChanges === 0 || this.saving) {
+		if (this.totalChanges === 0 || this.saving || this.hasBlockingWarnings) {
 			return;
 		}
 		this.saving = true;

--- a/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
@@ -169,6 +169,9 @@ describe('validation', () => {
 		});
 		expect(proficiencyBlockingWarnings(outOfRange)).toEqual(['Modifier level 8 out of range']);
 
+		const rewardOutOfRange = tier({ id: 4, maxLevel: 5, levelRewards: [{ level: 9, rewardSkillId: 1 }] });
+		expect(proficiencyBlockingWarnings(rewardOutOfRange)).toEqual(['Reward level 9 out of range']);
+
 		const inRange = tier({ id: 3, maxLevel: 5 });
 		expect(proficiencyBlockingWarnings(inRange)).toHaveLength(0);
 	});

--- a/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
@@ -12,6 +12,7 @@ import {
 	pathIdentityDto,
 	pathWarnings,
 	payoutLevels,
+	proficiencyBlockingWarnings,
 	profIdentityDto,
 	proficiencyWarnings,
 	renumberTiers,
@@ -148,6 +149,28 @@ describe('validation', () => {
 			levelRewards: [{ level: 9, rewardSkillId: 1 }]
 		});
 		expect(proficiencyWarnings(ranged)).toContain('Reward level 9 out of range');
+	});
+
+	it('proficiencyBlockingWarnings flags only the out-of-range payout, not MaxLevel/XP-curve nags (#2222)', () => {
+		// Neither condition is enforced by AdminProficiencies/Contracts.Proficiency (confirmed against the
+		// backend), so gating Save on them would block a save the backend would actually accept.
+		const invalidCurve = tier({ id: 1, maxLevel: 0, baseXp: -1, xpGrowth: 0 });
+		expect(proficiencyWarnings(invalidCurve)).toEqual(
+			expect.arrayContaining(['Max level must be at least 1', 'XP curve must be positive'])
+		);
+		expect(proficiencyBlockingWarnings(invalidCurve)).toHaveLength(0);
+
+		const outOfRange = tier({
+			id: 2,
+			maxLevel: 5,
+			levelModifiers: [
+				{ level: 8, attributeId: EAttribute.Strength, modifierTypeId: EModifierType.Additive, amount: 1 }
+			]
+		});
+		expect(proficiencyBlockingWarnings(outOfRange)).toEqual(['Modifier level 8 out of range']);
+
+		const inRange = tier({ id: 3, maxLevel: 5 });
+		expect(proficiencyBlockingWarnings(inRange)).toHaveLength(0);
 	});
 });
 

--- a/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
@@ -332,6 +332,47 @@ describe('local editing', () => {
 	});
 });
 
+describe('blocking warnings (#2222)', () => {
+	it('hasBlockingWarnings is true only while a pending tier carries an out-of-range payout', async () => {
+		seedServer();
+		const store = new ProgressionStore();
+		await store.load();
+		expect(store.hasBlockingWarnings).toBe(false);
+
+		store.addModifier(0, 20); // baseline tier's maxLevel is 10 (fullTier default).
+		expect(store.hasBlockingWarnings).toBe(true);
+
+		store.removeModifier(0, store.profs[0].levelModifiers.length - 1);
+		expect(store.hasBlockingWarnings).toBe(false);
+	});
+
+	it('does not block on MaxLevel < 1 or a non-positive XP curve — the backend accepts both as-is', async () => {
+		seedServer();
+		const store = new ProgressionStore();
+		await store.load();
+
+		store.patchProf(0, (d) => {
+			d.maxLevel = 0;
+			d.baseXp = -1;
+			d.xpGrowth = 0;
+		});
+
+		expect(store.hasBlockingWarnings).toBe(false);
+	});
+
+	it('save refuses to persist while any pending tier carries a blocking warning', async () => {
+		seedServer();
+		const store = new ProgressionStore();
+		await store.load();
+
+		store.addModifier(0, 20);
+		await store.save();
+
+		expect(postMock).not.toHaveBeenCalled();
+		expect(store.profs[0].levelModifiers).toHaveLength(1);
+	});
+});
+
 describe('save orchestration', () => {
 	it('creates a path then its tier with the resolved path id, then child collections', async () => {
 		const store = new ProgressionStore();
@@ -626,7 +667,7 @@ describe('save orchestration', () => {
 		expect(identityCallIndex).toBeGreaterThan(rewardsCallIndex);
 	});
 
-	it('lowering MaxLevel without removing the offending payout is still rejected, same as before', async () => {
+	it('lowering MaxLevel without removing the offending payout is now blocked before any network call (#2222)', async () => {
 		serverPaths = [{ id: 0, name: 'Fire', description: 'd', activityKey: EActivityKey.Fire, retiredAt: null }];
 		serverProfs = [
 			fullTier({
@@ -642,11 +683,14 @@ describe('save orchestration', () => {
 		await store.load();
 
 		store.patchProf(0, (d) => (d.maxLevel = 5));
+		expect(store.hasBlockingWarnings).toBe(true);
 
 		await store.save();
 
-		expect(toastErrorMock).toHaveBeenCalled();
-		// Rejected pre-commit: nothing wrote, so the local edit is preserved for a clean retry.
+		// Blocked pre-flight — the backend's own FindShrunkenMaxLevelViolation guard (exercised by the
+		// #1827/#1804 case above, where the payout is fixed rather than left offending) is never reached.
+		expect(postMock).not.toHaveBeenCalled();
+		expect(toastErrorMock).not.toHaveBeenCalled();
 		expect(store.profs.find((p) => p.id === 0)?.maxLevel).toBe(5);
 		expect(serverProfs.find((p) => p.id === 0)?.maxLevel).toBe(10);
 	});


### PR DESCRIPTION
## Summary

Extends #2217/#2221's save-blocking mechanism — `EntityStore.hasBlockingWarnings` gating the generic Workbench's `SaveBar` — to the **progression editor** (`workbench/progression`), which was explicitly named in #2217 but deliberately scoped out of #2221 because it uses a different warning representation (`pathWarnings`/`proficiencyWarnings` return a flat `string[]`, and re-implements its own save orchestration).

- `progression-helpers.ts`: extracted the existing out-of-range modifier/reward-level check into `levelRangeWarnings` and exported it as `proficiencyBlockingWarnings`.
- `ProgressionStore` gained a `hasBlockingWarnings` derived (mirroring `EntityStore`) that's true while any pending (added/modified) tier carries an out-of-range payout, and `save()` now no-ops while it holds.
- `Progression.svelte` passes `blocked={store.hasBlockingWarnings}` into the shared `SaveBar`.
- `TierDetail.svelte`'s milestone-tab warning indicator now reads `proficiencyBlockingWarnings` directly instead of string-matching `proficiencyWarnings()` output for `"out of range"`.

## Deviation from the issue's stated scope

The issue asked to also flag **`MaxLevel < 1`** and a **non-positive XP curve** (`baseXp`/`xpGrowth`) as blocking, citing `AdminProficiencies` as the backend enforcer. I checked the backend before wiring that up (`AdminProficiencies.cs`, `Contracts/Proficiency.cs`, `ProgressionGraphChecker.cs`) and **neither condition is actually rejected server-side** — both fields are plain `int`/`decimal` with no data annotations, and `SaveProficiencies` only runs `FindPathViolation`, `FindTierOrdinalCollision`, and `FindShrunkenMaxLevelViolation`. A `MaxLevel` of 0 or a non-positive XP curve is accepted as-is today.

So I only wired blocking for the condition that **is** genuinely backend-enforced — an out-of-range modifier/reward level, via `AdminProficiencies.FindShrunkenMaxLevelViolation` (the identity edit, against a still-persisted payout) and `FindLevelOutOfRange` (`SetModifiers`/`SetRewards`, against the tier's saved `MaxLevel`). `MaxLevel < 1` and the XP-curve check stay advisory-only, same as before — gating Save on them would block a save the backend would actually accept, which is exactly the failure mode #2217 was designed to avoid causing.

## Test plan

- [x] `proficiencyBlockingWarnings` unit tests: flags only the out-of-range payout, not `MaxLevel`/XP-curve nags.
- [x] `ProgressionStore.hasBlockingWarnings` unit tests: true only while a pending tier carries the condition; false for `MaxLevel < 1` / non-positive XP curve; `save()` no-ops (no network call) while blocked.
- [x] Updated the existing "lowering MaxLevel without removing the offending payout" save-orchestration test — it's now blocked pre-flight instead of round-tripping to the backend and getting rejected.
- [x] `npm run lint` (eslint + svelte-check) passes.
- [x] `npm run test:unit:ci` — full suite passes.

Closes #2222


---
_Generated by [Claude Code](https://claude.ai/code/session_01GFHuRvbFDWoPWNPxKRzELm)_