### PR TITLE
Group npm dev-dependency minor/patch updates into one dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@ updates:
     directory: "/UI"
     schedule:
       interval: "weekly"
+    groups:
+      dev-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "@emnapi/core"
       - dependency-name: "@emnapi/runtime"


### PR DESCRIPTION
## Summary

- Adds a `groups` block to the `npm` ecosystem entry in `.github/dependabot.yml` that bundles minor/patch dev-dependency bumps into a single weekly PR.
- Every dependency in `UI/package.json` is a `devDependency` (there's no `dependencies` section — it's a SvelteKit tooling-only frontend), so this group covers the entire npm surface without needing to also match a `dependencies`-type group.

## Why

Closes #2282. With the config added in #2268, dependabot opens a separate PR per npm package each week, which is noisy given how many devDeps this project has. Grouping minor/patch bumps mirrors the pattern the `nuget` ecosystem entry already uses (`dotnet-runtime` pattern group) — major bumps are intentionally left ungrouped so they still surface individually for review.

## Scope notes

Per the issue, this only touches `npm`. I left `nuget` and `github-actions` alone:
- `nuget` already has a pattern-based group for the highest-volume families (EF Core, `Microsoft.Extensions.*`, `Microsoft.AspNetCore.*`); the remaining ungrouped packages are few enough that a second group didn't seem justified without evidence of noise.
- `github-actions` has a single workflow file with a handful of actions — unlikely to produce meaningful PR noise.

If a week or two of real output shows otherwise, that can be revisited as a follow-up per the issue's own framing.

## Test plan

- [x] Validated the resulting YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- Config-only change to `.github/dependabot.yml`; no application build/test suite covers dependabot behavior. Actual grouping behavior will be observable on dependabot's next weekly run.

Closes #2282

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnunoAVHWAeXgoMtJYW5eA)_