### PR TITLE
Move LoginTrackingMiddleware's DB write off the request latency path

### DIFF
--- a/Game.Api.Tests/Integration/LoginTrackingTests.cs
+++ b/Game.Api.Tests/Integration/LoginTrackingTests.cs
@@ -92,9 +92,13 @@ namespace Game.Api.Tests.Integration
         [Fact]
         public async Task DeviceInfoEndpoint_EnrichesStoredDevice()
         {
-            // Arrange
+            // Arrange — the frontend attaches the fingerprint header to every authenticated request, so in
+            // practice DeviceInfo is always preceded by at least one other authenticated request (e.g.
+            // SelectPlayer) that has already tracked the device. Prime that here with a Status call, since
+            // SaveDeviceInfo enriches an existing tracked device rather than creating one.
             await SeedUserAsync("enrichuser", "enrichpass");
             using var authClient = await LoginWithDeviceAsync("enrichuser", "enrichpass");
+            await authClient.GetAsync("/api/Auth/Status", CancellationToken);
 
             var body = new { DeviceMemory = 16.0, HardwareConcurrency = 8 };
 

--- a/Game.Api.Tests/Unit/LoginTrackingMiddlewareTests.cs
+++ b/Game.Api.Tests/Unit/LoginTrackingMiddlewareTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Collections.Generic;
 using System.Net;
 using Xunit;
 
@@ -128,6 +129,48 @@ namespace Game.Api.Tests.Unit
             Assert.True(nextCalled());
         }
 
+        [Fact]
+        public async Task Authenticated_NewDeviceIpUser_RunsTheHandlerBeforeRecordingTheConnection()
+        {
+            // Tracking must not sit in front of the request handler on the latency path (#2274) — the
+            // handler should observe no delay from it, and the DB write should only happen afterward.
+            var order = new List<string>();
+            var userLogins = new FakeUserLogins();
+            RequestDelegate next = _ =>
+            {
+                order.Add("next");
+                return Task.CompletedTask;
+            };
+            userLogins.OnRecordConnection = () => order.Add("recordConnection");
+            var middleware = new LoginTrackingMiddleware(next, NullLogger<LoginTrackingMiddleware>.Instance);
+            var session = AuthenticatedSession(userId: 5);
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var scopeFactory = ScopeFactory(userLogins);
+
+            await middleware.InvokeAsync(CreateContext(Ip, Fingerprint, UserAgent), session, scopeFactory, cache);
+
+            Assert.Equal(["next", "recordConnection"], order);
+        }
+
+        [Fact]
+        public async Task NextThrows_StillRecordsConnection_AndRethrowsTheOriginalException()
+        {
+            // Tracking runs in a finally so a handler failure doesn't skip recording the connection, and
+            // the original exception must still propagate unchanged rather than being swallowed here.
+            var userLogins = new FakeUserLogins();
+            RequestDelegate next = _ => throw new InvalidOperationException("handler failure");
+            var middleware = new LoginTrackingMiddleware(next, NullLogger<LoginTrackingMiddleware>.Instance);
+            var session = AuthenticatedSession(userId: 5);
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var scopeFactory = ScopeFactory(userLogins);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                middleware.InvokeAsync(CreateContext(Ip, Fingerprint, UserAgent), session, scopeFactory, cache));
+
+            Assert.Equal("handler failure", ex.Message);
+            Assert.Equal(1, userLogins.RecordConnectionCallCount);
+        }
+
         private static (LoginTrackingMiddleware Middleware, FakeUserLogins UserLogins, Func<bool> NextCalled) CreateMiddleware()
         {
             var nextCalled = false;
@@ -172,10 +215,12 @@ namespace Game.Api.Tests.Unit
 
         // Records how many times RecordConnection was actually invoked, so tests can tell whether the
         // dedupe memo skipped the DB round-trip. ThrowOnRecordConnection lets a test pin the failure path.
+        // OnRecordConnection lets a test observe when the call happened relative to other events.
         private sealed class FakeUserLogins : IUserLogins
         {
             public int RecordConnectionCallCount { get; private set; }
             public bool ThrowOnRecordConnection { get; set; }
+            public Action? OnRecordConnection { get; set; }
 
             public Task RecordConnection(
                 int userId,
@@ -188,6 +233,7 @@ namespace Game.Api.Tests.Unit
                 CancellationToken cancellationToken = default)
             {
                 RecordConnectionCallCount++;
+                OnRecordConnection?.Invoke();
                 if (ThrowOnRecordConnection)
                 {
                     throw new InvalidOperationException("simulated tracking failure");

--- a/Game.Api/Middleware/LoginTrackingMiddleware.cs
+++ b/Game.Api/Middleware/LoginTrackingMiddleware.cs
@@ -38,47 +38,73 @@ namespace Game.Api.Middleware
 
         public async Task InvokeAsync(HttpContext context, SessionService sessionService, IServiceScopeFactory scopeFactory, IMemoryCache cache)
         {
-            var fingerprint = ClientHints.DeviceFingerprint(context.Request.Headers);
-            if (sessionService.Authenticated && fingerprint is not null)
+            var cacheKey = ResolvePendingTracking(context, sessionService, cache);
+
+            // Tracking runs after the request handler (in a finally, so it still fires if the handler
+            // throws) rather than before it. It's best-effort telemetry the response never depends on, so
+            // it shouldn't sit on the endpoint's latency path — and during a DB outage, it shouldn't force
+            // every authenticated request through a tracking timeout before the endpoint (which may not
+            // even touch Postgres) gets a chance to run.
+            try
             {
-                var ipAddress = ClientIp.Resolve(context);
-                var cacheKey = new TrackingCacheKey(sessionService.UserId, ipAddress, fingerprint);
-
-                if (!cache.TryGetValue<bool>(cacheKey, out _))
+                await _next(context);
+            }
+            finally
+            {
+                if (cacheKey is not null)
                 {
-                    try
-                    {
-                        var hints = ClientHints.FromHeaders(context.Request.Headers);
-                        // Resolve tracking from a dedicated scope so its GameContext is independent of the
-                        // request's. RecordConnection self-commits; sharing the request context would let a
-                        // non-unique save failure leave queued inserts that the later per-request commit
-                        // re-flushes (or breaks on). The scope is disposed here whatever the outcome.
-                        await using var scope = scopeFactory.CreateAsyncScope();
-                        var trackingService = scope.ServiceProvider.GetRequiredService<LoginTrackingService>();
-                        await trackingService.RecordConnection(
-                            sessionService.UserId,
-                            ipAddress,
-                            fingerprint,
-                            hints.UserAgent,
-                            hints.SecChUa,
-                            hints.SecChUaMobile,
-                            hints.SecChUaPlatform,
-                            context.RequestAborted);
-
-                        cache.Set(cacheKey, true, new MemoryCacheEntryOptions
-                        {
-                            AbsoluteExpirationRelativeToNow = DedupeWindow,
-                            Size = 1,
-                        });
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning(ex, "Failed to record login tracking for user {UserId}.", sessionService.UserId);
-                    }
+                    await RecordConnectionAsync(context, scopeFactory, cache, cacheKey.Value);
                 }
             }
+        }
 
-            await _next(context);
+        private static TrackingCacheKey? ResolvePendingTracking(HttpContext context, SessionService sessionService, IMemoryCache cache)
+        {
+            var fingerprint = ClientHints.DeviceFingerprint(context.Request.Headers);
+            if (!sessionService.Authenticated || fingerprint is null)
+            {
+                return null;
+            }
+
+            var cacheKey = new TrackingCacheKey(sessionService.UserId, ClientIp.Resolve(context), fingerprint);
+            return cache.TryGetValue<bool>(cacheKey, out _) ? null : cacheKey;
+        }
+
+        private async Task RecordConnectionAsync(
+            HttpContext context,
+            IServiceScopeFactory scopeFactory,
+            IMemoryCache cache,
+            TrackingCacheKey cacheKey)
+        {
+            try
+            {
+                var hints = ClientHints.FromHeaders(context.Request.Headers);
+                // Resolve tracking from a dedicated scope so its GameContext is independent of the
+                // request's. RecordConnection self-commits; sharing the request context would let a
+                // non-unique save failure leave queued inserts that the later per-request commit
+                // re-flushes (or breaks on). The scope is disposed here whatever the outcome.
+                await using var scope = scopeFactory.CreateAsyncScope();
+                var trackingService = scope.ServiceProvider.GetRequiredService<LoginTrackingService>();
+                await trackingService.RecordConnection(
+                    cacheKey.UserId,
+                    cacheKey.IpAddress,
+                    cacheKey.Fingerprint,
+                    hints.UserAgent,
+                    hints.SecChUa,
+                    hints.SecChUaMobile,
+                    hints.SecChUaPlatform,
+                    context.RequestAborted);
+
+                cache.Set(cacheKey, true, new MemoryCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = DedupeWindow,
+                    Size = 1,
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to record login tracking for user {UserId}.", cacheKey.UserId);
+            }
         }
 
         private readonly record struct TrackingCacheKey(int UserId, string IpAddress, string Fingerprint);

--- a/Game.DataAccess/Repositories/UserLogins.cs
+++ b/Game.DataAccess/Repositories/UserLogins.cs
@@ -128,7 +128,7 @@ namespace Game.DataAccess.Repositories
             {
                 // Only enrich a device this user actually has a tracked login for — never create or attach
                 // to one here — so a caller can't touch another account's device by guessing/replaying its
-                // fingerprint (#2064). RecordConnection (which runs earlier in the same request, via
+                // fingerprint (#2064). RecordConnection (on a prior authenticated request, via
                 // LoginTrackingMiddleware) is solely responsible for establishing that link.
                 var device = await _context.Devices
                     .Include(d => d.BrowserInfo)


### PR DESCRIPTION
## Summary

- `LoginTrackingMiddleware.RecordConnection` now runs **after** `await _next(context)` (in a `finally`, so it still fires if the handler throws) instead of before it.
- Tracking is documented and structurally implemented as best-effort telemetry the response never depends on, yet it previously executed serially in front of the request handler. That cost two things:
  - **Steady state:** every memo miss (first request per (user, IP, device) per 5-minute window) added the multi-query get-or-create upsert to that request's user-visible latency.
  - **During a DB outage/slowdown:** since the memo is only set after a successful save, *every* authenticated fingerprint-carrying request paid the tracking failure — potentially a full connection timeout — inline before the actual endpoint ran, including endpoints whose own path never touches Postgres (Status, Players, switch flow, admin tools).
- Kept the dedicated-scope pattern as-is; only the ordering relative to `_next` changed.

## A wrinkle I found and fixed along the way

The naive "just move it after `_next`" fix breaks a real invariant: `AuthController.DeviceInfo`'s `SaveDeviceInfo` is documented as a no-op unless the caller already has a tracked device for that fingerprint — it enriches an existing device row rather than creating one. Previously this worked because tracking ran *before* the handler, so even if `DeviceInfo` were the very first authenticated+fingerprinted request, the device row would already exist by the time the handler ran.

I verified this isn't a real production risk: the frontend (`UI/src/lib/api/api-request.ts`) attaches the device fingerprint header to **every** authenticated request, and `reportDeviceInfo()` (`UI/src/routes/select/+page.svelte:70`, `UI/src/lib/engine/session.ts:64`) is always called only after a separate, prior authenticated request (`SelectPlayer` or `Auth/Status`) has already completed — so in practice a device is always tracked before `DeviceInfo` ever runs.

The one integration test that broke (`DeviceInfoEndpoint_EnrichesStoredDevice`) was an artifact of the test helper: `SelectPlayerAsync` uses the base test `HttpClient` without a fingerprint header, so the test's `DeviceInfo` POST was — unrealistically — the very first fingerprinted authenticated request. Fixed by priming tracking with a `Status` call first, matching real frontend sequencing.

## Test plan

- [x] `dotnet build` — clean, 0 warnings/errors
- [x] `dotnet test` (full backend suite: Core, Infrastructure, Application, Api) — all 3440 tests pass
- [x] Added `Authenticated_NewDeviceIpUser_RunsTheHandlerBeforeRecordingTheConnection`, asserting the handler runs before the tracking DB write.
- [x] Added `NextThrows_StillRecordsConnection_AndRethrowsTheOriginalException`, confirming the `finally` still records the connection when the handler throws, and the original exception propagates unchanged.
- [x] Updated `DeviceInfoEndpoint_EnrichesStoredDevice` to prime tracking via a preceding authenticated request, matching real frontend sequencing.

Closes #2274


---
_Generated by [Claude Code](https://claude.ai/code/session_015EHsHLgWSXMue7tgAbAMEq)_