### PR TITLE
Extend ProgInput maxLength to Path/Proficiency's other DB-bounded fields

### DIFF
--- a/UI/src/routes/admin/workbench/progression/ConlangIdentity.svelte
+++ b/UI/src/routes/admin/workbench/progression/ConlangIdentity.svelte
@@ -4,6 +4,7 @@
 		value={tier.name}
 		grow
 		warn={!tier.name.trim()}
+		maxLength={50}
 		onChange={(v) => store.patchProf(tier.id, (d) => (d.name = v))}
 	/>
 	<ProgInput
@@ -11,6 +12,7 @@
 		value={tier.iconPath}
 		mono
 		warn={!tier.iconPath.trim()}
+		maxLength={50}
 		onChange={(v) => store.patchProf(tier.id, (d) => (d.iconPath = v))}
 	/>
 	<div class="ro">
@@ -35,6 +37,7 @@
 			mono
 			fullWidth
 			warn={!tier.word.trim()}
+			maxLength={50}
 			onChange={(v) => store.patchProf(tier.id, (d) => (d.word = v))}
 		/>
 		<ProgInput
@@ -42,6 +45,7 @@
 			value={tier.pronunciation}
 			fullWidth
 			warn={!tier.pronunciation.trim()}
+			maxLength={50}
 			onChange={(v) => store.patchProf(tier.id, (d) => (d.pronunciation = v))}
 		/>
 		<ProgInput
@@ -49,6 +53,7 @@
 			value={tier.translation}
 			fullWidth
 			warn={!tier.translation.trim()}
+			maxLength={100}
 			onChange={(v) => store.patchProf(tier.id, (d) => (d.translation = v))}
 		/>
 	</div>
@@ -80,6 +85,7 @@
 		value={tier.designerNotes}
 		textarea
 		fullWidth
+		maxLength={2000}
 		onChange={(v) => store.patchProf(tier.id, (d) => (d.designerNotes = v))}
 	/>
 </div>

--- a/UI/src/routes/admin/workbench/progression/PathDetail.svelte
+++ b/UI/src/routes/admin/workbench/progression/PathDetail.svelte
@@ -29,6 +29,7 @@
 						value={path.name}
 						grow
 						warn={!path.name.trim()}
+						maxLength={50}
 						onChange={(v) => store.patchPath(path.id, (d) => (d.name = v))}
 					/>
 					<ProgSelect
@@ -55,6 +56,7 @@
 						value={path.designerNotes}
 						textarea
 						fullWidth
+						maxLength={2000}
 						onChange={(v) => store.patchPath(path.id, (d) => (d.designerNotes = v))}
 					/>
 				</div>


### PR DESCRIPTION
## Summary

- Threads the `maxLength` prop `ProgInput.svelte` already supports (added in #2257) through the remaining progression-editor fields that have a matching `HasMaxLength` DB bound but were missed by #2257's explicit scope:
  - `Path.Name` (50), `Path.DesignerNotes` (2000) — `PathDetail.svelte`
  - `Proficiency.Name` (50), `Proficiency.IconPath` (50), `Proficiency.Word` (50), `Proficiency.Pronunciation` (50), `Proficiency.Translation` (100), `Proficiency.DesignerNotes` (2000) — `ConlangIdentity.svelte`
- All bounds verified against `GameContext.cs` (`Path`/`Proficiency` entity configuration) — no backend/migration changes; this is purely additive client-side UX that prevents typing past a limit the backend would reject anyway.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — 0 errors
- [x] `npm run test:unit:ci` — 310 files / 3879 tests passed
- No new tests added: mirrors the precedent set by #2257/#2262 (a declarative `maxLength` value passed through existing prop plumbing), which also shipped without dedicated tests.

Closes #2261


---
_Generated by [Claude Code](https://claude.ai/code/session_017f5pYTcMYcYuNWUTjCuVCi)_