### PR TITLE
Guard SaveLogPreferences against no-op writes

### DIFF
--- a/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
@@ -765,12 +765,15 @@ namespace Game.Application.Tests.Services
                 new() { LogType = ELogType.Exp, Enabled = true },
             };
 
-            await playerService.SaveLogPreferences(player, preferences);
-            await DrainPlayerUpdateQueue(scope.ServiceProvider);
-
             var options = ConfigurationOptions.Parse(Containers.PubSubConnectionString);
             using var multiplexer = await ConnectionMultiplexer.ConnectAsync(options);
             var db = multiplexer.GetDatabase();
+
+            // The first save actually changes both preferences, so it must enqueue both events — proving the
+            // no-op assertion below isn't trivially true (e.g. from a broken queue rather than the no-op guard).
+            await playerService.SaveLogPreferences(player, preferences);
+            Assert.Equal(2, await db.ListLengthAsync(Constants.PUBSUB_PLAYER_QUEUE));
+            await DrainPlayerUpdateQueue(scope.ServiceProvider);
 
             // Re-submitting the same values is a no-op: no LogPreferenceChangedEvent should be raised or saved.
             await playerService.SaveLogPreferences(player, preferences);

--- a/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs
@@ -13,6 +13,7 @@ using Game.TestInfrastructure.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using StackExchange.Redis;
 using Xunit;
 
 namespace Game.Application.Tests.Services
@@ -741,6 +742,40 @@ namespace Game.Application.Tests.Services
 
             Assert.Single(rows, lp => lp.LogTypeId == (int)ELogType.Damage && !lp.Enabled);
             Assert.Single(rows, lp => lp.LogTypeId == (int)ELogType.Exp && lp.Enabled);
+        }
+
+        [Fact]
+        public async Task SaveLogPreferences_NoValuesChanged_DoesNotEnqueueWriteBehindEvents()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerService = scope.ServiceProvider.GetRequiredService<PlayerService>();
+            var player = await playerService.LoadPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var preferences = new List<LogPreference>
+            {
+                new() { LogType = ELogType.Damage, Enabled = false },
+                new() { LogType = ELogType.Exp, Enabled = true },
+            };
+
+            await playerService.SaveLogPreferences(player, preferences);
+            await DrainPlayerUpdateQueue(scope.ServiceProvider);
+
+            var options = ConfigurationOptions.Parse(Containers.PubSubConnectionString);
+            using var multiplexer = await ConnectionMultiplexer.ConnectAsync(options);
+            var db = multiplexer.GetDatabase();
+
+            // Re-submitting the same values is a no-op: no LogPreferenceChangedEvent should be raised or saved.
+            await playerService.SaveLogPreferences(player, preferences);
+
+            Assert.Equal(0, await db.ListLengthAsync(Constants.PUBSUB_PLAYER_QUEUE));
         }
 
         private async Task DrainPlayerUpdateQueue(IServiceProvider services)

--- a/Game.Application/Services/PlayerService.cs
+++ b/Game.Application/Services/PlayerService.cs
@@ -52,12 +52,14 @@ namespace Game.Application.Services
 
         public async Task SaveLogPreferences(Player player, IEnumerable<LogPreference> preferences, CancellationToken cancellationToken = default)
         {
+            var changed = false;
             foreach (var preference in preferences)
             {
-                player.UpdateLogPreference(preference.LogType, preference.Enabled);
+                // Bitwise OR (not ||) so every preference is applied regardless of earlier ones' outcome.
+                changed |= player.UpdateLogPreference(preference.LogType, preference.Enabled);
             }
 
-            await _playerRepo.SavePlayer(player, cancellationToken);
+            await SaveIf(player, changed, cancellationToken);
         }
 
         public async Task UnlockLesson(Player player, int lessonId, CancellationToken cancellationToken = default)

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -708,28 +708,42 @@ namespace Game.Core.Tests.Players
         // ── UpdateLogPreference ──────────────────────────────────────────────
 
         [Fact]
-        public void UpdateLogPreference_NewType_AddsPreference()
+        public void UpdateLogPreference_NewType_AddsPreferenceAndReturnsTrue()
         {
             var player = MakePlayer();
 
-            player.UpdateLogPreference(ELogType.Damage, false);
+            var result = player.UpdateLogPreference(ELogType.Damage, false);
 
+            Assert.True(result);
             var pref = player.LogPreferences.SingleOrDefault(p => p.LogType == ELogType.Damage);
             Assert.NotNull(pref);
             Assert.False(pref.Enabled);
         }
 
         [Fact]
-        public void UpdateLogPreference_ExistingType_UpdatesInPlace()
+        public void UpdateLogPreference_ExistingTypeChangedValue_UpdatesInPlaceAndReturnsTrue()
         {
             var player = MakePlayer();
             player.LogPreferences.Add(new LogPreference { LogType = ELogType.Damage, Enabled = true });
 
-            player.UpdateLogPreference(ELogType.Damage, false);
+            var result = player.UpdateLogPreference(ELogType.Damage, false);
 
+            Assert.True(result);
             var pref = Assert.Single(player.LogPreferences);
             Assert.Equal(ELogType.Damage, pref.LogType);
             Assert.False(pref.Enabled);
+        }
+
+        [Fact]
+        public void UpdateLogPreference_ExistingTypeUnchangedValue_ReturnsFalseAndDoesNotRaiseEvent()
+        {
+            var player = MakePlayer();
+            player.LogPreferences.Add(new LogPreference { LogType = ELogType.Damage, Enabled = true });
+
+            var result = player.UpdateLogPreference(ELogType.Damage, true);
+
+            Assert.False(result);
+            Assert.Empty(player.DomainEvents.OfType<LogPreferenceChangedEvent>());
         }
 
         [Fact]

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -414,11 +414,19 @@ namespace Game.Core.Players
             return true;
         }
 
-        public void UpdateLogPreference(ELogType logType, bool enabled)
+        // Returns whether the preference's value actually changed, so callers (SaveLogPreferences) can skip
+        // enqueuing a write-behind event and save for an unchanged toggle, matching the "no mutation → no
+        // save" pattern every sibling command follows.
+        public bool UpdateLogPreference(ELogType logType, bool enabled)
         {
             var pref = LogPreferences.FirstOrDefault(p => p.LogType == logType);
             if (pref is not null)
             {
+                if (pref.Enabled == enabled)
+                {
+                    return false;
+                }
+
                 pref.Enabled = enabled;
             }
             else
@@ -427,6 +435,7 @@ namespace Game.Core.Players
             }
 
             RaiseEvent(new LogPreferenceChangedEvent(Id, logType, enabled));
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

`PlayerService.SaveLogPreferences` was the only mutation command not using the `SaveIf` guard: it always looped every preference in the incoming list through `Player.UpdateLogPreference` and always called `SavePlayer`, regardless of whether any value actually changed. Since `UpdateLogPreference` unconditionally raised `LogPreferenceChangedEvent`, one toggle from the client enqueued N write-behind events (one per preference in the list) and the drain side paid one `ExecuteUpdate` round-trip per event — even for preferences whose value didn't change.

## Changes

- `Player.UpdateLogPreference` (`Game.Core/Players/Player.cs`) now returns `bool` and is a no-op (no event raised) when the incoming value equals the existing one — mirroring the value-equality guard used elsewhere in the codebase (e.g. `TrySetFavorite`, `UnlockLesson`).
- `PlayerService.SaveLogPreferences` (`Game.Application/Services/PlayerService.cs`) now tracks whether *any* preference in the batch actually changed (via bitwise `|=`, so every preference is still applied — not short-circuited) and routes through the existing private `SaveIf` helper, so an all-unchanged batch performs no save and enqueues nothing.

This brings `SaveLogPreferences` in line with the "no mutation → no save" pattern every sibling command (`SetFavorite`, `UnlockItem`, `ApplyMod`, etc.) already follows.

Note: the frontend (`options-view.svelte.ts`) already computes and sends only the dirty preferences, so this mainly hardens the backend invariant itself (defense in depth against other/future callers) rather than fixing an everyday user-visible flood — but it closes the gap the issue called out.

## Test plan

- [x] `Game.Core.Tests/Players/PlayerTests.cs`: added `UpdateLogPreference_ExistingTypeUnchangedValue_ReturnsFalseAndDoesNotRaiseEvent`; updated the add/update tests to assert the new `true` return value.
- [x] `Game.Application.Tests/Services/PlayerServiceIntegrationTests.cs`: added `SaveLogPreferences_NoValuesChanged_DoesNotEnqueueWriteBehindEvents`, asserting the Redis write-behind queue stays empty when re-saving identical preference values.
- [x] `dotnet build` — succeeds, no warnings.
- [x] `dotnet test` for `Game.Core.Tests`, `Game.Application.Tests`, and `Game.Api.Tests` — all green (no regressions).

Closes #2241

---
_Generated by [Claude Code](https://claude.ai/code/session_015tpGR2Df29Npy8gPkdYKDq)_