### PR TITLE
Hygiene sweep: trim/document minor nits from the health review

### DIFF
--- a/Game.Abstractions/Infrastructure/Enums.cs
+++ b/Game.Abstractions/Infrastructure/Enums.cs
@@ -2,6 +2,8 @@
 {
     public enum CacheSystem
     {
+        // Deliberately starts at 0, unlike DatabaseSystem: an unset config selects Redis rather than failing
+        // loud. A missing connection string still throws in RedisMultiplexerFactory, so this stays safe.
         Redis = 0
     }
 
@@ -14,6 +16,8 @@
 
     public enum PubSubSystem
     {
+        // Deliberately starts at 0, unlike DatabaseSystem: an unset config selects Redis rather than failing
+        // loud. A missing connection string still throws in RedisMultiplexerFactory, so this stays safe.
         Redis = 0
     }
 }

--- a/Game.Core/Battle/Offline/OfflineLoopMode.cs
+++ b/Game.Core/Battle/Offline/OfflineLoopMode.cs
@@ -13,7 +13,7 @@ namespace Game.Core.Battle.Offline
         Idle,
 
         /// <summary>Auto-challenging the current zone's dedicated boss: the same boss each battle, with a fresh
-        /// seed so the crit/dodge/block RNG can vary the outcome.</summary>
+        /// seed so the crit/dodge/parry/reflection RNG can vary the outcome.</summary>
         Boss,
     }
 }

--- a/Game.Infrastructure/BackgroundWorker.cs
+++ b/Game.Infrastructure/BackgroundWorker.cs
@@ -11,7 +11,9 @@ namespace Game.Infrastructure
     /// is no longer needed. <see cref="Dispose"/> implies <see cref="Kill"/>.
     /// </para>
     /// </summary>
-    public class BackgroundWorker : IDisposable
+    // No consumer outside Game.Infrastructure; internal rather than public keeps it out of the assembly's public
+    // surface (both test assemblies reach it via InternalsVisibleTo).
+    internal class BackgroundWorker : IDisposable
     {
         private readonly AutoResetEvent _resetEvent = new(false);
         private readonly ILogger<BackgroundWorker> _logger;

--- a/Game.Infrastructure/Database/GameContextFactory.cs
+++ b/Game.Infrastructure/Database/GameContextFactory.cs
@@ -6,6 +6,9 @@ namespace Game.Infrastructure.Database
 {
     internal static class GameContextFactory
     {
+        // Production only uses the Configure seam below (via AddGameContext); this wrapper exists so unit tests
+        // can assert the fully-configured DbContextOptions (e.g. the resolved provider) without opening a
+        // connection or standing up DI.
         public static GameContext GetGameContext(IDatabaseOptions config, ILoggerFactory loggerFactory)
         {
             var optionsBuilder = new DbContextOptionsBuilder<GameContext>();

--- a/UI/src/routes/admin/workbench/components/UsageSection.svelte
+++ b/UI/src/routes/admin/workbench/components/UsageSection.svelte
@@ -7,8 +7,8 @@
 		<span class="usage-note">read-only · derived from item &amp; mod tag lists</span>
 	</div>
 	<div class="usage-groups">
-		{@render group('Items', 'box', usage.itemList, 'items', true)}
-		{@render group('Item Mods', 'rune', usage.modList, 'mods', true)}
+		{@render group('Items', 'box', usage.itemList, 'items')}
+		{@render group('Item Mods', 'rune', usage.modList, 'mods')}
 	</div>
 </div>
 
@@ -16,8 +16,7 @@
 	label: string,
 	glyph: WorkbenchIconKind,
 	list: { id: number; name: string; rarityId?: number }[],
-	noun: string,
-	withRarity: boolean
+	noun: string
 )}
 	<div class="usage-group">
 		<div class="sec-title">
@@ -30,7 +29,7 @@
 			<div class="usage-tags">
 				{#each list.slice(0, 40) as record (record.id)}
 					<span class="ov-tag">
-						{#if withRarity && record.rarityId}
+						{#if record.rarityId}
 							<span class="tdot" style:background={reference.rarityColor(record.rarityId)}></span>
 						{/if}
 						{record.name}


### PR DESCRIPTION
## Summary

Addresses the smaller items from the #2245 hygiene sweep:

- **`BackgroundWorker`** (`Game.Infrastructure/BackgroundWorker.cs`): changed from `public` to `internal`. Its only production consumer is `RedisPubSubService` within the same assembly; `Game.Infrastructure.csproj` grants `InternalsVisibleTo` to `Game.TestInfrastructure` and `Game.Infrastructure.Tests`, so both still reach it.
- **`GameContextFactory.GetGameContext`**: added a short comment explaining it's an intentional test seam (production only uses the shared `Configure` method via `AddGameContext`), rather than dropping it — two test files rely on it to assert the fully-configured `DbContextOptions` (e.g. resolved provider name) without opening a connection.
- **`CacheSystem`/`PubSubSystem`** (`Game.Abstractions/Infrastructure/Enums.cs`): documented the deliberate `0 = Redis` default (contrasting with `DatabaseSystem`'s intentional fail-loud `1`-start policy from #453) directly on the enums, matching the existing test-level documentation in `CacheServiceFactoryTests`/`PubSubServiceFactoryTests`.
- **`UsageSection.svelte`**: removed the `withRarity` snippet parameter, which was always passed `true` at both call sites — dead branch flag.
- **`OfflineLoopMode.Boss`**: fixed a stale doc comment referencing "block" RNG (retired in spike #1330, replaced by parry/reflection).

### Deliberately out of scope

The issue also flagged `SortedLinkedList.Count`/its `Comparison<T>` convenience ctor and `BackgroundWorker`'s `IsRunning`/synchronous ctor/`Kill()` as test-only surface. I left these alone:

- `SortedLinkedList` is a small general-purpose collection type; `Count` is standard collection API, and both members are exercised across a substantial, legitimate test suite (`SortedLinkedListTests`). Trimming them wouldn't reduce risk meaningfully and would just make the type less idiomatic.
- `BackgroundWorker`'s `IsRunning`/sync ctor/`Kill()` back a fairly elaborate concurrency test suite (`BackgroundWorkerTests`) that pins real invariants (double-run prevention, signal coalescing, disposal races). Removing them for "no production reader" would gut that coverage without a production benefit — `internal` already addresses the actual public-surface concern the issue raised.

Both felt like judgment calls beyond what a bundled hygiene sweep should force through, so I scoped this PR to the safe, unambiguous items.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test --no-build --no-restore` — all 4 backend suites green (Core, Infrastructure, Application, Api)
- [x] `npm run lint` (UI) — clean
- [x] `npm run test:unit:ci` (UI) — 310 files / 3879 tests passed

Closes #2245
