### PR TITLE
Close the tier-reorder bypass of the root-tier-only prerequisite rule

### DIFF
--- a/Game.Application.Tests/DataAccess/AdminProficienciesIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminProficienciesIntegrationTests.cs
@@ -136,6 +136,81 @@ namespace Game.Application.Tests.DataAccess
         }
 
         [Fact]
+        public async Task SaveProficiencies_ReorderStrandsPersistedPrerequisiteOffRoot_ReturnsFailure()
+        {
+            // A root tier already gated by a cross-path prerequisite (via SetPrerequisites) must not be
+            // movable off ordinal 0 through the identity save alone — the progression editor's tier reorder
+            // produces exactly this shape (an ordinal-only Edit that never touches prerequisiteIds), so
+            // ValidatePrerequisiteIds (which only fires from SetPrerequisites) would never see it.
+            int gatedId, prerequisiteId, gatedPathId;
+            using (var seedScope = CreateScope())
+            {
+                var gatedPath = await SeedPathAsync(seedScope);
+                gatedPathId = gatedPath.Id;
+                gatedId = (await SeedProficiencyAsync(seedScope, gatedPath.Id, pathOrdinal: 0, name: "Fire I")).Id;
+                prerequisiteId = (await SeedProficiencyAsync(seedScope, (await SeedPathAsync(seedScope)).Id, pathOrdinal: 0, name: "Frost I")).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            using (var setupScope = CreateScope())
+            {
+                var setupAdmin = setupScope.ServiceProvider.GetRequiredService<IAdminProficiencies>();
+                Assert.True(setupAdmin.SetPrerequisites([
+                    new SetProficiencyPrerequisitesData { Id = gatedId, PrerequisiteIds = [prerequisiteId] },
+                ]).Succeeded);
+                await setupScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+            await ReloadReferenceCachesAsync();
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminProficiencies>();
+
+            var result = admin.SaveProficiencies(
+            [
+                new Change<Contracts.Proficiency> { ChangeType = EChangeType.Edit, Item = NewProficiency(id: gatedId, pathId: gatedPathId, pathOrdinal: 1, name: "Fire I") },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("root tier", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SaveProficiencies_EditsRootTierWithPrerequisitesWithoutMovingOrdinal_IsAccepted()
+        {
+            // The guard must not false-reject an identity edit that leaves an already-gated root tier at
+            // ordinal 0 — only an actual move off root is a violation.
+            int gatedId, prerequisiteId, gatedPathId;
+            using (var seedScope = CreateScope())
+            {
+                var gatedPath = await SeedPathAsync(seedScope);
+                gatedPathId = gatedPath.Id;
+                gatedId = (await SeedProficiencyAsync(seedScope, gatedPath.Id, pathOrdinal: 0, name: "Fire I")).Id;
+                prerequisiteId = (await SeedProficiencyAsync(seedScope, (await SeedPathAsync(seedScope)).Id, pathOrdinal: 0, name: "Frost I")).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            using (var setupScope = CreateScope())
+            {
+                var setupAdmin = setupScope.ServiceProvider.GetRequiredService<IAdminProficiencies>();
+                Assert.True(setupAdmin.SetPrerequisites([
+                    new SetProficiencyPrerequisitesData { Id = gatedId, PrerequisiteIds = [prerequisiteId] },
+                ]).Succeeded);
+                await setupScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+            await ReloadReferenceCachesAsync();
+
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminProficiencies>();
+
+            var result = admin.SaveProficiencies(
+            [
+                new Change<Contracts.Proficiency> { ChangeType = EChangeType.Edit, Item = NewProficiency(id: gatedId, pathId: gatedPathId, pathOrdinal: 0, name: "Fire I Renamed") },
+            ]);
+
+            Assert.True(result.Succeeded, result.ErrorMessage);
+        }
+
+        [Fact]
         public async Task SaveProficiencies_TwoAddsSameOrdinalSamePath_IsRejected()
         {
             int pathId;

--- a/Game.DataAccess/Repositories/Admin/AdminProficiencies.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminProficiencies.cs
@@ -50,6 +50,14 @@ namespace Game.DataAccess.Repositories.Admin
                 return maxLevelRejection;
             }
 
+            // ValidatePrerequisiteIds only fires from SetPrerequisites, so an identity-only ordinal edit
+            // (e.g. a reorder that never touches the prerequisite set) can move an already-gated tier off
+            // its path's root without ever being checked against the same rule. Reject that here too.
+            if (FindPrerequisiteRootViolation(changes) is { } prerequisiteRootRejection)
+            {
+                return prerequisiteRootRejection;
+            }
+
             return ChangeSetProcessor.Apply(changes,
                 add: item => _entityStore.Insert(ToEntity(item)),
                 edit: item =>
@@ -363,6 +371,43 @@ namespace Game.DataAccess.Repositories.Admin
                     var pathName = _proficiencies.LookupPath(tier.PathId)?.Name;
                     var pathLabel = pathName is null ? $"{tier.PathId}" : $"'{pathName}'";
                     return AdminSaveResult.Failure($"Path {pathLabel} has two tiers at ordinal {tier.PathOrdinal}.");
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>Returns a rejection if the prospective per-proficiency ordinals would leave a
+        /// prerequisite-carrying tier off its path's root (ordinal 0), else null. Mirrors the rule
+        /// <see cref="ValidatePrerequisiteIds"/> enforces on <c>SetPrerequisites</c>, but that check only
+        /// fires when the prerequisite set itself changes — an identity-only ordinal edit (e.g. the
+        /// progression editor's tier reorder) never calls it, so a tier that already carries persisted
+        /// prerequisites could otherwise be reordered off root through this save alone. Only Edits can move
+        /// an existing tier's ordinal; an Add starts with no prerequisites, so it can't violate this on its
+        /// own.</summary>
+        private AdminSaveResult? FindPrerequisiteRootViolation(IReadOnlyList<Change<Contracts.Proficiency>> changes)
+        {
+            var prospectiveOrdinal = new Dictionary<int, int>();
+            foreach (var change in changes)
+            {
+                if (change.ChangeType == EChangeType.Edit)
+                {
+                    prospectiveOrdinal[change.Item.Id] = change.Item.PathOrdinal;
+                }
+            }
+
+            foreach (var proficiency in _proficiencies.AllProficiencyEntities())
+            {
+                if (proficiency.Prerequisites.Count == 0)
+                {
+                    continue;
+                }
+
+                var ordinal = prospectiveOrdinal.TryGetValue(proficiency.Id, out var edited) ? edited : proficiency.PathOrdinal;
+                if (ordinal != 0)
+                {
+                    return AdminSaveResult.Failure(
+                        $"Proficiency '{proficiency.Name}' carries prerequisites and cannot move off its path's root tier (ordinal {ordinal}).");
                 }
             }
 

--- a/UI/src/routes/admin/workbench/progression/GatewaysEditor.svelte
+++ b/UI/src/routes/admin/workbench/progression/GatewaysEditor.svelte
@@ -31,11 +31,19 @@
 			<div class="opens-name">{tier.name || 'This tier'} · Tier {tier.pathOrdinal}</div>
 		</div>
 	</div>
+	{#if tier.pathOrdinal !== 0}
+		<div class="non-root-warning">
+			This tier is no longer its path's root — prerequisites are only allowed on a root tier. Remove them or move this
+			tier back to the top.
+		</div>
+	{/if}
 {/if}
 
-<div class="add-prereq">
-	<ProgSelect label="Add prerequisite" width={340} value={addPick} options={addOptions} onChange={onAddPrereq} />
-</div>
+{#if tier.pathOrdinal === 0}
+	<div class="add-prereq">
+		<ProgSelect label="Add prerequisite" width={340} value={addPick} options={addOptions} onChange={onAddPrereq} />
+	</div>
+{/if}
 
 <script lang="ts">
 import WorkbenchIcon from '../WorkbenchIcon.svelte';
@@ -104,6 +112,15 @@ const onAddPrereq = (value: number) => {
 	padding: 16px;
 	font-size: 13px;
 	color: var(--text-tertiary);
+}
+.non-root-warning {
+	margin-top: 12px;
+	background: color-mix(in srgb, var(--warning) 10%, transparent);
+	border: 1px solid var(--warning);
+	border-radius: 5px;
+	padding: 12px 16px;
+	font-size: 12.5px;
+	color: var(--text-secondary);
 }
 .gated {
 	display: flex;

--- a/UI/src/routes/admin/workbench/progression/TierDetail.svelte
+++ b/UI/src/routes/admin/workbench/progression/TierDetail.svelte
@@ -15,7 +15,8 @@
 				key: 'gateways',
 				label: 'Gateways',
 				count: tier.prerequisiteIds.length,
-				disabled: !isRoot && tier.prerequisiteIds.length === 0
+				disabled: !isRoot && tier.prerequisiteIds.length === 0,
+				warn: gatewaysWarn
 			}
 		]}
 		activeTab={store.tierTab}
@@ -68,7 +69,7 @@
 import { childChanged } from '../save-helpers';
 import { referenceSourcesFromStatic, retireWithConfirm } from '../retire-confirm';
 import type { ProgressionStore, TierTab } from './progression-store.svelte';
-import { payoutLevels, proficiencyBlockingWarnings } from './progression-helpers';
+import { levelRangeWarnings, payoutLevels, prerequisiteRootWarnings } from './progression-helpers';
 import DetailHeader from '../components/DetailHeader.svelte';
 import ConlangIdentity from './ConlangIdentity.svelte';
 import XpCurve from './XpCurve.svelte';
@@ -111,7 +112,8 @@ const identityWarn = $derived(
 			!tier.iconPath.trim())
 );
 const xpWarn = $derived(!!tier && (tier.maxLevel < 1 || !(tier.baseXp > 0) || !(tier.xpGrowth > 0)));
-const milestoneWarn = $derived(!!tier && proficiencyBlockingWarnings(tier).length > 0);
+const milestoneWarn = $derived(!!tier && levelRangeWarnings(tier).length > 0);
+const gatewaysWarn = $derived(!!tier && prerequisiteRootWarnings(tier).length > 0);
 const milestonesDirty = $derived(
 	!!baseline &&
 		(childChanged(tier?.levelModifiers, baseline.levelModifiers) ||

--- a/UI/src/routes/admin/workbench/progression/progression-helpers.ts
+++ b/UI/src/routes/admin/workbench/progression/progression-helpers.ts
@@ -158,13 +158,23 @@ export const pathWarnings = (path: WorkbenchPath): string[] => {
 };
 
 /**
+ * A tier carrying prerequisites that isn't (or would no longer be) its path's root tier — the same rule
+ * AdminProficiencies.ValidatePrerequisiteIds/FindPrerequisiteRootViolation hard-rejects a save over.
+ * Root-only gating is asserted at authoring time (#2236); a tier reorder can strand an already-gated
+ * root tier off ordinal 0 without ever touching prerequisiteIds, so this must be checked against the
+ * about-to-be-saved pathOrdinal, not just at the point prerequisites are edited.
+ */
+export const prerequisiteRootWarnings = (prof: WorkbenchProficiency): string[] =>
+	prof.pathOrdinal !== 0 && prof.prerequisiteIds.length > 0 ? ['Prerequisites are only allowed on a root tier'] : [];
+
+/**
  * An out-of-range modifier/reward level, checked against the tier's own (about-to-be-saved) MaxLevel.
  * This is the one proficiency condition the backend genuinely hard-rejects a save over — via
  * AdminProficiencies.FindShrunkenMaxLevelViolation (the identity edit, against a still-persisted
  * payout) or FindLevelOutOfRange (SetModifiers/SetRewards, against the tier's saved MaxLevel) — so it
  * doubles as {@link proficiencyBlockingWarnings}, unlike the rest of {@link proficiencyWarnings}.
  */
-const levelRangeWarnings = (prof: WorkbenchProficiency): string[] => {
+export const levelRangeWarnings = (prof: WorkbenchProficiency): string[] => {
 	const warnings: string[] = [];
 	for (const modifier of prof.levelModifiers) {
 		if (modifier.level < 0 || modifier.level > prof.maxLevel) {
@@ -198,16 +208,19 @@ export const proficiencyWarnings = (prof: WorkbenchProficiency): string[] => {
 	if (!(prof.baseXp > 0) || !(prof.xpGrowth > 0)) {
 		warnings.push('XP curve must be positive');
 	}
-	return [...warnings, ...levelRangeWarnings(prof)];
+	return [...warnings, ...levelRangeWarnings(prof), ...prerequisiteRootWarnings(prof)];
 };
 
 /**
  * The subset of {@link proficiencyWarnings} the backend is known to hard-reject a save over — see
- * {@link levelRangeWarnings}. `MaxLevel < 1` and a non-positive XP curve stay advisory-only: neither
- * `Contracts.Proficiency` nor `AdminProficiencies` rejects them, so gating Save on them would block a
- * save the backend would actually accept.
+ * {@link levelRangeWarnings} and {@link prerequisiteRootWarnings}. `MaxLevel < 1` and a non-positive XP
+ * curve stay advisory-only: neither `Contracts.Proficiency` nor `AdminProficiencies` rejects them, so
+ * gating Save on them would block a save the backend would actually accept.
  */
-export const proficiencyBlockingWarnings = (prof: WorkbenchProficiency): string[] => levelRangeWarnings(prof);
+export const proficiencyBlockingWarnings = (prof: WorkbenchProficiency): string[] => [
+	...levelRangeWarnings(prof),
+	...prerequisiteRootWarnings(prof)
+];
 
 // ── Persisted DTOs (identity-level Add/Edit; child collections go through their own endpoints) ──
 

--- a/UI/src/tests/routes/admin/workbench/progression/GatewaysEditor.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/GatewaysEditor.test.ts
@@ -82,6 +82,36 @@ describe('GatewaysEditor — cross-path-only prerequisite picker (#2128)', () =>
 	});
 });
 
+describe('GatewaysEditor — root-tier-only authoring (#2275)', () => {
+	it('hides the "Add prerequisite" picker on a non-root tier', () => {
+		const nonRoot = tier({ id: 0, pathId: 0, pathOrdinal: 1, name: 'Fire II' });
+		const store = makeStore([nonRoot]);
+
+		render(GatewaysEditor, { store, tier: nonRoot });
+
+		expect(screen.queryByRole('combobox', { name: 'Add prerequisite' })).toBeNull();
+	});
+
+	it('still shows the picker on a root tier', () => {
+		const root = tier({ id: 0, pathId: 0, pathOrdinal: 0, name: 'Fire I' });
+		const store = makeStore([root]);
+
+		render(GatewaysEditor, { store, tier: root });
+
+		expect(screen.getByRole('combobox', { name: 'Add prerequisite' })).toBeTruthy();
+	});
+
+	it('warns when an already-gated tier has been reordered off root', () => {
+		const strandedGateway = tier({ id: 0, pathId: 0, pathOrdinal: 1, name: 'Fire II', prerequisiteIds: [2] });
+		const prerequisite = tier({ id: 2, pathId: 1, name: 'Frost I' });
+		const store = makeStore([strandedGateway, prerequisite]);
+
+		render(GatewaysEditor, { store, tier: strandedGateway });
+
+		expect(screen.getByText(/no longer its path's root/)).toBeTruthy();
+	});
+});
+
 describe('GatewaysEditor — excludes tiers of a retired path (#2176)', () => {
 	it('omits a tier whose own record is live but whose owning path is retired', async () => {
 		const gated = tier({ id: 0, pathId: 0, name: 'Fire I' });

--- a/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
@@ -244,6 +244,19 @@ describe('TierDetail — tab bodies', () => {
 		expect(store.setTierTab).toHaveBeenCalledWith('gateways');
 	});
 
+	it('warns the Gateways tab when a tier reordered off root still carries prerequisites (#2275)', () => {
+		const stranded = makeStore(tier({ pathOrdinal: 1, prerequisiteIds: [3] }), { tierTab: 'milestones' });
+		render(TierDetail, { props: { store: stranded } });
+		const strandedTab = screen.getByText('Gateways').closest('button');
+		expect(strandedTab?.querySelector('svg')).toBeTruthy();
+		cleanup();
+
+		const rootGateway = makeStore(tier({ pathOrdinal: 0, prerequisiteIds: [3] }), { tierTab: 'milestones' });
+		render(TierDetail, { props: { store: rootGateway } });
+		const rootTab = screen.getByText('Gateways').closest('button');
+		expect(rootTab?.querySelector('svg')).toBeNull();
+	});
+
 	it('lists an existing prerequisite chip, removes it, and adds a new one', async () => {
 		// Gateways are cross-path only (#2128), so the prerequisite candidates live on a different
 		// path than the gated tier's own (pathId 0, the tier() default).

--- a/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
@@ -12,6 +12,7 @@ import {
 	pathIdentityDto,
 	pathWarnings,
 	payoutLevels,
+	prerequisiteRootWarnings,
 	proficiencyBlockingWarnings,
 	profIdentityDto,
 	proficiencyWarnings,
@@ -174,6 +175,22 @@ describe('validation', () => {
 
 		const inRange = tier({ id: 3, maxLevel: 5 });
 		expect(proficiencyBlockingWarnings(inRange)).toHaveLength(0);
+	});
+
+	it('prerequisiteRootWarnings flags a non-root tier carrying prerequisites (#2275)', () => {
+		// AdminProficiencies rejects this shape whenever it's reachable — either directly (SetPrerequisites'
+		// ValidatePrerequisiteIds) or through an identity-only ordinal edit that strands an already-gated
+		// root tier (FindPrerequisiteRootViolation) — so it must block Save, mirroring the level-range rule.
+		const strandedGateway = tier({ id: 1, pathOrdinal: 1, prerequisiteIds: [7] });
+		expect(prerequisiteRootWarnings(strandedGateway)).toEqual(['Prerequisites are only allowed on a root tier']);
+		expect(proficiencyBlockingWarnings(strandedGateway)).toContain('Prerequisites are only allowed on a root tier');
+		expect(proficiencyWarnings(strandedGateway)).toContain('Prerequisites are only allowed on a root tier');
+
+		const rootGateway = tier({ id: 2, pathOrdinal: 0, prerequisiteIds: [7] });
+		expect(prerequisiteRootWarnings(rootGateway)).toHaveLength(0);
+
+		const nonRootNoPrereqs = tier({ id: 3, pathOrdinal: 1, prerequisiteIds: [] });
+		expect(prerequisiteRootWarnings(nonRootNoPrereqs)).toHaveLength(0);
 	});
 });
 

--- a/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-store.test.ts
@@ -516,10 +516,15 @@ describe('save orchestration', () => {
 	});
 
 	it('batches cross-path prerequisite changes into one call so a gateway swap posts as a single combined set', async () => {
-		serverPaths = [{ id: 0, name: 'Fire', description: 'd', activityKey: EActivityKey.Fire, retiredAt: null }];
+		// Both tiers are cross-path *root* tiers (#2275: gateways are root-tier-only), so the swap below
+		// stays authorable on both ends throughout.
+		serverPaths = [
+			{ id: 0, name: 'Fire', description: 'd', activityKey: EActivityKey.Fire, retiredAt: null },
+			{ id: 1, name: 'Water', description: 'd', activityKey: EActivityKey.Water, retiredAt: null }
+		];
 		serverProfs = [
 			fullTier({ id: 0, pathId: 0, pathOrdinal: 0, name: 'Fire T0', prerequisiteIds: [1] }),
-			fullTier({ id: 1, pathId: 0, pathOrdinal: 1, name: 'Fire T1' })
+			fullTier({ id: 1, pathId: 1, pathOrdinal: 0, name: 'Water T0' })
 		];
 		const store = new ProgressionStore();
 		await store.load();
@@ -543,10 +548,14 @@ describe('save orchestration', () => {
 	});
 
 	it('a non-retiring save keeps every prerequisite change in one batch, even spanning a brand-new tier', async () => {
-		serverPaths = [{ id: 0, name: 'Fire', description: 'd', activityKey: EActivityKey.Fire, retiredAt: null }];
+		// Both tiers are cross-path *root* tiers (#2275: gateways are root-tier-only) throughout.
+		serverPaths = [
+			{ id: 0, name: 'Fire', description: 'd', activityKey: EActivityKey.Fire, retiredAt: null },
+			{ id: 1, name: 'Water', description: 'd', activityKey: EActivityKey.Water, retiredAt: null }
+		];
 		serverProfs = [
 			fullTier({ id: 0, pathId: 0, pathOrdinal: 0, name: 'Fire T0', prerequisiteIds: [1] }),
-			fullTier({ id: 1, pathId: 0, pathOrdinal: 1, name: 'Fire T1' })
+			fullTier({ id: 1, pathId: 1, pathOrdinal: 0, name: 'Water T0' })
 		];
 		const store = new ProgressionStore();
 		await store.load();


### PR DESCRIPTION
## Summary

#2249 added the "prerequisites are root-tier-only" rule, but it only lived inside `AdminProficiencies.ValidatePrerequisiteIds`, which fires solely on `SetPrerequisites`. The progression editor's tier reorder (`TiersSpine` ▲/▼) produces an **identity-only** `pathOrdinal` edit through `SaveProficiencies` — `SetPrerequisites` is never called when the prerequisite set itself is unchanged — so an already-gated root tier could be reordered off root, resurrecting the exact runtime inconsistency #2249 closed (a tier announced open by `OpenSuccessors` while `AllPrerequisitesMaxed` withholds all XP).

There was also no client-side Save gate for this: the Gateways tab only disabled itself for a non-root tier with *zero* prerequisites, so a non-root tier that already carries prerequisites (e.g. after a reorder) still offered the full add-picker, and prerequisite changes post late in the save pipeline — after identity batches commit — so a known-in-advance rejection would land on the partial-failure rebase path instead of being blocked pre-save.

- **Backend**: `AdminProficiencies.SaveProficiencies` now runs `FindPrerequisiteRootViolation`, which computes the prospective per-proficiency ordinal (folding in this batch's identity edits) and rejects the save if any tier that still carries persisted prerequisites would end up off ordinal 0 — mirroring `ValidatePrerequisiteIds`'s rule but reachable through the reorder path too.
- **Frontend**: `proficiencyBlockingWarnings` now also flags `pathOrdinal !== 0 && prerequisiteIds.length > 0`, gating Save the same way an out-of-range payout level does. The Gateways tab surfaces this as a warning triangle, and `GatewaysEditor` hides the "Add prerequisite" picker entirely on a non-root tier (previously it only hid when the tier had zero prerequisites), with an inline warning banner explaining why an already-gated non-root tier can't add more.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test` (full solution) — 3434 tests passed, including 2 new `AdminProficienciesIntegrationTests` covering the reorder-strands-a-gateway rejection and a same-ordinal regression check
- [x] `npm run lint` — clean (eslint + svelte-check)
- [x] `npm run test:unit:ci` — 3887 tests passed, including new/updated coverage in `progression-helpers.test.ts`, `GatewaysEditor.test.ts`, `TierDetail.test.ts`, and two `progression-store.test.ts` scenarios updated to use valid root-tier cross-path data (their prior same-path/non-root setup would now — correctly — trip the new Save gate)

Closes #2275


---
_Generated by [Claude Code](https://claude.ai/code/session_011x4Hboc2QsUnPCcGCGxpG3)_