### PR TITLE
Consolidate the duplicated Lexicon test fixture builders (#2407)

### DIFF
--- a/UI/src/tests/routes/game/screens/proficiencies/TierCard.test.ts
+++ b/UI/src/tests/routes/game/screens/proficiencies/TierCard.test.ts
@@ -1,37 +1,10 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent, within } from '@testing-library/svelte';
 import TierCard from '$routes/game/screens/proficiencies/TierCard.svelte';
-import type { TierView, WordTooltipController } from '$routes/game/screens/proficiencies/proficiencies-lexicon';
+import type { TierView } from '$routes/game/screens/proficiencies/proficiencies-lexicon';
+import { stubController, tierView } from './lexicon-test-utils';
 
-const tierView = (o: Partial<TierView> & { id: number }): TierView => ({
-	name: `Tier ${o.id}`,
-	description: '',
-	pathOrdinal: 0,
-	level: 0,
-	maxLevel: 10,
-	xp: 0,
-	xpForNext: 100,
-	state: 'unlocked',
-	frontier: false,
-	milestoneLevels: [],
-	levelModifiers: [],
-	levelRewards: [],
-	decipher: 'undeciphered',
-	word: `word${o.id}`,
-	pronunciation: `pron${o.id}`,
-	translation: `means${o.id}`,
-	iconPath: '',
-	...o
-});
-
-const stubController = (): WordTooltipController => ({
-	describedById: 'tooltip-9',
-	show: vi.fn(),
-	move: vi.fn(),
-	hide: vi.fn()
-});
-
-const renderCard = (tier: TierView, controller = stubController(), selected = false, last = true) => {
+const renderCard = (tier: TierView, controller = stubController('tooltip-9'), selected = false, last = true) => {
 	const onSelect = vi.fn();
 	render(TierCard, { tier, selected, last, onSelect, controller });
 	return { onSelect, controller };

--- a/UI/src/tests/routes/game/screens/proficiencies/TierSpine.test.ts
+++ b/UI/src/tests/routes/game/screens/proficiencies/TierSpine.test.ts
@@ -1,51 +1,13 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup, screen } from '@testing-library/svelte';
-import { EActivityKey } from '$lib/api';
 import TierSpine from '$routes/game/screens/proficiencies/TierSpine.svelte';
-import type {
-	PathView,
-	TierView,
-	WordTooltipController
-} from '$routes/game/screens/proficiencies/proficiencies-lexicon';
+import type { PathView, TierView } from '$routes/game/screens/proficiencies/proficiencies-lexicon';
+import { pathView as basePathView, stubController, tierView } from './lexicon-test-utils';
 
-const tierView = (o: Partial<TierView> & { id: number }): TierView => ({
-	name: `Tier ${o.id}`,
-	description: '',
-	pathOrdinal: o.id,
-	level: 0,
-	maxLevel: 10,
-	xp: 0,
-	xpForNext: 100,
-	state: 'unlocked',
-	frontier: false,
-	milestoneLevels: [],
-	levelModifiers: [],
-	levelRewards: [],
-	decipher: 'undeciphered',
-	word: `word${o.id}`,
-	pronunciation: `pron${o.id}`,
-	translation: `means${o.id}`,
-	iconPath: '',
-	...o
-});
-
-const pathView = (tiers: TierView[], o: Partial<PathView> = {}): PathView => ({
-	id: 0,
-	name: 'Pyromancy',
-	description: '',
-	word: tiers[0]?.word ?? '',
-	iconPath: '',
-	activityKey: EActivityKey.Physical,
-	tiers,
-	...o
-});
-
-const stubController = (): WordTooltipController => ({
-	describedById: 'tooltip-1',
-	show: vi.fn(),
-	move: vi.fn(),
-	hide: vi.fn()
-});
+// This suite builds a path *from* its spine, so the root tier's word carries up to the path (which is what
+// the header renders) — the shared builder takes a plain override object and defaults to an empty spine.
+const pathView = (tiers: TierView[], o: Partial<PathView> = {}): PathView =>
+	basePathView({ word: tiers[0]?.word ?? '', tiers, ...o });
 
 const renderSpine = (path: PathView) =>
 	render(TierSpine, { path, selectedTierId: undefined, onSelect: vi.fn(), controller: stubController() });

--- a/UI/src/tests/routes/game/screens/proficiencies/WordDetail.test.ts
+++ b/UI/src/tests/routes/game/screens/proficiencies/WordDetail.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent, within } from '@testing-library/svelte';
 import { EActivityKey, EAttribute, EModifierType } from '$lib/api';
 import type { TierView } from '$routes/game/screens/proficiencies/proficiencies-lexicon';
-import { attribute, pathView, stubController, tierView } from './lexicon-test-utils';
+import { makeAttribute } from '../../../../fixtures/attributes';
+import { pathView, stubController, tierView } from './lexicon-test-utils';
 
 /* WordDetail reads the proficiency/skill/attribute reference data from staticData (skills are id-indexed,
    mirroring ItemTooltip); the rest of $stores stays real (the $components barrel transitively imports the
@@ -41,8 +42,8 @@ const renderInspector = (tier: TierView, path = pathView(), controller = stubCon
 beforeEach(() => {
 	staticData.skills = SKILLS;
 	staticData.attributes = [
-		attribute(EAttribute.CriticalChanceMultiplier, 'Fire Damage', true),
-		attribute(EAttribute.Toughness, 'Toughness')
+		makeAttribute(EAttribute.CriticalChanceMultiplier, 'Fire Damage', { isPercentage: true }),
+		makeAttribute(EAttribute.Toughness, 'Toughness')
 	];
 });
 

--- a/UI/src/tests/routes/game/screens/proficiencies/WordDetail.test.ts
+++ b/UI/src/tests/routes/game/screens/proficiencies/WordDetail.test.ts
@@ -1,11 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent, within } from '@testing-library/svelte';
-import { EActivityKey, EAttribute, EAttributeType, EModifierType } from '$lib/api';
-import type {
-	PathView,
-	TierView,
-	WordTooltipController
-} from '$routes/game/screens/proficiencies/proficiencies-lexicon';
+import { EActivityKey, EAttribute, EModifierType } from '$lib/api';
+import type { TierView } from '$routes/game/screens/proficiencies/proficiencies-lexicon';
+import { attribute, pathView, stubController, tierView } from './lexicon-test-utils';
 
 /* WordDetail reads the proficiency/skill/attribute reference data from staticData (skills are id-indexed,
    mirroring ItemTooltip); the rest of $stores stays real (the $components barrel transitively imports the
@@ -24,18 +21,6 @@ import WordDetail from '$routes/game/screens/proficiencies/WordDetail.svelte';
 
 /* ── fixtures ──────────────────────────────────────────────────────────────── */
 
-const attribute = (id: EAttribute, name: string, isPercentage = false) => ({
-	id,
-	name,
-	description: '',
-	attributeType: EAttributeType.Secondary,
-	isPercentage,
-	isHarmful: false,
-	code: '',
-	displayOrder: 0,
-	decimals: 1
-});
-
 // Skills are id-indexed (staticData.skills[id]); a sparse array keyed by id matches the live shape.
 const SKILLS: { id: number; name: string }[] = [];
 for (const s of [
@@ -48,46 +33,7 @@ for (const s of [
 	SKILLS[s.id] = s;
 }
 
-const tierView = (o: Partial<TierView> & { id: number }): TierView => ({
-	name: `Tier ${o.id}`,
-	description: '',
-	pathOrdinal: 0,
-	level: 0,
-	maxLevel: 10,
-	xp: 0,
-	xpForNext: 100,
-	state: 'unlocked',
-	frontier: false,
-	milestoneLevels: [],
-	levelModifiers: [],
-	levelRewards: [],
-	decipher: 'undeciphered',
-	word: `word${o.id}`,
-	pronunciation: `pron${o.id}`,
-	translation: `means${o.id}`,
-	iconPath: '',
-	...o
-});
-
-const pathView = (o: Partial<PathView> = {}): PathView => ({
-	id: 0,
-	name: 'Pyromancy',
-	description: '',
-	word: 'aenkor',
-	iconPath: '',
-	activityKey: EActivityKey.Physical,
-	tiers: [],
-	...o
-});
-
-const stubController = (): WordTooltipController => ({
-	describedById: 'tooltip-7',
-	show: vi.fn(),
-	move: vi.fn(),
-	hide: vi.fn()
-});
-
-const renderInspector = (tier: TierView, path = pathView(), controller = stubController()) => {
+const renderInspector = (tier: TierView, path = pathView(), controller = stubController('tooltip-7')) => {
 	render(WordDetail, { tier, path, controller });
 	return { controller };
 };

--- a/UI/src/tests/routes/game/screens/proficiencies/WordOfPowerTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/proficiencies/WordOfPowerTooltip.test.ts
@@ -1,28 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, cleanup, screen } from '@testing-library/svelte';
 import WordOfPowerTooltip from '$routes/game/screens/proficiencies/WordOfPowerTooltip.svelte';
-import type { TierView } from '$routes/game/screens/proficiencies/proficiencies-lexicon';
-
-const tierView = (o: Partial<TierView> & { id: number }): TierView => ({
-	name: `Tier ${o.id}`,
-	description: '',
-	pathOrdinal: 0,
-	level: 0,
-	maxLevel: 10,
-	xp: 0,
-	xpForNext: 100,
-	state: 'unlocked',
-	frontier: false,
-	milestoneLevels: [],
-	levelModifiers: [],
-	levelRewards: [],
-	decipher: 'undeciphered',
-	word: `word${o.id}`,
-	pronunciation: `pron${o.id}`,
-	translation: `means${o.id}`,
-	iconPath: '',
-	...o
-});
+import { tierView } from './lexicon-test-utils';
 
 afterEach(() => cleanup());
 

--- a/UI/src/tests/routes/game/screens/proficiencies/lexicon-test-utils.ts
+++ b/UI/src/tests/routes/game/screens/proficiencies/lexicon-test-utils.ts
@@ -1,0 +1,84 @@
+import { vi } from 'vitest';
+import { EActivityKey, EAttribute, EAttributeType, type IAttribute } from '$lib/api';
+import type {
+	PathView,
+	TierView,
+	WordTooltipController
+} from '$routes/game/screens/proficiencies/proficiencies-lexicon';
+
+/* Shared fixtures for the Lexicon (Proficiencies) suites (#2407). Vitest only collects
+   `*.{test,spec}.{js,ts}`, so this plain `.ts` module is imported, never run as an empty suite.
+
+   `WordDetail.test.ts` keeps its own `vi.mock('$stores', …)` — `vi.mock` is hoisted within the file it
+   appears in and its factory cannot close over that file's imports — but the stub it installs is
+   unrelated to anything here, so this module is a plain static import for every suite. */
+
+/**
+ * Base tier fixture — the id is required because the conlang defaults are generated from it, which is
+ * what lets a suite assert on `word1`/`pron1`/`means1` without restating them per call.
+ *
+ * `pathOrdinal` defaults to the id so a spine built from ascending ids is ordinal-consistent. Nothing in
+ * the screen actually reads it today (`TierSpine` orders by array position, reversing `path.tiers`), so
+ * this is about keeping the fixture coherent rather than about any current assertion.
+ */
+export const tierView = (o: Partial<TierView> & { id: number }): TierView => ({
+	name: `Tier ${o.id}`,
+	description: '',
+	pathOrdinal: o.id,
+	level: 0,
+	maxLevel: 10,
+	xp: 0,
+	xpForNext: 100,
+	state: 'unlocked',
+	frontier: false,
+	milestoneLevels: [],
+	levelModifiers: [],
+	levelRewards: [],
+	decipher: 'undeciphered',
+	word: `word${o.id}`,
+	pronunciation: `pron${o.id}`,
+	translation: `means${o.id}`,
+	iconPath: '',
+	...o
+});
+
+/**
+ * Base path fixture — an empty Pyromancy spine.
+ *
+ * A suite building a path *from* tiers derives `word` from the root tier itself (the rail and spine header
+ * reuse the root's word, per `PathView.word`), so that derivation stays at the call site rather than
+ * being guessed at here.
+ */
+export const pathView = (o: Partial<PathView> = {}): PathView => ({
+	id: 0,
+	name: 'Pyromancy',
+	description: '',
+	word: 'aenkor',
+	iconPath: '',
+	activityKey: EActivityKey.Physical,
+	tiers: [],
+	...o
+});
+
+/** The shared word-of-power tooltip controller the spine cards and inspector drive on hover. The id is a
+ *  parameter because suites assert their own value back out of `aria-describedby`. */
+export const stubController = (describedById = 'tooltip-1'): WordTooltipController => ({
+	describedById,
+	show: vi.fn(),
+	move: vi.fn(),
+	hide: vi.fn()
+});
+
+/** An attribute reference row, for the payout-ladder formatters. `isPercentage` picks between a `+2%`-style
+ *  delta and a plain `+5`, which is the only field the ladder branches on. */
+export const attribute = (id: EAttribute, name: string, isPercentage = false): IAttribute => ({
+	id,
+	name,
+	description: '',
+	attributeType: EAttributeType.Secondary,
+	isPercentage,
+	isHarmful: false,
+	code: '',
+	displayOrder: 0,
+	decimals: 1
+});

--- a/UI/src/tests/routes/game/screens/proficiencies/lexicon-test-utils.ts
+++ b/UI/src/tests/routes/game/screens/proficiencies/lexicon-test-utils.ts
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import { EActivityKey, EAttribute, EAttributeType, type IAttribute } from '$lib/api';
+import { EActivityKey } from '$lib/api';
 import type {
 	PathView,
 	TierView,
@@ -67,18 +67,4 @@ export const stubController = (describedById = 'tooltip-1'): WordTooltipControll
 	show: vi.fn(),
 	move: vi.fn(),
 	hide: vi.fn()
-});
-
-/** An attribute reference row, for the payout-ladder formatters. `isPercentage` picks between a `+2%`-style
- *  delta and a plain `+5`, which is the only field the ladder branches on. */
-export const attribute = (id: EAttribute, name: string, isPercentage = false): IAttribute => ({
-	id,
-	name,
-	description: '',
-	attributeType: EAttributeType.Secondary,
-	isPercentage,
-	isHarmful: false,
-	code: '',
-	displayOrder: 0,
-	decimals: 1
 });

--- a/UI/src/tests/routes/game/screens/proficiencies/word-detail.test.ts
+++ b/UI/src/tests/routes/game/screens/proficiencies/word-detail.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import {
 	EActivityKey,
 	EAttribute,
-	EAttributeType,
 	EModifierType,
 	type IAttribute,
 	type IProficiencyLevelModifier,
@@ -17,26 +16,14 @@ import {
 	xpProgressText,
 	type SkillNameResolver
 } from '$routes/game/screens/proficiencies/word-detail';
-import type { TierView } from '$routes/game/screens/proficiencies/proficiencies-lexicon';
+import { attribute, tierView } from './lexicon-test-utils';
 
 /* ── fixtures ──────────────────────────────────────────────────────────────── */
 
-const attr = (id: EAttribute, name: string, isPercentage = false): IAttribute => ({
-	id,
-	name,
-	description: '',
-	attributeType: EAttributeType.Secondary,
-	isPercentage,
-	isHarmful: false,
-	code: '',
-	displayOrder: 0,
-	decimals: 1
-});
-
 // A percentage attribute (renders a `+2%`-style delta) and a flat one (renders a plain `+5`).
 const ATTRIBUTES: IAttribute[] = [
-	attr(EAttribute.CriticalChanceMultiplier, 'Fire Damage', true),
-	attr(EAttribute.Toughness, 'Toughness', false)
+	attribute(EAttribute.CriticalChanceMultiplier, 'Fire Damage', true),
+	attribute(EAttribute.Toughness, 'Toughness', false)
 ];
 
 const modifier = (o: Partial<IProficiencyLevelModifier> & { level: number }): IProficiencyLevelModifier => ({
@@ -47,27 +34,6 @@ const modifier = (o: Partial<IProficiencyLevelModifier> & { level: number }): IP
 });
 
 const reward = (level: number, rewardSkillId: number): IProficiencyLevelReward => ({ level, rewardSkillId });
-
-const tierView = (o: Partial<TierView> & { id: number }): TierView => ({
-	name: `Tier ${o.id}`,
-	description: '',
-	pathOrdinal: 0,
-	level: 0,
-	maxLevel: 10,
-	xp: 0,
-	xpForNext: 100,
-	state: 'unlocked',
-	frontier: false,
-	milestoneLevels: [],
-	levelModifiers: [],
-	levelRewards: [],
-	decipher: 'undeciphered',
-	word: `word${o.id}`,
-	pronunciation: `pron${o.id}`,
-	translation: `means${o.id}`,
-	iconPath: '',
-	...o
-});
 
 // Resolves a handful of skill ids; everything else is unknown (undefined), exercising the drop path.
 const SKILL_NAMES: Record<number, string> = { 100: 'Fireball', 200: 'Ember Strike', 300: 'Flame Burst' };

--- a/UI/src/tests/routes/game/screens/proficiencies/word-detail.test.ts
+++ b/UI/src/tests/routes/game/screens/proficiencies/word-detail.test.ts
@@ -16,14 +16,15 @@ import {
 	xpProgressText,
 	type SkillNameResolver
 } from '$routes/game/screens/proficiencies/word-detail';
-import { attribute, tierView } from './lexicon-test-utils';
+import { makeAttribute } from '../../../../fixtures/attributes';
+import { tierView } from './lexicon-test-utils';
 
 /* ── fixtures ──────────────────────────────────────────────────────────────── */
 
 // A percentage attribute (renders a `+2%`-style delta) and a flat one (renders a plain `+5`).
 const ATTRIBUTES: IAttribute[] = [
-	attribute(EAttribute.CriticalChanceMultiplier, 'Fire Damage', true),
-	attribute(EAttribute.Toughness, 'Toughness', false)
+	makeAttribute(EAttribute.CriticalChanceMultiplier, 'Fire Damage', { isPercentage: true }),
+	makeAttribute(EAttribute.Toughness, 'Toughness')
 ];
 
 const modifier = (o: Partial<IProficiencyLevelModifier> & { level: number }): IProficiencyLevelModifier => ({


### PR DESCRIPTION
Closes #2407.

Test-only: no production code touched, no behavior change. **193 lines deleted, 91 added** across six files (the shared module plus the five converted suites).

## Summary

Adds `UI/src/tests/routes/game/screens/proficiencies/lexicon-test-utils.ts` and converts the five Lexicon suites onto it. Every suite keeps the local call signature it already used, so no assertion or call site changed — only the fixture declarations moved.

What was consolidated:

| Builder | Copies before | Divergence |
|---|---|---|
| `tierView` | 5 | `TierSpine`'s `pathOrdinal: o.id`; the other four byte-identical |
| `pathView` | 2 | positional-`tiers` vs override-object signature; different `word` default |
| `stubController` | 3 | `describedById` — `tooltip-1` / `tooltip-7` / `tooltip-9` |

The two hand-rolled `IAttribute` builders (`attribute` / `attr`) were also removed, but folded onto the **existing** shared `UI/src/tests/fixtures/attributes.ts` → `makeAttribute` rather than into this module — see [Review round 1](#user-content-review-round-1) below.

## Two corrections to the issue's analysis

Both were checked against the tree rather than taken on faith, and neither changes the recommended outcome:

- **The issue says `pathView` had three copies.** It has two — `WordDetail.test.ts` and `TierSpine.test.ts`. The issue's own file list only names those two.
- **The issue calls `TierSpine`'s `pathOrdinal: o.id` "load-bearing for its ordering test".** It isn't. `TierSpine.svelte:55` derives its render order as `[...path.tiers].reverse()` — array position, not ordinal — and `pathOrdinal` is not read anywhere in the screen (only `proficiencies-lexicon.ts` reads it, off `IProficiency`, when *building* the view-model the suites bypass). The `draws the spine most-advanced first` test passes identically either way.

  The issue's preferred resolution — default it to `o.id` — is still the right call, just for a different reason: it preserves `TierSpine`'s existing values byte-for-byte and keeps a spine built from ascending ids ordinal-coherent, rather than defending a live assertion. That's what the shared builder's comment says.

## Notes on the shared module

- **`stubController` takes the tooltip id as a parameter** (defaulting to `tooltip-1`, `TierSpine`'s value). `TierCard` and `WordDetail` genuinely assert their own ids back out of `aria-describedby`, so this divergence had to survive rather than be reconciled away.
- **`TierSpine` keeps its positional `pathView(tiers, o)` as a one-line adapter** over the shared builder. That preserves its ~6 call sites *and* keeps the root-word derivation (`word: tiers[0]?.word`) at the call site where it's meaningful — a path built from its spine — instead of putting conditional logic in a base fixture. This mirrors the thin-adapter approach #2412 recommends for the sibling progression-map case.
- **`WordDetail.test.ts` keeps its `vi.hoisted` + `vi.mock('$stores', …)` block per-file**, as the issue requires. That stub is unrelated to anything in the shared module, so the module is a plain static import for every suite — it needs none of the "must not transitively reach `$stores`" care that `progression-test-utils.ts` documents, since nothing resolves it from inside a mock factory.

<a id="review-round-1"></a>
## Review round 1 — the `attribute` builder (fixed in 9cbc761)

The first push folded a local `attribute` builder into the new module. That was wrong: it was a **fifth copy** of `UI/src/tests/fixtures/attributes.ts` → `makeAttribute`, which four suites already use — net-new duplication in a PR whose purpose is removing it. Caught in review, removed, and the four call sites now use the shared builder. The module imports `EActivityKey` only.

The differing defaults (`makeAttribute` uses `attributeType: Primary`, `decimals: 0`; the local copy used `Secondary` / `1`) are unreachable here, but for a narrower reason than "the ladder only branches on `isPercentage`":

- `formatAttributeValue` (`attribute-display.ts:150-153`) **does** read `decimals` (`toFixed(attribute.decimals)`). Had the ladder routed through it, `decimals: 0` vs `1` would have been a live behaviour change on the `+2%` assertions.
- It doesn't: `formatModifier` (`word-detail.ts:76-81`) calls **`formatAttributeDelta`**, which reads only `isPercentage` and deliberately uses adaptive precision *instead of* `decimals` (its comment gives the reason — CooldownRecovery's `+0.004` → `+0.4%` must not round away), plus `attributeName`, which reads `name`.
- `WordDetail.svelte:117` routes attributes solely through `buildLadder`, so nothing on the screen reaches the `decimals` path.

## Test plan

- [x] Converted **one file at a time, running that suite in between** (per the issue's process note), so a changed default would fail loudly rather than pass weakly: `WordOfPowerTooltip` (4) → `TierCard` (7) → `word-detail` (18) → `TierSpine` (5) → `WordDetail`.
- [x] `npx vitest run src/tests/routes/game/screens/proficiencies/` — **9 files, 112 tests passed**, before and after the `makeAttribute` swap. The 9 collected files confirm `lexicon-test-utils.ts` is imported, not picked up as an empty suite (`vite.config.ts:8` collects only `*.{test,spec}.{js,ts}`).
- [x] `npm run lint` (eslint + `svelte-check`) — **1222 files, 0 errors, 0 warnings**. This is what pins the unused-import cleanup: `EAttributeType` and the `PathView`/`TierView`/`WordTooltipController` type imports left dangling by the extraction were removed.
- [x] `npm run test:unit:ci` — **312 files, 4009 tests passed**, no regression elsewhere.
- [x] Backend untouched, so no `dotnet` run applies and CI's changed-path gate skips those jobs (`verify-backend` / `test-backend` / `test-hooks` all report `skipped`).
- [x] Full CI green on `9cbc761` — `all-checks-passed: success`, including all three `test-e2e` browsers.