### PR TITLE
Consolidate the hand-rolled IZone test builders onto a shared fixture (#2434)

### DIFF
--- a/UI/src/tests/fixtures/zones.ts
+++ b/UI/src/tests/fixtures/zones.ts
@@ -1,0 +1,33 @@
+import type { IZone } from '$lib/api';
+
+/* Shared `IZone` contract builder (#2434), following the `fixtures/skills.ts` / `fixtures/items.ts`
+   convention.
+
+   The target set is much narrower than the `grep "bossLevel:"` the issue proposed: only a suite that
+   constructs a *typed* `IZone` pays the contract-drift tax, and a throwaway required field on the
+   contract flushes out exactly nine suites plus the workbench's production `newItem`. Suites that
+   seed zone-shaped literals into an untyped `staticData` mock are excluded on purpose — they see no
+   new required field, and filling their previously-`undefined` fields could change what they render.
+   A `grep` still finding zone literals under `src/tests/` is expected, not a gap. */
+
+/**
+ * Builds an {@link IZone} reference-data entry for tests. Everything but the id is a neutral
+ * placeholder so a suite states only what it asserts on.
+ *
+ * `order` defaults to 0 rather than the id — a suite proving order-driven behaviour is expected to
+ * place each zone explicitly rather than inherit a position from the Id-as-index invariant. The
+ * optional FKs (`bossEnemyId`, `unlockChallengeId`) and `retiredAt` are left unset for the same
+ * reason: a live, boss-less, ungated zone is the neutral case, and each of those fields flips a
+ * distinct branch (the boss pill, the unlock gate, retirement filtering) when present.
+ */
+export const makeZone = (overrides: Partial<IZone> & { id: number }): IZone => ({
+	name: `Zone ${overrides.id}`,
+	description: '',
+	designerNotes: '',
+	order: 0,
+	levelMin: 1,
+	levelMax: 10,
+	bossLevel: 1,
+	isHome: false,
+	...overrides
+});

--- a/UI/src/tests/fixtures/zones.ts
+++ b/UI/src/tests/fixtures/zones.ts
@@ -8,7 +8,10 @@ import type { IZone } from '$lib/api';
    contract flushes out exactly nine suites plus the workbench's production `newItem`. Suites that
    seed zone-shaped literals into an untyped `staticData` mock are excluded on purpose — they see no
    new required field, and filling their previously-`undefined` fields could change what they render.
-   A `grep` still finding zone literals under `src/tests/` is expected, not a gap. */
+   So are the few that assert a deliberately partial literal `as IZone` (`challenge-unlocks`,
+   `ChallengeTooltip`, `enemy-level`) — the cast opts them out of drift detection too, so they raise
+   no error either (#2447). A `grep` still finding zone literals under `src/tests/` is expected, not
+   a gap. */
 
 /**
  * Builds an {@link IZone} reference-data entry for tests. Everything but the id is a neutral

--- a/UI/src/tests/lib/common/zone-progression.test.ts
+++ b/UI/src/tests/lib/common/zone-progression.test.ts
@@ -1,20 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import type { IZone } from '$lib/api';
 import { isZoneUnlocked, navigableZones, nextZoneByOrder, zonesByOrder } from '$lib/common/zone-progression';
+import { makeZone } from '../../fixtures/zones';
 
-const zone = (id: number, order: number, unlockChallengeId?: number, retiredAt?: string): IZone => ({
-	id,
-	name: `Zone ${id}`,
-	description: '',
-	designerNotes: '',
-	order,
-	levelMin: 1,
-	levelMax: 10,
-	bossLevel: 1,
-	unlockChallengeId,
-	isHome: false,
-	retiredAt
-});
+const zone = (id: number, order: number, unlockChallengeId?: number, retiredAt?: string): IZone =>
+	makeZone({ id, order, unlockChallengeId, retiredAt });
 
 describe('zonesByOrder', () => {
 	it('sorts by authored order without mutating the input', () => {

--- a/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
+++ b/UI/src/tests/lib/engine/battle/enemy-manager-boss.test.ts
@@ -3,6 +3,7 @@ import { apiSocket, ELogType, type IApiSocketResponse, type IEnemyInstance, type
 import { delay } from '$lib/common';
 import { logMessage } from '$lib/engine/log';
 import { EnemyManager, onNewEnemyLoaded } from '$lib/engine/battle/enemy-manager';
+import { makeZone } from '../../../fixtures/zones';
 
 // Share a holder so the mocked onBattleStageChanged can hand the registered stage callback back
 // to the test, letting it drive Victorious/Defeated transitions deterministically.
@@ -178,18 +179,8 @@ describe('EnemyManager boss mode', () => {
 		return release;
 	};
 
-	const zone = (id: number, order: number, unlockChallengeId?: number): IZone => ({
-		id,
-		name: `Zone ${id}`,
-		description: '',
-		designerNotes: '',
-		order,
-		levelMin: 1,
-		levelMax: 10,
-		bossLevel: 1,
-		unlockChallengeId,
-		isHome: false
-	});
+	const zone = (id: number, order: number, unlockChallengeId?: number): IZone =>
+		makeZone({ id, order, unlockChallengeId });
 
 	// bossUnlockedNextZone is reset by returnToIdle/challengeBoss once the (mocked-immediate) overlay
 	// delay elapses, so capture it at the overlay moment — the instant `delay` is called, right after

--- a/UI/src/tests/routes/admin/workbench/entities/zone.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/zone.test.ts
@@ -37,6 +37,7 @@ vi.mock('$lib/api', async (importOriginal) => {
 });
 
 import { zoneEntity, type WorkbenchZone } from '$routes/admin/workbench/entities/zone';
+import { makeZone } from '../../../../fixtures/zones';
 
 /** Finds the body posted to a given AdminTools endpoint (or undefined if never called). */
 const postBodyTo = (endpoint: string) => mockPost.mock.calls.find((c) => c[0] === endpoint)?.[1];
@@ -111,18 +112,10 @@ describe('zoneEntity', () => {
 	});
 
 	it('persist maps the sentinel back to an absent FK, passes real ids through, and saves the spawn table against the resolved id', async () => {
+		// Mirrors `zoneEntity.newItem`: a blank name and the picker's -1 "None" sentinel on both
+		// optional FKs, which is exactly what the mapping under test converts back to an absent FK.
 		const newZone = (over: Partial<WorkbenchZone>): WorkbenchZone => ({
-			id: -1,
-			name: '',
-			description: '',
-			designerNotes: '',
-			order: 0,
-			levelMin: 1,
-			levelMax: 10,
-			bossEnemyId: -1,
-			bossLevel: 1,
-			unlockChallengeId: -1,
-			isHome: false,
+			...makeZone({ id: -1, name: '', bossEnemyId: -1, unlockChallengeId: -1 }),
 			zoneEnemies: [],
 			...over
 		});

--- a/UI/src/tests/routes/admin/workbench/references.test.ts
+++ b/UI/src/tests/routes/admin/workbench/references.test.ts
@@ -27,6 +27,7 @@ import {
 import { makePath, makeProficiency } from '../../../fixtures/proficiencies';
 import { makeSkill } from '../../../fixtures/skills';
 import { makeItem } from '../../../fixtures/items';
+import { makeZone } from '../../../fixtures/zones';
 
 const enemy = (id: number, name: string, opts: Partial<IEnemy> = {}): IEnemy => ({
 	id,
@@ -39,18 +40,7 @@ const enemy = (id: number, name: string, opts: Partial<IEnemy> = {}): IEnemy => 
 	...opts
 });
 
-const zone = (id: number, name: string, opts: Partial<IZone> = {}): IZone => ({
-	id,
-	name,
-	description: '',
-	designerNotes: '',
-	order: 0,
-	levelMin: 1,
-	levelMax: 10,
-	bossLevel: 1,
-	isHome: false,
-	...opts
-});
+const zone = (id: number, name: string, opts: Partial<IZone> = {}): IZone => makeZone({ id, name, ...opts });
 
 const challenge = (id: number, name: string, opts: Partial<IChallenge> = {}): IChallenge => ({
 	id,

--- a/UI/src/tests/routes/game/screens/fight/Fight.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/Fight.test.ts
@@ -62,20 +62,11 @@ vi.mock('$stores', () => ({ staticData, statistics, playerChallenges, registerTo
 
 import Fight from '$routes/game/screens/fight/Fight.svelte';
 import { makeBattler } from './fight-fixtures';
+import { makeZone as makeZoneContract } from '../../../../fixtures/zones';
 
-const makeZone = (over: Partial<IZone> = {}): IZone => ({
-	// Zone id == its index in staticData.zones (the Id-as-index invariant the boss view indexes by).
-	id: 0,
-	name: 'Verdant Hollow',
-	description: '',
-	designerNotes: '',
-	order: 1,
-	levelMin: 1,
-	levelMax: 10,
-	bossLevel: 1,
-	isHome: false,
-	...over
-});
+// Zone id == its index in staticData.zones (the Id-as-index invariant the boss view indexes by).
+const makeZone = (over: Partial<IZone> = {}): IZone =>
+	makeZoneContract({ id: 0, name: 'Verdant Hollow', order: 1, ...over });
 
 beforeEach(() => {
 	mockBattleEngine.player = makeBattler({ name: 'Aelara' });

--- a/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
@@ -49,6 +49,7 @@ vi.mock('$stores', () => ({
 }));
 
 import ZoneNav from '$routes/game/screens/fight/ZoneNav.svelte';
+import { makeZone } from '../../../../fixtures/zones';
 
 const challenge = (id: number, name: string, description: string): IChallenge =>
 	({ id, name, description, challengeTypeId: EChallengeType.EnemiesKilled, progressGoal: 10 }) as IChallenge;
@@ -60,19 +61,7 @@ const zone = (
 	unlockChallengeId?: number,
 	retiredAt?: string,
 	isHome = false
-): IZone => ({
-	id,
-	name,
-	description: '',
-	designerNotes: '',
-	order,
-	levelMin: 1,
-	levelMax: 10,
-	bossLevel: 1,
-	unlockChallengeId,
-	isHome,
-	retiredAt
-});
+): IZone => makeZone({ id, name, order, unlockChallengeId, isHome, retiredAt });
 
 beforeEach(() => {
 	playerChallenges.isChallengeCompleted.mockReset();

--- a/UI/src/tests/routes/game/screens/fight/boss/boss-view.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/boss/boss-view.test.ts
@@ -22,30 +22,18 @@ vi.mock('$lib/engine', () => ({ enemyManager, playerManager }));
 vi.mock('$stores', () => ({ staticData, statistics }));
 
 import { BossView } from '$routes/game/screens/fight/boss/boss-view.svelte';
+import { makeZone } from '../../../../../fixtures/zones';
 
-const bossZone: IZone = {
+const bossZone: IZone = makeZone({
 	id: 3,
 	name: 'Forgotten Catacombs',
-	description: '',
-	designerNotes: '',
 	order: 3,
 	levelMin: 8,
 	levelMax: 11,
 	bossEnemyId: 0,
-	bossLevel: 18,
-	isHome: false
-};
-const bosslessZone: IZone = {
-	id: 1,
-	name: 'Verdant Hollow',
-	description: '',
-	designerNotes: '',
-	order: 1,
-	levelMin: 1,
-	levelMax: 10,
-	bossLevel: 1,
-	isHome: false
-};
+	bossLevel: 18
+});
+const bosslessZone: IZone = makeZone({ id: 1, name: 'Verdant Hollow', order: 1 });
 const boss: IEnemy = {
 	id: 0,
 	name: 'Catacomb Lich',

--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -12,6 +12,7 @@ import {
 	type IZone
 } from '$lib/api';
 import { makeSkill } from '../../../../fixtures/skills';
+import { makeZone } from '../../../../fixtures/zones';
 import type { AttributeModifier } from '$lib/battle';
 import { classSignaturePassiveModifier } from '$lib/battle/class-modifiers';
 
@@ -121,20 +122,7 @@ const SKILLS: ISkill[] = [
 ];
 
 // Zone 0 (idle range [2,8], boss enemy 2 at level 10): one in-zone spawn + the boss pill.
-const ZONES: IZone[] = [
-	{
-		id: 0,
-		name: 'Vale',
-		description: '',
-		designerNotes: '',
-		order: 0,
-		levelMin: 2,
-		levelMax: 8,
-		bossEnemyId: 2,
-		bossLevel: 10,
-		isHome: false
-	}
-];
+const ZONES: IZone[] = [makeZone({ id: 0, name: 'Vale', levelMin: 2, levelMax: 8, bossEnemyId: 2, bossLevel: 10 })];
 
 // amountPerLevel 1 gives each enemy Toughness 2·(1·level), within the preset-derived slider ceiling.
 const enemy = (over: Partial<IEnemy> & { id: number }): IEnemy => ({

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -10,6 +10,7 @@ import {
 	type IZone
 } from '$lib/api';
 import { makeSkill } from '../../../../fixtures/skills';
+import { makeZone } from '../../../../fixtures/zones';
 import { EAttributeModifierSource, type AttributeModifier } from '$lib/battle';
 import { classSignaturePassiveModifier } from '$lib/battle/class-modifiers';
 
@@ -161,20 +162,7 @@ const enemyDist = (endurancePerLevel: number) => [
 ];
 
 // Zone 0: idle range [2, 8] (midpoint level 5), dedicated boss enemy 2 fought at level 10.
-const ZONES: IZone[] = [
-	{
-		id: 0,
-		name: 'Vale',
-		description: '',
-		designerNotes: '',
-		order: 0,
-		levelMin: 2,
-		levelMax: 8,
-		bossEnemyId: 2,
-		bossLevel: 10,
-		isHome: false
-	}
-];
+const ZONES: IZone[] = [makeZone({ id: 0, name: 'Vale', levelMin: 2, levelMax: 8, bossEnemyId: 2, bossLevel: 10 })];
 
 const ENEMIES: IEnemy[] = [
 	enemy({ id: 0, name: 'Imp', attributeDistribution: enemyDist(2), spawns: [{ zoneId: 0, weight: 1 }] }),


### PR DESCRIPTION
The `IZone` half of #2425, following #2414 (`IAttribute`/`IPath`/`IProficiency`), #2425 (`ISkill`) and #2433/#2443 (`IItem`).

## Summary

Adds `UI/src/tests/fixtures/zones.ts` exporting `makeZone(overrides)` and converts the nine suites that construct a **typed** `IZone` onto it. Each suite keeps its local call signature as a thin adapter, so no call site churns.

Test-only — no production code, no behaviour change. 119 lines of duplicated contract literal out, 27 in.

## The probe corrected the issue's survey, in both directions

The issue estimated *"~16 suites (`grep -rl "bossLevel:" UI/src/tests/`)"* and flagged that number as untrustworthy. It was — the real typed set is **9**, and the grep was wrong both ways, exactly as #2433 predicted:

- **Over-counts.** Several hits seed zone literals into a `staticData: {} as any` mock. Nothing type-checks them as `IZone`, so they pay no contract-drift tax, and filling their previously-`undefined` fields could change what the suite renders. Left alone.
- **Under-counts.** `boss-view.test.ts`'s `bosslessZone` never sets `bossLevel` at all, so the grep misses it — but it's a typed `IZone` literal and does pay the tax.

Converted (from the `svelte-check` error list, not the grep):

| Suite | Local builder |
|---|---|
| `lib/common/zone-progression.test.ts` | `zone(id, order, unlockChallengeId?, retiredAt?)` |
| `lib/engine/battle/enemy-manager-boss.test.ts` | `zone(id, order, unlockChallengeId?)` |
| `routes/admin/workbench/references.test.ts` | `zone(id, name, opts)` |
| `routes/admin/workbench/entities/zone.test.ts` | `newZone` (a `WorkbenchZone`) |
| `routes/game/screens/fight/Fight.test.ts` | `makeZone(over)` |
| `routes/game/screens/fight/ZoneNav.test.ts` | `zone(id, order, name, …)` |
| `routes/game/screens/fight/boss/boss-view.test.ts` | two inline literals |
| `routes/game/screens/skills/Skills.test.ts` | inline `ZONES[0]` literal |
| `routes/game/screens/skills/skills-view.test.ts` | inline `ZONES[0]` literal |

## Defaults, reconciled explicitly

- **Unanimous across all nine:** `description: ''`, `designerNotes: ''`, `isHome: false`.
- **Majority, and asserted nowhere that doesn't restate them:** `levelMin: 1`, `levelMax: 10`, `bossLevel: 1`. The three divergent builders (`boss-view`'s `bossZone`, the two Skills suites' `Vale`) all assert on their level range or boss level, so they state it as an override — the divergence stays visible at the call site rather than being absorbed into a default.
- **`order` defaults to 0, not the id.** A suite proving order-driven behaviour is expected to place each zone explicitly rather than inherit a position from the Id-as-index invariant — the same call `makeProficiency` makes for `pathOrdinal`. `ZoneNav`'s "deliberately out of array order" fixture depends on that being explicit.
- **`bossEnemyId` / `unlockChallengeId` / `retiredAt` stay unset.** Each flips a distinct branch (the boss pill, the unlock gate, retirement filtering), so a live, boss-less, ungated zone is the neutral case.

`name` defaults to `Zone {id}`; the suites that assert on authored names (`Verdant Hollow`, `Vale`, …) pass one.

### One note on the workbench adapter

`entities/zone.test.ts`'s `newZone` builds a `WorkbenchZone` whose `bossEnemyId`/`unlockChallengeId` are the picker's **-1 "None" sentinel** — not neutral defaults, but the exact input the mapping under test converts back to an absent FK. It composes `makeZone` and states both sentinels plus `zoneEnemies` as its divergence, with a comment tying it to `zoneEntity.newItem`. This is the `progression-test-utils` pattern from #2426.

The production `zoneEntity.newItem` itself still hand-rolls the literal, which is correct — it's the authoritative blank record an admin gets, not a test builder, and it's one of the two remaining probe errors below.

## Test plan

- [x] **The issue's stated verification passes.** Adding a throwaway required field to `IZone` produced 12 errors across 10 files before, and after the change produces exactly **one** test-file error — `src/tests/fixtures/zones.ts`. The only other two are production (`routes/admin/workbench/entities/zone.ts`'s `newItem` and its persist mapping), which are out of scope.
- [x] Converted one suite at a time, running each in between, so a changed default would have failed loudly rather than quietly weakening an assertion. None did.
- [x] `npm run lint` (eslint + `svelte-check`): clean — 1226 files, 0 errors, 0 warnings.
- [x] `npm run test:unit:ci`: **4035/4035 passing across 1157 suites.**
- No backend files touched, so CI's changed-path gate skips the backend jobs.

## Follow-up filed

`IEnemy` has the identical duplication class and the same size — the probe flushes out **9** typed suites, six of them the very files this PR just converted for `IZone`. It wasn't in #2425's survey either, so like #2444 (`IItemMod`) it's filed separately rather than widened into this PR: **#2446**.

Closes #2434.