### PR TITLE
Normalize username in Login to match CreateAccount

### DIFF
--- a/Game.Application.Tests/Services/AccountServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/AccountServiceIntegrationTests.cs
@@ -5,6 +5,7 @@ using Game.Application.Auth;
 using Game.Application.Services;
 using Game.Core;
 using Game.Core.Battle;
+using Game.Core.Identity;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
@@ -328,6 +329,23 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
+        public async Task Login_PaddedUsername_NormalizesAndSucceeds()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context, "paddeduser", "paddedpass");
+
+            var accountService = CreateAccountService(scope.ServiceProvider);
+
+            // CreateAccount normalizes (trims) before storing, so Login must apply the same normalization —
+            // otherwise a padded variant of a stored username can never match the exact-match lookup.
+            var result = await accountService.Login("  paddeduser  ", "paddedpass");
+
+            Assert.True(result.Success);
+            Assert.Equal(user.Id, result.UserId);
+        }
+
+        [Fact]
         public async Task Login_UserWithMultiplePlayers_ReturnsAllSummaries()
         {
             using var scope = CreateScope();
@@ -425,6 +443,23 @@ namespace Game.Application.Tests.Services
             // The unknown-user branch must spend the dummy derivation work (and never a real verify it has no
             // hash for), so its response time matches a known-user verify and can't be used to enumerate names.
             Assert.Equal(1, hasher.VerifyDummyCalls);
+            Assert.Equal(0, hasher.VerifyCalls);
+        }
+
+        [Fact]
+        public async Task Login_UnNormalizableUsername_FailsFastWithoutPasswordWork()
+        {
+            using var scope = CreateScope();
+            var hasher = new RecordingPasswordHasher(TestPepper);
+            var accountService = CreateAccountService(scope.ServiceProvider, passwordHasher: hasher);
+
+            // A username that can never match a stored (already-normalized) value is rejected before any
+            // backoff/database/PBKDF2 work runs — there is no account this input could possibly resolve to.
+            var result = await accountService.Login(new string('a', UsernamePolicy.MaxLength + 1), "whatever");
+
+            Assert.False(result.Success);
+            Assert.Equal(LoginStatus.InvalidCredentials, result.Status);
+            Assert.Equal(0, hasher.VerifyDummyCalls);
             Assert.Equal(0, hasher.VerifyCalls);
         }
 

--- a/Game.Application/Services/AccountService.cs
+++ b/Game.Application/Services/AccountService.cs
@@ -84,36 +84,45 @@ namespace Game.Application.Services
         /// </summary>
         public async Task<AccountLoginResult> Login(string username, string password, CancellationToken cancellationToken = default)
         {
+            // Normalize the same way CreateAccount does before the account is ever looked up, so a padded
+            // variant of a stored username (e.g. " bob ") resolves to the same account and the same backoff
+            // streak. An un-normalizable input can never match a stored (already-normalized) username, so it
+            // fails fast as invalid credentials without touching the backoff store, the database, or PBKDF2.
+            if (!UsernamePolicy.TryNormalize(username, out var normalized))
+            {
+                return AccountLoginResult.Failed(LoginStatus.InvalidCredentials);
+            }
+
             // Defence-in-depth on top of the per-IP rate limiter: if too many consecutive failures have
             // accrued for this account, reject before any database hit or PBKDF2 work. Keyed per account so a
             // slow distributed guess is slowed regardless of source IP; it is a bounded backoff (never a hard
             // lockout), so an attacker who knows a username can only briefly slow the owner, not lock them out.
-            var activeBackoff = await _backoffGuard.GetActiveBackoff(username, cancellationToken);
+            var activeBackoff = await _backoffGuard.GetActiveBackoff(normalized, cancellationToken);
             if (activeBackoff is TimeSpan retryAfter)
             {
                 return AccountLoginResult.BackedOff(retryAfter);
             }
 
-            var account = await _users.GetUser(username, cancellationToken);
+            var account = await _users.GetUser(normalized, cancellationToken);
             if (account is null)
             {
                 // Spend the same PBKDF2 work a real account's verify would, so an unknown username is not
                 // distinguishable by response time (defeating timing-based username enumeration).
                 _passwordHasher.VerifyDummy(password);
-                await _backoffGuard.RegisterFailure(username, cancellationToken);
+                await _backoffGuard.RegisterFailure(normalized, cancellationToken);
                 return AccountLoginResult.Failed(LoginStatus.InvalidCredentials);
             }
 
             var verification = _passwordHasher.Verify(password, account.PassHash);
             if (verification == PasswordVerificationResult.Failed)
             {
-                await _backoffGuard.RegisterFailure(username, cancellationToken);
+                await _backoffGuard.RegisterFailure(normalized, cancellationToken);
                 return AccountLoginResult.Failed(LoginStatus.InvalidCredentials);
             }
 
             // Credentials verified — the attempt is not a brute-force guess, so reset the failure streak
             // before any later (ban / no-player) rejection, which is not a credential failure.
-            await _backoffGuard.Reset(username, cancellationToken);
+            await _backoffGuard.Reset(normalized, cancellationToken);
 
             // Reject a banned account only after its credentials check out, so an anonymous probe can't
             // enumerate ban status — only the account owner learns they are banned. This is also the first


### PR DESCRIPTION
## Summary

`AccountService.CreateAccount` normalizes (trims) the username via `UsernamePolicy.TryNormalize` before storing it, but `Login` was passing the raw, un-normalized username straight to `LoginBackoffGuard` and `IUsers.GetUser` (an exact-match query). This meant:

- An account persisted as `"bob"` could not authenticate as `" bob "` via the API (not exploitable — the exact-match lookup fails before any password check).
- The per-account backoff streak fragmented across un-normalized variants of the same logical account, since `LoginBackoffStore` keys on a hash of the raw string.

## Fix

`Login` now runs `UsernamePolicy.TryNormalize` at the top, before the backoff check, the database lookup, and any PBKDF2 work, and uses the normalized value everywhere it previously used the raw input. An un-normalizable input (e.g. too long, disallowed characters) can never match a stored username, so it fails fast as `InvalidCredentials` without touching the backoff store, the database, or the password hasher.

## Test plan

- [x] Added `Login_PaddedUsername_NormalizesAndSucceeds` — a padded variant of a stored username now authenticates successfully.
- [x] Added `Login_UnNormalizableUsername_FailsFastWithoutPasswordWork` — an unnormalizable username is rejected before any dummy/real password verification runs.
- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] `dotnet test` (full solution) — 3392 tests passed, 0 failed.

Closes #2239


---
_Generated by [Claude Code](https://claude.ai/code/session_01GjfGB7SGMBuHqBaRcASZLC)_