### PR TITLE
Bump EF Core and Microsoft.Extensions.* to 10.0.10 in lockstep (supersedes #2296)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="StackExchange.Redis" Version="3.0.0" />


### PR DESCRIPTION
## Summary

Dependabot PR #2296 bumped the three `Microsoft.EntityFrameworkCore*` packages `10.0.9 → 10.0.10` on their own, but that PR **fails the backend build**. Dependabot's nuget config has no grouping, so it split the coupled framework packages into separate PRs — and EF Core `10.0.10` transitively requires a newer `Microsoft.Extensions.*` than the manifest still pins:

```
error NU1605: Detected package downgrade: Microsoft.Extensions.Logging.Abstractions from 10.0.10 to 10.0.9.
  Game.Infrastructure -> Microsoft.EntityFrameworkCore 10.0.10
    -> Microsoft.Extensions.Caching.Memory 10.0.10
    -> Microsoft.Extensions.Logging.Abstractions (>= 10.0.10)
  Game.Infrastructure -> Microsoft.Extensions.Logging.Abstractions (>= 10.0.9)
```

Under central package management (`Directory.Packages.props`) with `dotnet build -warnaserror`, that downgrade is a hard error and takes down `verify-backend`, `test-backend`, and all e2e suites (which need the backend to build).

This PR does the **coordinated bump** #2296 should have been: the EF Core trio **and** the `Microsoft.Extensions.*` servicing family move to `10.0.10` together, keeping the whole runtime set aligned.

### Changed (`Directory.Packages.props`)

| Package | From | To |
| --- | --- | --- |
| `Microsoft.EntityFrameworkCore` | 10.0.9 | 10.0.10 |
| `Microsoft.EntityFrameworkCore.Design` | 10.0.9 | 10.0.10 |
| `Microsoft.EntityFrameworkCore.Relational` | 10.0.9 | 10.0.10 |
| `Microsoft.Extensions.DependencyInjection.Abstractions` | 10.0.9 | 10.0.10 |
| `Microsoft.Extensions.Hosting.Abstractions` | 10.0.9 | 10.0.10 |
| `Microsoft.Extensions.Logging.Abstractions` | 10.0.9 | 10.0.10 |
| `Microsoft.Extensions.Options` | 10.0.9 | 10.0.10 |

The `Microsoft.AspNetCore.*` packages (`JwtBearer`, `Mvc.Testing`) are intentionally left out — EF Core doesn't force them up, and they already have their own dependabot PRs (#2293, #2294).

**Supersedes #2296** — once this merges, dependabot will auto-close #2296 as its bump is already applied.

## Test plan

- [x] `dotnet build -warnaserror` — 0 warnings, 0 errors (reproduced the NU1605 failure first, confirmed this fix clears it).
- [x] No source changes — version-alignment only; CI (`verify-backend`, `test-backend`, e2e) exercises the full backend + integration suite against the new versions.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1dZ7c45qH6J86MxeaGHec

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1dZ7c45qH6J86MxeaGHec)_