### PR TITLE
Skip boss-victory celebration on a definitive DefeatEnemy rejection

### DIFF
--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -42,6 +42,11 @@ interface BattleEndResult {
 	cooldown: number;
 	nextEnemy?: IEnemyInstance;
 	nextZoneId?: number;
+	/** True only when the server definitively rejected the victory claim — an error response that still
+	 *  carries `data` (see docs/frontend-sockets.md: a transport-level failure, the ambiguous case, never
+	 *  carries `data` at all). Lets a caller tell "the claim genuinely didn't happen" apart from "we don't
+	 *  know if it happened," so it can skip celebrating a win the server never credited. */
+	rejected: boolean;
 }
 
 /** A server-prefetched next idle battle, held across the post-battle cooldown so the loop can begin it
@@ -678,11 +683,20 @@ export class EnemyManager {
 		// awaits below — otherwise the clear and the "next zone unlocked" check could target the wrong zone.
 		const clearedZoneId = playerManager.currentZone;
 
-		await this.claimVictory();
+		const { rejected } = await this.claimVictory();
 		// A stop / retreat that landed during the victory claim has already transitioned us out of the boss
 		// loop (or this resolution spans a stop()→start() cycle, #2331); abandon so we don't resurrect the
 		// cleared overlay over the new state.
 		if (!this.bossLoopActive(generation)) {
+			return;
+		}
+		if (rejected) {
+			// The server definitively rejected the claim (not just a lost/ambiguous response) — the zone was
+			// never actually cleared, so skip the celebration entirely rather than faking the Zone-Cleared
+			// seal/overlay and, with auto-fight on, looping rejected claims against that fanfare. Fall back to
+			// the idle loop, mirroring a boss loss/draw.
+			this.returnToIdle();
+			await this.getNewEnemy();
 			return;
 		}
 
@@ -803,7 +817,8 @@ export class EnemyManager {
 		return {
 			cooldown: defeatResponse.data?.cooldown ?? 0,
 			nextEnemy: defeatResponse.data?.nextEnemy,
-			nextZoneId: defeatResponse.data?.nextZoneId
+			nextZoneId: defeatResponse.data?.nextZoneId,
+			rejected: !!defeatResponse.error && defeatResponse.data !== undefined
 		};
 	}
 }

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -365,6 +365,58 @@ describe('EnemyManager boss mode', () => {
 		expect(send).toHaveBeenCalledWith('ChallengeBoss', expect.objectContaining({ zoneId: 3 }));
 	});
 
+	it('on a boss victory the server definitively rejects: skips the celebration and falls back to idle (#2344)', async () => {
+		// A definitive rejection carries `data` (e.g. the cooldown) alongside the error — the signal that
+		// distinguishes "the server said no" from the ambiguous lost-response case below, which never
+		// carries `data` at all.
+		send.mockImplementation((name: string) =>
+			name === 'DefeatEnemy'
+				? Promise.resolve({
+						id: '1',
+						name: 'DefeatEnemy',
+						error: 'Enemy could not be defeated.',
+						data: { cooldown: 0 }
+					} as IApiSocketResponse<'DefeatEnemy'>)
+				: Promise.resolve(newEnemyResponse)
+		);
+
+		await manager.challengeBoss();
+		manager.setAutoFight(true);
+		send.mockClear(); // isolate the calls the victory resolution itself makes
+
+		await fireStage(h.BattleStage.Victorious);
+
+		expect(h.statistics.markZoneCleared).not.toHaveBeenCalled();
+		expect(manager.bossOutcome).toBeUndefined();
+		// Even with auto-fight on, a rejected claim must not loop back into another boss challenge — fall
+		// back to the idle loop exactly like a loss/draw instead.
+		expect(manager.mode).toBe('idle');
+		expect(send).not.toHaveBeenCalledWith('ChallengeBoss', expect.anything());
+		expect(send).toHaveBeenCalledWith('NewEnemy', expect.objectContaining({ newZoneId: 3 }));
+	});
+
+	it('on a boss victory with an ambiguous (lost-response) DefeatEnemy error: keeps the optimistic celebration', async () => {
+		// A transport-level failure (timeout/dropped connection) never carries `data` — the command may
+		// still have succeeded server-side, so the boss path keeps today's optimistic behavior instead of
+		// treating it as a rejection.
+		send.mockImplementation((name: string) =>
+			name === 'DefeatEnemy'
+				? Promise.resolve({
+						id: '1',
+						name: 'DefeatEnemy',
+						error: 'Timed out waiting for the server.'
+					} as IApiSocketResponse<'DefeatEnemy'>)
+				: Promise.resolve(newEnemyResponse)
+		);
+
+		await manager.challengeBoss();
+
+		await fireStage(h.BattleStage.Victorious);
+
+		expect(h.statistics.markZoneCleared).toHaveBeenCalledWith(3);
+		expect(manager.mode).toBe('idle');
+	});
+
 	it('on a boss victory that completes the next zone gate: refetches and flags the unlock', async () => {
 		// Cleared zone 3; zone 4 (next by order) is gated behind challenge 7. The gate is incomplete
 		// until the post-victory refetch flips it (mirroring the backend completing it on the clear).


### PR DESCRIPTION
## Summary

`resolveBossVictory()` (`UI/src/lib/engine/battle/enemy-manager.ts`) called `claimVictory()` but never inspected its outcome. On a *definitive* server rejection of the boss's `DefeatEnemy` claim (not just a lost/timed-out response), the client still:

- marked the zone cleared (`statistics.markZoneCleared`) — the "Cleared" seal shows wrong until the next `statistics.load()`
- played the Zone-Cleared overlay (`bossOutcome = 'victory'`)
- with auto-fight on, immediately re-challenged the boss, potentially looping rejected claims against the Zone-Cleared fanfare

## Fix

`claimVictory()` now returns a `rejected` flag distinguishing a **definitive rejection** from the existing **ambiguous lost-response** case:

- The backend's `DefeatEnemy` handler always attaches `data` (e.g. the cooldown) via `ErrorWithData` when it rejects a claim, while a transport-level failure (timeout / dropped connection) never carries `data` at all — the command may still have succeeded server-side in that case. That's the reliable signal to tell the two apart (see `docs/frontend-sockets.md`'s socket request lifecycle).
- `resolveBossVictory` now checks `rejected`: on a genuine rejection it skips the celebration entirely and falls back to the idle loop, mirroring how a boss loss/draw is already handled. On the ambiguous case, it keeps today's optimistic behavior unchanged.
- The idle victory path is unaffected — it has no equivalent "celebration" side effect to guard.

## How this addresses the issue

Closes #2344.

## Test plan

- [x] Added a unit test covering a definitive rejection: no zone-cleared, no overlay, falls back to idle, and — critically — does not re-challenge even with auto-fight on.
- [x] Added a unit test covering the ambiguous (ex: timed-out) case: celebration still proceeds as before.
- [x] `npm run lint` (ESLint + svelte-check) — clean
- [x] `npm run test:unit:ci` — full suite green (3954 tests)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRyzD2yvfqybR8cCtnUy3N)_