### PR TITLE
Remove BattleStats.PlayerRating, a production-write-only field with misleading comments

### DIFF
--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -313,7 +313,7 @@ namespace Game.Application.Tests.Services
         }
 
         [Fact]
-        public async Task RecordVictory_SnapshotsPlayerRatingOntoStats_FromSnapshotNotLiveAggregate()
+        public async Task RecordVictory_RatesPlayerRewardFromSnapshotNotLiveAggregate()
         {
             using var scope = CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
@@ -339,8 +339,8 @@ namespace Game.Application.Tests.Services
             await battleService.StartBattle(player, state, zoneId: zone.Id);
 
             // Deflate the LIVE player's power to almost nothing after the snapshot is frozen (a valid mid-battle
-            // stat reallocation). The accrual must normalize by the snapshot-era rating, so a regression sourcing
-            // PlayerRating from the live aggregate — or dropping the assignment — would read a far lower value.
+            // stat reallocation). The reward must rate the snapshot-era attributes, so a regression sourcing
+            // PlayerRating from the live aggregate would read a far lower value.
             foreach (var allocation in player.StatPoints.StatAllocations)
             {
                 allocation.Amount = 1;
@@ -361,7 +361,6 @@ namespace Game.Application.Tests.Services
                 new Battler(new AttributeCollection(player.GetAllModifiers()), [], player.Level), isPlayer: true);
             Assert.True(rewards.PlayerRating > deflatedRating,
                 $"Expected the snapshot-era rating ({rewards.PlayerRating}) to exceed the deflated live rating ({deflatedRating}).");
-            Assert.Equal(rewards.PlayerRating, result.Stats.PlayerRating, precision: 9);
         }
 
         [Fact]

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -598,10 +598,9 @@ namespace Game.Application.Services
         // (AbandonBattle's elapsedMs) — a win only resolves if the enemy died within time the server itself
         // observed, so the server-measured cap is the (stronger) control there and nothing else is needed.
         // Both paths therefore require a server-validated timeline; neither can be claimed early.
-        // internal (not private) so an integration test can assert the live PlayerRating snapshot directly:
-        // EndBattleVictory returns only a client-facing DefeatResult, and the BattleStats this mutates is
-        // carried on the BattleCompletedEvent, which the dispatcher clears after handling — leaving no other
-        // seam to observe that result.Stats.PlayerRating is set from the snapshot rather than the live aggregate.
+        // internal (not private) so integration tests can call it directly — bypassing TryResolveActiveBattle's
+        // SimulateBattle call — to assert on the returned DefeatRewards (e.g. that PlayerRating reflects the
+        // frozen battle snapshot, not the live aggregate) without needing a battle to actually run and be won.
         internal DefeatRewards RecordVictory(
             Player player, CoreEnemy enemy, BattleResult result, PlayerState state, DateTime timestamp,
             bool notify = true, BattlerMaterials? playerMaterials = null)
@@ -632,11 +631,6 @@ namespace Game.Application.Services
 
             var playerBattler = playerMaterials.Build();
             var rewards = new DefeatRewards(playerBattler, enemy);
-
-            // Snapshot the player's rating onto the battle stats so the proficiency accrual normalizes activity
-            // by the identical measure the reward curve uses (spike #1526 Decision 5) — captured here from the
-            // same snapshot-built battler, not the live aggregate.
-            result.Stats.PlayerRating = rewards.PlayerRating;
 
             player.GrantExp(rewards.ExpReward);
             // Thread both combat ratings onto the battle-completed event so the progress handler can normalize

--- a/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
+++ b/Game.Core.Tests/Battle/Offline/OfflineProgressSimulatorTests.cs
@@ -466,10 +466,10 @@ namespace Game.Core.Tests.Battle.Offline
         }
 
         [Fact]
-        public void Simulate_SnapshotsPlayerRatingOntoEachVictoryStats()
+        public void Simulate_SnapshotsPlayerRatingOntoEachVictoryOutcome()
         {
             // The effect-based proficiency accrual normalizes activity by the player's rating, so the simulator
-            // snapshots it onto each won battle's stats — the same stationary CombatRating.Rate DefeatRewards
+            // snapshots it onto each won battle's outcome — the same stationary CombatRating.Rate DefeatRewards
             // measures from the snapshot (the player's power never changes while away, so every victory's
             // snapshot rating is identical).
             var scenario = StrongPlayerWinScenario();
@@ -480,19 +480,19 @@ namespace Game.Core.Tests.Battle.Offline
 
             Assert.True(result.Wins > 1);
             Assert.Equal(result.BattlesSimulated, result.Wins); // the strong player wins every battle
-            Assert.All(result.Battles, battle => Assert.Equal(expectedRating, battle.Result.Stats.PlayerRating, precision: 9));
+            Assert.All(result.Battles, battle => Assert.Equal(expectedRating, battle.PlayerRating, precision: 9));
         }
 
         [Fact]
         public void Simulate_LeavesPlayerRatingAtZeroForLosses()
         {
-            // A loss earns no DefeatRewards, so (like the live path) its stats carry no rating snapshot — the
+            // A loss earns no DefeatRewards, so (like the live path) its outcome carries no rating — the
             // default 0. Accrual is victory-only, so a loss's rating is never read.
             var result = _simulator.Simulate(BossParameters(ManyStepsBudget(), AlwaysLoseBossScenario()));
 
             Assert.True(result.Losses > 1);
             Assert.Equal(result.BattlesSimulated, result.Losses);
-            Assert.All(result.Battles, battle => Assert.Equal(0, battle.Result.Stats.PlayerRating));
+            Assert.All(result.Battles, battle => Assert.Equal(0, battle.PlayerRating));
         }
 
         // ── Idle enemy rating memo (#2130) ───────────────────────────────────

--- a/Game.Core/Battle/BattleStats.cs
+++ b/Game.Core/Battle/BattleStats.cs
@@ -154,13 +154,6 @@ namespace Game.Core.Battle
         /// </summary>
         public Dictionary<EDamageType, double> TypedDamageResistanceMitigated { get; set; } = [];
 
-        /// <summary>
-        /// The player's combat rating for this battle (<see cref="Battle.CombatRating.Rate"/>), superseding the
-        /// old core-attribute sum (spike #1526). Populated at battle completion from
-        /// <see cref="DefeatRewards.PlayerRating"/> (victory-only, like the rewards); <c>0</c> until then.
-        /// </summary>
-        public double PlayerRating { get; set; }
-
         /// <summary>Accumulates a direct hit's or DoT tick's booked <paramref name="amount"/> (already capped at
         /// the health it removed and floored at 0 by the caller — #1482/#2101) into the typed offense book.</summary>
         public void AddTypedDamageDealt(EDamageType type, double amount)

--- a/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
+++ b/Game.Core/Battle/Offline/OfflineProgressSimulator.cs
@@ -135,11 +135,6 @@ namespace Game.Core.Battle.Offline
                 var proficiencyGains = ProficiencyAccrualResult.Empty;
                 if (rewards is not null)
                 {
-                    // Snapshot the player's rating onto this battle's stats so the offline accrual normalizes by
-                    // the identical measure the live path does (spike #1526 Decision 5) — victory-only, like the
-                    // rewards.
-                    result.Stats.PlayerRating = rewards.PlayerRating;
-
                     // Accrue proficiency XP in-loop (#1602): the same domain math the live per-battle path
                     // runs, against this run's own working proficiency state, so a milestone attribute payout
                     // crossed here is already baked into the next battle's snapshot below — unlike the pre-#1602


### PR DESCRIPTION
## Summary

Closes #2278.

`BattleStats.PlayerRating` was written at two sites (`BattleService.RecordVictory` and `OfflineProgressSimulator`), and its doc comment — plus the comments at both write sites — claimed it existed "so the proficiency accrual normalizes activity by the identical measure." That claim doesn't hold up:

- The live path normalizes off `BattleCompletedEvent.PlayerRating`/`EnemyRating` (`BattleStatisticsEventHandler.cs:43`), not `BattleStats.PlayerRating`.
- The offline loop passes `Math.Max(rewards.PlayerRating, rewards.EnemyRating)` directly into `ProficiencyAccrual.Accrue` (`OfflineProgressSimulator.cs`), never reading the stats field either.
- `ProficiencyAccrual` itself has no reference to `BattleStats.PlayerRating` at all.

A repo-wide grep confirmed the only readers were tests — it isn't logged (`BattleCompletedEvent.GetLogProperties` excludes stats) and isn't mapped to any API model.

## Changes

- Removed `BattleStats.PlayerRating` and its doc comment.
- Removed both write sites and their now-inaccurate comments (`BattleService.RecordVictory`, `OfflineProgressSimulator`).
- Updated the `RecordVictory` "internal (not private)" comment, which specifically cited the removed field as the reason for that visibility — it's still `internal` because integration tests call it directly to bypass `TryResolveActiveBattle`'s `SimulateBattle` call, which is unrelated to the removed field.
- Re-pointed the three tests that read `BattleStats.PlayerRating` at the values that were already available and equivalent:
  - `BattleServiceIntegrationTests`: dropped the redundant stats assertion, keeping the `DefeatRewards.PlayerRating` assertion (renamed the test since it's no longer about a stats snapshot).
  - `OfflineProgressSimulatorTests` (×2): re-pointed at `OfflineBattleOutcome.PlayerRating`, which already carried the identical value.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] `dotnet test --no-build --no-restore` — full backend suite green (Core, Infrastructure, Application, Api: 1431 + 68 + 1085 + 858 passing).
- No frontend changes (this field has no frontend/API surface).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WtMQ6iujM1yQK6VMY1dm5o)_