### PR TITLE
Fix ensureValidAccessToken discarding a still-valid token on retryable refresh failures

### DIFF
--- a/UI/src/lib/api/auth.ts
+++ b/UI/src/lib/api/auth.ts
@@ -140,10 +140,17 @@ export const ensureValidAccessToken = async (): Promise<AccessTokenResult> => {
 
 	if (expiry === null || expiry - EXPIRY_LEEWAY_SECONDS <= nowSeconds) {
 		const outcome = await refreshTokens();
-		return {
-			accessToken: outcome.status === 'success' ? outcome.tokens.accessToken : null,
-			rejected: outcome.status === 'rejected'
-		};
+		if (outcome.status === 'success') {
+			return { accessToken: outcome.tokens.accessToken, rejected: false };
+		}
+
+		// A retryable failure (rate limit, transient 5xx, network blip) doesn't invalidate the stored
+		// token — if it hasn't actually expired yet, use it rather than forcing a guaranteed 401.
+		if (outcome.status === 'retryable' && expiry !== null && expiry > nowSeconds) {
+			return { accessToken: getAccessToken(), rejected: false };
+		}
+
+		return { accessToken: null, rejected: outcome.status === 'rejected' };
 	}
 
 	return { accessToken: getAccessToken(), rejected: false };

--- a/UI/src/tests/lib/api/auth.test.ts
+++ b/UI/src/tests/lib/api/auth.test.ts
@@ -216,8 +216,23 @@ describe('auth', () => {
 			expect(result).toEqual({ accessToken: null, rejected: true });
 		});
 
-		it('reports retryable (not rejected) without a token on a network error', async () => {
-			setTokens({ accessToken: makeAccessToken(10), refreshToken: 'r' });
+		it('falls back to the stored access token on a retryable failure when it has not actually expired', async () => {
+			const token = makeAccessToken(10);
+			setTokens({ accessToken: token, refreshToken: 'r' });
+			vi.stubGlobal(
+				'fetch',
+				vi.fn(async () => {
+					throw new TypeError('Failed to fetch');
+				})
+			);
+
+			const result = await ensureValidAccessToken();
+
+			expect(result).toEqual({ accessToken: token, rejected: false });
+		});
+
+		it('reports retryable (not rejected) without a token when the stored token has actually expired', async () => {
+			setTokens({ accessToken: makeAccessToken(-10), refreshToken: 'r' });
 			vi.stubGlobal(
 				'fetch',
 				vi.fn(async () => {


### PR DESCRIPTION
## Summary

- `ensureValidAccessToken` (`UI/src/lib/api/auth.ts:137-150`) refreshes pre-emptively whenever the stored access token is inside its 30s expiry leeway. When that pre-emptive refresh returned a **retryable** outcome (the auth rate-limiter's 429, a transient 5xx, or a network blip on the refresh endpoint alone), it unconditionally returned `accessToken: null` — even though the stored token was still genuinely valid (`expiry > now`, just inside the leeway window).
- `api-request.ts` then sent the request with no `Authorization` header — a guaranteed 401 — and `api-socket.ts` similarly bailed a reconnect that would otherwise have succeeded.
- Fixed by falling back to the stored (still-valid) access token when the refresh outcome is `retryable` and the token hasn't actually expired yet. `rejected`/`null` is still reported when the refresh is definitively rejected, or when the stored token really has expired.

## How this addresses the issue

Implements the issue's suggested one-line fallback exactly: only report "no token" when the stored token is genuinely expired or the refresh was definitively rejected.

## Test plan

- [x] Existing `UI/src/tests/lib/api/auth.test.ts` test `reports retryable (not rejected) without a token on a network error` was pinning the buggy behavior (it used a token 10s from expiry — still valid — and asserted `accessToken: null`). Replaced it with two tests: one confirming the fallback now returns the still-valid stored token on a retryable failure, and one confirming a **genuinely expired** token still correctly returns `null`/not-rejected on a retryable failure.
- [x] `npm run test:unit:ci` — full frontend suite green, 3960/3960 tests passed.
- [x] `npm run lint` — eslint + svelte-check clean, 0 errors/warnings.

Closes #2368

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MN8xDjxcLK9yrZCdpYEVPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MN8xDjxcLK9yrZCdpYEVPJ)_