### PR TITLE
Fix logout() reading a stale refresh token ahead of ApiRequest's rotation

### DIFF
--- a/UI/src/lib/api/logout.ts
+++ b/UI/src/lib/api/logout.ts
@@ -1,5 +1,6 @@
 import { ApiRequest } from './api-request';
-import { clearTokens, getRefreshToken } from './token-store';
+import { getRotatedRefreshToken } from './auth';
+import { clearTokens } from './token-store';
 
 /**
  * Ends the current session: revokes the refresh token on the server, clears the locally stored token
@@ -11,7 +12,9 @@ import { clearTokens, getRefreshToken } from './token-store';
  * no stored tokens and keeps the user on the login screen.
  */
 export const logout = async () => {
-	const refreshToken = getRefreshToken();
+	// Settled before reading, so a refresh due to fire inside ApiRequest's own pre-emptive check
+	// (execute -> ensureValidAccessToken) can't rotate the token out from under this read (#2386).
+	const refreshToken = await getRotatedRefreshToken();
 	try {
 		if (refreshToken) {
 			await new ApiRequest('Auth/Logout').post({ refreshToken });

--- a/UI/src/tests/lib/api/logout.test.ts
+++ b/UI/src/tests/lib/api/logout.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const postMock = vi.fn();
-const constructorMock = vi.fn();
+const { postMock, constructorMock, getRotatedRefreshTokenMock } = vi.hoisted(() => ({
+	postMock: vi.fn(),
+	constructorMock: vi.fn(),
+	getRotatedRefreshTokenMock: vi.fn()
+}));
 
 vi.mock('$lib/api/api-request', () => ({
 	ApiRequest: class {
@@ -10,6 +13,10 @@ vi.mock('$lib/api/api-request', () => ({
 		}
 		post = postMock;
 	}
+}));
+
+vi.mock('$lib/api/auth', () => ({
+	getRotatedRefreshToken: getRotatedRefreshTokenMock
 }));
 
 import { logout } from '$lib/api/logout';
@@ -21,6 +28,7 @@ describe('logout', () => {
 	beforeEach(() => {
 		constructorMock.mockReset();
 		postMock.mockReset().mockResolvedValue({ status: 200 });
+		getRotatedRefreshTokenMock.mockReset().mockImplementation(async () => getTokens()?.refreshToken ?? null);
 		localStorage.clear();
 		setTokens({ accessToken: 'access', refreshToken: 'refresh' });
 		originalLocation = window.location;
@@ -75,5 +83,16 @@ describe('logout', () => {
 		await pending;
 
 		expect(window.location.href).toBe('/');
+	});
+
+	it('sends the token getRotatedRefreshToken resolves, settled before ApiRequest can rotate it (#2386)', async () => {
+		// A pre-emptive refresh due inside ApiRequest's own execute() can rotate the stored refresh
+		// token out from under a plain read; getRotatedRefreshToken settles that first so the token
+		// sent here is the one actually live in storage.
+		getRotatedRefreshTokenMock.mockResolvedValue('rotated');
+
+		await logout();
+
+		expect(postMock).toHaveBeenCalledWith({ refreshToken: 'rotated' });
 	});
 });


### PR DESCRIPTION
## Summary

- `logout()` read `getRefreshToken()` directly into the `Auth/Logout` request body *before* `ApiRequest.post` ran. But `execute()` calls `ensureValidAccessToken()` first, which rotates the single-use refresh token whenever the access token is inside its 30s pre-expiry leeway — so if that race fired, `Auth/Logout` was sent the already-rotated-out (stale) token instead of the one now live in storage.
- Switches `logout.ts` to `getRotatedRefreshToken()` (added in #2370's fix), which settles any due pre-emptive refresh before reading the token — the same fix already applied to `CharacterSwitcher.switchPlayer` and `select/+page.svelte`'s `selectPlayer` for the identical race.

## How this addresses the issue

Implements #2386's suggested fix exactly: swap the direct `getRefreshToken()` read for `getRotatedRefreshToken()`.

Closes #2386

## Test plan

- [x] Added a unit test (`sends the token getRotatedRefreshToken resolves, settled before ApiRequest can rotate it (#2386)`) mirroring the existing #2370/#1767 regression tests in `character-switcher.test.ts`/`select-page.test.ts`.
- [x] `npm run lint` — 0 errors, 0 warnings.
- [x] `npm run test:unit:ci` (full suite) — 3,988 tests passed across 1,149 suites, coverage thresholds met.
- [x] Backend untouched; no `dotnet build`/`dotnet test` needed for this frontend-only change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nwn28R8uSxdkX5EeZLHsWP)_