### PR TITLE
Give write-behind envelopes a unique identity

### DIFF
--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -959,9 +959,10 @@ namespace Game.Application.Tests.DataAccess
                 AutoChallengeBoss: false,
                 LastCreditedBattleSeed: null);
 
+            var message = Serialize(validEvent);
             var realPubSub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
             var queue = realPubSub.GetQueue(Constants.PUBSUB_PLAYER_QUEUE);
-            await queue.AddToQueueAsync(Serialize(validEvent));
+            await queue.AddToQueueAsync(message);
 
             var logger = new CapturingLogger<DataProviderSynchronizer>();
             var pubsub = new SubscribeSuppressingPubSubService(realPubSub);
@@ -976,7 +977,7 @@ namespace Game.Application.Tests.DataAccess
             Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
 
             // The event was never drained: it is still waiting on the queue and the player is unchanged.
-            Assert.Equal(Serialize(validEvent), await queue.GetNextAsync());
+            Assert.Equal(message, await queue.GetNextAsync());
 
             using var verifyScope = CreateScope();
             var verifyContext = verifyScope.ServiceProvider.GetRequiredService<GameContext>();
@@ -1267,6 +1268,59 @@ namespace Game.Application.Tests.DataAccess
             Assert.Contains(logger.Entries, e => e.Level == LogLevel.Information && e.Message.Contains("stranded"));
             Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
             Assert.Empty(await queue.PeekProcessingAsync(10));
+        }
+
+        [Fact]
+        public async Task ProcessQueue_DuplicatePayloadReplacesProcessingHeadWithinGracePeriod_RestartsClockInsteadOfReclaiming()
+        {
+            using var scope = CreateScope();
+            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
+            var logger = new CapturingLogger<DataProviderSynchronizer>();
+            var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+            var synchronizer = new DataProviderSynchronizer(
+                scope.ServiceProvider, pubsub, logger, TestRetryPolicy,
+                reclaimGracePeriod: TimeSpan.FromSeconds(30), timeProvider: timeProvider);
+
+            // Two independently-raised envelopes with byte-identical Type+Payload (e.g. a duplicated
+            // SkillUnlockedEvent) must not alias one another in the stranded-head clock (#2341): DomainEventEnvelope
+            // now carries its own Id, so two envelopes built from the same event content still serialize to
+            // distinct raw strings. Before that fix, "itemB" below would be indistinguishable from "itemA" by
+            // value, and the clock would (wrongly) treat itemB as itemA still dwelling at the head.
+            var itemA = new DomainEventEnvelope { Type = nameof(PlayerCoreUpdatedEvent), Payload = "not valid json" }.Serialize();
+            var itemB = new DomainEventEnvelope { Type = nameof(PlayerCoreUpdatedEvent), Payload = "not valid json" }.Serialize();
+            Assert.NotEqual(itemA, itemB);
+
+            var queue = new InMemoryPubSubQueue();
+            await queue.AddToQueueAsync(itemA);
+            Assert.NotNull(await queue.ReserveNextAsync());
+
+            // First pass only starts the clock against itemA.
+            await synchronizer.ProcessQueue(queue);
+            Assert.DoesNotContain(logger.Entries, e => e.Message.Contains("stranded"));
+
+            // itemA is acknowledged and a duplicate-content item takes its place at the head, all before the
+            // original clock's grace period would have elapsed.
+            await queue.AcknowledgeAsync(itemA);
+            await queue.AddToQueueAsync(itemB);
+            Assert.NotNull(await queue.ReserveNextAsync());
+
+            timeProvider.Advance(TimeSpan.FromSeconds(31));
+
+            // A clock keyed on raw value alone (with no per-envelope identity) would treat itemB as the same
+            // item still dwelling at the head and reclaim here — tracking must restart against it instead.
+            await synchronizer.ProcessQueue(queue);
+            Assert.DoesNotContain(logger.Entries, e => e.Message.Contains("stranded"));
+            Assert.Single(await queue.PeekProcessingAsync(10));
+
+            // Only once itemB has itself dwelled at the head past the grace period does it reclaim (and, once
+            // reclaimed, dead-letter on its own malformed inner payload rather than being lost).
+            timeProvider.Advance(TimeSpan.FromSeconds(31));
+            await synchronizer.ProcessQueue(queue);
+
+            Assert.Contains(logger.Entries, e => e.Level == LogLevel.Information && e.Message.Contains("stranded"));
+            Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+            Assert.Empty(await queue.PeekProcessingAsync(10));
+            Assert.Equal([itemB], await DrainDeadLetterQueue(pubsub));
         }
 
         [Fact]

--- a/Game.Application.Tests/DataAccess/DomainEventEnvelopeTests.cs
+++ b/Game.Application.Tests/DataAccess/DomainEventEnvelopeTests.cs
@@ -1,0 +1,40 @@
+using Game.Core;
+using Game.DataAccess;
+using Xunit;
+
+namespace Game.Application.Tests.DataAccess
+{
+    /// <summary>
+    /// Unit tests for <see cref="DomainEventEnvelope"/>'s per-instance <c>Id</c>. It is pure in-process logic
+    /// with no out-of-process dependency, so it is covered here classically rather than through an integration test.
+    /// </summary>
+    public class DomainEventEnvelopeTests
+    {
+        [Fact]
+        public void TwoEnvelopesWithIdenticalTypeAndPayload_SerializeToDistinctRawStrings()
+        {
+            // Two independently-raised events can carry byte-identical Type+Payload (e.g. a duplicated
+            // SkillUnlockedEvent, or two ItemFavoriteChangedEvents toggling to the same value). The write-behind
+            // queue's stranded-head tracking and LREM acknowledge/dead-letter removal key off the raw serialized
+            // string, so without a per-envelope identity, equal payloads would alias one another there (#2341).
+            var first = new DomainEventEnvelope { Type = "SkillUnlockedEvent", Payload = "{\"playerId\":1,\"skillId\":2}" };
+            var second = new DomainEventEnvelope { Type = "SkillUnlockedEvent", Payload = "{\"playerId\":1,\"skillId\":2}" };
+
+            Assert.NotEqual(first.Id, second.Id);
+            Assert.NotEqual(first.Serialize(), second.Serialize());
+        }
+
+        [Fact]
+        public void Deserialize_MissingId_DefaultsRatherThanFailing()
+        {
+            // An envelope enqueued by a pre-upgrade instance mid-rolling-deploy carries no "id" field. Id is
+            // therefore not required, so it must still deserialize cleanly on a newer instance rather than throw.
+            var legacyMessage = "{\"type\":\"SkillUnlockedEvent\",\"payload\":\"{}\"}";
+
+            var envelope = legacyMessage.Deserialize<DomainEventEnvelope>();
+
+            Assert.NotNull(envelope);
+            Assert.Equal("SkillUnlockedEvent", envelope.Type);
+        }
+    }
+}

--- a/Game.DataAccess/DomainEventEnvelope.cs
+++ b/Game.DataAccess/DomainEventEnvelope.cs
@@ -1,7 +1,17 @@
 namespace Game.DataAccess
 {
+    /// <summary>
+    /// A queued player-update event. <see cref="Id"/> gives every envelope a unique identity even when two
+    /// independently-raised events serialize to byte-identical Type+Payload (e.g. two duplicate
+    /// <c>SkillUnlockedEvent</c>s, or two <c>ItemFavoriteChangedEvent</c>s toggling to the same value) — the
+    /// write-behind queue's stranded-head tracking and LREM acknowledge/dead-letter removal all key off the raw
+    /// serialized string, and equal payloads would otherwise alias one another there (#2341). Defaulted rather
+    /// than required so an envelope enqueued by a pre-upgrade instance mid-rolling-deploy (carrying no "id")
+    /// still deserializes cleanly on a newer instance.
+    /// </summary>
     internal class DomainEventEnvelope
     {
+        public Guid Id { get; init; } = Guid.NewGuid();
         public required string Type { get; set; }
         public required string Payload { get; set; }
     }


### PR DESCRIPTION
## Summary

`DomainEventEnvelope` (`Game.DataAccess/DomainEventEnvelope.cs`) was `{Type, Payload}` only, so two independently-raised events that happen to serialize to byte-identical content (e.g. a duplicated `SkillUnlockedEvent`, or two `ItemFavoriteChangedEvent`s toggling to the same value) produced byte-identical queue items. `DataProviderSynchronizer`'s stranded-processing-head tracking and `RedisQueue.AcknowledgeAsync`'s `LREM value 1` both key off that raw serialized string, so equal payloads could alias one another there:

- The stranded-head clock (`TryReclaimStrandedProcessingAsync`) compares the processing list's head by value — if item A is acknowledged and a *different* item with an equal payload rotates to the head, the dwell clock wrongly fails to reset, risking a premature reclaim that races another instance's genuinely in-flight work.
- `LREM` removes by value, so with equal payloads reserved on two instances, each could acknowledge the other's copy.

Both were harmless today only because every write-behind handler is idempotent, but the grace-period guarantee the head-tracking comment promises didn't actually hold for equal payloads.

## Fix

`DomainEventEnvelope` now carries a `Guid Id` generated per instance, so two envelopes with identical `Type`+`Payload` still serialize to distinct raw strings — giving every queued item a genuine identity for both the stranded-head clock and per-item Redis list operations to key off. The property defaults (`Guid.NewGuid()`) rather than being `required`, so an envelope enqueued by a pre-upgrade instance mid-rolling-deploy (carrying no `"id"`) still deserializes cleanly on a newer instance.

## Test plan

- [x] New `DomainEventEnvelopeTests`: two envelopes with identical Type+Payload serialize to distinct strings and carry distinct Ids; a legacy envelope missing `"id"` still deserializes.
- [x] New `DataProviderSynchronizerTests.ProcessQueue_DuplicatePayloadReplacesProcessingHeadWithinGracePeriod_RestartsClockInsteadOfReclaiming`: reproduces the exact regression scenario — a duplicate-content envelope taking the processing-list head must restart the stranded-head clock rather than being aliased with the item it replaced.
- [x] Fixed an existing test (`StartAsync_CancellationAlreadyRequested_SkipsReclaimAndStartupDrain`) that incidentally relied on two independently-serialized envelopes of the same event being byte-identical; it now serializes once and reuses the string.
- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] `dotnet test` (full solution) — 3,464 tests passed (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests).

Closes #2341

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017LayWk8rjQ9KEuCX8XoD8Q)_