### PR TITLE
Workbench blocking warnings for five more backend hard-rejects (#2376)

### DIFF
--- a/UI/src/lib/common/attribute-display.ts
+++ b/UI/src/lib/common/attribute-display.ts
@@ -11,6 +11,19 @@ import { formatNum, normalizeText } from './functions';
  * (e.g. `challengeTypeName`).
  */
 
+/** The six core attributes a player directly invests stat points into — the frontend mirror of the
+ *  backend `Attribute.CoreAttributes` invariant (`Game.Core/Attributes/Attribute.cs`). Every other
+ *  attribute is "derived" (computed from these), so this is the meaningful measure of raw attribute
+ *  investment, deliberately kept distinct from the `attributeType` display taxonomy (spike #528). */
+export const CORE_ATTRIBUTES: EAttribute[] = [
+	EAttribute.Strength,
+	EAttribute.Endurance,
+	EAttribute.Intellect,
+	EAttribute.Agility,
+	EAttribute.Dexterity,
+	EAttribute.Luck
+];
+
 /** Suffix matching the `--attr-*` custom properties (e.g. `strength`). */
 const ATTRIBUTE_KEY: Partial<Record<EAttribute, string>> = {
 	[EAttribute.Strength]: 'strength',

--- a/UI/src/routes/admin/workbench/entities/attribute-table-sections.ts
+++ b/UI/src/routes/admin/workbench/entities/attribute-table-sections.ts
@@ -32,10 +32,11 @@ export const attributeDistributionSection = <T extends Identified>(config: {
 	 */
 	attributeFilter?: (attributeId: number) => boolean;
 }): TableSectionConfig<T> => {
+	const { attributeFilter } = config;
 	const rowsOf = (rec: T) => fieldsOf(rec)[config.itemsKey] as AttributeDistributionRow[];
 	const attributeOptions = () =>
-		config.attributeFilter
-			? reference.attributeOptions().filter((o) => config.attributeFilter!(o.value))
+		attributeFilter
+			? reference.attributeOptions().filter((o) => attributeFilter(o.value))
 			: reference.attributeOptions();
 	return {
 		key: config.key,
@@ -50,7 +51,7 @@ export const attributeDistributionSection = <T extends Identified>(config: {
 			}
 			// A row can violate the restriction even though the picker excludes it from new authoring —
 			// e.g. it was set before the restriction existed. Hard-rejected on save, so it blocks (#2376).
-			const violator = config.attributeFilter && rows.find((r) => !config.attributeFilter!(r.attributeId));
+			const violator = attributeFilter && rows.find((r) => !attributeFilter(r.attributeId));
 			if (violator) {
 				return {
 					message: `'${attributeName(violator.attributeId, staticData.attributes)}' is not a core attribute and cannot have a distribution here`,

--- a/UI/src/routes/admin/workbench/entities/attribute-table-sections.ts
+++ b/UI/src/routes/admin/workbench/entities/attribute-table-sections.ts
@@ -1,3 +1,5 @@
+import { attributeName } from '$lib/common';
+import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import { firstFree } from './helpers';
 import { fieldsOf, type Identified, type TableSectionConfig } from './types';
@@ -23,15 +25,40 @@ export const attributeDistributionSection = <T extends Identified>(config: {
 	itemsKey: keyof T & string;
 	desc: string;
 	emptySub: string;
+	/**
+	 * Restricts which attributes are selectable/valid in this table — e.g. a class distribution is
+	 * core-attribute-only (`AdminClasses.FindAttributeDistributionViolation`), while an enemy's stays
+	 * unrestricted. Omit for no restriction.
+	 */
+	attributeFilter?: (attributeId: number) => boolean;
 }): TableSectionConfig<T> => {
 	const rowsOf = (rec: T) => fieldsOf(rec)[config.itemsKey] as AttributeDistributionRow[];
+	const attributeOptions = () =>
+		config.attributeFilter
+			? reference.attributeOptions().filter((o) => config.attributeFilter!(o.value))
+			: reference.attributeOptions();
 	return {
 		key: config.key,
 		label: 'Attributes',
 		glyph: 'bars',
 		desc: config.desc,
 		count: (rec) => rowsOf(rec).length,
-		warn: (rec) => (rowsOf(rec).length ? null : 'No attribute distribution'),
+		warn: (rec) => {
+			const rows = rowsOf(rec);
+			if (!rows.length) {
+				return 'No attribute distribution';
+			}
+			// A row can violate the restriction even though the picker excludes it from new authoring —
+			// e.g. it was set before the restriction existed. Hard-rejected on save, so it blocks (#2376).
+			const violator = config.attributeFilter && rows.find((r) => !config.attributeFilter!(r.attributeId));
+			if (violator) {
+				return {
+					message: `'${attributeName(violator.attributeId, staticData.attributes)}' is not a core attribute and cannot have a distribution here`,
+					blocking: true
+				};
+			}
+			return null;
+		},
 		kind: 'table',
 		itemsKey: config.itemsKey,
 		rowKey: 'attributeId',
@@ -42,7 +69,7 @@ export const attributeDistributionSection = <T extends Identified>(config: {
 		newRow: (rec) => ({
 			attributeId: firstFree(
 				rowsOf(rec).map((a) => a.attributeId),
-				reference.attributeOptions()
+				attributeOptions()
 			),
 			baseAmount: 0,
 			amountPerLevel: 0
@@ -52,7 +79,7 @@ export const attributeDistributionSection = <T extends Identified>(config: {
 				key: 'attributeId',
 				label: 'Attribute',
 				type: 'attribute',
-				options: reference.attributeOptions,
+				options: attributeOptions,
 				min: 190,
 				unique: true
 			},

--- a/UI/src/routes/admin/workbench/entities/class.ts
+++ b/UI/src/routes/admin/workbench/entities/class.ts
@@ -7,7 +7,7 @@ import {
 	fetchSocketData,
 	type IClass
 } from '$lib/api';
-import { hasFlag } from '$lib/common';
+import { CORE_ATTRIBUTES, hasFlag } from '$lib/common';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import { childChanged, guardedSave, persistEntity } from '../save-helpers';
@@ -226,7 +226,10 @@ export const classEntity: EntityConfig<WorkbenchClass> = {
 			key: 'attributes',
 			itemsKey: 'attributeDistributions',
 			desc: 'Locked-base stat distribution per level',
-			emptySub: 'This class has no stat distribution yet.'
+			emptySub: 'This class has no stat distribution yet.',
+			// Unlike an enemy's distribution, a class distribution is core-attribute-only
+			// (AdminClasses.FindAttributeDistributionViolation).
+			attributeFilter: (id) => CORE_ATTRIBUTES.includes(id)
 		})
 	],
 	refresh,

--- a/UI/src/routes/admin/workbench/entities/item.ts
+++ b/UI/src/routes/admin/workbench/entities/item.ts
@@ -71,7 +71,9 @@ export const itemEntity: EntityConfig<WorkbenchItem> = {
 			// granted skill's own signature type must match the weapon's (FindWeaponInvariantViolation).
 			// Independently, any granted skill (weapon or not) must stay Item-flagged — the picker's
 			// `keep` exception leaves a flag-lost grant visible as a stale value, so this is the
-			// backstop (FindGrantedSkillFlagViolation).
+			// backstop (FindGrantedSkillFlagViolation). A gating proficiency must also stay live and
+			// the required level must stay in its range (FindProficiencyGateViolation) — the picker
+			// only excludes a retired proficiency from new authoring, not one retired after the fact.
 			warn: (it) => {
 				if (it.itemCategoryId === EItemCategory.Weapon) {
 					if (it.weaponType === -1) {
@@ -100,6 +102,23 @@ export const itemEntity: EntityConfig<WorkbenchItem> = {
 							message: `Granted skill '${grantedSkill.name}' is no longer flagged as Item-acquirable`,
 							blocking: true
 						};
+					}
+				}
+				if (it.requiredProficiencyId != null && it.requiredProficiencyId !== -1) {
+					const proficiency = staticData.proficiencies?.[it.requiredProficiencyId];
+					if (proficiency) {
+						if (proficiency.retiredAt) {
+							return {
+								message: `Required proficiency '${proficiency.name}' is retired and cannot gate an item`,
+								blocking: true
+							};
+						}
+						if (it.requiredProficiencyLevel < 1 || it.requiredProficiencyLevel > proficiency.maxLevel) {
+							return {
+								message: `Required proficiency level must be between 1 and ${proficiency.maxLevel} for '${proficiency.name}'`,
+								blocking: true
+							};
+						}
 					}
 				}
 				return null;

--- a/UI/src/routes/admin/workbench/entities/lesson.ts
+++ b/UI/src/routes/admin/workbench/entities/lesson.ts
@@ -55,6 +55,11 @@ export const lessonEntity: EntityConfig<WorkbenchLesson> = {
 				if (l.triggerType === ELessonTriggerType.ScreenVisit && l.triggerMechanicEvent !== -1) {
 					return { message: 'Screen-visit lessons cannot also carry a mechanic-event trigger', blocking: true };
 				}
+				// A key must be unique across every lesson, including retired ones (which still hold their key) —
+				// hard-rejected by AdminLessons.FindKeyCollision, so it blocks Save (#2217).
+				if (l.key && staticData.lessons?.some((other) => other.id !== l.id && other.key === l.key)) {
+					return { message: `Another lesson already uses the key '${l.key}'`, blocking: true };
+				}
 				return null;
 			},
 			fields: [

--- a/UI/src/routes/admin/workbench/entities/skill-recipe.ts
+++ b/UI/src/routes/admin/workbench/entities/skill-recipe.ts
@@ -12,10 +12,12 @@ import { chipsSection, type EntityConfig } from './types';
  * (and retirement); the input skills and proficiency conditions are persisted through their own relationship
  * setters (the `persistEntity` child-saver pattern, mirroring how the class editor saves its child collections).
  *
- * The result/input pickers exclude retired skills (a hard block; an already-authored value stays visible), and
- * the result picker is further restricted to Synthesis-flagged skills. The remaining authoritative checks
- * (acyclicity/reachability, an input equal to the result, the proficiency-level range) live on the backend and
- * surface as a save-failure toast; the cheap, local rules are flagged as warnings here.
+ * The result/input pickers exclude retired skills (a hard block; an already-authored value stays visible), the
+ * result picker is further restricted to Synthesis-flagged skills not already claimed by another live recipe
+ * (one producing recipe per skill), and the condition-level warn covers the level range against the gating
+ * proficiency's own MaxLevel. The one remaining authoritative check the backend owns alone — acyclicity/
+ * reachability of the recipe graph — surfaces as a save-failure toast; everything else cheap enough to check
+ * locally is flagged as a warning here.
  */
 // Written through to staticData.skillRecipes so retire-confirm's reference computation (recipe-result/
 // recipe-input/recipe-condition groups) sees post-save edits, mirroring how entities/skill.ts writes through (#1633).
@@ -38,7 +40,7 @@ export const skillRecipeEntity: EntityConfig<ISkillRecipe> = {
 	newItem: (id) => ({
 		id,
 		// Default to the first authorable Synthesis result; -1 (no valid option yet) surfaces as a warning.
-		resultSkillId: reference.synthesisResultSkillOptions()[0]?.value ?? -1,
+		resultSkillId: reference.availableSynthesisResultSkillOptions()[0]?.value ?? -1,
 		designerNotes: '',
 		inputSkillIds: [],
 		conditions: []
@@ -72,7 +74,7 @@ export const skillRecipeEntity: EntityConfig<ISkillRecipe> = {
 					key: 'resultSkillId',
 					label: 'Result Skill',
 					type: 'select',
-					options: reference.synthesisResultSkillOptions,
+					options: reference.availableSynthesisResultSkillOptions,
 					width: 260
 				},
 				{
@@ -116,11 +118,25 @@ export const skillRecipeEntity: EntityConfig<ISkillRecipe> = {
 			glyph: 'gauge',
 			desc: 'Proficiency-level gates that must be met',
 			count: (r) => r.conditions.length,
-			// Hard-rejected by AdminSkillRecipes.SetConditions, so it blocks Save (#2217).
-			warn: (r) =>
-				r.conditions.some((c) => c.minLevel < 1)
-					? { message: 'Condition level must be at least 1', blocking: true }
-					: null,
+			// Hard-rejected by AdminSkillRecipes.SetConditions, so it blocks Save (#2217); a level above
+			// the gating proficiency's own MaxLevel is equally rejected (AdminSkillRecipes.cs:152).
+			warn: (r) => {
+				if (r.conditions.some((c) => c.minLevel < 1)) {
+					return { message: 'Condition level must be at least 1', blocking: true };
+				}
+				const overCap = r.conditions.find((c) => {
+					const proficiency = staticData.proficiencies?.[c.proficiencyId];
+					return proficiency && c.minLevel > proficiency.maxLevel;
+				});
+				if (overCap) {
+					const proficiency = staticData.proficiencies?.[overCap.proficiencyId];
+					return {
+						message: `Condition level exceeds '${proficiency?.name}'s max level (${proficiency?.maxLevel})`,
+						blocking: true
+					};
+				}
+				return null;
+			},
 			kind: 'table',
 			itemsKey: 'conditions',
 			rowKey: 'proficiencyId',

--- a/UI/src/routes/admin/workbench/entities/skill.ts
+++ b/UI/src/routes/admin/workbench/entities/skill.ts
@@ -123,7 +123,8 @@ export const skillEntity: EntityConfig<ISkill> = {
 					flags: [
 						{ label: 'Player', value: ESkillAcquisition.Player },
 						{ label: 'Item', value: ESkillAcquisition.Item },
-						{ label: 'Enemy', value: ESkillAcquisition.Enemy }
+						{ label: 'Enemy', value: ESkillAcquisition.Enemy },
+						{ label: 'Synthesis', value: ESkillAcquisition.Synthesis }
 					]
 				},
 				{

--- a/UI/src/routes/admin/workbench/reference.svelte.ts
+++ b/UI/src/routes/admin/workbench/reference.svelte.ts
@@ -239,6 +239,20 @@ class WorkbenchReference {
 		const skill = staticData.skills?.[id];
 		return !!skill && !skill.retiredAt && hasFlag(skill.acquisition, ESkillAcquisition.Synthesis);
 	};
+	/**
+	 * {@link synthesisResultSkillOptions} narrowed further: a skill already claimed as another live
+	 * recipe's result is excluded from new authoring too (`AdminSkillRecipes.FindDuplicateResultViolation`
+	 * — each Synthesis skill may have only one producing recipe). The current value stays selectable even
+	 * if it's this recipe's own already-claimed result.
+	 */
+	availableSynthesisResultSkillOptions = (current?: number): SelectOption[] => {
+		const claimed = new Set(
+			(staticData.skillRecipes ?? [])
+				.filter((r) => !r.retiredAt && r.resultSkillId !== current)
+				.map((r) => r.resultSkillId)
+		);
+		return this.synthesisResultSkillOptions(current).filter((o) => !claimed.has(o.value));
+	};
 
 	// ── Progression (paths & proficiencies) ──
 	/**

--- a/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
+++ b/UI/src/routes/game/screens/attributes/attributes-view.svelte.ts
@@ -31,7 +31,7 @@ import {
 	type ISkill
 } from '$lib/api';
 import { BattleAttributes, isSkillDormant } from '$lib/battle';
-import { attributeName, SaveFlash } from '$lib/common';
+import { attributeName, CORE_ATTRIBUTES, SaveFlash } from '$lib/common';
 import { safeLocalStorage } from '$lib/common/local-storage';
 import { inventoryManager, playerManager } from '$lib/engine';
 import { staticData, toastError } from '$stores';
@@ -47,20 +47,12 @@ const sum = (arr: number[]): number => arr.reduce((a, b) => a + b, 0);
  *  which a coarser 2-decimal round would collapse to zero and drop from the surfaced yields. */
 const roundYield = (n: number): number => Math.round(n * 1e6) / 1e6;
 
-/** The six core attributes that accept stat-point allocation (EAttribute 0..5), in display order.
- *  This is the **allocation domain** (the frontend mirror of the backend `Attribute.CoreAttributes`
- *  invariant), deliberately kept distinct from the `attributeType` display taxonomy — the spike (#528)
- *  warns the two must not be collapsed, though the `Primary` set is expected to equal this one. The
- *  per-attribute display metadata (name/code) is read from the reference set via `attributeName`/
- *  `attributeCode`; only the allocatable membership stays a domain constant here. */
-export const CORE_ATTRIBUTES: EAttribute[] = [
-	EAttribute.Strength,
-	EAttribute.Endurance,
-	EAttribute.Intellect,
-	EAttribute.Agility,
-	EAttribute.Dexterity,
-	EAttribute.Luck
-];
+/** Re-exported for this screen's own consumers (`Attributes.svelte`, `TheoryRow.svelte`, etc.), which
+ *  import it from here rather than reaching into `$lib/common` directly — the allocation domain
+ *  (EAttribute 0..5, in display order) now lives in `$lib/common/attribute-display` since the admin
+ *  Workbench needs it too (a class's stat distribution is core-attribute-only), but this screen is
+ *  still where its "allocation domain" meaning is documented. */
+export { CORE_ATTRIBUTES };
 
 /** Display grouping for the derived-stats panel. Rendered in this order; groups
  *  with no surfaced stats are skipped. */

--- a/UI/src/tests/routes/admin/workbench/entities/attribute-table-sections.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/attribute-table-sections.test.ts
@@ -50,6 +50,44 @@ describe('attributeDistributionSection', () => {
 	});
 });
 
+describe('attributeDistributionSection with an attributeFilter (#2376)', () => {
+	// A stand-in restriction (only even-numbered attribute ids) exercising the filter plumbing without
+	// depending on the real EAttribute/CoreAttributes membership.
+	const filtered = attributeDistributionSection<Distributed>({
+		key: 'attrs',
+		itemsKey: 'dist',
+		desc: 'Restricted distribution',
+		emptySub: 'No distribution yet.',
+		attributeFilter: (id) => id % 2 === 0
+	});
+
+	it('excludes filtered-out attributes from the picker options', () => {
+		const options = filtered.columns[0].options?.();
+		expect(options?.some((o) => o.value % 2 !== 0)).toBe(false);
+	});
+
+	it('newRow only picks a free attribute that passes the filter', () => {
+		// id 0 is taken; the next even id (2) is picked over the odd id 1.
+		const rec: Distributed = { id: 0, dist: [{ attributeId: 0, baseAmount: 0, amountPerLevel: 0 }] };
+		expect(filtered.newRow(rec).attributeId).toBe(2);
+	});
+
+	it('warns when an existing row violates the filter, blocking Save', () => {
+		const violating: Distributed = { id: 0, dist: [{ attributeId: 1, baseAmount: 1, amountPerLevel: 0 }] };
+		const warning = filtered.warn?.(violating);
+		expect(warning).toMatchObject({ blocking: true });
+	});
+
+	it('does not warn when every row passes the filter', () => {
+		const clean: Distributed = { id: 0, dist: [{ attributeId: 0, baseAmount: 1, amountPerLevel: 0 }] };
+		expect(filtered.warn?.(clean)).toBeNull();
+	});
+
+	it('still reports the advisory empty-collection warning when there are no rows', () => {
+		expect(filtered.warn?.({ id: 0, dist: [] })).toBe('No attribute distribution');
+	});
+});
+
 describe('attributeBonusSection', () => {
 	const section = attributeBonusSection<Bonused>({
 		itemsKey: 'bonuses',

--- a/UI/src/tests/routes/admin/workbench/entities/class.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/class.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EAttribute, EEquipmentSlot, EItemCategory, EModifierType, ESkillAcquisition } from '$lib/api';
 import type { ChipsSectionConfig, TableSectionConfig } from '$routes/admin/workbench/entities/types';
 
+/** A non-core, derived attribute — any id past the six-member core set works for the restriction tests. */
+const NON_CORE_ATTRIBUTE = EAttribute.MaxHealth;
+
 /* Only the refresh() write-through added for #1633 — classEntity's field/table configs aren't touched here.
    `fetchSocketData` is stubbed; the write-through into staticData.classes is what retire-confirm's reference
    computation (starter-skill/starter-equipment groups) reads. */
@@ -163,5 +166,32 @@ describe('starterSkills chips section (#2333)', () => {
 
 	it('warn falls back to the advisory "no starter skills" nag when the list is empty', () => {
 		expect(starterSkillsSection().warn?.(classEntity.newItem(0))).toBe('No starter skills');
+	});
+});
+
+describe('attributes distribution section (#2376)', () => {
+	const attributesSection = () =>
+		classEntity.sections.find((s) => s.key === 'attributes') as TableSectionConfig<WorkbenchClass>;
+
+	it("the attribute picker offers only core attributes, unlike an enemy's unrestricted one", () => {
+		const options = attributesSection().columns[0].options?.();
+		expect(options?.some((o) => o.value === NON_CORE_ATTRIBUTE)).toBe(false);
+		expect(options?.some((o) => o.value === EAttribute.Strength)).toBe(true);
+	});
+
+	it('warns a distribution row on a non-core attribute, blocking Save (backend-enforced)', () => {
+		const cls: WorkbenchClass = {
+			...classEntity.newItem(0),
+			attributeDistributions: [{ attributeId: NON_CORE_ATTRIBUTE, baseAmount: 1, amountPerLevel: 0 }]
+		};
+		expect(attributesSection().warn?.(cls)).toMatchObject({ blocking: true });
+	});
+
+	it('does not warn a distribution made up entirely of core attributes', () => {
+		const cls: WorkbenchClass = {
+			...classEntity.newItem(0),
+			attributeDistributions: [{ attributeId: EAttribute.Strength, baseAmount: 1, amountPerLevel: 0 }]
+		};
+		expect(attributesSection().warn?.(cls)).toBeNull();
 	});
 });

--- a/UI/src/tests/routes/admin/workbench/entities/item.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/item.test.ts
@@ -162,6 +162,41 @@ describe('itemEntity weapon type', () => {
 		expect(identityWarn(cloak)).toBeNull();
 	});
 
+	it('warns a gate pointing at a retired proficiency, blocking Save (#2376, backend-enforced)', () => {
+		staticData.proficiencies = [{ id: 0, name: 'Swordsmanship', maxLevel: 10, retiredAt: '2026-01-01T00:00:00Z' }];
+		const gated: WorkbenchItem = {
+			...itemEntity.newItem(1),
+			requiredProficiencyId: 0,
+			requiredProficiencyLevel: 5
+		};
+		expect(identityWarn(gated)).toEqual({
+			message: "Required proficiency 'Swordsmanship' is retired and cannot gate an item",
+			blocking: true
+		});
+	});
+
+	it("warns a required level outside the gating proficiency's [1, MaxLevel] range, blocking Save (#2376)", () => {
+		staticData.proficiencies = [{ id: 0, name: 'Swordsmanship', maxLevel: 10, retiredAt: null }];
+		const tooHigh: WorkbenchItem = { ...itemEntity.newItem(1), requiredProficiencyId: 0, requiredProficiencyLevel: 11 };
+		expect(identityWarn(tooHigh)).toEqual({
+			message: "Required proficiency level must be between 1 and 10 for 'Swordsmanship'",
+			blocking: true
+		});
+
+		const tooLow: WorkbenchItem = { ...itemEntity.newItem(1), requiredProficiencyId: 0, requiredProficiencyLevel: 0 };
+		expect(identityWarn(tooLow)).toEqual({
+			message: "Required proficiency level must be between 1 and 10 for 'Swordsmanship'",
+			blocking: true
+		});
+	});
+
+	it('accepts a live, in-range proficiency gate, and an ungated item', () => {
+		staticData.proficiencies = [{ id: 0, name: 'Swordsmanship', maxLevel: 10, retiredAt: null }];
+		const gated: WorkbenchItem = { ...itemEntity.newItem(1), requiredProficiencyId: 0, requiredProficiencyLevel: 10 };
+		expect(identityWarn(gated)).toBeNull();
+		expect(identityWarn(itemEntity.newItem(1))).toBeNull();
+	});
+
 	it('weaponTypeOptions offers None plus every damage-type leaf, martial or caster', () => {
 		const options = reference.weaponTypeOptions();
 		expect(options[0]).toEqual({ value: -1, text: 'None' });

--- a/UI/src/tests/routes/admin/workbench/entities/lesson.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/lesson.test.ts
@@ -126,6 +126,28 @@ describe('lessonEntity', () => {
 		expect(identity && 'warn' in identity ? identity.warn?.(lessonEntity.newItem(0)) : null).toBeNull();
 	});
 
+	it('warns when another lesson (including a retired one) already uses the key, blocking Save (#2376, backend-enforced)', () => {
+		staticData.lessons = [
+			{ ...screenVisitLesson(), id: 1, key: 'idle-loop-basics' },
+			{ ...screenVisitLesson(), id: 2, key: 'retired-key', retiredAt: '2026-01-01T00:00:00Z' }
+		];
+		const identity = lessonEntity.sections.find((s) => s.key === 'identity');
+		const warn = (l: ReturnType<typeof lessonEntity.newItem>) =>
+			identity && 'warn' in identity ? identity.warn?.(l) : null;
+
+		expect(warn({ ...lessonEntity.newItem(3), key: 'idle-loop-basics' })).toEqual({
+			message: "Another lesson already uses the key 'idle-loop-basics'",
+			blocking: true
+		});
+		// A retired lesson's key still collides (it still holds the key, mirroring AdminLessons.FindKeyCollision).
+		expect(warn({ ...lessonEntity.newItem(3), key: 'retired-key' })).toEqual({
+			message: "Another lesson already uses the key 'retired-key'",
+			blocking: true
+		});
+		// Editing lesson 1 itself keeps its own key selectable — it isn't a collision with itself.
+		expect(warn({ ...lessonEntity.newItem(1), id: 1, key: 'idle-loop-basics' })).toBeNull();
+	});
+
 	it('persist maps the -1 sentinel back to an absent mechanic-event trigger and drops steps', async () => {
 		const record = { ...lessonEntity.newItem(0), key: 'idle-loop-basics', name: 'New', triggerMechanicEvent: -1 };
 		const baseline = { ...record, name: 'Old' };

--- a/UI/src/tests/routes/admin/workbench/entities/skill-recipe.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/skill-recipe.test.ts
@@ -79,8 +79,8 @@ beforeEach(() => {
 		skill(5, 'Old Flame', { synth: true, retired: true })
 	];
 	staticData.proficiencies = [
-		{ id: 0, name: 'Fire', retiredAt: null },
-		{ id: 1, name: 'Earth', retiredAt: null }
+		{ id: 0, name: 'Fire', maxLevel: 10, retiredAt: null },
+		{ id: 1, name: 'Earth', maxLevel: 10, retiredAt: null }
 	];
 });
 
@@ -136,6 +136,29 @@ describe('skillRecipeEntity', () => {
 		]);
 	});
 
+	it('the result picker excludes a Synthesis skill already claimed by another live recipe (#2376)', () => {
+		staticData.skills = [
+			...staticData.skills,
+			skill(6, 'Cinder', { synth: true }) // a second Synthesis-flagged skill, unclaimed
+		];
+		staticData.skillRecipes = [recipe({ id: 0, resultSkillId: 3 })]; // Lava already has a producing recipe
+		const options = fieldsSection('result').fields[0].options;
+
+		// A brand-new recipe (no current value) must not offer the already-claimed Lava.
+		expect(options?.()).toEqual([{ value: 6, text: 'Cinder' }]);
+		// Editing the recipe that itself owns the Lava claim keeps Lava selectable (it's not a duplicate of itself).
+		expect(options?.(3)).toEqual([
+			{ value: 3, text: 'Lava' },
+			{ value: 6, text: 'Cinder' }
+		]);
+	});
+
+	it('newItem defaults skip a Synthesis skill already claimed by a live recipe (#2376)', () => {
+		staticData.skillRecipes = [recipe({ id: 0, resultSkillId: 3 })]; // Lava already claimed
+		staticData.skills = [...staticData.skills, skill(6, 'Cinder', { synth: true })];
+		expect(skillRecipeEntity.newItem(7).resultSkillId).toBe(6);
+	});
+
 	it('the inputs catalogue blocks adding a retired skill but keeps it visible', () => {
 		const catalogue = chipsSection('inputs').catalogue();
 		expect(catalogue.find((c) => c.id === 0)).toMatchObject({ name: 'Ember', addable: true });
@@ -178,6 +201,15 @@ describe('skillRecipeEntity', () => {
 		expect(warn?.(recipe({ conditions: [{ proficiencyId: 0, minLevel: 1 }] }))).toBeNull();
 		expect(warn?.(recipe({ conditions: [{ proficiencyId: 0, minLevel: 0 }] }))).toEqual({
 			message: 'Condition level must be at least 1',
+			blocking: true
+		});
+	});
+
+	it("warns when a condition level exceeds its proficiency's MaxLevel, blocking Save (#2376, backend-enforced)", () => {
+		const warn = tableSection('conditions').warn;
+		expect(warn?.(recipe({ conditions: [{ proficiencyId: 0, minLevel: 10 }] }))).toBeNull();
+		expect(warn?.(recipe({ conditions: [{ proficiencyId: 0, minLevel: 11 }] }))).toEqual({
+			message: "Condition level exceeds 'Fire's max level (10)",
 			blocking: true
 		});
 	});

--- a/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
@@ -102,6 +102,18 @@ describe('skillEntity', () => {
 		expect(rarityField).toMatchObject({ type: 'select', label: 'Rarity' });
 	});
 
+	it('the acquisition field offers Synthesis alongside Player/Item/Enemy (#2376)', () => {
+		const identity = skillEntity.sections.find((s) => s.key === 'identity');
+		const fields = identity && 'fields' in identity ? identity.fields : [];
+		const acquisitionField = fields.find((f) => f.key === 'acquisition');
+		expect(acquisitionField?.flags?.map((f) => f.value)).toEqual([
+			ESkillAcquisition.Player,
+			ESkillAcquisition.Item,
+			ESkillAcquisition.Enemy,
+			ESkillAcquisition.Synthesis
+		]);
+	});
+
 	it('meta shows the damage, multiplier count, effect count and cooldown', () => {
 		const skill: ISkill = {
 			...skillEntity.newItem(1),


### PR DESCRIPTION
## Summary

Follow-up to #2350/#2333/#2276 — the same class of gap (a backend `AdminSaveResult.Failure` hard-reject the Workbench neither warns about nor blocks Save for). Closes all five gaps listed in #2376:

1. **Skill editor can now author the `Synthesis` acquisition flag.** `entities/skill.ts`'s acquisition field previously offered only Player/Item/Enemy, so a newly-authored skill could never be flagged as a synthesis result — new synthesis content was unauthorable end-to-end. Added the missing flag option.
2. **Item proficiency-gate rejects are now warned.** `entities/item.ts`'s identity warn now covers `AdminItems.FindProficiencyGateViolation`: a retired `RequiredProficiencyId`, or a `RequiredProficiencyLevel` outside `[1, MaxLevel]`.
3. **Class distributions are restricted to core attributes.** `AdminClasses.FindAttributeDistributionViolation` hard-rejects any non-core attribute in a *class* distribution (enemies stay unrestricted). Added an optional `attributeFilter` to the shared `attributeDistributionSection` factory, applied only by `class.ts`. This needed the six-member core-attribute set, previously private to the Attributes screen (`attributes-view.svelte.ts`) — moved it to `$lib/common/attribute-display.ts` as `CORE_ATTRIBUTES` so the Workbench can reuse it without pulling game-engine imports into the admin bundle; the Attributes screen re-exports it for its own existing consumers.
4. **Skill recipes: duplicate-result rule now enforced client-side.** Added `reference.availableSynthesisResultSkillOptions`, which narrows the result picker to exclude a Synthesis skill already claimed by another *live* recipe (`AdminSkillRecipes.FindDuplicateResultViolation` — one producing recipe per skill), used by both the result field and `newItem`'s default. Also extended the conditions warn to cover `minLevel > proficiency.MaxLevel` (previously only `minLevel < 1` was checked).
5. **Duplicate lesson keys are now warned.** `entities/lesson.ts`'s identity warn now covers `AdminLessons.FindKeyCollision` — a key collision against another lesson, including a retired one (which still holds its key, matching the backend's own check).

All five follow the same pattern as #2350: blocking `warn`s (or a picker exclusion for the duplicate-result case, per the challenge-reward picker precedent) mirroring each backend guard.

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean, 0 errors/warnings.
- [x] `npm run test:unit:ci` — full frontend suite green (3987 tests).
- [x] New/extended unit tests for each of the five gaps in `entities/*.test.ts` and `attribute-table-sections.test.ts`, pinning both the warn/exclusion behavior and the non-restricted (enemy) case staying unaffected.
- [x] `dotnet build` — 0 warnings, 0 errors (backend untouched by this PR; confirms nothing else broke).

Closes #2376

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BA3yA8VwWX3wyMYXxXwkAH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BA3yA8VwWX3wyMYXxXwkAH)_