### PR TITLE
Skip the write-behind save on a no-op SetAutoChallengeBoss toggle

### DIFF
--- a/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
+++ b/Game.Application.Tests/Services/BattleServiceIntegrationTests.cs
@@ -8,11 +8,13 @@ using Game.Core.Battle.Events;
 using Game.Core.Battle.Offline;
 using Game.Core.Players;
 using Game.Core.TestInfrastructure.Builders;
+using Game.DataAccess;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
 using Game.TestInfrastructure.Helpers;
 using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
 using Xunit;
 
 namespace Game.Application.Tests.Services
@@ -2773,6 +2775,75 @@ namespace Game.Application.Tests.Services
             var reloaded = await playerRepo.GetPlayer(playerEntity.Id);
             Assert.NotNull(reloaded);
             Assert.False(reloaded.AutoChallengeBoss);
+        }
+
+        [Fact]
+        public async Task SetAutoChallengeBoss_AlreadyActiveMode_SkipsSaveButStillReturnsTrue()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var boss = await TestDataSeeder.CreateEnemyAsync(context, "Zone Boss", isBoss: true);
+            var zone = await TestDataSeeder.CreateZoneAsync(context, "Boss Zone", bossEnemyId: boss.Id, bossLevel: 5);
+
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+
+            var options = ConfigurationOptions.Parse(Containers.PubSubConnectionString);
+            using var multiplexer = await ConnectionMultiplexer.ConnectAsync(options);
+            var db = multiplexer.GetDatabase();
+
+            // The first enable actually changes the mode, so it must enqueue a write-behind event — proving
+            // the no-op assertions below aren't trivially true (e.g. from a broken queue).
+            await battleService.SetAutoChallengeBoss(player, enabled: true);
+            Assert.Equal(1, await db.ListLengthAsync(Constants.PUBSUB_PLAYER_QUEUE));
+            await db.KeyDeleteAsync(Constants.PUBSUB_PLAYER_QUEUE);
+
+            // Re-enabling the already-active mode is accepted (still returns true) but is a no-op: no event,
+            // no write-behind save.
+            var success = await battleService.SetAutoChallengeBoss(player, enabled: true);
+
+            Assert.True(success);
+            Assert.True(player.AutoChallengeBoss);
+            Assert.Equal(0, await db.ListLengthAsync(Constants.PUBSUB_PLAYER_QUEUE));
+        }
+
+        [Fact]
+        public async Task SetAutoChallengeBoss_AlreadyIdle_DisableIsNoOpButStillReturnsTrue()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+
+            var zone = await TestDataSeeder.CreateZoneAsync(context);
+            var user = await TestDataSeeder.CreateUserAsync(context);
+            var playerEntity = await TestDataSeeder.CreatePlayerAsync(context, user.Id, zoneId: zone.Id);
+
+            await ReloadReferenceCachesAsync();
+
+            var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+            var player = await playerRepo.GetPlayer(playerEntity.Id);
+            Assert.NotNull(player);
+
+            var battleService = scope.ServiceProvider.GetRequiredService<BattleService>();
+
+            var options = ConfigurationOptions.Parse(Containers.PubSubConnectionString);
+            using var multiplexer = await ConnectionMultiplexer.ConnectAsync(options);
+            var db = multiplexer.GetDatabase();
+
+            // The player already loads idle (AutoChallengeBoss defaults false), so disabling is a no-op.
+            var success = await battleService.SetAutoChallengeBoss(player, enabled: false);
+
+            Assert.True(success);
+            Assert.False(player.AutoChallengeBoss);
+            Assert.Equal(0, await db.ListLengthAsync(Constants.PUBSUB_PLAYER_QUEUE));
         }
 
         [Fact]

--- a/Game.Application/Services/BattleService.cs
+++ b/Game.Application/Services/BattleService.cs
@@ -256,15 +256,20 @@ namespace Game.Application.Services
         /// always the player's current zone's boss — the loop never targets a separate zone — so enabling
         /// validates <see cref="Player.CurrentZoneId"/> as anti-cheat the same way <see cref="StartBossBattle"/>
         /// does (in circulation, unlocked, has a dedicated boss), rejecting (no mutation) otherwise; disabling
-        /// is always accepted (returning to idle needs no target). The change rides the existing write-behind
-        /// save via the player's core-updated event.
+        /// is always accepted (returning to idle needs no target). A toggle to the already-active mode saves
+        /// nothing (no mutation, no event) but still returns <c>true</c> — accepting is not the same as
+        /// changing. Otherwise the change rides the existing write-behind save via the player's core-updated
+        /// event.
         /// </summary>
         public async Task<bool> SetAutoChallengeBoss(Player player, bool enabled, CancellationToken cancellationToken = default)
         {
             if (!enabled)
             {
-                player.SetAutoChallengeBoss(false);
-                await _playerRepo.SavePlayer(player, cancellationToken);
+                if (player.SetAutoChallengeBoss(false))
+                {
+                    await _playerRepo.SavePlayer(player, cancellationToken);
+                }
+
                 return true;
             }
 
@@ -276,8 +281,11 @@ namespace Game.Application.Services
                 return false;
             }
 
-            player.SetAutoChallengeBoss(true);
-            await _playerRepo.SavePlayer(player, cancellationToken);
+            if (player.SetAutoChallengeBoss(true))
+            {
+                await _playerRepo.SavePlayer(player, cancellationToken);
+            }
+
             return true;
         }
 

--- a/Game.Core.Tests/Players/PlayerTests.cs
+++ b/Game.Core.Tests/Players/PlayerTests.cs
@@ -1024,8 +1024,9 @@ namespace Game.Core.Tests.Players
         {
             var player = MakePlayer();
 
-            player.SetAutoChallengeBoss(true);
+            var changed = player.SetAutoChallengeBoss(true);
 
+            Assert.True(changed);
             Assert.True(player.AutoChallengeBoss);
             var evt = Assert.IsType<PlayerCoreUpdatedEvent>(Assert.Single(player.DomainEvents));
             Assert.True(evt.AutoChallengeBoss);
@@ -1038,11 +1039,38 @@ namespace Game.Core.Tests.Players
             player.SetAutoChallengeBoss(true);
             player.ClearEvents();
 
-            player.SetAutoChallengeBoss(false);
+            var changed = player.SetAutoChallengeBoss(false);
 
+            Assert.True(changed);
             Assert.False(player.AutoChallengeBoss);
             var evt = Assert.IsType<PlayerCoreUpdatedEvent>(Assert.Single(player.DomainEvents));
             Assert.False(evt.AutoChallengeBoss);
+        }
+
+        [Fact]
+        public void SetAutoChallengeBoss_AlreadyEnabled_ReturnsFalseAndDoesNotRaiseEvent()
+        {
+            var player = MakePlayer();
+            player.SetAutoChallengeBoss(true);
+            player.ClearEvents();
+
+            var changed = player.SetAutoChallengeBoss(true);
+
+            Assert.False(changed);
+            Assert.True(player.AutoChallengeBoss);
+            Assert.Empty(player.DomainEvents);
+        }
+
+        [Fact]
+        public void SetAutoChallengeBoss_AlreadyDisabled_ReturnsFalseAndDoesNotRaiseEvent()
+        {
+            var player = MakePlayer();
+
+            var changed = player.SetAutoChallengeBoss(false);
+
+            Assert.False(changed);
+            Assert.False(player.AutoChallengeBoss);
+            Assert.Empty(player.DomainEvents);
         }
 
         // ── RecordBattleCompleted — boss-mode backstop ───────────────────────

--- a/Game.Core/Players/Player.cs
+++ b/Game.Core/Players/Player.cs
@@ -71,13 +71,20 @@ namespace Game.Core.Players
         /// Persists the active idle-loop mode: <paramref name="enabled"/> enters boss mode (auto-challenging
         /// the current zone's dedicated boss), <c>false</c> returns the loop to idle-farming. Anti-cheat
         /// validation of the current zone (in circulation, unlocked, has a boss) is the caller's
-        /// responsibility. Raises a <see cref="PlayerCoreUpdatedEvent"/> so the change rides the existing
-        /// write-behind save.
+        /// responsibility. A no-op (the mode already matches <paramref name="enabled"/>) raises no event and
+        /// returns <c>false</c>; otherwise raises a <see cref="PlayerCoreUpdatedEvent"/> so the change rides
+        /// the existing write-behind save and returns <c>true</c>.
         /// </summary>
-        public void SetAutoChallengeBoss(bool enabled)
+        public bool SetAutoChallengeBoss(bool enabled)
         {
+            if (AutoChallengeBoss == enabled)
+            {
+                return false;
+            }
+
             AutoChallengeBoss = enabled;
             RaiseCoreUpdated();
+            return true;
         }
 
         public bool TryUpdateAttributes(IEnumerable<IAttributeUpdate> changedAttributes)


### PR DESCRIPTION
## Summary

Closes #2280.

`Player.SetAutoChallengeBoss` unconditionally raised `PlayerCoreUpdatedEvent` and `BattleService.SetAutoChallengeBoss` unconditionally saved, even when the toggle matched the mode already in effect — the same "no mutation → no save" gap just closed for `SaveLogPreferences` in #2254.

## Changes

- `Player.SetAutoChallengeBoss` (`Game.Core/Players/Player.cs`) now returns `bool` and is a no-op (no event raised) when `enabled` already matches `AutoChallengeBoss` — mirroring the guard `Player.UpdateLogPreference` got in #2254.
- `BattleService.SetAutoChallengeBoss` (`Game.Application/Services/BattleService.cs`) now only calls `SavePlayer` when the toggle actually changed the mode, on both the enable and disable paths. It still returns `true` for an already-active no-op — accepting the command is not the same as changing state, and the anti-cheat/success contract for callers (the `SetAutoChallengeBoss` socket command) is unchanged.

## Test plan

- [x] `Game.Core.Tests/Players/PlayerTests.cs`: added `SetAutoChallengeBoss_AlreadyEnabled_ReturnsFalseAndDoesNotRaiseEvent` and `SetAutoChallengeBoss_AlreadyDisabled_ReturnsFalseAndDoesNotRaiseEvent`; updated the existing enable/disable tests to assert the new `true` return value.
- [x] `Game.Application.Tests/Services/BattleServiceIntegrationTests.cs`: added `SetAutoChallengeBoss_AlreadyActiveMode_SkipsSaveButStillReturnsTrue` (proves a real toggle enqueues a write-behind event first, then that re-enabling is a no-op — same shape as the #2254 `SaveLogPreferences_NoValuesChanged_DoesNotEnqueueWriteBehindEvents` test) and `SetAutoChallengeBoss_AlreadyIdle_DisableIsNoOpButStillReturnsTrue`.
- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] `dotnet test --no-build --no-restore` — full backend suite green (Core: 1433, Infrastructure: 68, Application: 1087, Api: 858 passing).
- No frontend changes (the frontend already dedups this sync via `enemy-manager.ts`'s `#lastSyncedAutoChallengeBoss`, so this change hardens the backend invariant itself — same framing as #2254).

---
_Generated by [Claude Code](https://claude.ai/code/session_016DSrVXT3jtU9kkeRNbRkgd)_