### PR TITLE
Connect Redis multiplexers outside the process-wide lock, add failure backoff

### DIFF
--- a/Game.Infrastructure.Tests/RedisMultiplexerFactoryTests.cs
+++ b/Game.Infrastructure.Tests/RedisMultiplexerFactoryTests.cs
@@ -232,6 +232,33 @@ namespace Game.Infrastructure.Tests
         }
 
         [Fact]
+        public async Task DiscardLoserAsync_DisposesTheDiscardedValue()
+        {
+            var loser = new FakeAsyncDisposable();
+
+            await RedisMultiplexerFactory.DiscardLoserAsync(loser, NullLogger.Instance);
+
+            Assert.Equal(1, loser.DisposeCount);
+        }
+
+        [Fact]
+        public async Task DiscardLoserAsync_DisposeFaults_LogsAWarning_AndDoesNotThrow()
+        {
+            var loser = new FakeAsyncDisposable(throwOnDispose: true);
+            var logger = new CapturingLogger();
+
+            // A discarded loser's connection failing to close cleanly must not propagate out of the caller (the
+            // publish path that decided this instance lost the race) — the same contract DisposeAllAsync holds
+            // for a faulting shutdown close.
+            await RedisMultiplexerFactory.DiscardLoserAsync(loser, logger);
+
+            Assert.Equal(1, loser.DisposeCount);
+            var entry = Assert.Single(logger.Entries);
+            Assert.Equal(LogLevel.Warning, entry.Level);
+            Assert.NotNull(entry.Exception);
+        }
+
+        [Fact]
         public async Task DisposeAllAsync_DisposesEveryEntry_AndClearsTheCache()
         {
             var cache = new Dictionary<string, FakeAsyncDisposable>();

--- a/Game.Infrastructure.Tests/RedisMultiplexerFactoryTests.cs
+++ b/Game.Infrastructure.Tests/RedisMultiplexerFactoryTests.cs
@@ -6,18 +6,21 @@ using Xunit;
 namespace Game.Infrastructure.Tests
 {
     /// <summary>
-    /// Tests the keyed get-or-add reuse semantics of <see cref="RedisMultiplexerFactory"/> (#696). The connect
-    /// step itself opens a real Redis connection, so it is covered by integration tests rather than here; this
-    /// exercises the cache/lock logic through the generic <c>GetOrAdd</c> seam with sentinel values and a stub
-    /// factory, which is exactly the branch that decides whether two requests share a multiplexer or each open
-    /// their own.
+    /// Tests the keyed get-or-connect reuse semantics of <see cref="RedisMultiplexerFactory"/> (#696, #2371). The
+    /// connect step itself opens a real Redis connection, so it is covered by integration tests rather than here;
+    /// this exercises the cache/lock/negative-cache logic through the generic <c>GetOrConnect</c> seam with
+    /// sentinel values and a stub factory, which is exactly the branch that decides whether resolvers share a
+    /// multiplexer, race a first connect, or fail fast during an outage.
     /// </summary>
     public class RedisMultiplexerFactoryTests
     {
+        private static readonly Action<object> NoOpDiscard = _ => { };
+
         [Fact]
-        public void GetOrAdd_SameKey_ReturnsSameValueAndCreatesOnce()
+        public void GetOrConnect_SameKey_ReturnsSameValueAndCreatesOnce()
         {
             var cache = new Dictionary<string, object>();
+            var failures = new Dictionary<string, RedisMultiplexerFactory.ConnectFailure>();
             var syncRoot = new object();
             var created = 0;
             object Factory(string _)
@@ -26,58 +29,77 @@ namespace Game.Infrastructure.Tests
                 return new object();
             }
 
-            var first = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "localhost:6379", Factory);
-            var second = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "localhost:6379", Factory);
+            var first = RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "localhost:6379", Factory, NoOpDiscard, NullLogger.Instance, () => DateTime.UtcNow);
+            var second = RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "localhost:6379", Factory, NoOpDiscard, NullLogger.Instance, () => DateTime.UtcNow);
 
-            // Same key reuses the cached instance and never invokes the factory again.
+            // Same key reuses the cached instance and never invokes the factory again once one is published.
             Assert.Same(first, second);
             Assert.Equal(1, created);
         }
 
         [Fact]
-        public void GetOrAdd_DifferentKeys_ReturnsDistinctValues()
+        public void GetOrConnect_DifferentKeys_ReturnsDistinctValues()
         {
             var cache = new Dictionary<string, object>();
+            var failures = new Dictionary<string, RedisMultiplexerFactory.ConnectFailure>();
             var syncRoot = new object();
             object Factory(string _) => new object();
 
-            var cacheValue = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "cache:6379", Factory);
-            var pubSubValue = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "pubsub:6380", Factory);
+            var cacheValue = RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "cache:6379", Factory, NoOpDiscard, NullLogger.Instance, () => DateTime.UtcNow);
+            var pubSubValue = RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "pubsub:6380", Factory, NoOpDiscard, NullLogger.Instance, () => DateTime.UtcNow);
 
             // Distinct connection strings get distinct instances; identical ones (above) would share.
             Assert.NotSame(cacheValue, pubSubValue);
         }
 
         [Fact]
-        public void GetOrAdd_KeysByExactString_DoesNotNormalize()
+        public void GetOrConnect_KeysByExactString_DoesNotNormalize()
         {
             var cache = new Dictionary<string, object>();
+            var failures = new Dictionary<string, RedisMultiplexerFactory.ConnectFailure>();
             var syncRoot = new object();
             object Factory(string _) => new object();
 
             // Two strings that are semantically equivalent but not byte-identical are treated as different keys —
             // the deliberate trade-off of keying by the raw string rather than a normalized configuration.
-            var lower = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "localhost:6379", Factory);
-            var upper = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "LOCALHOST:6379", Factory);
+            var lower = RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "localhost:6379", Factory, NoOpDiscard, NullLogger.Instance, () => DateTime.UtcNow);
+            var upper = RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "LOCALHOST:6379", Factory, NoOpDiscard, NullLogger.Instance, () => DateTime.UtcNow);
 
             Assert.NotSame(lower, upper);
         }
 
         [Fact]
-        public void GetOrAdd_ConcurrentFirstRequests_ShareOneCreatedValue()
+        public void GetOrConnect_ConcurrentFirstRequests_PublishOneWinner_AndDiscardEveryLoser()
         {
             var cache = new Dictionary<string, object>();
+            var failures = new Dictionary<string, RedisMultiplexerFactory.ConnectFailure>();
             var syncRoot = new object();
-            var created = 0;
+            var createdValues = new List<object>();
+            var createdGate = new object();
             object Factory(string _)
             {
-                Interlocked.Increment(ref created);
-                return new object();
+                var value = new object();
+                lock (createdGate)
+                {
+                    createdValues.Add(value);
+                }
+
+                return value;
             }
 
-            // Many threads racing on the same key must collapse onto a single created instance — the startup race
-            // the locked get-or-add closes. Dedicated threads (not the thread pool) start together on a barrier so
-            // the race is genuine and so the test does not starve the pool the BackgroundWorker tests share.
+            var discarded = new List<object>();
+            var discardGate = new object();
+            void Discard(object value)
+            {
+                lock (discardGate)
+                {
+                    discarded.Add(value);
+                }
+            }
+
+            // Many threads racing on the same key no longer serialize behind one connect (#2371): each may create
+            // its own value, but only one is ever published and every other created value is discarded exactly
+            // once, so callers still converge on a single shared instance.
             const int threadCount = 16;
             var results = new object[threadCount];
             using var barrier = new Barrier(threadCount);
@@ -89,7 +111,7 @@ namespace Game.Infrastructure.Tests
                 threads[index] = new Thread(() =>
                 {
                     barrier.SignalAndWait();
-                    results[index] = RedisMultiplexerFactory.GetOrAdd(cache, syncRoot, "localhost:6379", Factory);
+                    results[index] = RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "localhost:6379", Factory, Discard, NullLogger.Instance, () => DateTime.UtcNow);
                 });
                 threads[index].Start();
             }
@@ -99,8 +121,114 @@ namespace Game.Infrastructure.Tests
                 thread.Join();
             }
 
-            Assert.Equal(1, created);
-            Assert.All(results, value => Assert.Same(results[0], value));
+            var winner = results[0];
+            Assert.All(results, value => Assert.Same(winner, value));
+            Assert.Contains(winner, createdValues);
+
+            // Every created value except the published winner was discarded, and none twice.
+            var expectedDiscarded = createdValues.Where(value => !ReferenceEquals(value, winner)).ToList();
+            Assert.Equal(expectedDiscarded.Count, discarded.Count);
+            Assert.All(expectedDiscarded, value => Assert.Contains(value, discarded));
+            Assert.All(discarded, value => Assert.Contains(value, expectedDiscarded));
+        }
+
+        [Fact]
+        public void GetOrConnect_FactoryThrows_CachesFailureAndFailsFastWithoutRetryingWithinBackoff()
+        {
+            var cache = new Dictionary<string, object>();
+            var failures = new Dictionary<string, RedisMultiplexerFactory.ConnectFailure>();
+            var syncRoot = new object();
+            var attempts = 0;
+            var now = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            object Factory(string _)
+            {
+                attempts++;
+                throw new InvalidOperationException("redis unreachable");
+            }
+
+            var first = Assert.Throws<InvalidOperationException>(() =>
+                RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "localhost:6379", Factory, NoOpDiscard, NullLogger.Instance, () => now));
+
+            // A second resolver arriving moments later must not pay for another ~5s connect attempt — it gets the
+            // same remembered failure back immediately instead.
+            var second = Assert.Throws<InvalidOperationException>(() =>
+                RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "localhost:6379", Factory, NoOpDiscard, NullLogger.Instance, () => now));
+
+            Assert.Equal(1, attempts);
+            Assert.Same(first, second);
+        }
+
+        [Fact]
+        public void GetOrConnect_FactoryThrows_RetriesOnceBackoffElapses()
+        {
+            var cache = new Dictionary<string, object>();
+            var failures = new Dictionary<string, RedisMultiplexerFactory.ConnectFailure>();
+            var syncRoot = new object();
+            var attempts = 0;
+            var now = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            object Factory(string _)
+            {
+                attempts++;
+                throw new InvalidOperationException($"redis unreachable, attempt {attempts}");
+            }
+
+            Assert.Throws<InvalidOperationException>(() =>
+                RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "localhost:6379", Factory, NoOpDiscard, NullLogger.Instance, () => now));
+
+            // Once the backoff window has fully elapsed, the next resolver is allowed to retry rather than being
+            // fast-failed forever.
+            var later = now.AddSeconds(10);
+            Assert.Throws<InvalidOperationException>(() =>
+                RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "localhost:6379", Factory, NoOpDiscard, NullLogger.Instance, () => later));
+
+            Assert.Equal(2, attempts);
+        }
+
+        [Fact]
+        public void GetOrConnect_SucceedsAfterAPriorFailure_ClearsTheRememberedFailure()
+        {
+            var cache = new Dictionary<string, object>();
+            var failures = new Dictionary<string, RedisMultiplexerFactory.ConnectFailure>();
+            var syncRoot = new object();
+            var attempts = 0;
+            var now = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            object Factory(string _)
+            {
+                attempts++;
+                if (attempts == 1)
+                {
+                    throw new InvalidOperationException("redis unreachable");
+                }
+
+                return new object();
+            }
+
+            Assert.Throws<InvalidOperationException>(() =>
+                RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "localhost:6379", Factory, NoOpDiscard, NullLogger.Instance, () => now));
+
+            var later = now.AddSeconds(10);
+            var value = RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "localhost:6379", Factory, NoOpDiscard, NullLogger.Instance, () => later);
+
+            Assert.NotNull(value);
+            Assert.Empty(failures);
+            Assert.Same(value, cache["localhost:6379"]);
+        }
+
+        [Fact]
+        public void GetOrConnect_FactoryThrows_LogsAWarning()
+        {
+            var cache = new Dictionary<string, object>();
+            var failures = new Dictionary<string, RedisMultiplexerFactory.ConnectFailure>();
+            var syncRoot = new object();
+            var logger = new CapturingLogger();
+            object Factory(string _) => throw new InvalidOperationException("redis unreachable");
+
+            Assert.Throws<InvalidOperationException>(() =>
+                RedisMultiplexerFactory.GetOrConnect(cache, failures, syncRoot, "localhost:6379", Factory, NoOpDiscard, logger, () => DateTime.UtcNow));
+
+            var entry = Assert.Single(logger.Entries);
+            Assert.Equal(LogLevel.Warning, entry.Level);
+            Assert.IsType<InvalidOperationException>(entry.Exception);
         }
 
         [Fact]

--- a/Game.Infrastructure/Cache/CacheServiceFactory.cs
+++ b/Game.Infrastructure/Cache/CacheServiceFactory.cs
@@ -21,7 +21,8 @@ namespace Game.Infrastructure.Cache
 
         private static ICacheService CreateRedisService(ICacheOptions config, ILoggerFactory loggerFactory)
         {
-            return new RedisService(RedisMultiplexerFactory.GetMultiplexer(config), loggerFactory.CreateLogger<RedisService>());
+            var multiplexer = RedisMultiplexerFactory.GetMultiplexer(config, loggerFactory.CreateLogger(nameof(RedisMultiplexerFactory)));
+            return new RedisService(multiplexer, loggerFactory.CreateLogger<RedisService>());
         }
     }
 }

--- a/Game.Infrastructure/PubSub/PubSubServiceFactory.cs
+++ b/Game.Infrastructure/PubSub/PubSubServiceFactory.cs
@@ -21,7 +21,8 @@ namespace Game.Infrastructure.PubSub
 
         private static IPubSubService CreateRedisPubSubService(IPubSubOptions config, ILoggerFactory loggerFactory)
         {
-            return new RedisPubSubService(RedisMultiplexerFactory.GetMultiplexer(config), loggerFactory);
+            var multiplexer = RedisMultiplexerFactory.GetMultiplexer(config, loggerFactory.CreateLogger(nameof(RedisMultiplexerFactory)));
+            return new RedisPubSubService(multiplexer, loggerFactory);
         }
     }
 }

--- a/Game.Infrastructure/Redis/RedisMultiplexerFactory.cs
+++ b/Game.Infrastructure/Redis/RedisMultiplexerFactory.cs
@@ -1,4 +1,4 @@
-﻿using Game.Infrastructure.Cache;
+using Game.Infrastructure.Cache;
 using Game.Infrastructure.PubSub;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -8,58 +8,70 @@ namespace Game.Infrastructure.Redis
 {
     internal static class RedisMultiplexerFactory
     {
-        // Multiplexers are keyed by the *original* connection string under a single lock. Keying by the raw
-        // string (rather than comparing against ConnectionMultiplexer.Configuration, which StackExchange.Redis
-        // normalizes/rewrites) makes reuse reliable: the cache and pub/sub services share one multiplexer
-        // whenever their connection strings match, and two getters racing on first startup resolve to the same
-        // instance instead of each opening their own (#696). The whole get-or-add runs under the lock, so a
-        // partially-constructed multiplexer is never published to another thread.
+        // Multiplexers are keyed by the *original* connection string. Keying by the raw string (rather than
+        // comparing against ConnectionMultiplexer.Configuration, which StackExchange.Redis normalizes/rewrites)
+        // makes reuse reliable: the cache and pub/sub services share one multiplexer whenever their connection
+        // strings match.
         private static readonly Dictionary<string, IConnectionMultiplexer> _multiplexers = new();
+
+        // A connect attempt that failed recently, keyed the same way. Checked before paying for another ~5s
+        // Connect() so an outage fails callers fast instead of serializing them one behind another (#2371).
+        private static readonly Dictionary<string, ConnectFailure> _recentFailures = new();
         private static readonly object _lock = new();
+
+        // How long a failed connect is remembered before the next resolver is allowed to retry. Bounds the
+        // fail-fast window to roughly one connect attempt's worth of time so the app notices Redis recovering
+        // promptly, while still collapsing a burst of concurrent callers during an outage onto one attempt.
+        private static readonly TimeSpan FailureBackoff = TimeSpan.FromSeconds(5);
 
         // Minimum size to grow the thread pool to before connecting (see ConnectMultiplexer).
         private const int MinThreadPoolThreads = 32;
 
-        public static IConnectionMultiplexer GetMultiplexer(ICacheOptions config)
+        public static IConnectionMultiplexer GetMultiplexer(ICacheOptions config, ILogger logger)
         {
             if (config.CacheConnectionString is null)
             {
                 throw new InvalidOperationException($"{nameof(config.CacheConnectionString)} cannot be null.");
             }
 
-            return GetOrConnect(config.CacheConnectionString);
+            return GetOrConnect(config.CacheConnectionString, logger);
         }
 
-        public static IConnectionMultiplexer GetMultiplexer(IPubSubOptions config)
+        public static IConnectionMultiplexer GetMultiplexer(IPubSubOptions config, ILogger logger)
         {
             if (config.PubSubConnectionString is null)
             {
                 throw new InvalidOperationException($"{nameof(config.PubSubConnectionString)} cannot be null.");
             }
 
-            return GetOrConnect(config.PubSubConnectionString);
+            return GetOrConnect(config.PubSubConnectionString, logger);
         }
 
-        private static IConnectionMultiplexer GetOrConnect(string connectionString)
+        private static IConnectionMultiplexer GetOrConnect(string connectionString, ILogger logger)
         {
-            return GetOrAdd(_multiplexers, _lock, connectionString, ConnectMultiplexer);
+            return GetOrConnect(_multiplexers, _recentFailures, _lock, connectionString, ConnectMultiplexer, m => DiscardLoser(m, logger), logger, () => DateTime.UtcNow);
         }
 
         /// <summary>
-        /// Closes and disposes every cached multiplexer, clearing the cache so a later request reconnects fresh.
-        /// Called from the host's graceful-shutdown hook (<see cref="RedisConnectionLifetime"/>) so the process-
-        /// lifetime connections are torn down cleanly on stop rather than left to be force-killed (#954). Each
-        /// connection is closed independently so one faulting close still lets the rest tear down.
+        /// Closes and disposes every cached multiplexer and clears any remembered connect failures, so a later
+        /// request reconnects fresh. Called from the host's graceful-shutdown hook (<see cref="RedisConnectionLifetime"/>)
+        /// so the process-lifetime connections are torn down cleanly on stop rather than left to be force-killed
+        /// (#954). Each connection is closed independently so one faulting close still lets the rest tear down.
         /// </summary>
-        public static Task DisposeAllAsync(ILogger logger)
+        public static async Task DisposeAllAsync(ILogger logger)
         {
-            return DisposeAllAsync(_multiplexers, _lock, logger);
+            await DisposeAllAsync(_multiplexers, _lock, logger);
+
+            lock (_lock)
+            {
+                _recentFailures.Clear();
+            }
         }
 
         /// <summary>
         /// Locked drain-and-dispose of a multiplexer cache: snapshots the values under <paramref name="syncRoot"/>,
         /// clears the cache, then disposes each entry. Generic and seam-extracted so the dispose/clear semantics
-        /// are unit-testable with a fake disposable, mirroring how <see cref="GetOrAdd{T}"/> is tested without a
+        /// are unit-testable with a fake disposable, mirroring how <see cref="GetOrConnect{T}"/> is tested without a
         /// live connection (#954). Each entry's dispose is wrapped independently so a faulting close is logged and
         /// skipped rather than aborting the rest of the drain.
         /// </summary>
@@ -87,25 +99,68 @@ namespace Game.Infrastructure.Redis
         }
 
         /// <summary>
-        /// Locked get-or-add: returns the value cached for <paramref name="key"/>, or invokes
-        /// <paramref name="factory"/> under <paramref name="syncRoot"/> to create and cache one on first request.
-        /// Running the whole lookup-and-create inside the lock is what makes the cache safe to read from multiple
-        /// threads without a partially-constructed value escaping, and what collapses a first-startup race onto a
-        /// single created instance. Generic over the value type so the keyed-reuse semantics are unit-testable
-        /// without a live connection (#696); production keys <see cref="ConnectionMultiplexer"/> by connection
-        /// string.
+        /// Locked get-or-connect with a fail-fast negative cache and a connect step that runs *outside* the lock
+        /// (#2371). The lock only ever guards short dictionary reads/writes: whether <paramref name="key"/> is
+        /// already connected, whether a recent failure is still within <see cref="FailureBackoff"/> (throw the
+        /// remembered exception immediately rather than retry), and publishing the result of a connect attempt.
+        /// The potentially-slow <paramref name="factory"/> call itself is never made under the lock, so a Redis
+        /// outage no longer serializes every resolver behind one blocking ~5s connect apiece.
+        /// Two callers can race a first-time connect for the same key since neither holds the lock while
+        /// connecting; whichever publishes first wins and the loser's already-open connection is discarded via
+        /// <paramref name="discardLoser"/> — every future caller for that key still shares the one winning
+        /// instance (#696), even though the connect attempt itself wasn't serialized.
         /// </summary>
-        internal static T GetOrAdd<T>(Dictionary<string, T> cache, object syncRoot, string key, Func<string, T> factory)
+        internal static T GetOrConnect<T>(
+            Dictionary<string, T> cache,
+            Dictionary<string, ConnectFailure> recentFailures,
+            object syncRoot,
+            string key,
+            Func<string, T> factory,
+            Action<T> discardLoser,
+            ILogger logger,
+            Func<DateTime> utcNow)
         {
             lock (syncRoot)
             {
-                if (!cache.TryGetValue(key, out var value))
+                if (cache.TryGetValue(key, out var existing))
                 {
-                    value = factory(key);
-                    cache[key] = value;
+                    return existing;
                 }
 
-                return value;
+                if (recentFailures.TryGetValue(key, out var failure) && utcNow() - failure.OccurredAtUtc < FailureBackoff)
+                {
+                    // Fail fast: rethrow the remembered failure rather than pay for another attempt this soon.
+                    throw failure.Error;
+                }
+            }
+
+            T created;
+            try
+            {
+                created = factory(key);
+            }
+            catch (Exception ex)
+            {
+                lock (syncRoot)
+                {
+                    recentFailures[key] = new ConnectFailure(utcNow(), ex);
+                }
+
+                logger.LogWarning(ex, "Redis connect failed; remembering the failure for {Backoff} so concurrent/subsequent resolvers fail fast instead of each retrying immediately.", FailureBackoff);
+                throw;
+            }
+
+            lock (syncRoot)
+            {
+                if (cache.TryGetValue(key, out var winner))
+                {
+                    discardLoser(created);
+                    return winner;
+                }
+
+                cache[key] = created;
+                recentFailures.Remove(key);
+                return created;
             }
         }
 
@@ -136,5 +191,26 @@ namespace Game.Infrastructure.Redis
 
             return ConnectionMultiplexer.Connect(connectionString);
         }
+
+        // A discarded loser's connection failing to close cleanly doesn't affect the winner already published
+        // for other callers, but it's still worth surfacing rather than swallowing outright.
+        private static void DiscardLoser(IConnectionMultiplexer multiplexer, ILogger logger)
+        {
+            _ = DiscardLoserAsync(multiplexer, logger);
+        }
+
+        private static async Task DiscardLoserAsync(IConnectionMultiplexer multiplexer, ILogger logger)
+        {
+            try
+            {
+                await multiplexer.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to close a duplicate Redis multiplexer created while racing another connect for the same key.");
+            }
+        }
+
+        internal readonly record struct ConnectFailure(DateTime OccurredAtUtc, Exception Error);
     }
 }

--- a/Game.Infrastructure/Redis/RedisMultiplexerFactory.cs
+++ b/Game.Infrastructure/Redis/RedisMultiplexerFactory.cs
@@ -199,11 +199,14 @@ namespace Game.Infrastructure.Redis
             _ = DiscardLoserAsync(multiplexer, logger);
         }
 
-        private static async Task DiscardLoserAsync(IConnectionMultiplexer multiplexer, ILogger logger)
+        // Generic (rather than IConnectionMultiplexer-specific) so the dispose/log branch is unit-testable with a
+        // fake IAsyncDisposable, mirroring DisposeAllAsync<T> above.
+        internal static async Task DiscardLoserAsync<T>(T disposable, ILogger logger)
+            where T : IAsyncDisposable
         {
             try
             {
-                await multiplexer.DisposeAsync();
+                await disposable.DisposeAsync();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary

`RedisMultiplexerFactory.GetOrAdd` ran the synchronous `ConnectionMultiplexer.Connect` (~5s, `abortConnect=true`) for the *entire* invocation inside the static process-wide lock. A successful connect is cached for the process lifetime, but a **failed** connect was never negatively cached — during a Redis outage (or the window after `RedisConnectionLifetime` clears the cache on shutdown), every scope resolving `ICacheService`/`IPubSubService` would re-attempt a synchronous ~5s connect, serialized one at a time behind the lock. A Redis outage collapsed into head-of-line blocking of the whole instance instead of fast per-request failures.

- `GetOrConnect` (renamed from `GetOrAdd`) now only holds the lock for short dictionary operations: checking whether the key is already connected, checking whether a recent failure is still within a 5s backoff window (fail fast with the remembered exception), and publishing a successful connect.
- The connect attempt itself now runs **outside** the lock, via a double-checked publish: two callers can race a first-time connect for the same key since neither blocks the other, but only the first to publish wins — the loser's already-open connection is cleanly discarded (`DisposeAsync`, best-effort logged on failure) so every future caller still shares one instance (preserves #696's dedup guarantee for anything actually handed out, just not for the connect attempt itself).
- A failed connect is remembered for 5s so concurrent/subsequent resolvers fail fast with the same exception instead of each paying for another ~5s attempt. The failure cache is cleared on a subsequent successful connect and on the graceful-shutdown teardown (`RedisConnectionLifetime`/`ResetForTesting`), alongside the existing multiplexer cache clear (#954).
- Threaded an `ILogger` into `RedisMultiplexerFactory.GetMultiplexer` (from the existing `ILoggerFactory` already available in `CacheServiceFactory`/`PubSubServiceFactory`) so a failed connect and a failed loser-discard are both logged — without ever logging the raw connection string, since it may carry a password.

## How this addresses the issue

Implements the suggested fix in #2371: connect outside the lock with double-checked publish, plus a short negative cache with backoff so concurrent resolvers fail fast during an outage instead of queuing. Keeps the #696 single-instance-per-connection-string semantics and the #954 graceful-dispose path intact.

## Test plan

- [x] `dotnet build` (full solution) — 0 warnings, 0 errors.
- [x] `dotnet test` (full solution) — 3,477 tests passed (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests).
- [x] Updated `RedisMultiplexerFactoryTests` to pin the new contract: same-key reuse, distinct-key/exact-string-keying (unchanged), concurrent first-time racers converge on one published winner with every loser discarded exactly once, a failed connect fails fast within the backoff window without retrying, a retry is allowed once the backoff elapses, a subsequent success clears the remembered failure, and a failed connect logs a warning.
- [ ] The connect step itself (`ConnectionMultiplexer.Connect` against a live/down Redis) is exercised by existing integration tests rather than new ones, per the existing test-layering convention documented on `RedisMultiplexerFactoryTests`.

Closes #2371

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01T9T9U1rFKqFuZ1ndcsx3pH

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9T9U1rFKqFuZ1ndcsx3pH)_