### PR TITLE
Add CI guard against dependabot NuGet-rebase csproj artifact

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -89,7 +89,7 @@ jobs:
     if: |
       always() && !cancelled() &&
       github.event_name == 'pull_request' &&
-      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
       needs.detect-changes.outputs.csproj == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,6 +34,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      csproj: ${{ steps.filter.outputs.csproj }}
     steps:
     - name: Checkout
       uses: actions/checkout@v7
@@ -74,6 +75,30 @@ jobs:
             - 'UI/**'
             - 'content/**'
             - '.github/workflows/**'
+          csproj:
+            - '**/*.csproj'
+
+  # Guards against a known dependabot-core artifact under Central Package Management: rebasing a
+  # NuGet version-bump PR (because another PR touched Directory.Packages.props first) can make
+  # Dependabot's updater re-add a redundant <PackageReference> to a *.csproj that already gets the
+  # dependency transitively — see #2299. A version bump should only ever touch
+  # Directory.Packages.props, so any .csproj change on a dependabot PR is almost certainly this
+  # artifact rather than an intended edit.
+  guard-dependabot-csproj-scope:
+    needs: [detect-changes]
+    if: |
+      always() && !cancelled() &&
+      github.event_name == 'pull_request' &&
+      github.actor == 'dependabot[bot]' &&
+      needs.detect-changes.outputs.csproj == 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fail — dependabot PR modified a .csproj file
+      run: |
+        echo "This dependabot PR modifies one or more .csproj files."
+        echo "Under Central Package Management, a version bump should only touch Directory.Packages.props."
+        echo "This is a known dependabot-core rebase artifact (see issue #2299) — strip the spurious <PackageReference> edit before merging."
+        exit 1
 
   # Non-test backend verifications (codegen drift + formatter), split out of test-backend so that
   # job is left with just build + tests/coverage (its longest path). Both checks need the build, so
@@ -356,7 +381,7 @@ jobs:
     # skipped (path-filtered out); fails if any job failed or was cancelled, including
     # detect-changes itself (a change-detection failure should block the PR, not silently skip tests).
     if: always()
-    needs: [detect-changes, verify-backend, verify-frontend, test-backend, test-frontend, test-e2e]
+    needs: [detect-changes, guard-dependabot-csproj-scope, verify-backend, verify-frontend, test-backend, test-frontend, test-e2e]
     runs-on: ubuntu-latest
     steps:
     - name: Verify all jobs passed or were skipped

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -101,7 +101,7 @@ The backend re-simulates **every** battle after the client reports it (the anti-
 
 Under Central Package Management, a version-bump PR should only ever touch `Directory.Packages.props` — but Dependabot's NuGet updater has a known rebase artifact: when a PR is rebased because another PR merged and touched `Directory.Packages.props` first, the updater can re-add a redundant `<PackageReference>` (with an explicit version) to a `*.csproj` that already gets that dependency transitively (#2299). That's out of scope for a version bump and leaves a dead direct reference behind if merged as-is.
 
-`run-tests.yml`'s `guard-dependabot-csproj-scope` job catches this at the CI boundary rather than relying on manual review: it runs only when `github.actor == 'dependabot[bot]'` and the PR's diff touches any `.csproj` (via the `detect-changes` path-filter), and fails outright — a version bump from Dependabot has no legitimate reason to touch project files, so this only ever guards against the artifact, never a real bump.
+`run-tests.yml`'s `guard-dependabot-csproj-scope` job catches this at the CI boundary rather than relying on manual review: it runs only when `github.event.pull_request.user.login == 'dependabot[bot]'` (the PR's author, not whoever triggered the run — a maintainer manually re-running CI on a Dependabot PR must not silently bypass the guard) and the PR's diff touches any `.csproj` (via the `detect-changes` path-filter), and fails outright — a version bump from Dependabot has no legitimate reason to touch project files, so this only ever guards against the artifact, never a real bump.
 
 ## Code coverage
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -97,6 +97,12 @@ The backend re-simulates **every** battle after the client reports it (the anti-
 - **They run on the PR gate but carry an escape hatch.** The tests are tagged `[Trait("Category", "Performance")]`; if runner contention ever makes even the coarse backstop flake, excluding them is one flag — `dotnet test … -- --filter-not-trait "Category=Performance"` (the flag is passed to the xUnit v3 native runner the suite uses, after the `--` separator) — with no code change.
 - **Intentionally backend-only.** Unlike the battle-simulation *parity* tests, these assert nothing about correctness or determinism (only cost), so — although the simulation itself is mirrored on the client — there is deliberately **no frontend mirror** to keep in sync. JS-vs-C# performance is not comparable anyway, and the client is not on the anti-cheat critical path.
 
+## Dependabot NuGet rebase guard
+
+Under Central Package Management, a version-bump PR should only ever touch `Directory.Packages.props` — but Dependabot's NuGet updater has a known rebase artifact: when a PR is rebased because another PR merged and touched `Directory.Packages.props` first, the updater can re-add a redundant `<PackageReference>` (with an explicit version) to a `*.csproj` that already gets that dependency transitively (#2299). That's out of scope for a version bump and leaves a dead direct reference behind if merged as-is.
+
+`run-tests.yml`'s `guard-dependabot-csproj-scope` job catches this at the CI boundary rather than relying on manual review: it runs only when `github.actor == 'dependabot[bot]'` and the PR's diff touches any `.csproj` (via the `detect-changes` path-filter), and fails outright — a version bump from Dependabot has no legitimate reason to touch project files, so this only ever guards against the artifact, never a real bump.
+
 ## Code coverage
 
 Both tiers gate test coverage with a **per-area ratchet**: each area carries a floor seeded at its current level that only ever rises, so a regression fails the build while no global percentage has to be hand-maintained. The design deliberately leans on the existing architecture rather than trying to detect "is this real logic?" line by line — strict floors where logic concentrates, *measure-only* elsewhere, and explicit, reviewable exclusions for no-logic code (generated clients, DTOs/entities, EF migrations, styles, barrel files). An exclusion is a visible line in a diff, never a silent gap.


### PR DESCRIPTION
## Summary

Under Central Package Management, a NuGet version bump should only ever touch `Directory.Packages.props`. Dependabot's NuGet updater has a known artifact under CPM: when a version-bump PR is **rebased** (because another PR merged and touched `Directory.Packages.props` first), the updater's re-run can inject a redundant `<PackageReference Include="..." Version="..." />` into a `*.csproj` that already reaches the dependency transitively. That's out of scope for a version bump and leaves a dead direct reference behind if merged as-is (concrete instance: PR #2293, described in #2299).

This adds a CI guard rather than relying on a manual scope check on every rebased dependabot PR:

- `detect-changes` gets a new `csproj` path-filter output (`**/*.csproj`).
- A new job, `guard-dependabot-csproj-scope`, runs only when the PR's author is `dependabot[bot]` **and** the diff touches a `.csproj`, and fails outright with a message pointing at the cause. A version bump from Dependabot has no legitimate reason to touch project files, so this only ever fires on the artifact, never a real bump.
- `all-checks-passed` now lists the new job so it's part of the required branch-protection check.
- Documented the guard in `docs/infrastructure.md` (CI/build tooling doc) alongside the other CI-job design notes.

## Closes #2299

Resolves the "systemic fix" ask in #2299. The issue's "immediate remediation for #2293" item is moot — that PR was already closed/manually remediated before this PR was opened.

### A note on scope

#2299 listed three possible directions to evaluate. I went with **"add a lightweight CI/lint check that fails when a Dependabot PR modifies a `.csproj`"** rather than the other two:
- Restricting Dependabot's NuGet updates to `Directory.Packages.props` only isn't something `dependabot.yml` config can actually enforce — this is an upstream `dependabot-core` behavior with CPM, not something the allow/ignore knobs reach.
- Tracking the upstream issue alone would leave the repo exposed to the same artifact recurring silently on every future rebase.

A CI guard is self-contained, testable at the workflow level, and turns a manual "did dependabot sneak in an extra csproj edit" review step into an automatic block.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/run-tests.yml'))"` — validates the YAML parses.
- [x] Manually traced the `if:` condition against real dependabot PR context (`github.actor == 'dependabot[bot]'`) and the existing `detect-changes` gating pattern used by other jobs in this workflow.
- [ ] Since GitHub Actions workflow changes can't be exercised locally, please confirm this behaves as expected the next time a dependabot NuGet PR is rebased (or revert if it misfires — the condition is narrow, dependabot-actor + csproj-diff only, so it should never affect a human-authored PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YKY1jCdWhd1wWJUCsw5tc

---
_Generated by [Claude Code](https://claude.ai/code/session_014YKY1jCdWhd1wWJUCsw5tc)_