### PR TITLE
Clamp CombatRating's offense-side proc chances to probability 1 (#2416)

### DIFF
--- a/Game.Core.Tests/Battle/CombatRatingTests.cs
+++ b/Game.Core.Tests/Battle/CombatRatingTests.cs
@@ -119,6 +119,80 @@ namespace Game.Core.Tests.Battle
             Assert.False(double.IsInfinity(rate));
         }
 
+        // ── Rate: offense-side proc-chance clamp (#2416) ────────────────────────
+
+        [Fact]
+        public void Rate_RiposteChanceBeyondCertainty_RatesTheSameAsExactlyAtCertainty()
+        {
+            // The engine draws a parry from [0, 1), so ParryChance 1.0 already parries every incoming attack —
+            // authoring more cannot buy additional riposte fires. The offense-side riposte term must price the
+            // clamped chance, not the raw product (which would scale the counter's expected hit linearly).
+            var counter = MakeSkill(cooldownMs: 1000, baseDamage: 20);
+            var atCertainty = MakeBattlerWithSkills([(ParryChance, 1.0)], [], counterSkill: counter);
+            var beyondCertainty = MakeBattlerWithSkills([(ParryChance, 5.0)], [], counterSkill: counter);
+
+            Assert.Equal(
+                CombatRating.Rate(atCertainty, isPlayer: true),
+                CombatRating.Rate(beyondCertainty, isPlayer: true), 6);
+        }
+
+        [Fact]
+        public void Rate_NegativeParryChance_IsPricedAsNoRiposte()
+        {
+            // A debuffed-below-zero ParryChance never procs in the engine, so the riposte term must contribute
+            // nothing — an unclamped product would price it as a negative offense contribution instead.
+            var counter = MakeSkill(cooldownMs: 1000, baseDamage: 20);
+            var negativeParry = MakeBattlerWithSkills([(ParryChance, -0.5)], [], counterSkill: counter);
+            var noParry = MakeBattlerWithSkills([], [], counterSkill: counter);
+
+            Assert.Equal(
+                CombatRating.Rate(noParry, isPlayer: true),
+                CombatRating.Rate(negativeParry, isPlayer: true), 6);
+        }
+
+        [Fact]
+        public void Rate_CriticalChanceBeyondCertainty_RatesTheSameAsExactlyAtCertainty()
+        {
+            // Same clamp on the crit expectation: a skill authored at CriticalChance 1.0 already crits every
+            // fire, so the CriticalDamage premium must not keep scaling past it.
+            var atCertainty = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50, criticalChance: 1.0)]);
+            var beyondCertainty = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50, criticalChance: 5.0)]);
+
+            Assert.Equal(
+                CombatRating.Rate(atCertainty, isPlayer: true),
+                CombatRating.Rate(beyondCertainty, isPlayer: true), 6);
+        }
+
+        [Fact]
+        public void Rate_CriticalChanceRampedPastCertaintyByMultiplier_RatesTheSameAsExactlyAtCertainty()
+        {
+            // The realistic route past 1: a modestly authored CriticalChance times a Luck-ramped
+            // CriticalChanceMultiplier. 0.5 × 2 already reaches certainty, so 0.5 × 4 must rate identically.
+            var atCertainty = MakeBattlerWithSkills(
+                [(CriticalChanceMultiplier, 1.0)], [MakeSkill(cooldownMs: 1000, baseDamage: 50, criticalChance: 0.5)]);
+            var beyondCertainty = MakeBattlerWithSkills(
+                [(CriticalChanceMultiplier, 3.0)], [MakeSkill(cooldownMs: 1000, baseDamage: 50, criticalChance: 0.5)]);
+
+            Assert.Equal(
+                CombatRating.Rate(atCertainty, isPlayer: true),
+                CombatRating.Rate(beyondCertainty, isPlayer: true), 6);
+        }
+
+        [Fact]
+        public void Rate_ParryPastCertaintyDoesNotLetDodgeSubtractAvoidance()
+        {
+            // The survivability composition `parry + (1 - parry) × dodge` is only meaningful for probabilities:
+            // an unclamped parry above 1 makes (1 - parry) negative, so adding dodge would *lower* the credit.
+            // With both clamped, certain parry already avoids everything and dodge cannot reduce it.
+            var parryOnly = MakeBattlerWithSkills([(ParryChance, 1.01)], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+            var parryAndDodge = MakeBattlerWithSkills(
+                [(ParryChance, 1.01), (DodgeChance, 50.0)], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+
+            Assert.Equal(
+                CombatRating.Rate(parryOnly, isPlayer: true),
+                CombatRating.Rate(parryAndDodge, isPlayer: true), 6);
+        }
+
         // ── Rate: offense ─────────────────────────────────────────────────────
 
         [Fact]

--- a/Game.Core.Tests/Battle/CombatRatingTests.cs
+++ b/Game.Core.Tests/Battle/CombatRatingTests.cs
@@ -179,11 +179,44 @@ namespace Game.Core.Tests.Battle
         }
 
         [Fact]
+        public void Rate_NegativeDodgeChance_IsPricedAsNoDodge()
+        {
+            // The dodge mirror of the negative-parry case, and the only direction in which the dodge clamp is
+            // observable at all: for any parry in [0, 1] a dodge above 1 already drives `avoid` past
+            // MaxMitigationCredit clamped or not, so the cap flattens the positive direction. A negative dodge
+            // instead makes `avoid` negative, inflating the mitigation fraction above 1 and understating the
+            // rating — the engine simply never dodges.
+            var negativeDodge = MakeBattlerWithSkills([(DodgeChance, -0.5)], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+            var noDodge = MakeBattlerWithSkills([], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
+
+            Assert.Equal(
+                CombatRating.Rate(noDodge, isPlayer: true),
+                CombatRating.Rate(negativeDodge, isPlayer: true), 6);
+        }
+
+        [Fact]
+        public void Rate_NegativeCriticalChanceMultiplier_IsPricedAsNoCrit()
+        {
+            // CriticalDamage has a base of 1.5, so (CriticalDamage - 1) is non-zero and a debuffed-negative
+            // multiplier is observable: unclamped it would price crit as a damage *penalty* on every fire.
+            var negativeCrit = MakeBattlerWithSkills(
+                [(CriticalChanceMultiplier, -2.0)], [MakeSkill(cooldownMs: 1000, baseDamage: 50, criticalChance: 0.5)]);
+            var noCrit = MakeBattlerWithSkills(
+                [(CriticalChanceMultiplier, -2.0)], [MakeSkill(cooldownMs: 1000, baseDamage: 50, criticalChance: 0.0)]);
+
+            Assert.Equal(
+                CombatRating.Rate(noCrit, isPlayer: true),
+                CombatRating.Rate(negativeCrit, isPlayer: true), 6);
+        }
+
+        [Fact]
         public void Rate_ParryPastCertaintyDoesNotLetDodgeSubtractAvoidance()
         {
             // The survivability composition `parry + (1 - parry) × dodge` is only meaningful for probabilities:
             // an unclamped parry above 1 makes (1 - parry) negative, so adding dodge would *lower* the credit.
-            // With both clamped, certain parry already avoids everything and dodge cannot reduce it.
+            // With both clamped, certain parry already avoids everything and dodge cannot reduce it. Note this
+            // pins the *parry* clamp only — once parry pins to 1, (1 - parry) annihilates the dodge term either
+            // way; Rate_NegativeDodgeChance_IsPricedAsNoDodge is what covers the dodge clamp.
             var parryOnly = MakeBattlerWithSkills([(ParryChance, 1.01)], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);
             var parryAndDodge = MakeBattlerWithSkills(
                 [(ParryChance, 1.01), (DodgeChance, 50.0)], [MakeSkill(cooldownMs: 1000, baseDamage: 50)]);

--- a/Game.Core/Battle/CombatRating.cs
+++ b/Game.Core/Battle/CombatRating.cs
@@ -55,6 +55,18 @@ namespace Game.Core.Battle
         // zero-survivability battler never divides a downstream consumer (e.g. a rating ratio) by zero.
         private const double Epsilon = 1e-6;
 
+        // A proc chance as the engine can actually deliver it. Every proc draw is `_rng.Next() < chance`
+        // against a [0, 1) draw (BattleContext.DamageTarget/ResolvePlayerHit), so a product at or above 1
+        // always fires and one at or below 0 never does. The authored-only enablers (ParryChance,
+        // DodgeChance, a skill's CriticalChance) are uncapped and their derived multipliers can be ramped
+        // by shared-expiry effect stacking, so the raw product overshoots what the engine can produce —
+        // pricing it unclamped would credit unreachable capability. Structural, not tunable: this is the
+        // definition of a probability, unlike ServerGameConstants.MaxMitigationCredit's tuned ceiling.
+        private static double ProcChance(double chance)
+        {
+            return Math.Clamp(chance, 0.0, 1.0);
+        }
+
         /// <summary>
         /// The rating for <paramref name="battler"/> as assembled — <c>√(OffenseRate × Survivability)</c>
         /// against the fixed reference profiles in <see cref="ServerGameConstants"/>. Pass
@@ -210,7 +222,8 @@ namespace Game.Core.Battle
             // Riposte (player-side only): effectiveParryChance × reference attack rate × the counter's expected hit.
             if (isPlayer && battler.CounterSkill is Skill counterSkill)
             {
-                var effectiveParryChance = effectiveCaster.GetAttributeValue(ParryChance) * effectiveCaster.GetAttributeValue(ParryChanceMultiplier);
+                var effectiveParryChance = ProcChance(
+                    effectiveCaster.GetAttributeValue(ParryChance) * effectiveCaster.GetAttributeValue(ParryChanceMultiplier));
                 total += effectiveParryChance * ServerGameConstants.RefAttackRate
                     * ExpectedDirectHit(counterSkill, isPlayer, effectiveCaster, referenceDefense);
             }
@@ -243,7 +256,7 @@ namespace Game.Core.Battle
             // damage pipeline enforces (BattleContext.DamageTarget), so an authored enemy CriticalChance is
             // never priced as a capability that cannot fire.
             var critExpectation = isPlayer
-                ? 1.0 + skill.CriticalChance * effectiveCaster.GetAttributeValue(CriticalChanceMultiplier)
+                ? 1.0 + ProcChance(skill.CriticalChance * effectiveCaster.GetAttributeValue(CriticalChanceMultiplier))
                       * (effectiveCaster.GetAttributeValue(CriticalDamage) - 1.0)
                 : 1.0;
             // Enemies never execute in this engine either — ResolvePlayerHit (BattleContext.DamageTarget) is the
@@ -264,12 +277,16 @@ namespace Game.Core.Battle
             var regenRate = effectiveCaster.GetAttributeValue(HealthRegenPerSecond);
             var effectiveHealth = maxHealth + regenRate * ServerGameConstants.RefFightDuration;
 
-            // Avoid (parry-then-dodge) is player-only — enemies never parry or dodge in this engine.
+            // Avoid (parry-then-dodge) is player-only — enemies never parry or dodge in this engine. Each
+            // chance is clamped before composing: the sequential form only holds for probabilities, so a raw
+            // parry product above 1 would turn (1 - parry) negative and have dodge *subtract* avoidance.
             var avoid = 0.0;
             if (isPlayer)
             {
-                var parry = effectiveCaster.GetAttributeValue(ParryChance) * effectiveCaster.GetAttributeValue(ParryChanceMultiplier);
-                var dodge = effectiveCaster.GetAttributeValue(DodgeChance) * effectiveCaster.GetAttributeValue(DodgeChanceMultiplier);
+                var parry = ProcChance(
+                    effectiveCaster.GetAttributeValue(ParryChance) * effectiveCaster.GetAttributeValue(ParryChanceMultiplier));
+                var dodge = ProcChance(
+                    effectiveCaster.GetAttributeValue(DodgeChance) * effectiveCaster.GetAttributeValue(DodgeChanceMultiplier));
                 avoid = parry + (1 - parry) * dodge;
             }
 

--- a/Game.Core/Battle/CombatRating.cs
+++ b/Game.Core/Battle/CombatRating.cs
@@ -67,6 +67,19 @@ namespace Game.Core.Battle
             return Math.Clamp(chance, 0.0, 1.0);
         }
 
+        // The two avoidance chances, each read once so the offense (riposte) and survivability readings cannot
+        // drift apart — the very failure this clamp exists to fix was those two sites disagreeing about what a
+        // parry chance means. Mirrors the engine's own products (BattleContext.cs:230-233).
+        private static double EffectiveParryChance(Battler caster)
+        {
+            return ProcChance(caster.GetAttributeValue(ParryChance) * caster.GetAttributeValue(ParryChanceMultiplier));
+        }
+
+        private static double EffectiveDodgeChance(Battler caster)
+        {
+            return ProcChance(caster.GetAttributeValue(DodgeChance) * caster.GetAttributeValue(DodgeChanceMultiplier));
+        }
+
         /// <summary>
         /// The rating for <paramref name="battler"/> as assembled — <c>√(OffenseRate × Survivability)</c>
         /// against the fixed reference profiles in <see cref="ServerGameConstants"/>. Pass
@@ -222,9 +235,7 @@ namespace Game.Core.Battle
             // Riposte (player-side only): effectiveParryChance × reference attack rate × the counter's expected hit.
             if (isPlayer && battler.CounterSkill is Skill counterSkill)
             {
-                var effectiveParryChance = ProcChance(
-                    effectiveCaster.GetAttributeValue(ParryChance) * effectiveCaster.GetAttributeValue(ParryChanceMultiplier));
-                total += effectiveParryChance * ServerGameConstants.RefAttackRate
+                total += EffectiveParryChance(effectiveCaster) * ServerGameConstants.RefAttackRate
                     * ExpectedDirectHit(counterSkill, isPlayer, effectiveCaster, referenceDefense);
             }
 
@@ -283,10 +294,8 @@ namespace Game.Core.Battle
             var avoid = 0.0;
             if (isPlayer)
             {
-                var parry = ProcChance(
-                    effectiveCaster.GetAttributeValue(ParryChance) * effectiveCaster.GetAttributeValue(ParryChanceMultiplier));
-                var dodge = ProcChance(
-                    effectiveCaster.GetAttributeValue(DodgeChance) * effectiveCaster.GetAttributeValue(DodgeChanceMultiplier));
+                var parry = EffectiveParryChance(effectiveCaster);
+                var dodge = EffectiveDodgeChance(effectiveCaster);
                 avoid = parry + (1 - parry) * dodge;
             }
 


### PR DESCRIPTION
Closes #2416.

## Summary

`CombatRating` priced two offense-side proc chances as raw products with no clamp:

- the riposte term (`CombatRating.cs:211-216`) — `ParryChance × ParryChanceMultiplier`;
- the crit expectation (`CombatRating.cs:245-248`) — `skill.CriticalChance × CriticalChanceMultiplier`.

The engine resolves every proc as `_rng.Next() < chance` against a `[0, 1)` draw (`BattleContext.cs:230-233` for parry/dodge, `:308` for crit), so a product at or above 1 always fires and one at or below 0 never does. Pricing the raw product credits capability the engine cannot deliver — inflating `OffenseRate`, which via `min(EnemyRating ÷ PlayerRating, 1)²` and the `max(PlayerRating, EnemyRating)` proficiency denominator **undercuts that player's XP and proficiency gains**. #2171 already capped the survivability side's credits; this is the other half of the same root cause.

Adds a shared `ProcChance` helper (`Math.Clamp(chance, 0, 1)`) and applies it at every chance read site.

## How it addresses the issue

Both sites the issue names are clamped, via the shared helper it suggests. Two deliberate calls beyond the literal ask:

**Clamped to `[0, 1]`, not just to 1.** A negative chance can't proc either — the draw is non-negative — and neither `ParryChance` nor `CriticalChance` is floored anywhere (`AttributeCollection` does no clamping), so an `Opponent`-targeted debuff can drive one below zero. Unclamped, the riposte term then contributed *negative* offense. Same one-line cost, so it's covered rather than left as a second issue.

**The survivability parry/dodge products are clamped too.** The issue frames this as offense-only, but `avoid = parry + (1 - parry) × dodge` is a sequential-probability composition and only means anything for probabilities: an unclamped parry above 1 makes `(1 - parry)` negative, so dodge *subtracts* avoidance. Concretely, `ParryChance 1.01` + a ramped dodge of 50 gave `avoid ≈ 0.51` — a certain-parry build priced as barely evasive. The existing `MaxMitigationCredit` cap didn't catch it because that value never crossed 0.95. The cap itself is unchanged and still applies on top; the clamp only fixes what's fed into it.

The helper's comment states why this clamp is structural (the definition of a probability) rather than a tuned ceiling like `MaxMitigationCredit`, so a future reader doesn't move it into `ServerGameConstants`.

Server-only pricing — the rating carries no frontend parity surface, so there is no mirrored frontend change.

## Verification of the issue's claims

Per CLAUDE.md, the issue's assertions were checked against the tree rather than taken as given. All three hold: both offense read sites are unclamped as described; the survivability credits are capped at `CombatRating.cs:284-285`; and the engine's `[0, 1)` draw semantics are as claimed. The one thing the issue understates is the survivability composition bug above.

## Test plan

Five new cases in `Game.Core.Tests/Battle/CombatRatingTests.cs`, covering both terms, both directions of the clamp, and the composition:

- [x] `Rate_RiposteChanceBeyondCertainty_RatesTheSameAsExactlyAtCertainty` — `ParryChance` 1.0 vs 5.0 with a counter skill.
- [x] `Rate_NegativeParryChance_IsPricedAsNoRiposte` — a below-zero chance rates identically to no parry at all.
- [x] `Rate_CriticalChanceBeyondCertainty_RatesTheSameAsExactlyAtCertainty` — authored `CriticalChance` 1.0 vs 5.0.
- [x] `Rate_CriticalChanceRampedPastCertaintyByMultiplier_RatesTheSameAsExactlyAtCertainty` — the realistic route past 1 (0.5 × 2 vs 0.5 × 4).
- [x] `Rate_ParryPastCertaintyDoesNotLetDodgeSubtractAvoidance` — the survivability composition case.

- [x] Each new test confirmed to **fail** with the clamp neutered to the identity function (exactly 5 failures, no more), then pass with it restored — so none of them is vacuously green.
- [x] `dotnet build` clean, 0 warnings.
- [x] Full suite green: `Game.Core.Tests` 1451, `Game.Application.Tests` 1105, `Game.Api.Tests` 871, `Game.Infrastructure.Tests` 74 — 0 failures.
- [x] The existing #2171 cap tests (`Rate_ParryBeyondCertainty_RatesTheSameAsExactlyAtTheCap`, `Rate_DodgeBeyondCertainty_DoesNotExplodeRating`, …) still pass unchanged — the clamp composes with the cap rather than replacing it.

No frontend tests: server-only, no parity surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8uJc1ebma8uwdXCAk6rRJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8uJc1ebma8uwdXCAk6rRJ)_