### PR TITLE
Consolidate the hand-rolled IItem test builders onto a shared fixture (#2433)

### DIFF
--- a/UI/src/tests/fixtures/items.ts
+++ b/UI/src/tests/fixtures/items.ts
@@ -2,21 +2,13 @@ import { EItemCategory, ERarity, type IItem } from '$lib/api';
 
 /* Shared `IItem` contract builder (#2433), following the `fixtures/skills.ts` convention.
 
-   The target set is narrower than a `grep` for item-shaped literals suggests: only seven modules
-   actually construct a *typed* `IItem`, and they are the only ones that pay the contract-drift tax.
-   Three groups are excluded on purpose:
-
-   · The inventory screens (`EquipSlot`, `GridSlot`, `ItemDrawer`, `ItemTooltip`, `ModSlots`,
-     `EquippedRail`, `Inventory`, `InventoryGrid`, `inventory-view`, `RewardTooltip`) build the live
-     `Item` domain object via `as unknown as Item`, not the contract — a different shape with the
-     merged mod totals attached.
-   · `ChallengeTooltip`, `challenge-unlocks` and `offline-summary` assert deliberately *partial*
-     literals to `IItem`, so a new required field never reaches them.
-   · The workbench `reference`/`entities` suites and `engine.test.ts` seed literals into a
-     `staticData: {} as any` mock, which type-checks nothing.
-
-   Filling the previously-`undefined` fields of any of those could change what a suite renders, so a
-   `grep` still finding item literals under `src/tests/` is expected, not a gap. */
+   The target set is narrower than a `grep` for item-shaped literals suggests: only a suite that
+   constructs a *typed* `IItem` pays the contract-drift tax. Three kinds of item literal are excluded
+   on purpose — those that build the live `Item` domain object via `as unknown as Item` (the
+   inventory screens), assert a deliberately *partial* literal to `IItem` (`challenge-unlocks`), or
+   seed an untyped `staticData` mock (the workbench `entities` suites). None of them see a new
+   required field, and filling their previously-`undefined` fields could change what a suite renders,
+   so a `grep` still finding item literals under `src/tests/` is expected, not a gap. */
 
 /**
  * Builds an {@link IItem} reference-data entry for tests. Everything but the id is a neutral

--- a/UI/src/tests/fixtures/items.ts
+++ b/UI/src/tests/fixtures/items.ts
@@ -1,0 +1,43 @@
+import { EItemCategory, ERarity, type IItem } from '$lib/api';
+
+/* Shared `IItem` contract builder (#2433), following the `fixtures/skills.ts` convention.
+
+   The target set is narrower than a `grep` for item-shaped literals suggests: only seven modules
+   actually construct a *typed* `IItem`, and they are the only ones that pay the contract-drift tax.
+   Three groups are excluded on purpose:
+
+   · The inventory screens (`EquipSlot`, `GridSlot`, `ItemDrawer`, `ItemTooltip`, `ModSlots`,
+     `EquippedRail`, `Inventory`, `InventoryGrid`, `inventory-view`, `RewardTooltip`) build the live
+     `Item` domain object via `as unknown as Item`, not the contract — a different shape with the
+     merged mod totals attached.
+   · `ChallengeTooltip`, `challenge-unlocks` and `offline-summary` assert deliberately *partial*
+     literals to `IItem`, so a new required field never reaches them.
+   · The workbench `reference`/`entities` suites and `engine.test.ts` seed literals into a
+     `staticData: {} as any` mock, which type-checks nothing.
+
+   Filling the previously-`undefined` fields of any of those could change what a suite renders, so a
+   `grep` still finding item literals under `src/tests/` is expected, not a gap. */
+
+/**
+ * Builds an {@link IItem} reference-data entry for tests. Everything but the id is a neutral
+ * placeholder so a suite states only what it asserts on.
+ *
+ * `itemCategoryId` defaults to `Accessory` — the categories that carry extra meaning (`Weapon`
+ * implies a `weaponType`, the armour slots map to a specific `EEquipmentSlot`) would make the
+ * default load-bearing. The optional fields (`grantedSkillId`, `weaponType`,
+ * `requiredProficiencyId`, `retiredAt`) are left unset for the same reason: an unequipped,
+ * ungated, un-retired item is the neutral case.
+ */
+export const makeItem = (overrides: Partial<IItem> & { id: number }): IItem => ({
+	name: `Item ${overrides.id}`,
+	description: '',
+	itemCategoryId: EItemCategory.Accessory,
+	rarityId: ERarity.Common,
+	iconPath: '',
+	attributes: [],
+	modSlots: [],
+	tags: [],
+	requiredProficiencyLevel: 0,
+	designerNotes: '',
+	...overrides
+});

--- a/UI/src/tests/lib/battle/battle-sim-test-utils.ts
+++ b/UI/src/tests/lib/battle/battle-sim-test-utils.ts
@@ -1,10 +1,10 @@
 import { Battler, newItem } from '$lib/battle';
 // Aliased: this module's own `makeSkill` builds a `SkillSpec` (pre-registration), not the contract.
 import { makeSkill as makeSkillContract } from '../../fixtures/skills';
+import { makeItem } from '../../fixtures/items';
 import {
 	EAttribute,
 	EDamageType,
-	EItemCategory,
 	ERarity,
 	type EModifierType,
 	type ESkillEffectTarget,
@@ -223,19 +223,7 @@ export function equipmentFactory(itemRegistry: IItem[], itemModRegistry: IItemMo
 		});
 
 		const itemId = itemRegistry.length;
-		itemRegistry.push({
-			id: itemId,
-			name: `Item ${itemId}`,
-			description: '',
-			designerNotes: '',
-			itemCategoryId: EItemCategory.Accessory,
-			rarityId: ERarity.Common,
-			iconPath: '',
-			requiredProficiencyLevel: 0,
-			attributes: spec.attributes,
-			modSlots: [],
-			tags: []
-		});
+		itemRegistry.push(makeItem({ id: itemId, attributes: spec.attributes }));
 
 		const item = newItem({ itemId, equipped: true, favorite: false, appliedMods });
 		// The item was just registered, so resolution is guaranteed; assert it to satisfy the nullable

--- a/UI/src/tests/lib/battle/item.test.ts
+++ b/UI/src/tests/lib/battle/item.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EAttribute, EItemCategory, EItemModType, ERarity } from '$lib/api';
 import type { IInventoryItem, IItem, IItemMod } from '$lib/api';
+import { makeItem } from '../../fixtures/items';
 
 const { mockItems, mockItemMods } = vi.hoisted(() => ({
 	mockItems: [] as IItem[],
@@ -20,19 +21,13 @@ vi.mock('$stores', () => ({
 
 import { newItem } from '$lib/battle/item';
 
-mockItems[1] = {
+mockItems[1] = makeItem({
 	id: 1,
 	name: 'Sword',
-	description: '',
-	designerNotes: '',
 	itemCategoryId: EItemCategory.Weapon,
 	rarityId: ERarity.Epic,
-	iconPath: '',
-	requiredProficiencyLevel: 0,
-	attributes: [{ attributeId: EAttribute.Strength, amount: 5 }],
-	modSlots: [],
-	tags: []
-};
+	attributes: [{ attributeId: EAttribute.Strength, amount: 5 }]
+});
 mockItemMods[7] = {
 	id: 7,
 	name: 'Flaming',

--- a/UI/src/tests/lib/common/item-requirements.test.ts
+++ b/UI/src/tests/lib/common/item-requirements.test.ts
@@ -1,22 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { EItemCategory, ERarity, type IItem } from '$lib/api';
+import type { IItem } from '$lib/api';
 import { itemProficiencyRequirement, meetsItemProficiencyRequirement } from '$lib/common';
+import { makeItem } from '../../fixtures/items';
 
 const item = (requiredProficiencyId?: number, requiredProficiencyLevel = 0): IItem =>
-	({
-		id: 1,
-		name: 'Item',
-		description: '',
-		designerNotes: '',
-		itemCategoryId: EItemCategory.Accessory,
-		rarityId: ERarity.Common,
-		iconPath: '',
-		requiredProficiencyId,
-		requiredProficiencyLevel,
-		attributes: [],
-		modSlots: [],
-		tags: []
-	}) as IItem;
+	makeItem({ id: 1, requiredProficiencyId, requiredProficiencyLevel });
 
 // A simple per-proficiency level lookup; a missing id is the "never trained" state (level 0).
 const levelOf = (levels: Record<number, number>) => (id: number) => levels[id] ?? 0;

--- a/UI/src/tests/lib/engine/player/inventory-manager-reactivity.svelte.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager-reactivity.svelte.test.ts
@@ -3,6 +3,8 @@ import { flushSync } from 'svelte';
 import { EAttribute, EItemCategory, EItemModType, ERarity } from '$lib/api';
 import type { IInventoryData, IInventoryItem, IItem, IItemMod } from '$lib/api';
 import { statify } from '$lib/common';
+// Aliased: this suite's own `makeItem` is an id-only adapter over the shared contract builder.
+import { makeItem as makeItemContract } from '../../../fixtures/items';
 
 const mockInventoryData: IInventoryData = {
 	unlockedItems: [],
@@ -52,19 +54,17 @@ vi.mock('$lib/engine/log', () => ({ logMessage: vi.fn() }));
 
 import { InventoryManager, EEquipmentSlot } from '$lib/engine/player/inventory-manager';
 
-const makeItem = (id: number): IItem => ({
-	id,
-	name: `Item ${id}`,
-	description: `Description ${id}`,
-	designerNotes: '',
-	itemCategoryId: EItemCategory.Weapon,
-	rarityId: ERarity.Common,
-	iconPath: `/icons/${id}.png`,
-	requiredProficiencyLevel: 0,
-	attributes: [{ attributeId: EAttribute.Strength, amount: 5 }],
-	modSlots: [{ id: 0, itemId: id, itemModSlotTypeId: EItemModType.Component }],
-	tags: []
-});
+/** Defaults to a Weapon with 5 Strength and one Component slot — the reactivity assertions here
+ *  equip the item and apply a mod into that slot. */
+const makeItem = (id: number): IItem =>
+	makeItemContract({
+		id,
+		description: `Description ${id}`,
+		itemCategoryId: EItemCategory.Weapon,
+		iconPath: `/icons/${id}.png`,
+		attributes: [{ attributeId: EAttribute.Strength, amount: 5 }],
+		modSlots: [{ id: 0, itemId: id, itemModSlotTypeId: EItemModType.Component }]
+	});
 
 const makeItemMod = (id: number): IItemMod => ({
 	id,

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -3,6 +3,8 @@ import { EAttribute, EDamageType, EItemCategory, EItemModType, ELogType, ERarity
 import type { IInventoryData, IItem, IItemMod, ISkill } from '$lib/api';
 import { PUNCH_SKILL_ID } from '$lib/api/types/game-constants';
 import { makeSkill } from '../../../fixtures/skills';
+// Aliased: this suite's own `makeItem` is a positional adapter over the shared contract builder.
+import { makeItem as makeItemContract } from '../../../fixtures/items';
 
 const mockInventoryData: IInventoryData = {
 	unlockedItems: [],
@@ -64,26 +66,22 @@ import { logMessage } from '$lib/engine/log';
 import { playerManager } from '$lib/engine';
 import type { IInventoryItem } from '$lib/api';
 
+/** Defaults to a Weapon carrying 5 Strength — the equipment-stat assertions here read that amount. */
 const makeItem = (
 	id: number,
 	category: EItemCategory = EItemCategory.Weapon,
 	grantedSkillId?: number,
 	weaponType?: EDamageType
-): IItem => ({
-	id,
-	name: `Item ${id}`,
-	description: `Description ${id}`,
-	designerNotes: '',
-	itemCategoryId: category,
-	rarityId: ERarity.Common,
-	iconPath: `/icons/${id}.png`,
-	grantedSkillId,
-	weaponType,
-	requiredProficiencyLevel: 0,
-	attributes: [{ attributeId: EAttribute.Strength, amount: 5 }],
-	modSlots: [],
-	tags: []
-});
+): IItem =>
+	makeItemContract({
+		id,
+		description: `Description ${id}`,
+		itemCategoryId: category,
+		iconPath: `/icons/${id}.png`,
+		grantedSkillId,
+		weaponType,
+		attributes: [{ attributeId: EAttribute.Strength, amount: 5 }]
+	});
 
 const makeItemMod = (id: number): IItemMod => ({
 	id,

--- a/UI/src/tests/routes/admin/workbench/references.test.ts
+++ b/UI/src/tests/routes/admin/workbench/references.test.ts
@@ -26,6 +26,7 @@ import {
 } from '$routes/admin/workbench/references';
 import { makePath, makeProficiency } from '../../../fixtures/proficiencies';
 import { makeSkill } from '../../../fixtures/skills';
+import { makeItem } from '../../../fixtures/items';
 
 const enemy = (id: number, name: string, opts: Partial<IEnemy> = {}): IEnemy => ({
 	id,
@@ -62,20 +63,8 @@ const challenge = (id: number, name: string, opts: Partial<IChallenge> = {}): IC
 	...opts
 });
 
-const item = (id: number, name: string, opts: Partial<IItem> = {}): IItem => ({
-	id,
-	name,
-	description: '',
-	itemCategoryId: EItemCategory.Helm,
-	rarityId: ERarity.Common,
-	iconPath: '',
-	attributes: [],
-	modSlots: [],
-	tags: [],
-	requiredProficiencyLevel: 1,
-	designerNotes: '',
-	...opts
-});
+const item = (id: number, name: string, opts: Partial<IItem> = {}): IItem =>
+	makeItem({ id, name, itemCategoryId: EItemCategory.Helm, ...opts });
 
 const itemMod = (id: number, name: string, opts: Partial<IItemMod> = {}): IItemMod => ({
 	id,

--- a/UI/src/tests/routes/game/screens/challenges/challenges-view.svelte.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/challenges-view.svelte.test.ts
@@ -54,21 +54,20 @@ import {
 	sortChallenges,
 	typeStats
 } from '$routes/game/screens/challenges/challenges-view.svelte';
+import { makeItem } from '../../../../fixtures/items';
 
-const item = (id: number, name: string, rarity: ERarity, cat: EItemCategory, extra: Partial<IItem> = {}): IItem => ({
-	id,
-	name,
-	description: `${name} description`,
-	designerNotes: '',
-	itemCategoryId: cat,
-	rarityId: rarity,
-	iconPath: '',
-	requiredProficiencyLevel: 0,
-	attributes: [{ attributeId: EAttribute.Strength, amount: 5 }],
-	modSlots: [{ id: id * 10, itemId: id, itemModSlotTypeId: EItemModType.Prefix }],
-	tags: [],
-	...extra
-});
+/** Carries attributes and a mod slot by default — the reward tooltip renders both. */
+const item = (id: number, name: string, rarity: ERarity, cat: EItemCategory, extra: Partial<IItem> = {}): IItem =>
+	makeItem({
+		id,
+		name,
+		description: `${name} description`,
+		itemCategoryId: cat,
+		rarityId: rarity,
+		attributes: [{ attributeId: EAttribute.Strength, amount: 5 }],
+		modSlots: [{ id: id * 10, itemId: id, itemModSlotTypeId: EItemModType.Prefix }],
+		...extra
+	});
 
 const mod = (id: number, name: string, rarity: ERarity): IItemMod => ({
 	id,


### PR DESCRIPTION
Adds `UI/src/tests/fixtures/items.ts` (`makeItem`) following the `fixtures/attributes.ts` / `fixtures/proficiencies.ts` / `fixtures/skills.ts` convention, and converts every module that constructs a **typed** `IItem` onto it. Test-only — no production code, no behaviour change.

## The target set is seven modules, not ~20

The issue estimated ~20 suites from `grep -rl "itemCategoryId: EItemCategory"`, while warning that the probe both under- and over-counts. It over-counts here, by a lot. Running the check the issue prescribes — add a throwaway required field to `IItem`, read `svelte-check` — gives the real answer:

| Converted (constructs a typed `IItem`) |
|---|
| `lib/battle/battle-sim-test-utils.ts` — the `equipmentFactory` registry literal |
| `lib/battle/item.test.ts` |
| `lib/common/item-requirements.test.ts` |
| `lib/engine/player/inventory-manager.test.ts` |
| `lib/engine/player/inventory-manager-reactivity.svelte.test.ts` |
| `routes/admin/workbench/references.test.ts` |
| `routes/game/screens/challenges/challenges-view.svelte.test.ts` |

Everything else the grep found pays **no** contract-drift tax and is deliberately left alone:

- **The inventory screens** (`EquipSlot`, `GridSlot`, `ItemDrawer`, `ItemTooltip`, `ModSlots`, `EquippedRail`, `Inventory`, `InventoryGrid`, `inventory-view`, `RewardTooltip`) build the live `Item` domain object via `as unknown as Item` — a different shape, with the merged mod totals attached, not the contract.
- **`ChallengeTooltip`, `challenge-unlocks`, `offline-summary`** assert deliberately *partial* literals to `IItem`, so a new required field never reaches them.
- **The workbench `reference`/`entities` suites and `engine.test.ts`** seed literals into a `staticData: {} as any` mock, which type-checks nothing.

Converting any of those would fill fields that were previously `undefined` — a real risk of changing what the suite renders. That criterion is recorded in the fixture's module comment, so a future `grep` still finding item literals under `src/tests/` reads as expected rather than as a gap.

## Reconciled defaults

`itemCategoryId` defaults to `Accessory`: `Weapon` implies a `weaponType` and the armour categories map to a specific `EEquipmentSlot`, so either would make the default load-bearing. The optional fields (`grantedSkillId`, `weaponType`, `requiredProficiencyId`, `retiredAt`) are left unset for the same reason.

One drifted default was **inert** and is reconciled to the shared value rather than preserved: `references.test.ts` used `requiredProficiencyLevel: 1`, which no assertion reads — its gear-gate case (`computeReferences('proficiencies', 5, …)`) asserts only the referencing item's *name*. Every default that **is** load-bearing stays stated at its adapter, with a one-line comment saying what reads it (5 Strength for the equipment-stat assertions; the Component slot the reactivity suite applies a mod into; the attributes + mod slot the reward tooltip renders).

## Test plan

- [x] `npm run lint` (eslint + `svelte-check`) — clean, 1225 files, 0 errors, 0 warnings.
- [x] `npm run test:unit:ci` — **312 files / 4035 tests passed**, no failures.
- [x] Each suite converted and run individually, so a changed default would have failed loudly rather than quietly weakening an assertion.
- [x] **The issue's verification check**: re-probing `IItem` with a required field afterwards produces exactly **one** test-file error — `src/tests/fixtures/items.ts`. (The five remaining errors are production files — `lib/battle/item.ts`, `workbench/entities/item.ts`, and three inventory components — which a genuinely new field would have to change anyway.)
- Backend untouched, so no `dotnet` run applies.

Closes #2433. The `IZone` half remains as #2434.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJ7PcEwkqQRoG534KxCbH5)_