### PR TITLE
Guard subject enemy's own retirement in the Spawns tab's share column

### DIFF
--- a/UI/src/routes/admin/workbench/entities/enemy.ts
+++ b/UI/src/routes/admin/workbench/entities/enemy.ts
@@ -144,7 +144,8 @@ export const enemyEntity: EntityConfig<WorkbenchEnemy> = {
 					type: 'share',
 					width: 150,
 					weightKey: 'weight',
-					shareTotal: reference.enemySpawnShareTotal
+					shareTotal: reference.enemySpawnShareTotal,
+					shareValue: reference.enemySpawnShareValue
 				}
 			]
 		}

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -328,15 +328,17 @@ class WorkbenchReference {
 	};
 
 	/**
-	 * Total spawn weight competing in a zone: this row's weight plus every OTHER
-	 * LIVE enemy's weight in the same zone (so an enemy's share reflects zone competition,
-	 * not its own zone list). A retired competitor is excluded — the runtime spawn table
-	 * (`EnemiesCacheHolder.BuildZoneEnemyTables`) drops it too, so its weight is not real
-	 * competition.
+	 * Total spawn weight competing in a zone: this row's weight (unless the subject enemy
+	 * itself is retired — its own spawns never roll, so it isn't real competition either)
+	 * plus every OTHER LIVE enemy's weight in the same zone (so an enemy's share reflects
+	 * zone competition, not its own zone list). A retired competitor is excluded — the
+	 * runtime spawn table (`EnemiesCacheHolder.BuildZoneEnemyTables`) drops it too, so its
+	 * weight is not real competition.
 	 */
 	enemySpawnShareTotal = (row: TableRow, _rows: TableRow[], record: unknown): number => {
 		const enemyId = (record as { id: number }).id;
-		let sum = Number(row.weight) || 0;
+		const subjectRetired = !!(record as { retiredAt?: string | null }).retiredAt;
+		let sum = subjectRetired ? 0 : Number(row.weight) || 0;
 		for (const enemy of staticData.enemies ?? []) {
 			if (enemy.id === enemyId || enemy.retiredAt) {
 				continue;
@@ -348,6 +350,10 @@ class WorkbenchReference {
 		}
 		return sum || 1;
 	};
+
+	/** A retired enemy's own spawns never roll, so its displayed share is 0 regardless of weight. */
+	enemySpawnShareValue = (row: TableRow, _rows: TableRow[], record: unknown): number =>
+		(record as { retiredAt?: string | null }).retiredAt ? 0 : Number(row.weight) || 0;
 }
 
 export const reference = new WorkbenchReference();

--- a/UI/src/tests/routes/admin/workbench/reference.test.ts
+++ b/UI/src/tests/routes/admin/workbench/reference.test.ts
@@ -482,4 +482,28 @@ describe('enemySpawnShareTotal', () => {
 		const total = reference.enemySpawnShareTotal({ zoneId: 0, weight: 30 }, [], { id: 2 });
 		expect(total).toBe(45);
 	});
+
+	it("drops the subject's own weight from the total when the subject record itself is retired (#2237)", () => {
+		// Zone 0: only the live competitors count — Cave Bat (5) + Catacomb Lich (15) = 20, not +30.
+		const total = reference.enemySpawnShareTotal({ zoneId: 0, weight: 30 }, [], {
+			id: 2,
+			retiredAt: '2026-01-01T00:00:00Z'
+		});
+		expect(total).toBe(20);
+	});
+});
+
+describe('enemySpawnShareValue (#2237)', () => {
+	it("reports 0 for a retired subject's own row, mirroring the zone editor's shareValue", () => {
+		const value = reference.enemySpawnShareValue({ zoneId: 0, weight: 30 }, [], {
+			id: 2,
+			retiredAt: '2026-01-01T00:00:00Z'
+		});
+		expect(value).toBe(0);
+	});
+
+	it('passes through the row weight unchanged for a live subject', () => {
+		const value = reference.enemySpawnShareValue({ zoneId: 0, weight: 30 }, [], { id: 2 });
+		expect(value).toBe(30);
+	});
 });


### PR DESCRIPTION
## Summary

Residual of #2206/#2214: that fix made the zone editor's spawn-share column retirement-aware for **competitors** (both the denominator and a `shareValue` override), but the enemy editor's own **Spawns** tab never got the subject-side half of the fix.

- `WorkbenchReference.enemySpawnShareTotal` (`UI/src/routes/admin/workbench/reference.svelte.ts`) started the denominator from the row's own weight unconditionally, never checking whether the subject enemy record itself is retired.
- The enemy spawns column (`UI/src/routes/admin/workbench/entities/enemy.ts`) passed `shareTotal` but no `shareValue` override, so a retired enemy's raw weight was always divided into the total as-is.

Since the runtime spawn table (`EnemiesCacheHolder.BuildZoneEnemyTables`) drops **all** of a retired enemy's spawns, its true share is 0% — but the enemy editor could show up to 100% for the same data the zone editor correctly showed as 0%.

## Fix

- `enemySpawnShareTotal`: when the subject record's `retiredAt` is set, its own row weight is excluded from the total (it isn't real competition either — mirrors how a retired competitor is already excluded).
- Added `enemySpawnShareValue`, wired into the enemy spawns column's `shareValue`, which reports `0` for a retired subject and passes the row weight through unchanged otherwise — mirroring `zone.ts`'s existing `shareValue` pattern for retired competitors.

## Test plan

- [x] Added `reference.test.ts` cases: subject retirement drops its own weight from `enemySpawnShareTotal`'s denominator; new `enemySpawnShareValue` describe block covering the retired-subject-reports-0 and live-subject-passthrough cases.
- [x] `npm run test:unit:ci` — full suite green (310 files / 3878 tests, coverage thresholds met).
- [x] `npm run lint` — eslint + svelte-check clean.

Closes #2237


---
_Generated by [Claude Code](https://claude.ai/code/session_018X4ZAJKkyWa7hrjMQHkgo9)_