### PR TITLE
Reject arrays from CodeGen's NeedsInterface so they hit the unmapped-type throw

### DIFF
--- a/Game.Api.Tests/CodeGen/CodeGenExtensionsTests.cs
+++ b/Game.Api.Tests/CodeGen/CodeGenExtensionsTests.cs
@@ -244,6 +244,20 @@ namespace Game.Api.Tests.CodeGen
             Assert.True(typeof(Dictionary<TestEnum, SimpleModel>).NeedsInterface());
         }
 
+        [Fact]
+        public void NeedsInterface_IntArray_ReturnsFalse()
+        {
+            // Arrays are IsClass but not enumerable per IsEnumerable (not generic); NeedsInterface must
+            // reject them too so GetTypeText's unmapped-type throw fires instead of emitting IInt32[].
+            Assert.False(typeof(int[]).NeedsInterface());
+        }
+
+        [Fact]
+        public void NeedsInterface_ClassArray_ReturnsFalse()
+        {
+            Assert.False(typeof(SimpleModel[]).NeedsInterface());
+        }
+
         [Theory]
         [InlineData("HelloWorld", "helloWorld")]
         [InlineData("A", "a")]

--- a/Game.Api.Tests/CodeGen/CodeGenTypeFormatterTests.cs
+++ b/Game.Api.Tests/CodeGen/CodeGenTypeFormatterTests.cs
@@ -391,6 +391,16 @@ namespace Game.Api.Tests.CodeGen
             var ex = Assert.Throws<InvalidOperationException>(() => CodeGenTypeFormatter.GetTypeText(descriptor));
             Assert.Contains("DateTimeOffset", ex.Message);
         }
+
+        [Fact]
+        public void GetTypeText_UnmappedArray_Throws()
+        {
+            // Arrays have no TypeScript mapping (List<>/IEnumerable<> are the supported shapes);
+            // NeedsInterface must reject them so this throws instead of emitting a garbage IString[].
+            var descriptor = GetPropertyDescriptor<ModelWithArray>("Tags");
+            var ex = Assert.Throws<InvalidOperationException>(() => CodeGenTypeFormatter.GetTypeText(descriptor));
+            Assert.Contains("String[]", ex.Message);
+        }
     }
 
     public class GenericHolder

--- a/Game.Api.Tests/CodeGen/TestFixtures.cs
+++ b/Game.Api.Tests/CodeGen/TestFixtures.cs
@@ -109,6 +109,14 @@ namespace Game.Api.Tests.CodeGen
         public string Title { get; set; } = "";
     }
 
+    // An array-typed member has no TypeScript mapping (List<>/IEnumerable<> are the supported shapes);
+    // GetTypeText must throw rather than silently emit a reference to an interface reflecting the
+    // array's CLR members (Length, SyncRoot, ...).
+    public class ModelWithArray : IModel
+    {
+        public string[] Tags { get; set; } = [];
+    }
+
     public class ModelWithDictionary : IModel
     {
         public Dictionary<string, int> StringToInt { get; set; } = [];

--- a/Game.Api/CodeGen/Extensions.cs
+++ b/Game.Api/CodeGen/Extensions.cs
@@ -108,7 +108,11 @@ namespace Game.Api.CodeGen
 
         private static bool IsClassThatNeedsInterface(Type type)
         {
-            return type.IsClass && !type.IsGenericParameter && type != typeof(string);
+            // Arrays are IsClass but not IsGenericType, so IsEnumerable rejects them and they would
+            // otherwise reach here and wrongly resolve to an interface reference. Excluding them lets
+            // NeedsInterface return false so GetTypeText hits its deliberate unmapped-type throw instead
+            // of silently emitting a reference to an interface that reflects the array's CLR members.
+            return type.IsClass && !type.IsGenericParameter && !type.IsArray && type != typeof(string);
         }
 
         // Structs intended to be mirrored to TypeScript as interfaces. This is an explicit allow-list,


### PR DESCRIPTION
## Summary

- `CodeGenExtensions.IsClassThatNeedsInterface` (`Game.Api/CodeGen/Extensions.cs`) matched arrays (`type.IsClass` is `true` for arrays and they aren't `string`), because arrays aren't generic and so are rejected by `IsEnumerable()` and fall through to this check.
- That meant `NeedsInterface()` returned `true` for an array-typed DTO member, and `GetTypeText` would resolve it via `GetInterfaceName` — emitting a garbage interface (e.g. `IInt32[]`) that walks the array's own CLR properties (`Length`, `SyncRoot`, …) instead of reaching the deliberate "no TypeScript mapping" throw every other unmapped type gets.
- Fix: exclude `type.IsArray` in `IsClassThatNeedsInterface`, so an array now correctly falls through to `GetTypeText`'s existing throw, surfacing at generation time instead of silently emitting a broken interface.

No current DTO uses an array (all use `List<>`/`IEnumerable<>`), so this is latent hardening, not a live-bug fix — the issue calls out `string[]` as the natural place a new DTO could reach for one.

## How this addresses the issue

Closes #2338. Went with the "make arrays hit the `GetTypeText` throw" option from the issue's suggested fix rather than adding full array codegen support — the latter would require threading `NullabilityInfo.ElementType` through `CodeGenTypeDescriptor.GenericArgumentDescriptors`, `GetImportTexts`, and `GetInterfaceName`'s generic-parameter handling, which is a materially larger change for a shape nothing in the codebase currently uses. If a real need for array-typed DTOs comes up, `List<>`/`IEnumerable<>` already work and are the house convention.

## Test plan

- [x] Added `NeedsInterface_IntArray_ReturnsFalse` / `NeedsInterface_ClassArray_ReturnsFalse` in `CodeGenExtensionsTests.cs`.
- [x] Added `ModelWithArray` fixture and `GetTypeText_UnmappedArray_Throws` in `CodeGenTypeFormatterTests.cs`, pinning that an array property now throws `InvalidOperationException` instead of emitting a broken interface reference.
- [x] `dotnet build Game.sln` — succeeds, 0 warnings/errors.
- [x] `dotnet test Game.Api.Tests` — 864 passed, 0 failed.

Closes #2338

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSUFPmdoXsdZSy5isVbtcw)_