### PR TITLE
Fold the progression map suites' fixture builders into progression-test-utils (#2412)

### DIFF
--- a/UI/src/tests/routes/admin/workbench/progression/ProgressionMap.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/ProgressionMap.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest';
-import { EActivityKey } from '$lib/api';
 import { render, cleanup, fireEvent } from '@testing-library/svelte';
 import ProgressionMap from '$routes/admin/workbench/progression/ProgressionMap.svelte';
 import type { ProgressionStore } from '$routes/admin/workbench/progression/progression-store.svelte';
 import type { WorkbenchPath, WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+import { mapPath as path, mapTier as tier } from './progression-test-utils';
 
 // jsdom has no ResizeObserver; the map observes its container on mount.
 class ResizeObserverStub {
@@ -14,40 +14,6 @@ class ResizeObserverStub {
 
 beforeAll(() => {
 	(globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver = ResizeObserverStub;
-});
-
-const path = (id: number, over: Partial<WorkbenchPath> = {}): WorkbenchPath => ({
-	id,
-	name: `Path ${id}`,
-	description: '',
-	designerNotes: '',
-	activityKey: EActivityKey.Physical,
-	...over
-});
-
-const tier = (
-	id: number,
-	pathId: number,
-	ordinal: number,
-	over: Partial<WorkbenchProficiency> = {}
-): WorkbenchProficiency => ({
-	id,
-	name: `Tier ${id}`,
-	description: '',
-	designerNotes: '',
-	iconPath: '',
-	word: '',
-	pronunciation: '',
-	translation: '',
-	pathId,
-	pathOrdinal: ordinal,
-	maxLevel: 10,
-	baseXp: 100,
-	xpGrowth: 1.4,
-	levelModifiers: [],
-	levelRewards: [],
-	prerequisiteIds: [],
-	...over
 });
 
 const makeStore = (paths: WorkbenchPath[], profs: WorkbenchProficiency[]) =>

--- a/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EActivityKey, EAttribute, EModifierType, ESkillAcquisition } from '$lib/api';
 
-const { staticData } = vi.hoisted(() => ({
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	staticData: {} as any
-}));
-vi.mock('$stores', () => ({ staticData }));
+// `vi.mock` is hoisted within this file, so the factory resolves the shared stub by dynamic import
+// rather than closing over the static one below.
+vi.mock('$stores', async () => (await import('./progression-test-utils')).stubStores());
 
 import {
 	activityKeyGroups,
@@ -30,12 +28,9 @@ import {
 	xpCostCurve
 } from '$routes/admin/workbench/progression/progression-helpers';
 import type { WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+import { resetStores, staticData } from './progression-test-utils';
 
-beforeEach(() => {
-	for (const key of Object.keys(staticData)) {
-		delete staticData[key];
-	}
-});
+beforeEach(resetStores);
 
 const tier = (overrides: Partial<WorkbenchProficiency> & Pick<WorkbenchProficiency, 'id'>): WorkbenchProficiency => ({
 	...newProficiency(overrides.id, overrides.pathId ?? 1, overrides.pathOrdinal ?? 0),

--- a/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-helpers.test.ts
@@ -221,6 +221,16 @@ describe('validation', () => {
 		expect(rewardSkillFlagWarnings(stillFlagged)).toHaveLength(0);
 		expect(proficiencyBlockingWarnings(stillFlagged)).toHaveLength(0);
 	});
+
+	it('tolerates the pre-load catalogue state, when the reward lookup runs before skills load', () => {
+		// `staticData.skills` is genuinely `undefined` until the loading screen populates it, which is
+		// what `rewardSkillFlagWarnings`' `?.` guards; warn on nothing rather than throwing.
+		staticData.skills = undefined;
+
+		const withReward = tier({ id: 1, maxLevel: 5, levelRewards: [{ level: 3, rewardSkillId: 1 }] });
+		expect(rewardSkillFlagWarnings(withReward)).toHaveLength(0);
+		expect(proficiencyBlockingWarnings(withReward)).toHaveLength(0);
+	});
 });
 
 describe('DTO builders', () => {

--- a/UI/src/tests/routes/admin/workbench/progression/progression-map.test.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-map.test.ts
@@ -1,41 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { EActivityKey } from '$lib/api';
 import { bezierPath, mapColumns, mapEdgeDefs, tierNodeId } from '$routes/admin/workbench/progression/progression-map';
-import type { WorkbenchPath, WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
-
-const path = (id: number, over: Partial<WorkbenchPath> = {}): WorkbenchPath => ({
-	id,
-	name: `Path ${id}`,
-	description: '',
-	designerNotes: '',
-	activityKey: EActivityKey.Physical,
-	...over
-});
-
-const tier = (
-	id: number,
-	pathId: number,
-	ordinal: number,
-	over: Partial<WorkbenchProficiency> = {}
-): WorkbenchProficiency => ({
-	id,
-	name: `Tier ${id}`,
-	description: '',
-	designerNotes: '',
-	iconPath: '',
-	word: '',
-	pronunciation: '',
-	translation: '',
-	pathId,
-	pathOrdinal: ordinal,
-	maxLevel: 10,
-	baseXp: 100,
-	xpGrowth: 1.4,
-	levelModifiers: [],
-	levelRewards: [],
-	prerequisiteIds: [],
-	...over
-});
+import { mapPath as path, mapTier as tier } from './progression-test-utils';
 
 describe('tierNodeId', () => {
 	it('prefixes the tier id with t', () => {

--- a/UI/src/tests/routes/admin/workbench/progression/progression-test-utils.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-test-utils.ts
@@ -81,6 +81,23 @@ export const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProfici
 	...over
 });
 
+/* The map suites (`ProgressionMap.test.ts`, `progression-map.test.ts`) build topology — several tiers
+   across several paths — so identity is positional at their call sites (`mapTier(10, 0, 0)`), and their
+   assertions read the generated `Path {id}` name back out of the rendered column header. The two
+   adapters below keep the field set in one place while preserving both. */
+
+/** Positional path fixture for the map suites — `Path {id}`, keyed on physical damage. */
+export const mapPath = (id: number, over: Partial<WorkbenchPath> = {}): WorkbenchPath =>
+	path({ id, name: `Path ${id}`, activityKey: EActivityKey.Physical, ...over });
+
+/** Positional tier fixture for the map suites — `Tier {id}` at `ordinal` on `pathId`. */
+export const mapTier = (
+	id: number,
+	pathId: number,
+	ordinal: number,
+	over: Partial<WorkbenchProficiency> = {}
+): WorkbenchProficiency => tier({ id, name: `Tier ${id}`, pathId, pathOrdinal: ordinal, ...over });
+
 /**
  * Casts a partial fake to the store the components read. The suites drive these rather than the real
  * `ProgressionStore`, which only loads through a socket-backed `load()`.

--- a/UI/src/tests/routes/admin/workbench/progression/progression-test-utils.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-test-utils.ts
@@ -12,17 +12,32 @@ import type { WorkbenchPath, WorkbenchProficiency } from '$routes/admin/workbenc
    import that did would re-enter the factory resolving it. Everything below `$lib/api` is `import type`
    and therefore erased, which is what keeps that true today. */
 
-/** The last-saved `staticData` catalogues the editor's reference lookups read. */
-export const staticData = {
-	enemies: [] as unknown[],
-	zones: [] as unknown[],
-	challenges: [] as unknown[],
-	items: [] as unknown[],
-	classes: [] as unknown[],
-	skillRecipes: [] as unknown[],
-	proficiencies: [] as unknown[],
-	skills: [] as unknown[],
-	paths: [] as unknown[]
+const catalogueKeys = [
+	'enemies',
+	'zones',
+	'challenges',
+	'items',
+	'classes',
+	'skillRecipes',
+	'proficiencies',
+	'skills',
+	'paths'
+] as const;
+
+/* The last-saved `staticData` catalogues the editor's reference lookups read. Each slot is
+   `unknown[] | undefined` because the real store's is: the backing `$state` is genuinely `undefined`
+   until the loading screen populates it, and that state is load-bearing (`static-data.svelte.ts`), so
+   production readers guard with `?.`. A suite covering a pre-load read assigns `undefined` directly. */
+export const staticData: Record<(typeof catalogueKeys)[number], unknown[] | undefined> = {
+	enemies: [],
+	zones: [],
+	challenges: [],
+	items: [],
+	classes: [],
+	skillRecipes: [],
+	proficiencies: [],
+	skills: [],
+	paths: []
 };
 
 export const dangerModal = vi.fn();
@@ -40,8 +55,8 @@ export const stubStores = () => ({ staticData, dangerModal });
 /** Restores the stub to its empty, uncalled baseline. Call from `beforeEach`. */
 export const resetStores = () => {
 	dangerModal.mockReset();
-	for (const catalogue of Object.values(staticData)) {
-		catalogue.length = 0;
+	for (const key of catalogueKeys) {
+		staticData[key] = [];
 	}
 };
 
@@ -86,11 +101,9 @@ export const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProfici
    assertions read the generated `Path {id}` name back out of the rendered column header. The two
    adapters below keep the field set in one place while preserving both. */
 
-/** Positional path fixture for the map suites — `Path {id}`, keyed on physical damage. */
 export const mapPath = (id: number, over: Partial<WorkbenchPath> = {}): WorkbenchPath =>
 	path({ id, name: `Path ${id}`, activityKey: EActivityKey.Physical, ...over });
 
-/** Positional tier fixture for the map suites — `Tier {id}` at `ordinal` on `pathId`. */
 export const mapTier = (
 	id: number,
 	pathId: number,


### PR DESCRIPTION
Closes #2412.

> **Updated after review** (0023cd7). One claim below was disproved by the review and is corrected: the `progression-helpers.test.ts` fold *dropped* coverage of the pre-load catalogue state rather than being strictly closer to the real `$stores`. Fixed inline; details in the [reply](https://github.com/ginderjeremiah/GameServer/pull/2423#discussion_r3650135331).

## Summary

`ProgressionMap.test.ts:19-50` and `progression-map.test.ts:6-37` each carried a **byte-for-byte identical** pair of `path`/`tier` builders — 44 duplicated lines in two files sitting next to each other. This folds them onto the shared `progression-test-utils` module #2411 introduced.

## How it addresses the issue

**Adapter over call-site migration.** The issue asked this be decided rather than assumed, so: adapter. Two positional wrappers land in `progression-test-utils.ts`:

```ts
export const mapPath = (id, over = {}) => path({ id, name: `Path ${id}`, activityKey: EActivityKey.Physical, ...over });
export const mapTier = (id, pathId, ordinal, over = {}) => tier({ id, name: `Tier ${id}`, pathId, pathOrdinal: ordinal, ...over });
```

Each suite imports them as `mapPath as path, mapTier as tier`, so the ~15 call sites (`tier(10, 0, 0)`) don't churn. On the "is two signatures for one type a smell?" question — **no, not here.** These two suites build *topology* (several tiers spread across several paths), so `pathId`/`ordinal` are the subject of nearly every assertion, not incidental overrides; the positional form makes that legible in a way `tier({ id: 10, pathId: 0, pathOrdinal: 0 })` does not. Divergent *defaults* would be the smell — the adapters carry only the shape, and the field set now has exactly one definition. It also matches the precedent already in the folder: `PathDetail.test.ts:22` wraps the shared `tier` in a local adapter for the same reason.

**Verified the defaults still bite.** Per #2405's process note, this is the hazard — a reconciled default can silently weaken a DOM-text assertion into passing. Mutating `Path ${id}` → `PathX ${id}` in the shared adapter fails `progression-map.test.ts:53` (`expect(cols[0].name).toBe('Path 0')`), confirming the generated name is still load-bearing and read back out of the rendered column header. Each file was converted and run individually before the next.

**Also folded in** (the issue's "worth a look while in there"): `progression-helpers.test.ts` now resolves the shared `stubStores` / `resetStores` / `staticData` instead of its own `vi.hoisted` `{} as any` stub and `delete`-key-loop reset, removing an `any` and its `eslint-disable`.

That swap initially cost real coverage, caught in review. The old `{}` stub left `staticData.skills` **`undefined`** at the top of every test, so the suite was implicitly exercising the `staticData.skills?.[…]` guard at `progression-helpers.ts:203` everywhere; the shared stub started it as `[]`, and nothing hit that branch any more. The `undefined` slot isn't a stub artifact — `static-data.svelte.ts` documents it as load-bearing (`loaded` and `reference-data.ts` detect "not yet loaded" by the slot being null), and the real getters expose `T[] | undefined`. So the shared stub was closer to the *loaded* state and further from the *pre-load* one, which is the state the production guard exists for.

Fixed by widening the shared stub's catalogue slots to `unknown[] | undefined` behind a `catalogueKeys` const tuple — which also lets `resetStores` reassign fresh empties without a `keyof` cast, so the removed `any` stays removed — plus a case covering the pre-load read. All nine slots widened rather than only `skills`: every slot is `undefined` pre-load, so the asymmetry would be arbitrary, and the other eight are only ever assigned in these suites, never read.

Its local `tier` builder is deliberately **left alone**: unlike the map suites' hand-rolled literal, it composes the *production* `newProficiency` factory, so it isn't duplication — it's coverage of the real factory's defaults, and replacing it would lose that.

## Test plan

Test-only change; no production code touched. The existing assertions are the regression guard and must keep passing unchanged; the one added test covers the pre-load branch this PR would otherwise have left uncovered.

- [x] `npx vitest run src/tests/routes/admin/workbench/progression/` — 10 files passing (run per-file during conversion, then together).
- [x] Mutation check on the dedup: `Path ${id}` → `PathX ${id}` in the shared adapter fails exactly 1 test, proving the generated-name default is still asserted rather than silently unused.
- [x] Mutation check on the restored coverage: `staticData.skills?.[…]` → `!` in `progression-helpers.ts` fails exactly the new test — and, with the fix reverted, fails **nothing**, which is what confirms the regression was real rather than theoretical.
- [x] `npm run test:unit:ci` — 312 files, 4017 tests passing.
- [x] `npm run lint` (eslint + `svelte-check`) — 1222 files, 0 errors, 0 warnings.