### PR TITLE
Fold the cast-built contract literals back into drift detection (#2447)

### DIFF
--- a/UI/src/tests/components/tooltip/ChallengeTooltip.test.ts
+++ b/UI/src/tests/components/tooltip/ChallengeTooltip.test.ts
@@ -19,12 +19,15 @@ const { staticData, playerChallenges } = vi.hoisted(() => ({
 vi.mock('$stores', () => ({ staticData, playerChallenges }));
 
 import ChallengeTooltip from '$components/tooltip/ChallengeTooltip.svelte';
+import { makeItem } from '../../fixtures/items';
+import { makeZone } from '../../fixtures/zones';
 
 const zone = (id: number, order: number, name: string, unlockChallengeId?: number): IZone =>
-	({ id, name, description: '', order, levelMin: 1, levelMax: 10, bossLevel: 1, unlockChallengeId }) as IZone;
+	makeZone({ id, name, order, unlockChallengeId });
 
 const setup = (over: Partial<IChallenge> = {}) => {
 	staticData.challenges = [];
+	// Deliberately partial: `IChallenge` has no shared fixture yet (#2456); the tooltip reads only these fields.
 	staticData.challenges[5] = {
 		id: 5,
 		name: 'Cull the Swarm',
@@ -76,12 +79,12 @@ describe('ChallengeTooltip', () => {
 	it('seals a reward name while the challenge is incomplete, then reveals it once complete', () => {
 		setup({ rewardItemId: 3 });
 		staticData.items = [];
-		staticData.items[3] = {
+		staticData.items[3] = makeItem({
 			id: 3,
 			name: 'Iron Helm',
 			itemCategoryId: EItemCategory.Helm,
 			rarityId: ERarity.Rare
-		} as IItem;
+		});
 
 		const { container, unmount } = render(ChallengeTooltip, { props: { challengeId: 5 } });
 		const sealed = container.querySelector('.ct-name.sealed') as HTMLElement;

--- a/UI/src/tests/fixtures/attributes.ts
+++ b/UI/src/tests/fixtures/attributes.ts
@@ -1,5 +1,10 @@
 import { EAttribute, EAttributeType, type IAttribute } from '$lib/api';
 
+/* A literal asserted `as IAttribute` claims the contract to its consumer while silencing a missing
+   required field, so it looks covered and isn't. #2447 folded those in (`battle/battle-attributes`,
+   `skills/SkillDamageBreakdown`, `select/class-summary`); reintroducing such a cast re-opens the hole,
+   so state why if you do. */
+
 /**
  * Builds an {@link IAttribute} reference-data entry for tests. The display metadata defaults to
  * neutral placeholders so tests that only care about id/name resolution stay terse; pass `overrides`

--- a/UI/src/tests/fixtures/enemies.ts
+++ b/UI/src/tests/fixtures/enemies.ts
@@ -3,14 +3,12 @@ import type { IEnemy } from '$lib/api';
 /* Shared `IEnemy` contract builder (#2446), following the `fixtures/items.ts` / `fixtures/zones.ts`
    convention.
 
-   The target set comes from the throwaway-required-field probe, not a `grep` — a
-   `grep "IEnemy => ({"` finds three of the eight suites. Excluded on purpose:
+   The target set came from the throwaway-required-field probe, not a `grep`. That probe is blind to
+   one class by construction: a builder that asserts a partial literal `as IEnemy` keeps compiling
+   when the contract gains a required field, so it never showed up. #2447 folded those in —
    `lib/common/enemy-attributes.test.ts` (two builders) and
-   `routes/game/screens/codex/enemy-level.test.ts` (one), which assert a partial literal `as IEnemy`.
-   The cast opts them out of drift detection, so the probe never sees them and converting them is
-   #2447's call, not this one's — note that issue's table lists `enemy-level.test.ts` only under
-   `IZone`, so its `IEnemy` builder needs picking up there too. A `grep` still finding enemy literals
-   under `src/tests/` is expected, not a gap. */
+   `routes/game/screens/codex/enemy-level.test.ts` (one) — so every typed `IEnemy` under `src/tests/`
+   now builds through here. Reintroducing an `as IEnemy` cast re-opens that hole; state why if you do. */
 
 /**
  * Builds an {@link IEnemy} reference-data entry for tests. Everything but the id is a neutral

--- a/UI/src/tests/fixtures/item-mods.ts
+++ b/UI/src/tests/fixtures/item-mods.ts
@@ -5,12 +5,15 @@ import { EItemModType, ERarity, type IItemMod } from '$lib/api';
    that drift independently, even though a suite exercising applied mods usually imports both.
 
    The target set was confirmed with the throwaway-required-field probe, not a `grep` — only a suite
-   that constructs a *typed* `IItemMod` pays the contract-drift tax. Exclusions are deliberate, in two
-   classes: the production blank record (`routes/admin/workbench/entities/item-mod.ts`) and the live
+   that constructs a *typed* `IItemMod` pays the contract-drift tax. Two exclusions are deliberate and
+   permanent: the production blank record (`routes/admin/workbench/entities/item-mod.ts`) and the live
    `ItemMod` domain class (`lib/battle/item-mod.ts`) are the authoritative shapes and correctly stay
-   literals; `challenges/OverviewPane.test.ts` and `lib/common/challenge-unlocks.test.ts` each assert a
-   deliberately partial literal `as IItemMod`, which opts them out of drift detection entirely (#2447).
-   A `grep` still finding mod literals under `src/tests/` is expected, not a gap. */
+   literals. A `grep` still finding mod literals under `src/tests/` is expected, not a gap.
+
+   A third class was invisible to the probe rather than excluded: a literal asserted `as IItemMod`
+   keeps compiling when the contract gains a required field. #2447 folded those in
+   (`challenges/OverviewPane.test.ts`, `lib/common/challenge-unlocks.test.ts`); reintroducing such a
+   cast re-opens the hole, so state why if you do. */
 
 /**
  * Builds an {@link IItemMod} reference-data entry for tests. Everything but the id is a neutral

--- a/UI/src/tests/fixtures/items.ts
+++ b/UI/src/tests/fixtures/items.ts
@@ -3,12 +3,17 @@ import { EItemCategory, ERarity, type IItem } from '$lib/api';
 /* Shared `IItem` contract builder (#2433), following the `fixtures/skills.ts` convention.
 
    The target set is narrower than a `grep` for item-shaped literals suggests: only a suite that
-   constructs a *typed* `IItem` pays the contract-drift tax. Three kinds of item literal are excluded
-   on purpose — those that build the live `Item` domain object via `as unknown as Item` (the
-   inventory screens), assert a deliberately *partial* literal to `IItem` (`challenge-unlocks`), or
-   seed an untyped `staticData` mock (the workbench `entities` suites). None of them see a new
-   required field, and filling their previously-`undefined` fields could change what a suite renders,
-   so a `grep` still finding item literals under `src/tests/` is expected, not a gap. */
+   constructs a *typed* `IItem` pays the contract-drift tax. Two kinds of item literal are excluded on
+   purpose — those that build the live `Item` domain object via `as unknown as Item` (the inventory
+   screens) and those that seed an untyped `staticData` mock (the workbench `entities` suites).
+   Neither sees a new required field, and filling their previously-`undefined` fields could change
+   what a suite renders, so a `grep` still finding item literals under `src/tests/` is expected, not
+   a gap.
+
+   A third kind — a literal asserted `as IItem` — *does* claim the contract to its consumer while
+   silencing the missing field, which opts it out of drift detection. #2447 folded those in
+   (`challenge-unlocks`, `ChallengeTooltip`, `skill-provenance`, `offline-summary`); reintroducing
+   such a cast re-opens the hole, so state why if you do. */
 
 /**
  * Builds an {@link IItem} reference-data entry for tests. Everything but the id is a neutral

--- a/UI/src/tests/fixtures/skills.ts
+++ b/UI/src/tests/fixtures/skills.ts
@@ -13,7 +13,12 @@ import { EDamageType, ERarity, ESkillAcquisition, type ISkill } from '$lib/api';
    the progression pair via `progression-test-utils`' `unknown[]`. Nothing type-checks them as `ISkill`,
    so they pay no contract-drift tax, and filling their previously-`undefined` fields could change what
    a suite renders. A `grep` for skill-shaped literals under `src/tests/` still finding them is
-   expected, not a gap. */
+   expected, not a gap.
+
+   A literal asserted `as ISkill` is a different case — it claims the contract to its consumer while
+   silencing the missing field, so it looks covered and isn't. #2447 folded those in
+   (`fight/ActiveEffectChips.test.ts`, `inventory/inventory-view.test.ts`); reintroducing such a cast
+   re-opens the hole, so state why if you do. */
 
 /**
  * Builds an {@link ISkill} reference-data entry for tests. Everything but the id is a neutral

--- a/UI/src/tests/fixtures/zones.ts
+++ b/UI/src/tests/fixtures/zones.ts
@@ -8,10 +8,12 @@ import type { IZone } from '$lib/api';
    contract flushes out exactly nine suites plus the workbench's production `newItem`. Suites that
    seed zone-shaped literals into an untyped `staticData` mock are excluded on purpose — they see no
    new required field, and filling their previously-`undefined` fields could change what they render.
-   So are the few that assert a deliberately partial literal `as IZone` (`challenge-unlocks`,
-   `ChallengeTooltip`, `enemy-level`) — the cast opts them out of drift detection too, so they raise
-   no error either (#2447). A `grep` still finding zone literals under `src/tests/` is expected, not
-   a gap. */
+   A `grep` still finding zone literals under `src/tests/` is expected, not a gap.
+
+   A builder that asserted a partial literal `as IZone` was invisible to that probe by construction —
+   the cast silences the missing field, so it kept compiling. #2447 folded those three in
+   (`challenge-unlocks`, `ChallengeTooltip`, `enemy-level`); reintroducing such a cast re-opens the
+   hole, so state why if you do. */
 
 /**
  * Builds an {@link IZone} reference-data entry for tests. Everything but the id is a neutral

--- a/UI/src/tests/lib/battle/battle-attributes.test.ts
+++ b/UI/src/tests/lib/battle/battle-attributes.test.ts
@@ -7,6 +7,7 @@ import {
 	EAttributeModifierSource,
 	type AttributeModifier
 } from '$lib/battle/attribute-modifier';
+import { makeAttribute } from '../../fixtures/attributes';
 
 // The projection resolves names through `attributeName(id, staticData.attributes)`, so mock the
 // store to drive that reference set. Empty by default → names fall back to the normalised enum.
@@ -298,7 +299,7 @@ describe('BattleAttributes', () => {
 		});
 
 		it('resolves names from the Attributes reference set when available', () => {
-			mockAttributes[EAttribute.Strength] = { id: EAttribute.Strength, name: 'Physical Power' } as IAttribute;
+			mockAttributes[EAttribute.Strength] = makeAttribute(EAttribute.Strength, 'Physical Power');
 			const ba = new BattleAttributes(makeAttrs([EAttribute.Strength, 10]), false);
 
 			expect(ba.getAttributeMap()).toEqual([{ name: 'Physical Power', value: 10 }]);

--- a/UI/src/tests/lib/common/challenge-type.test.ts
+++ b/UI/src/tests/lib/common/challenge-type.test.ts
@@ -17,7 +17,9 @@ describe('challengeTypeColor', () => {
 });
 
 describe('challengeTypeName', () => {
-	const types = [{ id: EChallengeType.EnemiesKilled, name: 'Slayer' }] as IChallengeType[];
+	const types: IChallengeType[] = [
+		{ id: EChallengeType.EnemiesKilled, name: 'Slayer', goalComparison: EChallengeGoalComparison.AtLeast }
+	];
 
 	it('prefers the authored name from the reference set', () => {
 		expect(challengeTypeName(EChallengeType.EnemiesKilled, types)).toBe('Slayer');

--- a/UI/src/tests/lib/common/challenge-unlocks.test.ts
+++ b/UI/src/tests/lib/common/challenge-unlocks.test.ts
@@ -1,20 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { EItemCategory, EItemModType, ERarity, type IChallenge, type IItem, type IItemMod, type IZone } from '$lib/api';
 import { challengeCompletedMessage, resolveUnlockReward, zonesUnlockedBy, type UnlockReward } from '$lib/common';
+import { makeItem } from '../../fixtures/items';
+import { makeItemMod } from '../../fixtures/item-mods';
+import { makeZone } from '../../fixtures/zones';
 
 const zone = (id: number, order: number, name: string, unlockChallengeId?: number, retiredAt?: string): IZone =>
-	({
-		id,
-		name,
-		description: '',
-		order,
-		levelMin: 1,
-		levelMax: 10,
-		bossLevel: 1,
-		unlockChallengeId,
-		retiredAt
-	}) as IZone;
+	makeZone({ id, name, order, unlockChallengeId, retiredAt });
 
+/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456), and `resolveUnlockReward`
+   reads only the two reward ids. */
 const challenge = (over: Partial<IChallenge> = {}): IChallenge =>
 	({ id: 1, name: 'C', description: '', challengeTypeId: 0, entityType: 0, progressGoal: 10, ...over }) as IChallenge;
 
@@ -43,9 +38,9 @@ describe('zonesUnlockedBy', () => {
 
 describe('resolveUnlockReward', () => {
 	const items: (IItem | undefined)[] = [];
-	items[3] = { id: 3, name: 'Iron Helm', itemCategoryId: EItemCategory.Helm, rarityId: ERarity.Rare } as IItem;
+	items[3] = makeItem({ id: 3, name: 'Iron Helm', itemCategoryId: EItemCategory.Helm, rarityId: ERarity.Rare });
 	const itemMods: (IItemMod | undefined)[] = [];
-	itemMods[4] = { id: 4, name: 'of Fury', itemModTypeId: EItemModType.Suffix, rarityId: ERarity.Epic } as IItemMod;
+	itemMods[4] = makeItemMod({ id: 4, name: 'of Fury', itemModTypeId: EItemModType.Suffix, rarityId: ERarity.Epic });
 	const refs = { items, itemMods };
 
 	it('resolves an item reward with rarity tier/accent, "rarity · category" sub-label and the source record', () => {

--- a/UI/src/tests/lib/common/enemy-attributes.test.ts
+++ b/UI/src/tests/lib/common/enemy-attributes.test.ts
@@ -6,6 +6,7 @@ vi.mock('$stores', () => ({ staticData: {} }));
 
 import { enemyAttributesAtLevel, enemyBattleAttributes, enemyToughness } from '$lib/common/enemy-attributes';
 import { BattleAttributes } from '$lib/battle/battle-attributes';
+import { makeEnemy } from '../../fixtures/enemies';
 
 const distribution = [
 	{ attributeId: EAttribute.Strength, baseAmount: 12, amountPerLevel: 1.4 },
@@ -16,36 +17,17 @@ const distribution = [
 	{ attributeId: EAttribute.Luck, baseAmount: 3, amountPerLevel: 0.2 }
 ];
 
-const makeEnemy = (): IEnemy =>
-	({
-		id: 0,
-		name: 'Marauder',
-		designerNotes: '',
-		isBoss: false,
-		attributeDistribution: distribution,
-		skillPool: [],
-		spawns: []
-	}) as IEnemy;
+const marauder = (): IEnemy => makeEnemy({ id: 0, name: 'Marauder', attributeDistribution: distribution });
 
-/* A leaner enemy whose Toughness resolves to a clean value: Toughness = 2·Endurance, so with only
-   per-level Endurance, Toughness = 2 · amountPerLevel · level. */
-const enemy = (over: Partial<IEnemy> & { id: number }): IEnemy =>
-	({
-		name: `Enemy ${over.id}`,
-		isBoss: false,
-		attributeDistribution: [],
-		skillPool: [],
-		spawns: [],
-		...over
-	}) as IEnemy;
-
+/* Resolves Toughness to a clean value: Toughness = 2·Endurance, so an enemy carrying only per-level
+   Endurance has Toughness = 2 · amountPerLevel · level. */
 const enduranceDist = (amountPerLevel: number) => [
 	{ attributeId: EAttribute.Endurance, baseAmount: 0, amountPerLevel }
 ];
 
 describe('enemyBattleAttributes', () => {
 	it('builds the canonical BattleAttributes the battle uses (additive distribution at the level)', () => {
-		const built = enemyBattleAttributes(makeEnemy(), 20);
+		const built = enemyBattleAttributes(marauder(), 20);
 		const expected = new BattleAttributes(
 			distribution.map((d) => ({ attributeId: d.attributeId, amount: d.baseAmount + d.amountPerLevel * 20 })),
 			true
@@ -55,7 +37,7 @@ describe('enemyBattleAttributes', () => {
 	});
 
 	it('memoises the build per enemy + level', () => {
-		const e = makeEnemy();
+		const e = marauder();
 		expect(enemyBattleAttributes(e, 7)).toBe(enemyBattleAttributes(e, 7));
 		expect(enemyBattleAttributes(e, 7)).not.toBe(enemyBattleAttributes(e, 8));
 	});
@@ -64,12 +46,12 @@ describe('enemyBattleAttributes', () => {
 describe('enemyToughness', () => {
 	it('resolves an enemy Toughness through the derived attribute composition', () => {
 		// Toughness = 2·Endurance; these enemies carry only per-level Endurance.
-		expect(enemyToughness(enemy({ id: 0, attributeDistribution: enduranceDist(2) }), 5)).toBe(20); // 2·(2*5)
-		expect(enemyToughness(enemy({ id: 1, attributeDistribution: enduranceDist(3) }), 10)).toBe(60); // 2·(3*10)
+		expect(enemyToughness(makeEnemy({ id: 0, attributeDistribution: enduranceDist(2) }), 5)).toBe(20); // 2·(2*5)
+		expect(enemyToughness(makeEnemy({ id: 1, attributeDistribution: enduranceDist(3) }), 10)).toBe(60); // 2·(3*10)
 	});
 
 	it('memoises enemy toughness per enemy and level', () => {
-		const e = enemy({ id: 99, attributeDistribution: enduranceDist(4) });
+		const e = makeEnemy({ id: 99, attributeDistribution: enduranceDist(4) });
 		expect(enemyToughness(e, 5)).toBe(40); // 2·(4*5)
 
 		// The result is cached by enemy identity, so a later mutation of the (in practice immutable)
@@ -81,7 +63,7 @@ describe('enemyToughness', () => {
 	});
 
 	it('delegates to the same build as enemyAttributesAtLevel (the single enemy battle source)', () => {
-		const e = makeEnemy();
+		const e = marauder();
 		const toughnessSecondary = enemyAttributesAtLevel(e, 14).secondary.find(
 			(s) => s.attributeId === EAttribute.Toughness
 		);
@@ -92,7 +74,7 @@ describe('enemyToughness', () => {
 
 describe('enemyAttributesAtLevel', () => {
 	it('scales each primary attribute by base + perLevel × level', () => {
-		const { primary } = enemyAttributesAtLevel(makeEnemy(), 20);
+		const { primary } = enemyAttributesAtLevel(marauder(), 20);
 		const str = primary.find((p) => p.attributeId === EAttribute.Strength);
 		expect(str).toMatchObject({ base: 12, perLevel: 1.4 });
 		expect(str?.value).toBe(Math.round(12 + 1.4 * 20)); // 40
@@ -100,7 +82,7 @@ describe('enemyAttributesAtLevel', () => {
 	});
 
 	it('derives Max Health and Toughness (absent from the distribution) via the battle composition', () => {
-		const enemyRecord = makeEnemy();
+		const enemyRecord = marauder();
 		const { secondary } = enemyAttributesAtLevel(enemyRecord, 20);
 		expect(secondary.map((s) => s.attributeId)).toEqual([EAttribute.MaxHealth, EAttribute.Toughness]);
 
@@ -116,7 +98,7 @@ describe('enemyAttributesAtLevel', () => {
 	});
 
 	it('exposes a constant per-level slope for derived stats (linear in level)', () => {
-		const enemyRecord = makeEnemy();
+		const enemyRecord = marauder();
 		const a = enemyAttributesAtLevel(enemyRecord, 5).secondary;
 		const b = enemyAttributesAtLevel(enemyRecord, 30).secondary;
 		expect(a[0].perLevel).toBeCloseTo(b[0].perLevel, 6);
@@ -125,7 +107,7 @@ describe('enemyAttributesAtLevel', () => {
 	});
 
 	it('memoises the result per enemy + level', () => {
-		const enemyRecord = makeEnemy();
+		const enemyRecord = marauder();
 		expect(enemyAttributesAtLevel(enemyRecord, 12)).toBe(enemyAttributesAtLevel(enemyRecord, 12));
 		expect(enemyAttributesAtLevel(enemyRecord, 12)).not.toBe(enemyAttributesAtLevel(enemyRecord, 13));
 	});

--- a/UI/src/tests/routes/admin/workbench/UsageSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/UsageSection.test.ts
@@ -26,7 +26,7 @@ const mockUsage = (items: UsageRecord[], mods: UsageRecord[]) => ({
 	modList: mods
 });
 
-const tag: ITag = { id: 5, name: 'Fire', tagCategoryId: 10 } as ITag;
+const tag: ITag = { id: 5, name: 'Fire', tagCategoryId: 10 };
 
 beforeEach(() => {
 	mockReference.tagColor.mockClear();

--- a/UI/src/tests/routes/admin/workbench/challenge/ChallengeConditionSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ChallengeConditionSection.test.ts
@@ -45,6 +45,7 @@ const config = (): EntityConfig<Identified> =>
 	}) as unknown as EntityConfig<Identified>;
 
 const setup = (over: Partial<IChallenge> = {}) => {
+	/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456). */
 	const challenge: IChallenge = {
 		id: 1,
 		name: 'Test',

--- a/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
@@ -48,6 +48,7 @@ const config = (): EntityConfig<Identified> =>
 	}) as unknown as EntityConfig<Identified>;
 
 const setup = (over: Partial<IChallenge> = {}) => {
+	/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456). */
 	const challenge: IChallenge = {
 		id: 1,
 		name: 'Test',

--- a/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
@@ -47,8 +47,9 @@ const config = (): EntityConfig<Identified> =>
 		persist: async () => []
 	}) as unknown as EntityConfig<Identified>;
 
+/* Every `as IChallenge` literal in this file is deliberately partial: `IChallenge` has no shared
+   fixture yet (#2456). */
 const setup = (over: Partial<IChallenge> = {}) => {
-	/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456). */
 	const challenge: IChallenge = {
 		id: 1,
 		name: 'Test',

--- a/UI/src/tests/routes/admin/workbench/challenge/GoalField.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/GoalField.test.ts
@@ -29,6 +29,7 @@ const config = (): EntityConfig<Identified> =>
 	}) as unknown as EntityConfig<Identified>;
 
 const setup = (over: Partial<IChallenge>) => {
+	/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456). */
 	const challenge: IChallenge = {
 		id: 1,
 		name: 'Test',

--- a/UI/src/tests/routes/admin/workbench/challenge/GoalField.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/GoalField.test.ts
@@ -28,8 +28,9 @@ const config = (): EntityConfig<Identified> =>
 		persist: async () => []
 	}) as unknown as EntityConfig<Identified>;
 
+/* Every `as IChallenge` literal in this file is deliberately partial: `IChallenge` has no shared
+   fixture yet (#2456). */
 const setup = (over: Partial<IChallenge>) => {
-	/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456). */
 	const challenge: IChallenge = {
 		id: 1,
 		name: 'Test',

--- a/UI/src/tests/routes/admin/workbench/challenge/RewardPicker.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/RewardPicker.test.ts
@@ -10,6 +10,7 @@ const RECORDS: PickerRecord[] = [
 	{ id: 3, name: 'Leather Boots', color: 'var(--rarity-common)', tag: 'Common' }
 ];
 
+/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456). */
 const claimedBy = (id: number, name: string): Map<number, IChallenge> =>
 	new Map([[id, { id: 99, name } as IChallenge]]);
 

--- a/UI/src/tests/routes/admin/workbench/challenge/ScopeField.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ScopeField.test.ts
@@ -34,6 +34,7 @@ const config = (): EntityConfig<Identified> =>
 	}) as unknown as EntityConfig<Identified>;
 
 const setup = (over: Partial<IChallenge>) => {
+	/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456). */
 	const challenge: IChallenge = {
 		id: 1,
 		name: 'Test',

--- a/UI/src/tests/routes/game/screens/challenges/OverviewPane.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/OverviewPane.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup, fireEvent } from '@testing-library/svelte';
-import { EChallengeType, ERarity, EItemModType, type IItemMod } from '$lib/api';
+import { EChallengeType, ERarity, EItemModType } from '$lib/api';
 import OverviewPane from '$routes/game/screens/challenges/OverviewPane.svelte';
+import { makeItemMod } from '../../../../fixtures/item-mods';
 import type {
 	ChallengeVM,
 	OverallSummary,
@@ -11,12 +12,12 @@ import type {
 
 afterEach(cleanup);
 
-const sampleMod: IItemMod = {
+const sampleMod = makeItemMod({
 	id: 5,
 	name: 'of Fury',
 	itemModTypeId: EItemModType.Suffix,
 	rarityId: ERarity.Common
-} as IItemMod;
+});
 
 const reward: ResolvedReward = {
 	kind: 'mod',

--- a/UI/src/tests/routes/game/screens/codex/enemy-level.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/enemy-level.test.ts
@@ -1,15 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import type { IEnemy, IZone } from '$lib/api';
+import type { IEnemy } from '$lib/api';
 import { levelRange, spawnShare, zoneTotalWeight } from '$routes/game/screens/codex/enemy-level';
+import { makeEnemy } from '../../../../fixtures/enemies';
+import { makeZone } from '../../../../fixtures/zones';
 
 const zones = [
-	{ id: 0, name: 'Emberreach', order: 1, levelMin: 1, levelMax: 10, bossEnemyId: 2, bossLevel: 10 },
-	{ id: 1, name: 'Ashfen Marsh', order: 2, levelMin: 11, levelMax: 22, bossLevel: 22 },
-	{ id: 2, name: 'Sunken Causeway', order: 3, levelMin: 18, levelMax: 28, bossLevel: 28 }
-] as IZone[];
+	makeZone({ id: 0, name: 'Emberreach', order: 1, levelMin: 1, levelMax: 10, bossEnemyId: 2, bossLevel: 10 }),
+	makeZone({ id: 1, name: 'Ashfen Marsh', order: 2, levelMin: 11, levelMax: 22, bossLevel: 22 }),
+	makeZone({ id: 2, name: 'Sunken Causeway', order: 3, levelMin: 18, levelMax: 28, bossLevel: 28 })
+];
 
-const enemy = (over: Partial<IEnemy>): IEnemy =>
-	({ id: 0, name: 'E', isBoss: false, attributeDistribution: [], skillPool: [], spawns: [], ...over }) as IEnemy;
+const enemy = (over: Partial<IEnemy>): IEnemy => makeEnemy({ id: 0, name: 'E', ...over });
 
 describe('levelRange', () => {
 	it('fixes a boss at its zone’s bossLevel (min === max)', () => {

--- a/UI/src/tests/routes/game/screens/codex/skill-provenance.test.ts
+++ b/UI/src/tests/routes/game/screens/codex/skill-provenance.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { ESkillAcquisition, type IItem, type ISkill } from '$lib/api';
 import { resolveSkillProvenance } from '$routes/game/screens/codex/skill-provenance';
+import { makeItem } from '../../../../fixtures/items';
 import { makeSkill } from '../../../../fixtures/skills';
 
 // Minimal fixtures — provenance only reads ids, names, the item-grant references and the flag.
@@ -8,7 +9,7 @@ import { makeSkill } from '../../../../fixtures/skills';
 const skill = (id: number, acquisition: ESkillAcquisition): ISkill => makeSkill({ id, acquisition });
 
 const item = (id: number, grantedSkillId?: number, retiredAt?: string): IItem =>
-	({ id, name: `Item ${id}`, grantedSkillId, retiredAt }) as IItem;
+	makeItem({ id, grantedSkillId, retiredAt });
 
 describe('resolveSkillProvenance', () => {
 	it('reports an item grant as a source', () => {

--- a/UI/src/tests/routes/game/screens/fight/ActiveEffectChips.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/ActiveEffectChips.test.ts
@@ -20,6 +20,7 @@ vi.mock('$stores', () => ({ staticData }));
 import ActiveEffectChips from '$routes/game/screens/fight/ActiveEffectChips.svelte';
 import { makeBattler } from './fight-fixtures';
 import { makeAttribute } from '../../../../fixtures/attributes';
+import { makeSkill } from '../../../../fixtures/skills';
 import type { Battler } from '$lib/battle';
 
 const effect = (over: Partial<ISkillEffect> = {}): ISkillEffect => ({
@@ -42,7 +43,7 @@ beforeEach(() => {
 		makeAttribute(EAttribute.Toughness, 'Toughness')
 	];
 	// A skill owning the effect id the fixtures use, so the tooltip can resolve the source.
-	staticData.skills = [{ id: 0, name: 'Battle Cry', effects: [effect({ id: 1 })] } as ISkill];
+	staticData.skills = [makeSkill({ id: 0, name: 'Battle Cry', effects: [effect({ id: 1 })] })];
 	battler = makeBattler();
 });
 
@@ -92,8 +93,8 @@ describe('ActiveEffectChips', () => {
 		// Two DIFFERENT effects on the same (Strength, additive) from two DIFFERENT skills, with DIFFERENT
 		// amounts — the case the removed `combineEffectAmount(amount × count)` shortcut couldn't total correctly.
 		staticData.skills = [
-			{ id: 0, name: 'Battle Cry', effects: [effect({ id: 1 })] } as ISkill,
-			{ id: 1, name: 'War Drum', effects: [effect({ id: 2, amount: 3 })] } as ISkill
+			makeSkill({ id: 0, name: 'Battle Cry', effects: [effect({ id: 1 })] }),
+			makeSkill({ id: 1, name: 'War Drum', effects: [effect({ id: 2, amount: 3 })] })
 		];
 		battler.applyEffect(effect({ id: 1, attributeId: EAttribute.Strength, amount: 5 }));
 		battler.applyEffect(effect({ id: 2, attributeId: EAttribute.Strength, amount: 3 }));

--- a/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
@@ -51,6 +51,7 @@ vi.mock('$stores', () => ({
 import ZoneNav from '$routes/game/screens/fight/ZoneNav.svelte';
 import { makeZone } from '../../../../fixtures/zones';
 
+/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456). */
 const challenge = (id: number, name: string, description: string): IChallenge =>
 	({ id, name, description, challengeTypeId: EChallengeType.EnemiesKilled, progressGoal: 10 }) as IChallenge;
 

--- a/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
+++ b/UI/src/tests/routes/game/screens/inventory/inventory-view.test.ts
@@ -97,6 +97,12 @@ vi.mock('$stores', () => ({
 
 import { itemCategoryColor, itemCategoryName } from '$lib/common';
 import { InventoryView, SORTS, EQUIP_SLOTS } from '$routes/game/screens/inventory/inventory-view.svelte';
+import { makeSkill } from '../../../../fixtures/skills';
+
+/* A skill whose damage is wholly one type — the only axis the weapon-match gate reads. Thin adapter over
+   the shared contract fixture so the call sites stay positional. */
+const damageSkill = (id: number, name: string, type: EDamageType): ISkill =>
+	makeSkill({ id, name, damagePortions: [{ type, weight: 1 }] });
 
 const makeItem = (itemId: number, name: string, cat: EItemCategory, rarity: ERarity, extra: Partial<Item> = {}): Item =>
 	({
@@ -485,16 +491,13 @@ describe('InventoryView.compatibleMods', () => {
    prompts before applying, naming the skills that go dormant. The dormant derivation reuses the shared gate,
    so it can't disagree with what the battle fields. */
 describe('InventoryView weapon-swap warning', () => {
-	const makeSkill = (id: number, name: string, type: EDamageType): ISkill =>
-		({ id, name, damagePortions: [{ type, weight: 1 }] }) as unknown as ISkill;
-
 	const weapon = (itemId: number, name: string, weaponType: EDamageType) =>
 		makeItem(itemId, name, EItemCategory.Weapon, ERarity.Rare, { weaponType });
 
 	it('warns before equipping a weapon that dims a fielded selected skill, naming it', async () => {
 		// Wielding a Sword (a Sword skill is fielded); equipping an Axe leaves that Sword skill dormant.
 		weaponState.equippedWeaponType = EDamageType.Sword;
-		staticData.skills = [makeSkill(0, 'Slash', EDamageType.Sword)];
+		staticData.skills = [damageSkill(0, 'Slash', EDamageType.Sword)];
 		playerState.selectedSkills = [0];
 		unlockedItems.set(7, weapon(7, 'War Axe', EDamageType.Axe));
 
@@ -511,7 +514,7 @@ describe('InventoryView weapon-swap warning', () => {
 	it('warns when arming from bare hands dims a fielded Unarmed skill', async () => {
 		// Bare-handed, an Unarmed (punch-style) skill is fielded; equipping a Sword dims it.
 		weaponState.equippedWeaponType = EDamageType.Unarmed;
-		staticData.skills = [makeSkill(0, 'Jab', EDamageType.Unarmed)];
+		staticData.skills = [damageSkill(0, 'Jab', EDamageType.Unarmed)];
 		playerState.selectedSkills = [0];
 		unlockedItems.set(7, weapon(7, 'Iron Sword', EDamageType.Sword));
 
@@ -525,7 +528,7 @@ describe('InventoryView weapon-swap warning', () => {
 	it('aborts the equip when the player declines the warning', async () => {
 		confirmModal.mockResolvedValue(false);
 		weaponState.equippedWeaponType = EDamageType.Sword;
-		staticData.skills = [makeSkill(0, 'Slash', EDamageType.Sword)];
+		staticData.skills = [damageSkill(0, 'Slash', EDamageType.Sword)];
 		playerState.selectedSkills = [0];
 		unlockedItems.set(7, weapon(7, 'War Axe', EDamageType.Axe));
 
@@ -538,7 +541,7 @@ describe('InventoryView weapon-swap warning', () => {
 	it('does not warn when every selected skill is weapon-agnostic', async () => {
 		// Physical / elemental skills are never gated, so a weapon swap dims nothing.
 		weaponState.equippedWeaponType = EDamageType.Sword;
-		staticData.skills = [makeSkill(0, 'Strike', EDamageType.Physical), makeSkill(1, 'Ember', EDamageType.Fire)];
+		staticData.skills = [damageSkill(0, 'Strike', EDamageType.Physical), damageSkill(1, 'Ember', EDamageType.Fire)];
 		playerState.selectedSkills = [0, 1];
 		unlockedItems.set(7, weapon(7, 'War Axe', EDamageType.Axe));
 
@@ -550,7 +553,7 @@ describe('InventoryView weapon-swap warning', () => {
 
 	it('does not warn when the selected weapon-skill matches the incoming weapon', async () => {
 		weaponState.equippedWeaponType = EDamageType.Sword;
-		staticData.skills = [makeSkill(0, 'Cleave', EDamageType.Axe)];
+		staticData.skills = [damageSkill(0, 'Cleave', EDamageType.Axe)];
 		playerState.selectedSkills = [0];
 		unlockedItems.set(7, weapon(7, 'War Axe', EDamageType.Axe));
 
@@ -563,7 +566,7 @@ describe('InventoryView weapon-swap warning', () => {
 	it('does not warn when a skill was already dormant under the current weapon', async () => {
 		// Wielding a Sword, a Bow skill is already dormant; swapping to an Axe dims nothing new.
 		weaponState.equippedWeaponType = EDamageType.Sword;
-		staticData.skills = [makeSkill(0, 'Snipe', EDamageType.Bow)];
+		staticData.skills = [damageSkill(0, 'Snipe', EDamageType.Bow)];
 		playerState.selectedSkills = [0];
 		unlockedItems.set(7, weapon(7, 'War Axe', EDamageType.Axe));
 
@@ -577,9 +580,9 @@ describe('InventoryView weapon-swap warning', () => {
 		// Two fielded Sword skills dim when swapping to an Axe; the agnostic skill never does.
 		weaponState.equippedWeaponType = EDamageType.Sword;
 		staticData.skills = [
-			makeSkill(0, 'Slash', EDamageType.Sword),
-			makeSkill(1, 'Parry', EDamageType.Sword),
-			makeSkill(2, 'Strike', EDamageType.Physical)
+			damageSkill(0, 'Slash', EDamageType.Sword),
+			damageSkill(1, 'Parry', EDamageType.Sword),
+			damageSkill(2, 'Strike', EDamageType.Physical)
 		];
 		playerState.selectedSkills = [0, 1, 2];
 		unlockedItems.set(7, weapon(7, 'War Axe', EDamageType.Axe));
@@ -595,7 +598,7 @@ describe('InventoryView weapon-swap warning', () => {
 
 	it('does not run the weapon warning when equipping into a non-weapon slot', async () => {
 		weaponState.equippedWeaponType = EDamageType.Sword;
-		staticData.skills = [makeSkill(0, 'Slash', EDamageType.Sword)];
+		staticData.skills = [damageSkill(0, 'Slash', EDamageType.Sword)];
 		playerState.selectedSkills = [0];
 		const helm = makeItem(8, 'Iron Helm', EItemCategory.Helm, ERarity.Common);
 		unlockedItems.set(8, helm);
@@ -611,13 +614,10 @@ describe('InventoryView weapon-swap warning', () => {
    isn't Unarmed — the same silent surprise the equip warning guards against, reached via a different action.
    The unequip path runs the same gate against `nextWeaponType = Unarmed`. */
 describe('InventoryView weapon-unequip warning', () => {
-	const makeSkill = (id: number, name: string, type: EDamageType): ISkill =>
-		({ id, name, damagePortions: [{ type, weight: 1 }] }) as unknown as ISkill;
-
 	it('warns before unequipping a weapon that dims a fielded selected skill, naming it', async () => {
 		// Wielding a Sword (a Sword skill is fielded); unequipping leaves that Sword skill dormant.
 		weaponState.equippedWeaponType = EDamageType.Sword;
-		staticData.skills = [makeSkill(0, 'Slash', EDamageType.Sword)];
+		staticData.skills = [damageSkill(0, 'Slash', EDamageType.Sword)];
 		playerState.selectedSkills = [0];
 
 		await new InventoryView().unequip(4); // WeaponSlot
@@ -633,7 +633,7 @@ describe('InventoryView weapon-unequip warning', () => {
 	it('aborts the unequip when the player declines the warning', async () => {
 		confirmModal.mockResolvedValue(false);
 		weaponState.equippedWeaponType = EDamageType.Sword;
-		staticData.skills = [makeSkill(0, 'Slash', EDamageType.Sword)];
+		staticData.skills = [damageSkill(0, 'Slash', EDamageType.Sword)];
 		playerState.selectedSkills = [0];
 
 		await new InventoryView().unequip(4);
@@ -646,9 +646,9 @@ describe('InventoryView weapon-unequip warning', () => {
 		// Two fielded Sword skills dim when unequipping; the agnostic skill never does.
 		weaponState.equippedWeaponType = EDamageType.Sword;
 		staticData.skills = [
-			makeSkill(0, 'Slash', EDamageType.Sword),
-			makeSkill(1, 'Parry', EDamageType.Sword),
-			makeSkill(2, 'Strike', EDamageType.Physical)
+			damageSkill(0, 'Slash', EDamageType.Sword),
+			damageSkill(1, 'Parry', EDamageType.Sword),
+			damageSkill(2, 'Strike', EDamageType.Physical)
 		];
 		playerState.selectedSkills = [0, 1, 2];
 
@@ -663,7 +663,7 @@ describe('InventoryView weapon-unequip warning', () => {
 
 	it('does not warn when every selected skill is weapon-agnostic', async () => {
 		weaponState.equippedWeaponType = EDamageType.Sword;
-		staticData.skills = [makeSkill(0, 'Strike', EDamageType.Physical), makeSkill(1, 'Ember', EDamageType.Fire)];
+		staticData.skills = [damageSkill(0, 'Strike', EDamageType.Physical), damageSkill(1, 'Ember', EDamageType.Fire)];
 		playerState.selectedSkills = [0, 1];
 
 		await new InventoryView().unequip(4);
@@ -674,7 +674,7 @@ describe('InventoryView weapon-unequip warning', () => {
 
 	it('does not run the weapon warning when unequipping a non-weapon slot', async () => {
 		weaponState.equippedWeaponType = EDamageType.Sword;
-		staticData.skills = [makeSkill(0, 'Slash', EDamageType.Sword)];
+		staticData.skills = [damageSkill(0, 'Slash', EDamageType.Sword)];
 		playerState.selectedSkills = [0];
 
 		await new InventoryView().unequip(0); // HelmSlot
@@ -685,7 +685,7 @@ describe('InventoryView weapon-unequip warning', () => {
 
 	it('warns through toggleEquip when unequipping an equipped weapon dims a fielded skill', async () => {
 		weaponState.equippedWeaponType = EDamageType.Sword;
-		staticData.skills = [makeSkill(0, 'Slash', EDamageType.Sword)];
+		staticData.skills = [damageSkill(0, 'Slash', EDamageType.Sword)];
 		playerState.selectedSkills = [0];
 		const equippedWeapon = makeItem(2, 'Alpha Blade', EItemCategory.Weapon, ERarity.Legendary, {
 			equipped: true,

--- a/UI/src/tests/routes/game/screens/skills/SkillDamageBreakdown.test.ts
+++ b/UI/src/tests/routes/game/screens/skills/SkillDamageBreakdown.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
-import { EAttribute, type IAttribute, type ISkill } from '$lib/api';
+import { EAttribute, type ISkill } from '$lib/api';
+import { makeAttribute } from '../../../../fixtures/attributes';
 import { makeSkill } from '../../../../fixtures/skills';
 
 // The breakdown resolves the crit-chance label and attribute names through the reference-data store,
@@ -16,8 +17,8 @@ import type { SkillMetrics, SkillsView } from '$routes/game/screens/skills/skill
 // CriticalChanceMultiplier is flagged `isPercentage`, reused for the per-skill crit chance's display
 // formatting, so the chance renders as e.g. `50%`.
 staticData.attributes = [
-	{ id: EAttribute.CriticalChanceMultiplier, name: 'Critical Chance', code: 'CRIT', isPercentage: true, decimals: 0 }
-] as unknown as IAttribute[];
+	makeAttribute(EAttribute.CriticalChanceMultiplier, 'Critical Chance', { code: 'CRIT', isPercentage: true })
+];
 
 const stubSkill = (over: Partial<ISkill> = {}): ISkill => makeSkill({ id: 0, name: 'Cleave', baseDamage: 50, ...over });
 

--- a/UI/src/tests/routes/game/welcome-back/offline-summary.test.ts
+++ b/UI/src/tests/routes/game/welcome-back/offline-summary.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { ERarity, type IChallenge, type IChallengeCompletedModel, type IItem } from '$lib/api';
+import { ERarity, type IChallenge, type IChallengeCompletedModel } from '$lib/api';
 import { formatAwayDuration, resolveCompletedChallenges } from '$routes/game/welcome-back/offline-summary';
+import { makeItem } from '../../../fixtures/items';
 
 describe('formatAwayDuration', () => {
 	it('shows whole minutes under an hour', () => {
@@ -26,8 +27,10 @@ describe('formatAwayDuration', () => {
 });
 
 describe('resolveCompletedChallenges', () => {
-	const item: IItem = { id: 2, name: 'Aegis', rarityId: ERarity.Rare, itemCategoryId: 0 } as unknown as IItem;
-	// Id-indexed catalogue: index 1 is unused here but kept so id 2 stays at index 2.
+	const item = makeItem({ id: 2, name: 'Aegis', rarityId: ERarity.Rare });
+	/* Id-indexed catalogue: index 1 is unused here but kept so id 2 stays at index 2. The challenges stay
+	   deliberately partial — `IChallenge` has no shared fixture yet (#2456) — and the resolver reads only
+	   the name and reward id. */
 	const challenges: (IChallenge | undefined)[] = [
 		{ id: 0, name: 'First Blood', rewardItemId: 2 } as IChallenge,
 		undefined,

--- a/UI/src/tests/routes/select/ClassPicker.test.ts
+++ b/UI/src/tests/routes/select/ClassPicker.test.ts
@@ -7,6 +7,7 @@ import ClassPicker from '$routes/select/ClassPicker.svelte';
 import { staticData } from '$stores/static-data.svelte';
 import { EEquipmentSlot, EModifierType, type ICreatableClass } from '$lib/api';
 
+/* Deliberately partial: `ICreatableClass` has no shared fixture yet (#2456). */
 const cls = (overrides: Partial<ICreatableClass> = {}): ICreatableClass =>
 	({
 		id: 0,

--- a/UI/src/tests/routes/select/class-summary.test.ts
+++ b/UI/src/tests/routes/select/class-summary.test.ts
@@ -1,20 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import {
+	EAttribute,
 	EEquipmentSlot,
 	EModifierType,
-	type IAttribute,
 	type ICreatableClass,
 	type ICreatableClassEquipment
 } from '$lib/api';
 import { passiveSummary, weaponFirst } from '$routes/select/class-summary';
+import { makeAttribute } from '../../fixtures/attributes';
 
+/* Deliberately partial: `ICreatableClass` has no shared fixture yet (#2456). */
 const cls = (overrides: Partial<ICreatableClass> = {}): ICreatableClass =>
 	({
 		id: 0,
 		name: 'Warrior',
 		description: '',
 		word: 'kor',
-		passiveAttributeId: 1,
+		passiveAttributeId: EAttribute.Endurance,
 		passiveAmount: 8,
 		passiveScalingAmount: 0,
 		passiveModifierType: EModifierType.Additive,
@@ -25,9 +27,9 @@ const cls = (overrides: Partial<ICreatableClass> = {}): ICreatableClass =>
 	}) as ICreatableClass;
 
 const attributes = [
-	{ id: 1, code: 'END' },
-	{ id: 2, code: 'INT' }
-] as unknown as IAttribute[];
+	makeAttribute(EAttribute.Endurance, 'Endurance', { code: 'END' }),
+	makeAttribute(EAttribute.Intellect, 'Intellect', { code: 'INT' })
+];
 
 describe('weaponFirst', () => {
 	it('orders the weapon ahead of other equipment', () => {
@@ -64,12 +66,18 @@ describe('passiveSummary', () => {
 	});
 
 	it('appends the scaling clause for an attribute-scaled passive', () => {
-		const summary = passiveSummary(cls({ passiveScalingAttributeId: 2, passiveScalingAmount: 0.5 }), attributes);
+		const summary = passiveSummary(
+			cls({ passiveScalingAttributeId: EAttribute.Intellect, passiveScalingAmount: 0.5 }),
+			attributes
+		);
 		expect(summary).toBe('+8 END (+0.5 per INT)');
 	});
 
 	it('omits the scaling clause when the scaling amount is zero', () => {
-		const summary = passiveSummary(cls({ passiveScalingAttributeId: 2, passiveScalingAmount: 0 }), attributes);
+		const summary = passiveSummary(
+			cls({ passiveScalingAttributeId: EAttribute.Intellect, passiveScalingAmount: 0 }),
+			attributes
+		);
 		expect(summary).toBe('+8 END');
 	});
 

--- a/UI/src/tests/routes/select/player-select-view.test.ts
+++ b/UI/src/tests/routes/select/player-select-view.test.ts
@@ -10,8 +10,12 @@ const summary = (id: number, name = `Hero${id}`): IPlayerSummary => ({
 	lastActivity: '2026-06-20T00:00:00Z'
 });
 
+/* Deliberately partial: `IPlayerData` is a 15-field aggregate (attributes, inventory, lessons,
+   signature passive) and this is its only test builder — the view under test reads id/name — so a
+   shared fixture would be ceremony for one consumer. */
 const player = (id: number): IPlayerData => ({ id, name: `Hero${id}` }) as IPlayerData;
 
+/* Deliberately partial: `ICreatableClass` has no shared fixture yet (#2456). */
 const creatable = (id: number): ICreatableClass =>
 	({
 		id,


### PR DESCRIPTION
Closes #2447.

## Summary

A builder that asserts a partial literal `as IContract` is annotated with the contract and read as one by the code under test, but the assertion silences a missing required field — so it keeps compiling when the contract grows one. That made these sites invisible to the throwaway-required-field probe the fixture series (#2414 / #2425 / #2433 / #2434 / #2444 / #2446) used to define its target set, and left them quietly outside the guarantee each of those PRs stated.

This converts every such site for the six contracts that **already have a shared fixture** onto `make<Contract>`, dropping the cast so each rejoins drift detection. The issue's **category 1** applied everywhere it was reached: the fields the casts hid are inert at each site (the code under test reads spawn/level fields, reward ids, damage portions, or display metadata), and the fixtures supply neutral values for the rest.

## Sites converted

| Contract | Sites |
|---|---|
| `IZone` | `lib/common/challenge-unlocks`, `components/tooltip/ChallengeTooltip`, `codex/enemy-level` |
| `IEnemy` | `lib/common/enemy-attributes` (two), `codex/enemy-level` |
| `IItem` | `codex/skill-provenance`, `welcome-back/offline-summary`, `components/tooltip/ChallengeTooltip`, `lib/common/challenge-unlocks` |
| `IItemMod` | `challenges/OverviewPane`, `lib/common/challenge-unlocks` |
| `ISkill` | `fight/ActiveEffectChips` (three), `inventory/inventory-view` (two builders) |
| `IAttribute` | `skills/SkillDamageBreakdown`, `battle/battle-attributes`, `select/class-summary` |
| `IChallengeType` | `lib/common/challenge-type` |

Two consolidations fell out of the pass: `enemy-attributes` had two local `IEnemy` builders where the leaner one duplicated the shared fixture exactly (now deleted; the richer one became `marauder()`), and `inventory-view` carried the *same* `makeSkill` builder in two separate describes (now one `damageSkill` adapter over the shared fixture, keeping the positional call signature so the 16 call sites didn't churn).

## Corrections to the issue's table

The table is captioned "known", and the pass turned up more:

- **`IItem`** also at `ChallengeTooltip.test.ts:84` and `challenge-unlocks.test.ts:46`; **`IItemMod`** at `challenge-unlocks.test.ts:48` and `OverviewPane.test.ts:19`. These were already named in the `fixtures/items.ts` / `fixtures/item-mods.ts` headers but didn't make the table.
- **`ISkill`** was absent from the table entirely — `ActiveEffectChips` (three literals) and `inventory-view` (two builders, via `as unknown as ISkill`).
- **`IAttribute`** also at `battle-attributes.test.ts:301` and `class-summary.test.ts:30`.
- The `IEnemy` row correction from the issue's own comment (`enemy-level.test.ts:11`) is included.

## What is deferred, and why

`IChallenge` and `ICreatableClass` have **no shared fixture** — the series never covered them — so their cast sites have nothing to convert *onto*. Dropping the cast in place would mean hand-writing all seven required `IChallenge` fields at each of nine sites, which is the duplication the series exists to remove, not a fix. They take the issue's **category 2** instead: the cast stays with a stated reason, and each site now carries a note pointing at **#2456**, filed for the full `IChallenge` consolidation (15 suites construct one) with `ICreatableClass` folded in as a smaller companion.

`IChallengeType` was **not** deferred despite also lacking a fixture: three required fields, one site, and the same suite already carried a complete non-cast literal to copy — so standing up a module for it would have been over-engineering.

Per-contract fixture headers now name this class explicitly, as the issue asks — `fixtures/zones.ts` previously did not, and `fixtures/enemies.ts` / `item-mods.ts` carried "that's #2447's call" notes that are now resolved.

## One judgement call worth flagging

`offline-summary.test.ts` built its item with `itemCategoryId: 0`, which is not a member of `EItemCategory` (it starts at `Helm = 1`) — a meaningless value the double cast permitted. Nothing asserts on the category, so it now takes the fixture's neutral `Accessory` default rather than inventing a category.

## Test plan

- `npm run lint` (eslint + `svelte-check`) — clean, **1227 files, 0 errors, 0 warnings**.
- `npm run test:unit:ci` — **312 files, 4046 tests, all passing**.
- **The probe itself**, which is the actual point of the issue: adding a throwaway required field to all six contracts at once produces **exactly six errors under `src/tests/` — one per fixture module, and none at any test site**. Every remaining error is production code (the workbench blank records, the live `Item`/`ItemMod`/`Skill` domain classes) that legitimately must change on a contract change. Before this PR the converted sites contributed zero errors.
- No production code is touched; the diff is test-only and behaviour-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcqgkY3pQuJym53w1qH9b3


---
_Generated by [Claude Code](https://claude.ai/code/session_01XcqgkY3pQuJym53w1qH9b3)_