### PR TITLE
Bind docker-compose.local.yml published ports to 127.0.0.1

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -28,7 +28,7 @@ services:
   postgres:
     image: postgres:18-alpine
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-game}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-game}
@@ -42,7 +42,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "${REDIS_PORT:-6379}:6379"
+      - "127.0.0.1:${REDIS_PORT:-6379}:6379"
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ping | grep -q PONG"]
       interval: 3s
@@ -54,7 +54,7 @@ services:
       context: .
       dockerfile: Game.Api/Dockerfile
     ports:
-      - "${API_PORT:-5008}:5008"
+      - "127.0.0.1:${API_PORT:-5008}:5008"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- `docker-compose.local.yml` published Postgres, Redis, and the API's ports with unprefixed host bindings (`"${PORT}:CONTAINER_PORT"`), which Docker binds to `0.0.0.0` by default.
- On a dev laptop on a shared/untrusted network, that made Postgres (password `game`), Redis (no auth), and the API (placeholder JWT signing key) all reachable from the LAN — broader exposure than intended for a local-dev-only stack whose secrets are explicitly documented as placeholders.
- Prefixed all three port publishes with `127.0.0.1:` so they only bind to loopback.

## How this addresses the issue

Exactly the fix suggested in #2337. Zero functional impact: the SvelteKit dev server's Vite proxy and external tools (`psql`, `redis-cli`) already target `localhost`, which resolves to the loopback interface these bindings now restrict to.

I did not extend the same treatment to `docker-compose.yml` — that stack uses `network_mode: host` (no `ports:` section to prefix at all) and is documented as targeting CI/the constrained sandbox rather than a shared dev laptop, so the issue's own "if its published ports are only consumed locally by CI" hedge doesn't apply there.

Closes #2337

## Test plan

- [x] `docker compose -f docker-compose.local.yml config --quiet` validates the compose file after the change.
- [x] No functional/test coverage impact — this is a host-port-binding change only, not exercised by the dotnet/npm test suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGM1Nk6k2px6MXLd5rDWEk)_