### PR TITLE
Close the Workbench maxLength gap and bound LessonStep.Text

### DIFF
--- a/Game.Infrastructure/Database/GameContext.cs
+++ b/Game.Infrastructure/Database/GameContext.cs
@@ -748,6 +748,9 @@ namespace Game.Infrastructure.Database
             {
                 entity.HasKey(s => new { s.LessonId, s.Ordinal });
 
+                entity.Property(s => s.Text)
+                    .HasMaxLength(500);
+
                 entity.Property(s => s.AnchorKey)
                     .HasMaxLength(100);
 

--- a/Game.Infrastructure/Migrations/20260722161431_BoundLessonStepText.Designer.cs
+++ b/Game.Infrastructure/Migrations/20260722161431_BoundLessonStepText.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Game.Infrastructure.Migrations
 {
     [DbContext(typeof(GameContext))]
-    partial class GameContextModelSnapshot : ModelSnapshot
+    [Migration("20260722161431_BoundLessonStepText")]
+    partial class BoundLessonStepText
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Game.Infrastructure/Migrations/20260722161431_BoundLessonStepText.cs
+++ b/Game.Infrastructure/Migrations/20260722161431_BoundLessonStepText.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Game.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class BoundLessonStepText : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Text",
+                table: "LessonSteps",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Text",
+                table: "LessonSteps",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500);
+        }
+    }
+}

--- a/UI/src/routes/admin/workbench/components/TableCell.svelte
+++ b/UI/src/routes/admin/workbench/components/TableCell.svelte
@@ -51,6 +51,7 @@
 				class:dirty
 				aria-label={col.label}
 				placeholder={col.placeholder}
+				maxlength={col.maxLength}
 				value={(row[col.key] as string) ?? ''}
 				oninput={(e) => onChange(col.optional ? e.currentTarget.value || undefined : e.currentTarget.value)}
 			/>

--- a/UI/src/routes/admin/workbench/entities/challenge.ts
+++ b/UI/src/routes/admin/workbench/entities/challenge.ts
@@ -59,7 +59,8 @@ export const challengeEntity: EntityConfig<IChallenge> = {
 					placeholder: 'Name this challenge…',
 					grow: true,
 					required: true,
-					reqMsg: 'Missing name'
+					reqMsg: 'Missing name',
+					maxLength: 100
 				},
 				{
 					key: 'description',

--- a/UI/src/routes/admin/workbench/entities/class.ts
+++ b/UI/src/routes/admin/workbench/entities/class.ts
@@ -77,7 +77,8 @@ export const classEntity: EntityConfig<WorkbenchClass> = {
 					placeholder: 'Name this class…',
 					grow: true,
 					required: true,
-					reqMsg: 'Missing name'
+					reqMsg: 'Missing name',
+					maxLength: 50
 				},
 				{
 					key: 'word',
@@ -86,7 +87,8 @@ export const classEntity: EntityConfig<WorkbenchClass> = {
 					placeholder: 'Conlang label (decorative)…',
 					grow: true,
 					required: true,
-					reqMsg: 'Missing word of power'
+					reqMsg: 'Missing word of power',
+					maxLength: 50
 				},
 				{
 					key: 'description',
@@ -95,14 +97,16 @@ export const classEntity: EntityConfig<WorkbenchClass> = {
 					placeholder: 'Describe the class shown to players…',
 					grow: true,
 					required: true,
-					reqMsg: 'No description'
+					reqMsg: 'No description',
+					maxLength: 500
 				},
 				{
 					key: 'designerNotes',
 					label: 'Designer Notes',
 					type: 'textarea',
 					placeholder: 'Why this class exists — authoring notes (never shown to players)…',
-					grow: true
+					grow: true,
+					maxLength: 2000
 				}
 			]
 		},

--- a/UI/src/routes/admin/workbench/entities/enemy.ts
+++ b/UI/src/routes/admin/workbench/entities/enemy.ts
@@ -74,7 +74,8 @@ export const enemyEntity: EntityConfig<WorkbenchEnemy> = {
 					placeholder: 'Name this enemy…',
 					grow: true,
 					required: true,
-					reqMsg: 'Missing name'
+					reqMsg: 'Missing name',
+					maxLength: 50
 				},
 				{ key: 'isBoss', label: 'Classification', type: 'toggle', onLabel: 'Boss enemy', offLabel: 'Standard enemy' },
 				{
@@ -82,7 +83,8 @@ export const enemyEntity: EntityConfig<WorkbenchEnemy> = {
 					label: 'Designer Notes',
 					type: 'textarea',
 					placeholder: 'Why this enemy exists — authoring notes (never shown to players)…',
-					grow: true
+					grow: true,
+					maxLength: 2000
 				}
 			]
 		},

--- a/UI/src/routes/admin/workbench/entities/item-mod.ts
+++ b/UI/src/routes/admin/workbench/entities/item-mod.ts
@@ -51,7 +51,8 @@ export const itemModEntity: EntityConfig<IItemMod> = {
 					placeholder: 'Name this mod…',
 					grow: true,
 					required: true,
-					reqMsg: 'Missing name'
+					reqMsg: 'Missing name',
+					maxLength: 50
 				},
 				{ key: 'itemModTypeId', label: 'Type', type: 'select', options: reference.modTypeOptions, width: 170 },
 				{ key: 'rarityId', label: 'Rarity', type: 'select', options: reference.rarityOptions, width: 170 },

--- a/UI/src/routes/admin/workbench/entities/item.ts
+++ b/UI/src/routes/admin/workbench/entities/item.ts
@@ -86,7 +86,8 @@ export const itemEntity: EntityConfig<WorkbenchItem> = {
 					placeholder: 'Name this item…',
 					grow: true,
 					required: true,
-					reqMsg: 'Missing name'
+					reqMsg: 'Missing name',
+					maxLength: 50
 				},
 				{
 					key: 'itemCategoryId',

--- a/UI/src/routes/admin/workbench/entities/lesson.ts
+++ b/UI/src/routes/admin/workbench/entities/lesson.ts
@@ -65,7 +65,8 @@ export const lessonEntity: EntityConfig<WorkbenchLesson> = {
 					placeholder: 'idle-loop-basics',
 					width: 220,
 					required: true,
-					reqMsg: 'Missing key'
+					reqMsg: 'Missing key',
+					maxLength: 100
 				},
 				{
 					key: 'name',
@@ -74,7 +75,8 @@ export const lessonEntity: EntityConfig<WorkbenchLesson> = {
 					placeholder: 'Name this lesson…',
 					grow: true,
 					required: true,
-					reqMsg: 'Missing name'
+					reqMsg: 'Missing name',
+					maxLength: 100
 				},
 				{
 					key: 'triggerType',
@@ -90,7 +92,8 @@ export const lessonEntity: EntityConfig<WorkbenchLesson> = {
 					placeholder: 'fight',
 					width: 170,
 					required: true,
-					reqMsg: 'Missing host screen'
+					reqMsg: 'Missing host screen',
+					maxLength: 50
 				},
 				{
 					key: 'triggerMechanicEvent',
@@ -105,7 +108,8 @@ export const lessonEntity: EntityConfig<WorkbenchLesson> = {
 					label: 'Designer Notes',
 					type: 'textarea',
 					placeholder: 'Why this lesson exists — authoring notes (never shown to players)…',
-					grow: true
+					grow: true,
+					maxLength: 2000
 				}
 			]
 		},
@@ -153,7 +157,8 @@ export const lessonEntity: EntityConfig<WorkbenchLesson> = {
 					label: 'Callout Text',
 					type: 'text',
 					min: 260,
-					placeholder: 'What this step teaches the player…'
+					placeholder: 'What this step teaches the player…',
+					maxLength: 500
 				},
 				{
 					key: 'anchorKey',

--- a/UI/src/routes/admin/workbench/entities/lesson.ts
+++ b/UI/src/routes/admin/workbench/entities/lesson.ts
@@ -166,7 +166,8 @@ export const lessonEntity: EntityConfig<WorkbenchLesson> = {
 					type: 'text',
 					width: 200,
 					placeholder: 'Optional — centered if blank',
-					optional: true
+					optional: true,
+					maxLength: 100
 				}
 			]
 		}

--- a/UI/src/routes/admin/workbench/entities/skill-recipe.ts
+++ b/UI/src/routes/admin/workbench/entities/skill-recipe.ts
@@ -80,7 +80,8 @@ export const skillRecipeEntity: EntityConfig<ISkillRecipe> = {
 					label: 'Designer Notes',
 					type: 'textarea',
 					placeholder: 'Why this recipe exists — authoring notes (never shown to players)…',
-					grow: true
+					grow: true,
+					maxLength: 2000
 				}
 			]
 		},

--- a/UI/src/routes/admin/workbench/entities/skill.ts
+++ b/UI/src/routes/admin/workbench/entities/skill.ts
@@ -98,9 +98,23 @@ export const skillEntity: EntityConfig<ISkill> = {
 					grow: true,
 					maxLength: 50
 				},
-				{ key: 'word', label: 'Word of Power', type: 'text', placeholder: 'sijren', width: 200 },
-				{ key: 'pronunciation', label: 'Pronunciation', type: 'text', placeholder: 'sij·ren', width: 200 },
-				{ key: 'translation', label: 'Translation', type: 'text', placeholder: 'The Riven Frost', grow: true },
+				{ key: 'word', label: 'Word of Power', type: 'text', placeholder: 'sijren', width: 200, maxLength: 50 },
+				{
+					key: 'pronunciation',
+					label: 'Pronunciation',
+					type: 'text',
+					placeholder: 'sij·ren',
+					width: 200,
+					maxLength: 50
+				},
+				{
+					key: 'translation',
+					label: 'Translation',
+					type: 'text',
+					placeholder: 'The Riven Frost',
+					grow: true,
+					maxLength: 100
+				},
 				{
 					key: 'acquisition',
 					label: 'Acquisition (channels allowed to grant this skill)',

--- a/UI/src/routes/admin/workbench/entities/skill.ts
+++ b/UI/src/routes/admin/workbench/entities/skill.ts
@@ -78,7 +78,8 @@ export const skillEntity: EntityConfig<ISkill> = {
 					placeholder: 'Name this skill…',
 					grow: true,
 					required: true,
-					reqMsg: 'Missing name'
+					reqMsg: 'Missing name',
+					maxLength: 50
 				},
 				{ key: 'baseDamage', label: 'Base Damage', type: 'number', suffix: 'dmg', width: 150 },
 				{

--- a/UI/src/routes/admin/workbench/entities/tag.ts
+++ b/UI/src/routes/admin/workbench/entities/tag.ts
@@ -40,7 +40,8 @@ export const tagEntity: EntityConfig<ITag> = {
 					placeholder: 'Name this tag…',
 					grow: true,
 					required: true,
-					reqMsg: 'Missing name'
+					reqMsg: 'Missing name',
+					maxLength: 50
 				},
 				{ key: 'tagCategoryId', label: 'Category', type: 'select', options: reference.tagCategoryOptions, width: 200 }
 			]

--- a/UI/src/routes/admin/workbench/entities/types.ts
+++ b/UI/src/routes/admin/workbench/entities/types.ts
@@ -96,6 +96,8 @@ export interface ColumnConfig {
 	/** Text columns: a cleared input stores as `undefined` rather than `''`, so an optional field reads
 	 *  as unmodified against a baseline that omits it (e.g. a tour step's Anchor Key). */
 	optional?: boolean;
+	/** Text columns: enforces the backend column's `HasMaxLength` bound. */
+	maxLength?: number;
 	/** Share columns: which numeric field drives the bar (default "weight"). */
 	weightKey?: string;
 	/**

--- a/UI/src/routes/admin/workbench/entities/zone.ts
+++ b/UI/src/routes/admin/workbench/entities/zone.ts
@@ -104,7 +104,8 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 					placeholder: 'Name this zone…',
 					grow: true,
 					required: true,
-					reqMsg: 'Missing name'
+					reqMsg: 'Missing name',
+					maxLength: 50
 				},
 				{ key: 'order', label: 'Order', type: 'number', width: 110 },
 				{ key: 'levelMin', label: 'Level Min', type: 'number', suffix: 'lv', width: 130 },


### PR DESCRIPTION
## Summary

Closes #2277.

The client-side `maxLength` convention (#2257, closed by #2262/#2263) didn't reach every Workbench entity config, and one authored text column (`LessonStep.Text`) was still left unbounded at the DB level.

- **Missing configs entirely**: `entities/enemy.ts` (Name 50, DesignerNotes 2000), `entities/class.ts` (Name 50, Description 500, Word 50, DesignerNotes 2000), `entities/lesson.ts` (Key 100, Name 100, ScreenKey 50, DesignerNotes 2000), `entities/skill-recipe.ts` (DesignerNotes 2000).
- **Partially missing**: `entities/skill.ts` was missing the word/pronunciation/translation bounds (50/50/100).
- **`LessonStep.Text`** was an unbounded `text` column — missed by the earlier #2243/#2256 bounding sweep, which only bounded `AnchorKey`. Bounded it at 500 chars (matching the `Description` precedent used elsewhere for player-facing authored text; the current authored content's longest step is 202 chars) via a new EF migration (`Game.Infrastructure/Migrations/20260722161431_BoundLessonStepText.*`).
- **`TableCell.svelte`** (the table-row editor used by, e.g., the lesson steps table) had no `maxLength` support at all for its `text` column type — added `ColumnConfig.maxLength`, threaded through mirroring `FieldControl`'s existing `text`/`textarea` support, and used it for the lesson steps table's Callout Text column.
- While in the same file family: every other config's `name` field (`item.ts`, `zone.ts`, `challenge.ts`, `item-mod.ts`, `tag.ts`) also never got a `maxLength` despite 50/100-char DB bounds — a one-line-each fix in the same pattern, so folded in here rather than filed separately.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] `dotnet test --no-build --no-restore` — full backend suite green (Core, Infrastructure, Application, Api).
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — 310 test files / 3893 tests passing.
- [x] Verified the generated migration (`AlterColumn` to `character varying(500)`) matches the model snapshot and the current longest authored lesson-step text (202 chars) fits comfortably under the new bound.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HdPjTvyUkgrg3w9NHj4nC8)_