### PR TITLE
Log rate-limiter 429 rejections to the structured request log (#2375)

### DIFF
--- a/Game.Api.Tests/Integration/AuthRateLimitLoggingTests.cs
+++ b/Game.Api.Tests/Integration/AuthRateLimitLoggingTests.cs
@@ -1,0 +1,82 @@
+using Game.Api.RateLimiting;
+using Game.TestInfrastructure.Base;
+using Game.TestInfrastructure.Fixtures;
+using Game.TestInfrastructure.Helpers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace Game.Api.Tests.Integration
+{
+    /// <summary>
+    /// Covers #2375: <c>UseRateLimiter</c> runs before <c>UseRequestLogging</c>, so a 429 short-circuits
+    /// before the structured request log ever fires. The rejection handler emits its own log entry instead.
+    /// </summary>
+    [Collection("Integration")]
+    public class AuthRateLimitLoggingTests : ApiIntegrationTestBase
+    {
+        private const int PermitLimit = 3;
+
+        // Field initializer runs before the base constructor so _capturingProvider is ready
+        // when CreateFactory is called from the base constructor.
+        private readonly CapturingLoggerProvider _capturingProvider = new();
+
+        private static readonly string LoggerCategory = typeof(RateLimiterServiceCollectionExtensions).FullName!;
+
+        public AuthRateLimitLoggingTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+            : base(containers, testOutputHelper) { }
+
+        protected override GameServerFactory CreateFactory(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
+        {
+            return new RateLimitedFactory(containers, testOutputHelper, _capturingProvider);
+        }
+
+        [Fact]
+        public async Task Rejection_LogsWarningWithPathAndIpPartitionKey()
+        {
+            var creds = new { Username = "nobody", Password = "wrong" };
+
+            for (var i = 0; i < PermitLimit; i++)
+            {
+                await Client.PostAsJsonAsync("/api/Auth", creds, CancellationToken);
+            }
+
+            var startIndex = _capturingProvider.Entries.Count;
+            var throttled = await Client.PostAsJsonAsync("/api/Auth", creds, CancellationToken);
+
+            var entry = Assert.Single(
+                _capturingProvider.Entries.Skip(startIndex), e => e.Category == LoggerCategory);
+
+            Assert.Equal(LogLevel.Warning, entry.Level);
+            Assert.Contains("Rate limit rejected", entry.Message);
+            Assert.Contains("/api/Auth", entry.Message);
+            Assert.Equal("IP", entry.Properties.Single(p => p.Key == "PartitionKeyType").Value);
+            // The in-memory TestServer has no socket peer, so every request shares the "unknown" partition
+            // key — this only pins that *some* IP-derived value (never the request body's credentials) is
+            // logged, not a real address.
+            Assert.NotNull(entry.Properties.Single(p => p.Key == "PartitionKey").Value);
+        }
+
+        private sealed class RateLimitedFactory(
+            IntegrationTestContainers containers, ITestOutputHelper testOutputHelper, CapturingLoggerProvider capturingProvider)
+            : GameServerFactory(containers, testOutputHelper, [capturingProvider])
+        {
+            protected override void ConfigureWebHost(IWebHostBuilder builder)
+            {
+                base.ConfigureWebHost(builder);
+
+                // Registered after the base config, so this small limit overrides the suite-wide high one.
+                builder.ConfigureAppConfiguration((_, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["RateLimiting:Auth:PermitLimit"] = PermitLimit.ToString(),
+                        ["RateLimiting:Auth:WindowSeconds"] = "60",
+                    });
+                });
+            }
+        }
+    }
+}

--- a/Game.Api/RateLimiting/RateLimiterServiceCollectionExtensions.cs
+++ b/Game.Api/RateLimiting/RateLimiterServiceCollectionExtensions.cs
@@ -64,6 +64,9 @@ namespace Game.Api.RateLimiting
             // which would pay full structured-logging volume under attack.
             var logger = context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>()
                 .CreateLogger(typeof(RateLimiterServiceCollectionExtensions).FullName!);
+            // OnRejected is registered globally, so it fires for every policy's rejections. "IP" is correct
+            // today since the only policy (auth) partitions purely by client IP; revisit if an
+            // account-partitioned policy is ever added.
             logger.LogWarning(
                 "Rate limit rejected {Path} PartitionKeyType={PartitionKeyType} PartitionKey={PartitionKey}",
                 context.HttpContext.Request.Path.Value, "IP", ClientIp.Resolve(context.HttpContext));

--- a/Game.Api/RateLimiting/RateLimiterServiceCollectionExtensions.cs
+++ b/Game.Api/RateLimiting/RateLimiterServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Game.Api.Models.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Globalization;
 using System.Threading.RateLimiting;
@@ -57,6 +58,15 @@ namespace Game.Api.RateLimiting
         private static async ValueTask OnRejected(OnRejectedContext context, CancellationToken token)
         {
             context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+
+            // UseRateLimiter runs before UseRequestLogging, so a 429 never reaches the structured request
+            // log otherwise (#2375) — log it here instead of moving the limiter into that middleware,
+            // which would pay full structured-logging volume under attack.
+            var logger = context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>()
+                .CreateLogger(typeof(RateLimiterServiceCollectionExtensions).FullName!);
+            logger.LogWarning(
+                "Rate limit rejected {Path} PartitionKeyType={PartitionKeyType} PartitionKey={PartitionKey}",
+                context.HttpContext.Request.Path.Value, "IP", ClientIp.Resolve(context.HttpContext));
 
             if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
             {


### PR DESCRIPTION
## Summary

- `Game.Api/Startup.cs:285-289`: `UseRateLimiter()` runs before `UseSessionLoader`/`UseRequestLogging`, so a 429 short-circuits before "Request Start"/"Request Ended" ever fire. During the exact incident the limiter exists for (credential stuffing against `/api/Auth`), the request log showed nothing about throttled traffic — an operator would see only the successful trickle.
- Fix: `OnRejected` in `Game.Api/RateLimiting/RateLimiterServiceCollectionExtensions.cs` now resolves an `ILogger` from the request's `RequestServices` and emits a `Warning`-level structured entry (`Rate limit rejected {Path} PartitionKeyType={PartitionKeyType} PartitionKey={PartitionKey}`) before writing the 429 response.
- Per the issue's own cost tradeoff, this logs from `OnRejected` rather than moving the rate limiter inside `RequestLoggingMiddleware`, which would pay full structured-logging volume for every request under attack instead of just the rejected ones.
- Logs the partition-key **kind** (currently always `"IP"`, since the only policy today — `BuildAuthPartition` — partitions solely by client IP) alongside the resolved key value, never the request body (so no credential ever reaches this log line — this layer doesn't have access to it anyway).

## How this addresses the issue

Implements #2375's suggested fix directly: emits a log/counter from `OnRejected` rather than restructuring the middleware pipeline, and includes the partition key's class without exposing anything credential-shaped.

Closes #2375

## Test plan

- [x] New integration test `AuthRateLimitLoggingTests.Rejection_LogsWarningWithPathAndIpPartitionKey` (`Game.Api.Tests/Integration/AuthRateLimitLoggingTests.cs`) — drives the auth endpoint past a small configured limit and asserts the `Warning`-level log entry's message, path, and `PartitionKeyType`/`PartitionKey` properties, using the existing `CapturingLoggerProvider` test helper (same pattern as `RequestLoggingTests`).
- [x] `dotnet build` (full solution) — 0 warnings, 0 errors.
- [x] `dotnet test` (full solution) — 3,480 tests passed (Game.Core.Tests, Game.Infrastructure.Tests, Game.Application.Tests, Game.Api.Tests), including the new test and the existing `AuthRateLimitingTests` suite.
- [x] Backend-only change; no frontend touched, so no `npm run lint`/`test:unit:ci` needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LS7B1XsjJbruGo9XCXmiqk)_