### PR TITLE
Workbench: blocking warnings for acquisition-flag & weapon-signature hard-rejects

### DIFF
--- a/UI/src/routes/admin/workbench/entities/class.ts
+++ b/UI/src/routes/admin/workbench/entities/class.ts
@@ -148,7 +148,19 @@ export const classEntity: EntityConfig<WorkbenchClass> = {
 			glyph: 'rune',
 			desc: 'Skills granted at character creation',
 			count: (c) => c.starterSkillIds.length,
-			warn: (c) => (c.starterSkillIds.length ? null : 'No starter skills'),
+			// A starter skill that's since lost its Player flag stays visible as a removable chip
+			// (the catalogue's `addable` filter only blocks new authoring); AdminClasses.SetClassStarterSkills
+			// (FindStarterSkillFlagViolation) hard-rejects the whole list if any assigned skill lacks the
+			// flag, so this blocks Save too.
+			warn: (c) => {
+				const flagLost = c.starterSkillIds
+					.map((id) => staticData.skills?.[id])
+					.find((skill) => skill && !hasFlag(skill.acquisition, ESkillAcquisition.Player));
+				if (flagLost) {
+					return { message: `'${flagLost.name}' is no longer flagged as Player-acquirable`, blocking: true };
+				}
+				return c.starterSkillIds.length ? null : 'No starter skills';
+			},
 			kind: 'chips',
 			itemsKey: 'starterSkillIds',
 			// Only Player-flagged skills can be newly assigned (the backend enforces this too); an

--- a/UI/src/routes/admin/workbench/entities/enemy.ts
+++ b/UI/src/routes/admin/workbench/entities/enemy.ts
@@ -100,7 +100,19 @@ export const enemyEntity: EntityConfig<WorkbenchEnemy> = {
 			glyph: 'rune',
 			desc: 'Skill pool used in battle',
 			count: (e) => e.skillPool.length,
-			warn: (e) => (e.skillPool.length ? null : 'No skills assigned'),
+			// A pool skill that's since lost its Enemy flag stays visible as a removable chip (the
+			// catalogue's `addable` filter only blocks new authoring); AdminEnemies.SetEnemySkills
+			// (FindEnemySkillFlagViolation) hard-rejects the whole list if any assigned skill lacks the
+			// flag, so this blocks Save too.
+			warn: (e) => {
+				const flagLost = e.skillPool
+					.map((id) => staticData.skills?.[id])
+					.find((skill) => skill && !hasFlag(skill.acquisition, ESkillAcquisition.Enemy));
+				if (flagLost) {
+					return { message: `'${flagLost.name}' is no longer flagged as an Enemy skill`, blocking: true };
+				}
+				return e.skillPool.length ? null : 'No skills assigned';
+			},
 			kind: 'chips',
 			itemsKey: 'skillPool',
 			// Only Enemy-flagged skills can be newly assigned (the backend enforces this too); an

--- a/UI/src/routes/admin/workbench/entities/item.ts
+++ b/UI/src/routes/admin/workbench/entities/item.ts
@@ -1,4 +1,6 @@
-import { ApiRequest, EItemCategory, ERarity, fetchSocketData, type IItem } from '$lib/api';
+import { ApiRequest, EItemCategory, ERarity, ESkillAcquisition, fetchSocketData, type IItem } from '$lib/api';
+import { isWeaponLeaf, primaryDamageType } from '$lib/battle/damage-types';
+import { hasFlag } from '$lib/common';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import { attributeChanges, childChanged, guardedSave, modSlotChanges, persistEntity } from '../save-helpers';
@@ -64,19 +66,43 @@ export const itemEntity: EntityConfig<WorkbenchItem> = {
 			glyph: 'tag',
 			desc: 'Name, category & rarity',
 			kind: 'fields',
-			// The no-stranding invariant, hard-rejected by AdminItems on save, so every branch blocks (#2217):
-			// a weapon must declare a weapon type and a granted signature skill; only a weapon may carry one.
+			// The no-stranding invariant, hard-rejected by AdminItems on save (#2217): a weapon must
+			// declare a weapon type and a granted signature skill; only a weapon may carry one; and the
+			// granted skill's own signature type must match the weapon's (FindWeaponInvariantViolation).
+			// Independently, any granted skill (weapon or not) must stay Item-flagged — the picker's
+			// `keep` exception leaves a flag-lost grant visible as a stale value, so this is the
+			// backstop (FindGrantedSkillFlagViolation).
 			warn: (it) => {
 				if (it.itemCategoryId === EItemCategory.Weapon) {
 					if (it.weaponType === -1) {
 						return { message: 'Weapon needs a weapon type', blocking: true };
 					}
-					if (it.grantedSkillId === -1) {
+					if (it.grantedSkillId == null || it.grantedSkillId === -1) {
 						return { message: 'Weapon needs a granted skill', blocking: true };
 					}
-					return null;
+					const grantedSkill = staticData.skills?.[it.grantedSkillId];
+					if (grantedSkill) {
+						const signatureType = primaryDamageType(grantedSkill.damagePortions);
+						if (isWeaponLeaf(signatureType) && signatureType !== it.weaponType) {
+							return {
+								message: "Weapon type doesn't match its granted skill's signature type, which strands the wielder",
+								blocking: true
+							};
+						}
+					}
+				} else if (it.weaponType !== -1) {
+					return { message: 'Only weapons have a weapon type', blocking: true };
 				}
-				return it.weaponType === -1 ? null : { message: 'Only weapons have a weapon type', blocking: true };
+				if (it.grantedSkillId != null && it.grantedSkillId !== -1) {
+					const grantedSkill = staticData.skills?.[it.grantedSkillId];
+					if (grantedSkill && !hasFlag(grantedSkill.acquisition, ESkillAcquisition.Item)) {
+						return {
+							message: `Granted skill '${grantedSkill.name}' is no longer flagged as Item-acquirable`,
+							blocking: true
+						};
+					}
+				}
+				return null;
 			},
 			fields: [
 				{

--- a/UI/src/routes/admin/workbench/progression/TierDetail.svelte
+++ b/UI/src/routes/admin/workbench/progression/TierDetail.svelte
@@ -69,7 +69,12 @@
 import { childChanged } from '../save-helpers';
 import { referenceSourcesFromStatic, retireWithConfirm } from '../retire-confirm';
 import type { ProgressionStore, TierTab } from './progression-store.svelte';
-import { levelRangeWarnings, payoutLevels, prerequisiteRootWarnings } from './progression-helpers';
+import {
+	levelRangeWarnings,
+	payoutLevels,
+	prerequisiteRootWarnings,
+	rewardSkillFlagWarnings
+} from './progression-helpers';
 import DetailHeader from '../components/DetailHeader.svelte';
 import ConlangIdentity from './ConlangIdentity.svelte';
 import XpCurve from './XpCurve.svelte';
@@ -112,7 +117,9 @@ const identityWarn = $derived(
 			!tier.iconPath.trim())
 );
 const xpWarn = $derived(!!tier && (tier.maxLevel < 1 || !(tier.baseXp > 0) || !(tier.xpGrowth > 0)));
-const milestoneWarn = $derived(!!tier && levelRangeWarnings(tier).length > 0);
+const milestoneWarn = $derived(
+	!!tier && (levelRangeWarnings(tier).length > 0 || rewardSkillFlagWarnings(tier).length > 0)
+);
 const gatewaysWarn = $derived(!!tier && prerequisiteRootWarnings(tier).length > 0);
 const milestonesDirty = $derived(
 	!!baseline &&

--- a/UI/src/routes/admin/workbench/progression/progression-helpers.ts
+++ b/UI/src/routes/admin/workbench/progression/progression-helpers.ts
@@ -1,6 +1,7 @@
 import type { IProficiencyLevelModifier, IProficiencyLevelReward } from '$lib/api';
-import { EActivityKey, EAttribute, EModifierType } from '$lib/api';
-import { activityKeyDisplay, type ActivityKeyKind } from '$lib/common';
+import { EActivityKey, EAttribute, EModifierType, ESkillAcquisition } from '$lib/api';
+import { activityKeyDisplay, hasFlag, type ActivityKeyKind } from '$lib/common';
+import { staticData } from '$stores';
 import type { SelectOption } from '../entities/types';
 import type { WorkbenchPath, WorkbenchProficiency } from './types';
 
@@ -169,10 +170,9 @@ export const prerequisiteRootWarnings = (prof: WorkbenchProficiency): string[] =
 
 /**
  * An out-of-range modifier/reward level, checked against the tier's own (about-to-be-saved) MaxLevel.
- * This is the one proficiency condition the backend genuinely hard-rejects a save over — via
- * AdminProficiencies.FindShrunkenMaxLevelViolation (the identity edit, against a still-persisted
- * payout) or FindLevelOutOfRange (SetModifiers/SetRewards, against the tier's saved MaxLevel) — so it
- * doubles as {@link proficiencyBlockingWarnings}, unlike the rest of {@link proficiencyWarnings}.
+ * Hard-rejected by AdminProficiencies.FindShrunkenMaxLevelViolation (the identity edit, against a
+ * still-persisted payout) or FindLevelOutOfRange (SetModifiers/SetRewards, against the tier's saved
+ * MaxLevel) — so it feeds {@link proficiencyBlockingWarnings}, unlike the rest of {@link proficiencyWarnings}.
  */
 export const levelRangeWarnings = (prof: WorkbenchProficiency): string[] => {
 	const warnings: string[] = [];
@@ -185,6 +185,24 @@ export const levelRangeWarnings = (prof: WorkbenchProficiency): string[] => {
 	for (const reward of prof.levelRewards) {
 		if (reward.level < 1 || reward.level > prof.maxLevel) {
 			warnings.push(`Reward level ${reward.level} out of range`);
+			break;
+		}
+	}
+	return warnings;
+};
+
+/**
+ * A milestone reward skill that's since lost its Player acquisition flag — hard-rejected by
+ * AdminProficiencies.SetRewards (CheckPlayerSkill), mirroring the class starter-skill / enemy
+ * skill-pool flag guards. The reward picker (reference.playerSkillOptions) keeps such a skill
+ * visible via its `keep` exception, so this is the backstop that surfaces the drift.
+ */
+export const rewardSkillFlagWarnings = (prof: WorkbenchProficiency): string[] => {
+	const warnings: string[] = [];
+	for (const reward of prof.levelRewards) {
+		const skill = staticData.skills?.[reward.rewardSkillId];
+		if (skill && !hasFlag(skill.acquisition, ESkillAcquisition.Player)) {
+			warnings.push(`Reward skill '${skill.name}' is no longer flagged as Player-acquirable`);
 			break;
 		}
 	}
@@ -208,18 +226,25 @@ export const proficiencyWarnings = (prof: WorkbenchProficiency): string[] => {
 	if (!(prof.baseXp > 0) || !(prof.xpGrowth > 0)) {
 		warnings.push('XP curve must be positive');
 	}
-	return [...warnings, ...levelRangeWarnings(prof), ...prerequisiteRootWarnings(prof)];
+	return [
+		...warnings,
+		...levelRangeWarnings(prof),
+		...prerequisiteRootWarnings(prof),
+		...rewardSkillFlagWarnings(prof)
+	];
 };
 
 /**
  * The subset of {@link proficiencyWarnings} the backend is known to hard-reject a save over — see
- * {@link levelRangeWarnings} and {@link prerequisiteRootWarnings}. `MaxLevel < 1` and a non-positive XP
- * curve stay advisory-only: neither `Contracts.Proficiency` nor `AdminProficiencies` rejects them, so
- * gating Save on them would block a save the backend would actually accept.
+ * {@link levelRangeWarnings}, {@link prerequisiteRootWarnings}, and {@link rewardSkillFlagWarnings}.
+ * `MaxLevel < 1` and a non-positive XP curve stay advisory-only: neither `Contracts.Proficiency` nor
+ * `AdminProficiencies` rejects them, so gating Save on them would block a save the backend would
+ * actually accept.
  */
 export const proficiencyBlockingWarnings = (prof: WorkbenchProficiency): string[] => [
 	...levelRangeWarnings(prof),
-	...prerequisiteRootWarnings(prof)
+	...prerequisiteRootWarnings(prof),
+	...rewardSkillFlagWarnings(prof)
 ];
 
 // ── Persisted DTOs (identity-level Add/Edit; child collections go through their own endpoints) ──

--- a/UI/src/tests/routes/admin/workbench/entities/class.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/class.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { EAttribute, EEquipmentSlot, EItemCategory, EModifierType } from '$lib/api';
-import type { TableSectionConfig } from '$routes/admin/workbench/entities/types';
+import { EAttribute, EEquipmentSlot, EItemCategory, EModifierType, ESkillAcquisition } from '$lib/api';
+import type { ChipsSectionConfig, TableSectionConfig } from '$routes/admin/workbench/entities/types';
 
 /* Only the refresh() write-through added for #1633 — classEntity's field/table configs aren't touched here.
    `fetchSocketData` is stubbed; the write-through into staticData.classes is what retire-confirm's reference
@@ -31,6 +31,10 @@ import { classEntity, type WorkbenchClass } from '$routes/admin/workbench/entiti
 /** The starter-equipment table section, for exercising its `newRow`/column-options/`warn` (#1782). */
 const starterEquipmentSection = () =>
 	classEntity.sections.find((s) => s.key === 'starterEquipment') as TableSectionConfig<WorkbenchClass>;
+
+/** The starter-skills chips section, for exercising its Player-flag `warn` predicate. */
+const starterSkillsSection = () =>
+	classEntity.sections.find((s) => s.key === 'starterSkills') as ChipsSectionConfig<WorkbenchClass>;
 
 const blankClass = (starterEquipment: WorkbenchClass['starterEquipment'] = []): WorkbenchClass => ({
 	...classEntity.newItem(0),
@@ -133,5 +137,31 @@ describe('starterEquipment section (#1782)', () => {
 			message: "Item doesn't match its equipment slot's category",
 			blocking: true
 		});
+	});
+});
+
+describe('starterSkills chips section (#2333)', () => {
+	beforeEach(() => {
+		staticData.skills = [
+			{ id: 0, name: 'Slash', acquisition: ESkillAcquisition.Player },
+			{ id: 1, name: 'Bite', acquisition: ESkillAcquisition.Enemy } // flag stripped after assignment
+		];
+	});
+
+	it('warn flags a starter skill that lost its Player flag, blocking Save (backend-enforced)', () => {
+		const cls: WorkbenchClass = { ...classEntity.newItem(0), starterSkillIds: [0, 1] };
+		expect(starterSkillsSection().warn?.(cls)).toEqual({
+			message: "'Bite' is no longer flagged as Player-acquirable",
+			blocking: true
+		});
+	});
+
+	it('warn is null when every starter skill is still Player-flagged', () => {
+		const cls: WorkbenchClass = { ...classEntity.newItem(0), starterSkillIds: [0] };
+		expect(starterSkillsSection().warn?.(cls)).toBeNull();
+	});
+
+	it('warn falls back to the advisory "no starter skills" nag when the list is empty', () => {
+		expect(starterSkillsSection().warn?.(classEntity.newItem(0))).toBe('No starter skills');
 	});
 });

--- a/UI/src/tests/routes/admin/workbench/entities/enemy.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/enemy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { EChangeType } from '$lib/api';
+import { EChangeType, ESkillAcquisition } from '$lib/api';
 import type { TableSectionConfig } from '$routes/admin/workbench/entities/types';
 
 /* Enemy config transforms: `newItem` defaults, the boss list badge, and the
@@ -48,6 +48,9 @@ const tableSection = (key: string) =>
 
 /** The spawns section, used to exercise its boss-aware `warn` predicate. */
 const spawnsWarn = () => enemyEntity.sections.find((s) => s.key === 'spawns')?.warn;
+
+/** The skills chips section, used to exercise its Enemy-flag `warn` predicate. */
+const skillsWarn = () => enemyEntity.sections.find((s) => s.key === 'skills')?.warn;
 
 beforeEach(() => {
 	mockPost.mockReset().mockResolvedValue(undefined);
@@ -243,6 +246,19 @@ describe('enemyEntity', () => {
 		expect(warn?.({ ...baseline, spawns: [{ zoneId: 0, weight: 5 }], bossZones: [] })).toBeNull();
 		// Neither a spawn nor a boss assignment → it never appears, so warn.
 		expect(warn?.({ ...baseline, spawns: [], bossZones: [] })).toBe('Not assigned to any zone');
+	});
+
+	it('skills warn flags a pool skill that lost its Enemy flag, blocking Save (backend-enforced) (#2333)', () => {
+		const warn = skillsWarn();
+		staticData.skills = [
+			{ id: 0, name: 'Claw', acquisition: ESkillAcquisition.Enemy },
+			{ id: 1, name: 'Roar', acquisition: ESkillAcquisition.Player } // flag stripped after assignment
+		];
+		expect(warn?.({ ...baseline, skillPool: [0] })).toBeNull();
+		expect(warn?.({ ...baseline, skillPool: [0, 1] })).toEqual({
+			message: "'Roar' is no longer flagged as an Enemy skill",
+			blocking: true
+		});
 	});
 
 	describe('newRow factories', () => {

--- a/UI/src/tests/routes/admin/workbench/entities/item.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/item.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { EChangeType, EDamageType, EItemCategory, ERarity } from '$lib/api';
+import { EChangeType, EDamageType, EItemCategory, ERarity, ESkillAcquisition } from '$lib/api';
 import type { FieldsSectionConfig, Warning } from '$routes/admin/workbench/entities/types';
 
 /* Item config transforms specific to the WeaponType field (#1372, relaxed to any leaf by #1456): the
@@ -93,6 +93,73 @@ describe('itemEntity weapon type', () => {
 
 	it('accepts a clean non-weapon item', () => {
 		expect(identityWarn(itemEntity.newItem(1))).toBeNull();
+	});
+
+	it('warns a weapon whose granted skill signature type no longer matches its own weapon type (#2333)', () => {
+		// Axe is a martial weapon-leaf type distinct from the item's own Sword weapon type, so this
+		// mirrors an authored weapon whose granted skill's portions were retuned to a different weapon leaf.
+		staticData.skills = [
+			{
+				id: 0,
+				name: 'Axe Strike',
+				acquisition: ESkillAcquisition.Item,
+				damagePortions: [{ type: EDamageType.Axe, weight: 1 }]
+			}
+		];
+		const weapon: WorkbenchItem = {
+			...itemEntity.newItem(1),
+			itemCategoryId: EItemCategory.Weapon,
+			weaponType: EDamageType.Sword,
+			grantedSkillId: 0
+		};
+		expect(identityWarn(weapon)).toEqual({
+			message: "Weapon type doesn't match its granted skill's signature type, which strands the wielder",
+			blocking: true
+		});
+	});
+
+	it('accepts a weapon whose granted skill has no weapon-leaf signature (a caster element)', () => {
+		staticData.skills = [
+			{
+				id: 0,
+				name: 'Firebolt',
+				acquisition: ESkillAcquisition.Item,
+				damagePortions: [{ type: EDamageType.Fire, weight: 1 }]
+			}
+		];
+		const weapon: WorkbenchItem = {
+			...itemEntity.newItem(1),
+			itemCategoryId: EItemCategory.Weapon,
+			weaponType: EDamageType.Fire,
+			grantedSkillId: 0
+		};
+		expect(identityWarn(weapon)).toBeNull();
+	});
+
+	it('warns a granted skill (weapon or not) that lost its Item acquisition flag, blocking Save (#2333)', () => {
+		staticData.skills = [{ id: 0, name: 'Sword Strike', acquisition: ESkillAcquisition.Player, damagePortions: [] }];
+		const weapon: WorkbenchItem = {
+			...itemEntity.newItem(1),
+			itemCategoryId: EItemCategory.Weapon,
+			weaponType: EDamageType.Sword,
+			grantedSkillId: 0
+		};
+		expect(identityWarn(weapon)).toEqual({
+			message: "Granted skill 'Sword Strike' is no longer flagged as Item-acquirable",
+			blocking: true
+		});
+
+		const cloak: WorkbenchItem = { ...itemEntity.newItem(1), itemCategoryId: EItemCategory.Chest, grantedSkillId: 0 };
+		expect(identityWarn(cloak)).toEqual({
+			message: "Granted skill 'Sword Strike' is no longer flagged as Item-acquirable",
+			blocking: true
+		});
+	});
+
+	it('accepts a granted skill that is still Item-flagged', () => {
+		staticData.skills = [{ id: 0, name: 'Sword Strike', acquisition: ESkillAcquisition.Item, damagePortions: [] }];
+		const cloak: WorkbenchItem = { ...itemEntity.newItem(1), itemCategoryId: EItemCategory.Chest, grantedSkillId: 0 };
+		expect(identityWarn(cloak)).toBeNull();
 	});
 
 	it('weaponTypeOptions offers None plus every damage-type leaf, martial or caster', () => {

--- a/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent, waitFor } from '@testing-library/svelte';
-import { EAttribute, EModifierType } from '$lib/api';
+import { EAttribute, EModifierType, ESkillAcquisition } from '$lib/api';
 
 // Hoisted so individual tests can seed staticData and assert the retire-confirm flow, mirroring
 // WorkbenchDetail.test.ts's pattern for the generic Workbench's retire dialog.
@@ -255,6 +255,22 @@ describe('TierDetail — tab bodies', () => {
 		render(TierDetail, { props: { store: rootGateway } });
 		const rootTab = screen.getByText('Gateways').closest('button');
 		expect(rootTab?.querySelector('svg')).toBeNull();
+	});
+
+	it('warns the Milestones tab when a reward skill lost its Player flag (#2333)', () => {
+		staticData.skills = [{ id: 0, name: 'Roar', acquisition: ESkillAcquisition.Enemy }]; // flag stripped after reward
+
+		const flagLost = makeStore(tier({ maxLevel: 5, levelRewards: [{ level: 3, rewardSkillId: 0 }] }));
+		render(TierDetail, { props: { store: flagLost } });
+		const flagLostTab = screen.getByText('Milestones').closest('button');
+		expect(flagLostTab?.querySelector('svg')).toBeTruthy();
+		cleanup();
+
+		staticData.skills = [{ id: 0, name: 'Roar', acquisition: ESkillAcquisition.Player }];
+		const stillFlagged = makeStore(tier({ maxLevel: 5, levelRewards: [{ level: 3, rewardSkillId: 0 }] }));
+		render(TierDetail, { props: { store: stillFlagged } });
+		const stillFlaggedTab = screen.getByText('Milestones').closest('button');
+		expect(stillFlaggedTab?.querySelector('svg')).toBeNull();
 	});
 
 	it('lists an existing prerequisite chip, removes it, and adds a new one', async () => {

--- a/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { EActivityKey, EAttribute, EModifierType } from '$lib/api';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EActivityKey, EAttribute, EModifierType, ESkillAcquisition } from '$lib/api';
+
+const { staticData } = vi.hoisted(() => ({
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	staticData: {} as any
+}));
+vi.mock('$stores', () => ({ staticData }));
+
 import {
 	activityKeyGroups,
 	cumulativeXp,
@@ -18,10 +25,17 @@ import {
 	proficiencyWarnings,
 	renumberTiers,
 	rewardAtLevel,
+	rewardSkillFlagWarnings,
 	tiersOfPath,
 	xpCostCurve
 } from '$routes/admin/workbench/progression/progression-helpers';
 import type { WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+
+beforeEach(() => {
+	for (const key of Object.keys(staticData)) {
+		delete staticData[key];
+	}
+});
 
 const tier = (overrides: Partial<WorkbenchProficiency> & Pick<WorkbenchProficiency, 'id'>): WorkbenchProficiency => ({
 	...newProficiency(overrides.id, overrides.pathId ?? 1, overrides.pathOrdinal ?? 0),
@@ -191,6 +205,26 @@ describe('validation', () => {
 
 		const nonRootNoPrereqs = tier({ id: 3, pathOrdinal: 1, prerequisiteIds: [] });
 		expect(prerequisiteRootWarnings(nonRootNoPrereqs)).toHaveLength(0);
+	});
+
+	it('rewardSkillFlagWarnings flags a milestone reward skill that lost its Player flag, blocking Save (#2333)', () => {
+		staticData.skills = [
+			{ id: 0, name: 'Slash', acquisition: ESkillAcquisition.Player },
+			{ id: 1, name: 'Roar', acquisition: ESkillAcquisition.Enemy } // flag stripped after being made a reward
+		];
+
+		const flagLost = tier({ id: 1, maxLevel: 5, levelRewards: [{ level: 3, rewardSkillId: 1 }] });
+		expect(rewardSkillFlagWarnings(flagLost)).toEqual([
+			"Reward skill 'Roar' is no longer flagged as Player-acquirable"
+		]);
+		expect(proficiencyBlockingWarnings(flagLost)).toContain(
+			"Reward skill 'Roar' is no longer flagged as Player-acquirable"
+		);
+		expect(proficiencyWarnings(flagLost)).toContain("Reward skill 'Roar' is no longer flagged as Player-acquirable");
+
+		const stillFlagged = tier({ id: 2, maxLevel: 5, levelRewards: [{ level: 3, rewardSkillId: 0 }] });
+		expect(rewardSkillFlagWarnings(stillFlagged)).toHaveLength(0);
+		expect(proficiencyBlockingWarnings(stillFlagged)).toHaveLength(0);
 	});
 });
 


### PR DESCRIPTION
## Summary

The #2217/#2222 convention: any condition the backend is *known* to hard-reject on save must surface as a `blocking` warning that disables Save. The "keep a stale reference visible" picker convention (`reference.svelte.ts`'s `keep`s, chips catalogues keeping flag-lost skills as removable chips) left four such hard-rejected states reachable with no blocking warning, since none of `AdminSkills.SaveSkills`, the class/enemy/proficiency/item child savers have a cross-reference guard preventing an admin from freely removing a skill's acquisition flag (or retuning its damage portions) after it's already referenced elsewhere.

## How this addresses the issue

Mirrors the existing zone/challenge "no longer flagged as…" blocking-warn pattern onto the four gaps identified in #2333:

- **Class starter skills** (`entities/class.ts`): the `starterSkills` chips section now blocks Save when an assigned skill has lost its `Player` acquisition flag — mirrors `AdminClasses.FindStarterSkillFlagViolation`.
- **Enemy skill pool** (`entities/enemy.ts`): the `skills` chips section now blocks Save when a pool skill has lost its `Enemy` acquisition flag — mirrors `AdminEnemies.FindEnemySkillFlagViolation`.
- **Proficiency milestone rewards** (`progression/progression-helpers.ts`): new `rewardSkillFlagWarnings`, wired into both `proficiencyWarnings` (advisory list) and `proficiencyBlockingWarnings` (gates Save), flags a reward skill that lost its `Player` acquisition flag — mirrors `AdminProficiencies.SetRewards`/`CheckPlayerSkill`. Also corrects the stale doc comment on `levelRangeWarnings` that claimed level-range was "the one" proficiency condition the backend hard-rejects (it's no longer the only one) and wires the new check into `TierDetail.svelte`'s Milestones tab warning indicator.
- **Items** (`entities/item.ts`): the identity section's `warn` now additionally flags (a) a granted skill (weapon or not) that lost its `Item` acquisition flag, and (b) a weapon whose granted skill's primary damage-type signature no longer matches the item's own `weaponType` — mirrors `AdminItems.FindGrantedSkillFlagViolation` / `FindWeaponInvariantViolation`. Reuses the existing frontend `primaryDamageType`/`isWeaponLeaf` resolvers (`$lib/battle/damage-types`) rather than re-deriving the signature type.

## Test plan

- [x] Added unit tests for each new `warn` predicate (flag-lost blocking, flag-still-present clean, weapon-signature mismatch, weapon-signature match for a non-weapon-leaf caster element) across `class.test.ts`, `enemy.test.ts`, `item.test.ts`, and `progression-helpers.test.ts`.
- [x] Added a component test in `TierDetail.test.ts` asserting the Milestones tab surfaces the warning icon when a reward skill loses its Player flag, and clears when it's restored.
- [x] `npm run lint` (ESLint + svelte-check) — 0 errors/warnings.
- [x] `npm run test:unit:ci` — all 311 frontend test files / 3942 tests pass.
- [x] No backend files touched — this is a frontend-only Workbench validation change (mirrors existing hard-reject rules, doesn't add new ones), so no backend test suite is affected.

Closes #2333

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1bzoy8cWA7Ky1CxLUPkky)_