### PR TITLE
Fix RevokeAccess logging a spurious no-active-socket warning

### DIFF
--- a/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
+++ b/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
@@ -535,6 +535,29 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(nameof(AccessRevoked), revoked.Name);
         }
 
+        [Fact]
+        public async Task RevokeAccess_PlayerHeldBySwitchCreditSentinel_IsSilentNoOp()
+        {
+            // A ban/archive landing while the target's presence key holds the switch-credit sentinel (rather
+            // than a real socket id or being unset) is the gap #2233 fixes: HasActiveSocket reports this
+            // player as present (see TryClaimForSwitchCredit's doc comment), but there is no real socket to
+            // push AccessRevoked to, so the old HasActiveSocket-gated check fell through to EmitSocketCommand's
+            // no-active-socket warning branch. RevokeAccess must recognize the sentinel and skip silently.
+            const int playerId = 918273;
+            var startIndex = _capturingProvider.Entries.Count;
+
+            using (var scope = CreateScope())
+            {
+                var socketManager = scope.ServiceProvider.GetRequiredService<SocketManagerService>();
+                Assert.True(await socketManager.TryClaimForSwitchCredit(playerId));
+
+                await socketManager.RevokeAccess([playerId]);
+            }
+
+            Assert.DoesNotContain(_capturingProvider.Entries.Skip(startIndex),
+                e => e.Category == SocketManagerCategory && e.Level == LogLevel.Warning);
+        }
+
         private async Task<bool> HasActiveSocketAsync(int playerId)
         {
             using var scope = CreateScope();

--- a/Game.Api/Services/SocketManagerService.cs
+++ b/Game.Api/Services/SocketManagerService.cs
@@ -350,19 +350,25 @@ namespace Game.Api.Services
         /// client's access token expires (up to the 15-minute TTL) or the socket next goes idle. Silent when
         /// none are connected: unlike a gameplay push (<see cref="EmitSocketCommand(SocketCommandInfo, int)"/>),
         /// the target of a ban/archive is very often already offline, so that is the common case here, not a
-        /// warning-worthy anomaly — <see cref="HasActiveSocket"/> is checked per player first specifically to
-        /// avoid that log noise. Best-effort like the rest of this service's presence handling: a player who
-        /// connects in the narrow race between the admin action committing and this call reaching their
-        /// socket is not caught, which is acceptable since any subsequent refresh/select for the account is
-        /// already rejected by the live ban/archive check (see docs/backend-auth.md).
+        /// warning-worthy anomaly. Reads the presence key directly (mirroring the <c>otherSocketId</c> check
+        /// in <see cref="RegisterSocket"/>) and skips a null or switch-credit-sentinel value, rather than
+        /// gating on <see cref="HasActiveSocket"/> and then calling the int-keyed <see cref="EmitSocketCommand(SocketCommandInfo, int)"/>
+        /// overload — that combination re-reads the key and, during the brief window a switch-credit claim
+        /// holds it (see <see cref="TryClaimForSwitchCredit"/>), finds no real socket and logs the very
+        /// no-active-socket warning this method exists to suppress (#2233). Best-effort like the rest of this
+        /// service's presence handling: a player who connects in the narrow race between the admin action
+        /// committing and this call reaching their socket is not caught, which is acceptable since any
+        /// subsequent refresh/select for the account is already rejected by the live ban/archive check (see
+        /// docs/backend-auth.md).
         /// </summary>
         public async Task RevokeAccess(IReadOnlyList<int> playerIds)
         {
             foreach (var playerId in playerIds)
             {
-                if (await HasActiveSocket(playerId))
+                var socketId = await CurrentSocketId(playerId);
+                if (socketId is not null && socketId != SwitchCreditClaimValue)
                 {
-                    await EmitSocketCommand(new AccessRevokedInfo(), playerId);
+                    await EmitSocketCommand(new AccessRevokedInfo(), socketId);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Follow-up from #2230. `SocketManagerService.RevokeAccess` gated its push with `HasActiveSocket(playerId)` specifically to avoid `EmitSocketCommand`'s no-active-socket warning for the common (offline) ban/archive case. But `HasActiveSocket` is a presence-key *existence* check, so it also returns `true` while the key holds the **switch-credit sentinel** (`TryClaimForSwitchCredit`) rather than a real socket id. In that window, `EmitSocketCommand(_, playerId)` re-reads the key, finds no real socket in the registry, and logs the very warning the pre-check exists to suppress.

## Fix

`RevokeAccess` now reads `CurrentSocketId` directly and skips a `null` or sentinel value before pushing — mirroring the existing `otherSocketId != SwitchCreditClaimValue` check in `RegisterSocket` — instead of gating on `HasActiveSocket` and then re-resolving the socket id through the int-keyed `EmitSocketCommand` overload.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test` (`Game.Api.Tests`, `SocketManagerServiceTests`) — 847 passed, 0 failed
- [x] Added `RevokeAccess_PlayerHeldBySwitchCreditSentinel_IsSilentNoOp`, seeding the sentinel via `TryClaimForSwitchCredit` and asserting no warning is logged by `RevokeAccess`

Closes #2233


---
_Generated by [Claude Code](https://claude.ai/code/session_01DTNA9fiEBpRYC2ji9P8b32)_