### PR TITLE
CI: add Playwright cache restore-keys, overlap API boot wait with Node setup

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -301,7 +301,42 @@ jobs:
       # (An earlier revision built the image via buildx with a GitHub Actions layer cache; measured
       # runs showed the cache-transfer + image-load overhead outweighed the savings on the hosted
       # runners, so the plain compose build is both simpler and faster here.)
+      #
+      # `up -d` returns once the containers start, not once the API finishes migrating/seeding, so
+      # the Node/Playwright setup below runs concurrently with that startup work instead of blocking
+      # on it — the blocking wait moved to "Apply the e2e admin-role fixture", just before the tests.
       run: docker compose up -d --build
+
+    - name: Set up Node
+      uses: actions/setup-node@v7
+      with:
+        node-version-file: UI/.nvmrc
+        cache: npm
+        cache-dependency-path: UI/package-lock.json
+
+    - name: Install node modules
+      working-directory: UI
+      run: npm ci
+
+    - name: Cache Playwright browser
+      id: playwright-cache
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('UI/package-lock.json') }}
+        restore-keys: |
+          playwright-${{ runner.os }}-${{ matrix.browser }}-
+
+    - name: Install Playwright browser
+      working-directory: UI
+      # Only this job's browser is needed. On a cache hit the binaries are already present, so just
+      # (re)install the OS-level dependencies, which actions/cache can't carry. On a miss, install both.
+      run: |
+        if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+          npx playwright install-deps ${{ matrix.browser }}
+        else
+          npx playwright install --with-deps ${{ matrix.browser }}
+        fi
 
     - name: Apply the e2e admin-role fixture
       # The API seeds the static content (Skills, Enemies, Zones, …) itself on startup from the
@@ -331,35 +366,6 @@ jobs:
         wait_for_api
         # Runs inside the Postgres container so it needs no client tooling on the runner; idempotent.
         docker compose exec -T postgres psql -U game -d game -p 5544 -v ON_ERROR_STOP=1 -f - < e2e-admin-provision.sql
-
-    - name: Set up Node
-      uses: actions/setup-node@v7
-      with:
-        node-version-file: UI/.nvmrc
-        cache: npm
-        cache-dependency-path: UI/package-lock.json
-
-    - name: Install node modules
-      working-directory: UI
-      run: npm ci
-
-    - name: Cache Playwright browser
-      id: playwright-cache
-      uses: actions/cache@v6
-      with:
-        path: ~/.cache/ms-playwright
-        key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('UI/package-lock.json') }}
-
-    - name: Install Playwright browser
-      working-directory: UI
-      # Only this job's browser is needed. On a cache hit the binaries are already present, so just
-      # (re)install the OS-level dependencies, which actions/cache can't carry. On a miss, install both.
-      run: |
-        if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
-          npx playwright install-deps ${{ matrix.browser }}
-        else
-          npx playwright install --with-deps ${{ matrix.browser }}
-        fi
 
     - name: Run Playwright e2e tests
       working-directory: UI


### PR DESCRIPTION
## Summary

Two independent wall-clock wins on `test-e2e`, the longest job in `run-tests.yml`:

1. **Playwright cache had no `restore-keys`.** The cache key was keyed solely on `hashFiles('UI/package-lock.json')`, so any lockfile change (including weekly dependabot npm bumps) missed the cache entirely and forced a full browser download — WebKit is the slow one — in all 3 matrix jobs. `~/.cache/ms-playwright` stores per-version directories, so adding a `restore-keys: playwright-${{ runner.os }}-${{ matrix.browser }}-` prefix lets a lockfile-only change fall back to the previous cache and makes `npx playwright install` incremental (only the genuinely new browser version downloads).
2. **The blocking API-boot wait ran ahead of Node/browser setup.** `docker compose up -d --build` returns once the containers start, not once the API finishes migrating + seeding content + building its reference-data caches. The "Apply the e2e admin-role fixture" step (which contains the blocking `wait_for_api` poll loop) previously ran immediately after, before "Set up Node" / `npm ci` / Playwright browser install — so the workflow blocked doing nothing while the API was still booting. Moved that step (wait + `psql` fixture) to run after Node/browser setup, so API boot now overlaps with Node/npm/Playwright setup instead of serializing ahead of it.

## How this addresses the issue

Closes #2336.

## Changes

- `.github/workflows/run-tests.yml`: added `restore-keys` to the Playwright browser cache step; reordered `test-e2e` steps so "Set up Node" → "Install node modules" → "Cache/Install Playwright browser" run before "Apply the e2e admin-role fixture" (previously the reverse). No behavior change to what each step does, only when it runs — the wait loop still blocks on the same readiness check before the fixture SQL and the tests run.

## Test plan

- [x] Validated the workflow YAML still parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] Manually traced the reordered step dependencies: nothing in "Set up Node" / `npm ci` / Playwright cache-and-install depends on the backing stack being *ready* (only depends on the repo being checked out), so moving them ahead of the readiness wait is safe.
- [ ] This is a CI-workflow-only change with no application code — the real verification is a green `test-e2e` matrix run on this PR itself (can't be run locally in the sandbox).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUkVhg4TW9ge7mmTcCbcV4)_