### PR TITLE
Remove unused less dev dependency from UI

### DIFF
--- a/UI/package-lock.json
+++ b/UI/package-lock.json
@@ -25,7 +25,6 @@
 				"eslint-plugin-svelte": "^3.17.1",
 				"globals": "^17.6.0",
 				"jsdom": "^29.1.1",
-				"less": "^4.8.0",
 				"prettier": "^3.8.3",
 				"prettier-plugin-svelte": "^4.0.1",
 				"sass": "^1.101.4",
@@ -2696,22 +2695,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/copy-anything": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
-			"integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-what": "^4.1.8"
-			},
-			"engines": {
-				"node": ">=12.13"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mesqueeb"
-			}
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2862,20 +2845,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/errno": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"prr": "~1.0.1"
-			},
-			"bin": {
-				"errno": "cli.js"
 			}
 		},
 		"node_modules/es-errors": {
@@ -3395,14 +3364,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/graceful-fs": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true
-		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3445,20 +3406,6 @@
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -3558,19 +3505,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "*"
-			}
-		},
-		"node_modules/is-what": {
-			"version": "4.1.16",
-			"resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
-			"integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.13"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mesqueeb"
 			}
 		},
 		"node_modules/isexe": {
@@ -3714,46 +3648,6 @@
 			"integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/less": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/less/-/less-4.8.0.tgz",
-			"integrity": "sha512-7Y7DJBMbsW29UGjOG6NGvxQEx71AaDcrryBwYCMaFwn0kj8FkSueKN9r9WexVOetKEhXh38kL++WJncfkEpS+g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"copy-anything": "^3.0.5",
-				"parse-node-version": "^1.0.1"
-			},
-			"bin": {
-				"lessc": "bin/lessc"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"errno": "^0.1.1",
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^5.1.0",
-				"mime": "^1.4.1",
-				"needle": "^3.1.0",
-				"probe-image-size": "^7.2.3",
-				"source-map": "~0.6.0"
-			}
-		},
-		"node_modules/less/node_modules/make-dir": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-5.1.0.tgz",
-			"integrity": "sha512-IfpFq6UM39dUNiphpA6uDezNx/AvWyhwfICWPR3t1VspkgkMZrL+Rk1RbN1bx+aeNYwOrqGJgEgV3yotk+ZUVw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/levn": {
 			"version": "0.4.1",
@@ -4075,14 +3969,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lodash.merge": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/lru-cache": {
 			"version": "11.5.2",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
@@ -4147,20 +4033,6 @@
 			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
 			"dev": true,
 			"license": "CC0-1.0"
-		},
-		"node_modules/mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
@@ -4241,24 +4113,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/needle": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
-			"integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"iconv-lite": "^0.6.3",
-				"sax": "^1.2.4"
-			},
-			"bin": {
-				"needle": "bin/needle"
-			},
-			"engines": {
-				"node": ">= 4.4.x"
-			}
-		},
 		"node_modules/node-addon-api": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -4329,16 +4183,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/parse-node-version": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
-			"integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.10"
 			}
 		},
 		"node_modules/parse5": {
@@ -4658,81 +4502,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/probe-image-size": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.3.0.tgz",
-			"integrity": "sha512-7CaDeBwiAbh6ohXsvLbAZhO7wzsZAmaevfxe39qvCwRh8LyaZfDlBGGLU1CCTgrTLtCOdwBBhjOrIHaIIimHfQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/puzrin"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/nodeca"
-				}
-			],
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"lodash.merge": "^4.6.2",
-				"needle": "^2.5.2",
-				"stream-parser": "~0.3.1"
-			}
-		},
-		"node_modules/probe-image-size/node_modules/debug": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"ms": "^2.1.1"
-			}
-		},
-		"node_modules/probe-image-size/node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/probe-image-size/node_modules/needle": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
-			"integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"debug": "^3.2.6",
-				"iconv-lite": "^0.4.4",
-				"sax": "^1.2.4"
-			},
-			"bin": {
-				"needle": "bin/needle"
-			},
-			"engines": {
-				"node": ">= 4.4.x"
-			}
-		},
-		"node_modules/prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4902,14 +4671,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/sass": {
 			"version": "1.101.4",
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.101.4.tgz",
@@ -4929,17 +4690,6 @@
 			},
 			"optionalDependencies": {
 				"@parcel/watcher": "^2.4.1"
-			}
-		},
-		"node_modules/sax": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"optional": true,
-			"engines": {
-				"node": ">=11.0.0"
 			}
 		},
 		"node_modules/saxes": {
@@ -5020,17 +4770,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5054,36 +4793,6 @@
 			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/stream-parser": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
-			"integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"debug": "2"
-			}
-		},
-		"node_modules/stream-parser/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/stream-parser/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
 		},
 		"node_modules/strip-indent": {
 			"version": "3.0.0",

--- a/UI/package.json
+++ b/UI/package.json
@@ -37,7 +37,6 @@
 		"eslint-plugin-svelte": "^3.17.1",
 		"globals": "^17.6.0",
 		"jsdom": "^29.1.1",
-		"less": "^4.8.0",
 		"prettier": "^3.8.3",
 		"prettier-plugin-svelte": "^4.0.1",
 		"sass": "^1.101.4",


### PR DESCRIPTION
## Summary

- Removes the `less` devDependency from `UI/package.json` and regenerates `UI/package-lock.json`.
- Nothing in the frontend uses Less: no `.less` files exist under `UI/`, no Svelte block uses `lang="less"`, and no source module imports it. Styles are preprocessed with SCSS/Sass, not Less.
- Removing it stops Dependabot's recurring version-bump churn on a dependency nothing consumes (e.g. #2322 bumped it for no functional reason).

## Test plan

- [x] `npm run lint` — clean (0 errors, 0 warnings)
- [x] `npm run test:unit:ci` — all 3931 tests pass
- [x] `npm run build` — succeeds

Closes #2323

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuHULid4XEXGcGDVoPf5qG)_