### PR TITLE
Build the Help screen (tutorial reading room)

### DIFF
--- a/UI/src/lib/engine/tutorials.ts
+++ b/UI/src/lib/engine/tutorials.ts
@@ -5,7 +5,7 @@ import { navigation, staticData, tutorialTour } from '$stores';
 import { playerManager } from './player/player-manager';
 
 /** Live (non-retired) lessons from reference data, or `[]` before it has loaded. */
-const liveLessons = (): ILesson[] => (staticData.lessons ?? []).filter((lesson) => !lesson.retiredAt);
+export const liveLessons = (): ILesson[] => (staticData.lessons ?? []).filter((lesson) => !lesson.retiredAt);
 
 /** A lesson is locked until the player has an entry for it (unlocked or read) — see
  *  {@link PlayerManager.unlockLesson}/{@link PlayerManager.markLessonRead}. */

--- a/UI/src/routes/game/screens/help/Help.svelte
+++ b/UI/src/routes/game/screens/help/Help.svelte
@@ -1,0 +1,182 @@
+<!-- Help screen (#1589) — the tutorial reading room. Lists every live lesson with its per-player
+     locked/unread/read state; unread lessons are emphasized (this is where the sidebar's unread
+     badge leads). Selecting an unread or read lesson reuses the shared open flow: navigate to its
+     host screen and play its tour, marking it read either way. A locked lesson is a name-only
+     teaser — greyed out and not clickable, so it doesn't spoil content-arc surprises. -->
+<div class="help-frame" data-testid="help-screen">
+	<div class="header">
+		<div class="eyebrow">Settings · Help</div>
+		<div class="title-line">
+			<h1 class="title">Help</h1>
+			<span class="sub">tutorial lessons — replay anything you've read</span>
+		</div>
+	</div>
+
+	<div class="body">
+		{#if view.lessonRows.length === 0}
+			<div class="empty" data-testid="help-empty">No lessons yet.</div>
+		{:else}
+			<div class="lesson-list" data-testid="help-lesson-rows">
+				{#each view.lessonRows as row (row.id)}
+					<button
+						type="button"
+						class="lesson-row"
+						class:unread={row.state === 'unread'}
+						class:locked={row.state === 'locked'}
+						disabled={row.state === 'locked'}
+						data-testid="help-lesson-{row.id}"
+						onclick={() => view.openLesson(row.id)}
+					>
+						<span class="dot" class:show={row.state === 'unread'}></span>
+						<span class="name">{row.name}</span>
+						<span class="state-label">{STATE_LABEL[row.state]}</span>
+					</button>
+				{/each}
+			</div>
+		{/if}
+	</div>
+</div>
+
+<script lang="ts">
+import { HelpView, type LessonState } from './help-view.svelte';
+
+const STATE_LABEL: Record<LessonState, string> = {
+	locked: 'Locked',
+	unread: 'New',
+	read: 'Replay'
+};
+
+const view = new HelpView();
+</script>
+
+<style lang="scss">
+.help-frame {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	position: relative;
+	color: var(--text-primary);
+	font-family: var(--sans);
+	overflow: hidden;
+}
+
+.header {
+	padding: 20px 28px 0;
+	flex-shrink: 0;
+}
+
+.eyebrow {
+	font-family: var(--mono);
+	font-size: 9.5px;
+	letter-spacing: 2px;
+	text-transform: uppercase;
+	color: var(--eyebrow);
+	margin-bottom: 6px;
+}
+
+.title-line {
+	display: flex;
+	align-items: baseline;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+
+.title {
+	margin: 0;
+	font-size: 23px;
+	font-weight: 500;
+	letter-spacing: -0.3px;
+}
+
+.sub {
+	font-size: 12.5px;
+	color: var(--text-tertiary);
+}
+
+.body {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 16px 28px 28px;
+}
+
+.empty {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	color: var(--text-tertiary);
+	font-size: 13px;
+}
+
+.lesson-list {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.lesson-row {
+	width: 100%;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 13px 14px;
+	border: none;
+	border-radius: 4px;
+	background: transparent;
+	cursor: pointer;
+	text-align: left;
+	font-family: var(--sans);
+	color: var(--text-primary);
+
+	&:hover:not(:disabled) {
+		background: color-mix(in srgb, var(--white) 3%, transparent);
+	}
+
+	&.unread {
+		background: color-mix(in srgb, var(--accent) 8%, transparent);
+
+		.name {
+			font-weight: 600;
+		}
+	}
+
+	&.locked,
+	&:disabled {
+		cursor: default;
+		color: color-mix(in srgb, var(--text-primary) 38%, transparent);
+	}
+}
+
+.dot {
+	width: 7px;
+	height: 7px;
+	flex: none;
+	border-radius: 50%;
+	background: var(--accent);
+	box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 65%, transparent);
+	opacity: 0;
+
+	&.show {
+		opacity: 1;
+	}
+}
+
+.name {
+	flex: 1;
+	min-width: 0;
+	font-size: 13.5px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.state-label {
+	flex: none;
+	font-family: var(--mono);
+	font-size: 8.5px;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	color: var(--text-tertiary);
+}
+</style>

--- a/UI/src/routes/game/screens/help/help-view.svelte.ts
+++ b/UI/src/routes/game/screens/help/help-view.svelte.ts
@@ -1,0 +1,45 @@
+/* The Help screen's reactive layer (#1589): the tutorial reading room listing every live lesson
+   with its per-player locked/unread/read state. Selecting an unlocked lesson reuses the shared
+   open flow (`$lib/engine/tutorials`'s `openLesson`) — navigate to its host screen and play its
+   tour — the same flow a screen/mechanic trigger uses, so replaying from here behaves identically. */
+
+import { playerManager } from '$lib/engine';
+import { liveLessons, openLesson as openLessonTour } from '$lib/engine/tutorials';
+import { staticData } from '$stores';
+
+export type LessonState = 'locked' | 'unread' | 'read';
+
+export interface LessonRowVM {
+	id: number;
+	name: string;
+	state: LessonState;
+}
+
+export class HelpView {
+	/** Every live lesson, authored order, with this player's lifecycle state. */
+	readonly lessonRows = $derived.by<LessonRowVM[]>(() => {
+		const playerLessons = playerManager.lessons;
+		return liveLessons()
+			.slice()
+			.sort((a, b) => a.ordinal - b.ordinal)
+			.map((lesson) => {
+				const entry = playerLessons.find((pl) => pl.lessonId === lesson.id);
+				const state: LessonState = !entry ? 'locked' : entry.readAt ? 'read' : 'unread';
+				return { id: lesson.id, name: lesson.name, state };
+			});
+	});
+
+	/** Opens the lesson's tour via the shared flow. A no-op for a locked lesson — defensive, since
+	 *  a locked row isn't clickable in the first place. */
+	openLesson(lessonId: number) {
+		const row = this.lessonRows.find((r) => r.id === lessonId);
+		if (!row || row.state === 'locked') {
+			return;
+		}
+		// Zero-based-id catalogue — index, not `.find` (see frontend.md → Reference Data).
+		const lesson = staticData.lessons?.[lessonId];
+		if (lesson) {
+			openLessonTour(lesson);
+		}
+	}
+}

--- a/UI/src/routes/game/screens/screen-defs.ts
+++ b/UI/src/routes/game/screens/screen-defs.ts
@@ -12,6 +12,7 @@ import AttributeBreakdown from './attribute-breakdown/AttributeBreakdown.svelte'
 import Statistics from './stats/Statistics.svelte';
 import Codex from './codex/Codex.svelte';
 import Options from './options/Options.svelte';
+import Help from './help/Help.svelte';
 
 /** A navigable game screen shown in the sidebar. */
 export interface ScreenDef {
@@ -57,7 +58,7 @@ export const GAME_SCREENS: ScreenDef[] = [
 	{ key: 'codex', label: 'Codex', group: 'character', built: true, component: Codex },
 	{ key: 'options', label: 'Options', group: 'settings', built: true, component: Options },
 	{ key: 'switch', label: 'Switch Character', group: 'settings', built: true },
-	{ key: 'help', label: 'Help', group: 'settings', built: false },
+	{ key: 'help', label: 'Help', group: 'settings', built: true, component: Help },
 	{ key: 'quit', label: 'Quit', group: 'settings', built: true },
 	{ key: 'admin', label: 'Admin', group: 'admin', built: true, requiresRole: ERole.Admin }
 ];

--- a/UI/src/tests/routes/game/screens/help/Help.test.ts
+++ b/UI/src/tests/routes/game/screens/help/Help.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, screen } from '@testing-library/svelte';
+import { ELessonTriggerType, type ILesson, type IPlayerLesson } from '$lib/api';
+
+const { mockLessons, mockPlayerLessons, mockOpenLesson } = vi.hoisted(() => ({
+	mockLessons: [] as ILesson[],
+	mockPlayerLessons: [] as IPlayerLesson[],
+	mockOpenLesson: vi.fn()
+}));
+
+vi.mock('$lib/engine', () => ({
+	playerManager: {
+		get lessons() {
+			return mockPlayerLessons;
+		}
+	}
+}));
+
+vi.mock('$lib/engine/tutorials', () => ({
+	liveLessons: () => mockLessons.filter((l) => !l.retiredAt),
+	openLesson: mockOpenLesson
+}));
+
+vi.mock('$stores', () => ({
+	get staticData() {
+		return { lessons: mockLessons };
+	}
+}));
+
+import Help from '$routes/game/screens/help/Help.svelte';
+
+const makeLesson = (overrides: Partial<ILesson> = {}): ILesson => ({
+	id: 0,
+	key: 'lesson-key',
+	name: 'Lesson Name',
+	triggerType: ELessonTriggerType.ScreenVisit,
+	screenKey: 'fight',
+	ordinal: 0,
+	designerNotes: '',
+	steps: [{ ordinal: 0, text: 'Step text' }],
+	...overrides
+});
+
+afterEach(() => {
+	cleanup();
+	mockLessons.length = 0;
+	mockPlayerLessons.length = 0;
+	mockOpenLesson.mockClear();
+});
+
+describe('Help screen', () => {
+	it('shows an empty state with no lessons', () => {
+		render(Help);
+
+		expect(screen.getByTestId('help-empty')).toBeTruthy();
+	});
+
+	it('lists every live lesson with its state label', () => {
+		mockLessons.push(
+			makeLesson({ id: 0, name: 'Locked One' }),
+			makeLesson({ id: 1, name: 'Unread One', ordinal: 1 }),
+			makeLesson({ id: 2, name: 'Read One', ordinal: 2 })
+		);
+		mockPlayerLessons.push({ lessonId: 1, unlockedAt: 'now' }, { lessonId: 2, unlockedAt: 'now', readAt: 'now' });
+
+		render(Help);
+
+		const locked = screen.getByTestId('help-lesson-0');
+		const unread = screen.getByTestId('help-lesson-1');
+		const read = screen.getByTestId('help-lesson-2');
+
+		expect(locked.textContent).toContain('Locked One');
+		expect(locked.textContent).toContain('Locked');
+		expect(unread.textContent).toContain('Unread One');
+		expect(unread.textContent).toContain('New');
+		expect(read.textContent).toContain('Read One');
+		expect(read.textContent).toContain('Replay');
+	});
+
+	it('emphasizes an unread lesson and leaves a locked one disabled', () => {
+		mockLessons.push(makeLesson({ id: 0, name: 'Locked One' }), makeLesson({ id: 1, name: 'Unread One', ordinal: 1 }));
+		mockPlayerLessons.push({ lessonId: 1, unlockedAt: 'now' });
+
+		render(Help);
+
+		expect((screen.getByTestId('help-lesson-0') as HTMLButtonElement).disabled).toBe(true);
+		expect((screen.getByTestId('help-lesson-1') as HTMLButtonElement).disabled).toBe(false);
+		expect(screen.getByTestId('help-lesson-1').className).toContain('unread');
+	});
+
+	it('clicking a locked lesson does not open the tour', async () => {
+		mockLessons.push(makeLesson({ id: 0, name: 'Locked One' }));
+
+		render(Help);
+		await fireEvent.click(screen.getByTestId('help-lesson-0'));
+
+		expect(mockOpenLesson).not.toHaveBeenCalled();
+	});
+
+	it('clicking an unread lesson invokes the shared open flow', async () => {
+		const lesson = makeLesson({ id: 0, name: 'Unread One' });
+		mockLessons.push(lesson);
+		mockPlayerLessons.push({ lessonId: 0, unlockedAt: 'now' });
+
+		render(Help);
+		await fireEvent.click(screen.getByTestId('help-lesson-0'));
+
+		expect(mockOpenLesson).toHaveBeenCalledWith(lesson);
+	});
+
+	it('clicking a read lesson replays it via the shared open flow', async () => {
+		const lesson = makeLesson({ id: 0, name: 'Read One' });
+		mockLessons.push(lesson);
+		mockPlayerLessons.push({ lessonId: 0, unlockedAt: 'now', readAt: 'now' });
+
+		render(Help);
+		await fireEvent.click(screen.getByTestId('help-lesson-0'));
+
+		expect(mockOpenLesson).toHaveBeenCalledWith(lesson);
+	});
+});

--- a/UI/src/tests/routes/game/screens/help/help-view.test.ts
+++ b/UI/src/tests/routes/game/screens/help/help-view.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ELessonTriggerType, type ILesson, type IPlayerLesson } from '$lib/api';
+
+const { mockLessons, mockPlayerLessons, mockOpenLesson } = vi.hoisted(() => ({
+	mockLessons: [] as ILesson[],
+	mockPlayerLessons: [] as IPlayerLesson[],
+	mockOpenLesson: vi.fn()
+}));
+
+vi.mock('$lib/engine', () => ({
+	playerManager: {
+		get lessons() {
+			return mockPlayerLessons;
+		}
+	}
+}));
+
+vi.mock('$lib/engine/tutorials', () => ({
+	liveLessons: () => mockLessons.filter((l) => !l.retiredAt),
+	openLesson: mockOpenLesson
+}));
+
+vi.mock('$stores', () => ({
+	get staticData() {
+		return { lessons: mockLessons };
+	}
+}));
+
+import { HelpView } from '$routes/game/screens/help/help-view.svelte';
+
+const makeLesson = (overrides: Partial<ILesson> = {}): ILesson => ({
+	id: 0,
+	key: 'lesson-key',
+	name: 'Lesson Name',
+	triggerType: ELessonTriggerType.ScreenVisit,
+	screenKey: 'fight',
+	ordinal: 0,
+	designerNotes: '',
+	steps: [{ ordinal: 0, text: 'Step text' }],
+	...overrides
+});
+
+describe('HelpView.lessonRows', () => {
+	it('classifies a lesson with no player entry as locked', () => {
+		mockLessons.length = 0;
+		mockLessons.push(makeLesson({ id: 0, name: 'Alpha' }));
+		mockPlayerLessons.length = 0;
+
+		const view = new HelpView();
+
+		expect(view.lessonRows).toEqual([{ id: 0, name: 'Alpha', state: 'locked' }]);
+	});
+
+	it('classifies an unlocked-but-unread lesson as unread', () => {
+		mockLessons.length = 0;
+		mockLessons.push(makeLesson({ id: 0, name: 'Alpha' }));
+		mockPlayerLessons.length = 0;
+		mockPlayerLessons.push({ lessonId: 0, unlockedAt: 'now' });
+
+		const view = new HelpView();
+
+		expect(view.lessonRows[0].state).toBe('unread');
+	});
+
+	it('classifies a lesson with a readAt as read', () => {
+		mockLessons.length = 0;
+		mockLessons.push(makeLesson({ id: 0, name: 'Alpha' }));
+		mockPlayerLessons.length = 0;
+		mockPlayerLessons.push({ lessonId: 0, unlockedAt: 'now', readAt: 'now' });
+
+		const view = new HelpView();
+
+		expect(view.lessonRows[0].state).toBe('read');
+	});
+
+	it('sorts rows by ordinal regardless of catalogue order', () => {
+		mockLessons.length = 0;
+		mockLessons.push(
+			makeLesson({ id: 0, name: 'Second', ordinal: 1 }),
+			makeLesson({ id: 1, name: 'First', ordinal: 0 })
+		);
+		mockPlayerLessons.length = 0;
+
+		const view = new HelpView();
+
+		expect(view.lessonRows.map((r) => r.name)).toEqual(['First', 'Second']);
+	});
+
+	it('excludes retired lessons', () => {
+		mockLessons.length = 0;
+		mockLessons.push(makeLesson({ id: 0, name: 'Alpha' }), makeLesson({ id: 1, name: 'Retired', retiredAt: 'now' }));
+		mockPlayerLessons.length = 0;
+
+		const view = new HelpView();
+
+		expect(view.lessonRows.map((r) => r.name)).toEqual(['Alpha']);
+	});
+});
+
+describe('HelpView.openLesson', () => {
+	it('is a no-op for a locked lesson', () => {
+		mockLessons.length = 0;
+		mockLessons.push(makeLesson({ id: 0, name: 'Alpha' }));
+		mockPlayerLessons.length = 0;
+		mockOpenLesson.mockClear();
+
+		const view = new HelpView();
+		view.openLesson(0);
+
+		expect(mockOpenLesson).not.toHaveBeenCalled();
+	});
+
+	it('delegates to the shared open flow for an unread lesson', () => {
+		mockLessons.length = 0;
+		const lesson = makeLesson({ id: 0, name: 'Alpha' });
+		mockLessons.push(lesson);
+		mockPlayerLessons.length = 0;
+		mockPlayerLessons.push({ lessonId: 0, unlockedAt: 'now' });
+		mockOpenLesson.mockClear();
+
+		const view = new HelpView();
+		view.openLesson(0);
+
+		expect(mockOpenLesson).toHaveBeenCalledWith(lesson);
+	});
+
+	it('delegates to the shared open flow for a read lesson (replay)', () => {
+		mockLessons.length = 0;
+		const lesson = makeLesson({ id: 0, name: 'Alpha' });
+		mockLessons.push(lesson);
+		mockPlayerLessons.length = 0;
+		mockPlayerLessons.push({ lessonId: 0, unlockedAt: 'now', readAt: 'now' });
+		mockOpenLesson.mockClear();
+
+		const view = new HelpView();
+		view.openLesson(0);
+
+		expect(mockOpenLesson).toHaveBeenCalledWith(lesson);
+	});
+
+	it('is a no-op for an unknown lesson id', () => {
+		mockLessons.length = 0;
+		mockPlayerLessons.length = 0;
+		mockOpenLesson.mockClear();
+
+		const view = new HelpView();
+		view.openLesson(99);
+
+		expect(mockOpenLesson).not.toHaveBeenCalled();
+	});
+});

--- a/docs/frontend-screens.md
+++ b/docs/frontend-screens.md
@@ -35,6 +35,13 @@ The Options screen (`src/routes/game/screens/options`) reimagines the old loggin
 - **Live preview reuses the real log row.** The preview renders a sample event stream through the actual `LogRow`, filtered by the *draft* preferences, so it looks exactly like the real combat log and reflects each toggle before you save.
 - **All colour flows from the root `--log-*` vars** (the theming rule in frontend.md): one `var(--log-*)` reference map is shared by the real log, the preview, and the per-type rows, with every neutral/alpha shade a `color-mix` over a base token.
 
+## Help screen (the tutorial reading room)
+
+The Help screen (`src/routes/game/screens/help`, #1589) is the reserved `help` slot's implementation: a flat list of every live `Lesson` (spike #1392) in authored `ordinal` order, each showing this player's `locked`/`unread`/`read` state — the destination the sidebar's unread badge leads to.
+
+- **No screen-local open/read logic.** Selecting an unread or read (replayable) row calls straight into the shared `openLesson` flow (`$lib/engine/tutorials`) — navigate to the lesson's host screen and play its tour — the same path a screen/mechanic trigger uses, so replaying from Help behaves identically to a live trigger. A locked row is a disabled, name-only teaser (no step content), matching the "no spoilers" framing the trigger system already uses elsewhere.
+- **State is derived, not stored** — a lesson with no `PlayerLesson` entry is locked; an entry with no `readAt` is unread; otherwise read. No screen-local state beyond the view-model's derived read.
+
 ## Character-select screen (login → game)
 
 The character-select screen (`src/routes/select`) sits between the login page and the loading screen: an account can own multiple characters (see [game-design.md](./game-design.md) and the spike `docs/spikes/922-multiple-players-per-account.md`), so `Login` now returns the account's `playerSummaries` instead of binding the first one, and this screen is where the player picks who to enter as or creates a new character. Selecting one calls `SelectPlayer` — which binds the session and rotates the token to carry the chosen `playerId` — then runs the per-player active-session takeover check before entering the game.


### PR DESCRIPTION
## Summary

Implements the last remaining sub-issue of the #1392 "Add UI tutorials" spike: the reserved `help` screen slot (`screen-defs.ts`, previously `built: false`) is now the tutorial **reading room**.

- Lists every live `Lesson` in authored `ordinal` order, showing this player's `locked` / `unread` / `read` state (per `PlayerLesson`).
- A **locked** lesson renders as a disabled, name-only teaser (greyed, no step content — no spoilers).
- Selecting an **unread** or **read** (replayable) lesson reuses the existing shared open flow (`openLesson` in `$lib/engine/tutorials`) — navigates to the lesson's host screen and plays its tour, marking it read either way. This is the same flow a live screen/mechanic trigger already uses, so replaying from Help behaves identically.
- Exported `liveLessons` from `$lib/engine/tutorials` (was already module-private) so the new view-model can reuse the same non-retired filter rather than duplicating it.

All three of this issue's stated dependencies (#1587, #1588, #1592) were already closed, so no further design/plumbing work was needed — this was purely the reading-room UI itself. With this merged, all 7 sub-issues of #1392 are complete; I'll leave closing that spike issue to the maintainer.

Docs: added a short "Help screen" entry to `docs/frontend-screens.md` following the existing per-screen convention.

## How this addresses the issue

- ✅ Build the reserved `help` screen listing every lesson with its per-player state (locked / unread / read)
- ✅ Unread lessons emphasized (accent background + bold name + dot marker) — this is where the sidebar's unread badge (already wired) leads
- ✅ Selecting a lesson navigates to its host screen and plays its tour, marking it read — same open flow as a live trigger
- ✅ Read lessons are replayable the same way
- ✅ Locked lessons display greyed with name only, no step content

## Test plan

- [x] New unit tests: `help-view.test.ts` (state classification: locked/unread/read, ordinal sort, retired-lesson exclusion, `openLesson` guard/delegation)
- [x] New component tests: `Help.test.ts` (empty state, per-state rendering, unread emphasis, locked disabled + non-clickable, click delegates to the shared open flow for unread/read)
- [x] `npm run lint` — clean (eslint + svelte-check, 0 errors/warnings)
- [x] `npm run test:unit:ci` — 3,870 passed, 0 failed (full suite, including the new tests)

No backend changes; e2e coverage intentionally not added — this is a settings-page list view, not a new critical path (the tutorial trigger/tour flow itself already has e2e coverage in `tutorial.test.ts`).

Closes #1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bTxz6XGVhcKxhyoy5roNH

---
_Generated by [Claude Code](https://claude.ai/code/session_019bTxz6XGVhcKxhyoy5roNH)_