### PR TITLE
Consolidate the hand-rolled ISkill test builders onto a shared fixture (#2425)

### DIFF
--- a/UI/src/tests/fixtures/skills.ts
+++ b/UI/src/tests/fixtures/skills.ts
@@ -6,7 +6,11 @@ import { EDamageType, ERarity, ESkillAcquisition, type ISkill } from '$lib/api';
    · `lib/battle/battle-sim-test-utils.ts` (`registerSkill`) assigns ids by registry position so a
      Battler resolves a skill exactly as the live game does — it builds on this module but owns the id.
    · `routes/game/screens/fight/fight-fixtures.ts` (`makeSkill`) returns a live `Skill` domain object
-     bound to an owner, not the `ISkill` contract, so it consumes this module rather than replacing it. */
+     bound to an owner, not the `ISkill` contract, so it consumes this module rather than replacing it.
+   · Nine suites seed untyped skill literals into a `staticData: {} as any` mock (codex, workbench
+     entities/progression). They type-check as nothing, so they pay no contract-drift tax — and filling
+     their previously-`undefined` fields could change what the suite renders. Left alone deliberately;
+     a `grep` for skill-shaped literals under `src/tests/` still finding them is expected, not a gap. */
 
 /**
  * Builds an {@link ISkill} reference-data entry for tests. Everything but the id is a neutral

--- a/UI/src/tests/fixtures/skills.ts
+++ b/UI/src/tests/fixtures/skills.ts
@@ -7,10 +7,13 @@ import { EDamageType, ERarity, ESkillAcquisition, type ISkill } from '$lib/api';
      Battler resolves a skill exactly as the live game does — it builds on this module but owns the id.
    · `routes/game/screens/fight/fight-fixtures.ts` (`makeSkill`) returns a live `Skill` domain object
      bound to an owner, not the `ISkill` contract, so it consumes this module rather than replacing it.
-   · Nine suites seed untyped skill literals into a `staticData: {} as any` mock (codex, workbench
-     entities/progression). They type-check as nothing, so they pay no contract-drift tax — and filling
-     their previously-`undefined` fields could change what the suite renders. Left alone deliberately;
-     a `grep` for skill-shaped literals under `src/tests/` still finding them is expected, not a gap. */
+
+   Nine suites are excluded on purpose: the codex pair, `workbench/reference`, and the workbench
+   entities/progression suites all seed skill literals into a mocked `staticData` — most as `{} as any`,
+   the progression pair via `progression-test-utils`' `unknown[]`. Nothing type-checks them as `ISkill`,
+   so they pay no contract-drift tax, and filling their previously-`undefined` fields could change what
+   a suite renders. A `grep` for skill-shaped literals under `src/tests/` still finding them is
+   expected, not a gap. */
 
 /**
  * Builds an {@link ISkill} reference-data entry for tests. Everything but the id is a neutral

--- a/UI/src/tests/fixtures/skills.ts
+++ b/UI/src/tests/fixtures/skills.ts
@@ -1,0 +1,37 @@
+import { EDamageType, ERarity, ESkillAcquisition, type ISkill } from '$lib/api';
+
+/* Shared `ISkill` contract builder (#2425). Two other modules build adjacent shapes and deliberately
+   stay separate:
+
+   · `lib/battle/battle-sim-test-utils.ts` (`registerSkill`) assigns ids by registry position so a
+     Battler resolves a skill exactly as the live game does — it builds on this module but owns the id.
+   · `routes/game/screens/fight/fight-fixtures.ts` (`makeSkill`) returns a live `Skill` domain object
+     bound to an owner, not the `ISkill` contract, so it consumes this module rather than replacing it. */
+
+/**
+ * Builds an {@link ISkill} reference-data entry for tests. Everything but the id is a neutral
+ * placeholder so a suite states only what it asserts on.
+ *
+ * The conlang fields (`word`/`pronunciation`/`translation`) default to **blank**, unlike
+ * {@link import('./proficiencies').makeProficiency}, which generates them from the id. A blank word is
+ * what marks a skill as un-deciphered, so the synthesis reveal suites depend on the empty default —
+ * generating one here would silently make every fixture skill deciphered.
+ */
+export const makeSkill = (overrides: Partial<ISkill> & { id: number }): ISkill => ({
+	name: `Skill ${overrides.id}`,
+	baseDamage: 10,
+	criticalChance: 0,
+	damageMultipliers: [],
+	effects: [],
+	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
+	description: '',
+	cooldownMs: 1000,
+	iconPath: '',
+	rarityId: ERarity.Common,
+	word: '',
+	pronunciation: '',
+	translation: '',
+	acquisition: ESkillAcquisition.Player,
+	designerNotes: '',
+	...overrides
+});

--- a/UI/src/tests/lib/battle/battle-formulas.test.ts
+++ b/UI/src/tests/lib/battle/battle-formulas.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { ERarity, EAttribute, EDamageType, ESkillAcquisition } from '$lib/api';
+import { EAttribute, EDamageType } from '$lib/api';
 import type { ISkill } from '$lib/api';
 import { BattleAttributes } from '$lib/battle/battle-attributes';
 import {
@@ -12,26 +12,10 @@ import {
 	resistanceTotal,
 	skillContributions
 } from '$lib/battle/battle-formulas';
+import { makeSkill } from '../../fixtures/skills';
 
-const makeSkillData = (overrides: Partial<ISkill> = {}): ISkill => ({
-	id: 1,
-	name: 'Slash',
-	baseDamage: 10,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	description: 'A basic slash',
-	cooldownMs: 1000,
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	iconPath: '/icons/slash.png',
-	rarityId: ERarity.Common,
-	designerNotes: '',
-	word: '',
-	pronunciation: '',
-	translation: '',
-	acquisition: ESkillAcquisition.Player,
-	...overrides
-});
+const makeSkillData = (overrides: Partial<ISkill> = {}): ISkill =>
+	makeSkill({ id: 1, name: 'Slash', description: 'A basic slash', iconPath: '/icons/slash.png', ...overrides });
 
 /** Raw attribute values without the derived/static pass, so tests control every input. */
 const makeAttributes = (attrs: [EAttribute, number][] = []) =>

--- a/UI/src/tests/lib/battle/battle-sim-test-utils.ts
+++ b/UI/src/tests/lib/battle/battle-sim-test-utils.ts
@@ -1,10 +1,11 @@
 import { Battler, newItem } from '$lib/battle';
+// Aliased: this module's own `makeSkill` builds a `SkillSpec` (pre-registration), not the contract.
+import { makeSkill as makeSkillContract } from '../../fixtures/skills';
 import {
 	EAttribute,
 	EDamageType,
 	EItemCategory,
 	ERarity,
-	ESkillAcquisition,
 	type EModifierType,
 	type ESkillEffectTarget,
 	type EItemModType,
@@ -88,26 +89,19 @@ export const makeEffect = (
  *  returning its assigned id so a Battler resolves it exactly as the live game does. */
 function registerSkill(registry: ISkill[], spec: SkillSpec): number {
 	const id = registry.length;
-	registry.push({
-		id,
-		name: `Skill ${id}`,
-		baseDamage: spec.baseDamage,
-		criticalChance: spec.criticalChance,
-		cooldownMs: spec.cooldownMs,
-		// The skill's weighted leaf-type split (#1343); a single full-weight portion is identical to the
-		// pre-portions single-type hit.
-		damagePortions: spec.damagePortions,
-		damageMultipliers: spec.multipliers,
-		effects: spec.effects,
-		description: '',
-		iconPath: '',
-		rarityId: ERarity.Common,
-		designerNotes: '',
-		word: '',
-		pronunciation: '',
-		translation: '',
-		acquisition: ESkillAcquisition.Player
-	});
+	registry.push(
+		makeSkillContract({
+			id,
+			baseDamage: spec.baseDamage,
+			criticalChance: spec.criticalChance,
+			cooldownMs: spec.cooldownMs,
+			// The skill's weighted leaf-type split (#1343); a single full-weight portion is identical to the
+			// pre-portions single-type hit.
+			damagePortions: spec.damagePortions,
+			damageMultipliers: spec.multipliers,
+			effects: spec.effects
+		})
+	);
 	return id;
 }
 

--- a/UI/src/tests/lib/battle/battler-effects.test.ts
+++ b/UI/src/tests/lib/battle/battler-effects.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { EDamageType, ERarity, EAttribute, EModifierType, ESkillAcquisition, ESkillEffectTarget } from '$lib/api';
+import { EAttribute, EModifierType, ESkillEffectTarget } from '$lib/api';
 import type { ISkill } from '$lib/api';
 
 // A mutable skill registry backing the mocked `staticData.skills`, so the battleStep ordering test can
@@ -16,6 +16,8 @@ vi.mock('$stores', () => ({
 import { Battler, Skill, battleStep } from '$lib/battle';
 import { Mulberry32 } from '$lib/engine/mulberry32';
 import { battlerFactory, makeSkill, makeEffect } from './battle-sim-test-utils';
+// Aliased: `makeSkill` above builds a `SkillSpec` for the battler factory, not the contract.
+import { makeSkill as makeSkillContract } from '../../fixtures/skills';
 
 /**
  * Unit coverage for the timed skill-effect bookkeeping on {@link Battler}, {@link Skill} and
@@ -43,6 +45,22 @@ const effect = (
 	durationMs = 1000,
 	target: ESkillEffectTarget = ESkillEffectTarget.Self
 ) => makeEffect(id, target, attribute, type, amount, durationMs);
+
+/** A damageless skill carrying one Self and one Opponent effect, so a fire exercises both routes. */
+const dualEffectSkill = (caster: Battler) =>
+	new Skill(
+		makeSkillContract({
+			id: 0,
+			name: 'Dual',
+			baseDamage: 0,
+			cooldownMs: 40,
+			effects: [
+				effect(1, EAttribute.Strength, EModifierType.Additive, 5, 1000, ESkillEffectTarget.Self),
+				effect(2, EAttribute.Strength, EModifierType.Additive, 7, 1000, ESkillEffectTarget.Opponent)
+			]
+		}),
+		caster
+	);
 
 describe('Battler skill-effect bookkeeping', () => {
 	beforeEach(() => {
@@ -200,30 +218,7 @@ describe('Battler skill-effect bookkeeping', () => {
 	it('routes a skill’s Self effect to the caster and Opponent effect to the foe', () => {
 		const caster = makeBattler();
 		const foe = makeBattler();
-		const skill = new Skill(
-			{
-				id: 0,
-				name: 'Dual',
-				baseDamage: 0,
-				criticalChance: 0,
-				cooldownMs: 40,
-				damageMultipliers: [],
-				effects: [
-					effect(1, EAttribute.Strength, EModifierType.Additive, 5, 1000, ESkillEffectTarget.Self),
-					effect(2, EAttribute.Strength, EModifierType.Additive, 7, 1000, ESkillEffectTarget.Opponent)
-				],
-				description: '',
-				iconPath: '',
-				rarityId: ERarity.Common,
-				designerNotes: '',
-				word: '',
-				pronunciation: '',
-				translation: '',
-				damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-				acquisition: ESkillAcquisition.Player
-			},
-			caster
-		);
+		const skill = dualEffectSkill(caster);
 
 		skill.applyEffects(foe);
 
@@ -234,30 +229,7 @@ describe('Battler skill-effect bookkeeping', () => {
 	it('reports each newly-applied effect (and the battler it landed on) to the onApplied callback', () => {
 		const caster = makeBattler();
 		const foe = makeBattler();
-		const skill = new Skill(
-			{
-				id: 0,
-				name: 'Dual',
-				baseDamage: 0,
-				criticalChance: 0,
-				cooldownMs: 40,
-				damageMultipliers: [],
-				effects: [
-					effect(1, EAttribute.Strength, EModifierType.Additive, 5, 1000, ESkillEffectTarget.Self),
-					effect(2, EAttribute.Strength, EModifierType.Additive, 7, 1000, ESkillEffectTarget.Opponent)
-				],
-				description: '',
-				iconPath: '',
-				rarityId: ERarity.Common,
-				designerNotes: '',
-				word: '',
-				pronunciation: '',
-				translation: '',
-				damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-				acquisition: ESkillAcquisition.Player
-			},
-			caster
-		);
+		const skill = dualEffectSkill(caster);
 
 		const applied: { id: number; onCaster: boolean }[] = [];
 		skill.applyEffects(foe, (e, target) => applied.push({ id: e.id, onCaster: target === caster }));
@@ -403,27 +375,7 @@ describe('Battler skill-effect bookkeeping', () => {
  */
 describe('Skill effect attribute scaling', () => {
 	const skillWith = (effect: ReturnType<typeof makeEffect>, caster: Battler) =>
-		new Skill(
-			{
-				id: 0,
-				name: 'Scaler',
-				baseDamage: 0,
-				criticalChance: 0,
-				cooldownMs: 40,
-				damageMultipliers: [],
-				effects: [effect],
-				description: '',
-				iconPath: '',
-				rarityId: ERarity.Common,
-				designerNotes: '',
-				word: '',
-				pronunciation: '',
-				translation: '',
-				damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-				acquisition: ESkillAcquisition.Player
-			},
-			caster
-		);
+		new Skill(makeSkillContract({ id: 0, name: 'Scaler', baseDamage: 0, cooldownMs: 40, effects: [effect] }), caster);
 
 	const poison = (baseAmount: number, scalingAmount: number) =>
 		makeEffect(

--- a/UI/src/tests/lib/battle/battler.test.ts
+++ b/UI/src/tests/lib/battle/battler.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ERarity, EAttribute, EDamageType, ESkillAcquisition, ESkillEffectTarget } from '$lib/api';
+import { EAttribute, EDamageType, ESkillEffectTarget } from '$lib/api';
 import type { ISkill } from '$lib/api';
 import { EModifierType, EAttributeModifierSource } from '$lib/battle/attribute-modifier';
 import { makeEffect } from './battle-sim-test-utils';
+import { makeSkill } from '../../fixtures/skills';
 
 const mockSkills: ISkill[] = [];
 
@@ -17,24 +18,8 @@ vi.mock('$stores', () => ({
 import { Battler, type BattlerData } from '$lib/battle/battler';
 import type { Skill } from '$lib/battle/skill';
 
-const makeSkillData = (id: number, baseDamage: number, cooldownMs: number): ISkill => ({
-	id,
-	name: `Skill ${id}`,
-	baseDamage,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	description: '',
-	cooldownMs,
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	iconPath: '',
-	rarityId: ERarity.Common,
-	designerNotes: '',
-	word: '',
-	pronunciation: '',
-	translation: '',
-	acquisition: ESkillAcquisition.Player
-});
+const makeSkillData = (id: number, baseDamage: number, cooldownMs: number): ISkill =>
+	makeSkill({ id, baseDamage, cooldownMs });
 
 const makeTypedSkillData = (id: number, type: EDamageType): ISkill => ({
 	...makeSkillData(id, 10, 1000),

--- a/UI/src/tests/lib/battle/skill.test.ts
+++ b/UI/src/tests/lib/battle/skill.test.ts
@@ -1,29 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { EDamageType, ERarity, EAttribute, EModifierType, ESkillAcquisition, ESkillEffectTarget } from '$lib/api';
+import { EAttribute, EModifierType, ESkillEffectTarget } from '$lib/api';
 import type { ISkill, IAttributeMultiplier } from '$lib/api';
 import { BattleAttributes } from '$lib/battle/battle-attributes';
 import { Skill } from '$lib/battle/skill';
 import { Battler } from '$lib/battle';
+import { makeSkill } from '../../fixtures/skills';
 
-const makeSkillData = (overrides: Partial<ISkill> = {}): ISkill => ({
-	id: 1,
-	name: 'Slash',
-	baseDamage: 10,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	description: 'A basic slash',
-	cooldownMs: 1000,
-	iconPath: '/icons/slash.png',
-	rarityId: ERarity.Common,
-	designerNotes: '',
-	word: '',
-	pronunciation: '',
-	translation: '',
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	acquisition: ESkillAcquisition.Player,
-	...overrides
-});
+const makeSkillData = (overrides: Partial<ISkill> = {}): ISkill =>
+	makeSkill({ id: 1, name: 'Slash', description: 'A basic slash', iconPath: '/icons/slash.png', ...overrides });
 
 const makeMockOwner = (attrs: [EAttribute, number][] = []) => {
 	const attributes = new BattleAttributes(

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -1,14 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-	EDamageType,
-	ERarity,
-	EAttribute,
-	ELogType,
-	EModifierType,
-	ESkillAcquisition,
-	ESkillEffectTarget
-} from '$lib/api';
+import { EDamageType, EAttribute, ELogType, EModifierType, ESkillEffectTarget } from '$lib/api';
 import type { ISkill, IEnemy, IEnemyInstance } from '$lib/api';
+import { makeSkill } from '../../../fixtures/skills';
 
 // Callbacks captured from the mocked engine hooks. `onLogicalUpdate` emits a delta,
 // `onRenderUpdate` a (renderDelta, logicalDelta) pair, and `onNewEnemyLoaded` an enemy instance.
@@ -178,24 +171,7 @@ describe('BattleEngine', () => {
 		vi.mocked(evaluateMechanicTriggers).mockClear();
 
 		mockSkills.length = 0;
-		mockSkills[0] = {
-			id: 0,
-			name: 'Slash',
-			baseDamage: 100,
-			criticalChance: 0,
-			damageMultipliers: [],
-			effects: [],
-			description: '',
-			cooldownMs: 500,
-			iconPath: '',
-			rarityId: ERarity.Common,
-			designerNotes: '',
-			word: '',
-			pronunciation: '',
-			translation: '',
-			damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-			acquisition: ESkillAcquisition.Player
-		};
+		mockSkills[0] = makeSkill({ id: 0, name: 'Slash', baseDamage: 100, cooldownMs: 500 });
 
 		mockEnemies.length = 0;
 		mockEnemies[1] = {

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EAttribute, EDamageType, EItemCategory, EItemModType, ELogType, ERarity } from '$lib/api';
 import type { IInventoryData, IItem, IItemMod, ISkill } from '$lib/api';
 import { PUNCH_SKILL_ID } from '$lib/api/types/game-constants';
+import { makeSkill } from '../../../fixtures/skills';
 
 const mockInventoryData: IInventoryData = {
 	unlockedItems: [],
@@ -332,24 +333,12 @@ describe('InventoryManager', () => {
 	// appended to the granted ids only when it resolves. A real weapon (any type) replaces the fists.
 	describe('virtual-fists punch + equippedWeaponType (#1342)', () => {
 		const seedPunchSkill = () => {
-			mockSkills[PUNCH_SKILL_ID] = {
+			mockSkills[PUNCH_SKILL_ID] = makeSkill({
 				id: PUNCH_SKILL_ID,
 				name: 'Punch',
 				baseDamage: 4,
-				criticalChance: 0,
-				damageMultipliers: [],
-				effects: [],
-				description: '',
-				cooldownMs: 1000,
-				damagePortions: [{ type: EDamageType.Unarmed, weight: 1 }],
-				iconPath: '',
-				rarityId: ERarity.Common,
-				designerNotes: '',
-				word: '',
-				pronunciation: '',
-				translation: '',
-				acquisition: 0
-			};
+				damagePortions: [{ type: EDamageType.Unarmed, weight: 1 }]
+			});
 		};
 
 		it('appends the punch signature when bare-handed and the punch skill resolves', () => {

--- a/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
@@ -10,6 +10,7 @@ import {
 	type ISkill
 } from '$lib/api';
 import type { TableSectionConfig } from '$routes/admin/workbench/entities/types';
+import { makeSkill } from '../../../../fixtures/skills';
 
 /* Skill config transforms: `newItem` defaults, the derived meta line, the effects
    `newRow` defaults, and the persist path — a child-only change (effects or
@@ -235,24 +236,14 @@ describe('skillEntity', () => {
 	});
 
 	it('persist saves the effects when only effects change, without an identity Edit or a multipliers call', async () => {
-		const baseline: ISkill = {
+		const baseline = makeSkill({
 			id: 0,
 			name: 'Poison Sting',
-			designerNotes: '',
-			baseDamage: 10,
-			criticalChance: 0,
 			cooldownMs: 2000,
-			iconPath: '',
-			rarityId: ERarity.Common,
-			word: '',
-			pronunciation: '',
-			translation: '',
-			damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-			acquisition: ESkillAcquisition.Player,
 			description: 'desc',
 			damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 1 }],
 			effects: [effect({ id: 1, amount: 0.5 })]
-		};
+		});
 		const record: ISkill = { ...baseline, effects: [effect({ id: 1, amount: 0.75 })] }; // only the effect amount changed
 		socket.skills = [record];
 
@@ -268,24 +259,14 @@ describe('skillEntity', () => {
 	});
 
 	it('persist saves the multipliers when only multipliers change, skipping the effects endpoint', async () => {
-		const baseline: ISkill = {
+		const baseline = makeSkill({
 			id: 0,
 			name: 'Slash',
-			designerNotes: '',
-			baseDamage: 10,
-			criticalChance: 0,
 			cooldownMs: 2000,
-			iconPath: '',
-			rarityId: ERarity.Common,
-			word: '',
-			pronunciation: '',
-			translation: '',
-			damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-			acquisition: ESkillAcquisition.Player,
 			description: 'desc',
 			damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 1 }],
 			effects: [effect({ id: 1 })]
-		};
+		});
 		const record: ISkill = { ...baseline, damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 2 }] };
 		socket.skills = [record];
 
@@ -303,24 +284,13 @@ describe('skillEntity', () => {
 	it('persist Adds a new skill and saves its effects against the resolved id', async () => {
 		// A freshly-added record has a temporary negative id; persistEntity resolves the real
 		// id from the post-save refetch before running the effects child saver.
-		const added: ISkill = {
+		const added = makeSkill({
 			id: -1,
 			name: 'Venom',
-			designerNotes: '',
 			baseDamage: 5,
-			criticalChance: 0,
-			cooldownMs: 1000,
-			iconPath: '',
-			rarityId: ERarity.Common,
-			word: '',
-			pronunciation: '',
-			translation: '',
-			damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-			acquisition: ESkillAcquisition.Player,
 			description: 'Poisons the foe',
-			damageMultipliers: [],
 			effects: [effect({ id: 0, target: ESkillEffectTarget.Opponent })] // new effect, id 0
-		};
+		});
 		socket.skills = [{ ...added, id: 7 }]; // the persisted record at its real id
 
 		await skillEntity.persist({ added: [added], modified: [], deleted: [], existingIds: [] });

--- a/UI/src/tests/routes/admin/workbench/references.test.ts
+++ b/UI/src/tests/routes/admin/workbench/references.test.ts
@@ -7,7 +7,6 @@ import {
 	EItemModType,
 	EModifierType,
 	ERarity,
-	ESkillAcquisition,
 	type IChallenge,
 	type IClass,
 	type IEnemy,
@@ -26,6 +25,7 @@ import {
 	type ReferenceSources
 } from '$routes/admin/workbench/references';
 import { makePath, makeProficiency } from '../../../fixtures/proficiencies';
+import { makeSkill } from '../../../fixtures/skills';
 
 const enemy = (id: number, name: string, opts: Partial<IEnemy> = {}): IEnemy => ({
 	id,
@@ -128,24 +128,7 @@ const bySlot = <T extends { id: number }>(...items: T[]): T[] => {
 	return arr;
 };
 
-const skill = (id: number, name: string): ISkill => ({
-	id,
-	name,
-	baseDamage: 10,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	damagePortions: [],
-	description: '',
-	cooldownMs: 1000,
-	iconPath: '',
-	rarityId: ERarity.Common,
-	word: '',
-	pronunciation: '',
-	translation: '',
-	acquisition: ESkillAcquisition.Player,
-	designerNotes: ''
-});
+const skill = (id: number, name: string): ISkill => makeSkill({ id, name });
 
 // Id-aligned reference sets shared across the computation cases. Only enemies/zones/challenges carry
 // cross-referencing fixture data by default — the item/class/recipe/proficiency describes below layer

--- a/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
+++ b/UI/src/tests/routes/game/screens/attributes/attributes-view.test.ts
@@ -3,12 +3,11 @@ import {
 	EAttribute,
 	EDamageType,
 	EModifierType,
-	ERarity,
-	ESkillAcquisition,
 	ESkillEffectTarget,
 	type IBattlerAttribute,
 	type ISkill
 } from '$lib/api';
+import { makeSkill } from '../../../../fixtures/skills';
 
 // Mutable player-manager stand-in: `save()` reassigns `attributes` and adopts the
 // server's `statPointsUsed` absolutely. Declared as a class instance (not an object
@@ -82,24 +81,7 @@ const skillsById = (skills: ISkill[]): ISkill[] => {
 };
 
 /* A skill with sensible defaults so each test only states what matters. */
-const skill = (over: Partial<ISkill> & { id: number }): ISkill => ({
-	name: `Skill ${over.id}`,
-	baseDamage: 0,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	description: '',
-	cooldownMs: 1000,
-	iconPath: '',
-	rarityId: ERarity.Common,
-	word: '',
-	pronunciation: '',
-	translation: '',
-	acquisition: ESkillAcquisition.Player,
-	designerNotes: '',
-	...over
-});
+const skill = (over: Partial<ISkill> & { id: number }): ISkill => makeSkill({ baseDamage: 0, ...over });
 
 beforeEach(() => {
 	sendSocketCommand.mockReset().mockResolvedValue({ data: { attributes: allFives(), statPointsUsed: 0 } });

--- a/UI/src/tests/routes/game/screens/codex/skill-provenance.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/skill-provenance.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { ESkillAcquisition, type IItem, type ISkill } from '$lib/api';
 import { resolveSkillProvenance } from '$routes/game/screens/codex/skill-provenance';
+import { makeSkill } from '../../../../fixtures/skills';
 
 // Minimal fixtures — provenance only reads ids, names, the item-grant references and the flag.
 // Challenges no longer grant skills (spike #982), so item grants are the only concrete source.
-const skill = (id: number, acquisition: ESkillAcquisition): ISkill =>
-	({ id, name: `Skill ${id}`, acquisition }) as ISkill;
+const skill = (id: number, acquisition: ESkillAcquisition): ISkill => makeSkill({ id, acquisition });
 
 const item = (id: number, grantedSkillId?: number, retiredAt?: string): IItem =>
 	({ id, name: `Item ${id}`, grantedSkillId, retiredAt }) as IItem;

--- a/UI/src/tests/routes/game/screens/fight/fight-fixtures.ts
+++ b/UI/src/tests/routes/game/screens/fight/fight-fixtures.ts
@@ -1,31 +1,15 @@
 /* Shared fixtures for the Fight screen tests. Not a test file (no
    .test/.spec suffix) so vitest does not collect it. */
 
-import { EDamageType, EAttribute, ERarity, ESkillAcquisition, type IBattlerAttribute, type ISkill } from '$lib/api';
+import { EAttribute, type IBattlerAttribute, type ISkill } from '$lib/api';
 import { Battler, Skill } from '$lib/battle';
+// Aliased: this module's own `makeSkill` returns a live `Skill` domain object, not the contract.
+import { makeSkill as makeSkillContract } from '../../../../fixtures/skills';
 
 /** Builds a real Skill bound to an owner, overriding only what a test cares about. */
 export const makeSkill = (owner: Battler, over: Partial<ISkill> = {}): Skill =>
 	new Skill(
-		{
-			id: 1,
-			name: 'Slash',
-			baseDamage: 10,
-			criticalChance: 0,
-			damageMultipliers: [],
-			effects: [],
-			description: 'A basic slash.',
-			cooldownMs: 1000,
-			iconPath: '/icons/slash.png',
-			rarityId: ERarity.Common,
-			word: '',
-			pronunciation: '',
-			translation: '',
-			designerNotes: '',
-			damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-			acquisition: ESkillAcquisition.Player,
-			...over
-		},
+		makeSkillContract({ id: 1, name: 'Slash', description: 'A basic slash.', iconPath: '/icons/slash.png', ...over }),
 		owner
 	);
 

--- a/UI/src/tests/routes/game/screens/inventory/ItemTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/ItemTooltip.test.ts
@@ -1,14 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
-import {
-	EDamageType,
-	EAttribute,
-	EItemCategory,
-	EItemModType,
-	ERarity,
-	ESkillAcquisition,
-	type ISkill
-} from '$lib/api';
+import { EAttribute, EItemCategory, EItemModType, ERarity, ESkillAcquisition, type ISkill } from '$lib/api';
+import { makeSkill } from '../../../../fixtures/skills';
 import { BattleAttributes } from '$lib/battle/battle-attributes';
 import type { Item } from '$lib/battle';
 import { staticData } from '$stores';
@@ -67,24 +60,8 @@ const makeItem = (): Item => {
 	} as unknown as Item;
 };
 
-const skill = (id: number, name: string): ISkill => ({
-	id,
-	name,
-	baseDamage: 0,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	description: '',
-	designerNotes: '',
-	cooldownMs: 1000,
-	iconPath: '',
-	rarityId: ERarity.Common,
-	word: '',
-	pronunciation: '',
-	translation: '',
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	acquisition: ESkillAcquisition.Item
-});
+const skill = (id: number, name: string): ISkill =>
+	makeSkill({ id, name, baseDamage: 0, acquisition: ESkillAcquisition.Item });
 
 afterEach(() => {
 	cleanup();

--- a/UI/src/tests/routes/game/screens/skills/EquippedBand.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/EquippedBand.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, fireEvent } from '@testing-library/svelte';
-import { EDamageType, EModifierType, EAttribute, ERarity, ESkillAcquisition } from '$lib/api';
+import { EModifierType, EAttribute } from '$lib/api';
+import { makeSkill } from '../../../../fixtures/skills';
 import type { IChallenge, IEnemy, ISignaturePassive, ISkill, IZone } from '$lib/api';
 import type { AttributeModifier } from '$lib/battle';
 import { classSignaturePassiveModifier } from '$lib/battle/class-modifiers';
@@ -67,24 +68,7 @@ vi.mock('$lib/api/types/game-constants', async (importOriginal) => {
 import { SkillsView } from '$routes/game/screens/skills/skills-view.svelte';
 import EquippedBand from '$routes/game/screens/skills/EquippedBand.svelte';
 
-const skill = (over: Partial<ISkill> & { id: number }): ISkill => ({
-	name: `Skill ${over.id}`,
-	baseDamage: 10,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	description: '',
-	designerNotes: '',
-	cooldownMs: 1000,
-	iconPath: '',
-	rarityId: ERarity.Common,
-	word: '',
-	pronunciation: '',
-	translation: '',
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	acquisition: ESkillAcquisition.Player,
-	...over
-});
+const skill = (over: Partial<ISkill> & { id: number }): ISkill => makeSkill(over);
 
 const SKILLS: ISkill[] = [
 	skill({ id: 0, name: 'Alpha' }),

--- a/UI/src/tests/routes/game/screens/skills/EquippedBand.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/EquippedBand.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, fireEvent } from '@testing-library/svelte';
 import { EModifierType, EAttribute } from '$lib/api';
-import { makeSkill } from '../../../../fixtures/skills';
+import { makeSkill as skill } from '../../../../fixtures/skills';
 import type { IChallenge, IEnemy, ISignaturePassive, ISkill, IZone } from '$lib/api';
 import type { AttributeModifier } from '$lib/battle';
 import { classSignaturePassiveModifier } from '$lib/battle/class-modifiers';
@@ -67,8 +67,6 @@ vi.mock('$lib/api/types/game-constants', async (importOriginal) => {
 
 import { SkillsView } from '$routes/game/screens/skills/skills-view.svelte';
 import EquippedBand from '$routes/game/screens/skills/EquippedBand.svelte';
-
-const skill = (over: Partial<ISkill> & { id: number }): ISkill => makeSkill(over);
 
 const SKILLS: ISkill[] = [
 	skill({ id: 0, name: 'Alpha' }),

--- a/UI/src/tests/routes/game/screens/skills/InnateBand.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/InnateBand.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
-import { EDamageType, EModifierType, EAttribute, ERarity, ESkillAcquisition } from '$lib/api';
+import { EModifierType, EAttribute, ESkillAcquisition } from '$lib/api';
+import { makeSkill } from '../../../../fixtures/skills';
 import type { IChallenge, IEnemy, ISignaturePassive, ISkill, IZone } from '$lib/api';
 import type { AttributeModifier } from '$lib/battle';
 import { classSignaturePassiveModifier } from '$lib/battle/class-modifiers';
@@ -59,24 +60,8 @@ vi.mock('$lib/api/types/game-constants', async (importOriginal) => {
 import { SkillsView } from '$routes/game/screens/skills/skills-view.svelte';
 import InnateBand from '$routes/game/screens/skills/InnateBand.svelte';
 
-const skill = (over: Partial<ISkill> & { id: number }): ISkill => ({
-	name: `Skill ${over.id}`,
-	baseDamage: 10,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	description: '',
-	designerNotes: '',
-	cooldownMs: 1000,
-	iconPath: '',
-	rarityId: ERarity.Common,
-	word: '',
-	pronunciation: '',
-	translation: '',
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	acquisition: ESkillAcquisition.Item,
-	...over
-});
+const skill = (over: Partial<ISkill> & { id: number }): ISkill =>
+	makeSkill({ acquisition: ESkillAcquisition.Item, ...over });
 
 const SKILLS: ISkill[] = [
 	skill({ id: 0, name: 'Alpha' }),

--- a/UI/src/tests/routes/game/screens/skills/SkillCardStats.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/SkillCardStats.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
-import { EDamageType, EModifierType, ERarity, EAttribute, ESkillAcquisition } from '$lib/api';
+import { EModifierType, EAttribute } from '$lib/api';
+import { makeSkill } from '../../../../fixtures/skills';
 import type { IChallenge, IEnemy, ISignaturePassive, ISkill, IZone } from '$lib/api';
 import type { AttributeModifier } from '$lib/battle';
 import { classSignaturePassiveModifier } from '$lib/battle/class-modifiers';
@@ -62,24 +63,7 @@ import ChipStub from './AttributeChipStub.svelte';
 import { SkillsView } from '$routes/game/screens/skills/skills-view.svelte';
 import SkillCardStats from '$routes/game/screens/skills/SkillCardStats.svelte';
 
-const skill = (over: Partial<ISkill> & { id: number }): ISkill => ({
-	name: `Skill ${over.id}`,
-	baseDamage: 10,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	description: '',
-	designerNotes: '',
-	cooldownMs: 2000,
-	iconPath: '',
-	rarityId: ERarity.Common,
-	word: '',
-	pronunciation: '',
-	translation: '',
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	acquisition: ESkillAcquisition.Player,
-	...over
-});
+const skill = (over: Partial<ISkill> & { id: number }): ISkill => makeSkill({ cooldownMs: 2000, ...over });
 
 let view: SkillsView;
 

--- a/UI/src/tests/routes/game/screens/skills/SkillDamageBreakdown.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/SkillDamageBreakdown.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
-import { EDamageType, ERarity, EAttribute, ESkillAcquisition, type IAttribute, type ISkill } from '$lib/api';
+import { EAttribute, type IAttribute, type ISkill } from '$lib/api';
+import { makeSkill } from '../../../../fixtures/skills';
 
 // The breakdown resolves the crit-chance label and attribute names through the reference-data store,
 // so it is mocked. The object backs the hoisted `vi.mock` factory, but its `attributes` are populated
@@ -18,25 +19,7 @@ staticData.attributes = [
 	{ id: EAttribute.CriticalChanceMultiplier, name: 'Critical Chance', code: 'CRIT', isPercentage: true, decimals: 0 }
 ] as unknown as IAttribute[];
 
-const stubSkill = (over: Partial<ISkill> = {}): ISkill => ({
-	id: 0,
-	name: 'Cleave',
-	baseDamage: 50,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	description: '',
-	designerNotes: '',
-	cooldownMs: 1000,
-	iconPath: '',
-	rarityId: ERarity.Common,
-	word: '',
-	pronunciation: '',
-	translation: '',
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	acquisition: ESkillAcquisition.Player,
-	...over
-});
+const stubSkill = (over: Partial<ISkill> = {}): ISkill => makeSkill({ id: 0, name: 'Cleave', baseDamage: 50, ...over });
 
 // The per-skill crit chance now rides SkillMetrics (#1453) rather than a page-wide SkillsView value.
 const stubMetrics = (over: Partial<SkillMetrics> = {}): SkillMetrics => ({

--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -1,11 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, fireEvent, screen } from '@testing-library/svelte';
 import {
-	EDamageType,
-	ERarity,
 	EAttribute,
 	EModifierType,
-	ESkillAcquisition,
 	ESkillEffectTarget,
 	type IChallenge,
 	type IEnemy,
@@ -14,6 +11,7 @@ import {
 	type ISkillEffect,
 	type IZone
 } from '$lib/api';
+import { makeSkill } from '../../../../fixtures/skills';
 import type { AttributeModifier } from '$lib/battle';
 import { classSignaturePassiveModifier } from '$lib/battle/class-modifiers';
 
@@ -105,24 +103,12 @@ vi.mock('$lib/api/types/game-constants', async (importOriginal) => {
 
 import Skills from '$routes/game/screens/skills/Skills.svelte';
 
-const skill = (over: Partial<ISkill> & { id: number }): ISkill => ({
-	name: `Skill ${over.id}`,
-	baseDamage: 10,
-	criticalChance: 0,
-	damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 1 }],
-	effects: [],
-	description: 'A skill.',
-	designerNotes: '',
-	cooldownMs: 1000,
-	iconPath: '',
-	rarityId: ERarity.Common,
-	word: '',
-	pronunciation: '',
-	translation: '',
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	acquisition: ESkillAcquisition.Player,
-	...over
-});
+const skill = (over: Partial<ISkill> & { id: number }): ISkill =>
+	makeSkill({
+		damageMultipliers: [{ attributeId: EAttribute.Strength, multiplier: 1 }],
+		description: 'A skill.',
+		...over
+	});
 
 // ids 0–3 are owned (see the unlockedSkills fixture below); Echo (id 4) is unowned, so the screen
 // must never list it now that the locked/aspirational catalogue is gone.

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -2,15 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
 	EDamageType,
 	EModifierType,
-	ERarity,
 	EAttribute,
-	ESkillAcquisition,
 	type IChallenge,
 	type IEnemy,
 	type ISignaturePassive,
 	type ISkill,
 	type IZone
 } from '$lib/api';
+import { makeSkill } from '../../../../fixtures/skills';
 import { EAttributeModifierSource, type AttributeModifier } from '$lib/battle';
 import { classSignaturePassiveModifier } from '$lib/battle/class-modifiers';
 
@@ -98,24 +97,7 @@ import { damagePerSecond } from '$lib/common';
 import { expectedCritMultiplier } from '$lib/battle';
 
 /* A skill with sensible defaults so each test only states what matters. */
-const skill = (over: Partial<ISkill> & { id: number }): ISkill => ({
-	name: `Skill ${over.id}`,
-	baseDamage: 0,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	description: '',
-	designerNotes: '',
-	cooldownMs: 1000,
-	iconPath: '',
-	rarityId: ERarity.Common,
-	word: '',
-	pronunciation: '',
-	translation: '',
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	acquisition: ESkillAcquisition.Player,
-	...over
-});
+const skill = (over: Partial<ISkill> & { id: number }): ISkill => makeSkill({ baseDamage: 0, ...over });
 
 const metric = (over: Partial<SkillMetrics> & { skill: ISkill }): SkillMetrics => ({
 	rawDamage: 0,

--- a/UI/src/tests/routes/game/screens/synthesis/Synthesis.test.ts
+++ b/UI/src/tests/routes/game/screens/synthesis/Synthesis.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent, waitFor } from '@testing-library/svelte';
-import { EDamageType, ERarity, ESkillAcquisition, type IProficiency, type ISkill, type ISkillRecipe } from '$lib/api';
+import { ERarity, ESkillAcquisition, type IProficiency, type ISkill, type ISkillRecipe } from '$lib/api';
+import { makeSkill } from '../../../../fixtures/skills';
 import { makeProficiency } from '../../../../fixtures/proficiencies';
 
 /* The screen drives the real playerProficiencies store (fetched over the socket) for the gate state and
@@ -33,25 +34,8 @@ import Synthesis from '$routes/game/screens/synthesis/Synthesis.svelte';
 import { cancelActiveModal, confirmActiveModal, navigation, playerProficiencies } from '$stores';
 import { playerManager } from '$lib/engine';
 
-const skill = (id: number, over: Partial<ISkill> = {}): ISkill => ({
-	id,
-	name: `Skill ${id}`,
-	baseDamage: 10,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	description: '',
-	designerNotes: '',
-	cooldownMs: 1000,
-	iconPath: '',
-	rarityId: ERarity.Common,
-	word: '',
-	pronunciation: '',
-	translation: '',
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	acquisition: ESkillAcquisition.Synthesis,
-	...over
-});
+const skill = (id: number, over: Partial<ISkill> = {}): ISkill =>
+	makeSkill({ id, acquisition: ESkillAcquisition.Synthesis, ...over });
 
 const SKILLS: ISkill[] = [
 	skill(0, { name: 'Ember Strike' }),

--- a/UI/src/tests/routes/game/screens/synthesis/synthesis-graph.test.ts
+++ b/UI/src/tests/routes/game/screens/synthesis/synthesis-graph.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { EDamageType, ERarity, ESkillAcquisition, type IProficiency, type ISkill, type ISkillRecipe } from '$lib/api';
+import { ERarity, ESkillAcquisition, type IProficiency, type ISkill, type ISkillRecipe } from '$lib/api';
+import { makeSkill } from '../../../../fixtures/skills';
 import { buildSynthesis, type RecipeView } from '$routes/game/screens/synthesis/synthesis';
 import {
 	clampScale,
@@ -16,25 +17,8 @@ import {
    through `buildSynthesis` first — the graph and the list can't diverge. Reference catalogues are
    zero-based-id arrays resolved by index, so fixture ids stay contiguous with their array position. */
 
-const skill = (id: number, over: Partial<ISkill> = {}): ISkill => ({
-	id,
-	name: `Skill ${id}`,
-	baseDamage: 10,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	description: '',
-	designerNotes: '',
-	cooldownMs: 1000,
-	iconPath: '',
-	rarityId: ERarity.Common,
-	word: '',
-	pronunciation: '',
-	translation: '',
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	acquisition: ESkillAcquisition.Synthesis,
-	...over
-});
+const skill = (id: number, over: Partial<ISkill> = {}): ISkill =>
+	makeSkill({ id, acquisition: ESkillAcquisition.Synthesis, ...over });
 
 const recipe = (
 	id: number,

--- a/UI/src/tests/routes/game/screens/synthesis/synthesis-reveal.test.ts
+++ b/UI/src/tests/routes/game/screens/synthesis/synthesis-reveal.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { EDamageType, ERarity, ESkillAcquisition, type IProficiency, type ISkill, type ISkillRecipe } from '$lib/api';
+import { ERarity, ESkillAcquisition, type IProficiency, type ISkill, type ISkillRecipe } from '$lib/api';
+import { makeSkill } from '../../../../fixtures/skills';
 import {
 	buildSynthesis,
 	recipeStateAccent,
@@ -11,25 +12,8 @@ import { makeProficiency } from '../../../../fixtures/proficiencies';
 /* The derivation takes explicit args and needs no mocks. The reference catalogues are zero-based-id
    arrays (resolved by index), so the fixtures keep ids contiguous with their array position. */
 
-const skill = (id: number, over: Partial<ISkill> = {}): ISkill => ({
-	id,
-	name: `Skill ${id}`,
-	baseDamage: 10,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	description: '',
-	designerNotes: '',
-	cooldownMs: 1000,
-	iconPath: '',
-	rarityId: ERarity.Common,
-	word: '',
-	pronunciation: '',
-	translation: '',
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	acquisition: ESkillAcquisition.Synthesis,
-	...over
-});
+const skill = (id: number, over: Partial<ISkill> = {}): ISkill =>
+	makeSkill({ id, acquisition: ESkillAcquisition.Synthesis, ...over });
 
 const recipe = (
 	id: number,

--- a/UI/src/tests/routes/game/screens/synthesis/synthesis-view.test.ts
+++ b/UI/src/tests/routes/game/screens/synthesis/synthesis-view.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { EDamageType, ERarity, ESkillAcquisition, type IProficiency, type ISkill, type ISkillRecipe } from '$lib/api';
+import { ESkillAcquisition, type IProficiency, type ISkill, type ISkillRecipe } from '$lib/api';
+import { makeSkill } from '../../../../fixtures/skills';
 import type { RecipeView } from '$routes/game/screens/synthesis/synthesis';
 
 /* The view-model reads the live stores + engine + socket, so those are mocked with mutable stand-ins the
@@ -33,25 +34,8 @@ vi.mock('$lib/api', async (importOriginal) => {
 
 import { SynthesisView } from '$routes/game/screens/synthesis/synthesis-view.svelte';
 
-const skill = (id: number, over: Partial<ISkill> = {}): ISkill => ({
-	id,
-	name: `Skill ${id}`,
-	baseDamage: 10,
-	criticalChance: 0,
-	damageMultipliers: [],
-	effects: [],
-	description: '',
-	designerNotes: '',
-	cooldownMs: 1000,
-	iconPath: '',
-	rarityId: ERarity.Common,
-	word: '',
-	pronunciation: '',
-	translation: '',
-	damagePortions: [{ type: EDamageType.Physical, weight: 1 }],
-	acquisition: ESkillAcquisition.Synthesis,
-	...over
-});
+const skill = (id: number, over: Partial<ISkill> = {}): ISkill =>
+	makeSkill({ id, acquisition: ESkillAcquisition.Synthesis, ...over });
 
 /** A minimal `ready` recipe view for the synthesize-action tests. */
 const readyRecipe = (over: Partial<RecipeView> = {}): RecipeView => ({

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -22,6 +22,8 @@ All frontend code lives in `UI`:
 
 Unit-test all UI logic (pages/components) and lib code; simple non-interactive display components don't need tests. Place tests under `tests` mirroring the source structure. Use Playwright e2e tests only for critical user flows, written from the user's perspective — they're costly to write and run.
 
+Shared contract builders for reference-data types (`IAttribute`, `IProficiency`, `ISkill`, …) live in `UI/src/tests/fixtures/`, one module per contract exporting a `make<Contract>(overrides)` with neutral defaults. Build on those rather than hand-rolling a contract literal per suite, so a new required field is one edit instead of dozens; where a suite needs different defaults, wrap the shared builder and state only the divergence.
+
 A test that reads committed content directly (e.g. asserting `content/lessons.json` only references real frontend keys) imports it via the `$content` alias (`kit.alias` in `svelte.config.js`, pointing at the repo-root `content/` folder) rather than a deep relative path out of the `UI/` package root.
 
 # Important Architectural Design Decisions


### PR DESCRIPTION
Closes #2425 — see **Scope** below for why this closes the umbrella rather than leaving it open.

> **Updated after review** (`deff6ab`). Three changes: the exclusion rationale now lives in the fixture's module comment rather than only here; `docs/frontend.md` documents the `fixtures/` convention; and `EquippedBand`'s adapter — which had degenerated to a pure passthrough — is now an import alias. The **Converged defaults** section below is also corrected: there are **two**, not one, and the excluded-suite count is **nine**, not eight.

## Summary

Adds `UI/src/tests/fixtures/skills.ts` (`makeSkill`), following the `fixtures/attributes.ts` / `fixtures/proficiencies.ts` convention, and converts every suite that hand-rolled the `ISkill` contract to build on it. Each suite keeps its local call signature as a thin adapter, stating its divergent defaults as explicit overrides rather than restating the whole 15-field set.

Net: **25 files, +157 / −516** — 23 converted suites, the new fixture, and the `docs/frontend.md` entry.

## The issue's probe was wrong in both directions

The issue sized this at "~30 suites" from `grep -rl "acquisition: ESkillAcquisition" UI/src/tests/`. I checked that against the tree rather than taking it on faith, and the real target set is different:

**It over-counts.** Nine suites seed a `staticData: {} as any` mock with *untyped partial* object literals — `Codex.test.ts`, `codex-view.svelte.test.ts`, `reference.test.ts`, `entities/{class,enemy,item,skill-recipe}.test.ts`, `progression/{TierDetail,progression-helpers}.test.ts`. Those pay **no** contract-drift tax, which is the entire cost the issue is about: a new required `ISkill` field doesn't touch them, because nothing type-checks them as `ISkill`. Converting them would also have *filled in fields that were previously `undefined`*, which is a real risk of changing what the suite renders. They're deliberately left alone, and that rationale now lives in the fixture's module comment so it survives this issue closing.

**It under-counts.** `inventory-manager.test.ts` builds a full, typed `ISkill` but writes `acquisition: 0` — a bare numeric literal, so the grep never saw it. It pays the tax like the rest, and is converted here.

(`entities/skill-recipe.test.ts` evades the grep for the same reason — it writes `acquisition: opts.synth ? … : …`. It lands in the untyped bucket: its `retiredAt: null` isn't even assignable to `string | undefined`.)

So the real set is **23 files**, not 30 — a different 23 than the grep suggested.

## Verification that the consolidation actually worked

The stated win is "one place to edit when the contract grows", so I measured it rather than asserting it. Adding a throwaway required field to `ISkill` and running `svelte-check`:

| | Test-file errors |
|---|---|
| Before | 23 (every converted suite) |
| After | **1** — `src/tests/fixtures/skills.ts` |

(The other 4 errors in the "after" run are production files — `lib/battle/skill.ts`, `admin/workbench/entities/skill.ts`, `fight/SkillTooltip.svelte` — which is correct and expected.) The probe was reverted; it isn't in the diff.

## Defaults

The shared defaults are the majority spelling across the 23 builders. Divergences are stated at each wrapper, so a suite's intent stays local and visible:

- `InnateBand` / `ItemTooltip` → `acquisition: Item`; the four synthesis suites → `acquisition: Synthesis`
- `SkillCardStats` → `cooldownMs: 2000`; `skills-view` / `attributes-view` → `baseDamage: 0`; `SkillDamageBreakdown` → `baseDamage: 50`
- `Skills.test.ts` → its Strength multiplier and `'A skill.'` description

### Converged defaults

Two values were **converged** onto the shared default rather than preserved. Both were checked against the suite's consumers first:

1. **`references.test.ts`** had `damagePortions: []` where every other builder has a single full-weight physical portion. That suite exercises name/id reference resolution and never reads portions; its 45 tests still pass.
2. **`inventory-manager.test.ts`** had `acquisition: 0`. `ESkillAcquisition` is a flags enum (`None = 0`, `Player = 1`), so this silently moves the Punch record from `None` to `Player`. Benign — no consumer in that suite reads `acquisition` (the readers are `skill-provenance.ts`, the codex views, and the workbench admin surfaces) — and arguably more faithful, since the real Punch record in `content/skills.json` is authored as `Player`. Flagged here because a bare numeric literal for a flags enum is exactly the shape the under-count lesson is about, and #2433/#2434 should watch for it.

**The conlang fields deliberately differ from `makeProficiency`.** That fixture generates `w1`/`p1`/`t1` from the id; this one defaults them to blank, because a blank `word` is what marks a skill *un-deciphered*. Generating one would silently make every fixture skill deciphered and quietly weaken the synthesis reveal suites. That reasoning is in the fixture's doc comment so the asymmetry doesn't read as an oversight later.

## Two naming collisions, handled by aliasing

`battle-sim-test-utils.ts` and `fight-fixtures.ts` both already export their own `makeSkill`, and neither is the contract — the first builds a pre-registration `SkillSpec`, the second a live `Skill` domain object bound to an owner. Both now consume the fixture as `makeSkillContract` with a one-line comment saying why, rather than being renamed or absorbed. This is the "decide, per contract, whether the existing helpers should delegate or stay separate" call the issue asks for: they delegate, they keep their names.

## Incidental cleanup

`battler-effects.test.ts` had the same 20-line "Dual" skill literal twice; it's now one `dualEffectSkill(caster)` helper. Newly-unused enum imports (`ERarity`, `EDamageType`, `ESkillAcquisition`) were pruned per file — each was checked for remaining uses rather than removed blind.

## Docs

`docs/frontend.md` gained a line under **Testing Guidelines** describing the `UI/src/tests/fixtures/` convention. It was undocumented despite this being its third module, with two more queued — inherited debt from #2414, closed here since it's cheaper than a follow-up issue.

## Scope, and why this closes #2425

The issue proposed "plausibly three issues, or one issue with three PRs". I've taken the first reading, since an umbrella that can never be closed by any of its own PRs is worse tracking than three closeable issues:

- `ISkill` (~30 → 23 files) — **this PR**
- `IItem` (~20) — **#2433**
- `IZone` (~16) — **#2434**

Both follow-ups carry forward the two probe lessons above, so the next session doesn't rediscover the over/under-count by hand.

Not touched here, and correctly out of scope: **#2426** (pointing `progression-test-utils`' tier/path builders at the shared `IProficiency`/`IPath` fixtures) is a different contract and already tracked.

## Test plan

- [x] `npm run test:unit:ci` — **4017 passed / 0 failed** (1153 suites). Re-run after the review commit.
- [x] `npm run lint` — clean; `svelte-check` 1224 files, **0 errors, 0 warnings**.
- [x] `npx prettier --check` — clean, including `docs/frontend.md`.
- [x] CI green on `deff6ab` — all 11 checks (frontend unit, verify, e2e on chromium/firefox/webkit); backend jobs correctly skipped by the changed-path gate.
- [x] Each suite run individually as it was converted, so a changed default would fail loudly rather than quietly weakening an assertion.
- [x] The anti-drift claim measured directly (the 23 → 1 table above), not assumed.
- [x] Both converged defaults traced to their consumers before accepting the convergence, rather than assumed benign.
- **No backend mirror needed.** This touches the battle suites (`battle-formulas`, `battler`, `skill`, `battler-effects`, `battle-sim-test-utils`, `battle-engine`), which are on the frontend/backend parity surface — but no scenario input or expected result changed. Every value those suites feed the simulator is either passed explicitly or identical to the shared default; only the construction of the fixture object moved. Verified per-file rather than assumed, since CLAUDE.md requires parity scenarios to stay in step.