### PR TITLE
Trim Docker build context: fix stock .dockerignore (#2335)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,7 +18,6 @@
 **/npm-debug.log
 **/obj
 LICENSE
-README.md
 *.md
 
 # Not needed by any Docker image build (API image only needs the runtime projects, the root

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,15 +11,27 @@
 **/*.*proj.user
 **/*.dbmdl
 **/*.jfm
-**/azds.yaml
 **/bin
-**/charts
 **/docker-compose*
 **/Dockerfile*
 **/node_modules
 **/npm-debug.log
 **/obj
-**/secrets.dev.yaml
-**/values.dev.yaml
 LICENSE
 README.md
+*.md
+
+# Not needed by any Docker image build (API image only needs the runtime projects, the root
+# props/solution files, and content/*.json). Excluding these keeps the build context small and
+# stops UI/docs/test churn from invalidating the csproj-first restore layer in Game.Api/Dockerfile.
+UI/
+docs/
+.github/
+.claude/
+coverage/
+Game.Api.Tests/
+Game.Application.Tests/
+Game.Core.Tests/
+Game.Core.TestInfrastructure/
+Game.Infrastructure.Tests/
+Game.TestInfrastructure/


### PR DESCRIPTION
## Summary

`.dockerignore` was still the stock Visual Studio template — no project-specific excludes, and dead Azure Dev Spaces entries (`azds.yaml`, `charts`, `secrets.dev.yaml`, `values.dev.yaml`) that this project never used. Both Dockerfiles build with the repo root as context, so every API image build was hauling the full ~84 MB repo (58 MB of it `UI/static/img` game art, plus `docs/`, all of `UI/src`, and every test project) even though `Game.Api/Dockerfile` only needs the runtime project sources, the two root props files, and `content/*.json`.

- Removed the dead stock-template entries (`azds.yaml`, `charts`, `secrets.dev.yaml`, `values.dev.yaml`).
- Added excludes for `UI/`, `docs/`, `.github/`, `.claude/`, `coverage/`, `*.md`, and the six test projects (`Game.Api.Tests`, `Game.Application.Tests`, `Game.Core.Tests`, `Game.Core.TestInfrastructure`, `Game.Infrastructure.Tests`, `Game.TestInfrastructure`) — none of these are referenced by `Game.Api/Dockerfile`'s `COPY` steps or either `docker-compose*.yml` service definition.
- Kept `content/` (linked into `Game.Api.csproj` via `..\content\*.json`) and every root file the Dockerfile's restore-layer `COPY`s reference.

## How this addresses the issue

Closes #2335. This restores the csproj-first restore layering's intended benefit locally (a UI/docs-only change no longer invalidates the `COPY . .` layer and forces a full `dotnet publish`), and cuts the context the `test-e2e` CI matrix transfers 3× per run (`docker compose up -d --build`).

## Verification

- Confirmed (via `Grep`/`Read`) that nothing excluded is referenced by `Game.Api/Dockerfile`, the root nginx `Dockerfile`, `docker-compose.yml`, or `docker-compose.local.yml` — neither compose file mounts any `UI/` path.
- Confirmed `content/*.json` (the one thing outside the runtime projects the API image needs) is preserved.
- Ran `docker build -f Game.Api/Dockerfile .` locally: with the new `.dockerignore`, the build context dropped from ~84 MB to **2.74 MB**, and every `COPY` layer up through `dotnet restore` resolved identically to before the change (same cache hits, same layer order). The build then fails on `NU1301`/`UntrustedRoot` reaching `api.nuget.org` — a pre-existing limitation of this sandbox (container builds can't reach the outbound TLS-intercepting proxy the host session uses), unrelated to this change and reproducible on `main` too.

### Test plan

- [x] Verified no Dockerfile/compose file references any newly-excluded path.
- [x] Verified `content/*.json` stays included.
- [x] Confirmed build context size drops from ~84 MB to ~2.7 MB via a local `docker build` dry run.
- [ ] CI's `test-e2e` job builds the image in an environment with real network access — the pre-existing sandbox NuGet/TLS limitation above doesn't apply there, so this is the real end-to-end confirmation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E9VnA9VN1TPjixMqYhjReS)_