### PR TITLE
Consolidate the hand-rolled IItemMod test builders onto a shared fixture (#2444)

### DIFF
--- a/UI/src/tests/fixtures/item-mods.ts
+++ b/UI/src/tests/fixtures/item-mods.ts
@@ -5,12 +5,12 @@ import { EItemModType, ERarity, type IItemMod } from '$lib/api';
    that drift independently, even though a suite exercising applied mods usually imports both.
 
    The target set was confirmed with the throwaway-required-field probe, not a `grep` — only a suite
-   that constructs a *typed* `IItemMod` pays the contract-drift tax. Two exclusions are deliberate:
-   the production blank record (`routes/admin/workbench/entities/item-mod.ts`) and the live `ItemMod`
-   domain class (`lib/battle/item-mod.ts`) are the authoritative shapes and correctly stay literals,
-   and `challenges/OverviewPane.test.ts` asserts a deliberately partial literal `as IItemMod`, which
-   opts it out of drift detection entirely (#2447). A `grep` still finding mod literals under
-   `src/tests/` is expected, not a gap. */
+   that constructs a *typed* `IItemMod` pays the contract-drift tax. Exclusions are deliberate, in two
+   classes: the production blank record (`routes/admin/workbench/entities/item-mod.ts`) and the live
+   `ItemMod` domain class (`lib/battle/item-mod.ts`) are the authoritative shapes and correctly stay
+   literals; `challenges/OverviewPane.test.ts` and `lib/common/challenge-unlocks.test.ts` each assert a
+   deliberately partial literal `as IItemMod`, which opts them out of drift detection entirely (#2447).
+   A `grep` still finding mod literals under `src/tests/` is expected, not a gap. */
 
 /**
  * Builds an {@link IItemMod} reference-data entry for tests. Everything but the id is a neutral

--- a/UI/src/tests/fixtures/item-mods.ts
+++ b/UI/src/tests/fixtures/item-mods.ts
@@ -1,0 +1,35 @@
+import { EItemModType, ERarity, type IItemMod } from '$lib/api';
+
+/* Shared `IItemMod` contract builder (#2444), following the `fixtures/items.ts` convention. It stays
+   a module of its own rather than joining `makeItem`: `IItem` and `IItemMod` are separate contracts
+   that drift independently, even though a suite exercising applied mods usually imports both.
+
+   The target set was confirmed with the throwaway-required-field probe, not a `grep` — only a suite
+   that constructs a *typed* `IItemMod` pays the contract-drift tax. Two exclusions are deliberate:
+   the production blank record (`routes/admin/workbench/entities/item-mod.ts`) and the live `ItemMod`
+   domain class (`lib/battle/item-mod.ts`) are the authoritative shapes and correctly stay literals,
+   and `challenges/OverviewPane.test.ts` asserts a deliberately partial literal `as IItemMod`, which
+   opts it out of drift detection entirely (#2447). A `grep` still finding mod literals under
+   `src/tests/` is expected, not a gap. */
+
+/**
+ * Builds an {@link IItemMod} reference-data entry for tests. Everything but the id is a neutral
+ * placeholder so a suite states only what it asserts on.
+ *
+ * `itemModTypeId` defaults to `Component`, matching the workbench's blank record: it is the one type
+ * with no naming semantics (a `Prefix`/`Suffix` affixes the host item's display name), so it stays
+ * inert for suites that only care that *a* mod applied. A suite whose mod has to fit a specific
+ * `modSlots` entry states the matching type explicitly, since the type is what binds mod to slot.
+ * `attributes`/`tags` default empty and `retiredAt` is left unset for the same reason — an
+ * unretired, statless, untagged mod is the neutral case, and each of those flips a distinct branch.
+ */
+export const makeItemMod = (overrides: Partial<IItemMod> & { id: number }): IItemMod => ({
+	name: `Mod ${overrides.id}`,
+	description: '',
+	itemModTypeId: EItemModType.Component,
+	rarityId: ERarity.Common,
+	attributes: [],
+	tags: [],
+	designerNotes: '',
+	...overrides
+});

--- a/UI/src/tests/lib/battle/battle-sim-test-utils.ts
+++ b/UI/src/tests/lib/battle/battle-sim-test-utils.ts
@@ -2,10 +2,10 @@ import { Battler, newItem } from '$lib/battle';
 // Aliased: this module's own `makeSkill` builds a `SkillSpec` (pre-registration), not the contract.
 import { makeSkill as makeSkillContract } from '../../fixtures/skills';
 import { makeItem } from '../../fixtures/items';
+import { makeItemMod } from '../../fixtures/item-mods';
 import {
 	EAttribute,
 	EDamageType,
-	ERarity,
 	type EModifierType,
 	type ESkillEffectTarget,
 	type EItemModType,
@@ -209,16 +209,7 @@ export function equipmentFactory(itemRegistry: IItem[], itemModRegistry: IItemMo
 	return (spec: ItemSpec): IBattlerAttribute[] => {
 		const appliedMods: IAppliedModModel[] = spec.mods.map((mod, slotIndex) => {
 			const id = itemModRegistry.length;
-			itemModRegistry.push({
-				id,
-				name: `Mod ${id}`,
-				description: '',
-				designerNotes: '',
-				itemModTypeId: mod.type,
-				rarityId: ERarity.Common,
-				attributes: mod.attributes,
-				tags: []
-			});
+			itemModRegistry.push(makeItemMod({ id, itemModTypeId: mod.type, attributes: mod.attributes }));
 			return { itemModId: id, itemModSlotId: slotIndex };
 		});
 

--- a/UI/src/tests/lib/battle/item-mod.test.ts
+++ b/UI/src/tests/lib/battle/item-mod.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EAttribute, EItemModType, ERarity, type IItemMod } from '$lib/api';
+import { makeItemMod } from '../../fixtures/item-mods';
 
 // `newItemMod` resolves the mod's static definition out of the in-memory
 // reference cache by id (positional, mirroring `newItem` for inventory items),
@@ -16,11 +17,10 @@ vi.mock('$stores', () => ({
 
 import { newItemMod } from '$lib/battle/item-mod';
 
-mockItemMods[7] = {
+mockItemMods[7] = makeItemMod({
 	id: 7,
 	name: 'Flaming',
 	description: 'Burns the wielder a little too',
-	designerNotes: '',
 	itemModTypeId: EItemModType.Prefix,
 	rarityId: ERarity.Legendary,
 	attributes: [
@@ -28,7 +28,7 @@ mockItemMods[7] = {
 		{ attributeId: EAttribute.Agility, amount: 2 }
 	],
 	tags: [1, 2]
-};
+});
 
 describe('newItemMod', () => {
 	it('merges the static mod definition with the applied slot binding', () => {

--- a/UI/src/tests/lib/battle/item.test.ts
+++ b/UI/src/tests/lib/battle/item.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { EAttribute, EItemCategory, EItemModType, ERarity } from '$lib/api';
 import type { IInventoryItem, IItem, IItemMod } from '$lib/api';
 import { makeItem } from '../../fixtures/items';
+import { makeItemMod } from '../../fixtures/item-mods';
 
 const { mockItems, mockItemMods } = vi.hoisted(() => ({
 	mockItems: [] as IItem[],
@@ -28,19 +29,16 @@ mockItems[1] = makeItem({
 	rarityId: ERarity.Epic,
 	attributes: [{ attributeId: EAttribute.Strength, amount: 5 }]
 });
-mockItemMods[7] = {
+mockItemMods[7] = makeItemMod({
 	id: 7,
 	name: 'Flaming',
-	description: '',
-	designerNotes: '',
 	itemModTypeId: EItemModType.Prefix,
 	rarityId: ERarity.Legendary,
 	attributes: [
 		{ attributeId: EAttribute.Strength, amount: 3 },
 		{ attributeId: EAttribute.Agility, amount: 2 }
-	],
-	tags: []
-};
+	]
+});
 
 const invItem: IInventoryItem = {
 	itemId: 1,

--- a/UI/src/tests/lib/engine/player/inventory-manager-reactivity.svelte.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager-reactivity.svelte.test.ts
@@ -5,6 +5,8 @@ import type { IInventoryData, IInventoryItem, IItem, IItemMod } from '$lib/api';
 import { statify } from '$lib/common';
 // Aliased: this suite's own `makeItem` is an id-only adapter over the shared contract builder.
 import { makeItem as makeItemContract } from '../../../fixtures/items';
+// Aliased for the same reason: the local `makeItemMod` is an id-only adapter over the shared builder.
+import { makeItemMod as makeItemModContract } from '../../../fixtures/item-mods';
 
 const mockInventoryData: IInventoryData = {
 	unlockedItems: [],
@@ -66,16 +68,15 @@ const makeItem = (id: number): IItem =>
 		modSlots: [{ id: 0, itemId: id, itemModSlotTypeId: EItemModType.Component }]
 	});
 
-const makeItemMod = (id: number): IItemMod => ({
-	id,
-	name: `Mod ${id}`,
-	description: `Mod description ${id}`,
-	designerNotes: '',
-	itemModTypeId: EItemModType.Component,
-	rarityId: ERarity.Uncommon,
-	attributes: [{ attributeId: EAttribute.Agility, amount: 3 }],
-	tags: []
-});
+const makeItemMod = (id: number): IItemMod =>
+	makeItemModContract({
+		id,
+		description: `Mod description ${id}`,
+		// Stated rather than inherited: it has to match the `Component` slot the fixture item carries.
+		itemModTypeId: EItemModType.Component,
+		rarityId: ERarity.Uncommon,
+		attributes: [{ attributeId: EAttribute.Agility, amount: 3 }]
+	});
 
 const makeInventoryItem = (overrides: Partial<IInventoryItem> & { itemId: number }): IInventoryItem => ({
 	equipped: false,

--- a/UI/src/tests/lib/engine/player/inventory-manager.test.ts
+++ b/UI/src/tests/lib/engine/player/inventory-manager.test.ts
@@ -5,6 +5,8 @@ import { PUNCH_SKILL_ID } from '$lib/api/types/game-constants';
 import { makeSkill } from '../../../fixtures/skills';
 // Aliased: this suite's own `makeItem` is a positional adapter over the shared contract builder.
 import { makeItem as makeItemContract } from '../../../fixtures/items';
+// Aliased for the same reason: the local `makeItemMod` is an id-only adapter over the shared builder.
+import { makeItemMod as makeItemModContract } from '../../../fixtures/item-mods';
 
 const mockInventoryData: IInventoryData = {
 	unlockedItems: [],
@@ -83,16 +85,15 @@ const makeItem = (
 		attributes: [{ attributeId: EAttribute.Strength, amount: 5 }]
 	});
 
-const makeItemMod = (id: number): IItemMod => ({
-	id,
-	name: `Mod ${id}`,
-	description: `Mod description ${id}`,
-	designerNotes: '',
-	itemModTypeId: EItemModType.Component,
-	rarityId: ERarity.Uncommon,
-	attributes: [{ attributeId: EAttribute.Agility, amount: 3 }],
-	tags: []
-});
+const makeItemMod = (id: number): IItemMod =>
+	makeItemModContract({
+		id,
+		description: `Mod description ${id}`,
+		// Stated rather than inherited: it has to match the `Component` slot type the fixture items carry.
+		itemModTypeId: EItemModType.Component,
+		rarityId: ERarity.Uncommon,
+		attributes: [{ attributeId: EAttribute.Agility, amount: 3 }]
+	});
 
 const makeInventoryItem = (overrides: Partial<IInventoryItem> & { itemId: number }): IInventoryItem => ({
 	equipped: false,

--- a/UI/src/tests/routes/admin/workbench/entities/item-mod.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/item-mod.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EChangeType, EItemModType, ERarity, type IItemMod } from '$lib/api';
 import type { TableSectionConfig } from '$routes/admin/workbench/entities/types';
+import { makeItemMod } from '../../../../fixtures/item-mods';
 
 /* Item-mod config transforms: `newItem` defaults, the derived meta line, and the
    persist path — a child-only attribute edit must NOT hit the identity Add/Edit
@@ -74,16 +75,15 @@ describe('itemModEntity', () => {
 	});
 
 	it('persist saves the tag set when tags change without re-sending an identity Edit', async () => {
-		const baseline: IItemMod = {
+		const baseline = makeItemMod({
 			id: 0,
 			name: 'Sharp',
 			description: 'desc',
-			designerNotes: '',
 			itemModTypeId: EItemModType.Prefix,
 			rarityId: ERarity.Rare,
 			attributes: [{ attributeId: 0, amount: 1 }],
 			tags: [1]
-		};
+		});
 		const record: IItemMod = { ...baseline, tags: [1, 2] }; // only the tag set changed
 		socket.itemMods = [record];
 
@@ -96,16 +96,14 @@ describe('itemModEntity', () => {
 	});
 
 	it('persist diffs attribute changes without sending an identity Edit when identity is unchanged', async () => {
-		const baseline: IItemMod = {
+		const baseline = makeItemMod({
 			id: 0,
 			name: 'Sharp',
-			description: '',
-			designerNotes: '',
 			itemModTypeId: EItemModType.Prefix,
 			rarityId: ERarity.Rare,
 			attributes: [{ attributeId: 0, amount: 1 }],
 			tags: [1]
-		};
+		});
 		const record: IItemMod = { ...baseline, attributes: [{ attributeId: 0, amount: 3 }] }; // only the bonus amount changed
 		socket.itemMods = [record];
 
@@ -125,16 +123,15 @@ describe('itemModEntity', () => {
 	it('persist Adds a new mod and saves its attributes/tags against the resolved id', async () => {
 		// A freshly-added record has a temporary negative id; persistEntity resolves the real
 		// id from the post-save refetch before running the attribute/tag child savers.
-		const added: IItemMod = {
+		const added = makeItemMod({
 			id: -1,
 			name: 'Keen',
 			description: 'Sharper edge',
-			designerNotes: '',
 			itemModTypeId: EItemModType.Prefix,
 			rarityId: ERarity.Rare,
 			attributes: [{ attributeId: 0, amount: 3 }],
 			tags: [5]
-		};
+		});
 		socket.itemMods = [{ ...added, id: 9 }]; // the persisted record at its real id
 
 		await itemModEntity.persist({ added: [added], modified: [], deleted: [], existingIds: [] });

--- a/UI/src/tests/routes/admin/workbench/references.test.ts
+++ b/UI/src/tests/routes/admin/workbench/references.test.ts
@@ -6,7 +6,6 @@ import {
 	EItemCategory,
 	EItemModType,
 	EModifierType,
-	ERarity,
 	type IChallenge,
 	type IClass,
 	type IEnemy,
@@ -27,6 +26,7 @@ import {
 import { makePath, makeProficiency } from '../../../fixtures/proficiencies';
 import { makeSkill } from '../../../fixtures/skills';
 import { makeItem } from '../../../fixtures/items';
+import { makeItemMod } from '../../../fixtures/item-mods';
 import { makeZone } from '../../../fixtures/zones';
 
 const enemy = (id: number, name: string, opts: Partial<IEnemy> = {}): IEnemy => ({
@@ -56,17 +56,8 @@ const challenge = (id: number, name: string, opts: Partial<IChallenge> = {}): IC
 const item = (id: number, name: string, opts: Partial<IItem> = {}): IItem =>
 	makeItem({ id, name, itemCategoryId: EItemCategory.Helm, ...opts });
 
-const itemMod = (id: number, name: string, opts: Partial<IItemMod> = {}): IItemMod => ({
-	id,
-	name,
-	description: '',
-	itemModTypeId: EItemModType.Prefix,
-	rarityId: ERarity.Common,
-	attributes: [],
-	tags: [],
-	designerNotes: '',
-	...opts
-});
+const itemMod = (id: number, name: string, opts: Partial<IItemMod> = {}): IItemMod =>
+	makeItemMod({ id, name, itemModTypeId: EItemModType.Prefix, ...opts });
 
 const wclass = (id: number, name: string, opts: Partial<IClass> = {}): IClass => ({
 	id,

--- a/UI/src/tests/routes/game/screens/challenges/ModTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/ModTooltip.test.ts
@@ -2,25 +2,25 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
 import { EAttribute, EItemModType, ERarity, type IItemMod } from '$lib/api';
 import ModTooltip from '$routes/game/screens/challenges/ModTooltip.svelte';
+import { makeItemMod } from '../../../../fixtures/item-mods';
 
 // A prefix mod with a positive and a negative attribute, so the signed/positive/negative
 // rendering of the shared TooltipStatsGrid is exercised. `MaxHealth` also covers the
 // `normalizeText` split (camelCase -> "Max Health").
-const makeMod = (overrides: Partial<IItemMod> = {}): IItemMod => ({
-	id: 1,
-	name: 'Flaming',
-	description: 'Wreathed in flame.',
-	designerNotes: '',
-	itemModTypeId: EItemModType.Prefix,
-	rarityId: ERarity.Legendary,
-	attributes: [
-		{ attributeId: EAttribute.Strength, amount: 5 },
-		{ attributeId: EAttribute.MaxHealth, amount: 12 },
-		{ attributeId: EAttribute.Toughness, amount: -2 }
-	],
-	tags: [],
-	...overrides
-});
+const makeMod = (overrides: Partial<IItemMod> = {}): IItemMod =>
+	makeItemMod({
+		id: 1,
+		name: 'Flaming',
+		description: 'Wreathed in flame.',
+		itemModTypeId: EItemModType.Prefix,
+		rarityId: ERarity.Legendary,
+		attributes: [
+			{ attributeId: EAttribute.Strength, amount: 5 },
+			{ attributeId: EAttribute.MaxHealth, amount: 12 },
+			{ attributeId: EAttribute.Toughness, amount: -2 }
+		],
+		...overrides
+	});
 
 afterEach(cleanup);
 

--- a/UI/src/tests/routes/game/screens/challenges/RewardAffordance.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/RewardAffordance.test.ts
@@ -5,17 +5,15 @@ import RewardAffordance from '$routes/game/screens/challenges/RewardAffordance.s
 import RewardAffordanceFixture from './RewardAffordanceFixture.svelte';
 import type { RewardTooltipController } from '$routes/game/screens/challenges/reward-tooltip-context';
 import type { ResolvedReward } from '$routes/game/screens/challenges/challenges-view.svelte';
+import { makeItemMod } from '../../../../fixtures/item-mods';
 
-const sampleMod: IItemMod = {
+const sampleMod: IItemMod = makeItemMod({
 	id: 213,
 	name: 'Honed',
 	description: 'Honed',
-	designerNotes: '',
 	itemModTypeId: EItemModType.Prefix,
-	rarityId: ERarity.Rare,
-	attributes: [],
-	tags: []
-};
+	rarityId: ERarity.Rare
+});
 
 const modReward = (revealed: boolean): ResolvedReward => ({
 	kind: 'mod',

--- a/UI/src/tests/routes/game/screens/challenges/RewardTooltip.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/RewardTooltip.test.ts
@@ -8,6 +8,7 @@ import type { ResolvedReward } from '$routes/game/screens/challenges/challenges-
 vi.mock('$stores', () => ({ staticData: {} }));
 
 import RewardTooltip from '$routes/game/screens/challenges/RewardTooltip.svelte';
+import { makeItemMod } from '../../../../fixtures/item-mods';
 
 const previewItem = (): Item =>
 	({
@@ -26,16 +27,15 @@ const previewItem = (): Item =>
 		totalAttributes: new BattleAttributes([{ attributeId: EAttribute.Strength, amount: 5 }], false)
 	}) as unknown as Item;
 
-const previewMod = (): IItemMod => ({
-	id: 1,
-	name: 'Blazing',
-	description: 'Hot.',
-	designerNotes: '',
-	itemModTypeId: EItemModType.Prefix,
-	rarityId: ERarity.Epic,
-	attributes: [{ attributeId: EAttribute.Strength, amount: 4 }],
-	tags: []
-});
+const previewMod = (): IItemMod =>
+	makeItemMod({
+		id: 1,
+		name: 'Blazing',
+		description: 'Hot.',
+		itemModTypeId: EItemModType.Prefix,
+		rarityId: ERarity.Epic,
+		attributes: [{ attributeId: EAttribute.Strength, amount: 4 }]
+	});
 
 const itemReward = (revealed: boolean): ResolvedReward =>
 	({

--- a/UI/src/tests/routes/game/screens/challenges/challenges-view.svelte.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/challenges-view.svelte.test.ts
@@ -55,6 +55,7 @@ import {
 	typeStats
 } from '$routes/game/screens/challenges/challenges-view.svelte';
 import { makeItem } from '../../../../fixtures/items';
+import { makeItemMod } from '../../../../fixtures/item-mods';
 
 /** Carries attributes and a mod slot by default — the reward tooltip renders both. */
 const item = (id: number, name: string, rarity: ERarity, cat: EItemCategory, extra: Partial<IItem> = {}): IItem =>
@@ -69,16 +70,16 @@ const item = (id: number, name: string, rarity: ERarity, cat: EItemCategory, ext
 		...extra
 	});
 
-const mod = (id: number, name: string, rarity: ERarity): IItemMod => ({
-	id,
-	name,
-	description: `${name} description`,
-	designerNotes: '',
-	itemModTypeId: EItemModType.Prefix,
-	rarityId: rarity,
-	attributes: [{ attributeId: EAttribute.Agility, amount: 3 }],
-	tags: []
-});
+const mod = (id: number, name: string, rarity: ERarity): IItemMod =>
+	makeItemMod({
+		id,
+		name,
+		description: `${name} description`,
+		// Stated rather than inherited: it has to match the `Prefix` slot the fixture items carry.
+		itemModTypeId: EItemModType.Prefix,
+		rarityId: rarity,
+		attributes: [{ attributeId: EAttribute.Agility, amount: 3 }]
+	});
 
 const challenge = (over: Partial<IChallenge> & Pick<IChallenge, 'id' | 'name' | 'challengeTypeId'>): IChallenge => ({
 	description: `${over.name} description`,


### PR DESCRIPTION
## Summary

Adds `UI/src/tests/fixtures/item-mods.ts` exporting `makeItemMod(o)`, following the `fixtures/items.ts` / `fixtures/zones.ts` convention, and converts every suite that constructed a **typed** `IItemMod` inline. Fifth run of the pattern from #2414 / #2425 / #2433 / #2434.

Test-only. No production code, no behaviour change: 11 files converted, −103/+81 lines.

## How it addresses the issue

**The target set differs from the issue's table**, because it was confirmed with the throwaway-required-field probe (`svelte-check`) rather than the grep — exactly the check the issue asked for, and it corrected the survey in both directions:

| Suite | Issue's table | Actual |
|---|---|---|
| `lib/battle/item-mod.test.ts` | *not listed* | **found** — inline `mockItemMods[7]` literal |
| `lib/battle/battle-sim-test-utils.ts` | *not listed* | **found** — inline literal in `equipmentFactory` |
| `routes/admin/workbench/entities/item-mod.test.ts` | "six inline literals" | **three** — the other three spread the production `newItem` blank record, so they aren't hand-rolled and correctly stay |
| `challenges/OverviewPane.test.ts` | "likely excluded" | **confirmed excluded** — partial `as IItemMod` cast opts it out of drift detection (#2447) |

The other nine matched the table. All eleven converted sites: `item-mod.test.ts`, `item.test.ts`, `battle-sim-test-utils.ts`, `inventory-manager.test.ts`, `inventory-manager-reactivity.svelte.test.ts`, `workbench/entities/item-mod.test.ts`, `workbench/references.test.ts`, `ModTooltip.test.ts`, `RewardTooltip.test.ts`, `RewardAffordance.test.ts`, `challenges-view.svelte.test.ts`.

### Module placement

A separate `item-mods.ts` rather than joining `makeItem` in `items.ts`, per the issue's lean — `IItem` and `IItemMod` are separate contracts that drift independently, even though suites usually import both.

### The one default that needed a call

`itemModTypeId` defaults to **`Component`**, matching the workbench's production blank record. It is the one type with no naming semantics — a `Prefix`/`Suffix` affixes the host item's display name — so it stays inert for suites that only care that *a* mod applied. Where the type is load-bearing (it binds a mod to a `modSlots` entry of the matching type), the suite states it explicitly with a comment saying why, rather than inheriting a default that would silently become load-bearing.

Everything else took the neutral default (`rarityId: Common`, empty `attributes`/`tags`, blank `description`/`designerNotes`, `retiredAt` unset). Drifted defaults were reconciled by stating the divergence at the call site — the inventory-manager pair keeps its `Uncommon`/Agility mod, `references.test.ts` and the challenges suites keep their `Prefix`.

### Parity surface

`battle-sim-test-utils.ts` feeds the frontend/backend battle-parity suite, so its conversion is byte-for-byte identity-preserving: the removed literal's `name`/`description`/`designerNotes`/`rarityId`/`tags` are all exactly the fixture's defaults, and only `itemModTypeId`/`attributes` (which the factory already passed through) are stated. No backend mirror is needed — this is test-fixture plumbing, not battle arithmetic.

Removed the now-dead `ERarity` import there and in `references.test.ts`.

## Test plan

- [x] `npm run lint` (eslint + `svelte-check`) — clean, 1226 files, 0 errors, 0 warnings
- [x] `npm run test:unit:ci` — **312 files / 4046 tests passed**
- [x] Each converted suite run individually as it was converted
- [x] **Drift-detection verification** (the issue's stated check): re-running the probe with a throwaway required field on `IItemMod` now yields exactly **one** test-file error — `src/tests/fixtures/item-mods.ts` — plus the two production hits that correctly stay literals (`lib/battle/item-mod.ts`'s `ItemMod` class and `routes/admin/workbench/entities/item-mod.ts`'s `newItem`). Before this change the same probe flagged 11 test files.

No backend changes, so no `dotnet` run was required.

## Note on scope

Left `OverviewPane.test.ts` alone deliberately — its `as IItemMod` cast is #2447's class, and converting it here would have pre-empted that issue's per-contract decision. The new fixture's header comment names that exclusion explicitly, as #2447 asks each fixture to do.

Closes #2444.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbnGYU6LxG62EbYwXJssht)_