### PR TITLE
Point progression-test-utils' tier/path builders at the shared fixtures (#2426)

### DIFF
--- a/UI/src/tests/fixtures/proficiencies.ts
+++ b/UI/src/tests/fixtures/proficiencies.ts
@@ -5,9 +5,9 @@ import { EActivityKey, type IPath, type IProficiency } from '$lib/api';
    · `lexicon-test-utils.ts` builds the derived `PathView` / `TierView` the Lexicon renders — a suite that
      needs both wants this module for the inputs and that one for the outputs.
    · `progression/progression-test-utils.ts` (`path`/`tier`) builds `WorkbenchPath`/`WorkbenchProficiency`,
-     which are *plain aliases* of these same two contracts — so a new contract field taxes that module too.
-     Its blank conlang defaults and `xpGrowth: 1.4` are load-bearing for the workbench detail suites and
-     deliberately diverge from the defaults here; converging the two is #2426. */
+     which are *plain aliases* of these same two contracts, so it now builds on this module (#2426). Its
+     blank conlang defaults and `xpGrowth: 1.4` deliberately diverge from the defaults here — they are
+     load-bearing for the workbench detail suites — and are stated as overrides at those two wrappers. */
 
 /**
  * Builds an {@link IProficiency} reference-data entry for tests. The conlang and icon fields are generated

--- a/UI/src/tests/routes/admin/workbench/progression/progression-test-utils.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-test-utils.ts
@@ -62,10 +62,6 @@ export const resetStores = () => {
 	}
 };
 
-/* `WorkbenchPath`/`WorkbenchProficiency` are plain aliases of `IPath`/`IProficiency`, so the two builders
-   below are the shared contract fixtures with the workbench's divergent defaults stated on top (#2426).
-   Only the divergences are restated here — everything else follows the contract fixture. */
-
 /** Base path fixture — id 5, the path the detail suites open. */
 export const path = (over: Partial<WorkbenchPath> = {}): WorkbenchPath =>
 	makePath({ id: 5, name: 'Fire Path', activityKey: EActivityKey.Fire, ...over });

--- a/UI/src/tests/routes/admin/workbench/progression/progression-test-utils.ts
+++ b/UI/src/tests/routes/admin/workbench/progression/progression-test-utils.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import { EActivityKey } from '$lib/api';
 import type { ProgressionStore } from '$routes/admin/workbench/progression/progression-store.svelte';
 import type { WorkbenchPath, WorkbenchProficiency } from '$routes/admin/workbench/progression/types';
+import { makePath, makeProficiency } from '../../../../fixtures/proficiencies';
 
 /* Shared scaffolding for the progression editor's component suites (#2405). Each suite still declares
    its own `vi.mock('$stores', …)` — `vi.mock` is hoisted within the file it appears in — but the factory
@@ -9,8 +10,9 @@ import type { WorkbenchPath, WorkbenchProficiency } from '$routes/admin/workbenc
 
    Because the suites resolve it from inside that factory, this module is evaluated *while `$stores` is
    being mocked, so it must stay free of runtime imports that transitively reach `$stores`* — a value
-   import that did would re-enter the factory resolving it. Everything below `$lib/api` is `import type`
-   and therefore erased, which is what keeps that true today. */
+   import that did would re-enter the factory resolving it. The only value imports here are `vitest`,
+   `$lib/api`, and `tests/fixtures/proficiencies` (whose own only import is `$lib/api`); everything else
+   is `import type` and therefore erased, which is what keeps that true today. */
 
 const catalogueKeys = [
 	'enemies',
@@ -60,49 +62,48 @@ export const resetStores = () => {
 	}
 };
 
+/* `WorkbenchPath`/`WorkbenchProficiency` are plain aliases of `IPath`/`IProficiency`, so the two builders
+   below are the shared contract fixtures with the workbench's divergent defaults stated on top (#2426).
+   Only the divergences are restated here — everything else follows the contract fixture. */
+
 /** Base path fixture — id 5, the path the detail suites open. */
-export const path = (over: Partial<WorkbenchPath> = {}): WorkbenchPath => ({
-	id: 5,
-	name: 'Fire Path',
-	description: '',
-	designerNotes: '',
-	activityKey: EActivityKey.Fire,
-	...over
-});
+export const path = (over: Partial<WorkbenchPath> = {}): WorkbenchPath =>
+	makePath({ id: 5, name: 'Fire Path', activityKey: EActivityKey.Fire, ...over });
 
 /**
  * Base tier fixture — id 0 on path 0, with blank conlang fields.
  *
+ * The blank `iconPath`/`word`/`pronunciation`/`translation` deliberately diverge from `makeProficiency`'s
+ * id-generated ones: these suites drive the *editor*, where an empty field is the authoring state under
+ * test, and a generated string would quietly pre-fill inputs the detail suites assert on. `xpGrowth: 1.4`
+ * likewise diverges so the XP curve is visibly non-flat.
+ *
  * A suite whose assertions depend on a different identity (TierDetail's populated conlang strings, say)
  * wraps this with its own defaults rather than changing them here; those divergences are load-bearing.
  */
-export const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency => ({
-	id: 0,
-	name: 'Blades',
-	description: '',
-	iconPath: '',
-	word: '',
-	pronunciation: '',
-	translation: '',
-	pathId: 0,
-	pathOrdinal: 0,
-	maxLevel: 10,
-	baseXp: 100,
-	xpGrowth: 1.4,
-	designerNotes: '',
-	levelModifiers: [],
-	levelRewards: [],
-	prerequisiteIds: [],
-	...over
-});
+export const tier = (over: Partial<WorkbenchProficiency> = {}): WorkbenchProficiency =>
+	makeProficiency({
+		id: 0,
+		name: 'Blades',
+		iconPath: '',
+		word: '',
+		pronunciation: '',
+		translation: '',
+		xpGrowth: 1.4,
+		...over
+	});
 
 /* The map suites (`ProgressionMap.test.ts`, `progression-map.test.ts`) build topology — several tiers
    across several paths — so identity is positional at their call sites (`mapTier(10, 0, 0)`), and their
    assertions read the generated `Path {id}` name back out of the rendered column header. The two
-   adapters below keep the field set in one place while preserving both. */
+   adapters below keep the field set in one place while preserving both.
 
-export const mapPath = (id: number, over: Partial<WorkbenchPath> = {}): WorkbenchPath =>
-	path({ id, name: `Path ${id}`, activityKey: EActivityKey.Physical, ...over });
+   `mapPath` goes to `makePath` directly rather than through `path`: the shared fixture already defaults to
+   the generated `Path {id}` name and a neutral `Physical` activity, so routing through `path` would set the
+   detail suites' `Fire Path`/`Fire` only to override both straight back. `mapTier` does go through `tier`,
+   because it wants that builder's blank conlang fields. */
+
+export const mapPath = (id: number, over: Partial<WorkbenchPath> = {}): WorkbenchPath => makePath({ id, ...over });
 
 export const mapTier = (
 	id: number,


### PR DESCRIPTION
Closes #2426.

## Summary

`WorkbenchPath`/`WorkbenchProficiency` are plain aliases of `IPath`/`IProficiency`, so `progression-test-utils.ts` was hand-rolling the same two contracts `tests/fixtures/proficiencies.ts` already centralises. Its `path`/`tier` builders now delegate to `makePath`/`makeProficiency`, restating only their **divergent** defaults as explicit overrides rather than the whole field set.

**2 files, +36 / −35.** Test-only; no production code, no behaviour change.

## What changed

- **`tier`** → `makeProficiency`, keeping `name: 'Blades'`, the four blank conlang/icon fields, and `xpGrowth: 1.4` as stated overrides. The 9 fields it shares with the contract fixture (`description`, `designerNotes`, `pathId`, `pathOrdinal`, `maxLevel`, `baseXp`, and the three arrays) are no longer restated.
- **`path`** → `makePath`, keeping `id: 5`, `name: 'Fire Path'`, `activityKey: Fire`.
- **`mapPath`** now goes to `makePath` **directly** rather than through `path`. `makePath` already defaults to the generated `Path {id}` name and a neutral `Physical` activity — exactly what the map suites want — so routing through `path` was setting `Fire Path`/`Fire` only to override both straight back. `mapTier` still routes through `tier`, because it does want that builder's blank conlang fields.

The blank-conlang divergence now carries the *reason* it's load-bearing, not just the assertion that it is: these suites drive the **editor**, where an empty field is the authoring state under test, so a generated `w0`/`p0`/`t0` would quietly pre-fill inputs the detail suites assert on. That's the same asymmetry `fixtures/skills.ts` documents for `ISkill`.

## The issue's file path was wrong

#2426 cites `UI/src/tests/routes/admin/workbench/progression/types.ts`. That file doesn't exist — the aliases are **production** code at `UI/src/routes/admin/workbench/progression/types.ts`. Doesn't change the work (the fix is entirely test-side), but it matters for the alias question below, which is a production-code question, not a test one.

## `Synthesis.test.ts` was already handled

#2426 notes that #2424 "should pick up `Synthesis.test.ts` directly". It did — `Synthesis.test.ts:50` already reads `makeProficiency({ id: 0, name: 'Geomancy' })` on `main`. I swept every remaining typed `IProficiency`/`IPath` construction in `src/tests/` to confirm; `progression-test-utils.ts` was the last one. That's what makes the measurement below land at exactly 1.

## Verification that it actually worked

The stated win is "one place to edit when the contract grows", so I measured it rather than asserting it. Adding a throwaway required field to **both** `IPath` and `IProficiency` and running `svelte-check`:

| | Test files with errors |
|---|---|
| Before | 2 — `fixtures/proficiencies.ts`, `progression-test-utils.ts` |
| After | **1** — `fixtures/proficiencies.ts` |

(The one remaining non-test error is `routes/admin/workbench/progression/progression-helpers.ts`, a production file — correct and expected.) The probe was reverted and is not in the diff.

I also proved the delegation is a **no-op on the produced objects**, since a silently-changed default is the exact risk the issue warns about. A throwaway suite ran the pre-change implementations verbatim beside the new ones and asserted `toEqual` for `path`/`tier`/`mapPath`/`mapTier` — bare and with overrides — plus identical sorted key sets, so nothing was added or dropped. Both passed; the file was deleted and is not in the diff.

## The alias question → #2436

#2426 asks as a side question whether `WorkbenchPath`/`WorkbenchProficiency` still earn their existence. I surveyed it and the answer is **probably not**, but acting on it doesn't belong here:

Five sibling `Workbench<Entity>` types exist, and **every one of them diverges from its contract** — `WorkbenchZone`/`WorkbenchEnemy` add derived fields, `WorkbenchItem`/`WorkbenchClass`/`WorkbenchLesson` widen an optional for the `-1` "None" sentinel. These two are the only pure aliases. They also live in `progression/types.ts` rather than `entities/*.ts`, and carry no `EntityConfig<T>` role, because the progression editor is bespoke rather than `EntityConfig`-driven. So the "consistency with the family" defence is nominal.

Removing them is a mechanical rename across **19 files, 11 of them production Svelte components** — which would swamp a 2-file test-only diff and make this harder to review. Filed as **#2436** with the full survey table.

## Test plan

- [x] `npx vitest run src/tests/routes/admin/workbench/progression/` — 10 files, **123 passed**.
- [x] `npm run test:unit:ci` — **4022 passed / 0 failed** (312 files).
- [x] `npm run lint` — clean; `svelte-check` 1224 files, **0 errors, 0 warnings**.
- [x] `npx prettier --check` on both changed files — clean.
- [x] The anti-drift claim measured directly (2 → 1 table above), not assumed.
- [x] Delegation proven output-identical against the verbatim old implementations, not inferred from the suites passing.
- **No backend mirror needed.** This is workbench admin-tooling scaffolding, not battle logic, so it isn't on the frontend/backend parity surface.

## One note on a comment I had to update

`progression-test-utils.ts` carries a load-bearing warning that it is evaluated *inside* a `vi.mock('$stores', …)` factory, so it must stay free of value imports that transitively reach `$stores`. This change adds the first value import below `$lib/api`, so that comment's justification ("everything below `$lib/api` is `import type`") was no longer accurate. The import is safe — `fixtures/proficiencies.ts`'s only import is `$lib/api`, which this module already value-imports — and the comment now names the three permitted value imports explicitly rather than stating a rule the file no longer follows.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KRFnV6XDTkMmRbVztFCRv5)_