### PR TITLE
Game.Api response-shape consistency: guard ActiveSession, clamp negative Cooldown (#2242)

### DIFF
--- a/Game.Api.Tests/Integration/AuthControllerTests.cs
+++ b/Game.Api.Tests/Integration/AuthControllerTests.cs
@@ -351,6 +351,28 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task ActiveSession_PreSelectionToken_ReturnsNoPlayerSelectedNotProbingPlayerZero()
+        {
+            // Mirrors Status_PreSelectionToken_ReturnsNoPlayerSelectedNotOpaque404 (#2242): a pre-selection
+            // token must surface the same distinguishable NoPlayerSelected category rather than resolving
+            // SelectedPlayerId to 0 and probing that socket's presence.
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var user = await TestDataSeeder.CreateUserAsync(context, "playerlessactive", "pass");
+
+            var client = Factory.CreateClient();
+            TestAuthHelper.AddAuthHeader(client, user.Id);
+
+            var response = await client.GetAsync("/api/Auth/ActiveSession", CancellationToken);
+
+            Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse<ActiveSessionResult>>(CancellationToken);
+            Assert.Null(result?.Data);
+            Assert.NotNull(result?.ErrorMessage);
+            client.Dispose();
+        }
+
+        [Fact]
         public async Task ActiveSession_ValidTokenWithNoSessionCache_RehydratesAndReturnsResult()
         {
             // The pre-game active-session takeover warning is the user-visible breakage from #693: an evicted

--- a/Game.Api.Tests/Integration/DefeatEnemySocketTests.cs
+++ b/Game.Api.Tests/Integration/DefeatEnemySocketTests.cs
@@ -114,6 +114,52 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task DefeatEnemy_BattleCompletedLongBeforePostBattleCooldownWindow_CooldownClampedToZero()
+        {
+            var (userId, playerId) = await SeedAndLoginAsync();
+
+            var wsClient = Factory.Server.CreateWebSocketClient();
+
+            await using (var socketClient1 = new TestSocketClient())
+            {
+                await socketClient1.ConnectAsync(wsClient, userId);
+
+                var newEnemyResponse = await socketClient1.SendCommandAsync<NewEnemyModel>(
+                    "NewEnemy", new { NewZoneId = (int?)null });
+                Assert.Null(newEnemyResponse.Error);
+
+                await socketClient1.CloseAsync();
+            }
+
+            // Backdate the battle start well past its own replay duration plus the 5s post-battle cooldown, so
+            // the victory's cooldown anchor (battleCompletedAt + cooldown, #2242) is already in the past by the
+            // time the command computes the response — reproducing the unclamped-negative-Cooldown scenario.
+            await SetPlayerState(userId, playerId, state =>
+            {
+                state.SetActiveBattle(
+                    state.ActiveEnemyId!.Value,
+                    state.ActiveEnemyLevel!.Value,
+                    state.ActiveEnemySkillIds!,
+                    state.BattleSeed!.Value,
+                    startTime: DateTime.UtcNow.AddMinutes(-30),
+                    state.Snapshot!,
+                    zoneId: state.BattleZoneId ?? 0,
+                    isBossBattle: state.IsBossBattle
+                );
+            });
+
+            await using var socketClient = new TestSocketClient();
+            await socketClient.ConnectAsync(wsClient, userId);
+
+            var response = await socketClient.SendCommandAsync<DefeatEnemyResponse>(
+                "DefeatEnemy", new { });
+
+            Assert.Null(response.Error);
+            Assert.NotNull(response.Data);
+            Assert.Equal(0, response.Data.Cooldown);
+        }
+
+        [Fact]
         public async Task DefeatEnemy_NoActiveBattle_ReturnsError()
         {
             var (userId, _) = await SeedAndLoginAsync();

--- a/Game.Api/Controllers/AuthController.cs
+++ b/Game.Api/Controllers/AuthController.cs
@@ -146,6 +146,13 @@ namespace Game.Api.Controllers
             // the HTTP pipeline no longer reads the session cache per request.
             await _sessionInitializer.EnsureSessionLoaded(HttpContext.RequestAborted);
 
+            // A pre-selection token (post-Login, pre-SelectPlayer) has no player to check presence for —
+            // mirrors Status's guard rather than probing player id 0.
+            if (_sessionService.TokenSelectedPlayerId is null)
+            {
+                return ApiResponse.Error("No character selected.", ApiErrorCategory.NoPlayerSelected);
+            }
+
             var active = await _socketManager.HasActiveSocket(_sessionService.SelectedPlayerId);
             return ApiResponse.Success(new ActiveSessionResult { Active = active });
         }

--- a/Game.Api/Sockets/Commands/BattleLost.cs
+++ b/Game.Api/Sockets/Commands/BattleLost.cs
@@ -49,7 +49,7 @@ namespace Game.Api.Sockets.Commands
                 var now = DateTime.UtcNow;
                 return Success(new BattleLostResponse
                 {
-                    Cooldown = (state.EnemyCooldown - now).TotalMilliseconds,
+                    Cooldown = state.IsOnCooldown(now) ? (state.EnemyCooldown - now).TotalMilliseconds : 0,
                     NextEnemy = next is not null ? EnemyInstance.FromSource(next) : null,
                     NextZoneId = next is not null ? player.CurrentZoneId : null,
                 });

--- a/Game.Api/Sockets/Commands/DefeatEnemy.cs
+++ b/Game.Api/Sockets/Commands/DefeatEnemy.cs
@@ -64,7 +64,7 @@ namespace Game.Api.Sockets.Commands
                 var now = DateTime.UtcNow;
                 return Success(new DefeatEnemyResponse
                 {
-                    Cooldown = (state.EnemyCooldown - now).TotalMilliseconds,
+                    Cooldown = state.IsOnCooldown(now) ? (state.EnemyCooldown - now).TotalMilliseconds : 0,
                     Rewards = new DefeatRewards(rewards),
                     NextEnemy = nextEnemy,
                     NextZoneId = nextZoneId,


### PR DESCRIPTION
## Summary

Two small consistency fixes in `Game.Api`, both one-line alignments with existing sibling patterns:

1. **`ActiveSession` now guards on a pre-selection token.** `Status` and the socket handshake already surface `NoPlayerSelected` when `TokenSelectedPlayerId` is null, but `ActiveSession` skipped that guard, letting `SelectedPlayerId` resolve to `0` and probing a nonexistent `PlayerSocket_0` in Redis. `ActiveSession` now returns the same `NoPlayerSelected` error as `Status` for a pre-selection token, instead of doing the pointless round trip.
2. **`DefeatEnemy`/`BattleLost` success paths now clamp `Cooldown` to 0.** Both emitted the raw `(state.EnemyCooldown - now).TotalMilliseconds`, which can go negative if the command runs longer than the post-battle cooldown (e.g. a slow prefetch/save). Their own error paths, and `NewEnemy`/`ChallengeBoss`, already guard with `state.IsOnCooldown(now)` before emitting — the two success paths now do the same.

## How this addresses the issue

Closes #2242 — implements exactly the two fixes described there.

## Test plan

- [x] Added `AuthControllerTests.ActiveSession_PreSelectionToken_ReturnsNoPlayerSelectedNotProbingPlayerZero`, mirroring the existing `Status_PreSelectionToken_ReturnsNoPlayerSelectedNotOpaque404`.
- [x] Added `DefeatEnemySocketTests.DefeatEnemy_BattleCompletedLongBeforePostBattleCooldownWindow_CooldownClampedToZero`, which backdates the battle start far enough that the victory's cooldown anchor (`battleCompletedAt + PostBattleCooldown`) is already in the past — deterministically reproducing the unclamped-negative-`Cooldown` scenario and asserting it's now clamped to `0`.
- [x] `BattleLost`'s identical clamp isn't independently regression-tested: unlike `DefeatEnemy`'s victory path (anchored to the server-replayed `battleCompletedAt`), a loss anchors its cooldown to `now + PostBattleCooldown` at computation time, so reproducing its negative case deterministically would require injecting a real ~5s delay (there's no clock abstraction in this codebase to fake it) rather than backdating state. The fix is the same one-line ternary already covered by the `DefeatEnemy` test and the existing `NewEnemy`/`ChallengeBoss` clamp pattern.
- [x] `dotnet build` — solution builds clean.
- [x] `dotnet test` — full backend suite green (1417 + 68 + 1062 + 850 = 3397 tests, 0 failures).
- No frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q73ZE94vP7qps6iLRKQHei)_