### PR TITLE
Add production (SSR) build step to verify-frontend CI job

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -182,6 +182,13 @@ jobs:
     - name: Run lint (ESLint + svelte-check)
       run: npm run lint
 
+    - name: Build production (SSR) bundle
+      # The UI ships as a SvelteKit adapter-node SSR service (svelte.config.js; nginx.conf routes
+      # / to the SSR host); nothing else in CI runs `vite build`, so a production-build-only
+      # failure (SSR-incompatible browser global, adapter-node bundling error) would otherwise
+      # first surface on the Railway deploy rather than here.
+      run: npm run build
+
   test-backend:
     needs: [detect-changes]
     # always()/!cancelled() lets this evaluate even when detect-changes was skipped (push events).


### PR DESCRIPTION
## Summary

- The UI ships as a SvelteKit **adapter-node SSR service** (`UI/svelte.config.js`; `nginx.conf:52` routes `/` to the SSR host), but no CI step ran `vite build` before this — `verify-frontend` ran ESLint + svelte-check, `test-frontend` ran Vitest (jsdom), and `test-e2e` ran Playwright against the Vite **dev server**. The deployed artifact was built for the first time on Railway.
- Adds a `Build production (SSR) bundle` step (`npm run build`) to the `verify-frontend` job, right after the existing lint step — that job already runs `npm ci`, so no extra setup is needed.

## How this addresses the issue

Closes #2334. Implements the fix suggested in the issue verbatim: append `npm run build` to `verify-frontend`.

## Test plan

- [x] Ran `npm run build` locally in `UI/` — completes cleanly in ~14s (matches the issue's measurement), producing the adapter-node SSR output with no errors.
- [x] CI will exercise this on the next push/PR touching frontend paths (the job is gated behind `detect-changes.outputs.frontend` on PRs, always-on for pushes to `main`, same as the existing lint/test steps).

---
_Generated by [Claude Code](https://claude.ai/code/session_01V478Dh5QyrbMSL7wvvDm6z)_