### PR TITLE
Fix SaveDeviceInfo clearing previously-captured DeviceMemory/HardwareConcurrency

### DIFF
--- a/Game.Application.Tests/DataAccess/UserLoginsCapAndOwnershipIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/UserLoginsCapAndOwnershipIntegrationTests.cs
@@ -212,6 +212,34 @@ namespace Game.Application.Tests.DataAccess
             Assert.Equal(8, device.HardwareConcurrency);
         }
 
+        [Fact]
+        public async Task SaveDeviceInfo_LaterCallWithoutHints_DoesNotClearPreviouslyCapturedValues()
+        {
+            // navigator.deviceMemory/hardwareConcurrency are unsupported in some browsers and stripped by some
+            // privacy extensions, so a later request can legitimately carry nulls for a device an earlier
+            // request already enriched (#2342) — those earlier values must survive, not be overwritten.
+            int userId;
+            using (var seedScope = CreateScope())
+            {
+                var context = seedScope.ServiceProvider.GetRequiredService<GameContext>();
+                userId = (await TestDataSeeder.CreateUserAsync(context)).Id;
+            }
+
+            using (var scope = CreateScope())
+            {
+                var repo = scope.ServiceProvider.GetRequiredService<IUserLogins>();
+                await repo.RecordConnection(userId, Ip, Fingerprint(0), UserAgent, null, null, null, CancellationToken);
+                await repo.SaveDeviceInfo(userId, Fingerprint(0), null, null, null, 16, 8, CancellationToken);
+                await repo.SaveDeviceInfo(userId, Fingerprint(0), null, null, null, null, null, CancellationToken);
+            }
+
+            using var assertScope = CreateScope();
+            var assertContext = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+            var device = await assertContext.Devices.SingleAsync(d => d.DeviceFingerprintHash == Fingerprint(0), CancellationToken);
+            Assert.Equal(16, device.DeviceMemory);
+            Assert.Equal(8, device.HardwareConcurrency);
+        }
+
         // A distinct, deterministic fingerprint per index — real fingerprints are 64 lowercase hex chars, but
         // the repository itself doesn't enforce that shape (only the HTTP-layer ClientHints does), so a
         // simple distinguishable string is enough here.

--- a/Game.DataAccess/Repositories/UserLogins.cs
+++ b/Game.DataAccess/Repositories/UserLogins.cs
@@ -144,8 +144,8 @@ namespace Game.DataAccess.Repositories
                 device.BrowserInfo.SecChUa ??= Truncate(secChUa, BrowserInfo.MaxClientHintLength);
                 device.BrowserInfo.SecChUaMobile ??= Truncate(secChUaMobile, BrowserInfo.MaxClientHintLength);
                 device.BrowserInfo.SecChUaPlatform ??= Truncate(secChUaPlatform, BrowserInfo.MaxClientHintLength);
-                device.DeviceMemory = deviceMemory;
-                device.HardwareConcurrency = hardwareConcurrency;
+                device.DeviceMemory ??= deviceMemory;
+                device.HardwareConcurrency ??= hardwareConcurrency;
             }, cancellationToken);
         }
 


### PR DESCRIPTION
## Summary

`UserLogins.SaveDeviceInfo` (`Game.DataAccess/Repositories/UserLogins.cs`) is supposed to follow a fill-when-missing policy for client-hint/device fields — "client hints are only filled in when missing so a later request with fewer hints never clears values an earlier one captured" (per the doc comment on the sibling `GetOrCreateBrowserInfo`). The `SecChUa*` fields already honor this via `??=`, but `DeviceMemory`/`HardwareConcurrency` were assigned unconditionally two lines below.

`navigator.deviceMemory` is unavailable in Firefox/Safari and can be stripped by privacy extensions, so a later `SaveDeviceInfo` call carrying nulls for a device an earlier request already enriched would null out the previously-captured values — contradicting the documented policy.

## Fix

Changed the two unconditional assignments to `??=`, matching the pattern already used for `SecChUa`/`SecChUaMobile`/`SecChUaPlatform` two lines above.

## Test plan

- [x] Added `SaveDeviceInfo_LaterCallWithoutHints_DoesNotClearPreviouslyCapturedValues` to `UserLoginsCapAndOwnershipIntegrationTests.cs`, pinning that a first call with values followed by a second call with nulls preserves the original values.
- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] `dotnet test` (Game.Application.Tests) — 1096 passed, 0 failed, including the existing `SaveDeviceInfo`/`UserLogins` integration tests (which already exercised same-value overwrites and remain green).

Closes #2342

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGH7gokMhWmWScsVUiBJ2S)_