### PR TITLE
Fix Codex enemy dossier rendering AtMost challenges as accumulating progress

### DIFF
--- a/UI/src/lib/common/challenge-type.ts
+++ b/UI/src/lib/common/challenge-type.ts
@@ -1,4 +1,4 @@
-import { EChallengeType, type IChallengeType } from '$lib/api';
+import { EChallengeGoalComparison, EChallengeType, type IChallengeType } from '$lib/api';
 import { normalizeText } from './functions';
 
 /*
@@ -37,6 +37,10 @@ export const challengeTypeColor = (id: EChallengeType): string =>
 export const challengeTypeName = (id: EChallengeType, challengeTypes?: IChallengeType[]): string =>
 	challengeTypes?.find((t) => t.id === id)?.name ?? normalizeText(EChallengeType[id] ?? '');
 
+/** A challenge type's goal-comparison direction, from the `ChallengeTypes` reference set (default: at-least). */
+export const comparisonFor = (id: EChallengeType, challengeTypes?: IChallengeType[]): EChallengeGoalComparison =>
+	challengeTypes?.find((t) => t.id === id)?.goalComparison ?? EChallengeGoalComparison.AtLeast;
+
 /**
  * Clamp an accumulating challenge's raw progress to its goal for display. Stored progress can
  * transiently exceed the goal in the window before a `ChallengeCompleted` push lands; every
@@ -44,3 +48,54 @@ export const challengeTypeName = (id: EChallengeType, challengeTypes?: IChalleng
  * diverge on how they handle it.
  */
 export const clampChallengeProgress = (progress: number, goal: number): number => Math.min(progress, goal);
+
+export interface ProgressInfo {
+	/** Minimisation goal (lower is better, e.g. TimeTrial) vs accumulating goal. */
+	atMost: boolean;
+	/** 0–100 fill for the proximity/progress bar. */
+	percent: number;
+	/* accumulating (atLeast) */
+	value: number;
+	goal: number;
+	/* minimisation (atMost) */
+	best: number;
+	target: number;
+	/** atMost only: whether a qualifying value has been recorded yet. */
+	hasData: boolean;
+}
+
+/**
+ * Comparison-aware progress maths, branching on the challenge type's goal-comparison direction.
+ * Every progress readout (Challenges screen, Codex dossier) should route through this so an
+ * at-most (minimisation) challenge can't render as if it were an accumulating one elsewhere.
+ */
+export function progressInfo(goal: number, comparison: EChallengeGoalComparison, progress: number): ProgressInfo {
+	if (comparison === EChallengeGoalComparison.AtMost) {
+		// Stored progress is the player's current best (0 = no qualifying value yet).
+		// Closeness to the target drives the bar; a 0→goal fill would be misleading.
+		const best = progress;
+		const hasData = best > 0;
+		const percent = hasData ? Math.min(100, (goal / best) * 100) : 0;
+		return { atMost: true, percent, value: 0, goal, best, target: goal, hasData };
+	}
+	const percent = Math.min(100, (progress / Math.max(1, goal)) * 100);
+	return {
+		atMost: false,
+		percent,
+		value: clampChallengeProgress(progress, goal),
+		goal,
+		best: 0,
+		target: 0,
+		hasData: true
+	};
+}
+
+/** `90` -> `1:30`, `45` -> `45s`, `0`/missing -> `—`. An at-most progress readout's time formatting. */
+export function formatTime(seconds: number): string {
+	if (!seconds || seconds <= 0) {
+		return '—';
+	}
+	const minutes = Math.floor(seconds / 60);
+	const secs = Math.round(seconds % 60);
+	return minutes > 0 ? `${minutes}:${String(secs).padStart(2, '0')}` : `${secs}s`;
+}

--- a/UI/src/routes/game/screens/challenges/ProgressReadout.svelte
+++ b/UI/src/routes/game/screens/challenges/ProgressReadout.svelte
@@ -29,7 +29,8 @@
 </div>
 
 <script lang="ts">
-import { formatCount, formatTime } from './challenge-meta';
+import { formatTime } from '$lib/common';
+import { formatCount } from './challenge-meta';
 import ProgressBar from './ProgressBar.svelte';
 import type { ChallengeVM } from './challenges-view.svelte';
 

--- a/UI/src/routes/game/screens/challenges/challenge-meta.ts
+++ b/UI/src/routes/game/screens/challenges/challenge-meta.ts
@@ -30,16 +30,6 @@ export const challengeTypeUnit = (id: EChallengeType): string => CHALLENGE_TYPE_
 /** A type's hero-banner blurb, with a sensible fallback for unknown types. */
 export const challengeTypeBlurb = (id: EChallengeType): string => CHALLENGE_TYPE_META[id]?.blurb ?? '';
 
-/** `90` -> `1:30`, `45` -> `45s`, `0`/missing -> `—`. */
-export function formatTime(seconds: number): string {
-	if (!seconds || seconds <= 0) {
-		return '—';
-	}
-	const minutes = Math.floor(seconds / 60);
-	const secs = Math.round(seconds % 60);
-	return minutes > 0 ? `${minutes}:${String(secs).padStart(2, '0')}` : `${secs}s`;
-}
-
 /** Thousands-separated for large counts, plain otherwise. */
 export function formatCount(value: number): string {
 	return value >= 1000 ? value.toLocaleString() : String(value);

--- a/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
+++ b/UI/src/routes/game/screens/challenges/challenges-view.svelte.ts
@@ -12,9 +12,11 @@ import {
 import { Item } from '$lib/battle';
 import {
 	challengeTypeColor,
+	comparisonFor as goalComparisonOf,
 	challengeTypeName,
-	clampChallengeProgress,
 	damageTypeKeyName,
+	type ProgressInfo,
+	progressInfo as computeProgressInfo,
 	rarityGlow,
 	rarityLevel,
 	resolveUnlockReward,
@@ -48,20 +50,7 @@ export interface ResolvedReward {
 	mod?: IItemMod;
 }
 
-export interface ProgressInfo {
-	/** Minimisation goal (lower is better, e.g. TimeTrial) vs accumulating goal. */
-	atMost: boolean;
-	/** 0–100 fill for the proximity/progress bar. */
-	percent: number;
-	/* accumulating (atLeast) */
-	value: number;
-	goal: number;
-	/* minimisation (atMost) */
-	best: number;
-	target: number;
-	/** atMost only: whether a qualifying value has been recorded yet. */
-	hasData: boolean;
-}
+export type { ProgressInfo };
 
 export interface ChallengeVM {
 	id: number;
@@ -101,7 +90,7 @@ function comparisonFor(
 	if (byType) {
 		return byType.get(typeId) ?? EChallengeGoalComparison.AtLeast;
 	}
-	return staticData.challengeTypes?.find((t) => t.id === typeId)?.goalComparison ?? EChallengeGoalComparison.AtLeast;
+	return goalComparisonOf(typeId, staticData.challengeTypes);
 }
 
 /** Resolve a scoped challenge's target entity name from the relevant reference pool. */
@@ -163,28 +152,6 @@ export function resolveReward(ch: IChallenge, revealed: boolean): ResolvedReward
 	return resolved;
 }
 
-/* ─── Progress maths (branches on comparison direction) ──────────────── */
-export function progressInfo(ch: IChallenge, comparison: EChallengeGoalComparison, progress: number): ProgressInfo {
-	if (comparison === EChallengeGoalComparison.AtMost) {
-		// Stored progress is the player's current best (0 = no qualifying value yet).
-		// Closeness to the target drives the bar; a 0→goal fill would be misleading.
-		const best = progress;
-		const hasData = best > 0;
-		const percent = hasData ? Math.min(100, (ch.progressGoal / best) * 100) : 0;
-		return { atMost: true, percent, value: 0, goal: ch.progressGoal, best, target: ch.progressGoal, hasData };
-	}
-	const percent = Math.min(100, (progress / Math.max(1, ch.progressGoal)) * 100);
-	return {
-		atMost: false,
-		percent,
-		value: clampChallengeProgress(progress, ch.progressGoal),
-		goal: ch.progressGoal,
-		best: 0,
-		target: 0,
-		hasData: true
-	};
-}
-
 /* ─── View-model assembly ────────────────────────────────────────────── */
 export function buildChallengeVM(
 	ch: IChallenge,
@@ -194,7 +161,7 @@ export function buildChallengeVM(
 	const completed = player?.completed ?? false;
 	const progress = player?.progress ?? 0;
 	const comparison = comparisonFor(ch.challengeTypeId, comparisonByType);
-	const prog = progressInfo(ch, comparison, progress);
+	const prog = computeProgressInfo(ch.progressGoal, comparison, progress);
 	const state: ChallengeState = completed ? 'done' : prog.percent > 0 ? 'active' : 'locked';
 	return {
 		id: ch.id,

--- a/UI/src/routes/game/screens/codex/enemies-tab-view.svelte.ts
+++ b/UI/src/routes/game/screens/codex/enemies-tab-view.svelte.ts
@@ -8,8 +8,10 @@ import {
 	type EnemyAttributes,
 	challengeTypeColor,
 	challengeTypeName,
-	clampChallengeProgress,
-	enemyAttributesAtLevel
+	comparisonFor,
+	enemyAttributesAtLevel,
+	formatTime,
+	progressInfo
 } from '$lib/common';
 import { playerChallenges, staticData } from '$stores';
 import {
@@ -266,9 +268,17 @@ export class EnemiesTabView {
 					const pc = progressById.get(c.id);
 					const progress = pc?.progress ?? 0;
 					const completed = pc?.completed ?? false;
-					const clampedProgress = clampChallengeProgress(progress, c.progressGoal);
-					const progressText =
-						c.progressGoal === 1 ? (completed ? 'done' : 'sealed') : `${Math.round(clampedProgress)}/${c.progressGoal}`;
+					const comparison = comparisonFor(c.challengeTypeId, staticData.challengeTypes);
+					const prog = progressInfo(c.progressGoal, comparison, progress);
+					const progressText = prog.atMost
+						? prog.hasData
+							? `${formatTime(prog.best)} best · ≤${formatTime(prog.target)}`
+							: `no time yet · ≤${formatTime(prog.target)}`
+						: c.progressGoal === 1
+							? completed
+								? 'done'
+								: 'sealed'
+							: `${Math.round(prog.value)}/${c.progressGoal}`;
 					return {
 						id: c.id,
 						name: c.name,

--- a/UI/src/tests/lib/common/challenge-type.test.ts
+++ b/UI/src/tests/lib/common/challenge-type.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { EChallengeType, type IChallengeType } from '$lib/api';
-import { challengeTypeColor, challengeTypeName, clampChallengeProgress } from '$lib/common';
+import { EChallengeGoalComparison, EChallengeType, type IChallengeType } from '$lib/api';
+import {
+	challengeTypeColor,
+	challengeTypeName,
+	clampChallengeProgress,
+	comparisonFor,
+	formatTime,
+	progressInfo
+} from '$lib/common';
 
 describe('challengeTypeColor', () => {
 	it('maps each type to its themeable --challenge-* accent variable', () => {
@@ -31,5 +38,80 @@ describe('clampChallengeProgress', () => {
 
 	it('clamps progress that overshoots the goal', () => {
 		expect(clampChallengeProgress(12, 10)).toBe(10);
+	});
+});
+
+describe('comparisonFor', () => {
+	const types: IChallengeType[] = [
+		{ id: EChallengeType.EnemiesKilled, name: 'Enemies Killed', goalComparison: EChallengeGoalComparison.AtLeast },
+		{ id: EChallengeType.TimeTrial, name: 'Time Trial', goalComparison: EChallengeGoalComparison.AtMost }
+	];
+
+	it("reads the type's intrinsic goal-comparison direction from reference data", () => {
+		expect(comparisonFor(EChallengeType.EnemiesKilled, types)).toBe(EChallengeGoalComparison.AtLeast);
+		expect(comparisonFor(EChallengeType.TimeTrial, types)).toBe(EChallengeGoalComparison.AtMost);
+	});
+
+	it('defaults to at-least when the type is missing from reference data', () => {
+		expect(comparisonFor(EChallengeType.TimeTrial, [])).toBe(EChallengeGoalComparison.AtLeast);
+		expect(comparisonFor(EChallengeType.TimeTrial)).toBe(EChallengeGoalComparison.AtLeast);
+	});
+});
+
+describe('progressInfo', () => {
+	it('computes an accumulating (atLeast) fill clamped to 100%', () => {
+		expect(progressInfo(50, EChallengeGoalComparison.AtLeast, 25)).toMatchObject({
+			atMost: false,
+			value: 25,
+			goal: 50,
+			percent: 50
+		});
+		expect(progressInfo(50, EChallengeGoalComparison.AtLeast, 80).percent).toBe(100);
+	});
+
+	it('clamps an over-goal value to the goal (transient race before the ChallengeCompleted push lands)', () => {
+		expect(progressInfo(10, EChallengeGoalComparison.AtLeast, 12)).toMatchObject({ value: 10, goal: 10 });
+	});
+
+	it('treats an atMost goal as best-vs-target proximity, with 0 meaning "no data"', () => {
+		// no qualifying value yet
+		expect(progressInfo(60, EChallengeGoalComparison.AtMost, 0)).toMatchObject({
+			atMost: true,
+			hasData: false,
+			percent: 0
+		});
+		// best 120s vs 60s target -> 50% of the way there
+		expect(progressInfo(60, EChallengeGoalComparison.AtMost, 120)).toMatchObject({
+			best: 120,
+			target: 60,
+			percent: 50,
+			hasData: true
+		});
+		// already beating the target clamps to 100%
+		expect(progressInfo(60, EChallengeGoalComparison.AtMost, 52).percent).toBe(100);
+	});
+});
+
+describe('formatTime', () => {
+	it('renders sub-minute durations in seconds', () => {
+		expect(formatTime(45)).toBe('45s');
+		expect(formatTime(9)).toBe('9s');
+	});
+
+	it('renders minute-spanning durations as m:ss with a zero-padded seconds field', () => {
+		expect(formatTime(90)).toBe('1:30');
+		expect(formatTime(125)).toBe('2:05');
+		expect(formatTime(60)).toBe('1:00');
+	});
+
+	it('rounds fractional seconds', () => {
+		expect(formatTime(45.4)).toBe('45s');
+		expect(formatTime(89.6)).toBe('1:30');
+	});
+
+	it('renders a dash for zero, negative, or missing input', () => {
+		expect(formatTime(0)).toBe('—');
+		expect(formatTime(-5)).toBe('—');
+		expect(formatTime(NaN)).toBe('—');
 	});
 });

--- a/UI/src/tests/routes/game/screens/challenges/challenge-meta.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/challenge-meta.test.ts
@@ -4,7 +4,6 @@ import {
 	CHALLENGE_TYPE_META,
 	challengeTypeUnit,
 	challengeTypeBlurb,
-	formatTime,
 	formatCount
 } from '$routes/game/screens/challenges/challenge-meta';
 
@@ -39,30 +38,6 @@ describe('challengeTypeBlurb', () => {
 
 	it('falls back to an empty string for an unknown type', () => {
 		expect(challengeTypeBlurb(999 as EChallengeType)).toBe('');
-	});
-});
-
-describe('formatTime', () => {
-	it('renders sub-minute durations in seconds', () => {
-		expect(formatTime(45)).toBe('45s');
-		expect(formatTime(9)).toBe('9s');
-	});
-
-	it('renders minute-spanning durations as m:ss with a zero-padded seconds field', () => {
-		expect(formatTime(90)).toBe('1:30');
-		expect(formatTime(125)).toBe('2:05');
-		expect(formatTime(60)).toBe('1:00');
-	});
-
-	it('rounds fractional seconds', () => {
-		expect(formatTime(45.4)).toBe('45s');
-		expect(formatTime(89.6)).toBe('1:30');
-	});
-
-	it('renders a dash for zero, negative, or missing input', () => {
-		expect(formatTime(0)).toBe('—');
-		expect(formatTime(-5)).toBe('—');
-		expect(formatTime(NaN)).toBe('—');
 	});
 });
 

--- a/UI/src/tests/routes/game/screens/challenges/challenges-view.svelte.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/challenges-view.svelte.test.ts
@@ -50,7 +50,6 @@ import {
 	groupByType,
 	nextUp,
 	overallSummary,
-	progressInfo,
 	resolveReward,
 	sortChallenges,
 	typeStats
@@ -154,43 +153,6 @@ describe('resolveReward', () => {
 		expect(
 			resolveReward(challenge({ id: 99, name: 'No Reward', challengeTypeId: EChallengeType.EnemiesKilled }), true)
 		).toBeNull();
-	});
-});
-
-describe('progressInfo', () => {
-	it('computes an accumulating (atLeast) fill clamped to 100%', () => {
-		const ch = challenge({ id: 1, name: 'x', challengeTypeId: EChallengeType.EnemiesKilled, progressGoal: 50 });
-		expect(progressInfo(ch, EChallengeGoalComparison.AtLeast, 25)).toMatchObject({
-			atMost: false,
-			value: 25,
-			goal: 50,
-			percent: 50
-		});
-		expect(progressInfo(ch, EChallengeGoalComparison.AtLeast, 80).percent).toBe(100);
-	});
-
-	it('clamps an over-goal value to the goal (transient race before the ChallengeCompleted push lands)', () => {
-		const ch = challenge({ id: 2, name: 'x', challengeTypeId: EChallengeType.EnemiesKilled, progressGoal: 10 });
-		expect(progressInfo(ch, EChallengeGoalComparison.AtLeast, 12)).toMatchObject({ value: 10, goal: 10 });
-	});
-
-	it('treats an atMost goal as best-vs-target proximity, with 0 meaning "no data"', () => {
-		const ch = challenge({ id: 9, name: 'x', challengeTypeId: EChallengeType.TimeTrial, progressGoal: 60 });
-		// no qualifying value yet
-		expect(progressInfo(ch, EChallengeGoalComparison.AtMost, 0)).toMatchObject({
-			atMost: true,
-			hasData: false,
-			percent: 0
-		});
-		// best 120s vs 60s target -> 50% of the way there
-		expect(progressInfo(ch, EChallengeGoalComparison.AtMost, 120)).toMatchObject({
-			best: 120,
-			target: 60,
-			percent: 50,
-			hasData: true
-		});
-		// already beating the target clamps to 100%
-		expect(progressInfo(ch, EChallengeGoalComparison.AtMost, 52).percent).toBe(100);
 	});
 });
 

--- a/UI/src/tests/routes/game/screens/codex/codex-view.svelte.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/codex-view.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { flushSync } from 'svelte';
 import {
 	EAttribute,
+	EChallengeGoalComparison,
 	EChallengeType,
 	EEntityType,
 	EModifierType,
@@ -435,6 +436,36 @@ describe('CodexView dossier projections', () => {
 		const view = new CodexView();
 		view.enemiesTab.selectEnemy(0);
 		expect(view.enemiesTab.challenges[0].progressText).toBe('100/100');
+	});
+
+	it('renders an atMost (time-trial) enemy-scoped challenge as best-vs-target, not accumulating progress', () => {
+		staticData.challengeTypes = [
+			...staticData.challengeTypes,
+			{ id: EChallengeType.TimeTrial, goalComparison: EChallengeGoalComparison.AtMost, name: 'Time Trial' }
+		];
+		staticData.challenges = [
+			...staticData.challenges,
+			{
+				id: 3,
+				name: 'Quick Kill',
+				challengeTypeId: EChallengeType.TimeTrial,
+				entityType: EEntityType.Enemy,
+				targetEntityId: 0,
+				progressGoal: 60
+			}
+		];
+		// No qualifying run yet -- must not read as "0/60" (as if progress exists).
+		const notYet = new CodexView();
+		notYet.enemiesTab.selectEnemy(0);
+		expect(notYet.enemiesTab.challenges.find((c) => c.id === 3)?.progressText).toBe('no time yet · ≤1:00');
+
+		// A 45s best beats the 60s target -- must not render as "45/60" (looking three-quarters incomplete).
+		playerChallenges.all = [...playerChallenges.all, { challengeId: 3, progress: 45, completed: true }];
+		const beaten = new CodexView();
+		beaten.enemiesTab.selectEnemy(0);
+		expect(beaten.enemiesTab.challenges.find((c) => c.id === 3)).toEqual(
+			expect.objectContaining({ progressText: '45s best · ≤1:00', completed: true })
+		);
 	});
 
 	it('hides a retired enemy-scoped challenge unless it was already completed', () => {


### PR DESCRIPTION
## Summary

`enemies-tab-view.svelte.ts`'s dossier challenges panel rendered every enemy-scoped challenge as `progress/goal`, ignoring the challenge type's goal-comparison direction. The main Challenges screen already branches on `EChallengeGoalComparison.AtMost` (best-vs-target proximity, since lower is better for a minimisation goal like a time trial) — the dossier didn't, so a beaten "defeat this boss in under 60s" trial with a 45s best rendered as `45/60`, reading as three-quarters *incomplete* rather than beaten. An unattempted AtMost challenge similarly rendered `0/60` as if progress existed.

## Fix

Per the issue's suggested direction, extracted the comparison-aware progress branch (previously private to the Challenges screen as `progressInfo`) into a shared `$lib/common/challenge-type` module so the dossier and the main screen can't drift on this again:

- `progressInfo(goal, comparison, progress)` — the comparison-aware maths, moved out of `challenges-view.svelte.ts` (which now calls the shared version).
- `comparisonFor(id, challengeTypes)` — the goal-comparison reference-data lookup, also de-duplicated between the two screens.
- `formatTime(seconds)` — moved out of the Challenges-screen-local `challenge-meta.ts` since the dossier now needs the same `45s`/`1:30` formatting for an AtMost readout.

The dossier's `progressText` now branches like the main screen: an AtMost challenge shows `"{best} best · ≤{target}"` (or `"no time yet · ≤{target}"` before a qualifying run), while an accumulating challenge keeps its existing `"{progress}/{goal}"` (and the goal-of-1 `"done"`/`"sealed"` special case).

## Test plan

- [x] Added `describe('progressInfo')`/`comparisonFor` coverage to `UI/src/tests/lib/common/challenge-type.test.ts` (moved from the Challenges-screen test file, plus new `comparisonFor` cases).
- [x] Added a Codex dossier test (`codex-view.svelte.test.ts`) with an AtMost/TimeTrial enemy-scoped challenge fixture: no-data case reads `"no time yet · ≤1:00"`, and a beaten 45s-best case reads `"45s best · ≤1:00"` rather than a misleading fraction.
- [x] `npm run lint` (eslint + svelte-check) — clean.
- [x] `npm run test:unit:ci` — full suite passes (no regressions).

Closes #2373

---
_Generated by [Claude Code](https://claude.ai/code/session_0127GCK9tgbBfPswaBpBkqQo)_