### PR TITLE
Write-behind read-path efficiency: single envelope parse + batched progress miss-reload (#2378)

### DIFF
--- a/Game.DataAccess/DataProviderSynchronizer.cs
+++ b/Game.DataAccess/DataProviderSynchronizer.cs
@@ -424,9 +424,10 @@ namespace Game.DataAccess
                         break;
                     }
 
-                    var playerId = PlayerUpdateEnvelopeReader.TryReadPlayerId(next) ?? UnknownPlayerLane;
+                    var (envelope, parseError) = PlayerUpdateEnvelopeReader.TryParseEnvelope(next);
+                    var playerId = envelope is null ? UnknownPlayerLane : PlayerUpdateEnvelopeReader.TryReadPlayerIdFromPayload(envelope.Payload) ?? UnknownPlayerLane;
                     var previous = playerLanes.TryGetValue(playerId, out var existingLane) ? existingLane : Task.CompletedTask;
-                    var itemTask = ProcessReservedItemAsync(previous, next, queue, deadLetterQueue, concurrencyGate, cancellationToken);
+                    var itemTask = ProcessReservedItemAsync(previous, next, envelope, parseError, queue, deadLetterQueue, concurrencyGate, cancellationToken);
                     playerLanes[playerId] = itemTask;
                     inFlight.Add(itemTask);
 
@@ -535,12 +536,12 @@ namespace Game.DataAccess
         /// converging, so a stop mid-drain still ends at a bounded number of in-flight items rather than an
         /// unbounded one.
         /// </summary>
-        private async Task ProcessReservedItemAsync(Task previous, string message, IPubSubQueue queue, IPubSubQueue deadLetterQueue, SemaphoreSlim concurrencyGate, CancellationToken cancellationToken)
+        private async Task ProcessReservedItemAsync(Task previous, string message, DomainEventEnvelope? envelope, JsonException? parseError, IPubSubQueue queue, IPubSubQueue deadLetterQueue, SemaphoreSlim concurrencyGate, CancellationToken cancellationToken)
         {
             try
             {
                 await previous;
-                await ProcessMessage(message, deadLetterQueue, cancellationToken);
+                await ProcessMessage(message, envelope, parseError, deadLetterQueue, cancellationToken);
                 await queue.AcknowledgeAsync(message);
             }
             finally
@@ -621,27 +622,26 @@ namespace Game.DataAccess
         }
 
         /// <summary>
-        /// Processes a single queued message. Malformed payloads (which can never succeed) are dead-lettered
-        /// immediately, while a valid event that fails on an unexpected error (e.g. a transient database error)
-        /// is retried with exponential backoff per <see cref="PlayerUpdateRetryPolicy"/>. Once retries are
-        /// exhausted, a genuine per-write failure is dead-lettered so the change is never silently dropped —
-        /// but a database-<b>infrastructure</b> failure (<see cref="InfrastructureFailureClassifier"/>) instead
-        /// propagates out of this method, leaving the item reserved rather than dead-lettered (see the catch
-        /// clause below and <see cref="SettleInFlightItemsAsync"/>). The apply itself runs uncancelled (so a
-        /// reserved item finishes cleanly); only the dead-time backoff between failed attempts honors
-        /// <paramref name="cancellationToken"/>, so a shutdown isn't stalled waiting one out.
+        /// Processes a single queued message. <paramref name="envelope"/>/<paramref name="parseError"/> are the
+        /// result of <see cref="DrainQueueAsync"/>'s single upfront <see cref="PlayerUpdateEnvelopeReader"/>
+        /// parse (reused here rather than re-deserializing <paramref name="message"/>) — <paramref name="message"/>
+        /// itself is kept only for acknowledge/dead-letter, which correctly key off the raw string. Malformed
+        /// payloads (which can never succeed) are dead-lettered immediately, while a valid event that fails on an
+        /// unexpected error (e.g. a transient database error) is retried with exponential backoff per
+        /// <see cref="PlayerUpdateRetryPolicy"/>. Once retries are exhausted, a genuine per-write failure is
+        /// dead-lettered so the change is never silently dropped — but a database-<b>infrastructure</b> failure
+        /// (<see cref="InfrastructureFailureClassifier"/>) instead propagates out of this method, leaving the item
+        /// reserved rather than dead-lettered (see the catch clause below and <see cref="SettleInFlightItemsAsync"/>).
+        /// The apply itself runs uncancelled (so a reserved item finishes cleanly); only the dead-time backoff
+        /// between failed attempts honors <paramref name="cancellationToken"/>, so a shutdown isn't stalled
+        /// waiting one out.
         /// </summary>
-        private async Task ProcessMessage(string message, IPubSubQueue deadLetterQueue, CancellationToken cancellationToken)
+        private async Task ProcessMessage(string message, DomainEventEnvelope? envelope, JsonException? parseError, IPubSubQueue deadLetterQueue, CancellationToken cancellationToken)
         {
-            DomainEventEnvelope? envelope;
-            try
-            {
-                envelope = message.Deserialize<DomainEventEnvelope>();
-            }
-            catch (JsonException ex)
+            if (parseError is not null)
             {
                 // A malformed payload can never be parsed successfully, so it is dead-lettered for inspection rather than retried.
-                _logger.LogWarning(ex, "Dead-lettering malformed player data event from queue '{Queue}'. Raw message: {Message}", Constants.PUBSUB_PLAYER_QUEUE, message);
+                _logger.LogWarning(parseError, "Dead-lettering malformed player data event from queue '{Queue}'. Raw message: {Message}", Constants.PUBSUB_PLAYER_QUEUE, message);
                 await deadLetterQueue.AddToQueueAsync(message);
                 return;
             }

--- a/Game.DataAccess/PlayerUpdates/PlayerUpdateEnvelopeReader.cs
+++ b/Game.DataAccess/PlayerUpdates/PlayerUpdateEnvelopeReader.cs
@@ -4,30 +4,28 @@ using System.Text.Json;
 namespace Game.DataAccess.PlayerUpdates
 {
     /// <summary>
-    /// Reads the owning player id out of a raw queued envelope generically (every persisted player-update
-    /// event's payload carries a <c>playerId</c>), without coupling to each concrete event type. Shared by the
-    /// dead-letter inspector (<see cref="Repositories.Admin.PlayerUpdateDeadLetters"/>, classifying entries for
-    /// display) and <see cref="DataProviderSynchronizer"/> (routing reserved items to a per-player ordering lane
-    /// for bounded cross-player concurrency, #1701). This is a best-effort peek, not an authoritative parse: a
-    /// malformed envelope or payload simply yields no player id here, and is left to whichever caller owns the
-    /// authoritative parse (the dead-letter classifier, or <c>ProcessMessage</c>'s own deserialize) to treat it
-    /// as a poison message.
+    /// Parses a raw queued envelope and reads the owning player id out of it generically (every persisted
+    /// player-update event's payload carries a <c>playerId</c>), without coupling to each concrete event type.
+    /// Shared by the dead-letter inspector (<see cref="Repositories.Admin.PlayerUpdateDeadLetters"/>, classifying
+    /// entries for display) and <see cref="DataProviderSynchronizer"/> (routing reserved items to a per-player
+    /// ordering lane for bounded cross-player concurrency, #1701, and threading the one parsed envelope through
+    /// to <c>ProcessMessage</c> rather than re-deserializing it). The player-id read is a best-effort peek, not
+    /// an authoritative parse: a malformed payload simply yields no player id here, and is left to whichever
+    /// caller owns the authoritative parse (the dead-letter classifier, or the event dispatcher's own inner
+    /// deserialize) to treat it as a poison message.
     /// </summary>
     internal static class PlayerUpdateEnvelopeReader
     {
-        public static int? TryReadPlayerId(string rawMessage)
+        public static (DomainEventEnvelope? Envelope, JsonException? ParseError) TryParseEnvelope(string rawMessage)
         {
-            DomainEventEnvelope? envelope;
             try
             {
-                envelope = rawMessage.Deserialize<DomainEventEnvelope>();
+                return (rawMessage.Deserialize<DomainEventEnvelope>(), null);
             }
-            catch (JsonException)
+            catch (JsonException ex)
             {
-                return null;
+                return (null, ex);
             }
-
-            return envelope is null ? null : TryReadPlayerIdFromPayload(envelope.Payload);
         }
 
         public static int? TryReadPlayerIdFromPayload(string? payload)

--- a/Game.DataAccess/Repositories/PlayerProgressRepository.cs
+++ b/Game.DataAccess/Repositories/PlayerProgressRepository.cs
@@ -224,43 +224,57 @@ namespace Game.DataAccess.Repositories
             return progress;
         }
 
+        private const int StatisticRowKind = 0;
+        private const int ChallengeRowKind = 1;
+        private const int ProficiencyRowKind = 2;
+
+        /// <summary>
+        /// Cold path only (first read after a TTL lapse/eviction, or a brand-new player) — reads the three
+        /// progress tables as one <c>UNION ALL</c> round trip instead of three sequential ones. EF Core cannot
+        /// run independent queries concurrently on one <see cref="GameContext"/>, so batching them onto one
+        /// round trip means projecting all three onto one shared anonymous shape and
+        /// <see cref="Queryable.Concat{T}"/>-ing them (the shape a translatable set operation requires) rather
+        /// than awaiting each in turn. Every column is populated for every row kind — defaulted rather than left
+        /// null on the kinds that don't use it — discriminated by <c>Kind</c> on the way back out, so the
+        /// reconstruction below never needs the null-forgiving operator.
+        /// </summary>
         private async Task<CachedPlayerProgress> LoadFromDb(int playerId, CancellationToken cancellationToken)
         {
-            var statistics = await _context.PlayerStatistics
+            var statistics = _context.PlayerStatistics
                 .AsNoTracking()
                 .Where(ps => ps.PlayerId == playerId)
-                .Select(ps => new CachedPlayerStatistic
-                {
-                    StatisticTypeId = ps.StatisticTypeId,
-                    EntityId = ps.EntityId,
-                    Value = ps.Value,
-                })
-                .ToListAsync(cancellationToken);
+                .Select(ps => new { Kind = StatisticRowKind, Id = ps.StatisticTypeId, EntityId = ps.EntityId, Level = 0, Amount = ps.Value, Completed = false, CompletedAt = (DateTime?)null });
 
-            var challenges = await _context.PlayerChallenges
+            var challenges = _context.PlayerChallenges
                 .AsNoTracking()
                 .Where(pc => pc.PlayerId == playerId)
-                .Select(pc => new CachedPlayerChallenge
-                {
-                    ChallengeId = pc.ChallengeId,
-                    Progress = pc.Progress,
-                    Completed = pc.Completed,
-                    CompletedAt = pc.CompletedAt,
-                })
-                .ToListAsync(cancellationToken);
+                .Select(pc => new { Kind = ChallengeRowKind, Id = pc.ChallengeId, EntityId = (int?)null, Level = 0, Amount = pc.Progress, Completed = pc.Completed, CompletedAt = pc.CompletedAt });
 
-            var proficiencies = await _context.PlayerProficiencies
+            var proficiencies = _context.PlayerProficiencies
                 .AsNoTracking()
                 .Where(pp => pp.PlayerId == playerId)
-                .Select(pp => new CachedPlayerProficiency
-                {
-                    ProficiencyId = pp.ProficiencyId,
-                    Level = pp.Level,
-                    Xp = pp.Xp,
-                })
-                .ToListAsync(cancellationToken);
+                .Select(pp => new { Kind = ProficiencyRowKind, Id = pp.ProficiencyId, EntityId = (int?)null, Level = pp.Level, Amount = pp.Xp, Completed = false, CompletedAt = (DateTime?)null });
 
-            return new CachedPlayerProgress { Statistics = statistics, Challenges = challenges, Proficiencies = proficiencies };
+            var rows = await statistics.Concat(challenges).Concat(proficiencies).ToListAsync(cancellationToken);
+
+            var progress = new CachedPlayerProgress();
+            foreach (var row in rows)
+            {
+                switch (row.Kind)
+                {
+                    case StatisticRowKind:
+                        progress.Statistics.Add(new CachedPlayerStatistic { StatisticTypeId = row.Id, EntityId = row.EntityId, Value = row.Amount });
+                        break;
+                    case ChallengeRowKind:
+                        progress.Challenges.Add(new CachedPlayerChallenge { ChallengeId = row.Id, Progress = row.Amount, Completed = row.Completed, CompletedAt = row.CompletedAt });
+                        break;
+                    case ProficiencyRowKind:
+                        progress.Proficiencies.Add(new CachedPlayerProficiency { ProficiencyId = row.Id, Level = row.Level, Xp = row.Amount });
+                        break;
+                }
+            }
+
+            return progress;
         }
 
         private static CoreStat ToCoreStatistic(CachedPlayerStatistic cached) => new()


### PR DESCRIPTION
## Summary

Two small, adjacent efficiency wins in the persistence tier, as filed in #2378:

- **Drain loop double-parses every envelope.** `DataProviderSynchronizer.DrainQueueAsync` used to call `PlayerUpdateEnvelopeReader.TryReadPlayerId(next)` (a full envelope deserialize + `JsonDocument.Parse` of the payload) for lane routing, then `ProcessMessage` re-deserialized the same raw string into a `DomainEventEnvelope` again. The envelope is now parsed once in `DrainQueueAsync` (`PlayerUpdateEnvelopeReader.TryParseEnvelope`) and threaded through `ProcessReservedItemAsync`/`ProcessMessage`, which reuses it instead of re-parsing — the raw string is kept only for acknowledge/dead-letter, which correctly key off it. The malformed-vs-null-envelope dead-letter distinction (and its log messages/exception) is preserved exactly, just computed from the upfront parse result instead of a second deserialize.
- **Progress cache-miss reload was 3 sequential round-trips.** `PlayerProgressRepository.LoadFromDb` awaited the statistics, challenges, and proficiencies queries one after another on one `GameContext`. Since EF Core can't run independent queries concurrently on a single context, the three queries are now projected onto one shared anonymous shape (discriminated by a `Kind` field, with unused columns defaulted rather than left null) and `Concat`-ed together, so EF Core translates the whole read into a single `UNION ALL` round trip. This only hits on the cold path (first read after a TTL lapse/eviction, or a brand-new player).

Neither change alters behavior — same dead-letter/log semantics, same `CachedPlayerProgress` shape returned from `LoadFromDb`.

## How this addresses the issue

Implements both suggested fixes from #2378 as filed.

## Test plan

- [x] `dotnet build` (full solution) — 0 warnings, 0 errors.
- [x] `dotnet test` (full solution, real Postgres/Redis containers) — 3,481 tests passed across `Game.Core.Tests`, `Game.Infrastructure.Tests`, `Game.Application.Tests`, `Game.Api.Tests`.
- [x] Targeted runs before the full suite: `DataProviderSynchronizerTests` (73 tests, including the lane-ordering and malformed-envelope dead-letter tests) and `PlayerProgressRepositoryIntegrationTests`/`PlayerUpdateDeadLettersIntegrationTests` all green.
- [x] The `Concat`-based UNION projection was validated against real Postgres — an initial attempt using a `record` projection failed EF Core's SQL translation (`Unable to translate set operation after client projection has been applied`); switching to an anonymous-type projection (the shape EF Core reliably translates for set operations) resolved it, confirmed by the integration tests above.

Closes #2378

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxPkpXruze3xoAiXprdM7m)_