### PR TITLE
Fix CoalescedLoader.invalidate() discarding the boot fetch without rescheduling (#2366)

### DIFF
--- a/UI/src/lib/common/coalesced-loader.ts
+++ b/UI/src/lib/common/coalesced-loader.ts
@@ -14,10 +14,15 @@
 export class CoalescedLoader {
 	/** Tail of the current load pipeline; concurrent callers await it instead of re-fetching. */
 	private inFlight: Promise<void> | undefined;
-	/** Whether a fresh (post-force) fetch is already queued behind the in-flight one. */
+	/** Whether a fresh fetch is already queued behind the in-flight one (via a force or {@link invalidate}). */
 	private freshQueued = false;
-	/** Bumped by {@link reset} so a queued fresh fetch from a discarded session never fires. */
+	/** Bumped by {@link reset} and {@link invalidate}; exposed via {@link currentEpoch}/{@link isStale}
+	 *  so `fetchFn` can recognize its own in-flight response as no longer trustworthy. */
 	private epoch = 0;
+	/** Bumped only by {@link reset}. A queued fresh fetch aborts on this moving (a discarded session)
+	 *  but, unlike {@link epoch}, does NOT move on {@link invalidate} — an invalidation must not abort
+	 *  a chain that still owes real data to a `loaded` store or a waiting `force` caller. */
+	private resetEpoch = 0;
 
 	/** `fetchFn` must never reject — the stores' fetchers catch and record errors internally. */
 	constructor(
@@ -40,17 +45,7 @@ export class CoalescedLoader {
 		if (force && !this.freshQueued) {
 			// The in-flight fetch predates this force, so its response may be stale — queue one
 			// fresh fetch behind it; later forces coalesce onto that queued fetch.
-			this.freshQueued = true;
-			const chainEpoch = this.epoch;
-			this.track(
-				this.inFlight.then(() => {
-					if (this.epoch !== chainEpoch) {
-						return;
-					}
-					this.freshQueued = false;
-					return this.fetchFn();
-				})
-			);
+			this.queueFreshFetch(this.inFlight);
 		}
 		await this.inFlight;
 	}
@@ -60,6 +55,7 @@ export class CoalescedLoader {
 		this.inFlight = undefined;
 		this.freshQueued = false;
 		this.epoch += 1;
+		this.resetEpoch += 1;
 	}
 
 	/** Bumps the epoch so an already-in-flight fetch's eventual response is recognized as stale by
@@ -68,13 +64,16 @@ export class CoalescedLoader {
 	 *  response was computed before the push landed, so a later `load()` should not still get to
 	 *  overwrite the push with it.
 	 *
-	 *  Also clears `freshQueued`: a force already queued behind the in-flight fetch captured the
-	 *  pre-bump epoch as its `chainEpoch` (see {@link load}), so this bump makes that queued chain
-	 *  abort without ever clearing the flag itself — leaving it stuck and silently disabling the
-	 *  force-queue path for the rest of the session unless cleared here. */
+	 *  If that now-stale in-flight fetch was the only thing that would ever bring the store to
+	 *  `loaded`, queue a fresh fetch behind it — otherwise a push landing before the store's first
+	 *  load ever completes strands it on push-delta-only data forever. A fetch already queued (from
+	 *  an earlier force, or a previous invalidation) is left alone: it isn't aborted by this bump (see
+	 *  {@link resetEpoch}), so it still delivers real data to whatever is waiting on it. */
 	invalidate(): void {
 		this.epoch += 1;
-		this.freshQueued = false;
+		if (this.inFlight && !this.isLoaded() && !this.freshQueued) {
+			this.queueFreshFetch(this.inFlight);
+		}
 	}
 
 	/** Current epoch, bumped by {@link reset} and {@link invalidate}. `fetchFn` should capture this
@@ -89,6 +88,23 @@ export class CoalescedLoader {
 	 *  discarded session, or a push whose mutation the write would otherwise revert). */
 	isStale(epoch: number): boolean {
 		return epoch !== this.epoch;
+	}
+
+	/** Queues a fresh fetch behind `inFlight`, replacing it as the tracked in-flight promise. Aborts
+	 *  without fetching only if {@link reset} runs before `inFlight` settles — an {@link invalidate}
+	 *  in that window must not cancel a fetch this chain owes to a `loaded` store or a `force` caller. */
+	private queueFreshFetch(inFlight: Promise<void>): void {
+		this.freshQueued = true;
+		const chainResetEpoch = this.resetEpoch;
+		this.track(
+			inFlight.then(() => {
+				if (this.resetEpoch !== chainResetEpoch) {
+					return;
+				}
+				this.freshQueued = false;
+				return this.fetchFn();
+			})
+		);
 	}
 
 	/** Publishes `pipeline` as the awaitable in-flight load, clearing it once it settles unless a

--- a/UI/src/tests/lib/common/coalesced-loader.test.ts
+++ b/UI/src/tests/lib/common/coalesced-loader.test.ts
@@ -225,53 +225,64 @@ describe('CoalescedLoader', () => {
 		expect(h.loader.isStale(h.loader.currentEpoch)).toBe(false);
 	});
 
-	it('invalidate() leaves in-flight/queued fetch state alone, unlike reset()', async () => {
+	it('invalidate() while unloaded queues a fresh fetch, and a concurrent load coalesces onto it', async () => {
 		const h = harness();
 		const initial = h.loader.load();
 
+		// A push lands (e.g. a ChallengeCompleted event) while the store's first-ever load is still in
+		// flight. Discarding that response without queuing a replacement would strand the store on
+		// push-delta-only data forever, since nothing else retries a store that already has some data.
 		h.loader.invalidate();
-
-		// A concurrent non-forced load still coalesces onto the in-flight fetch instead of a reset()'s
-		// abandon-and-restart behavior starting a second one.
 		const second = h.loader.load();
+		// The queued fetch hasn't fired yet (it waits on the stale in-flight one), and `second` coalesces
+		// onto it rather than starting a third, independent fetch.
 		expect(h.fetchFn).toHaveBeenCalledTimes(1);
 
 		h.settle(0);
-		await Promise.all([initial, second]);
-		expect(h.fetchFn).toHaveBeenCalledTimes(1);
+		await initial;
+		await flush();
+		// Settling the stale fetch releases the fresh one invalidate() queued.
+		expect(h.fetchFn).toHaveBeenCalledTimes(2);
+
+		h.settle(1);
+		await second;
 	});
 
-	it('invalidate() racing a queued force does not strand freshQueued, so a later force still queues fresh', async () => {
+	it('invalidate() leaves an in-flight/queued fetch alone once the store is loaded, unlike reset()', async () => {
+		const h = harness();
+		const first = h.loader.load();
+		h.settle(0);
+		await first;
+
+		const forced = h.loader.load(true);
+		// The store already has a full baseline (loaded), so unlike the unloaded case above, invalidate()
+		// must not queue an extra fetch on top of the force already running.
+		h.loader.invalidate();
+		expect(h.fetchFn).toHaveBeenCalledTimes(2);
+
+		h.settle(1);
+		await forced;
+		expect(h.fetchFn).toHaveBeenCalledTimes(2);
+	});
+
+	it('invalidate() racing a queued force does not abort it — the force still gets a genuinely fresh fetch', async () => {
 		const h = harness();
 		const initial = h.loader.load();
 		const forced = h.loader.load(true);
 		expect(h.fetchFn).toHaveBeenCalledTimes(1);
 
-		// A push (e.g. a battle victory) lands mid-flight and invalidates the epoch the queued force
-		// captured as its chainEpoch, so that chain will abort without ever fetching.
+		// A push lands mid-flight and invalidates while a force is already queued behind the in-flight
+		// fetch. The force's caller (e.g. resolveBossVictory's gate re-check) depends on genuinely fresh
+		// data, so this must not silently cancel the queued fetch and resolve the force with nothing.
 		h.loader.invalidate();
 
 		h.settle(0);
 		await initial;
-		await forced;
 		await flush();
-		// The aborted chain never issued a second fetch — expected either way.
-		expect(h.fetchFn).toHaveBeenCalledTimes(1);
-
-		// A brand-new fetch starts, and a force issued while it's in flight must still be honored
-		// with a genuinely fresh fetch — not silently coalesce onto it the way a stuck freshQueued
-		// flag (left over from the aborted chain above) would cause.
-		const second = h.loader.load(true);
-		expect(h.fetchFn).toHaveBeenCalledTimes(2);
-		const thirdForce = h.loader.load(true);
+		// The queued force fetch still fires once the stale in-flight fetch settles.
 		expect(h.fetchFn).toHaveBeenCalledTimes(2);
 
 		h.settle(1);
-		await second;
-		await flush();
-		expect(h.fetchFn).toHaveBeenCalledTimes(3);
-
-		h.settle(2);
-		await thirdForce;
+		await forced;
 	});
 });

--- a/UI/src/tests/stores/challenges.test.ts
+++ b/UI/src/tests/stores/challenges.test.ts
@@ -122,6 +122,9 @@ describe('challenges store', () => {
 		it('is not reverted by a fetch already in flight when it resolves with pre-completion data (#2332)', async () => {
 			const stale = Promise.withResolvers<IPlayerChallenge[]>();
 			mockFetchSocket.mockReturnValueOnce(stale.promise);
+			// The store isn't loaded yet, so invalidate() (#2366) queues a fresh fetch behind the stale
+			// one; it resolves after the completion was persisted server-side, so it already reflects it.
+			mockFetchSocket.mockResolvedValue([challenge(3, true)]);
 
 			const initial = playerChallenges.load();
 			playerChallenges.markCompleted(3);
@@ -130,6 +133,7 @@ describe('challenges store', () => {
 			// the completion was persisted server-side — must not revert it when it resolves.
 			stale.resolve([challenge(3, false)]);
 			await initial;
+			await vi.waitFor(() => expect(playerChallenges.loaded).toBe(true));
 
 			expect(playerChallenges.isChallengeCompleted(3)).toBe(true);
 		});

--- a/UI/src/tests/stores/proficiencies.svelte.test.ts
+++ b/UI/src/tests/stores/proficiencies.svelte.test.ts
@@ -232,6 +232,9 @@ describe('proficiencies store', () => {
 		it('is not reverted by a fetch already in flight when it resolves with pre-gain data (#2332)', async () => {
 			const stale = Promise.withResolvers<IPlayerProficiency[]>();
 			mockFetchSocket.mockReturnValueOnce(stale.promise);
+			// The store isn't loaded yet, so invalidate() (#2366) queues a fresh fetch behind the stale
+			// one; it resolves after the XP gain was persisted server-side, so it already reflects it.
+			mockFetchSocket.mockResolvedValue([playerProficiency(0, 4, 5)]);
 
 			const initial = playerProficiencies.load();
 			playerProficiencies.applyXpGained({ proficiencies: [xpResult(0, 4, 5)], opened: [] });
@@ -240,6 +243,7 @@ describe('proficiencies store', () => {
 			// the XP gain was persisted server-side — must not revert it when it resolves.
 			stale.resolve([playerProficiency(0, 3, 20)]);
 			await initial;
+			await vi.waitFor(() => expect(playerProficiencies.loaded).toBe(true));
 
 			expect(playerProficiencies.all).toEqual([playerProficiency(0, 4, 5)]);
 		});

--- a/UI/src/tests/stores/statistics.test.ts
+++ b/UI/src/tests/stores/statistics.test.ts
@@ -134,6 +134,9 @@ describe('statistics store', () => {
 	it('is not reverted by a fetch already in flight when it resolves with pre-clear data (#2332)', async () => {
 		const stale = Promise.withResolvers<IPlayerStatistic[]>();
 		mockFetchSocket.mockReturnValueOnce(stale.promise);
+		// The store isn't loaded yet, so invalidate() (#2366) queues a fresh fetch behind the stale
+		// one; it resolves after the clear was persisted server-side, so it already reflects it.
+		mockFetchSocket.mockResolvedValue([zonesCleared(3, 1)]);
 
 		const initial = statistics.load();
 		statistics.markZoneCleared(3);
@@ -142,6 +145,7 @@ describe('statistics store', () => {
 		// the clear was persisted server-side — must not revert it when it resolves.
 		stale.resolve([zonesCleared(3, 0)]);
 		await initial;
+		await vi.waitFor(() => expect(statistics.loaded).toBe(true));
 
 		expect(statistics.isZoneCleared(3)).toBe(true);
 	});


### PR DESCRIPTION
## Summary

- `CoalescedLoader.invalidate()` (`UI/src/lib/common/coalesced-loader.ts`) bumped the epoch to mark a now-stale in-flight fetch as untrustworthy, but never queued a replacement fetch. Two consequences, both described in #2366:
  1. A store that hadn't finished its first load yet (e.g. challenges/proficiencies during boot) was left stranded on push-delta-only data forever — nothing else ever retries a store that already holds *some* data, so `loaded` never becomes `true`.
  2. A `force` already queued behind the in-flight fetch was silently aborted by the same epoch bump, so its caller (e.g. `resolveBossVictory`'s gate re-check, `handleServerCommandFailed`'s divergence recovery) resolved without ever getting fresh data.
- Fixed by splitting epoch tracking into two counters:
  - `epoch` — bumped by both `reset()` and `invalidate()`, used only for the external `isStale()`/`currentEpoch` contract `fetchFn` relies on.
  - `resetEpoch` — bumped **only** by `reset()`, used internally to decide whether a queued chain should abort. A queued chain (from a `force`, or from `invalidate()`'s own re-queue) now only aborts on a genuine session reset, never on a racing `invalidate()`.
  - `invalidate()` now queues a fresh fetch behind the in-flight one whenever the store isn't loaded yet and no fetch is already queued, so the store still reaches a real baseline instead of being stuck on the pushed delta.
- Extended `coalesced-loader.test.ts` with the two scenarios from the issue (invalidate-while-unloaded queues a fresh fetch; a queued force survives a racing invalidate) and updated the two tests whose asserted behavior was the bug itself.
- Updated the three store-level "not reverted by a fetch already in flight" regression tests (`challenges.test.ts`, `statistics.test.ts`, `proficiencies.svelte.test.ts`) to mock a realistic response for the fetch this fix now queues (any fetch issued after a push already reflects the server-persisted state the push described), and to wait for the store to actually reach `loaded` before asserting.

## How this addresses the issue

Implements #2366's suggested fix directly: `invalidate()` re-queues a fetch when it fires while a fetch is in flight, specifically covering the "not yet loaded" case and the "force already queued" case, without discarding the baseline the way the original bug did.

Closes #2366

## Test plan

- [x] `npx vitest run` (full frontend suite) — 3959 tests passed, 0 failed.
- [x] `npm run lint` (eslint + svelte-check) — 0 errors, 0 warnings.
- [x] New/updated unit tests specifically pin: invalidate() while unloaded queues a fresh fetch and a concurrent load coalesces onto it; invalidate() leaves an already-loaded store's in-flight/queued fetch alone; a queued force is not aborted by a racing invalidate() and still resolves with genuinely fresh data.


---
_Generated by [Claude Code](https://claude.ai/code/session_011sZVAuevuF4UUUvFg5mG8K)_