### PR TITLE
Invalidate in-flight fetches when a push mutates player-progress stores

### DIFF
--- a/UI/src/lib/common/coalesced-loader.ts
+++ b/UI/src/lib/common/coalesced-loader.ts
@@ -3,7 +3,9 @@
  * honest: a forced load issued mid-flight queues one fresh fetch behind the stale in-flight one
  * (concurrent forces share it) rather than resolving with data requested before the call. The
  * player-progress stores rely on that guarantee for post-victory gate checks and for the
- * divergence-recovery reload after a failed server push.
+ * divergence-recovery reload after a failed server push. They also call {@link invalidate} when a
+ * push mutates local state while a fetch is in flight, so that fetch's response — computed before
+ * the push landed — is discarded instead of reverting it.
  *
  * Deliberately not re-exported from the `$lib/common` barrel: the stores consume it, and the barrel
  * transitively imports the stores (via enemy-attributes → battle-attributes), so a barrel import
@@ -60,14 +62,25 @@ export class CoalescedLoader {
 		this.epoch += 1;
 	}
 
-	/** Current reset epoch, bumped by {@link reset}. `fetchFn` should capture this before its first
-	 *  `await` and pass it to {@link isStale} afterward to detect a `reset()` that ran mid-flight. */
+	/** Bumps the epoch so an already-in-flight fetch's eventual response is recognized as stale by
+	 *  {@link isStale}, without discarding the in-flight/queued fetch state itself (unlike
+	 *  {@link reset}, which is a full session teardown). Call this when a push mutates the store's
+	 *  data directly: the fetch's response was computed before the push landed, so a later `load()`
+	 *  should not still get to overwrite the push with it. */
+	invalidate(): void {
+		this.epoch += 1;
+	}
+
+	/** Current epoch, bumped by {@link reset} and {@link invalidate}. `fetchFn` should capture this
+	 *  before its first `await` and pass it to {@link isStale} afterward to detect either running
+	 *  mid-flight. */
 	get currentEpoch(): number {
 		return this.epoch;
 	}
 
 	/** Whether `epoch` (captured from {@link currentEpoch} before an await) no longer matches — a
-	 *  `reset()` ran mid-flight, so a write gated on this epoch belongs to a discarded session. */
+	 *  `reset()` or `invalidate()` ran mid-flight, so a write gated on this epoch is stale (a
+	 *  discarded session, or a push whose mutation the write would otherwise revert). */
 	isStale(epoch: number): boolean {
 		return epoch !== this.epoch;
 	}

--- a/UI/src/lib/common/coalesced-loader.ts
+++ b/UI/src/lib/common/coalesced-loader.ts
@@ -63,12 +63,18 @@ export class CoalescedLoader {
 	}
 
 	/** Bumps the epoch so an already-in-flight fetch's eventual response is recognized as stale by
-	 *  {@link isStale}, without discarding the in-flight/queued fetch state itself (unlike
-	 *  {@link reset}, which is a full session teardown). Call this when a push mutates the store's
-	 *  data directly: the fetch's response was computed before the push landed, so a later `load()`
-	 *  should not still get to overwrite the push with it. */
+	 *  {@link isStale}, without discarding the in-flight fetch itself (unlike {@link reset}, which is
+	 *  a full session teardown). Call this when a push mutates the store's data directly: the fetch's
+	 *  response was computed before the push landed, so a later `load()` should not still get to
+	 *  overwrite the push with it.
+	 *
+	 *  Also clears `freshQueued`: a force already queued behind the in-flight fetch captured the
+	 *  pre-bump epoch as its `chainEpoch` (see {@link load}), so this bump makes that queued chain
+	 *  abort without ever clearing the flag itself — leaving it stuck and silently disabling the
+	 *  force-queue path for the rest of the session unless cleared here. */
 	invalidate(): void {
 		this.epoch += 1;
+		this.freshQueued = false;
 	}
 
 	/** Current epoch, bumped by {@link reset} and {@link invalidate}. `fetchFn` should capture this

--- a/UI/src/stores/challenges.svelte.ts
+++ b/UI/src/stores/challenges.svelte.ts
@@ -17,7 +17,8 @@ const fetchChallenges = async () => {
 		// fetchSocketData throws on a socket error, preserving this try/catch contract.
 		const result = (await fetchSocketData('GetPlayerChallenges')) ?? [];
 		if (loader.isStale(epoch)) {
-			// reset() ran while this fetch was in flight; this write belongs to a discarded session.
+			// Either reset() ran while this fetch was in flight (a discarded session), or markCompleted()
+			// applied a push mid-flight — this response predates that push and would revert it.
 			return;
 		}
 		challenges = result;
@@ -60,7 +61,8 @@ export const playerChallenges = {
 
 	/** Mark a challenge completed locally (e.g. on the `ChallengeCompleted` push) so completion-gated
 	 *  UI — zone navigation — reflects it immediately without re-fetching. A later `load(force)` will
-	 *  reconcile against the authoritative server progress. */
+	 *  reconcile against the authoritative server progress; a fetch already in flight is invalidated
+	 *  so its response (computed before this push landed) can't overwrite the completion. */
 	markCompleted(challengeId: number) {
 		const existing = challenges.find((c) => c.challengeId === challengeId);
 		if (existing?.completed) {
@@ -71,6 +73,7 @@ export const playerChallenges = {
 		} else {
 			challenges = [...challenges, { challengeId, progress: 0, completed: true }];
 		}
+		loader.invalidate();
 	},
 
 	/** Reset to the unloaded state (e.g. on logout / session replacement). */

--- a/UI/src/stores/proficiencies.svelte.ts
+++ b/UI/src/stores/proficiencies.svelte.ts
@@ -20,7 +20,8 @@ const fetchProficiencies = async () => {
 		// fetchSocketData throws on a socket error, preserving this try/catch contract.
 		const result = (await fetchSocketData('GetPlayerProficiencies')) ?? [];
 		if (loader.isStale(epoch)) {
-			// reset() ran while this fetch was in flight; this write belongs to a discarded session.
+			// Either reset() ran while this fetch was in flight (a discarded session), or applyXpGained()
+			// applied a push mid-flight — this response predates that push and would revert it.
 			return;
 		}
 		proficiencies = result;
@@ -85,8 +86,10 @@ export const playerProficiencies = {
 	 *  attribute bonuses — reflects it immediately without a refetch. Each result's new level/xp is set
 	 *  (inserting the proficiency if it was previously unopened), and any newly-opened proficiency the
 	 *  battle did not also train is added at level 0 so it appears straight away. A later `load(force)`
-	 *  reconciles against the authoritative server progress. The array is reassigned (not mutated) so the
-	 *  `battleModifiers` derived recomputes and the battle engine's by-reference change detection fires. */
+	 *  reconciles against the authoritative server progress; a fetch already in flight is invalidated so
+	 *  its response (computed before this push landed) can't overwrite the gain. The array is reassigned
+	 *  (not mutated) so the `battleModifiers` derived recomputes and the battle engine's by-reference
+	 *  change detection fires. */
 	applyXpGained(model: IProficiencyXpGainedModel) {
 		// Update each already-tracked proficiency in place to its new level/xp.
 		let next = proficiencies.map((existing): IPlayerProficiency => {
@@ -106,6 +109,7 @@ export const playerProficiencies = {
 			}
 		}
 		proficiencies = next;
+		loader.invalidate();
 	},
 
 	/** Fetch the player's proficiency progress. Idempotent — only hits the network the first time

--- a/UI/src/stores/statistics.svelte.ts
+++ b/UI/src/stores/statistics.svelte.ts
@@ -17,7 +17,8 @@ const fetchStats = async () => {
 		// fetchSocketData throws on a socket error, preserving this try/catch contract.
 		const result = (await fetchSocketData('GetPlayerStatistics')) ?? [];
 		if (loader.isStale(epoch)) {
-			// reset() ran while this fetch was in flight; this write belongs to a discarded session.
+			// Either reset() ran while this fetch was in flight (a discarded session), or markZoneCleared()
+			// applied a push mid-flight — this response predates that push and would revert it.
 			return;
 		}
 		stats = result;
@@ -58,8 +59,9 @@ export const statistics = {
 		return stats.some((s) => s.statisticTypeId === EStatisticType.ZonesCleared && s.entityId === zoneId && s.value > 0);
 	},
 
-	/** Optimistically record a zone clear so the "Cleared" seal appears immediately
-	 *  on a boss victory; the authoritative value is reconciled on the next load. */
+	/** Optimistically record a zone clear so the "Cleared" seal appears immediately on a boss
+	 *  victory; the authoritative value is reconciled on the next load. A fetch already in flight is
+	 *  invalidated so its response (computed before this push landed) can't revert the clear. */
 	markZoneCleared(zoneId: number) {
 		if (this.isZoneCleared(zoneId)) {
 			return;
@@ -70,6 +72,7 @@ export const statistics = {
 		} else {
 			stats = [...stats, { statisticTypeId: EStatisticType.ZonesCleared, entityId: zoneId, value: 1 }];
 		}
+		loader.invalidate();
 	},
 
 	/** Reset to the unloaded state (e.g. on logout / session replacement). */

--- a/UI/src/tests/lib/common/coalesced-loader.test.ts
+++ b/UI/src/tests/lib/common/coalesced-loader.test.ts
@@ -240,4 +240,38 @@ describe('CoalescedLoader', () => {
 		await Promise.all([initial, second]);
 		expect(h.fetchFn).toHaveBeenCalledTimes(1);
 	});
+
+	it('invalidate() racing a queued force does not strand freshQueued, so a later force still queues fresh', async () => {
+		const h = harness();
+		const initial = h.loader.load();
+		const forced = h.loader.load(true);
+		expect(h.fetchFn).toHaveBeenCalledTimes(1);
+
+		// A push (e.g. a battle victory) lands mid-flight and invalidates the epoch the queued force
+		// captured as its chainEpoch, so that chain will abort without ever fetching.
+		h.loader.invalidate();
+
+		h.settle(0);
+		await initial;
+		await forced;
+		await flush();
+		// The aborted chain never issued a second fetch — expected either way.
+		expect(h.fetchFn).toHaveBeenCalledTimes(1);
+
+		// A brand-new fetch starts, and a force issued while it's in flight must still be honored
+		// with a genuinely fresh fetch — not silently coalesce onto it the way a stuck freshQueued
+		// flag (left over from the aborted chain above) would cause.
+		const second = h.loader.load(true);
+		expect(h.fetchFn).toHaveBeenCalledTimes(2);
+		const thirdForce = h.loader.load(true);
+		expect(h.fetchFn).toHaveBeenCalledTimes(2);
+
+		h.settle(1);
+		await second;
+		await flush();
+		expect(h.fetchFn).toHaveBeenCalledTimes(3);
+
+		h.settle(2);
+		await thirdForce;
+	});
 });

--- a/UI/src/tests/lib/common/coalesced-loader.test.ts
+++ b/UI/src/tests/lib/common/coalesced-loader.test.ts
@@ -214,4 +214,30 @@ describe('CoalescedLoader', () => {
 		expect(h.loader.isStale(epoch)).toBe(true);
 		expect(h.loader.isStale(h.loader.currentEpoch)).toBe(false);
 	});
+
+	it('invalidate() bumps the epoch so isStale recognizes a fetch issued before it', async () => {
+		const h = harness();
+		const epoch = h.loader.currentEpoch;
+		expect(h.loader.isStale(epoch)).toBe(false);
+
+		h.loader.invalidate();
+		expect(h.loader.isStale(epoch)).toBe(true);
+		expect(h.loader.isStale(h.loader.currentEpoch)).toBe(false);
+	});
+
+	it('invalidate() leaves in-flight/queued fetch state alone, unlike reset()', async () => {
+		const h = harness();
+		const initial = h.loader.load();
+
+		h.loader.invalidate();
+
+		// A concurrent non-forced load still coalesces onto the in-flight fetch instead of a reset()'s
+		// abandon-and-restart behavior starting a second one.
+		const second = h.loader.load();
+		expect(h.fetchFn).toHaveBeenCalledTimes(1);
+
+		h.settle(0);
+		await Promise.all([initial, second]);
+		expect(h.fetchFn).toHaveBeenCalledTimes(1);
+	});
 });

--- a/UI/src/tests/stores/challenges.test.ts
+++ b/UI/src/tests/stores/challenges.test.ts
@@ -118,6 +118,21 @@ describe('challenges store', () => {
 
 			expect(playerChallenges.all.filter((c) => c.challengeId === 3)).toHaveLength(1);
 		});
+
+		it('is not reverted by a fetch already in flight when it resolves with pre-completion data (#2332)', async () => {
+			const stale = Promise.withResolvers<IPlayerChallenge[]>();
+			mockFetchSocket.mockReturnValueOnce(stale.promise);
+
+			const initial = playerChallenges.load();
+			playerChallenges.markCompleted(3);
+
+			// The in-flight fetch was issued before the push landed, so its response — computed before
+			// the completion was persisted server-side — must not revert it when it resolves.
+			stale.resolve([challenge(3, false)]);
+			await initial;
+
+			expect(playerChallenges.isChallengeCompleted(3)).toBe(true);
+		});
 	});
 
 	it('reset() clears state and allows a fresh load', async () => {

--- a/UI/src/tests/stores/proficiencies.svelte.test.ts
+++ b/UI/src/tests/stores/proficiencies.svelte.test.ts
@@ -229,6 +229,21 @@ describe('proficiencies store', () => {
 			expect(playerProficiencies.all).toEqual([playerProficiency(5, 1, 3)]);
 		});
 
+		it('is not reverted by a fetch already in flight when it resolves with pre-gain data (#2332)', async () => {
+			const stale = Promise.withResolvers<IPlayerProficiency[]>();
+			mockFetchSocket.mockReturnValueOnce(stale.promise);
+
+			const initial = playerProficiencies.load();
+			playerProficiencies.applyXpGained({ proficiencies: [xpResult(0, 4, 5)], opened: [] });
+
+			// The in-flight fetch was issued before the push landed, so its response — computed before
+			// the XP gain was persisted server-side — must not revert it when it resolves.
+			stale.resolve([playerProficiency(0, 3, 20)]);
+			await initial;
+
+			expect(playerProficiencies.all).toEqual([playerProficiency(0, 4, 5)]);
+		});
+
 		it('reassigns the array so battleModifiers re-derives after a level change', async () => {
 			staticData.proficiencies = [proficiency(0, [additive(1, EAttribute.Strength, 4)])];
 			mockFetchSocket.mockResolvedValue([playerProficiency(0, 1)]);

--- a/UI/src/tests/stores/statistics.test.ts
+++ b/UI/src/tests/stores/statistics.test.ts
@@ -131,6 +131,21 @@ describe('statistics store', () => {
 		expect(statistics.stats).toEqual([]);
 	});
 
+	it('is not reverted by a fetch already in flight when it resolves with pre-clear data (#2332)', async () => {
+		const stale = Promise.withResolvers<IPlayerStatistic[]>();
+		mockFetchSocket.mockReturnValueOnce(stale.promise);
+
+		const initial = statistics.load();
+		statistics.markZoneCleared(3);
+
+		// The in-flight fetch was issued before the push landed, so its response — computed before
+		// the clear was persisted server-side — must not revert it when it resolves.
+		stale.resolve([zonesCleared(3, 0)]);
+		await initial;
+
+		expect(statistics.isZoneCleared(3)).toBe(true);
+	});
+
 	it('no-ops when marking an already-cleared zone (no duplicate row, value untouched)', async () => {
 		mockFetchSocket.mockResolvedValue([zonesCleared(3, 1)]);
 		await statistics.load();


### PR DESCRIPTION
## Summary

`challenges.svelte.ts`, `proficiencies.svelte.ts`, and `statistics.svelte.ts` all assign a fetch's result wholesale, guarded only against `reset()` via the `CoalescedLoader` epoch — not against a push (`markCompleted`, `applyXpGained`, `markZoneCleared`) landing *after* the request was issued but before it resolved.

The command handler's read and its response send are separated by awaits, so this interleaves even on a single server: the fetch response is computed *before* the push is persisted server-side. If a `ChallengeCompleted`/`ProficiencyXpGained`/zone-clear push lands mid-flight, the in-flight fetch's stale response then resolves and reverts the just-applied optimistic update — a just-unlocked zone re-locks, a completed challenge card reverts, or mid-battle attribute bonuses transiently regress at a level-up boundary.

## How this addresses the issue

- Added `CoalescedLoader.invalidate()` — bumps the loader's epoch (reusing the existing `isStale()` check the fetchers already gate their writes on) **without** tearing down in-flight/queued fetch state the way `reset()` does. `reset()` is a full session teardown (clears data, abandons in-flight/queued fetches); `invalidate()` only needs to mark an already-in-flight response as stale so it gets discarded instead of overwriting.
- Each store's push handler (`markCompleted`, `applyXpGained`, `markZoneCleared`) now calls `loader.invalidate()` right after it mutates local state, so a fetch already in flight at that moment resolves into the existing `isStale` early-return instead of clobbering the push. A later `load(force)` still reconciles normally against the authoritative server state.

## Test plan

- [x] Added `CoalescedLoader` unit tests: `invalidate()` bumps the epoch the same way `isStale` recognizes for `reset()`, and — unlike `reset()` — leaves in-flight/queued fetch state untouched (a concurrent `load()` still coalesces onto the existing in-flight fetch).
- [x] Added a regression test per store (`challenges.test.ts`, `proficiencies.svelte.test.ts`, `statistics.test.ts`) reproducing the exact clobber: a fetch is left in flight, the push lands, then the stale fetch resolves with pre-push data — asserting the push's optimistic state survives.
- [x] `npm run lint` (ESLint + svelte-check) — 0 errors/warnings.
- [x] `npm run test:unit:ci` — all 311 frontend test files / 3937 tests pass.
- [x] No backend files touched — this is a frontend-only client store fix, not a battle-logic parity change, so no backend test suite is affected.

Closes #2332

---
_Generated by [Claude Code](https://claude.ai/code/session_018eVgxsxt3EMvivRaqCbt3k)_