### PR TITLE
Preempt Home-flip save rejection when spawns are cleared in the same edit

### DIFF
--- a/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
+++ b/UI/src/routes/admin/workbench/components/WorkbenchDetail.svelte
@@ -30,7 +30,7 @@
 				label: section.label,
 				count: section.count?.(record) ?? null,
 				dirty: sectionDirty(section),
-				warn: sectionWarnings(section, record).length > 0
+				warn: sectionWarnings(section, record, baseline).length > 0
 			}))}
 			activeTab={tab}
 			onTab={(key) => onTab(key)}

--- a/UI/src/routes/admin/workbench/entities/types.ts
+++ b/UI/src/routes/admin/workbench/entities/types.ts
@@ -132,8 +132,11 @@ interface BaseSection<T> {
 	/** Tab count badge. */
 	count?: (rec: T) => number;
 	/** Section-level validation warning (e.g. "No skills assigned"). Return a {@link Warning} instead
-	 *  of a plain string to mark a known backend hard-reject condition as save-blocking. */
-	warn?: (rec: T) => string | Warning | null;
+	 *  of a plain string to mark a known backend hard-reject condition as save-blocking. `baseline` is
+	 *  the record's last-saved copy (undefined for a not-yet-saved add) — a predicate whose backend
+	 *  counterpart validates against persisted state rather than the pending record (e.g. a child
+	 *  saver that hasn't run yet) needs it to preempt the same rejection. */
+	warn?: (rec: T, baseline?: T) => string | Warning | null;
 	/**
 	 * Record keys that constitute a change for this section's tab dirty-dot. Used by
 	 * custom-kind sections (which have no single `fields`/`itemsKey` to diff); the

--- a/UI/src/routes/admin/workbench/entities/zone.ts
+++ b/UI/src/routes/admin/workbench/entities/zone.ts
@@ -162,9 +162,19 @@ export const zoneEntity: EntityConfig<WorkbenchZone> = {
 			// rolls at runtime (mirrors the backend's EmptyCombatZone lint). A Home zone with any
 			// spawn rows is a harder problem: it's hard-rejected on save (AdminZones.SaveZones'
 			// edit guard, AdminZones.SetEnemies), so it blocks rather than merely warns.
-			warn: (z) => {
+			warn: (z, baseline) => {
 				if (z.isHome) {
-					return z.zoneEnemies.length ? { message: 'The Home zone cannot have enemy spawns', blocking: true } : null;
+					if (z.zoneEnemies.length) {
+						return { message: 'The Home zone cannot have enemy spawns', blocking: true };
+					}
+					// SaveZones' edit guard reads the *persisted* spawn count (AdminZones.cs), evaluated
+					// before this save's own SetZoneEnemies child-saver clears it — so clearing spawns and
+					// flipping isHome on in the same save still hard-rejects even though the pending record
+					// already reads empty. Check the baseline's count instead of the pending one to preempt
+					// it (#2314); an Add has no baseline and can't carry pre-existing spawns either way.
+					return baseline?.zoneEnemies.length
+						? { message: 'Clear spawns in a separate save before making this zone Home', blocking: true }
+						: null;
 				}
 				return z.zoneEnemies.some((ze) => isLiveEnemy(ze.enemyId)) ? null : 'No enemies spawn here';
 			},

--- a/UI/src/routes/admin/workbench/entity-store.svelte.ts
+++ b/UI/src/routes/admin/workbench/entity-store.svelte.ts
@@ -104,8 +104,8 @@ export class EntityStore<T extends Identified> {
 			if (!state) {
 				state = {
 					status: this.status(record),
-					warnings: entityWarnings(this.config, record),
-					blockingWarnings: entityBlockingWarnings(this.config, record)
+					warnings: entityWarnings(this.config, record, this.baselineOf(record.id)),
+					blockingWarnings: entityBlockingWarnings(this.config, record, this.baselineOf(record.id))
 				};
 				this.stateCache.set(record, state);
 			}
@@ -119,8 +119,8 @@ export class EntityStore<T extends Identified> {
 		return (
 			this.recordStates[record.id] ?? {
 				status: this.status(record),
-				warnings: entityWarnings(this.config, record),
-				blockingWarnings: entityBlockingWarnings(this.config, record)
+				warnings: entityWarnings(this.config, record, this.baselineOf(record.id)),
+				blockingWarnings: entityBlockingWarnings(this.config, record, this.baselineOf(record.id))
 			}
 		);
 	}

--- a/UI/src/routes/admin/workbench/validation.ts
+++ b/UI/src/routes/admin/workbench/validation.ts
@@ -16,13 +16,13 @@ export function fieldWarn<T>(field: FieldConfig<T>, rec: T): string | null {
 	return empty ? (field.reqMsg ?? `${field.label} required`) : null;
 }
 
-const resolveWarning = <T>(section: SectionConfig<T>, rec: T): Warning | null => {
-	const result = section.warn?.(rec) ?? null;
+const resolveWarning = <T>(section: SectionConfig<T>, rec: T, baseline?: T): Warning | null => {
+	const result = section.warn?.(rec, baseline) ?? null;
 	return result === null ? null : typeof result === 'string' ? { message: result } : result;
 };
 
-export function sectionWarnings<T>(section: SectionConfig<T>, rec: T): string[] {
-	const warning = resolveWarning(section, rec);
+export function sectionWarnings<T>(section: SectionConfig<T>, rec: T, baseline?: T): string[] {
+	const warning = resolveWarning(section, rec, baseline);
 	if (section.kind === 'fields') {
 		// A fields section warns on each failing required field, plus an optional section-level `warn`
 		// for a cross-field rule the per-field `required` check can't express (e.g. a recipe result that
@@ -35,15 +35,15 @@ export function sectionWarnings<T>(section: SectionConfig<T>, rec: T): string[] 
 
 /** The section's warning message when it's flagged {@link Warning.blocking}, else null — used to gate
  *  Save separately from the advisory triangle/list display, which shows every warning regardless. */
-export function sectionBlockingWarning<T>(section: SectionConfig<T>, rec: T): string | null {
-	const warning = resolveWarning(section, rec);
+export function sectionBlockingWarning<T>(section: SectionConfig<T>, rec: T, baseline?: T): string | null {
+	const warning = resolveWarning(section, rec, baseline);
 	return warning?.blocking ? warning.message : null;
 }
 
-export function entityWarnings<T extends Identified>(entity: EntityConfig<T>, rec: T): string[] {
-	return entity.sections.flatMap((s) => sectionWarnings(s, rec));
+export function entityWarnings<T extends Identified>(entity: EntityConfig<T>, rec: T, baseline?: T): string[] {
+	return entity.sections.flatMap((s) => sectionWarnings(s, rec, baseline));
 }
 
-export function entityBlockingWarnings<T extends Identified>(entity: EntityConfig<T>, rec: T): string[] {
-	return entity.sections.map((s) => sectionBlockingWarning(s, rec)).filter((w): w is string => !!w);
+export function entityBlockingWarnings<T extends Identified>(entity: EntityConfig<T>, rec: T, baseline?: T): string[] {
+	return entity.sections.map((s) => sectionBlockingWarning(s, rec, baseline)).filter((w): w is string => !!w);
 }

--- a/UI/src/tests/routes/admin/workbench/entities/zone.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/zone.test.ts
@@ -216,6 +216,26 @@ describe('zoneEntity', () => {
 			expect(enemiesWarn?.(z)).toBeNull();
 		});
 
+		it("blocks clearing spawns and flipping isHome in the same save — the backend reads the persisted count before this save's own SetZoneEnemies clears it (#2314)", () => {
+			const baseline = { ...zoneEntity.newItem(1), isHome: false, zoneEnemies: [{ enemyId: 0, weight: 3 }] };
+			const z = { ...baseline, isHome: true, zoneEnemies: [] };
+			expect(enemiesWarn?.(z, baseline)).toEqual({
+				message: 'Clear spawns in a separate save before making this zone Home',
+				blocking: true
+			});
+		});
+
+		it('passes flipping isHome on when the spawn table was already cleared in an earlier save (#2314)', () => {
+			const baseline = { ...zoneEntity.newItem(1), isHome: false, zoneEnemies: [] };
+			const z = { ...baseline, isHome: true };
+			expect(enemiesWarn?.(z, baseline)).toBeNull();
+		});
+
+		it('passes a brand-new Home zone (no baseline) even though it has no spawns to worry about (#2314)', () => {
+			const z = { ...zoneEntity.newItem(-1), isHome: true, zoneEnemies: [] };
+			expect(enemiesWarn?.(z, undefined)).toBeNull();
+		});
+
 		it("share total excludes a retired sibling's weight from the denominator", () => {
 			const rows = [
 				{ enemyId: 1, weight: 5 },

--- a/UI/src/tests/routes/admin/workbench/validation.test.ts
+++ b/UI/src/tests/routes/admin/workbench/validation.test.ts
@@ -81,6 +81,24 @@ describe('sectionWarnings', () => {
 		// Neither when both pass.
 		expect(sectionWarnings(section, { id: 1, name: 'Ok', icon: 'x', rows: [] })).toEqual([]);
 	});
+
+	it('passes the baseline through to the warn predicate', () => {
+		const section = {
+			key: 'rows',
+			label: 'Rows',
+			glyph: 'bars',
+			kind: 'table',
+			itemsKey: 'rows',
+			// Mirrors zone.ts's isHome gap: the pending record alone can't tell whether this is a
+			// same-save clear, only comparing against the persisted baseline can.
+			warn: (t: Thing, baseline: Thing | undefined) =>
+				!t.rows.length && baseline?.rows.length ? 'Cleared this save' : null
+		} as unknown as EntityConfig<Thing>['sections'][number];
+		const rec = { id: 1, name: 'x', icon: 'x', rows: [] };
+		expect(sectionWarnings(section, rec)).toEqual([]);
+		expect(sectionWarnings(section, rec, { id: 1, name: 'x', icon: 'x', rows: [] })).toEqual([]);
+		expect(sectionWarnings(section, rec, { id: 1, name: 'x', icon: 'x', rows: [1] })).toEqual(['Cleared this save']);
+	});
 });
 
 describe('entityWarnings', () => {


### PR DESCRIPTION
## Summary

Follow-up from #2313. The zone editor's Enemies-tab blocking warning (`zone.ts`'s `zoneEnemies` section `warn`) only checked the *pending* record's `zoneEnemies.length`, so it correctly caught a Home zone that visibly still has spawn rows. But it missed a real gap: if an admin **clears** a combat zone's spawn rows and toggles `isHome` on in the *same* save, the client sees `zoneEnemies.length === 0` and lets the save through — while the backend still rejects it.

`AdminZones.SaveZones`'s edit guard reads the zone's **persisted** spawn count (`_zones.LookupZone(...).ZoneEnemies.Count`), evaluated as part of the primary identity batch, *before* the child `SetZoneEnemies` saver has a chance to clear it. So a same-save clear-and-flip still hard-rejects with "clear the zone's spawn table before making it Home" — a clean, non-destructive rejection (nothing commits, all edits stay in place), but a warning the admin never sees coming.

## Fix

- Threaded the record's last-saved **baseline** into `SectionConfig.warn` (previously only received the pending record). `baseline` is optional so every other entity's `warn` predicate — which don't need it — is unaffected.
- `zone.ts`'s `zoneEnemies` `warn` now also checks the baseline's spawn count when the pending record is a soon-to-be Home zone with an already-cleared spawn table, surfacing "Clear spawns in a separate save before making this zone Home" as a blocking warning — mirroring the backend's actual rejection condition instead of the pending edit's.
- Wired the baseline through the two real call sites (`EntityStore.recordStates`/`stateOf` in `entity-store.svelte.ts`, and `WorkbenchDetail.svelte`'s tab-warn triangle) via the store's existing `baselineOf(id)`.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.
- [x] `npm run test:unit:ci` — 310 test files / 3897 tests passing.
- [x] Added unit tests in `zone.test.ts` covering: blocks the same-save clear+flip, passes when spawns were already cleared in a prior save (baseline already empty), and passes a brand-new Home zone (no baseline).
- [x] Added a `validation.test.ts` case asserting `sectionWarnings` threads the baseline through to a `warn` predicate that needs it.
- No backend changes — this is purely a client-side warning gap; the backend's own guard (already correct) is what this warning now mirrors.

Closes #2314

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZZzpZ98TnS5aGRig6KXeR)_