### PR TITLE
Group .NET runtime family Dependabot NuGet updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dotnet-runtime:
+        patterns:
+          - "Microsoft.EntityFrameworkCore*"
+          - "Microsoft.Extensions.*"
+          - "Microsoft.AspNetCore.*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

`.github/dependabot.yml`'s `nuget` entry had no grouping, so Dependabot opened a separate PR per package. The `Microsoft.EntityFrameworkCore*`, `Microsoft.Extensions.*`, and `Microsoft.AspNetCore.*` packages ship as a coupled .NET servicing set under Central Package Management — bumping one without the others is a hard build failure (`NU1605` package downgrade), not just noise.

### Concrete instance this fixes

PR #2296 bumped only the three `Microsoft.EntityFrameworkCore*` packages `10.0.9 → 10.0.10`. EF Core `10.0.10` transitively requires `Microsoft.Extensions.Logging.Abstractions >= 10.0.10`, but that package was still pinned at `10.0.9`, producing:

```
error NU1605: Detected package downgrade: Microsoft.Extensions.Logging.Abstractions from 10.0.10 to 10.0.9.
```

`verify-backend`, `test-backend`, and e2e all failed; #2296 had to be closed and manually replaced by #2297, which bumped the EF Core trio and the `Microsoft.Extensions.*` family together.

## Change

Added a `groups.dotnet-runtime` block to the `nuget` entry:

```yaml
groups:
  dotnet-runtime:
    patterns:
      - "Microsoft.EntityFrameworkCore*"
      - "Microsoft.Extensions.*"
      - "Microsoft.AspNetCore.*"
```

Patterns were checked against the current `Directory.Packages.props`: they cover exactly the 9 packages currently pinned at the shared `10.0.10` servicing version (EF Core trio, the 4 `Microsoft.Extensions.*` abstractions packages, and the 2 `Microsoft.AspNetCore.*` packages). `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` (pinned at an unrelated `1.23.0`) is intentionally not matched by any pattern.

Future .NET servicing bumps (`10.0.11`, `10.0.12`, …) will now land as one coordinated, buildable PR instead of N separate unbuildable ones needing manual consolidation — also reducing the rebase churn on `Directory.Packages.props` that #2299 (and its CI guard, PR #2319) deals with.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — validates the YAML parses.
- [x] Verified the three glob patterns against `Directory.Packages.props` match exactly the intended `Microsoft.*` servicing-family packages and nothing else.
- [ ] Since Dependabot grouping behavior can't be exercised locally, confirm on the next weekly run (or the next coordinated .NET servicing release) that these packages land in a single grouped PR.

Closes #2300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAccWnRmrwmrYkFwSXzVNf)_