### PR TITLE
Settle queued commands on a WebSocket constructor throw

### DIFF
--- a/UI/src/lib/api/api-socket.ts
+++ b/UI/src/lib/api/api-socket.ts
@@ -173,7 +173,22 @@ export class ApiSocket {
 		// carried as a WebSocket subprotocol instead of a query-string parameter — a query string ends up
 		// verbatim in any downstream access log (e.g. the edge proxy's), while a subprotocol is a
 		// handshake header a default access log format never records (#2211).
-		const socket = accessToken ? new WebSocket('/socket', [accessToken]) : new WebSocket('/socket');
+		let socket: WebSocket;
+		try {
+			socket = accessToken ? new WebSocket('/socket', [accessToken]) : new WebSocket('/socket');
+		} catch (ex) {
+			// The constructor throws synchronously (rather than failing the handshake asynchronously) if
+			// accessToken contains a character outside the RFC 6455 subprotocol token grammar — only
+			// possible with a corrupted/hand-edited stored token, since a real backend JWT is always valid
+			// base64url. A token that can't even form a handshake is dead, so this is unrecoverable like the
+			// "definitively rejected" branch above: settle the queue and route to re-auth rather than
+			// leaving the caller awaiting a connection that will never open.
+			console.error('WebSocket construction failed, likely due to a malformed access token', ex);
+			this.stopPingInterval();
+			this.settleQueuedRequests(CONNECTION_LOST_ERROR);
+			handleAuthFailure();
+			return;
+		}
 		this.socket = socket;
 		socket.onopen = this.onStart.bind(this);
 		socket.onmessage = this.receiveResponse.bind(this);

--- a/UI/src/tests/lib/api/api-socket.test.ts
+++ b/UI/src/tests/lib/api/api-socket.test.ts
@@ -128,6 +128,25 @@ describe('ApiSocket', () => {
 			// A never-logged-in caller (no prior refresh token) must not be routed to the auth-failure path.
 			expect(handleAuthFailure).not.toHaveBeenCalled();
 		});
+
+		it('settles the queue and routes to auth failure when the constructor throws on a malformed token', async () => {
+			// The real WebSocket constructor throws synchronously (a SyntaxError) if the subprotocol string
+			// contains a character outside the RFC 6455 token grammar — only reachable with a corrupted or
+			// hand-edited stored access token.
+			setTokens({ accessToken: 'bad token', refreshToken: 'r' });
+			webSocketMock.mockImplementationOnce(() => {
+				throw new SyntaxError("Failed to construct 'WebSocket': invalid subprotocol");
+			});
+
+			const promise = apiSocket.sendSocketCommand('DefeatEnemy', { clientTotalMs: 1 });
+			await flushMicrotasks();
+
+			// A token that can't even form a handshake is dead: settle the queued command rather than leaving
+			// the caller awaiting a connection that will never open, and route to re-auth.
+			expect(handleAuthFailure).toHaveBeenCalledTimes(1);
+			expect(internals(apiSocket).pingIntervalId).toBeNull();
+			await expect(promise).resolves.toMatchObject({ error: expect.any(String) });
+		});
 	});
 
 	describe('pre-emptive token refresh on open', () => {


### PR DESCRIPTION
## Summary

Since #2216, `openSocket()` passes the access token as a WebSocket subprotocol: `new WebSocket('/socket', [accessToken])`. Unlike the old query-string carry, the constructor **throws synchronously** (`SyntaxError`) if the stored token contains any character outside the RFC 6455 `token` grammar. When that happened, `openSocket()` returned via an uncaught exception, `processCommandQueue`'s `await this.ensureSocket()` rethrew into a `void`-ed call (unhandled rejection), and the queued command was never settled — the caller awaited forever, violating the transport's documented invariant that every terminal path settles the queue (`docs/frontend-sockets.md`).

## Change

`UI/src/lib/api/api-socket.ts`: wrap the `new WebSocket(...)` call in a try/catch. On a constructor throw, treat it like the existing "definitively rejected, no adoptable pair" branch just above it — a token that can't even form a handshake is dead:
- stop the keepalive interval
- settle the queued-but-unsent commands with the connection-lost error
- route to `handleAuthFailure()`

## Test plan

- [x] Added a unit test (`UI/src/tests/lib/api/api-socket.test.ts`) that forces the mocked `WebSocket` constructor to throw and asserts the queued command settles with an error, the keepalive is torn down, and `handleAuthFailure` is called once.
- [x] `npm run lint` (eslint + svelte-check) — clean
- [x] `npm run test:unit:ci` — 3882/3882 passing

This is a frontend-only change; no backend build/tests were affected.

Closes #2270


---
_Generated by [Claude Code](https://claude.ai/code/session_01RiooTCn1yfPtBVg6ESxBah)_