### PR TITLE
Bound the unbounded authored text columns

### DIFF
--- a/Game.Infrastructure/Database/GameContext.cs
+++ b/Game.Infrastructure/Database/GameContext.cs
@@ -104,6 +104,9 @@ namespace Game.Infrastructure.Database
                 entity.Property(a => a.Name)
                     .HasMaxLength(50);
 
+                entity.Property(a => a.Description)
+                    .HasMaxLength(500);
+
                 entity.HasData(Core.Attributes.Attribute.GetAllAttributes().Select(a =>
                 {
                     return new Attribute
@@ -276,6 +279,12 @@ namespace Game.Infrastructure.Database
                 entity.Property(i => i.Name)
                     .HasMaxLength(50);
 
+                entity.Property(i => i.Description)
+                    .HasMaxLength(500);
+
+                entity.Property(i => i.IconPath)
+                    .HasMaxLength(50);
+
                 entity.Property(i => i.DesignerNotes)
                     .HasMaxLength(2000);
 
@@ -331,6 +340,9 @@ namespace Game.Infrastructure.Database
 
                 entity.Property(im => im.Name)
                     .HasMaxLength(50);
+
+                entity.Property(im => im.Description)
+                    .HasMaxLength(500);
 
                 entity.Property(im => im.DesignerNotes)
                     .HasMaxLength(2000);
@@ -502,6 +514,9 @@ namespace Game.Infrastructure.Database
 
                 entity.Property(s => s.Name)
                     .HasMaxLength(50);
+
+                entity.Property(s => s.Description)
+                    .HasMaxLength(500);
 
                 entity.Property(s => s.IconPath)
                     .HasMaxLength(50);
@@ -900,6 +915,9 @@ namespace Game.Infrastructure.Database
 
                 entity.Property(z => z.Name)
                     .HasMaxLength(50);
+
+                entity.Property(z => z.Description)
+                    .HasMaxLength(500);
 
                 entity.Property(z => z.DesignerNotes)
                     .HasMaxLength(2000);

--- a/Game.Infrastructure/Migrations/20260721181331_BoundAuthoredTextColumns.Designer.cs
+++ b/Game.Infrastructure/Migrations/20260721181331_BoundAuthoredTextColumns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Game.Infrastructure.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20260721181331_BoundAuthoredTextColumns")]
+    partial class BoundAuthoredTextColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Game.Infrastructure/Migrations/20260721181331_BoundAuthoredTextColumns.cs
+++ b/Game.Infrastructure/Migrations/20260721181331_BoundAuthoredTextColumns.cs
@@ -1,0 +1,126 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Game.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class BoundAuthoredTextColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Zones",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Skills",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "IconPath",
+                table: "Items",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Items",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "ItemMods",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Attributes",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Zones",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Skills",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "IconPath",
+                table: "Items",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Items",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "ItemMods",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Attributes",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500);
+        }
+    }
+}

--- a/UI/src/routes/admin/workbench/components/FieldControl.svelte
+++ b/UI/src/routes/admin/workbench/components/FieldControl.svelte
@@ -24,6 +24,7 @@
 			class:invalid={!!warn}
 			aria-label={field.label}
 			placeholder={field.placeholder}
+			maxlength={field.maxLength}
 			value={value as string}
 			oninput={(e) => set(e.currentTarget.value)}
 		></textarea>
@@ -106,6 +107,7 @@
 			class:invalid={!!warn}
 			aria-label={field.label}
 			placeholder={field.placeholder}
+			maxlength={field.maxLength}
 			value={value as string}
 			oninput={(e) => set(e.currentTarget.value)}
 		/>

--- a/UI/src/routes/admin/workbench/entities/item-mod.ts
+++ b/UI/src/routes/admin/workbench/entities/item-mod.ts
@@ -62,7 +62,8 @@ export const itemModEntity: EntityConfig<IItemMod> = {
 					placeholder: 'Describe this mod…',
 					grow: true,
 					required: true,
-					reqMsg: 'No description'
+					reqMsg: 'No description',
+					maxLength: 500
 				},
 				{
 					key: 'designerNotes',

--- a/UI/src/routes/admin/workbench/entities/item.ts
+++ b/UI/src/routes/admin/workbench/entities/item.ts
@@ -103,7 +103,8 @@ export const itemEntity: EntityConfig<WorkbenchItem> = {
 					placeholder: 'items/icon.png',
 					grow: true,
 					required: true,
-					reqMsg: 'No icon path'
+					reqMsg: 'No icon path',
+					maxLength: 50
 				},
 				{
 					key: 'grantedSkillId',
@@ -127,7 +128,14 @@ export const itemEntity: EntityConfig<WorkbenchItem> = {
 					width: 240
 				},
 				{ key: 'requiredProficiencyLevel', label: 'Required Level', type: 'number', width: 150 },
-				{ key: 'description', label: 'Description', type: 'textarea', placeholder: 'Flavor text…', grow: true },
+				{
+					key: 'description',
+					label: 'Description',
+					type: 'textarea',
+					placeholder: 'Flavor text…',
+					grow: true,
+					maxLength: 500
+				},
 				{
 					key: 'designerNotes',
 					label: 'Designer Notes',

--- a/UI/src/routes/admin/workbench/entities/skill.ts
+++ b/UI/src/routes/admin/workbench/entities/skill.ts
@@ -111,7 +111,8 @@ export const skillEntity: EntityConfig<ISkill> = {
 					placeholder: 'Describe what this skill does…',
 					grow: true,
 					required: true,
-					reqMsg: 'No description'
+					reqMsg: 'No description',
+					maxLength: 500
 				},
 				{
 					key: 'designerNotes',

--- a/UI/src/routes/admin/workbench/entities/types.ts
+++ b/UI/src/routes/admin/workbench/entities/types.ts
@@ -45,6 +45,8 @@ export interface FieldConfig<T> {
 	 *  provider as `select` — used for every EAttribute picker now the enum is large (#1327). */
 	type: 'text' | 'number' | 'toggle' | 'textarea' | 'select' | 'attribute' | 'flags';
 	placeholder?: string;
+	/** Enforces the backend column's `HasMaxLength` bound on a text/textarea field. */
+	maxLength?: number;
 	/** Lets a text/textarea field stretch to fill the row. */
 	grow?: boolean;
 	/** Fixed width (px) for number/select fields. */

--- a/UI/src/routes/admin/workbench/entities/zone.ts
+++ b/UI/src/routes/admin/workbench/entities/zone.ts
@@ -127,7 +127,8 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 					placeholder: 'Describe this zone…',
 					grow: true,
 					required: true,
-					reqMsg: 'No description'
+					reqMsg: 'No description',
+					maxLength: 500
 				},
 				{
 					key: 'isHome',


### PR DESCRIPTION
## Summary

- Adds `HasMaxLength` configs in `GameContext.cs` for the six columns that had drifted to unbounded `text` while every other authored string is capped at the DB level: `Item.Description` (500), `Item.IconPath` (50), `ItemMod.Description` (500), `Skill.Description` (500), `Zone.Description` (500), `Attribute.Description` (500) — matching the existing `Challenge.Description`/`Path.Description`/`Proficiency.Description` (500) and `Skill.IconPath`/`Proficiency.IconPath` (50) precedent.
- One EF Core migration (`BoundAuthoredTextColumns`) altering those six columns to `varchar(n)`. No back-compat shim per CLAUDE.md (pre-release).
- Aligns the admin Workbench's input `maxlength` to match: added an optional `maxLength` prop to `FieldConfig<T>` (`entities/types.ts`) and threaded it through `FieldControl.svelte`'s `<input>`/`<textarea>`, then set it on the `Item`/`ItemMod`/`Skill`/`Zone` description fields and `Item.iconPath`. No `maxlength` convention existed anywhere in the Workbench before this (verified — none of the previously-bounded fields like `Challenge.Description` enforce one client-side either), so this introduces the pattern rather than mirroring an existing one; it's scoped to just the fields this issue touches.
- `Attribute` isn't editable through the Workbench (no admin endpoint/UI exists for it — it's only ever seeded/read as reference data), so there's no client-side counterpart to update for that column.

## How this addresses the issue

Closes #2243. Fixes the confirmed drift: `Item.IconPath` was unbounded while `Skill.IconPath`/`Proficiency.IconPath` are capped at 50 with no comment explaining the deviation, and the five `Description` columns were unbounded while every other authored `Description` is capped at 500.

## Test plan

- [x] `dotnet build Game.sln` — succeeds, 0 warnings/errors
- [x] `dotnet test Game.sln` — full suite passes (Core: 1417, Infrastructure: 68, Application: 1062, Api: 850 — all green)
- [x] `npm run lint` (ESLint + svelte-check) — clean
- [x] `npm run test:unit:ci` — 3879/3879 tests pass across 310 files
- [x] Reviewed the generated migration — `AlterColumn` on exactly the six flagged columns, `text` → `character varying(n)`, both `Up`/`Down` present

Closes #2243


---
_Generated by [Claude Code](https://claude.ai/code/session_01TfdMxjkkFNX291LaFnn98v)_