### PR TITLE
Consolidate the duplicated progression test scaffolding into a shared module (#2405)

### DIFF
--- a/UI/src/tests/routes/admin/workbench/progression/GatewaysEditor.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/GatewaysEditor.test.ts
@@ -2,51 +2,19 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup, screen } from '@testing-library/svelte';
 
 import GatewaysEditor from '$routes/admin/workbench/progression/GatewaysEditor.svelte';
-import type { ProgressionStore } from '$routes/admin/workbench/progression/progression-store.svelte';
 import type { WorkbenchPath, WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
-import { EActivityKey } from '$lib/api';
+import { asStore, path, tier } from './progression-test-utils';
 
 afterEach(cleanup);
 
-const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency => ({
-	id: 0,
-	name: 'Blades',
-	description: '',
-	iconPath: '',
-	word: '',
-	pronunciation: '',
-	translation: '',
-	pathId: 0,
-	pathOrdinal: 0,
-	maxLevel: 10,
-	baseXp: 100,
-	xpGrowth: 1.4,
-	designerNotes: '',
-	levelModifiers: [],
-	levelRewards: [],
-	prerequisiteIds: [],
-	...over
-});
-
-const path = (over: Partial<WorkbenchPath> = {}): WorkbenchPath => ({
-	id: 0,
-	name: 'Fire',
-	description: '',
-	activityKey: EActivityKey.Fire,
-	designerNotes: '',
-	...over
-});
-
-// A fake store exposing exactly what GatewaysEditor reads/calls — mirrors TierDetail.test.ts's
-// fake-store pattern rather than driving the real ProgressionStore through a socket-backed load().
+// A fake store exposing exactly what GatewaysEditor reads/calls.
 const makeStore = (profs: WorkbenchProficiency[], paths: WorkbenchPath[] = []) =>
-	({
+	asStore({
 		profs,
 		paths,
 		addPrerequisite: vi.fn(),
 		removePrerequisite: vi.fn()
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	}) as any as ProgressionStore;
+	});
 
 describe('GatewaysEditor — cross-path-only prerequisite picker (#2128)', () => {
 	it('excludes tiers of the gated tier\'s own path from the "Add prerequisite" options', async () => {

--- a/UI/src/tests/routes/admin/workbench/progression/MilestonesEditor.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/MilestonesEditor.test.ts
@@ -2,41 +2,20 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
 import { EAttribute, EModifierType } from '$lib/api';
 
-// MilestonesEditor's Reward-skill select reads staticData.skills via the reference module —
-// mirrors TierDetail.test.ts's hoisted staticData mock.
-const { staticData } = vi.hoisted(() => ({
-	staticData: { skills: [] as unknown[] }
-}));
-vi.mock('$stores', () => ({ staticData }));
+// MilestonesEditor's Reward-skill select reads staticData.skills via the reference module. `vi.mock` is
+// hoisted within this file, so the factory resolves the shared stub by dynamic import.
+vi.mock('$stores', async () => (await import('./progression-test-utils')).stubStores());
 
 import MilestonesEditor from '$routes/admin/workbench/progression/MilestonesEditor.svelte';
-import type { ProgressionStore } from '$routes/admin/workbench/progression/progression-store.svelte';
 import type { WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+import { asStore, resetStores, tier as baseTier } from './progression-test-utils';
 
-const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency => ({
-	id: 5,
-	name: 'Blades',
-	description: '',
-	iconPath: '',
-	word: '',
-	pronunciation: '',
-	translation: '',
-	pathId: 0,
-	pathOrdinal: 0,
-	maxLevel: 10,
-	baseXp: 100,
-	xpGrowth: 1.4,
-	designerNotes: '',
-	levelModifiers: [],
-	levelRewards: [],
-	prerequisiteIds: [],
-	...over
-});
+// The payout assertions below target tier id 5.
+const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency => baseTier({ id: 5, ...over });
 
-// A fake store exposing exactly what MilestonesEditor reads/calls — mirrors GatewaysEditor.test.ts's
-// fake-store pattern rather than driving the real ProgressionStore through a socket-backed load().
+// A fake store exposing exactly what MilestonesEditor reads/calls.
 const makeStore = (selectedLevel: number, overrides: Record<string, unknown> = {}) =>
-	({
+	asStore({
 		selectedLevel,
 		selectLevel: vi.fn(),
 		updateModifier: vi.fn(),
@@ -46,12 +25,9 @@ const makeStore = (selectedLevel: number, overrides: Record<string, unknown> = {
 		addPayout: vi.fn(),
 		removePayout: vi.fn(),
 		...overrides
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	}) as any as ProgressionStore;
+	});
 
-beforeEach(() => {
-	staticData.skills = [];
-});
+beforeEach(resetStores);
 afterEach(cleanup);
 
 describe('MilestonesEditor — level 0 (on-open) payouts (#2178)', () => {

--- a/UI/src/tests/routes/admin/workbench/progression/PathDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/PathDetail.test.ts
@@ -2,90 +2,26 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import { EActivityKey } from '$lib/api';
 
-// Hoisted so individual tests can seed staticData and assert the retire-confirm flow, mirroring
-// TierDetail.test.ts's pattern for the progression editor's retire dialog.
-const { staticData, dangerModal } = vi.hoisted(() => ({
-	staticData: {
-		enemies: [] as unknown[],
-		zones: [] as unknown[],
-		challenges: [] as unknown[],
-		items: [] as unknown[],
-		classes: [] as unknown[],
-		skillRecipes: [] as unknown[],
-		proficiencies: [] as unknown[],
-		skills: [] as unknown[],
-		paths: [] as unknown[]
-	},
-	dangerModal: vi.fn()
-}));
-vi.mock('$stores', () => ({ staticData, dangerModal }));
+// `vi.mock` is hoisted within this file, so the factory resolves the shared stub by dynamic import
+// rather than closing over the static one below.
+vi.mock('$stores', async () => (await import('./progression-test-utils')).stubStores());
 
 import PathDetail from '$routes/admin/workbench/progression/PathDetail.svelte';
-import type { ProgressionStore } from '$routes/admin/workbench/progression/progression-store.svelte';
-import type { WorkbenchPath, WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+import type { WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+import {
+	dangerModal,
+	makePathStore as makeStore,
+	path,
+	resetStores,
+	staticData,
+	tier as baseTier
+} from './progression-test-utils';
 
-const path = (over: Partial<WorkbenchPath> = {}): WorkbenchPath => ({
-	id: 5,
-	name: 'Fire Path',
-	description: '',
-	designerNotes: '',
-	activityKey: EActivityKey.Fire,
-	...over
-});
+// PathDetail's retire check walks the tiers carrying the selected path's id, so tiers here default
+// onto path 5 (`path()`'s id) rather than the shared fixture's path 0.
+const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency => baseTier({ pathId: 5, ...over });
 
-const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency => ({
-	id: 0,
-	name: 'Blades',
-	description: '',
-	iconPath: '',
-	word: '',
-	pronunciation: '',
-	translation: '',
-	pathId: 5,
-	pathOrdinal: 0,
-	maxLevel: 10,
-	baseXp: 100,
-	xpGrowth: 1.4,
-	designerNotes: '',
-	levelModifiers: [],
-	levelRewards: [],
-	prerequisiteIds: [],
-	...over
-});
-
-// A fake store exposing exactly what PathDetail reads — mirrors TierDetail.test.ts's fake-store
-// pattern rather than driving the real ProgressionStore through a socket-backed load().
-const makeStore = (selectedPath: WorkbenchPath, overrides: Record<string, unknown> = {}) =>
-	({
-		selectedPath,
-		profs: [],
-		paths: [],
-		currentTiers: [],
-		pathTab: 'identity',
-		saving: false,
-		pathStatus: vi.fn(() => 'clean'),
-		isRetired: vi.fn(() => false),
-		setPathTab: vi.fn(),
-		resetPath: vi.fn(),
-		retirePath: vi.fn(),
-		removePath: vi.fn(),
-		pathBaseline: vi.fn(() => selectedPath),
-		patchPath: vi.fn(),
-		...overrides
-	}) as unknown as ProgressionStore;
-
-beforeEach(() => {
-	dangerModal.mockReset();
-	staticData.enemies = [];
-	staticData.zones = [];
-	staticData.challenges = [];
-	staticData.items = [];
-	staticData.classes = [];
-	staticData.skillRecipes = [];
-	staticData.proficiencies = [];
-	staticData.skills = [];
-	staticData.paths = [];
-});
+beforeEach(resetStores);
 afterEach(cleanup);
 
 describe('PathDetail', () => {

--- a/UI/src/tests/routes/admin/workbench/progression/PathDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/PathDetail.test.ts
@@ -19,7 +19,8 @@ import {
 
 // PathDetail's retire check walks the tiers carrying the selected path's id, so tiers here default
 // onto path 5 (`path()`'s id) rather than the shared fixture's path 0.
-const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency => baseTier({ pathId: 5, ...over });
+const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency =>
+	baseTier({ pathId: path().id, ...over });
 
 beforeEach(resetStores);
 afterEach(cleanup);

--- a/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/TierDetail.test.ts
@@ -2,90 +2,33 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import { EAttribute, EModifierType, ESkillAcquisition } from '$lib/api';
 
-// Hoisted so individual tests can seed staticData and assert the retire-confirm flow, mirroring
-// WorkbenchDetail.test.ts's pattern for the generic Workbench's retire dialog.
-const { staticData, dangerModal } = vi.hoisted(() => ({
-	staticData: {
-		enemies: [] as unknown[],
-		zones: [] as unknown[],
-		challenges: [] as unknown[],
-		items: [] as unknown[],
-		classes: [] as unknown[],
-		skillRecipes: [] as unknown[],
-		proficiencies: [] as unknown[],
-		skills: [] as unknown[]
-	},
-	dangerModal: vi.fn()
-}));
-vi.mock('$stores', () => ({ staticData, dangerModal }));
+// `vi.mock` is hoisted within this file, so the factory resolves the shared stub by dynamic import
+// rather than closing over the static one below.
+vi.mock('$stores', async () => (await import('./progression-test-utils')).stubStores());
 
 import TierDetail from '$routes/admin/workbench/progression/TierDetail.svelte';
-import type { ProgressionStore } from '$routes/admin/workbench/progression/progression-store.svelte';
 import type { WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+import {
+	dangerModal,
+	makeTierStore as makeStore,
+	resetStores,
+	staticData,
+	tier as baseTier
+} from './progression-test-utils';
 
-const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency => ({
-	id: 5,
-	name: 'Blades',
-	description: '',
-	iconPath: 'i.png',
-	word: 'sijren',
-	pronunciation: 'sij-ren',
-	translation: 'The Riven Frost',
-	pathId: 0,
-	pathOrdinal: 0,
-	maxLevel: 10,
-	baseXp: 100,
-	xpGrowth: 1.4,
-	designerNotes: '',
-	levelModifiers: [],
-	levelRewards: [],
-	prerequisiteIds: [],
-	...over
-});
+// Tiers here carry id 5 and populated conlang fields: the retire/tab assertions below target id 5,
+// and ConlangIdentity's decipher preview reads the authored word/pronunciation/translation.
+const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency =>
+	baseTier({
+		id: 5,
+		iconPath: 'i.png',
+		word: 'sijren',
+		pronunciation: 'sij-ren',
+		translation: 'The Riven Frost',
+		...over
+	});
 
-// A fake store exposing exactly what TierDetail + ConlangIdentity (the 'identity' tab) read —
-// mirrors ProgressionMap.test.ts's fake-store pattern rather than driving the real ProgressionStore
-// through a socket-backed load(), since only TierDetail's own wiring (header, tabs, retire) is under
-// test here.
-const makeStore = (drilledTier: WorkbenchProficiency, overrides: Record<string, unknown> = {}) =>
-	({
-		drilledTier,
-		profs: [drilledTier],
-		paths: [],
-		tierTab: 'identity',
-		selectedPath: { name: 'Fire Path' },
-		selectedLevel: 1,
-		profStatus: vi.fn(() => 'clean'),
-		isRetired: vi.fn(() => false),
-		setTierTab: vi.fn(),
-		resetProf: vi.fn(),
-		retireProf: vi.fn(),
-		back: vi.fn(),
-		profBaseline: vi.fn(() => drilledTier),
-		patchProf: vi.fn(),
-		selectLevel: vi.fn(),
-		updateModifier: vi.fn(),
-		removeModifier: vi.fn(),
-		addModifier: vi.fn(),
-		setReward: vi.fn(),
-		addPayout: vi.fn(),
-		removePayout: vi.fn(),
-		addPrerequisite: vi.fn(),
-		removePrerequisite: vi.fn(),
-		...overrides
-	}) as unknown as ProgressionStore;
-
-beforeEach(() => {
-	dangerModal.mockReset();
-	staticData.enemies = [];
-	staticData.zones = [];
-	staticData.challenges = [];
-	staticData.items = [];
-	staticData.classes = [];
-	staticData.skillRecipes = [];
-	staticData.proficiencies = [];
-	staticData.skills = [];
-});
+beforeEach(resetStores);
 afterEach(cleanup);
 
 describe('TierDetail', () => {

--- a/UI/src/tests/routes/admin/workbench/progression/field-lengths.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/field-lengths.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
-import { EActivityKey } from '$lib/api';
 import {
 	PATH_DESCRIPTION_MAX_LENGTH,
 	PATH_DESIGNER_NOTES_MAX_LENGTH,
@@ -30,74 +29,25 @@ import {
    rather than constant identity, and is the residual the direct imports already make a deliberate act
    rather than a drift. */
 
-const { staticData, dangerModal } = vi.hoisted(() => ({
-	staticData: {
-		enemies: [] as unknown[],
-		zones: [] as unknown[],
-		challenges: [] as unknown[],
-		items: [] as unknown[],
-		classes: [] as unknown[],
-		skillRecipes: [] as unknown[],
-		proficiencies: [] as unknown[],
-		skills: [] as unknown[],
-		paths: [] as unknown[]
-	},
-	dangerModal: vi.fn()
-}));
-vi.mock('$stores', () => ({ staticData, dangerModal }));
+// `vi.mock` is hoisted within this file, so the factory resolves the shared stub by dynamic import
+// rather than closing over the static one below.
+vi.mock('$stores', async () => (await import('./progression-test-utils')).stubStores());
 
 import ConlangIdentity from '$routes/admin/workbench/progression/ConlangIdentity.svelte';
 import PathDetail from '$routes/admin/workbench/progression/PathDetail.svelte';
-import type { ProgressionStore } from '$routes/admin/workbench/progression/progression-store.svelte';
-import type { WorkbenchPath, WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+import { makePathStore, path as pathFixture, tier as tierFixture } from './progression-test-utils';
 
-const path: WorkbenchPath = {
-	id: 5,
-	name: 'Fire Path',
-	description: '',
-	designerNotes: '',
-	activityKey: EActivityKey.Fire
-};
+const path = pathFixture();
+const tier = tierFixture({ pathId: path.id });
 
-const tier: WorkbenchProficiency = {
-	id: 0,
-	name: 'Blades',
-	description: '',
-	iconPath: '',
-	word: '',
-	pronunciation: '',
-	translation: '',
-	pathId: 5,
-	pathOrdinal: 0,
-	maxLevel: 10,
-	baseXp: 100,
-	xpGrowth: 1.4,
-	designerNotes: '',
-	levelModifiers: [],
-	levelRewards: [],
-	prerequisiteIds: []
-};
-
-// Exposes only what the two identity surfaces read — the fake-store pattern PathDetail/TierDetail's
-// own tests use, rather than driving the real ProgressionStore through a socket-backed load().
-const store = {
-	selectedPath: path,
+// Only the two identity surfaces are rendered, so the path store carries the tier reads on top.
+const store = makePathStore(path, {
 	profs: [tier],
 	paths: [path],
 	currentTiers: [tier],
-	pathTab: 'identity',
-	saving: false,
-	pathStatus: vi.fn(() => 'clean'),
 	profStatus: vi.fn(() => 'clean'),
-	isRetired: vi.fn(() => false),
-	setPathTab: vi.fn(),
-	resetPath: vi.fn(),
-	retirePath: vi.fn(),
-	removePath: vi.fn(),
-	pathBaseline: vi.fn(() => path),
-	patchPath: vi.fn(),
 	patchProf: vi.fn()
-} as unknown as ProgressionStore;
+});
 
 /**
  * Every control `ProgInput` rendered, keyed by accessible label -> its `maxlength` (null when unbounded).

--- a/UI/src/tests/routes/admin/workbench/progression/progression-test-utils.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-test-utils.ts
@@ -5,7 +5,12 @@ import type { WorkbenchPath, WorkbenchProficiency } from '$routes/admin/workbenc
 
 /* Shared scaffolding for the progression editor's component suites (#2405). Each suite still declares
    its own `vi.mock('$stores', …)` — `vi.mock` is hoisted within the file it appears in — but the factory
-   resolves this module's singletons, so the stub's shape lives in exactly one place. */
+   resolves this module's singletons, so the stub's shape lives in exactly one place.
+
+   Because the suites resolve it from inside that factory, this module is evaluated *while `$stores` is
+   being mocked, so it must stay free of runtime imports that transitively reach `$stores`* — a value
+   import that did would re-enter the factory resolving it. Everything below `$lib/api` is `import type`
+   and therefore erased, which is what keeps that true today. */
 
 /** The last-saved `staticData` catalogues the editor's reference lookups read. */
 export const staticData = {
@@ -35,8 +40,8 @@ export const stubStores = () => ({ staticData, dangerModal });
 /** Restores the stub to its empty, uncalled baseline. Call from `beforeEach`. */
 export const resetStores = () => {
 	dangerModal.mockReset();
-	for (const catalogue of Object.keys(staticData) as (keyof typeof staticData)[]) {
-		staticData[catalogue] = [];
+	for (const catalogue of Object.values(staticData)) {
+		catalogue.length = 0;
 	}
 };
 

--- a/UI/src/tests/routes/admin/workbench/progression/progression-test-utils.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-test-utils.ts
@@ -1,0 +1,132 @@
+import { vi } from 'vitest';
+import { EActivityKey } from '$lib/api';
+import type { ProgressionStore } from '$routes/admin/workbench/progression/progression-store.svelte';
+import type { WorkbenchPath, WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+
+/* Shared scaffolding for the progression editor's component suites (#2405). Each suite still declares
+   its own `vi.mock('$stores', …)` — `vi.mock` is hoisted within the file it appears in — but the factory
+   resolves this module's singletons, so the stub's shape lives in exactly one place. */
+
+/** The last-saved `staticData` catalogues the editor's reference lookups read. */
+export const staticData = {
+	enemies: [] as unknown[],
+	zones: [] as unknown[],
+	challenges: [] as unknown[],
+	items: [] as unknown[],
+	classes: [] as unknown[],
+	skillRecipes: [] as unknown[],
+	proficiencies: [] as unknown[],
+	skills: [] as unknown[],
+	paths: [] as unknown[]
+};
+
+export const dangerModal = vi.fn();
+
+/**
+ * The `$stores` surface every progression suite stubs. Resolve it from an async `vi.mock` factory, which
+ * may `await import(…)` even though it cannot close over the file's static imports:
+ *
+ * ```ts
+ * vi.mock('$stores', async () => (await import('./progression-test-utils')).stubStores());
+ * ```
+ */
+export const stubStores = () => ({ staticData, dangerModal });
+
+/** Restores the stub to its empty, uncalled baseline. Call from `beforeEach`. */
+export const resetStores = () => {
+	dangerModal.mockReset();
+	for (const catalogue of Object.keys(staticData) as (keyof typeof staticData)[]) {
+		staticData[catalogue] = [];
+	}
+};
+
+/** Base path fixture — id 5, the path the detail suites open. */
+export const path = (over: Partial<WorkbenchPath> = {}): WorkbenchPath => ({
+	id: 5,
+	name: 'Fire Path',
+	description: '',
+	designerNotes: '',
+	activityKey: EActivityKey.Fire,
+	...over
+});
+
+/**
+ * Base tier fixture — id 0 on path 0, with blank conlang fields.
+ *
+ * A suite whose assertions depend on a different identity (TierDetail's populated conlang strings, say)
+ * wraps this with its own defaults rather than changing them here; those divergences are load-bearing.
+ */
+export const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency => ({
+	id: 0,
+	name: 'Blades',
+	description: '',
+	iconPath: '',
+	word: '',
+	pronunciation: '',
+	translation: '',
+	pathId: 0,
+	pathOrdinal: 0,
+	maxLevel: 10,
+	baseXp: 100,
+	xpGrowth: 1.4,
+	designerNotes: '',
+	levelModifiers: [],
+	levelRewards: [],
+	prerequisiteIds: [],
+	...over
+});
+
+/**
+ * Casts a partial fake to the store the components read. The suites drive these rather than the real
+ * `ProgressionStore`, which only loads through a socket-backed `load()`.
+ */
+export const asStore = (shape: Record<string, unknown>) => shape as unknown as ProgressionStore;
+
+/** A fake store exposing what the path-identity surfaces (`PathDetail`, its retire flow) read. */
+export const makePathStore = (selectedPath: WorkbenchPath, overrides: Record<string, unknown> = {}) =>
+	asStore({
+		selectedPath,
+		profs: [],
+		paths: [],
+		currentTiers: [],
+		pathTab: 'identity',
+		saving: false,
+		pathStatus: vi.fn(() => 'clean'),
+		isRetired: vi.fn(() => false),
+		setPathTab: vi.fn(),
+		resetPath: vi.fn(),
+		retirePath: vi.fn(),
+		removePath: vi.fn(),
+		pathBaseline: vi.fn(() => selectedPath),
+		patchPath: vi.fn(),
+		...overrides
+	});
+
+/** A fake store exposing what `TierDetail` and its tab bodies read. */
+export const makeTierStore = (drilledTier: WorkbenchProficiency, overrides: Record<string, unknown> = {}) =>
+	asStore({
+		drilledTier,
+		profs: [drilledTier],
+		paths: [],
+		tierTab: 'identity',
+		selectedPath: { name: 'Fire Path' },
+		selectedLevel: 1,
+		profStatus: vi.fn(() => 'clean'),
+		isRetired: vi.fn(() => false),
+		setTierTab: vi.fn(),
+		resetProf: vi.fn(),
+		retireProf: vi.fn(),
+		back: vi.fn(),
+		profBaseline: vi.fn(() => drilledTier),
+		patchProf: vi.fn(),
+		selectLevel: vi.fn(),
+		updateModifier: vi.fn(),
+		removeModifier: vi.fn(),
+		addModifier: vi.fn(),
+		setReward: vi.fn(),
+		addPayout: vi.fn(),
+		removePayout: vi.fn(),
+		addPrerequisite: vi.fn(),
+		removePrerequisite: vi.fn(),
+		...overrides
+	});


### PR DESCRIPTION
Closes #2405.

## Summary

Adds `UI/src/tests/routes/admin/workbench/progression/progression-test-utils.ts` holding the `$stores` stub, the `path`/`tier` fixtures, and the two detail-store builders, and points the progression suites at it. **Test-only — no production code is touched, and no assertion changes meaning.**

Net −291/+64 across the suites, plus the 128-line shared module.

## How it addresses the issue

**One deviation from the suggested direction, deliberately.** The issue states the `vi.hoisted` + `vi.mock('$stores', …)` block "has to stay per-file… that's ~6 lines left duplicated per file, which is the floor here." The premise (a sync factory can't close over the file's static imports) is correct, but an **async** factory may `await import(…)` — a pattern this repo already uses in five places, e.g. `src/tests/lib/engine/engine.test.ts:51`. So each suite still declares its own hoisted `vi.mock` call, but it resolves the shared singletons:

```ts
vi.mock('$stores', async () => (await import('./progression-test-utils')).stubStores());
```

That drops the per-file floor from ~14 lines to 1 and puts the stub's *shape* (the nine `staticData` catalogues) in exactly one place — which is the drift this issue exists to close. The `beforeEach` reset collapses to `beforeEach(resetStores)`.

**Fixture divergences stay literal in the suite that depends on them**, exactly as the issue asks — as thin wrappers over the shared builder rather than reconciled-away defaults:

| Suite | Wrapper over shared `tier()` | Why |
|---|---|---|
| `PathDetail` | `{ pathId: 5 }` | its retire check walks the tiers carrying the selected path's id |
| `TierDetail` | `{ id: 5 }` + the four conlang strings | 22 call sites assert against id 5; `ConlangIdentity`'s decipher preview reads the authored word/pronunciation/translation |
| `MilestonesEditor` | `{ id: 5 }` | payout assertions target id 5 |
| `GatewaysEditor` | none | its defaults already match the shared base, and every call site passes id/pathId explicitly |

Local `tier` / `makeStore` signatures are unchanged, so none of the ~40 call sites churn.

## Beyond the issue's scope (flagging explicitly)

- **Two extra copies folded in.** The issue names three files, but `MilestonesEditor.test.ts` and `GatewaysEditor.test.ts` carry the same `tier()` builder (and `GatewaysEditor` a `path()`) — 5 copies total. Leaving two behind would have defeated the point, so both are converted.
- **`as any as ProgressionStore` → `asStore`.** Those two suites cast through `any` and each carried an `@typescript-eslint/no-explicit-any` disable to do it; `PathDetail`/`TierDetail` used `as unknown as`, which needs no disable. The shared `asStore` helper uses the latter, so both disables are gone.

## Notes

The one-file-at-a-time process the issue prescribes did its job: transcribing `makeTierStore` dropped `addPrerequisite`/`removePrerequisite`, and `TierDetail`'s gateway tests failed loudly (`undefined is not a spy`) rather than silently weakening. Fixed before moving on.

## Test plan

- [x] Each suite run individually as it was converted — `PathDetail` 8/8, `TierDetail` 20/20 (after the fix above), `field-lengths` 2/2.
- [x] Whole progression folder: **122/122 passing**, same count as before the change.
- [x] `npm run lint` (eslint + `svelte-check`): 1221 files, 0 errors, 0 warnings.
- [x] Full unit suite `npm run test:unit:ci`: **312 files / 4009 tests passing**, coverage thresholds met.
- [x] Confirmed the new `.ts` helper isn't collected as an empty suite — Vitest's `include` is `src/**/*.{test,spec}.{js,ts}` (`vite.config.ts:8`), and the file count is unchanged at 312.

No backend code is touched, so `dotnet build`/`test` are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKUnP3UcX6UCkd15sihHx2)_