### PR TITLE
Bound tracked IPs per (user, device) in connection tracking

### DIFF
--- a/Game.Application.Tests/DataAccess/UserLoginsCapAndOwnershipIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/UserLoginsCapAndOwnershipIntegrationTests.cs
@@ -10,14 +10,15 @@ using Xunit;
 namespace Game.Application.Tests.DataAccess
 {
     /// <summary>
-    /// Integration coverage for the device/login-tracking hardening (#2064): a single account can't grow the
-    /// Devices/UserLogins tables without bound by cycling fresh fingerprints, and <c>SaveDeviceInfo</c> can
-    /// only enrich a device the caller actually has a tracked login for.
+    /// Integration coverage for the device/login-tracking hardening (#2064, #2240): a single account can't
+    /// grow the Devices/UserLogins tables without bound by cycling fresh fingerprints or IPs, and
+    /// <c>SaveDeviceInfo</c> can only enrich a device the caller actually has a tracked login for.
     /// </summary>
     [Collection("Integration")]
     public class UserLoginsCapAndOwnershipIntegrationTests : ApplicationIntegrationTestBase
     {
         private const int MaxTrackedDevicesPerUser = 20;
+        private const int MaxTrackedIpsPerUserDevice = 20;
         private const string UserAgent = "TestAgent/1.0";
         private const string Ip = "203.0.113.10";
 
@@ -74,6 +75,62 @@ namespace Game.Application.Tests.DataAccess
             {
                 var context = scope.ServiceProvider.GetRequiredService<GameContext>();
                 Assert.Equal(MaxTrackedDevicesPerUser + 1, await context.UserLogins.CountAsync(l => l.UserId == userId, CancellationToken));
+            }
+        }
+
+        [Fact]
+        public async Task RecordConnection_PastIpCapForKnownDevice_StopsTrackingNewIpsButStillUpdatesKnownOnes()
+        {
+            int userId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                var user = await TestDataSeeder.CreateUserAsync(context);
+                userId = user.Id;
+            }
+
+            // Reach the cap with distinct IPs against the same, already-tracked device.
+            for (var i = 0; i < MaxTrackedIpsPerUserDevice; i++)
+            {
+                using var scope = CreateScope();
+                var repo = scope.ServiceProvider.GetRequiredService<IUserLogins>();
+                await repo.RecordConnection(userId, IpForIndex(i), Fingerprint(0), UserAgent, null, null, null, CancellationToken);
+            }
+
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                Assert.Equal(MaxTrackedIpsPerUserDevice, await context.UserLogins.CountAsync(l => l.UserId == userId, CancellationToken));
+            }
+
+            // One more, brand-new IP for the same device: silently not tracked rather than growing past the cap.
+            using (var scope = CreateScope())
+            {
+                var repo = scope.ServiceProvider.GetRequiredService<IUserLogins>();
+                await repo.RecordConnection(userId, IpForIndex(MaxTrackedIpsPerUserDevice), Fingerprint(0), UserAgent, null, null, null, CancellationToken);
+            }
+
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                Assert.Equal(MaxTrackedIpsPerUserDevice, await context.UserLogins.CountAsync(l => l.UserId == userId, CancellationToken));
+                Assert.Empty(await context.UserLogins
+                    .Where(l => l.UserId == userId && l.IpAddress == IpForIndex(MaxTrackedIpsPerUserDevice))
+                    .ToListAsync(CancellationToken));
+            }
+
+            // An already-tracked (user, IP, device) combination is the fast-path update, not blocked by a
+            // cap that only governs *new* IPs — the row count stays put.
+            using (var scope = CreateScope())
+            {
+                var repo = scope.ServiceProvider.GetRequiredService<IUserLogins>();
+                await repo.RecordConnection(userId, IpForIndex(0), Fingerprint(0), UserAgent, null, null, null, CancellationToken);
+            }
+
+            using (var scope = CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+                Assert.Equal(MaxTrackedIpsPerUserDevice, await context.UserLogins.CountAsync(l => l.UserId == userId, CancellationToken));
             }
         }
 
@@ -159,5 +216,9 @@ namespace Game.Application.Tests.DataAccess
         // the repository itself doesn't enforce that shape (only the HTTP-layer ClientHints does), so a
         // simple distinguishable string is enough here.
         private static string Fingerprint(int index) => $"fp-cap-{index:D3}";
+
+        // A distinct IP per index, drawn from the TEST-NET-2 documentation range (RFC 5737) so it can't
+        // collide with the class-level Ip constant used elsewhere in this file.
+        private static string IpForIndex(int index) => $"198.51.100.{index}";
     }
 }

--- a/Game.DataAccess/Repositories/UserLogins.cs
+++ b/Game.DataAccess/Repositories/UserLogins.cs
@@ -20,6 +20,13 @@ namespace Game.DataAccess.Repositories
         // simply not tracked rather than erroring — tracking is best-effort telemetry, not a gate on play.
         private const int MaxTrackedDevicesPerUser = 20;
 
+        // Mirrors MaxTrackedDevicesPerUser for the IP dimension of an already-tracked device: a
+        // mobile/VPN user on carrier-NAT rotation would otherwise grow UserLogins rows for that one
+        // device without bound (#2240, the IP-side gap the device cap above didn't cover). Same
+        // best-effort policy — once reached, connections from an IP the user hasn't already been seen
+        // on for that device are simply not tracked, not evicted.
+        private const int MaxTrackedIpsPerUserDevice = 20;
+
         private readonly GameContext _context;
 
         public UserLogins(GameContext context)
@@ -71,6 +78,21 @@ namespace Game.DataAccess.Repositories
                         .CountAsync(cancellationToken);
 
                     if (trackedDeviceCount >= MaxTrackedDevicesPerUser)
+                    {
+                        return;
+                    }
+                }
+                else if (device is not null)
+                {
+                    // A device the user already has *some* login for, but not from this IP — bound the
+                    // IP dimension the same way the branch above bounds the device dimension.
+                    var trackedIpCount = await _context.UserLogins
+                        .Where(l => l.UserId == userId && l.DeviceId == device.Id)
+                        .Select(l => l.IpAddress)
+                        .Distinct()
+                        .CountAsync(cancellationToken);
+
+                    if (trackedIpCount >= MaxTrackedIpsPerUserDevice)
                     {
                         return;
                     }


### PR DESCRIPTION
## Summary

`UserLogins.SaveConnection` (now `RecordConnection`) only evaluated the `MaxTrackedDevicesPerUser` cap when a connection came from a *new device* for the user. For a device the user already has a login row for, every previously-unseen IP inserted a new `(userId, ipAddress, deviceId)` row with no bound — so a mobile/VPN user on carrier-NAT rotation could accrue `UserLogins` rows indefinitely per already-tracked device (up to 20 devices × unbounded IPs).

This mirrors the fix #2064 made for the device dimension:

- Added `MaxTrackedIpsPerUserDevice` (= 20, matching the device cap) alongside the existing `MaxTrackedDevicesPerUser`.
- When a connection is from an IP the user hasn't seen on an *already-tracked* device, the new IP-count check runs the same way the device-count check does for new devices.
- Same best-effort policy as the device cap: once the cap is reached, the new IP is simply **not tracked** rather than erroring or evicting an older row — tracking is diagnostic telemetry, not a gate on play.

The existing device cap and ownership tests in `UserLoginsCapAndOwnershipIntegrationTests` still pass unchanged (their IP counts per device stay well under the new cap), confirming no regression to that behavior.

## Test plan

- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet test Game.Application.Tests` — full suite green (1061 passed), including the new `RecordConnection_PastIpCapForKnownDevice_StopsTrackingNewIpsButStillUpdatesKnownOnes` integration test, which verifies: the cap is reached with distinct IPs against one device, one more new IP is silently dropped without growing the row count, and an already-tracked `(user, IP, device)` combination still updates via the fast path rather than being blocked by the cap.

Closes #2240


---
_Generated by [Claude Code](https://claude.ai/code/session_01TH4a4ZWKk31k9yFZKo69mg)_