### PR TITLE
Hygiene sweep: persist battle-end rejection clears, drop dead queue overloads, guard enemy-name fallback (#2345)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -365,7 +365,9 @@ jobs:
 
         wait_for_api
         # Runs inside the Postgres container so it needs no client tooling on the runner; idempotent.
-        docker compose exec -T postgres psql -U game -d game -p 5544 -v ON_ERROR_STOP=1 -f - < e2e-admin-provision.sql
+        # Mirrors docker-compose.yml's own POSTGRES_USER/POSTGRES_DB/POSTGRES_PORT overrides so a customized
+        # stack doesn't fail this step looking like a DB outage.
+        docker compose exec -T postgres psql -U "${POSTGRES_USER:-game}" -d "${POSTGRES_DB:-game}" -p "${POSTGRES_PORT:-5544}" -v ON_ERROR_STOP=1 -f - < e2e-admin-provision.sql
 
     - name: Run Playwright e2e tests
       working-directory: UI

--- a/Game.Abstractions/Infrastructure/IPubSubQueue.cs
+++ b/Game.Abstractions/Infrastructure/IPubSubQueue.cs
@@ -3,7 +3,6 @@
     public interface IPubSubQueue
     {
         public Task<string?> GetNextAsync(CancellationToken cancellationToken = default);
-        public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Atomically moves the next item from the head of this queue onto a side processing list and returns it
@@ -67,7 +66,6 @@
         public Task<long> RemoveRangeAsync(IReadOnlyList<string> values, CancellationToken cancellationToken = default);
 
         public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default);
-        public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Pushes multiple values onto the queue in a single round-trip (one multi-value LPUSH),

--- a/Game.Api.Tests/Integration/BattleLostSocketTests.cs
+++ b/Game.Api.Tests/Integration/BattleLostSocketTests.cs
@@ -1,5 +1,7 @@
+using Game.Abstractions.DataAccess;
 using Game.Api.Models.Enemies;
 using Game.Api.Services;
+using Game.Core.Battle;
 using Game.Core.Players;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Fixtures;
@@ -27,7 +29,16 @@ namespace Game.Api.Tests.Integration
             await sessionService.SavePlayerStateAsync();
         }
 
-        private async Task<int> SeedWeakPlayerVsStrongEnemyAsync()
+        private async Task<PlayerState> GetPlayerState(int userId)
+        {
+            using var scope = CreateScope();
+            var sessionService = scope.ServiceProvider.GetRequiredService<SessionService>();
+            sessionService.SetAuthenticatedUser(userId);
+            await sessionService.LoadPlayerState();
+            return sessionService.PlayerState;
+        }
+
+        private async Task<(int userId, int playerId)> SeedWeakPlayerVsStrongEnemyAsync()
         {
             using var scope = CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<GameContext>();
@@ -73,7 +84,7 @@ namespace Game.Api.Tests.Integration
                 new { Username = "weakplayer", Password = "weakpass" });
             Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
 
-            return user.Id;
+            return (user.Id, player.Id);
         }
 
         private async Task<int> SeedNormalPlayerAsync()
@@ -119,7 +130,7 @@ namespace Game.Api.Tests.Integration
         [Fact]
         public async Task BattleLost_ValidLoss_Succeeds()
         {
-            var userId = await SeedWeakPlayerVsStrongEnemyAsync();
+            var (userId, _) = await SeedWeakPlayerVsStrongEnemyAsync();
 
             var wsClient = Factory.Server.CreateWebSocketClient();
 
@@ -165,7 +176,7 @@ namespace Game.Api.Tests.Integration
         [Fact]
         public async Task BattleLost_ClaimedBeforeBattleCouldFinish_ReturnsError()
         {
-            var userId = await SeedWeakPlayerVsStrongEnemyAsync();
+            var (userId, _) = await SeedWeakPlayerVsStrongEnemyAsync();
 
             await using var socketClient = new TestSocketClient();
             var wsClient = Factory.Server.CreateWebSocketClient();
@@ -181,6 +192,95 @@ namespace Game.Api.Tests.Integration
             var response = await socketClient.SendCommandAsync<BattleLostResponse>("BattleLost", new { });
 
             Assert.NotNull(response.Error);
+        }
+
+        [Fact]
+        public async Task BattleLost_BattleAlreadyCredited_PersistsClearedBattleState()
+        {
+            var (userId, playerId) = await SeedWeakPlayerVsStrongEnemyAsync();
+
+            var wsClient = Factory.Server.CreateWebSocketClient();
+
+            await using (var socketClient1 = new TestSocketClient())
+            {
+                await socketClient1.ConnectAsync(wsClient, userId);
+
+                var newEnemyResponse = await socketClient1.SendCommandAsync<NewEnemyModel>(
+                    "NewEnemy", new { NewZoneId = (int?)null });
+                Assert.Null(newEnemyResponse.Error);
+
+                await socketClient1.CloseAsync();
+            }
+
+            // Capture this battle's identity before crediting it, then backdate so it resolves as a genuine
+            // loss — the fields are restored onto the session further down to reproduce the reconnect gap
+            // (#1874/#1993) this test targets.
+            int activeEnemyId = 0, activeEnemyLevel = 0, battleZoneId = 0;
+            List<int> activeEnemySkillIds = null!;
+            uint battleSeed = 0;
+            BattleSnapshot snapshot = null!;
+            bool isBossBattle = false;
+
+            await SetPlayerState(userId, state =>
+            {
+                activeEnemyId = state.ActiveEnemyId!.Value;
+                activeEnemyLevel = state.ActiveEnemyLevel!.Value;
+                activeEnemySkillIds = state.ActiveEnemySkillIds!;
+                battleSeed = state.BattleSeed!.Value;
+                snapshot = state.Snapshot!;
+                battleZoneId = state.BattleZoneId ?? 0;
+                isBossBattle = state.IsBossBattle;
+
+                state.SetActiveBattle(
+                    activeEnemyId, activeEnemyLevel, activeEnemySkillIds, battleSeed,
+                    startTime: DateTime.UtcNow.AddMinutes(-30),
+                    snapshot, zoneId: battleZoneId, isBossBattle: isBossBattle);
+            });
+
+            await using (var socketClient2 = new TestSocketClient())
+            {
+                await socketClient2.ConnectAsync(wsClient, userId);
+
+                var creditResponse = await socketClient2.SendCommandAsync<BattleLostResponse>("BattleLost", new { });
+                Assert.Null(creditResponse.Error);
+
+                await socketClient2.CloseAsync();
+            }
+
+            // The player-cache write behind the credit is fire-and-forget (docs/backend-persistence.md), so
+            // poll until it lands before restoring the session to the now-credited battle below.
+            using (var scope = CreateScope())
+            {
+                var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+                await PollingHelper.PollUntilAsync(
+                    () => playerRepo.GetPlayer(playerId),
+                    p => p?.LastCreditedBattleSeed == battleSeed);
+            }
+
+            // Reproduce the reconnect gap (#1874/#1993): the durable credit landed, but the session's own
+            // PlayerState still shows this exact (now-credited) battle as active.
+            await SetPlayerState(userId, state =>
+            {
+                state.SetActiveBattle(
+                    activeEnemyId, activeEnemyLevel, activeEnemySkillIds, battleSeed,
+                    startTime: DateTime.UtcNow.AddMinutes(-30),
+                    snapshot, zoneId: battleZoneId, isBossBattle: isBossBattle);
+            });
+
+            await using (var socketClient3 = new TestSocketClient())
+            {
+                await socketClient3.ConnectAsync(wsClient, userId);
+
+                var rejectedResponse = await socketClient3.SendCommandAsync<BattleLostResponse>("BattleLost", new { });
+                Assert.NotNull(rejectedResponse.Error);
+
+                await socketClient3.CloseAsync();
+            }
+
+            // The rejection clears the stale battle in memory (BattleAlreadyCredited) — pin that the clear is
+            // actually persisted rather than lost the moment socketClient3 disconnects (#2345).
+            var persistedState = await GetPlayerState(userId);
+            Assert.False(persistedState.HasActiveBattle);
         }
     }
 }

--- a/Game.Api.Tests/Integration/DefeatEnemySocketTests.cs
+++ b/Game.Api.Tests/Integration/DefeatEnemySocketTests.cs
@@ -1,5 +1,7 @@
+using Game.Abstractions.DataAccess;
 using Game.Api.Models.Enemies;
 using Game.Api.Services;
+using Game.Core.Battle;
 using Game.Core.Players;
 using Game.Infrastructure.Database;
 using Game.TestInfrastructure.Fixtures;
@@ -50,6 +52,15 @@ namespace Game.Api.Tests.Integration
             await sessionService.LoadPlayerState();
             modifyState(sessionService.PlayerState);
             await sessionService.SavePlayerStateAsync();
+        }
+
+        private async Task<PlayerState> GetPlayerState(int userId)
+        {
+            using var scope = CreateScope();
+            var sessionService = scope.ServiceProvider.GetRequiredService<SessionService>();
+            sessionService.SetAuthenticatedUser(userId);
+            await sessionService.LoadPlayerState();
+            return sessionService.PlayerState;
         }
 
         [Fact]
@@ -194,6 +205,95 @@ namespace Game.Api.Tests.Integration
                 "DefeatEnemy", new { });
 
             Assert.NotNull(response.Error);
+        }
+
+        [Fact]
+        public async Task DefeatEnemy_BattleAlreadyCredited_PersistsClearedBattleState()
+        {
+            var (userId, playerId) = await SeedAndLoginAsync();
+
+            var wsClient = Factory.Server.CreateWebSocketClient();
+
+            await using (var socketClient1 = new TestSocketClient())
+            {
+                await socketClient1.ConnectAsync(wsClient, userId);
+
+                var newEnemyResponse = await socketClient1.SendCommandAsync<NewEnemyModel>(
+                    "NewEnemy", new { NewZoneId = (int?)null });
+                Assert.Null(newEnemyResponse.Error);
+
+                await socketClient1.CloseAsync();
+            }
+
+            // Capture this battle's identity before crediting it, then backdate so it resolves as a genuine
+            // win — the fields are restored onto the session further down to reproduce the reconnect gap
+            // (#1874/#1993) this test targets.
+            int activeEnemyId = 0, activeEnemyLevel = 0, battleZoneId = 0;
+            List<int> activeEnemySkillIds = null!;
+            uint battleSeed = 0;
+            BattleSnapshot snapshot = null!;
+            bool isBossBattle = false;
+
+            await SetPlayerState(userId, playerId, state =>
+            {
+                activeEnemyId = state.ActiveEnemyId!.Value;
+                activeEnemyLevel = state.ActiveEnemyLevel!.Value;
+                activeEnemySkillIds = state.ActiveEnemySkillIds!;
+                battleSeed = state.BattleSeed!.Value;
+                snapshot = state.Snapshot!;
+                battleZoneId = state.BattleZoneId ?? 0;
+                isBossBattle = state.IsBossBattle;
+
+                state.SetActiveBattle(
+                    activeEnemyId, activeEnemyLevel, activeEnemySkillIds, battleSeed,
+                    startTime: DateTime.UtcNow.AddMinutes(-30),
+                    snapshot, zoneId: battleZoneId, isBossBattle: isBossBattle);
+            });
+
+            await using (var socketClient2 = new TestSocketClient())
+            {
+                await socketClient2.ConnectAsync(wsClient, userId);
+
+                var creditResponse = await socketClient2.SendCommandAsync<DefeatEnemyResponse>("DefeatEnemy", new { });
+                Assert.Null(creditResponse.Error);
+
+                await socketClient2.CloseAsync();
+            }
+
+            // The player-cache write behind the credit is fire-and-forget (docs/backend-persistence.md), so
+            // poll until it lands before restoring the session to the now-credited battle below.
+            using (var scope = CreateScope())
+            {
+                var playerRepo = scope.ServiceProvider.GetRequiredService<IPlayerRepository>();
+                await PollingHelper.PollUntilAsync(
+                    () => playerRepo.GetPlayer(playerId),
+                    p => p?.LastCreditedBattleSeed == battleSeed);
+            }
+
+            // Reproduce the reconnect gap (#1874/#1993): the durable credit landed, but the session's own
+            // PlayerState still shows this exact (now-credited) battle as active.
+            await SetPlayerState(userId, playerId, state =>
+            {
+                state.SetActiveBattle(
+                    activeEnemyId, activeEnemyLevel, activeEnemySkillIds, battleSeed,
+                    startTime: DateTime.UtcNow.AddMinutes(-30),
+                    snapshot, zoneId: battleZoneId, isBossBattle: isBossBattle);
+            });
+
+            await using (var socketClient3 = new TestSocketClient())
+            {
+                await socketClient3.ConnectAsync(wsClient, userId);
+
+                var rejectedResponse = await socketClient3.SendCommandAsync<DefeatEnemyResponse>("DefeatEnemy", new { });
+                Assert.NotNull(rejectedResponse.Error);
+
+                await socketClient3.CloseAsync();
+            }
+
+            // The rejection clears the stale battle in memory (BattleAlreadyCredited) — pin that the clear is
+            // actually persisted rather than lost the moment socketClient3 disconnects (#2345).
+            var persistedState = await GetPlayerState(userId);
+            Assert.False(persistedState.HasActiveBattle);
         }
     }
 }

--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -430,7 +430,6 @@ namespace Game.Api.Tests.Unit
                 return Task.FromResult<string?>(null);
             }
 
-            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<string?> ReserveNextAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AcknowledgeAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> ReclaimProcessingAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -439,7 +438,6 @@ namespace Game.Api.Tests.Unit
             public Task<IReadOnlyList<string>> PeekProcessingAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> RemoveRangeAsync(IReadOnlyList<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }
@@ -456,7 +454,6 @@ namespace Game.Api.Tests.Unit
                 throw toThrow;
             }
 
-            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<string?> ReserveNextAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AcknowledgeAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> ReclaimProcessingAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -465,7 +462,6 @@ namespace Game.Api.Tests.Unit
             public Task<IReadOnlyList<string>> PeekProcessingAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> RemoveRangeAsync(IReadOnlyList<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }
@@ -506,7 +502,6 @@ namespace Game.Api.Tests.Unit
             }
 
             public Task<string?> GetNextAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<string?> ReserveNextAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AcknowledgeAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> ReclaimProcessingAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -515,7 +510,6 @@ namespace Game.Api.Tests.Unit
             public Task<IReadOnlyList<string>> PeekAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<IReadOnlyList<string>> PeekProcessingAsync(long count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> RemoveRangeAsync(IReadOnlyList<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }

--- a/Game.Api/Sockets/Commands/BattleLost.cs
+++ b/Game.Api/Sockets/Commands/BattleLost.cs
@@ -56,6 +56,11 @@ namespace Game.Api.Sockets.Commands
             }
             else
             {
+                // A rejected already-credited claim clears the stale battle off PlayerState in memory (see
+                // BattleAlreadyCredited) — save unconditionally, like NewEnemy, so that clear is durable
+                // rather than lost the moment this connection closes.
+                await context.Session.SavePlayerStateAsync(cancellationToken);
+
                 return ErrorWithData("Battle was not a loss.", new BattleLostResponse
                 {
                     Cooldown = 0,

--- a/Game.Api/Sockets/Commands/DefeatEnemy.cs
+++ b/Game.Api/Sockets/Commands/DefeatEnemy.cs
@@ -72,7 +72,12 @@ namespace Game.Api.Sockets.Commands
             }
             else
             {
-                // BattleService logs the specific rejection reason (and its diagnostics) at the source.
+                // BattleService logs the specific rejection reason (and its diagnostics) at the source. A
+                // rejected already-credited claim clears the stale battle off PlayerState in memory (see
+                // BattleAlreadyCredited) — save unconditionally, like NewEnemy, so that clear is durable
+                // rather than lost the moment this connection closes.
+                await context.Session.SavePlayerStateAsync(cancellationToken);
+
                 var now = DateTime.UtcNow;
                 return ErrorWithData("Enemy could not be defeated.", new DefeatEnemyResponse
                 {

--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -2088,8 +2088,6 @@ namespace Game.Application.Tests.DataAccess
             }
 
             // Not exercised by DataProviderSynchronizer.ProcessQueue.
-            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> RemoveRangeAsync(IReadOnlyList<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }
 
@@ -2185,8 +2183,6 @@ namespace Game.Application.Tests.DataAccess
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> RemoveRangeAsync(IReadOnlyList<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }
 
@@ -2283,8 +2279,6 @@ namespace Game.Application.Tests.DataAccess
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> RemoveRangeAsync(IReadOnlyList<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }
 
@@ -2450,8 +2444,6 @@ namespace Game.Application.Tests.DataAccess
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> RemoveRangeAsync(IReadOnlyList<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }
 
@@ -2482,8 +2474,6 @@ namespace Game.Application.Tests.DataAccess
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => inner.RemoveAsync(value, cancellationToken);
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => inner.AddToQueueAsync(value, cancellationToken);
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => inner.AddRangeToQueueAsync(values, cancellationToken);
-            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> RemoveRangeAsync(IReadOnlyList<string> values, CancellationToken cancellationToken = default) => inner.RemoveRangeAsync(values, cancellationToken);
         }
 
@@ -2576,8 +2566,6 @@ namespace Game.Application.Tests.DataAccess
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> RemoveRangeAsync(IReadOnlyList<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }
 
@@ -2608,8 +2596,6 @@ namespace Game.Application.Tests.DataAccess
             public Task<bool> RemoveAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-            public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> RemoveRangeAsync(IReadOnlyList<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         }
 

--- a/Game.Application.Tests/DataAccess/RedisPubSubServiceIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisPubSubServiceIntegrationTests.cs
@@ -1,4 +1,5 @@
 using Game.Abstractions.Infrastructure;
+using Game.Core;
 using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
 using Microsoft.Extensions.DependencyInjection;
@@ -40,10 +41,10 @@ namespace Game.Application.Tests.DataAccess
             await pubsub.PublishBatch(channel, queueName, payloads);
 
             var queue = pubsub.GetQueue(queueName);
-            Assert.Equal(payloads[0], await queue.GetNextAsync<SamplePayload>());
-            Assert.Equal(payloads[1], await queue.GetNextAsync<SamplePayload>());
-            Assert.Equal(payloads[2], await queue.GetNextAsync<SamplePayload>());
-            Assert.Null(await queue.GetNextAsync<SamplePayload>());
+            Assert.Equal(payloads[0], (await queue.GetNextAsync()).Deserialize<SamplePayload>());
+            Assert.Equal(payloads[1], (await queue.GetNextAsync()).Deserialize<SamplePayload>());
+            Assert.Equal(payloads[2], (await queue.GetNextAsync()).Deserialize<SamplePayload>());
+            Assert.Null(await queue.GetNextAsync());
         }
 
         [Fact]
@@ -57,7 +58,7 @@ namespace Game.Application.Tests.DataAccess
             // An empty batch must not touch the queue (an empty RPUSH would otherwise be an error).
             await pubsub.PublishBatch(channel, queueName, Array.Empty<SamplePayload>());
 
-            Assert.Null(await pubsub.GetQueue(queueName).GetNextAsync<SamplePayload>());
+            Assert.Null(await pubsub.GetQueue(queueName).GetNextAsync());
         }
 
         private sealed record SamplePayload(int Id, string Name);

--- a/Game.Application.Tests/DataAccess/RedisQueueIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/RedisQueueIntegrationTests.cs
@@ -8,32 +8,15 @@ namespace Game.Application.Tests.DataAccess
 {
     /// <summary>
     /// Covers the Redis-backed <see cref="IPubSubQueue"/> (RedisQueue) overloads that the write-behind path leans on
-    /// but that the <see cref="Game.DataAccess.DataProviderSynchronizer"/> tests don't reach: the typed
-    /// serialize/deserialize round-trips and popping past the end of an empty queue. RedisQueue is a thin adapter over
-    /// an out-of-process dependency, so per the testing guidelines it is exercised through an integration test rather
-    /// than mocked. Each test uses a unique queue name so it is independent of any residual queue state.
+    /// but that the <see cref="Game.DataAccess.DataProviderSynchronizer"/> tests don't reach: popping past the end
+    /// of an empty queue. RedisQueue is a thin adapter over an out-of-process dependency, so per the testing
+    /// guidelines it is exercised through an integration test rather than mocked. Each test uses a unique queue name
+    /// so it is independent of any residual queue state.
     /// </summary>
     [Collection("Integration")]
     public class RedisQueueIntegrationTests : ApplicationIntegrationTestBase
     {
         public RedisQueueIntegrationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper) : base(containers, testOutputHelper) { }
-
-        [Fact]
-        public async Task TypedRoundTripAsync_SerializesAndDeserializes_ThenReturnsNullWhenDrained()
-        {
-            using var scope = CreateScope();
-            var pubsub = scope.ServiceProvider.GetRequiredService<IPubSubService>();
-            var queue = pubsub.GetQueue($"redis-queue-test-{Guid.NewGuid()}");
-
-            var payload = new SamplePayload(7, "hello");
-            await queue.AddToQueueAsync(payload);
-
-            var roundTripped = await queue.GetNextAsync<SamplePayload>();
-            Assert.Equal(payload, roundTripped);
-
-            // Popping past the end of the queue takes the "no value" branch and yields the default.
-            Assert.Null(await queue.GetNextAsync<SamplePayload>());
-        }
 
         [Fact]
         public async Task PreservesFifoOrder()
@@ -325,7 +308,5 @@ namespace Game.Application.Tests.DataAccess
             Assert.Equal(1, removed);
             Assert.Empty(await queue.PeekAsync(10));
         }
-
-        private sealed record SamplePayload(int Id, string Name);
     }
 }

--- a/Game.Application/Services/OfflineProgressService.cs
+++ b/Game.Application/Services/OfflineProgressService.cs
@@ -427,7 +427,7 @@ namespace Game.Application.Services
         public required IReadOnlyList<ProficiencyXpResult> ProficiencyGains { get; init; }
 
         /// <summary>The proficiency nodes opened over the window (a maxed tier's next tier or a newly-satisfied
-        /// gateway), each with the seed skill it granted (if any).</summary>
+        /// gateway) — notification-only, opening grants no skill itself (see <see cref="ProficiencyOpened"/>).</summary>
         public required IReadOnlyList<ProficiencyOpened> OpenedProficiencies { get; init; }
 
         /// <summary>

--- a/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
+++ b/Game.Infrastructure/PubSub/Redis/RedisQueue.cs
@@ -1,5 +1,4 @@
 ﻿using Game.Abstractions.Infrastructure;
-using Game.Core;
 using Game.Infrastructure.Redis;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
@@ -45,12 +44,6 @@ namespace Game.Infrastructure.PubSub.Redis
             }
 
             return value;
-        }
-
-        public async Task<T?> GetNextAsync<T>(CancellationToken cancellationToken = default)
-        {
-            var val = await GetNextAsync(cancellationToken);
-            return val.Deserialize<T>();
         }
 
         public async Task<string?> ReserveNextAsync(CancellationToken cancellationToken = default)
@@ -171,11 +164,6 @@ namespace Game.Infrastructure.PubSub.Redis
         {
             _logger.LogTrace("Added value to RedisQueue: {QueueName}, value: {Value}", QueueName, value);
             return ObserveWrite(_redis.ListRightPushAsync(QueueName, value), cancellationToken);
-        }
-
-        public Task AddToQueueAsync<T>(T value, CancellationToken cancellationToken = default)
-        {
-            return AddToQueueAsync(value.Serialize(), cancellationToken);
         }
 
         // Unlike every other write here, this one is not abandoned on a mid-flight cancellation once dispatched:

--- a/UI/src/lib/engine/battle/battle-engine.ts
+++ b/UI/src/lib/engine/battle/battle-engine.ts
@@ -200,6 +200,13 @@ export class BattleEngine {
 
 	public reset = (enemyInstance: IEnemyInstance) => {
 		const enemyData = staticData.enemies ?? [];
+		const staticEnemy = enemyData[enemyInstance.id];
+		if (!staticEnemy) {
+			// A freshly-authored enemy against a stale mid-session reference cache: degrade gracefully
+			// (mirroring InventoryManager.initialize's missing-item skip) rather than fielding a battler
+			// with an undefined name.
+			logMessage(ELogType.Debug, `Spawned enemy with unknown id ${enemyInstance.id}; reference cache may be stale.`);
+		}
 		// Re-arming the battle cancels any in-flight post-victory cooldown so its render hook is removed
 		// and the awaiting caller is released rather than stranded mid-countdown.
 		this.finishLoading?.();
@@ -209,7 +216,7 @@ export class BattleEngine {
 		this.#rng = new Mulberry32(enemyInstance.seed);
 		this.flushEffectDamage();
 		this.resetPlayer();
-		this.enemy.reset({ ...enemyInstance, ...enemyData[enemyInstance.id] });
+		this.enemy.reset({ ...enemyInstance, ...staticEnemy, name: staticEnemy?.name ?? 'Unknown enemy' });
 		// A non-null elapsedOffsetMs (#1595/#1596) means the server handed back a battle already in
 		// progress rather than a fresh spawn — fast-forward to its real elapsed time before going live.
 		if (enemyInstance.elapsedOffsetMs != null) {

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -289,6 +289,26 @@ describe('BattleEngine', () => {
 			expect(engine.stage).toBe(BattleStage.Active);
 		});
 
+		it('falls back to a placeholder name and logs a debug line for an unknown enemy id (#2345)', () => {
+			engine.start();
+
+			// A freshly-authored enemy the client's static reference cache hasn't caught up to yet — no
+			// mockEnemies entry for id 999, reproducing a stale mid-session reference cache.
+			const enemyInstance = {
+				id: 999,
+				level: 1,
+				seed: 0,
+				enemyRating: 100,
+				selectedSkills: [0],
+				attributes: [],
+				isBossBattle: false
+			};
+			enemyLoadedCallbacks[0](enemyInstance);
+
+			expect(engine.enemy.name).toBe('Unknown enemy');
+			expect(vi.mocked(logMessage)).toHaveBeenCalledWith(ELogType.Debug, expect.stringContaining('unknown id 999'));
+		});
+
 		it('transitions to Victorious when enemy dies', () => {
 			engine.start();
 


### PR DESCRIPTION
## Summary

Five of #2345's six independent nits, addressed in one PR since none warrants its own issue (matching #2245's precedent):

1. **Battle-end idempotency rejection now persists the cleared battle.** `TryValidateBattleEndClaim`'s `BattleAlreadyCredited` backstop calls `state.ClearBattle()` on a rejected already-credited claim, but `DefeatEnemy.cs`/`BattleLost.cs` only called `SavePlayerStateAsync` on the success branch — so the cache kept showing the credited battle as active until a later save happened to fire. Both commands now save unconditionally, mirroring `NewEnemy`'s existing unconditional save.
2. **Stale doc comment fixed.** `OfflineProgressSummary.OpenedProficiencies` claimed proficiency-opening grants "the seed skill it granted (if any)" — stale since the seed-skill design moved to skill synthesis (spike #1125); `ProficiencyOpened` is notification-only (`record(int ProficiencyId)`).
3. **Removed dead generic queue overloads.** `IPubSubQueue.GetNextAsync<T>`/`AddToQueueAsync<T>` have no production caller — `SocketManagerService` and every `Publish`/dead-letter path deliberately go through the string overload (a popped-before-deserialized item can't otherwise be recovered). Verified `AddToQueueAsync<T>` is equally dead (not called out in the issue, but the same pattern) and removed it alongside `GetNextAsync<T>`. The two integration tests that used them only as a serialize/deserialize convenience (`RedisPubSubServiceIntegrationTests`'s `PublishBatch<T>` coverage) now deserialize the popped string directly via the existing `string.Deserialize<T>()` extension; the one test whose entire purpose was pinning the now-removed typed round-trip (`RedisQueueIntegrationTests.TypedRoundTripAsync_...`) was removed.
4. **Guarded the unguarded enemy-name fallback.** `BattleEngine.reset` spread `enemyData[enemyInstance.id]` with no missing-record guard — a freshly-authored enemy against a stale mid-session reference cache fielded a battler with an `undefined` name. Now logs once (mirroring `InventoryManager.initialize`'s missing-item skip-and-log) and falls back to `'Unknown enemy'`, matching the house convention `claimVictory`'s name guard and `Battler.fillSkills` already use.
6. **CI fixture coupling fixed.** The e2e admin-fixture step hardcoded `psql -U game -d game -p 5544` while `docker-compose.yml` parametrizes `POSTGRES_USER`/`POSTGRES_DB`/`POSTGRES_PORT` — now uses the same env-var overrides so a customized stack doesn't fail this step looking like a DB outage.

**Item 5 skipped** (`CombatRating.Marginal` recomputing the baseline rating once per authored attribute in `ProgressionGraphChecker`): the issue's own text gates this behind "only if lint runtime ever matters," and there's no evidence the content-lint path is currently a problem, so implementing a baseline-accepting overload now would be premature optimization for an admin-only tool.

## Test plan

- [x] New `DefeatEnemy_BattleAlreadyCredited_PersistsClearedBattleState` / `BattleLost_BattleAlreadyCredited_PersistsClearedBattleState` integration tests reproduce the reconnect gap end-to-end over real sockets: win/lose a battle, restore the session to the now-credited battle, hit the command again, and assert the persisted session (not just the in-memory one) no longer shows it active.
- [x] New `battle-engine.test.ts` case pins the missing-enemy-id fallback: `'Unknown enemy'` name plus the debug log line.
- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] `dotnet test` (full solution) — 3,465 tests passed (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests).
- [x] `npm run lint` — clean (eslint + svelte-check).
- [x] `npm run test:unit:ci` — 3,958 tests passed across 311 files.

Closes #2345

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01CnB5wa2biSaRe11CR39t8u

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnB5wa2biSaRe11CR39t8u)_