### PR TITLE
Disarm background-throttle resume credit on the next regular tick

### DIFF
--- a/UI/src/lib/engine/background-throttle-notice.ts
+++ b/UI/src/lib/engine/background-throttle-notice.ts
@@ -1,4 +1,4 @@
-import { onIdleTimeLost } from './logical-engine';
+import { onIdleTimeLost, onLogicalUpdate } from './logical-engine';
 import { toastWarning } from '$stores';
 import { safeLocalStorage } from '$lib/common/local-storage';
 import type { Action } from '$lib/common';
@@ -42,6 +42,7 @@ export const backgroundThrottleGuidance = (): string => {
  */
 export class BackgroundThrottleMonitor {
 	private unhookIdleTimeLost?: Action;
+	private unhookResumeGuard?: Action;
 	private lostWhileHiddenMs = 0;
 	private resumeCatchUpPending = false;
 	private running = false;
@@ -53,6 +54,7 @@ export class BackgroundThrottleMonitor {
 		this.running = true;
 		this.lostWhileHiddenMs = 0;
 		this.resumeCatchUpPending = false;
+		this.clearResumeGuard();
 		this.unhookIdleTimeLost = onIdleTimeLost((lostMs) => this.recordLostTime(lostMs));
 		document.addEventListener('visibilitychange', this.handleVisibilityChange);
 	}
@@ -64,6 +66,7 @@ export class BackgroundThrottleMonitor {
 		this.running = false;
 		this.lostWhileHiddenMs = 0;
 		this.resumeCatchUpPending = false;
+		this.clearResumeGuard();
 		this.unhookIdleTimeLost?.();
 		this.unhookIdleTimeLost = undefined;
 		document.removeEventListener('visibilitychange', this.handleVisibilityChange);
@@ -81,6 +84,7 @@ export class BackgroundThrottleMonitor {
 		// that just ended rather than dropping it as a foreground stall.
 		if (this.resumeCatchUpPending) {
 			this.resumeCatchUpPending = false;
+			this.clearResumeGuard();
 			this.lostWhileHiddenMs += lostMs;
 			this.evaluate();
 		}
@@ -92,13 +96,32 @@ export class BackgroundThrottleMonitor {
 			// Entering a new hidden period — measure it on its own.
 			this.lostWhileHiddenMs = 0;
 			this.resumeCatchUpPending = false;
+			this.clearResumeGuard();
 			return;
 		}
 		// Back in the foreground. A throttled tab has already accumulated its loss (evaluate it now);
-		// a frozen tab's loss arrives as the next catch-up poll, so arm the one-shot resume credit.
+		// a frozen tab's loss arrives as the next catch-up poll, so arm the one-shot resume credit —
+		// but only through the very next logical tick. If that tick isn't itself the catch-up poll,
+		// nothing was actually lost to backgrounding, so the credit must not linger to be misapplied
+		// to some unrelated foreground stall much later.
 		this.resumeCatchUpPending = true;
+		this.armResumeGuard();
 		this.evaluate();
 	};
+
+	private armResumeGuard() {
+		this.clearResumeGuard();
+		this.unhookResumeGuard = onLogicalUpdate((_tickMs, unhook) => {
+			unhook();
+			this.unhookResumeGuard = undefined;
+			this.resumeCatchUpPending = false;
+		});
+	}
+
+	private clearResumeGuard() {
+		this.unhookResumeGuard?.();
+		this.unhookResumeGuard = undefined;
+	}
 
 	// Nudges once if the hidden period cost a meaningful amount of idle progress.
 	private evaluate() {

--- a/UI/src/tests/lib/engine/background-throttle-notice.test.ts
+++ b/UI/src/tests/lib/engine/background-throttle-notice.test.ts
@@ -4,13 +4,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const h = vi.hoisted(() => ({
 	toastWarning: vi.fn(),
 	unhook: vi.fn(),
-	unhookLogicalUpdate: vi.fn(),
 	state: {
 		lsStore: {} as Record<string, string>,
 		lsAvailable: true,
 		setItemThrows: false,
 		idleTimeLostCb: undefined as ((ms: number) => void) | undefined,
-		logicalUpdateCb: undefined as ((tickMs: number, unhook: () => void) => void) | undefined
+		// Every onLogicalUpdate() call gets its own {cb, unhook} entry (mirroring the real hook's
+		// per-subscriber tracker) so a test can tell a genuinely-unhooked stale subscription apart
+		// from one that was merely overwritten by a later subscribe.
+		logicalUpdateSubs: [] as { cb: (tickMs: number, unhook: () => void) => void; unhook: () => void }[]
 	}
 }));
 
@@ -39,8 +41,9 @@ vi.mock('$lib/engine/logical-engine', () => ({
 		return h.unhook;
 	},
 	onLogicalUpdate: (cb: (tickMs: number, unhook: () => void) => void) => {
-		h.state.logicalUpdateCb = cb;
-		return h.unhookLogicalUpdate;
+		const unhook = vi.fn<() => void>();
+		h.state.logicalUpdateSubs.push({ cb, unhook });
+		return unhook;
 	}
 }));
 
@@ -65,7 +68,7 @@ describe('BackgroundThrottleMonitor', () => {
 		h.state.lsAvailable = true;
 		h.state.setItemThrows = false;
 		h.state.idleTimeLostCb = undefined;
-		h.state.logicalUpdateCb = undefined;
+		h.state.logicalUpdateSubs = [];
 		hidden = false;
 		Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
 		monitor = new BackgroundThrottleMonitor();
@@ -80,9 +83,14 @@ describe('BackgroundThrottleMonitor', () => {
 	});
 
 	const lose = (ms: number) => h.state.idleTimeLostCb?.(ms);
+	const latestGuardSub = () => h.state.logicalUpdateSubs.at(-1);
 	// Simulates a regular logical tick that lost nothing — the common case, since the worker tick
-	// source polls every 10ms regardless of visibility.
-	const tick = () => h.state.logicalUpdateCb?.(10, h.unhookLogicalUpdate);
+	// source polls every 10ms regardless of visibility. Only the current (last-subscribed) guard is
+	// fired — a real, correctly-unhooked stale guard would never receive it.
+	const tick = () => {
+		const sub = latestGuardSub();
+		sub?.cb(10, sub.unhook);
+	};
 
 	it('shows a one-time dismissible notice after a hidden period loses past the threshold', () => {
 		monitor.start();
@@ -133,14 +141,19 @@ describe('BackgroundThrottleMonitor', () => {
 		expect(h.toastWarning).not.toHaveBeenCalled();
 	});
 
-	it('does not let a stale resume-guard subscription from an earlier cycle disarm a fresh one', () => {
+	it('unhooks a stale resume-guard subscription from an earlier cycle before arming a fresh one', () => {
 		monitor.start();
 		goHidden();
-		goVisible(); // arms guard #1
-		goHidden();
-		goVisible(); // re-arms: guard #1 must be unhooked, not left to fire later
-		lose(70_000); // credited to guard #2's hidden period
+		goVisible(); // arms guard #1; the hidden->visible edge also exercises the hidden-branch clear
+		// A second, back-to-back visible edge (no intervening hide) isolates armResumeGuard's own
+		// clearResumeGuard() call: without it, guard #1 would stay subscribed as a stale duplicate.
+		goVisible();
 
+		expect(h.state.logicalUpdateSubs).toHaveLength(2);
+		expect(h.state.logicalUpdateSubs[0].unhook).toHaveBeenCalled(); // guard #1: actually unhooked
+		expect(h.state.logicalUpdateSubs[1].unhook).not.toHaveBeenCalled(); // guard #2: still live
+
+		lose(70_000); // credited to guard #2's hidden period
 		expect(h.toastWarning).toHaveBeenCalledTimes(1);
 	});
 
@@ -150,7 +163,7 @@ describe('BackgroundThrottleMonitor', () => {
 		goVisible(); // arms the guard
 		monitor.stop();
 
-		expect(h.unhookLogicalUpdate).toHaveBeenCalled();
+		expect(latestGuardSub()?.unhook).toHaveBeenCalled();
 	});
 
 	it('ignores idle time lost while the tab is visible (a foreground stall is not backgrounding)', () => {

--- a/UI/src/tests/lib/engine/background-throttle-notice.test.ts
+++ b/UI/src/tests/lib/engine/background-throttle-notice.test.ts
@@ -4,11 +4,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const h = vi.hoisted(() => ({
 	toastWarning: vi.fn(),
 	unhook: vi.fn(),
+	unhookLogicalUpdate: vi.fn(),
 	state: {
 		lsStore: {} as Record<string, string>,
 		lsAvailable: true,
 		setItemThrows: false,
-		idleTimeLostCb: undefined as ((ms: number) => void) | undefined
+		idleTimeLostCb: undefined as ((ms: number) => void) | undefined,
+		logicalUpdateCb: undefined as ((tickMs: number, unhook: () => void) => void) | undefined
 	}
 }));
 
@@ -29,11 +31,16 @@ vi.mock('$lib/common/local-storage', () => ({
 			: null
 }));
 
-// Capture the callback the monitor registers so the test can drive lost-time events directly.
+// Capture the callbacks the monitor registers so the test can drive lost-time and regular-tick
+// events directly.
 vi.mock('$lib/engine/logical-engine', () => ({
 	onIdleTimeLost: (cb: (ms: number) => void) => {
 		h.state.idleTimeLostCb = cb;
 		return h.unhook;
+	},
+	onLogicalUpdate: (cb: (tickMs: number, unhook: () => void) => void) => {
+		h.state.logicalUpdateCb = cb;
+		return h.unhookLogicalUpdate;
 	}
 }));
 
@@ -58,6 +65,7 @@ describe('BackgroundThrottleMonitor', () => {
 		h.state.lsAvailable = true;
 		h.state.setItemThrows = false;
 		h.state.idleTimeLostCb = undefined;
+		h.state.logicalUpdateCb = undefined;
 		hidden = false;
 		Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
 		monitor = new BackgroundThrottleMonitor();
@@ -72,6 +80,9 @@ describe('BackgroundThrottleMonitor', () => {
 	});
 
 	const lose = (ms: number) => h.state.idleTimeLostCb?.(ms);
+	// Simulates a regular logical tick that lost nothing — the common case, since the worker tick
+	// source polls every 10ms regardless of visibility.
+	const tick = () => h.state.logicalUpdateCb?.(10, h.unhookLogicalUpdate);
 
 	it('shows a one-time dismissible notice after a hidden period loses past the threshold', () => {
 		monitor.start();
@@ -110,6 +121,36 @@ describe('BackgroundThrottleMonitor', () => {
 		lose(70_000); // a genuine later foreground stall — ignored
 
 		expect(h.toastWarning).not.toHaveBeenCalled();
+	});
+
+	it('disarms the resume credit once a regular tick passes with nothing lost, so a later foreground stall is not misattributed', () => {
+		monitor.start();
+		goHidden();
+		goVisible(); // arms the one-shot resume credit
+		tick(); // a normal post-resume tick with nothing lost — the credit must not survive this
+		lose(70_000); // hours-later foreground stall (OS suspend, debugger pause, etc.)
+
+		expect(h.toastWarning).not.toHaveBeenCalled();
+	});
+
+	it('does not let a stale resume-guard subscription from an earlier cycle disarm a fresh one', () => {
+		monitor.start();
+		goHidden();
+		goVisible(); // arms guard #1
+		goHidden();
+		goVisible(); // re-arms: guard #1 must be unhooked, not left to fire later
+		lose(70_000); // credited to guard #2's hidden period
+
+		expect(h.toastWarning).toHaveBeenCalledTimes(1);
+	});
+
+	it('unsubscribes the pending resume guard on stop', () => {
+		monitor.start();
+		goHidden();
+		goVisible(); // arms the guard
+		monitor.stop();
+
+		expect(h.unhookLogicalUpdate).toHaveBeenCalled();
 	});
 
 	it('ignores idle time lost while the tab is visible (a foreground stall is not backgrounding)', () => {


### PR DESCRIPTION
## Summary

`BackgroundThrottleMonitor.resumeCatchUpPending` (`UI/src/lib/engine/background-throttle-notice.ts`) was armed on every visibility resume and only ever consumed by the *next* idle-time-lost event — whenever that happened. If the tab wasn't actually throttled (no catch-up poll followed the resume), the credit lingered indefinitely. Hours later, a genuine **foreground** stall (OS suspend/wake with the tab focused, a long debugger pause) would then be misattributed to the earlier hidden period, potentially crossing the notice threshold and permanently burning the one-shot "add this site to Always keep active" guidance on a situation it can't help with.

## Fix

Bound the resume credit to the very next logical tick instead of letting it wait indefinitely for the next lost-time event:

- On resume, subscribe (one-shot) to `onLogicalUpdate` in addition to arming `resumeCatchUpPending`.
- If a real catch-up poll follows, `recordLostTime` still consumes the credit first — `onIdleTimeLost` fires before `onLogicalUpdate` within the same engine `update()` pass, so the frozen-tab crediting behavior (Memory Saver / tab discard) is unchanged.
- If instead the very next regular tick passes with nothing lost, the guard disarms the credit there, so it can no longer be misapplied to an unrelated stall much later.
- The guard is also cleared on re-arm (repeated hide/show cycles don't stack subscriptions), when entering a new hidden period, and on `stop()`.

## How this addresses the issue

Closes #2343.

## Test plan

- [x] `npm run lint` (ESLint + svelte-check) — clean
- [x] `npm run test:unit:ci` — full suite green
- [x] Added unit tests covering: the credit disarming on a no-loss regular tick after resume, stale-guard cleanup across repeated hide/show cycles, and guard unsubscription on `stop()`. Existing tests (frozen-tab crediting, foreground-stall ignoring, one-time notice) still pass unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WzRRQCGJJequWNTSYHfbFL)_