### PR TITLE
Dead-letter and re-sync-notify envelope-level malformed socket pushes

### DIFF
--- a/Game.Api.Tests/Integration/ApiIntegrationTestBase.cs
+++ b/Game.Api.Tests/Integration/ApiIntegrationTestBase.cs
@@ -219,6 +219,22 @@ namespace Game.Api.Tests.Integration
         /// <summary>A live socket's own pub/sub queue name.</summary>
         protected static string SocketQueueName(string socketId) => $"{Constants.PUBSUB_SOCKET_QUEUE_PREFIX}_{socketId}";
 
+        /// <summary>A live socket's own pub/sub channel name.</summary>
+        protected static string SocketChannel(string socketId) => $"{Constants.PUBSUB_SOCKET_CHANNEL_PREFIX}_{socketId}";
+
+        /// <summary>
+        /// Publishes a raw payload directly onto a live socket's own queue and wakes its command processor —
+        /// bypassing <c>SocketManagerService.EmitSocketCommand</c>'s <see cref="SocketCommandInfo"/> typing so
+        /// a test can simulate a malformed server push landing on the wire (#2272), which a well-formed
+        /// <see cref="SocketCommandInfo"/> can never reproduce.
+        /// </summary>
+        protected async Task PublishRawToSocketAsync(string socketId, string rawMessage)
+        {
+            using var scope = CreateScope();
+            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
+            await pubsub.Publish(SocketChannel(socketId), SocketQueueName(socketId), rawMessage);
+        }
+
         /// <summary>Wraps a server-initiated command as the socket-command dead-letter envelope shape
         /// <see cref="Game.Api.Services.Admin.SocketCommandDeadLetters"/> replays, for tests seeding the
         /// socket dead-letter queue directly.</summary>

--- a/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
+++ b/Game.Api.Tests/Integration/SocketManagerServiceTests.cs
@@ -1,6 +1,10 @@
+using Game.Abstractions.Contracts.Admin;
 using Game.Abstractions.Infrastructure;
+using Game.Api.Models.Common;
 using Game.Api.Services;
+using Game.Api.Services.Admin;
 using Game.Api.Sockets.Commands;
+using Game.Core;
 using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
@@ -586,6 +590,66 @@ namespace Game.Api.Tests.Integration
 
             Assert.DoesNotContain(_capturingProvider.Entries.Skip(startIndex),
                 e => e.Category == SocketManagerCategory && e.Level == LogLevel.Warning);
+        }
+
+        [Fact]
+        public async Task CommandProcessor_EnvelopeFailsToDeserialize_DeadLettersRawPayloadAndNotifiesClient()
+        {
+            // Simulates the envelope-level break #2272 covers (most plausibly wire-shape skew during a
+            // rolling deploy): a payload that never even parses into a SocketCommandInfo, landing directly on
+            // the live socket's own pub/sub queue the way a genuine server push would.
+            var (userId, playerId) = await SeedAndLoginAsync();
+
+            await using var socketA = new TestSocketClient();
+            await socketA.ConnectAsync(Factory.Server.CreateWebSocketClient(), userId, playerId);
+            await socketA.SendCommandAsync<object>("GetStatisticTypes");
+            var socketId = await ReadPresenceValueAsync(playerId);
+            Assert.NotNull(socketId);
+
+            await PublishRawToSocketAsync(socketId!, "this-is-not-json");
+
+            // The client still gets the re-sync notice even though the server can no longer name which
+            // command failed, mirroring the player write-behind queue's malformed-envelope handling.
+            var notice = await socketA.WaitForCommandAsync<ServerCommandFailedModel>(nameof(ServerCommandFailed));
+            Assert.Equal("Unknown", notice.Data?.CommandName);
+
+            using var scope = CreateScope();
+            var deadLetters = scope.ServiceProvider.GetRequiredService<SocketCommandDeadLetters>();
+            var inspection = await deadLetters.InspectAsync(50);
+            var entry = Assert.Single(inspection.Entries);
+            Assert.Equal(EDeadLetterReason.Malformed, entry.Reason);
+            Assert.Equal("this-is-not-json", entry.RawPayload);
+
+            // The processor kept draining afterward rather than abandoning the connection over a poison entry.
+            var stillAlive = await socketA.SendCommandAsync<object>("GetStatisticTypes");
+            Assert.Null(stillAlive.Error);
+        }
+
+        [Fact]
+        public async Task CommandProcessor_EnvelopeDeserializesToNull_DeadLettersRawPayloadAndNotifiesClient()
+        {
+            // A literal JSON "null" deserializes cleanly but carries no command — the same poison-payload
+            // treatment as an outright parse failure applies (mirroring DataProviderSynchronizer.ProcessMessage's
+            // empty-envelope branch for the player write-behind queue).
+            var (userId, playerId) = await SeedAndLoginAsync();
+
+            await using var socketA = new TestSocketClient();
+            await socketA.ConnectAsync(Factory.Server.CreateWebSocketClient(), userId, playerId);
+            await socketA.SendCommandAsync<object>("GetStatisticTypes");
+            var socketId = await ReadPresenceValueAsync(playerId);
+            Assert.NotNull(socketId);
+
+            await PublishRawToSocketAsync(socketId!, "null");
+
+            var notice = await socketA.WaitForCommandAsync<ServerCommandFailedModel>(nameof(ServerCommandFailed));
+            Assert.Equal("Unknown", notice.Data?.CommandName);
+
+            using var scope = CreateScope();
+            var deadLetters = scope.ServiceProvider.GetRequiredService<SocketCommandDeadLetters>();
+            var inspection = await deadLetters.InspectAsync(50);
+            var entry = Assert.Single(inspection.Entries);
+            Assert.Equal(EDeadLetterReason.Malformed, entry.Reason);
+            Assert.Equal("null", entry.RawPayload);
         }
 
         private async Task<bool> HasActiveSocketAsync(int playerId)

--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -5,6 +5,7 @@ using Game.Api.Services;
 using Game.Api.Sockets;
 using Game.Api.Sockets.Commands;
 using Game.Application;
+using Game.Core;
 using Game.Core.Players;
 using Game.TestInfrastructure.Helpers;
 using Microsoft.Extensions.DependencyInjection;
@@ -120,6 +121,48 @@ namespace Game.Api.Tests.Unit
             // The valid command after the dequeue fault still ran, proving the loop survived.
             Assert.Equal(["ok-1"], commands.ExecutedCommandIds);
             Assert.Contains(_logs.Entries, e => e.Level == LogLevel.Error && e.Message.Contains("dequeuing"));
+        }
+
+        [Fact]
+        public async Task Processor_EnvelopeFailsToDeserialize_DeadLettersRawPayloadAndNotifiesTheClientThenKeepsDraining()
+        {
+            // #2272: an envelope-level break (e.g. wire-shape skew during a rolling deploy) is popped before
+            // GetSocketCommandProcessor discovers it can't even parse into a SocketCommandInfo. Unlike a
+            // faulted-but-parseable command, there is no command name to report — the raw payload is what
+            // must be dead-lettered, and the queue must keep draining into the following valid command.
+            var commands = new CapturingCommandFactory(throwOn: _ => null);
+            var (processor, pubSub) = BuildProcessor(commands);
+
+            var queue = new FakeQueue(
+                FakeQueueStep.YieldRaw("this-is-not-json"),
+                new SocketCommandInfo("WillSucceed") { Id = "ok-1" });
+
+            await processor(queue);
+
+            var deadLettered = Assert.Single(pubSub.DeadLetterQueue.Added);
+            Assert.Equal("this-is-not-json", deadLettered);
+
+            // The re-sync notice still goes out, with a sentinel name since the failed command can't be named.
+            Assert.Equal(["ServerCommandFailed", "WillSucceed"], commands.ExecutedCommandNames);
+            Assert.Contains(_logs.Entries, e => e.Level == LogLevel.Error && e.Message.Contains("malformed envelope"));
+            Assert.Equal(["<null>", "ok-1"], commands.ExecutedCommandIds);
+        }
+
+        [Fact]
+        public async Task Processor_EnvelopeDeserializesToNull_DeadLettersRawPayloadAndNotifiesTheClient()
+        {
+            // A literal JSON "null" deserializes cleanly but carries no command — the same poison-payload
+            // treatment as an outright parse failure applies.
+            var commands = new CapturingCommandFactory(throwOn: _ => null);
+            var (processor, pubSub) = BuildProcessor(commands);
+
+            var queue = new FakeQueue(FakeQueueStep.YieldRaw("null"));
+
+            await processor(queue);
+
+            var deadLettered = Assert.Single(pubSub.DeadLetterQueue.Added);
+            Assert.Equal("null", deadLettered);
+            Assert.Equal(["ServerCommandFailed"], commands.ExecutedCommandNames);
         }
 
         [Fact]
@@ -348,24 +391,31 @@ namespace Game.Api.Tests.Unit
             }
         }
 
-        /// <summary>A scripted step for <see cref="FakeQueue"/>: either yield a command or throw on dequeue.
-        /// An implicit conversion from <see cref="SocketCommandInfo"/> keeps the plain command cases terse.</summary>
+        /// <summary>A scripted step for <see cref="FakeQueue"/>: yield a well-formed command, yield a raw
+        /// (possibly malformed) payload verbatim, or throw on dequeue. An implicit conversion from
+        /// <see cref="SocketCommandInfo"/> keeps the plain command cases terse.</summary>
         private sealed class FakeQueueStep
         {
             public SocketCommandInfo? Command { get; private init; }
+            public string? RawMessage { get; private init; }
             public Exception? Error { get; private init; }
 
             public static FakeQueueStep Yield(SocketCommandInfo command) => new() { Command = command };
+            public static FakeQueueStep YieldRaw(string rawMessage) => new() { RawMessage = rawMessage };
             public static FakeQueueStep Throw(Exception error) => new() { Error = error };
 
             public static implicit operator FakeQueueStep(SocketCommandInfo command) => Yield(command);
         }
 
+        /// <summary>An in-memory queue that hands back the raw serialized payload for each step, mirroring
+        /// production's pop-then-deserialize split (#2272): <see cref="GetSocketCommandProcessor"/> now pops
+        /// via the non-generic <see cref="GetNextAsync(CancellationToken)"/> and deserializes separately, so a
+        /// scripted <see cref="FakeQueueStep.YieldRaw"/> payload can exercise the envelope-malformed path.</summary>
         private sealed class FakeQueue(params FakeQueueStep[] steps) : IPubSubQueue
         {
             private readonly Queue<FakeQueueStep> _steps = new(steps);
 
-            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default)
+            public Task<string?> GetNextAsync(CancellationToken cancellationToken = default)
             {
                 if (_steps.TryDequeue(out var next))
                 {
@@ -374,16 +424,13 @@ namespace Game.Api.Tests.Unit
                         throw next.Error;
                     }
 
-                    if (next.Command is T typed)
-                    {
-                        return Task.FromResult<T?>(typed);
-                    }
+                    return Task.FromResult<string?>(next.RawMessage ?? next.Command?.Serialize());
                 }
 
-                return Task.FromResult<T?>(default);
+                return Task.FromResult<string?>(null);
             }
 
-            public Task<string?> GetNextAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<string?> ReserveNextAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AcknowledgeAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> ReclaimProcessingAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -403,13 +450,13 @@ namespace Game.Api.Tests.Unit
         {
             public int Attempts { get; private set; }
 
-            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default)
+            public Task<string?> GetNextAsync(CancellationToken cancellationToken = default)
             {
                 Attempts++;
                 throw toThrow;
             }
 
-            public Task<string?> GetNextAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<string?> ReserveNextAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AcknowledgeAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> ReclaimProcessingAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/Game.Api/Services/SocketManagerService.cs
+++ b/Game.Api/Services/SocketManagerService.cs
@@ -4,6 +4,7 @@ using Game.Api.Sockets.Commands;
 using Game.Core;
 using System.Globalization;
 using System.Net.WebSockets;
+using System.Text.Json;
 
 namespace Game.Api.Services
 {
@@ -445,18 +446,20 @@ namespace Game.Api.Services
                 var consecutiveFailures = 0;
                 while (true)
                 {
-                    SocketCommandInfo? nextCommandInfo;
+                    string? rawMessage;
                     try
                     {
-                        nextCommandInfo = await queue.GetNextAsync<SocketCommandInfo>();
+                        // Popped as the raw string (rather than queue.GetNextAsync<SocketCommandInfo>()) so a
+                        // payload that fails to deserialize is still available to dead-letter below — the
+                        // popped-before-deserialized item can't otherwise be recovered once GetNextAsync<T>
+                        // throws (#2272).
+                        rawMessage = await queue.GetNextAsync();
                     }
                     catch (Exception ex)
                     {
-                        // A fault dequeuing the next message (a malformed payload or a Redis blip) must not
-                        // escape the processor and kill the drain loop — that would silently drop every later
-                        // server push for this socket (#691). A malformed payload is already popped by
-                        // GetNextAsync before deserialization throws, so skipping it advances the queue; a
-                        // transient blip is retried on the next pass.
+                        // A fault popping the next message (a Redis blip) must not escape the processor and
+                        // kill the drain loop — that would silently drop every later server push for this
+                        // socket (#691). Retried on the next pass.
                         _logger.LogError(ex, "An error occurred while dequeuing a socket command on socket: {Id}, playerId: {PlayerId}.", socket.Id, socket.PlayerId);
 
                         // Bound a persistent fault: a hot retry loop would hammer Redis and the log for the
@@ -474,9 +477,35 @@ namespace Game.Api.Services
 
                     consecutiveFailures = 0;
 
-                    if (nextCommandInfo is null)
+                    if (rawMessage is null)
                     {
                         break;
+                    }
+
+                    SocketCommandInfo? nextCommandInfo;
+                    try
+                    {
+                        nextCommandInfo = rawMessage.Deserialize<SocketCommandInfo>();
+                    }
+                    catch (JsonException ex)
+                    {
+                        // An envelope-level break (most plausibly wire-shape skew during a rolling deploy) is a
+                        // genuine bug, since the payload is server-authored — escalate it the same as a fault
+                        // (dead-letter + client re-sync notice) rather than only logging it, mirroring the
+                        // player write-behind queue's malformed-envelope handling. The pop above already
+                        // advanced the queue, so this is purely an escalation add.
+                        _logger.LogError(ex, "Dead-lettering a socket command with a malformed envelope on socket: {Id}, playerId: {PlayerId}. Raw message: {RawMessage}", socket.Id, socket.PlayerId, rawMessage);
+                        await EscalateMalformedServerCommand(socket, rawMessage);
+                        continue;
+                    }
+
+                    if (nextCommandInfo is null)
+                    {
+                        // A null payload deserialized cleanly but carries no command; the same poison-payload
+                        // treatment as a JSON parse failure applies.
+                        _logger.LogError("Dead-lettering an empty socket command envelope on socket: {Id}, playerId: {PlayerId}. Raw message: {RawMessage}", socket.Id, socket.PlayerId, rawMessage);
+                        await EscalateMalformedServerCommand(socket, rawMessage);
+                        continue;
                     }
 
                     _logger.LogTrace("Received command on socket: {Id}, playerId: {PlayerId}, command: {CommandInfo}.", socket.Id, socket.PlayerId, nextCommandInfo);
@@ -525,20 +554,65 @@ namespace Game.Api.Services
             // that would risk an escalation loop. The dead-letter above already preserves it.
             if (commandInfo.Name != nameof(ServerCommandFailed))
             {
-                // Dispatched directly (not re-queued over pub/sub) since the failing socket is right here;
-                // ExecuteServerCommand runs it under the same command lock and owns the send to the client.
-                // Capture the outcome: if the notice itself doesn't get through (e.g. the socket just closed),
-                // the client never gets the re-sync cue for a gating command like ChallengeCompleted and would
-                // diverge silently — so surface it for an operator rather than ignoring the result.
-                var noticeOutcome = await socket.ExecuteServerCommand(new ServerCommandFailedInfo(commandInfo.Name));
-                if (noticeOutcome is not SocketCommandOutcome.Succeeded)
-                {
-                    _logger.LogWarning("The re-sync notice for a failed server command did not complete (outcome: {Outcome}); the client may not have received the re-sync cue for {Command} on socket: {Id}.", noticeOutcome, commandInfo.Name, socket.Id);
-                }
+                await SendServerCommandFailedNotice(socket, commandInfo.Name);
             }
 
             _logger.LogWarning("Dead-lettered a failing server-initiated command and notified the client: {CommandInfo} on socket: {Id}. Dead-letter queue depth: {Depth}", commandInfo, socket.Id, deadLetterDepth);
         }
+
+        /// <summary>
+        /// Escalates a server push whose envelope itself failed to deserialize — the payload is already popped
+        /// off the queue by the time <see cref="GetSocketCommandProcessor"/> discovers it's malformed, so
+        /// unlike <see cref="EscalateFailedServerCommand"/> there is no parsed <see cref="SocketCommandInfo"/>
+        /// to wrap in a <see cref="SocketCommandDeadLetterEnvelope"/> (and no failed command name to report).
+        /// The raw string is dead-lettered as-is: the Ops inspector's classifier already treats an entry that
+        /// doesn't parse as a <see cref="SocketCommandDeadLetterEnvelope"/> as malformed, so this needs no
+        /// reader-side change. The client still gets the re-sync notice — with a sentinel command name, since
+        /// which specific push it missed can no longer be recovered — mirroring the player write-behind
+        /// queue's malformed-envelope handling (#2272).
+        /// </summary>
+        private async Task EscalateMalformedServerCommand(SocketHandler socket, string rawMessage)
+        {
+            long? deadLetterDepth = null;
+            try
+            {
+                var deadLetterQueue = _pubSub.GetQueue(Constants.PUBSUB_SOCKET_DEAD_LETTER_QUEUE);
+                await deadLetterQueue.AddToQueueAsync(rawMessage);
+                deadLetterDepth = await deadLetterQueue.GetLengthAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to dead-letter a socket command with a malformed envelope on socket: {Id}. Raw message: {RawMessage}", socket.Id, rawMessage);
+            }
+
+            await SendServerCommandFailedNotice(socket, UnknownServerCommandName);
+
+            _logger.LogWarning("Dead-lettered a socket command with a malformed envelope and notified the client on socket: {Id}. Raw message: {RawMessage}. Dead-letter queue depth: {Depth}", socket.Id, rawMessage, deadLetterDepth);
+        }
+
+        /// <summary>
+        /// Dispatched directly (not re-queued over pub/sub) since the failing socket is right here;
+        /// ExecuteServerCommand runs it under the same command lock and owns the send to the client. Capture
+        /// the outcome: if the notice itself doesn't get through (e.g. the socket just closed), the client
+        /// never gets the re-sync cue for a gating command like ChallengeCompleted and would diverge silently
+        /// — so surface it for an operator rather than ignoring the result.
+        /// </summary>
+        private async Task SendServerCommandFailedNotice(SocketHandler socket, string failedCommandName)
+        {
+            var noticeOutcome = await socket.ExecuteServerCommand(new ServerCommandFailedInfo(failedCommandName));
+            if (noticeOutcome is not SocketCommandOutcome.Succeeded)
+            {
+                _logger.LogWarning("The re-sync notice for a failed server command did not complete (outcome: {Outcome}); the client may not have received the re-sync cue for {Command} on socket: {Id}.", noticeOutcome, failedCommandName, socket.Id);
+            }
+        }
+
+        /// <summary>
+        /// Sentinel <see cref="ServerCommandFailedModel.CommandName"/> for <see cref="EscalateMalformedServerCommand"/>:
+        /// an envelope-level parse failure never resolves a command name, but the model requires one. The
+        /// frontend's <c>handleServerCommandFailed</c> only special-cases known command names and otherwise
+        /// just logs the notice, so a sentinel that matches nothing is a safe, self-describing placeholder.
+        /// </summary>
+        private const string UnknownServerCommandName = "Unknown";
 
         private async Task<string?> CurrentSocketId(int playerId)
         {


### PR DESCRIPTION
## Summary

`SocketManagerService.GetSocketCommandProcessor` popped and deserialized a server push in a single call (`queue.GetNextAsync<SocketCommandInfo>()`), so a payload that failed **envelope-level** deserialization was only logged in the dequeue catch — never dead-lettered, and never triggering the client's `ServerCommandFailed` re-sync notice. `docs/backend-persistence.md` documents a malformed server push as escalating the same as a genuine fault (the payload is server-authored, so it's a bug, not client input), but that escalation only covered `MalformedParameters` inside an already-parseable envelope — an envelope-level break (most plausibly wire-shape skew during a rolling deploy) fell through the gap.

## Changes

- `GetSocketCommandProcessor` now pops the raw string first (`queue.GetNextAsync()`) and deserializes it into `SocketCommandInfo` as a separate step, mirroring `DataProviderSynchronizer.ProcessMessage`'s pop-then-deserialize split for the player write-behind queue.
- A `JsonException` from that deserialize — or a payload that parses cleanly to `null` — now calls a new `EscalateMalformedServerCommand`, which dead-letters the **raw string as-is** (no reader-side change needed: `SocketCommandDeadLetters.Classify`/`TryDeserialize` already treats an entry that doesn't parse as a `SocketCommandDeadLetterEnvelope` as `Malformed`) and sends the client a `ServerCommandFailed` notice with a sentinel command name (`"Unknown"`), since the failed push's own name can no longer be recovered.
- Extracted the shared "dispatch the `ServerCommandFailed` notice and log if it didn't land" logic out of `EscalateFailedServerCommand` into `SendServerCommandFailedNotice`, reused by both escalation paths.
- The Redis-blip dequeue-fault catch block (bounded backoff + abandon-after-ceiling) is unchanged and now only covers genuine pop-level faults, since deserialization moved to its own step.

## Test plan

- [x] New unit tests in `Game.Api.Tests/Unit/SocketCommandProcessorTests.cs`: an envelope that fails to deserialize dead-letters the raw payload, notifies the client, and the queue keeps draining into the next valid command; a `"null"` payload gets the same treatment.
- [x] New integration tests in `Game.Api.Tests/Integration/SocketManagerServiceTests.cs`, exercised end-to-end over real Redis + a live WebSocket connection: a raw malformed payload published directly onto a live socket's queue is dead-lettered (verified via `SocketCommandDeadLetters.InspectAsync` classifying it `Malformed`) and the client receives the `ServerCommandFailed` notice.
- [x] Updated the existing `FakeQueue`/`AlwaysThrowingQueue` test doubles to implement the raw (non-generic) `GetNextAsync` the production code now calls.
- [x] `dotnet build` (0 warnings/errors) and full `dotnet test` — 3438 tests passed across all four backend test projects.

Closes #2272


---
_Generated by [Claude Code](https://claude.ai/code/session_01HhtPDe4nzMSoibWysGbyuz)_