### PR TITLE
Workbench: exclude Home zone from spawn pickers, warn on boss/spawn conflicts

### DIFF
--- a/UI/src/routes/admin/workbench/entities/zone.ts
+++ b/UI/src/routes/admin/workbench/entities/zone.ts
@@ -82,10 +82,14 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 			// The dedicated-boss picker keeps an authored value visible even if it loses its
 			// boss flag (reference.bossEnemyOptions' `keep` exception); flag that drift here
 			// since the zone would otherwise silently point at a non-boss enemy. Hard-rejected
-			// by AdminZones.SaveZones, so it blocks Save (#2217).
+			// by AdminZones.SaveZones, so it blocks Save (#2217). A boss on a Home zone is
+			// likewise hard-rejected there (Home is a no-combat sanctuary) — flag it too.
 			warn: (z) => {
 				if (z.bossEnemyId == null || z.bossEnemyId < 0) {
 					return null;
+				}
+				if (z.isHome) {
+					return { message: 'The Home zone cannot have a boss', blocking: true };
 				}
 				const boss = staticData.enemies?.[z.bossEnemyId];
 				return boss && !boss.isBoss
@@ -154,8 +158,15 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 			desc: 'Enemies that spawn here & their weights',
 			count: (z) => z.zoneEnemies.length,
 			// A retired enemy's row doesn't count toward "does something spawn here" — it never
-			// rolls at runtime (mirrors the backend's EmptyCombatZone lint).
-			warn: (z) => (z.isHome || z.zoneEnemies.some((ze) => isLiveEnemy(ze.enemyId)) ? null : 'No enemies spawn here'),
+			// rolls at runtime (mirrors the backend's EmptyCombatZone lint). A Home zone with any
+			// spawn rows is a harder problem: it's hard-rejected on save (AdminZones.SaveZones'
+			// edit guard, AdminZones.SetEnemies), so it blocks rather than merely warns.
+			warn: (z) => {
+				if (z.isHome) {
+					return z.zoneEnemies.length ? { message: 'The Home zone cannot have enemy spawns', blocking: true } : null;
+				}
+				return z.zoneEnemies.some((ze) => isLiveEnemy(ze.enemyId)) ? null : 'No enemies spawn here';
+			},
 			kind: 'table',
 			itemsKey: 'zoneEnemies',
 			rowKey: 'enemyId',

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -156,8 +156,17 @@ class WorkbenchReference {
 	lessonTriggerTypeOptions = (): SelectOption[] => toOptions(enumPairs(ELessonTriggerType));
 	mechanicEventOptions = (): SelectOption[] => toOptions(enumPairs(EMechanicEvent));
 	tagCategoryOptions = (): SelectOption[] => this.tagCategories.map((c) => ({ value: c.id, text: c.name }));
+	/**
+	 * Zone spawn-target picker options: excludes the Home zone the same way a retired zone is
+	 * excluded — it's a no-combat sanctuary the backend categorically rejects a spawn against
+	 * (`AdminEnemies.SetSpawns`) — while keeping the current value visible if it's already Home.
+	 */
 	zoneOptions = (keep?: number): SelectOption[] =>
-		this.retireableOptions(staticData.zones ?? [], keep, (z) => `${z.name} · L${z.levelMin}–${z.levelMax}`);
+		this.retireableOptions(
+			(staticData.zones ?? []).filter((z) => !z.isHome || z.id === keep),
+			keep,
+			(z) => `${z.name} · L${z.levelMin}–${z.levelMax}`
+		);
 	enemyOptions = (keep?: number): SelectOption[] => this.retireableOptions(staticData.enemies ?? [], keep);
 	/**
 	 * Dedicated-boss picker options: a "None" sentinel (-1) plus every active boss enemy. The

--- a/UI/src/tests/routes/admin/workbench/entities/zone.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/zone.test.ts
@@ -206,6 +206,16 @@ describe('zoneEntity', () => {
 			expect(enemiesWarn?.(z)).toBeNull();
 		});
 
+		it('blocks Save when a Home zone carries spawn rows (#2276, backend-enforced)', () => {
+			const z = { ...zoneEntity.newItem(1), isHome: true, zoneEnemies: [{ enemyId: 0, weight: 3 }] };
+			expect(enemiesWarn?.(z)).toEqual({ message: 'The Home zone cannot have enemy spawns', blocking: true });
+		});
+
+		it('passes a Home zone with no spawn rows, without the "no enemies spawn here" nag (#2276)', () => {
+			const z = { ...zoneEntity.newItem(1), isHome: true, zoneEnemies: [] };
+			expect(enemiesWarn?.(z)).toBeNull();
+		});
+
 		it("share total excludes a retired sibling's weight from the denominator", () => {
 			const rows = [
 				{ enemyId: 1, weight: 5 },
@@ -261,6 +271,19 @@ describe('zoneEntity', () => {
 
 		it('passes when no dedicated boss is assigned', () => {
 			expect(identityWarn?.(zoneEntity.newItem(1))).toBeNull();
+		});
+
+		it('blocks Save when a Home zone carries a dedicated boss (#2276, backend-enforced)', () => {
+			const enemies: unknown[] = [];
+			enemies[7] = { id: 7, name: 'Warden', isBoss: true };
+			staticData.enemies = enemies;
+			const z = { ...zoneEntity.newItem(1), isHome: true, bossEnemyId: 7 };
+			expect(identityWarn?.(z)).toEqual({ message: 'The Home zone cannot have a boss', blocking: true });
+		});
+
+		it('passes a Home zone with no dedicated boss (#2276)', () => {
+			const z = { ...zoneEntity.newItem(1), isHome: true };
+			expect(identityWarn?.(z)).toBeNull();
 		});
 	});
 });

--- a/UI/src/tests/routes/admin/workbench/reference.test.ts
+++ b/UI/src/tests/routes/admin/workbench/reference.test.ts
@@ -140,6 +140,17 @@ describe('reference-data-backed select options', () => {
 		]);
 	});
 
+	it('excludes the Home zone from spawn-target picker options (#2276)', () => {
+		staticData.zones[1].isHome = true;
+		expect(reference.zoneOptions().map((o) => o.value)).toEqual([0]);
+	});
+
+	it('keeps the Home zone visible when it is the current value (#2276)', () => {
+		staticData.zones[1].isHome = true;
+		expect(reference.zoneOptions(1)).toContainEqual({ value: 1, text: 'Frost Cavern · L6–10' });
+		expect(reference.zoneOptions().map((o) => o.value)).not.toContain(1);
+	});
+
 	it('lists every enemy as an enemy option', () => {
 		expect(reference.enemyOptions().map((o) => o.text)).toEqual([
 			'Cave Bat',


### PR DESCRIPTION
## Summary

Home-zone authoring hard-rejects (`AdminZones.SaveZones:48-50,167-169`; `AdminEnemies.SetSpawns:164-167`) had no client-side surface: the Workbench let an admin pick the Home zone as a spawn target, assign it a boss, or leave spawn rows on it, only to have the save fail server-side.

- `reference.zoneOptions` now excludes the Home zone from spawn-target pickers (the enemy editor's Spawns tab) the same way a retired zone is excluded — the current value stays visible if it's already Home, mirroring the existing retired-record `keep` convention.
- The zone editor's identity `warn` now flags a boss assigned to a Home zone as a `blocking` warning, alongside the existing boss-flag-drift check.
- The zone editor's Enemies-tab `warn` now flags a Home zone carrying spawn rows as a `blocking` warning instead of silently passing (previously `isHome` short-circuited the check entirely).

All three follow the repo's established blocking-warning convention (#2217/#2221/#2250/#2214): `SaveBar` disables Save while any pending record carries a `blocking: true` warning, so these predictable backend rejections never reach the partial-failure rebase path.

## Test plan

- [x] Added unit tests in `reference.test.ts` covering the Home-zone exclusion from `zoneOptions` (and the `keep`-visible exception).
- [x] Added unit tests in `zone.test.ts` covering both new blocking-warning cases (boss-on-Home, spawn-rows-on-Home) and their pass-through counterparts.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — 310 files / 3893 tests passing.

Closes #2276


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJtD7GbMbXxyTVHoURk4aM)_