### PR TITLE
Consolidate the duplicated IProficiency test fixture builders (#2414)

### DIFF
--- a/UI/src/tests/fixtures/proficiencies.ts
+++ b/UI/src/tests/fixtures/proficiencies.ts
@@ -1,0 +1,40 @@
+import { EActivityKey, type IPath, type IProficiency } from '$lib/api';
+
+/* Shared `IPath` / `IProficiency` contract builders (#2414). These are the raw reference-data records,
+   distinct from `lexicon-test-utils.ts`'s `PathView` / `TierView` — those are the derived view models the
+   Lexicon renders. A suite that needs both wants this module for the inputs and that one for the outputs. */
+
+/**
+ * Builds an {@link IProficiency} reference-data entry for tests. The conlang and icon fields are generated
+ * from the id so a suite can assert on `icon-1`/`w1`/`p1`/`t1` without restating them per call; everything
+ * else is a neutral placeholder. `pathId`/`pathOrdinal` default to 0 — a suite building a spine is expected
+ * to place each tier explicitly rather than inherit a position.
+ */
+export const makeProficiency = (o: Partial<IProficiency> & { id: number }): IProficiency => ({
+	name: `Prof ${o.id}`,
+	description: '',
+	designerNotes: '',
+	iconPath: `icon-${o.id}`,
+	word: `w${o.id}`,
+	pronunciation: `p${o.id}`,
+	translation: `t${o.id}`,
+	pathId: 0,
+	pathOrdinal: 0,
+	maxLevel: 10,
+	baseXp: 100,
+	xpGrowth: 1,
+	levelModifiers: [],
+	levelRewards: [],
+	prerequisiteIds: [],
+	...o
+});
+
+/** Builds an {@link IPath} reference-data entry for tests. A path carries no word of its own — the rail and
+ *  spine header reuse the root tier's — so there is nothing conlang-shaped to generate here. */
+export const makePath = (o: Partial<IPath> & { id: number }): IPath => ({
+	name: `Path ${o.id}`,
+	description: '',
+	designerNotes: '',
+	activityKey: EActivityKey.Physical,
+	...o
+});

--- a/UI/src/tests/fixtures/proficiencies.ts
+++ b/UI/src/tests/fixtures/proficiencies.ts
@@ -1,8 +1,13 @@
 import { EActivityKey, type IPath, type IProficiency } from '$lib/api';
 
-/* Shared `IPath` / `IProficiency` contract builders (#2414). These are the raw reference-data records,
-   distinct from `lexicon-test-utils.ts`'s `PathView` / `TierView` — those are the derived view models the
-   Lexicon renders. A suite that needs both wants this module for the inputs and that one for the outputs. */
+/* Shared `IPath` / `IProficiency` contract builders (#2414). Two other modules build adjacent shapes:
+
+   · `lexicon-test-utils.ts` builds the derived `PathView` / `TierView` the Lexicon renders — a suite that
+     needs both wants this module for the inputs and that one for the outputs.
+   · `progression/progression-test-utils.ts` (`path`/`tier`) builds `WorkbenchPath`/`WorkbenchProficiency`,
+     which are *plain aliases* of these same two contracts — so a new contract field taxes that module too.
+     Its blank conlang defaults and `xpGrowth: 1.4` are load-bearing for the workbench detail suites and
+     deliberately diverge from the defaults here; converging the two is #2426. */
 
 /**
  * Builds an {@link IProficiency} reference-data entry for tests. The conlang and icon fields are generated
@@ -10,14 +15,14 @@ import { EActivityKey, type IPath, type IProficiency } from '$lib/api';
  * else is a neutral placeholder. `pathId`/`pathOrdinal` default to 0 — a suite building a spine is expected
  * to place each tier explicitly rather than inherit a position.
  */
-export const makeProficiency = (o: Partial<IProficiency> & { id: number }): IProficiency => ({
-	name: `Prof ${o.id}`,
+export const makeProficiency = (overrides: Partial<IProficiency> & { id: number }): IProficiency => ({
+	name: `Prof ${overrides.id}`,
 	description: '',
 	designerNotes: '',
-	iconPath: `icon-${o.id}`,
-	word: `w${o.id}`,
-	pronunciation: `p${o.id}`,
-	translation: `t${o.id}`,
+	iconPath: `icon-${overrides.id}`,
+	word: `w${overrides.id}`,
+	pronunciation: `p${overrides.id}`,
+	translation: `t${overrides.id}`,
 	pathId: 0,
 	pathOrdinal: 0,
 	maxLevel: 10,
@@ -26,15 +31,15 @@ export const makeProficiency = (o: Partial<IProficiency> & { id: number }): IPro
 	levelModifiers: [],
 	levelRewards: [],
 	prerequisiteIds: [],
-	...o
+	...overrides
 });
 
 /** Builds an {@link IPath} reference-data entry for tests. A path carries no word of its own — the rail and
  *  spine header reuse the root tier's — so there is nothing conlang-shaped to generate here. */
-export const makePath = (o: Partial<IPath> & { id: number }): IPath => ({
-	name: `Path ${o.id}`,
+export const makePath = (overrides: Partial<IPath> & { id: number }): IPath => ({
+	name: `Path ${overrides.id}`,
 	description: '',
 	designerNotes: '',
 	activityKey: EActivityKey.Physical,
-	...o
+	...overrides
 });

--- a/UI/src/tests/routes/admin/workbench/references.test.ts
+++ b/UI/src/tests/routes/admin/workbench/references.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import {
-	EActivityKey,
 	EAttribute,
 	EChallengeType,
 	EEntityType,
@@ -26,6 +25,7 @@ import {
 	type ReferenceGroup,
 	type ReferenceSources
 } from '$routes/admin/workbench/references';
+import { makePath, makeProficiency } from '../../../fixtures/proficiencies';
 
 const enemy = (id: number, name: string, opts: Partial<IEnemy> = {}): IEnemy => ({
 	id,
@@ -114,34 +114,10 @@ const recipe = (id: number, resultSkillId: number, opts: Partial<ISkillRecipe> =
 	...opts
 });
 
-const path = (id: number, name: string, opts: Partial<IPath> = {}): IPath => ({
-	id,
-	name,
-	description: '',
-	activityKey: EActivityKey.Fire,
-	designerNotes: '',
-	...opts
-});
+const path = (id: number, name: string, opts: Partial<IPath> = {}): IPath => makePath({ id, name, ...opts });
 
-const proficiency = (id: number, name: string, opts: Partial<IProficiency> = {}): IProficiency => ({
-	id,
-	name,
-	description: '',
-	iconPath: '',
-	word: '',
-	pronunciation: '',
-	translation: '',
-	pathId: 0,
-	pathOrdinal: 0,
-	maxLevel: 10,
-	baseXp: 100,
-	xpGrowth: 1.4,
-	designerNotes: '',
-	levelModifiers: [],
-	levelRewards: [],
-	prerequisiteIds: [],
-	...opts
-});
+const proficiency = (id: number, name: string, opts: Partial<IProficiency> = {}): IProficiency =>
+	makeProficiency({ id, name, ...opts });
 
 /** Places each record at its own id as the array index, honouring the zero-based-id/index invariant. */
 const bySlot = <T extends { id: number }>(...items: T[]): T[] => {

--- a/UI/src/tests/routes/game/screens/proficiencies/Proficiencies.test.ts
+++ b/UI/src/tests/routes/game/screens/proficiencies/Proficiencies.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
 import type { IPath, IProficiency } from '$lib/api';
 import { EActivityKey } from '$lib/api';
+import { makePath, makeProficiency } from '../../../../fixtures/proficiencies';
 
 /* The screen drives the real playerProficiencies store (fetched over the socket) and reads the
    proficiency/path reference data from staticData, so the socket fetch and staticData are stubbed; the
@@ -27,22 +28,9 @@ vi.mock('$stores', async (importOriginal) => {
 import Proficiencies from '$routes/game/screens/proficiencies/Proficiencies.svelte';
 import { playerProficiencies } from '$stores';
 
-const prof = (o: Partial<IProficiency> & { id: number; pathId: number; pathOrdinal: number }): IProficiency => ({
-	name: `Prof ${o.id}`,
-	description: '',
-	designerNotes: '',
-	iconPath: '',
-	word: `w${o.id}`,
-	pronunciation: '',
-	translation: '',
-	maxLevel: 10,
-	baseXp: 100,
-	xpGrowth: 1,
-	levelModifiers: [],
-	levelRewards: [],
-	prerequisiteIds: [],
-	...o
-});
+// A spine tier must state where it sits, so the local signature keeps pathId/pathOrdinal required.
+const prof = (o: Partial<IProficiency> & { id: number; pathId: number; pathOrdinal: number }): IProficiency =>
+	makeProficiency(o);
 
 const PROFICIENCIES: IProficiency[] = [
 	prof({ id: 0, pathId: 0, pathOrdinal: 0, name: 'Fire' }),
@@ -50,8 +38,8 @@ const PROFICIENCIES: IProficiency[] = [
 	prof({ id: 2, pathId: 1, pathOrdinal: 0, name: 'Earth' })
 ];
 const PATHS: IPath[] = [
-	{ id: 0, name: 'Pyromancy', description: '', designerNotes: '', activityKey: EActivityKey.Fire },
-	{ id: 1, name: 'Geomancy', description: '', designerNotes: '', activityKey: EActivityKey.Earth }
+	makePath({ id: 0, name: 'Pyromancy', activityKey: EActivityKey.Fire }),
+	makePath({ id: 1, name: 'Geomancy', activityKey: EActivityKey.Earth })
 ];
 
 beforeEach(() => {

--- a/UI/src/tests/routes/game/screens/proficiencies/proficiencies-view.test.ts
+++ b/UI/src/tests/routes/game/screens/proficiencies/proficiencies-view.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EActivityKey, EDamageType } from '$lib/api';
 import type { IPath, IPlayerProficiency, IProficiency } from '$lib/api';
+import { makePath as path, makeProficiency } from '../../../../fixtures/proficiencies';
 
 /* The pure derivation (buildLexicon and friends) takes explicit args and needs no mocks; the
    ProficienciesView reads the live stores, so those are stubbed with mutable stand-ins the view-class
@@ -38,30 +39,9 @@ import { ProficienciesView } from '$routes/game/screens/proficiencies/proficienc
 
 /* ── fixtures ──────────────────────────────────────────────────────────────── */
 
-const prof = (o: Partial<IProficiency> & { id: number; pathId: number; pathOrdinal: number }): IProficiency => ({
-	name: `Prof ${o.id}`,
-	description: '',
-	designerNotes: '',
-	iconPath: `icon-${o.id}`,
-	word: `w${o.id}`,
-	pronunciation: `p${o.id}`,
-	translation: `t${o.id}`,
-	maxLevel: 10,
-	baseXp: 100,
-	xpGrowth: 1,
-	levelModifiers: [],
-	levelRewards: [],
-	prerequisiteIds: [],
-	...o
-});
-
-const path = (o: Partial<IPath> & { id: number }): IPath => ({
-	name: `Path ${o.id}`,
-	description: '',
-	designerNotes: '',
-	activityKey: EActivityKey.Physical,
-	...o
-});
+// A spine tier must state where it sits, so the local signature keeps pathId/pathOrdinal required.
+const prof = (o: Partial<IProficiency> & { id: number; pathId: number; pathOrdinal: number }): IProficiency =>
+	makeProficiency(o);
 
 const row = (proficiencyId: number, level: number, xp = 0): IPlayerProficiency => ({ proficiencyId, level, xp });
 

--- a/UI/src/tests/routes/game/screens/synthesis/Synthesis.test.ts
+++ b/UI/src/tests/routes/game/screens/synthesis/Synthesis.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import { EDamageType, ERarity, ESkillAcquisition, type IProficiency, type ISkill, type ISkillRecipe } from '$lib/api';
+import { makeProficiency } from '../../../../fixtures/proficiencies';
 
 /* The screen drives the real playerProficiencies store (fetched over the socket) for the gate state and
    reads recipes/skills/proficiencies from staticData, so the socket fetch + staticData are stubbed; the
@@ -62,26 +63,7 @@ const SKILLS: ISkill[] = [
 	skill(6, { name: 'Graverend', rarityId: ERarity.Epic })
 ];
 
-const PROFICIENCIES: IProficiency[] = [
-	{
-		id: 0,
-		name: 'Geomancy',
-		description: '',
-		designerNotes: '',
-		iconPath: '',
-		word: '',
-		pronunciation: '',
-		translation: '',
-		pathId: 0,
-		pathOrdinal: 0,
-		maxLevel: 10,
-		baseXp: 100,
-		xpGrowth: 1,
-		levelModifiers: [],
-		levelRewards: [],
-		prerequisiteIds: []
-	}
-];
+const PROFICIENCIES: IProficiency[] = [makeProficiency({ id: 0, name: 'Geomancy' })];
 
 const RECIPES: ISkillRecipe[] = [
 	{ id: 0, resultSkillId: 3, inputSkillIds: [0, 1], conditions: [], designerNotes: '' }, // ready (owns 0,1)

--- a/UI/src/tests/routes/game/screens/synthesis/synthesis-reveal.test.ts
+++ b/UI/src/tests/routes/game/screens/synthesis/synthesis-reveal.test.ts
@@ -6,6 +6,7 @@ import {
 	representativeRecipe,
 	type RecipeState
 } from '$routes/game/screens/synthesis/synthesis';
+import { makeProficiency } from '../../../../fixtures/proficiencies';
 
 /* The derivation takes explicit args and needs no mocks. The reference catalogues are zero-based-id
    arrays (resolved by index), so the fixtures keep ids contiguous with their array position. */
@@ -38,24 +39,7 @@ const recipe = (
 	over: Partial<ISkillRecipe> = {}
 ): ISkillRecipe => ({ id, resultSkillId, inputSkillIds, conditions, designerNotes: '', ...over });
 
-const prof = (id: number, name: string): IProficiency => ({
-	id,
-	name,
-	description: '',
-	designerNotes: '',
-	iconPath: '',
-	word: '',
-	pronunciation: '',
-	translation: '',
-	pathId: 0,
-	pathOrdinal: 0,
-	maxLevel: 10,
-	baseXp: 100,
-	xpGrowth: 1,
-	levelModifiers: [],
-	levelRewards: [],
-	prerequisiteIds: []
-});
+const prof = (id: number, name: string): IProficiency => makeProficiency({ id, name });
 
 /* A small fixed world: skills 0..3 are inputs, skills 4..6 are synthesis results. */
 const skills: ISkill[] = [

--- a/UI/src/tests/stores/proficiencies.svelte.test.ts
+++ b/UI/src/tests/stores/proficiencies.svelte.test.ts
@@ -18,6 +18,7 @@ import {
 import { EAttributeModifierSource } from '$lib/battle/attribute-modifier';
 import { playerProficiencies } from '$stores/proficiencies.svelte';
 import { staticData } from '$stores/static-data.svelte';
+import { makeProficiency } from '../fixtures/proficiencies';
 
 const playerProficiency = (proficiencyId: number, level: number, xp = 0): IPlayerProficiency => ({
 	proficiencyId,
@@ -26,24 +27,8 @@ const playerProficiency = (proficiencyId: number, level: number, xp = 0): IPlaye
 });
 
 // A minimal proficiency reference record whose only meaningful payload here is its per-level modifiers.
-const proficiency = (id: number, levelModifiers: IProficiency['levelModifiers']): IProficiency => ({
-	id,
-	name: `Proficiency ${id}`,
-	description: '',
-	designerNotes: '',
-	iconPath: '',
-	word: '',
-	pronunciation: '',
-	translation: '',
-	pathId: 0,
-	pathOrdinal: id,
-	maxLevel: 10,
-	baseXp: 100,
-	xpGrowth: 1,
-	levelModifiers,
-	levelRewards: [],
-	prerequisiteIds: []
-});
+const proficiency = (id: number, levelModifiers: IProficiency['levelModifiers']): IProficiency =>
+	makeProficiency({ id, pathOrdinal: id, levelModifiers });
 
 const additive = (level: number, attributeId: EAttribute, amount: number) => ({
 	level,


### PR DESCRIPTION
Closes #2414.

## Summary

Six suites across five folders hand-rolled the same `IProficiency` contract fixture (and two of them an `IPath` one), so every new field on either contract taxed all six files to keep `svelte-check` green. This adds `UI/src/tests/fixtures/proficiencies.ts` exporting `makeProficiency` / `makePath` — the same home and shape as the existing `fixtures/attributes.ts` → `makeAttribute` — and points each suite at it.

Net: **~125 lines deleted, ~25 added.**

Two related modules stay separate, and the new file's header names both so the next person to add a contract field doesn't stop at the first one they find:

- `lexicon-test-utils.ts` builds the derived `PathView`/`TierView` (#2413) — a suite that needs both wants this module for the inputs and that one for the outputs.
- `progression-test-utils.ts` (#2412) builds `WorkbenchPath`/`WorkbenchProficiency`, which `progression/types.ts` declares as **plain aliases** of these same two contracts. Its blank conlang defaults and `xpGrowth: 1.4` are load-bearing for the workbench detail suites, so converging the two is its own change — #2426. This PR therefore narrows the edit surface for a new contract field from six places to two, not to one.

## How it addresses the issue

Per the issue's constraints:

- **Local call signatures preserved.** Each suite keeps its own `prof` / `proficiency` / `path` name as a thin one-line adapter over the shared builder, so the ~40 call sites don't churn. The two screens suites keep `pathId`/`pathOrdinal` **required** in their local signature — a spine tier that doesn't state where it sits is a meaningless fixture, and that guard is worth keeping even though the shared builder defaults them.
- **Defaults reconciled explicitly, toward the generated variants.** `iconPath`/`word`/`pronunciation`/`translation` are generated from the id (`icon-1`, `w1`, `p1`, `t1`). Those are the ones with a live assertion — `proficiencies-view.test.ts:219` asserts `iconPath === 'icon-0'` — whereas the suites that defaulted them to `''` assert nothing about them, so they take the generated values rather than being forced to pass `''` per call. I checked each of the four fields' assertions individually rather than assuming.
- **One file at a time, suite run in between**, so a changed default would have failed loudly instead of quietly weakening an assertion.

Two small deliberate calls worth flagging:

- `pathOrdinal` defaults to `0`, not to the id (which is what `lexicon-test-utils.ts`'s `tierView` does). Every suite that actually builds a spine passes it explicitly, and defaulting it to the id would silently reposition the fixtures in the suites that don't care about ordering.
- `references.test.ts`'s local `proficiency` used `xpGrowth: 1.4` where everything else used `1`; nothing in that suite reads it, so it now takes the shared `1`. Its `path` likewise moves from `EActivityKey.Fire` to the neutral `Physical` default — again unread there.

Two suites (`Proficiencies.test.ts`'s `PATHS`, `Synthesis.test.ts`'s `PROFICIENCIES`) had bare object literals rather than a builder; both now go through the shared fixtures. `Synthesis.test.ts` was a sixth instance the issue's survey missed — caught in review, and picked up here since it's in a folder this change already touched.

## Test plan

- [x] `npm run lint` (eslint + `svelte-check`) — clean, 1223 files, 0 errors / 0 warnings. The now-unused `EActivityKey` import in `references.test.ts` was removed with the builder that used it.
- [x] `npx prettier --check` on every touched file — clean.
- [x] Each converted suite run individually right after its conversion: `proficiencies-view` (42), `Proficiencies` (5), `synthesis-reveal` (11), `proficiencies.svelte` (19), `references` (45), `Synthesis` (12).
- [x] Full unit suite, re-run after the review fixes: **312 files / 4017 tests passed**.
- [x] No backend or production frontend code touched — test-only, no behavior change, no battle-parity surface.

## Follow-ups filed

- **#2425** — the same duplication class at much larger scale on other contracts: `ISkill` hand-rolled in ~30 suites, `IItem` in ~20, `IZone` in ~16. `references.test.ts` alone still carries seven more local builders (`enemy`, `zone`, `challenge`, `item`, `itemMod`, `wclass`, `recipe`, `skill`) that this change deliberately leaves in place.
- **#2426** — point `progression-test-utils.ts`'s `tier`/`path` at these shared builders, keeping its divergent defaults as stated overrides.