### PR TITLE
Extend Workbench client-side maxLength to the remaining already-bounded editable fields

### DIFF
--- a/UI/src/routes/admin/workbench/entities/challenge.ts
+++ b/UI/src/routes/admin/workbench/entities/challenge.ts
@@ -68,14 +68,16 @@ export const challengeEntity: EntityConfig<IChallenge> = {
 					placeholder: 'Describe the objective shown to players…',
 					grow: true,
 					required: true,
-					reqMsg: 'No description'
+					reqMsg: 'No description',
+					maxLength: 500
 				},
 				{
 					key: 'designerNotes',
 					label: 'Designer Notes',
 					type: 'textarea',
 					placeholder: 'Why this challenge exists — authoring notes (never shown to players)…',
-					grow: true
+					grow: true,
+					maxLength: 2000
 				}
 			]
 		},

--- a/UI/src/routes/admin/workbench/entities/item-mod.ts
+++ b/UI/src/routes/admin/workbench/entities/item-mod.ts
@@ -70,7 +70,8 @@ export const itemModEntity: EntityConfig<IItemMod> = {
 					label: 'Designer Notes',
 					type: 'textarea',
 					placeholder: 'Why this mod exists — authoring notes (never shown to players)…',
-					grow: true
+					grow: true,
+					maxLength: 2000
 				}
 			]
 		},

--- a/UI/src/routes/admin/workbench/entities/item.ts
+++ b/UI/src/routes/admin/workbench/entities/item.ts
@@ -141,7 +141,8 @@ export const itemEntity: EntityConfig<WorkbenchItem> = {
 					label: 'Designer Notes',
 					type: 'textarea',
 					placeholder: 'Why this item exists — authoring notes (never shown to players)…',
-					grow: true
+					grow: true,
+					maxLength: 2000
 				}
 			]
 		},

--- a/UI/src/routes/admin/workbench/entities/skill.ts
+++ b/UI/src/routes/admin/workbench/entities/skill.ts
@@ -90,7 +90,14 @@ export const skillEntity: EntityConfig<ISkill> = {
 				},
 				{ key: 'cooldownMs', label: 'Cooldown', type: 'number', suffix: 'ms', width: 150 },
 				{ key: 'rarityId', label: 'Rarity', type: 'select', options: reference.rarityOptions, width: 170 },
-				{ key: 'iconPath', label: 'Icon Path', type: 'text', placeholder: 'skills/icon.png', grow: true },
+				{
+					key: 'iconPath',
+					label: 'Icon Path',
+					type: 'text',
+					placeholder: 'skills/icon.png',
+					grow: true,
+					maxLength: 50
+				},
 				{ key: 'word', label: 'Word of Power', type: 'text', placeholder: 'sijren', width: 200 },
 				{ key: 'pronunciation', label: 'Pronunciation', type: 'text', placeholder: 'sij·ren', width: 200 },
 				{ key: 'translation', label: 'Translation', type: 'text', placeholder: 'The Riven Frost', grow: true },
@@ -119,7 +126,8 @@ export const skillEntity: EntityConfig<ISkill> = {
 					label: 'Designer Notes',
 					type: 'textarea',
 					placeholder: 'Why this skill exists — authoring notes (never shown to players)…',
-					grow: true
+					grow: true,
+					maxLength: 2000
 				}
 			]
 		},

--- a/UI/src/routes/admin/workbench/entities/zone.ts
+++ b/UI/src/routes/admin/workbench/entities/zone.ts
@@ -142,7 +142,8 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 					label: 'Designer Notes',
 					type: 'textarea',
 					placeholder: 'Why this zone exists — authoring notes (never shown to players)…',
-					grow: true
+					grow: true,
+					maxLength: 2000
 				}
 			]
 		},

--- a/UI/src/routes/admin/workbench/progression/PathDetail.svelte
+++ b/UI/src/routes/admin/workbench/progression/PathDetail.svelte
@@ -45,6 +45,7 @@
 						value={path.description}
 						textarea
 						fullWidth
+						maxLength={500}
 						onChange={(v) => store.patchPath(path.id, (d) => (d.description = v))}
 					/>
 				</div>

--- a/UI/src/routes/admin/workbench/progression/ProgInput.svelte
+++ b/UI/src/routes/admin/workbench/progression/ProgInput.svelte
@@ -6,6 +6,7 @@
 			class:invalid={warn}
 			aria-label={label}
 			{placeholder}
+			maxlength={maxLength}
 			{value}
 			oninput={(e) => onChange(e.currentTarget.value)}
 		></textarea>
@@ -16,6 +17,7 @@
 			class:invalid={warn}
 			aria-label={label}
 			{placeholder}
+			maxlength={maxLength}
 			{value}
 			oninput={(e) => onChange(e.currentTarget.value)}
 		/>
@@ -33,6 +35,7 @@ interface Props {
 	fullWidth?: boolean;
 	mono?: boolean;
 	warn?: boolean;
+	maxLength?: number;
 }
 
 const {
@@ -44,7 +47,8 @@ const {
 	grow = false,
 	fullWidth = false,
 	mono = false,
-	warn = false
+	warn = false,
+	maxLength
 }: Props = $props();
 </script>
 


### PR DESCRIPTION
## Summary

- Adds the matching client-side `maxLength` to every already-`HasMaxLength`-bounded Workbench field the #2256 convention missed: `Skill.IconPath` (50), `Challenge.Description` (500), and the `DesignerNotes` field on `Item`/`ItemMod`/`Skill`/`Zone`/`Challenge` (2000 each).
- Threads a new `maxLength` prop through `ProgInput.svelte` (the progression editor's own text/textarea control — separate from the generic `FieldConfig`/`FieldControl` system used everywhere else in the Workbench) and wires it to `Path.Description` (500) in `PathDetail.svelte`.
- No backend/migration changes — every DB bound already exists in `GameContext.cs`; this is purely additive client-side UX that prevents over-typing the backend would reject anyway.

## Scope note

`Proficiency.Description` was in the issue's list but is verified **not editable anywhere in the Workbench** — `ConlangIdentity.svelte` (the tier/proficiency editor) only exposes `name`/`iconPath`/`word`/`pronunciation`/`translation`/`designerNotes`, never `description`. So there's no UI counterpart to update for that column, mirroring the same call made for `Attribute.Description` in #2256.

While verifying the progression editor, I found other already-bounded `Path`/`Proficiency` fields (`Path.Name`, `Path.DesignerNotes`, `Proficiency.Name`/`IconPath`/`Word`/`Pronunciation`/`Translation`/`DesignerNotes`) that also lack the client-side bound now that `ProgInput` supports it — that's a distinct scope from this issue's explicit list, so I filed #2261 to track it rather than expanding this PR.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — 0 errors
- [x] `npm run test:unit:ci` — 310 files / 3879 tests passed
- No new tests added: this mirrors #2256's precedent exactly (a plain declarative `maxLength` value passed through the existing generic `field.maxLength` → `maxlength` attribute plumbing, which that PR also shipped without dedicated tests).

Closes #2257


---
_Generated by [Claude Code](https://claude.ai/code/session_01KX5xDYYwRRgR6jnHGtiqVb)_