### PR TITLE
Consolidate the hand-rolled IEnemy test builders onto a shared fixture (#2446)

### DIFF
--- a/UI/src/tests/fixtures/enemies.ts
+++ b/UI/src/tests/fixtures/enemies.ts
@@ -4,10 +4,13 @@ import type { IEnemy } from '$lib/api';
    convention.
 
    The target set comes from the throwaway-required-field probe, not a `grep` — a
-   `grep "IEnemy => ({"` finds three of the eight suites. Excluded on purpose: `lib/common/
-   enemy-attributes.test.ts`, whose two builders assert a partial literal `as IEnemy`. The cast opts
-   them out of drift detection, so the probe never sees them and converting them is #2447's call, not
-   this one's. A `grep` still finding enemy literals under `src/tests/` is expected, not a gap. */
+   `grep "IEnemy => ({"` finds three of the eight suites. Excluded on purpose:
+   `lib/common/enemy-attributes.test.ts` (two builders) and
+   `routes/game/screens/codex/enemy-level.test.ts` (one), which assert a partial literal `as IEnemy`.
+   The cast opts them out of drift detection, so the probe never sees them and converting them is
+   #2447's call, not this one's — note that issue's table lists `enemy-level.test.ts` only under
+   `IZone`, so its `IEnemy` builder needs picking up there too. A `grep` still finding enemy literals
+   under `src/tests/` is expected, not a gap. */
 
 /**
  * Builds an {@link IEnemy} reference-data entry for tests. Everything but the id is a neutral

--- a/UI/src/tests/fixtures/enemies.ts
+++ b/UI/src/tests/fixtures/enemies.ts
@@ -1,0 +1,31 @@
+import type { IEnemy } from '$lib/api';
+
+/* Shared `IEnemy` contract builder (#2446), following the `fixtures/items.ts` / `fixtures/zones.ts`
+   convention.
+
+   The target set comes from the throwaway-required-field probe, not a `grep` — a
+   `grep "IEnemy => ({"` finds three of the eight suites. Excluded on purpose: `lib/common/
+   enemy-attributes.test.ts`, whose two builders assert a partial literal `as IEnemy`. The cast opts
+   them out of drift detection, so the probe never sees them and converting them is #2447's call, not
+   this one's. A `grep` still finding enemy literals under `src/tests/` is expected, not a gap. */
+
+/**
+ * Builds an {@link IEnemy} reference-data entry for tests. Everything but the id is a neutral
+ * placeholder so a suite states only what it asserts on.
+ *
+ * `attributeDistribution` defaults to **empty** — a zero-Toughness, zero-health enemy. That is the
+ * neutral case (every derived attribute resolves to 0 at any level), so a suite whose assertions
+ * turn on an enemy's resolved attributes is expected to state its own distribution rather than
+ * inherit arithmetic from here. `spawns` and `skillPool` are empty and `isBoss` is false for the same
+ * reason: each one flips a distinct branch (zone spawn tables, the enemy's usable skills, the boss
+ * pill) when present. `retiredAt` is left unset so the fixture enemy is live.
+ */
+export const makeEnemy = (overrides: Partial<IEnemy> & { id: number }): IEnemy => ({
+	name: `Enemy ${overrides.id}`,
+	isBoss: false,
+	attributeDistribution: [],
+	skillPool: [],
+	spawns: [],
+	designerNotes: '',
+	...overrides
+});

--- a/UI/src/tests/lib/engine/battle/battle-engine-parity.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine-parity.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EAttribute, type IBattlerAttribute, type IEnemy, type ISkill } from '$lib/api';
 import { DEFAULT_MAX_BATTLE_MS } from '$lib/api/types/game-constants';
+import { makeEnemy } from '../../../fixtures/enemies';
 
 // Both consumers of the shared `battleStep` — the live, render-driven `BattleEngine.logicalUpdate` and the
 // headless `BattleSimulator` — must produce the same outcome for the same inputs and seed, since the backend
@@ -233,15 +234,10 @@ describe('BattleEngine parity with the headless BattleSimulator', () => {
 			// Configure the live engine to derive the identical player/enemy battlers and run it to completion.
 			mockPlayerManager.attributes = toBattlerAttributes(scenario.playerAttrs);
 			mockPlayerManager.selectedSkills = playerSkillIds;
-			mockEnemies[1] = {
-				id: 1,
-				name: 'Enemy',
-				designerNotes: '',
-				isBoss: false,
-				attributeDistribution: [],
-				skillPool: enemySkillIds,
-				spawns: []
-			};
+			// The engine derives the enemy's battler from the scenario's attributes, not the catalogue
+			// record, so an empty `attributeDistribution` keeps the live run arithmetically identical
+			// to the simulator's.
+			mockEnemies[1] = makeEnemy({ id: 1, name: 'Enemy', skillPool: enemySkillIds });
 
 			const engine = new BattleEngine();
 			engine.start();

--- a/UI/src/tests/lib/engine/battle/battle-engine.test.ts
+++ b/UI/src/tests/lib/engine/battle/battle-engine.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EDamageType, EAttribute, ELogType, EModifierType, ESkillEffectTarget } from '$lib/api';
 import type { ISkill, IEnemy, IEnemyInstance } from '$lib/api';
 import { makeSkill } from '../../../fixtures/skills';
+import { makeEnemy } from '../../../fixtures/enemies';
 
 // Callbacks captured from the mocked engine hooks. `onLogicalUpdate` emits a delta,
 // `onRenderUpdate` a (renderDelta, logicalDelta) pair, and `onNewEnemyLoaded` an enemy instance.
@@ -174,15 +175,7 @@ describe('BattleEngine', () => {
 		mockSkills[0] = makeSkill({ id: 0, name: 'Slash', baseDamage: 100, cooldownMs: 500 });
 
 		mockEnemies.length = 0;
-		mockEnemies[1] = {
-			id: 1,
-			name: 'Goblin',
-			designerNotes: '',
-			isBoss: false,
-			attributeDistribution: [],
-			skillPool: [0],
-			spawns: []
-		};
+		mockEnemies[1] = makeEnemy({ id: 1, name: 'Goblin', skillPool: [0] });
 
 		engine = new BattleEngine();
 	});

--- a/UI/src/tests/routes/admin/workbench/entities/enemy.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/enemy.test.ts
@@ -38,6 +38,7 @@ vi.mock('$lib/api', async (importOriginal) => {
 });
 
 import { enemyEntity, type WorkbenchEnemy } from '$routes/admin/workbench/entities/enemy';
+import { makeEnemy } from '../../../../fixtures/enemies';
 
 /** Finds the body posted to a given AdminTools endpoint (or undefined if never called). */
 const postBodyTo = (endpoint: string) => mockPost.mock.calls.find((c) => c[0] === endpoint)?.[1];
@@ -64,13 +65,13 @@ beforeEach(() => {
 
 describe('enemyEntity', () => {
 	const baseline: WorkbenchEnemy = {
-		id: 0,
-		name: 'Bat',
-		designerNotes: '',
-		isBoss: false,
-		attributeDistribution: [{ attributeId: 0, baseAmount: 1, amountPerLevel: 0 }],
-		skillPool: [1],
-		spawns: [{ zoneId: 0, weight: 5 }],
+		...makeEnemy({
+			id: 0,
+			name: 'Bat',
+			attributeDistribution: [{ attributeId: 0, baseAmount: 1, amountPerLevel: 0 }],
+			skillPool: [1],
+			spawns: [{ zoneId: 0, weight: 5 }]
+		}),
 		bossZones: []
 	};
 
@@ -149,13 +150,14 @@ describe('enemyEntity', () => {
 		// A freshly-added record carries a temporary negative id; after the identity Add the
 		// backend appends it at a real id, which persistEntity resolves before the child savers run.
 		const added: WorkbenchEnemy = {
-			id: -1,
-			name: 'New Enemy',
-			designerNotes: '',
-			isBoss: true,
-			attributeDistribution: [{ attributeId: 0, baseAmount: 3, amountPerLevel: 1 }],
-			skillPool: [2],
-			spawns: [{ zoneId: 1, weight: 8 }],
+			...makeEnemy({
+				id: -1,
+				name: 'New Enemy',
+				isBoss: true,
+				attributeDistribution: [{ attributeId: 0, baseAmount: 3, amountPerLevel: 1 }],
+				skillPool: [2],
+				spawns: [{ zoneId: 1, weight: 8 }]
+			}),
 			bossZones: []
 		};
 		socket.enemies = [{ ...added, id: 7 }]; // the persisted record at its real id
@@ -184,16 +186,7 @@ describe('enemyEntity', () => {
 	});
 
 	it('persist Adds a bare new enemy without posting empty child collections (#1895)', async () => {
-		const added: WorkbenchEnemy = {
-			id: -1,
-			name: 'New Enemy',
-			designerNotes: '',
-			isBoss: false,
-			attributeDistribution: [],
-			skillPool: [],
-			spawns: [],
-			bossZones: []
-		};
+		const added: WorkbenchEnemy = { ...makeEnemy({ id: -1, name: 'New Enemy' }), bossZones: [] };
 		socket.enemies = [{ ...added, id: 7 }];
 
 		await enemyEntity.persist({ added: [added], modified: [], deleted: [], existingIds: [] });

--- a/UI/src/tests/routes/admin/workbench/references.test.ts
+++ b/UI/src/tests/routes/admin/workbench/references.test.ts
@@ -28,17 +28,9 @@ import { makePath, makeProficiency } from '../../../fixtures/proficiencies';
 import { makeSkill } from '../../../fixtures/skills';
 import { makeItem } from '../../../fixtures/items';
 import { makeZone } from '../../../fixtures/zones';
+import { makeEnemy } from '../../../fixtures/enemies';
 
-const enemy = (id: number, name: string, opts: Partial<IEnemy> = {}): IEnemy => ({
-	id,
-	name,
-	designerNotes: '',
-	isBoss: false,
-	attributeDistribution: [],
-	skillPool: [],
-	spawns: [],
-	...opts
-});
+const enemy = (id: number, name: string, opts: Partial<IEnemy> = {}): IEnemy => makeEnemy({ id, name, ...opts });
 
 const zone = (id: number, name: string, opts: Partial<IZone> = {}): IZone => makeZone({ id, name, ...opts });
 

--- a/UI/src/tests/routes/game/screens/fight/Fight.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/Fight.test.ts
@@ -63,6 +63,7 @@ vi.mock('$stores', () => ({ staticData, statistics, playerChallenges, registerTo
 import Fight from '$routes/game/screens/fight/Fight.svelte';
 import { makeBattler } from './fight-fixtures';
 import { makeZone as makeZoneContract } from '../../../../fixtures/zones';
+import { makeEnemy } from '../../../../fixtures/enemies';
 
 // Zone id == its index in staticData.zones (the Id-as-index invariant the boss view indexes by).
 const makeZone = (over: Partial<IZone> = {}): IZone =>
@@ -152,17 +153,7 @@ describe('Fight', () => {
 	describe('with a dedicated boss', () => {
 		beforeEach(() => {
 			staticData.zones = [makeZone({ bossEnemyId: 0, bossLevel: 18 })];
-			staticData.enemies = [
-				{
-					id: 0,
-					name: 'Catacomb Lich',
-					designerNotes: '',
-					isBoss: true,
-					attributeDistribution: [],
-					skillPool: [],
-					spawns: []
-				}
-			];
+			staticData.enemies = [makeEnemy({ id: 0, name: 'Catacomb Lich', isBoss: true })];
 		});
 
 		it('shows the Challenge trigger naming the zone boss when available', () => {

--- a/UI/src/tests/routes/game/screens/fight/boss/boss-view.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/boss/boss-view.test.ts
@@ -23,6 +23,7 @@ vi.mock('$stores', () => ({ staticData, statistics }));
 
 import { BossView } from '$routes/game/screens/fight/boss/boss-view.svelte';
 import { makeZone } from '../../../../../fixtures/zones';
+import { makeEnemy } from '../../../../../fixtures/enemies';
 
 const bossZone: IZone = makeZone({
 	id: 3,
@@ -34,15 +35,7 @@ const bossZone: IZone = makeZone({
 	bossLevel: 18
 });
 const bosslessZone: IZone = makeZone({ id: 1, name: 'Verdant Hollow', order: 1 });
-const boss: IEnemy = {
-	id: 0,
-	name: 'Catacomb Lich',
-	designerNotes: '',
-	isBoss: true,
-	attributeDistribution: [],
-	skillPool: [],
-	spawns: []
-};
+const boss: IEnemy = makeEnemy({ id: 0, name: 'Catacomb Lich', isBoss: true });
 
 beforeEach(() => {
 	enemyManager.mode = 'idle';

--- a/UI/src/tests/routes/game/screens/skills/Skills.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/Skills.test.ts
@@ -13,6 +13,7 @@ import {
 } from '$lib/api';
 import { makeSkill } from '../../../../fixtures/skills';
 import { makeZone } from '../../../../fixtures/zones';
+import { makeEnemy } from '../../../../fixtures/enemies';
 import type { AttributeModifier } from '$lib/battle';
 import { classSignaturePassiveModifier } from '$lib/battle/class-modifiers';
 
@@ -124,16 +125,14 @@ const SKILLS: ISkill[] = [
 // Zone 0 (idle range [2,8], boss enemy 2 at level 10): one in-zone spawn + the boss pill.
 const ZONES: IZone[] = [makeZone({ id: 0, name: 'Vale', levelMin: 2, levelMax: 8, bossEnemyId: 2, bossLevel: 10 })];
 
-// amountPerLevel 1 gives each enemy Toughness 2·(1·level), within the preset-derived slider ceiling.
-const enemy = (over: Partial<IEnemy> & { id: number }): IEnemy => ({
-	name: `Enemy ${over.id}`,
-	designerNotes: '',
-	isBoss: false,
-	attributeDistribution: [{ attributeId: EAttribute.Endurance, baseAmount: 0, amountPerLevel: 1 }],
-	skillPool: [],
-	spawns: [],
-	...over
-});
+/* This suite's enemies need a non-zero Toughness, so it diverges from the shared fixture's neutral
+   empty distribution: amountPerLevel 1 gives each enemy Toughness 2·(1·level), which stays within the
+   preset-derived compare-slider ceiling. */
+const enemy = (over: Partial<IEnemy> & { id: number }): IEnemy =>
+	makeEnemy({
+		attributeDistribution: [{ attributeId: EAttribute.Endurance, baseAmount: 0, amountPerLevel: 1 }],
+		...over
+	});
 
 const ENEMIES: IEnemy[] = [
 	enemy({ id: 0, name: 'Imp', spawns: [{ zoneId: 0, weight: 1 }] }),

--- a/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/skills-view.test.ts
@@ -11,6 +11,7 @@ import {
 } from '$lib/api';
 import { makeSkill } from '../../../../fixtures/skills';
 import { makeZone } from '../../../../fixtures/zones';
+import { makeEnemy } from '../../../../fixtures/enemies';
 import { EAttributeModifierSource, type AttributeModifier } from '$lib/battle';
 import { classSignaturePassiveModifier } from '$lib/battle/class-modifiers';
 
@@ -145,18 +146,8 @@ const SKILLS: ISkill[] = [
 ];
 
 /* Compare-vs fixtures. Enemy Toughness resolves through the real BattleAttributes as
-   `2·Endurance` (no base, no Agility term), so each enemy's distribution is chosen for a
+   `2·Endurance` (no base, no Agility term), so each enemy states its own distribution for a
    clean expected value: with only per-level Endurance, Toughness = 2·amountPerLevel·level. */
-const enemy = (over: Partial<IEnemy> & { id: number }): IEnemy => ({
-	name: `Enemy ${over.id}`,
-	designerNotes: '',
-	isBoss: false,
-	attributeDistribution: [],
-	skillPool: [],
-	spawns: [],
-	...over
-});
-
 const enemyDist = (endurancePerLevel: number) => [
 	{ attributeId: EAttribute.Endurance, baseAmount: 0, amountPerLevel: endurancePerLevel }
 ];
@@ -165,10 +156,10 @@ const enemyDist = (endurancePerLevel: number) => [
 const ZONES: IZone[] = [makeZone({ id: 0, name: 'Vale', levelMin: 2, levelMax: 8, bossEnemyId: 2, bossLevel: 10 })];
 
 const ENEMIES: IEnemy[] = [
-	enemy({ id: 0, name: 'Imp', attributeDistribution: enemyDist(2), spawns: [{ zoneId: 0, weight: 1 }] }),
-	enemy({ id: 1, name: 'Wolf', attributeDistribution: enemyDist(5), spawns: [{ zoneId: 1, weight: 1 }] }),
-	enemy({ id: 2, name: 'Ogre King', isBoss: true, attributeDistribution: enemyDist(3) }),
-	enemy({
+	makeEnemy({ id: 0, name: 'Imp', attributeDistribution: enemyDist(2), spawns: [{ zoneId: 0, weight: 1 }] }),
+	makeEnemy({ id: 1, name: 'Wolf', attributeDistribution: enemyDist(5), spawns: [{ zoneId: 1, weight: 1 }] }),
+	makeEnemy({ id: 2, name: 'Ogre King', isBoss: true, attributeDistribution: enemyDist(3) }),
+	makeEnemy({
 		id: 3,
 		name: 'Wraith',
 		attributeDistribution: enemyDist(9),


### PR DESCRIPTION
## Summary

Adds `UI/src/tests/fixtures/enemies.ts` exporting `makeEnemy(o)`, following the `fixtures/items.ts` / `fixtures/zones.ts` convention, and converts every suite that constructed a **typed** `IEnemy` inline. Sixth run of the pattern from #2414 / #2425 / #2433 / #2434 / #2444.

Test-only. No production code, no behaviour change: 8 files converted, −97/+45 lines.

## How it addresses the issue

**The target set is eight suites, not the issue's nine** — confirmed with the throwaway-required-field probe (`svelte-check`), which is the check the issue asked for over the grep:

| Suite | Issue's table | Actual |
|---|---|---|
| `lib/common/enemy-attributes.test.ts` | listed | **excluded** — both its builders assert a partial literal `as IEnemy`, so the cast opts them out of drift detection and the probe never sees them (#2447's class) |
| the other eight | listed | all confirmed |

Converted: `battle-engine.test.ts`, `battle-engine-parity.test.ts`, `workbench/entities/enemy.test.ts` (3 sites), `workbench/references.test.ts`, `Fight.test.ts`, `boss/boss-view.test.ts`, `Skills.test.ts`, `skills-view.test.ts`.

The probe's tenth hit is `routes/admin/workbench/entities/enemy.ts`'s production `newItem`, which is the authoritative blank record and correctly stays a literal.

### The default that needed a deliberate call

`attributeDistribution` defaults to **empty** — the neutral zero-Toughness enemy, per the issue's lean. Every derived attribute resolves to 0 at any level, so nothing is silently load-bearing. The two Skills suites are then reconciled explicitly rather than averaged:

- **`skills-view.test.ts`** already defaulted to `[]` and passes a per-enemy `enemyDist(n)`, so its local builder was exactly the fixture — deleted, calls the fixture directly. Its comment (why each enemy states its own distribution) moved to the `ENEMIES` array it actually describes.
- **`Skills.test.ts`** genuinely needs a non-zero default, so it **keeps a local wrapper** over `makeEnemy` stating its `1` Endurance/level. The reason — staying under the preset-derived compare-slider ceiling — moved onto that wrapper, so it survives as a stated divergence instead of being lost.

### Parity surface

`battle-engine-parity.test.ts` sits on the frontend/backend parity surface, so its conversion is identity-preserving: the removed literal's `designerNotes`/`isBoss`/`attributeDistribution`/`spawns` are exactly the fixture's defaults, and only `name`/`skillPool` are stated. The engine derives the enemy battler from the scenario's attributes rather than the catalogue record, so the empty distribution is what keeps the live run arithmetically identical to the simulator's — noted in place at the call site. The parity matrix is unchanged, so no backend mirror is needed: this is fixture plumbing, not battle arithmetic.

### Other notes

- `workbench/entities/enemy.test.ts` builds `WorkbenchEnemy` (an `IEnemy` plus `bossZones`), so its three hand-rolled records spread the fixture and add that field. The five that already spread `baseline` are untouched.
- `workbench/references.test.ts` keeps its positional `enemy(id, name, opts)` wrapper, now a one-liner delegating to the fixture — matching the `zone`/`item` wrappers already in that file, so no call site moved.

## Test plan

- [x] `npm run lint` (eslint + `svelte-check`) — clean, 1226 files, 0 errors, 0 warnings
- [x] `npm run test:unit:ci` — **312 files / 4046 tests passed**
- [x] Each converted suite run individually as it was converted
- [x] **Drift-detection verification** (the issue's stated check): re-running the probe with a throwaway required field on `IEnemy` now yields exactly **one** test-file error — `src/tests/fixtures/enemies.ts` — plus the production `entities/enemy.ts` hit that correctly stays a literal. Before this change the same probe flagged 8 test files across 10 sites.

No backend changes, so no `dotnet` run was required.

## Note on scope

Left `enemy-attributes.test.ts` alone deliberately — its `as IEnemy` casts are #2447's class, and converting them here would have pre-empted that issue's per-contract decision. Worth flagging for whoever picks up #2447: its local `makeEnemy` there supplies *every* `IEnemy` field and still casts, so that cast looks vestigial rather than deliberate. The new fixture's header comment names the exclusion explicitly, as #2447 asks each fixture to do.

Closes #2446.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBTVXpjgoJXcYpoW5Xmv8W)_