### PR TITLE
Consolidate the IChallenge/ICreatableClass test builders onto shared fixtures (#2456)

### DIFF
--- a/UI/src/tests/components/tooltip/ChallengeTooltip.test.ts
+++ b/UI/src/tests/components/tooltip/ChallengeTooltip.test.ts
@@ -21,21 +21,21 @@ vi.mock('$stores', () => ({ staticData, playerChallenges }));
 import ChallengeTooltip from '$components/tooltip/ChallengeTooltip.svelte';
 import { makeItem } from '../../fixtures/items';
 import { makeZone } from '../../fixtures/zones';
+import { makeChallenge } from '../../fixtures/challenges';
 
 const zone = (id: number, order: number, name: string, unlockChallengeId?: number): IZone =>
 	makeZone({ id, name, order, unlockChallengeId });
 
 const setup = (over: Partial<IChallenge> = {}) => {
 	staticData.challenges = [];
-	// Deliberately partial: `IChallenge` has no shared fixture yet (#2456); the tooltip reads only these fields.
-	staticData.challenges[5] = {
+	// The type is stated rather than inherited: the suite asserts on its label and accent colour.
+	staticData.challenges[5] = makeChallenge({
 		id: 5,
 		name: 'Cull the Swarm',
 		description: 'Defeat 10 enemies',
 		challengeTypeId: EChallengeType.EnemiesKilled,
-		progressGoal: 10,
 		...over
-	} as IChallenge;
+	});
 	staticData.challengeTypes = [{ id: EChallengeType.EnemiesKilled, name: 'Enemies Killed' }];
 	staticData.zones = [zone(20, 2, 'Beta', 5)];
 };

--- a/UI/src/tests/fixtures/challenges.ts
+++ b/UI/src/tests/fixtures/challenges.ts
@@ -26,6 +26,11 @@ import { EChallengeType, EEntityType, type IChallenge } from '$lib/api';
  * surfaces, so a suite exercising either states **both** explicitly rather than leaning on these
  * defaults — as does one whose subject is the type→statistic derivation.
  *
+ * That pairing is deliberately **off the production manifold**: `deriveFromType` always writes
+ * `statisticType`/`entityType` from the type, so `EnemiesKilled` with `entityType: None` and no
+ * statistic is a record the workbench can never author. Neutral is the point here — don't read a bare
+ * `makeChallenge({ id })` as production-shaped.
+ *
  * The optional fields (`statisticType`, `targetEntityId`, `rewardItemId`, `rewardItemModId`,
  * `retiredAt`) are left unset for the same reason: each flips a distinct branch — the goal unit, the
  * scope target, reward resolution, retirement filtering — when present.

--- a/UI/src/tests/fixtures/challenges.ts
+++ b/UI/src/tests/fixtures/challenges.ts
@@ -1,0 +1,41 @@
+import { EChallengeType, EEntityType, type IChallenge } from '$lib/api';
+
+/* Shared `IChallenge` contract builder (#2456), following the `fixtures/items.ts` convention.
+
+   The target set was confirmed with the throwaway-required-field probe, not a `grep`: only a suite that
+   constructs a *typed* `IChallenge` pays the contract-drift tax, and a probe field flushes out four
+   suites plus the production blank record (`routes/admin/workbench/entities/challenge.ts`). That record
+   is the authoritative shape and correctly stays a literal. Two other classes of challenge literal are
+   excluded on purpose: the untyped `staticData` mocks (the Codex suites seed `{} as any`), which see no
+   new required field, and `entities/challenge.test.ts`, which spreads the production `newItem` rather
+   than hand-rolling a record. A `grep` still finding challenge literals under `src/tests/` is expected,
+   not a gap.
+
+   A third class was invisible to the probe rather than excluded: a literal asserted `as IChallenge`
+   keeps compiling when the contract gains a required field. #2447 handed those nine sites over here and
+   they are now converted; reintroducing such a cast re-opens the hole, so state why if you do. */
+
+/**
+ * Builds an {@link IChallenge} reference-data entry for tests. Everything but the id is a neutral
+ * placeholder so a suite states only what it asserts on.
+ *
+ * `challengeTypeId` defaults to `EnemiesKilled`, matching the workbench's blank record, but
+ * `entityType` deliberately defaults to `None` rather than the `Enemy` dimension that type implies:
+ * `None` is the inert scope (tracked globally, no target select, no target id), so a suite that doesn't
+ * care about scope gets no scope behaviour for free. The two fields drive the condition and scope
+ * surfaces, so a suite exercising either states **both** explicitly rather than leaning on these
+ * defaults — as does one whose subject is the type→statistic derivation.
+ *
+ * The optional fields (`statisticType`, `targetEntityId`, `rewardItemId`, `rewardItemModId`,
+ * `retiredAt`) are left unset for the same reason: each flips a distinct branch — the goal unit, the
+ * scope target, reward resolution, retirement filtering — when present.
+ */
+export const makeChallenge = (overrides: Partial<IChallenge> & { id: number }): IChallenge => ({
+	name: `Challenge ${overrides.id}`,
+	description: '',
+	designerNotes: '',
+	challengeTypeId: EChallengeType.EnemiesKilled,
+	entityType: EEntityType.None,
+	progressGoal: 10,
+	...overrides
+});

--- a/UI/src/tests/fixtures/classes.ts
+++ b/UI/src/tests/fixtures/classes.ts
@@ -1,0 +1,32 @@
+import { EAttribute, EModifierType, type ICreatableClass } from '$lib/api';
+
+/* Shared `ICreatableClass` contract builder (#2456), following the `fixtures/items.ts` convention.
+
+   `ICreatableClass` is the class-creation projection the player-select flow reads, not the `IClass`
+   reference-data catalogue entry; the two are separate contracts that drift independently. `IClass` has
+   exactly one hand-rolled test builder (`routes/admin/workbench/references.test.ts`), so it stays a
+   literal there rather than earning a builder for a single consumer — it would join this module if a
+   second site appears. */
+
+/**
+ * Builds an {@link ICreatableClass} entry for tests. Everything but the id is a neutral placeholder so
+ * a suite states only what it asserts on.
+ *
+ * The passive is inert by default — `passiveAmount`/`passiveScalingAmount` of 0 with an `Additive`
+ * modifier type — because a suite asserting on the passive summary states the amounts it expects to
+ * read back. `passiveScalingAttributeId` is left unset for the same reason: an unscaled passive is the
+ * neutral case, and its presence is what switches the summary to its scaling phrasing.
+ */
+export const makeCreatableClass = (overrides: Partial<ICreatableClass> & { id: number }): ICreatableClass => ({
+	name: `Class ${overrides.id}`,
+	description: '',
+	word: `w${overrides.id}`,
+	passiveAttributeId: EAttribute.Endurance,
+	passiveAmount: 0,
+	passiveScalingAmount: 0,
+	passiveModifierType: EModifierType.Additive,
+	attributeDistributions: [],
+	starterSkills: [],
+	starterEquipment: [],
+	...overrides
+});

--- a/UI/src/tests/lib/common/challenge-unlocks.test.ts
+++ b/UI/src/tests/lib/common/challenge-unlocks.test.ts
@@ -4,14 +4,12 @@ import { challengeCompletedMessage, resolveUnlockReward, zonesUnlockedBy, type U
 import { makeItem } from '../../fixtures/items';
 import { makeItemMod } from '../../fixtures/item-mods';
 import { makeZone } from '../../fixtures/zones';
+import { makeChallenge } from '../../fixtures/challenges';
 
 const zone = (id: number, order: number, name: string, unlockChallengeId?: number, retiredAt?: string): IZone =>
 	makeZone({ id, name, order, unlockChallengeId, retiredAt });
 
-/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456), and `resolveUnlockReward`
-   reads only the two reward ids. */
-const challenge = (over: Partial<IChallenge> = {}): IChallenge =>
-	({ id: 1, name: 'C', description: '', challengeTypeId: 0, entityType: 0, progressGoal: 10, ...over }) as IChallenge;
+const challenge = (over: Partial<IChallenge> = {}): IChallenge => makeChallenge({ id: 1, name: 'C', ...over });
 
 describe('zonesUnlockedBy', () => {
 	it('returns the zones gated on the challenge, in authored order', () => {

--- a/UI/src/tests/routes/admin/workbench/challenge-helpers.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge-helpers.test.ts
@@ -22,6 +22,7 @@ import {
 	typeEntityType,
 	typeStatistic
 } from '../../../../routes/admin/workbench/entities/challenge-helpers';
+import { makeChallenge } from '../../../fixtures/challenges';
 
 // Mirrors the GET /api/Challenges/ChallengeTypes metadata the page consumes.
 const TYPES: IChallengeType[] = [
@@ -110,20 +111,19 @@ const TYPES: IChallengeType[] = [
 	}
 ];
 
+/* Diverges from the fixture's neutral `statisticType`/`entityType` on purpose: this suite's subject is
+   the type→statistic→entity derivation, so each record carries the dimension its own type implies. */
 const make = (over: Partial<IChallenge>): IChallenge => {
 	const type = over.challengeTypeId ?? EChallengeType.EnemiesKilled;
 	const stat = typeStatistic(TYPES, type);
-	return {
+	return makeChallenge({
 		id: 1,
 		name: 'Test',
-		description: '',
-		designerNotes: '',
 		challengeTypeId: type,
 		statisticType: stat?.id,
 		entityType: stat?.entityType ?? EEntityType.None,
-		progressGoal: 10,
 		...over
-	};
+	});
 };
 
 // Tests resolve every entity dimension to a fixed token so the sentence is deterministic.

--- a/UI/src/tests/routes/admin/workbench/challenge/ChallengeConditionSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ChallengeConditionSection.test.ts
@@ -19,6 +19,7 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 import ChallengeConditionSection from '$routes/admin/workbench/components/challenge/ChallengeConditionSection.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
 import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+import { makeChallenge } from '../../../../fixtures/challenges';
 
 const CHALLENGE_TYPES = [
 	{
@@ -45,18 +46,17 @@ const config = (): EntityConfig<Identified> =>
 	}) as unknown as EntityConfig<Identified>;
 
 const setup = (over: Partial<IChallenge> = {}) => {
-	/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456). */
-	const challenge: IChallenge = {
+	/* The condition dimension is stated in full rather than inherited: the suite asserts these four fields
+	   are re-derived (and the target cleared) when the objective type changes. */
+	const challenge = makeChallenge({
 		id: 1,
 		name: 'Test',
-		description: '',
 		challengeTypeId: EChallengeType.EnemiesKilled,
 		statisticType: EStatisticType.EnemiesKilled,
 		entityType: EEntityType.Enemy,
 		targetEntityId: 0,
-		progressGoal: 10,
 		...over
-	} as IChallenge;
+	});
 	const store = new EntityStore(config(), [challenge as unknown as Identified]);
 	const record = store.items[0];
 	return { store, record, baseline: store.baselineOf(1) };

--- a/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
@@ -32,6 +32,7 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 import ChallengeRewardSection from '$routes/admin/workbench/components/challenge/ChallengeRewardSection.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
 import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+import { makeChallenge } from '../../../../fixtures/challenges';
 
 const config = (): EntityConfig<Identified> =>
 	({
@@ -47,18 +48,8 @@ const config = (): EntityConfig<Identified> =>
 		persist: async () => []
 	}) as unknown as EntityConfig<Identified>;
 
-/* Every `as IChallenge` literal in this file is deliberately partial: `IChallenge` has no shared
-   fixture yet (#2456). */
 const setup = (over: Partial<IChallenge> = {}) => {
-	const challenge: IChallenge = {
-		id: 1,
-		name: 'Test',
-		description: '',
-		challengeTypeId: 1,
-		entityType: 0,
-		progressGoal: 10,
-		...over
-	} as IChallenge;
+	const challenge = makeChallenge({ id: 1, name: 'Test', ...over });
 	const store = new EntityStore(config(), [challenge as unknown as Identified]);
 	const record = store.items[0];
 	return { store, record, baseline: store.baselineOf(1) };
@@ -194,8 +185,8 @@ describe('ChallengeRewardSection', () => {
 	it('collapses an open picker when the rendered record switches to a different challenge', async () => {
 		// Two sibling challenges in the same store; the section is reused as the detail
 		// pane switches between them, and its $effect must reset the open picker on switch.
-		const first = { id: 1, name: 'One', challengeTypeId: 1, entityType: 0, progressGoal: 5 } as IChallenge;
-		const second = { id: 2, name: 'Two', challengeTypeId: 1, entityType: 0, progressGoal: 5 } as IChallenge;
+		const first = makeChallenge({ id: 1, name: 'One', progressGoal: 5 });
+		const second = makeChallenge({ id: 2, name: 'Two', progressGoal: 5 });
 		const store = new EntityStore(config(), [first, second] as unknown as Identified[]);
 
 		const { container, rerender } = render(ChallengeRewardSection, {

--- a/UI/src/tests/routes/admin/workbench/challenge/GoalField.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/GoalField.test.ts
@@ -13,6 +13,7 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 import GoalField from '$routes/admin/workbench/components/challenge/GoalField.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
 import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+import { makeChallenge } from '../../../../fixtures/challenges';
 
 const config = (): EntityConfig<Identified> =>
 	({
@@ -28,17 +29,15 @@ const config = (): EntityConfig<Identified> =>
 		persist: async () => []
 	}) as unknown as EntityConfig<Identified>;
 
-/* Every `as IChallenge` literal in this file is deliberately partial: `IChallenge` has no shared
-   fixture yet (#2456). */
 const setup = (over: Partial<IChallenge>) => {
-	const challenge: IChallenge = {
+	/* The type is stated rather than inherited: it selects the goal comparison and unit under test. */
+	const challenge = makeChallenge({
 		id: 1,
 		name: 'Test',
-		description: '',
 		challengeTypeId: EChallengeType.EnemiesKilled,
 		progressGoal: 25,
 		...over
-	} as IChallenge;
+	});
 	const store = new EntityStore(config(), [challenge as unknown as Identified]);
 	const record = store.items[0] as unknown as IChallenge;
 	return { store, challenge: record, baseline: store.baselineOf(1) as unknown as IChallenge };
@@ -73,7 +72,7 @@ describe('GoalField', () => {
 
 	it('marks dirty against a differing baseline', () => {
 		const { store, challenge } = setup({ statisticType: EStatisticType.EnemiesKilled });
-		const baseline = { ...challenge, progressGoal: 99 } as IChallenge;
+		const baseline: IChallenge = { ...challenge, progressGoal: 99 };
 		const { container } = render(GoalField, { props: { challenge, baseline, store } });
 		expect(container.querySelector('.dirty-dot')).toBeTruthy();
 	});

--- a/UI/src/tests/routes/admin/workbench/challenge/RewardPicker.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/RewardPicker.test.ts
@@ -3,6 +3,7 @@ import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
 import type { IChallenge } from '$lib/api';
 
 import RewardPicker, { type PickerRecord } from '$routes/admin/workbench/components/challenge/RewardPicker.svelte';
+import { makeChallenge } from '../../../../fixtures/challenges';
 
 const RECORDS: PickerRecord[] = [
 	{ id: 1, name: 'Iron Helm', color: 'var(--rarity-common)', tag: 'Common' },
@@ -10,9 +11,8 @@ const RECORDS: PickerRecord[] = [
 	{ id: 3, name: 'Leather Boots', color: 'var(--rarity-common)', tag: 'Common' }
 ];
 
-/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456). */
 const claimedBy = (id: number, name: string): Map<number, IChallenge> =>
-	new Map([[id, { id: 99, name } as IChallenge]]);
+	new Map([[id, makeChallenge({ id: 99, name })]]);
 
 afterEach(cleanup);
 

--- a/UI/src/tests/routes/admin/workbench/challenge/ScopeField.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ScopeField.test.ts
@@ -18,6 +18,7 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 import ScopeField from '$routes/admin/workbench/components/challenge/ScopeField.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
 import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+import { makeChallenge } from '../../../../fixtures/challenges';
 
 const config = (): EntityConfig<Identified> =>
 	({
@@ -34,16 +35,15 @@ const config = (): EntityConfig<Identified> =>
 	}) as unknown as EntityConfig<Identified>;
 
 const setup = (over: Partial<IChallenge>) => {
-	/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456). */
-	const challenge: IChallenge = {
+	/* The type and entity dimension are stated rather than inherited: every case here turns on the scope
+	   the two drive. */
+	const challenge = makeChallenge({
 		id: 1,
 		name: 'Test',
-		description: '',
 		challengeTypeId: EChallengeType.EnemiesKilled,
 		entityType: EEntityType.Enemy,
-		progressGoal: 10,
 		...over
-	} as IChallenge;
+	});
 	const store = new EntityStore(config(), [challenge as unknown as Identified]);
 	const record = store.items[0] as unknown as IChallenge;
 	return { store, challenge: record, baseline: store.baselineOf(1) as unknown as IChallenge };

--- a/UI/src/tests/routes/admin/workbench/references.test.ts
+++ b/UI/src/tests/routes/admin/workbench/references.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
 	EAttribute,
-	EChallengeType,
 	EEntityType,
 	EItemCategory,
 	EItemModType,
@@ -29,21 +28,14 @@ import { makeItem } from '../../../fixtures/items';
 import { makeItemMod } from '../../../fixtures/item-mods';
 import { makeZone } from '../../../fixtures/zones';
 import { makeEnemy } from '../../../fixtures/enemies';
+import { makeChallenge } from '../../../fixtures/challenges';
 
 const enemy = (id: number, name: string, opts: Partial<IEnemy> = {}): IEnemy => makeEnemy({ id, name, ...opts });
 
 const zone = (id: number, name: string, opts: Partial<IZone> = {}): IZone => makeZone({ id, name, ...opts });
 
-const challenge = (id: number, name: string, opts: Partial<IChallenge> = {}): IChallenge => ({
-	id,
-	name,
-	description: '',
-	designerNotes: '',
-	challengeTypeId: EChallengeType.EnemiesKilled,
-	entityType: EEntityType.None,
-	progressGoal: 10,
-	...opts
-});
+const challenge = (id: number, name: string, opts: Partial<IChallenge> = {}): IChallenge =>
+	makeChallenge({ id, name, ...opts });
 
 const item = (id: number, name: string, opts: Partial<IItem> = {}): IItem =>
 	makeItem({ id, name, itemCategoryId: EItemCategory.Helm, ...opts });

--- a/UI/src/tests/routes/game/screens/challenges/Challenges.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/Challenges.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
-import { EChallengeGoalComparison, EChallengeType, type IChallenge, type IPlayerChallenge } from '$lib/api';
+import { EChallengeGoalComparison, EChallengeType, type IPlayerChallenge } from '$lib/api';
 
 // Challenges fetches the player's progress over the socket (via the playerChallenges store) and
 // resolves the challenge catalogue + reward pools from staticData.
@@ -25,12 +25,6 @@ vi.mock('$stores', async (importOriginal) => {
 import Challenges from '$routes/game/screens/challenges/Challenges.svelte';
 import { makeChallenge } from '../../../../fixtures/challenges';
 
-/* `challengeTypeId` stays required rather than inheriting the fixture default — the card's type badge and
-   objective sentence are driven by it — and the description is generated from the name so the rendered
-   card carries real prose instead of the fixture's empty placeholder. */
-const challenge = (over: Partial<IChallenge> & Pick<IChallenge, 'id' | 'name' | 'challengeTypeId'>): IChallenge =>
-	makeChallenge({ description: `${over.name} description`, ...over });
-
 const PLAYER_CHALLENGES: IPlayerChallenge[] = [{ challengeId: 1, progress: 5, completed: false }];
 
 beforeEach(() => {
@@ -42,8 +36,16 @@ beforeEach(() => {
 	staticData.challengeTypes = [
 		{ id: EChallengeType.EnemiesKilled, goalComparison: EChallengeGoalComparison.AtLeast, name: 'Enemies Killed' }
 	];
+	/* The type is stated rather than inherited (it drives the card's badge and objective sentence), and the
+	   description is real prose rather than the fixture's empty placeholder so the card renders one. */
 	staticData.challenges = [
-		challenge({ id: 1, name: 'First Blood', challengeTypeId: EChallengeType.EnemiesKilled, progressGoal: 10 })
+		makeChallenge({
+			id: 1,
+			name: 'First Blood',
+			description: 'First Blood description',
+			challengeTypeId: EChallengeType.EnemiesKilled,
+			progressGoal: 10
+		})
 	];
 	mockToastError.mockClear();
 	mockFetchSocket.mockClear();

--- a/UI/src/tests/routes/game/screens/challenges/Challenges.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/Challenges.test.ts
@@ -1,12 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, screen, fireEvent } from '@testing-library/svelte';
-import {
-	EChallengeGoalComparison,
-	EChallengeType,
-	EEntityType,
-	type IChallenge,
-	type IPlayerChallenge
-} from '$lib/api';
+import { EChallengeGoalComparison, EChallengeType, type IChallenge, type IPlayerChallenge } from '$lib/api';
 
 // Challenges fetches the player's progress over the socket (via the playerChallenges store) and
 // resolves the challenge catalogue + reward pools from staticData.
@@ -29,14 +23,13 @@ vi.mock('$stores', async (importOriginal) => {
 });
 
 import Challenges from '$routes/game/screens/challenges/Challenges.svelte';
+import { makeChallenge } from '../../../../fixtures/challenges';
 
-const challenge = (over: Partial<IChallenge> & Pick<IChallenge, 'id' | 'name' | 'challengeTypeId'>): IChallenge => ({
-	description: `${over.name} description`,
-	designerNotes: '',
-	entityType: EEntityType.None,
-	progressGoal: 10,
-	...over
-});
+/* `challengeTypeId` stays required rather than inheriting the fixture default — the card's type badge and
+   objective sentence are driven by it — and the description is generated from the name so the rendered
+   card carries real prose instead of the fixture's empty placeholder. */
+const challenge = (over: Partial<IChallenge> & Pick<IChallenge, 'id' | 'name' | 'challengeTypeId'>): IChallenge =>
+	makeChallenge({ description: `${over.name} description`, ...over });
 
 const PLAYER_CHALLENGES: IPlayerChallenge[] = [{ challengeId: 1, progress: 5, completed: false }];
 

--- a/UI/src/tests/routes/game/screens/challenges/challenges-view.svelte.test.ts
+++ b/UI/src/tests/routes/game/screens/challenges/challenges-view.svelte.test.ts
@@ -56,6 +56,7 @@ import {
 } from '$routes/game/screens/challenges/challenges-view.svelte';
 import { makeItem } from '../../../../fixtures/items';
 import { makeItemMod } from '../../../../fixtures/item-mods';
+import { makeChallenge } from '../../../../fixtures/challenges';
 
 /** Carries attributes and a mod slot by default — the reward tooltip renders both. */
 const item = (id: number, name: string, rarity: ERarity, cat: EItemCategory, extra: Partial<IItem> = {}): IItem =>
@@ -81,13 +82,11 @@ const mod = (id: number, name: string, rarity: ERarity): IItemMod =>
 		attributes: [{ attributeId: EAttribute.Agility, amount: 3 }]
 	});
 
-const challenge = (over: Partial<IChallenge> & Pick<IChallenge, 'id' | 'name' | 'challengeTypeId'>): IChallenge => ({
-	description: `${over.name} description`,
-	designerNotes: '',
-	entityType: EEntityType.None,
-	progressGoal: 10,
-	...over
-});
+/* `challengeTypeId` stays required rather than inheriting the fixture default — the view-model's goal
+   comparison and target resolution are driven by it — and the description is generated from the name so
+   each card carries real prose instead of the fixture's empty placeholder. */
+const challenge = (over: Partial<IChallenge> & Pick<IChallenge, 'id' | 'name' | 'challengeTypeId'>): IChallenge =>
+	makeChallenge({ description: `${over.name} description`, ...over });
 
 beforeEach(() => {
 	staticData.items = [];

--- a/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
+++ b/UI/src/tests/routes/game/screens/fight/ZoneNav.test.ts
@@ -50,10 +50,10 @@ vi.mock('$stores', () => ({
 
 import ZoneNav from '$routes/game/screens/fight/ZoneNav.svelte';
 import { makeZone } from '../../../../fixtures/zones';
+import { makeChallenge } from '../../../../fixtures/challenges';
 
-/* Deliberately partial: `IChallenge` has no shared fixture yet (#2456). */
 const challenge = (id: number, name: string, description: string): IChallenge =>
-	({ id, name, description, challengeTypeId: EChallengeType.EnemiesKilled, progressGoal: 10 }) as IChallenge;
+	makeChallenge({ id, name, description, challengeTypeId: EChallengeType.EnemiesKilled });
 
 const zone = (
 	id: number,

--- a/UI/src/tests/routes/game/welcome-back/offline-summary.test.ts
+++ b/UI/src/tests/routes/game/welcome-back/offline-summary.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { ERarity, type IChallenge, type IChallengeCompletedModel } from '$lib/api';
 import { formatAwayDuration, resolveCompletedChallenges } from '$routes/game/welcome-back/offline-summary';
 import { makeItem } from '../../../fixtures/items';
+import { makeChallenge } from '../../../fixtures/challenges';
 
 describe('formatAwayDuration', () => {
 	it('shows whole minutes under an hour', () => {
@@ -28,13 +29,11 @@ describe('formatAwayDuration', () => {
 
 describe('resolveCompletedChallenges', () => {
 	const item = makeItem({ id: 2, name: 'Aegis', rarityId: ERarity.Rare });
-	/* Id-indexed catalogue: index 1 is unused here but kept so id 2 stays at index 2. The challenges stay
-	   deliberately partial — `IChallenge` has no shared fixture yet (#2456) — and the resolver reads only
-	   the name and reward id. */
+	/* Id-indexed catalogue: index 1 is unused here but kept so id 2 stays at index 2. */
 	const challenges: (IChallenge | undefined)[] = [
-		{ id: 0, name: 'First Blood', rewardItemId: 2 } as IChallenge,
+		makeChallenge({ id: 0, name: 'First Blood', rewardItemId: 2 }),
 		undefined,
-		{ id: 2, name: 'Persistence' } as IChallenge // no direct reward
+		makeChallenge({ id: 2, name: 'Persistence' }) // no direct reward
 	];
 	const refs = {
 		challenges,

--- a/UI/src/tests/routes/select/ClassPicker.test.ts
+++ b/UI/src/tests/routes/select/ClassPicker.test.ts
@@ -8,15 +8,14 @@ import { staticData } from '$stores/static-data.svelte';
 import { EEquipmentSlot, type ICreatableClass } from '$lib/api';
 import { makeCreatableClass } from '../../fixtures/classes';
 
-/* The passive diverges from the fixture's inert default: the picker renders its attribute chip, so the
-   class carries a real passive (Endurance +8) for those assertions to read. */
+/* `passiveAmount` diverges from the fixture's inert 0: the picker renders the passive as an attribute
+   chip, so the class needs a real amount for those assertions to read. The attribute itself is the
+   fixture's default (Endurance), which is what the mocked `staticData.attributes` resolves to. */
 const cls = (overrides: Partial<ICreatableClass> = {}): ICreatableClass =>
 	makeCreatableClass({
 		id: 0,
 		name: 'Warrior',
 		description: 'A frontline fighter.',
-		word: 'kor',
-		passiveAttributeId: 1,
 		passiveAmount: 8,
 		...overrides
 	});
@@ -59,9 +58,6 @@ describe('ClassPicker', () => {
 		const classes = [
 			cls({
 				id: 0,
-				description: 'A frontline fighter.',
-				passiveAttributeId: 1,
-				passiveAmount: 8,
 				starterSkills: [
 					{ id: 1, name: 'Slash' },
 					{ id: 0, name: 'Punch' }

--- a/UI/src/tests/routes/select/ClassPicker.test.ts
+++ b/UI/src/tests/routes/select/ClassPicker.test.ts
@@ -5,24 +5,21 @@ import { render, fireEvent, cleanup, screen } from '@testing-library/svelte';
 // exercised: with no attribute-tooltip context here, the chips must stay out of the tab order.
 import ClassPicker from '$routes/select/ClassPicker.svelte';
 import { staticData } from '$stores/static-data.svelte';
-import { EEquipmentSlot, EModifierType, type ICreatableClass } from '$lib/api';
+import { EEquipmentSlot, type ICreatableClass } from '$lib/api';
+import { makeCreatableClass } from '../../fixtures/classes';
 
-/* Deliberately partial: `ICreatableClass` has no shared fixture yet (#2456). */
+/* The passive diverges from the fixture's inert default: the picker renders its attribute chip, so the
+   class carries a real passive (Endurance +8) for those assertions to read. */
 const cls = (overrides: Partial<ICreatableClass> = {}): ICreatableClass =>
-	({
+	makeCreatableClass({
 		id: 0,
 		name: 'Warrior',
 		description: 'A frontline fighter.',
 		word: 'kor',
 		passiveAttributeId: 1,
 		passiveAmount: 8,
-		passiveScalingAmount: 0,
-		passiveModifierType: EModifierType.Additive,
-		attributeDistributions: [],
-		starterSkills: [],
-		starterEquipment: [],
 		...overrides
-	}) as ICreatableClass;
+	});
 
 beforeEach(() => {
 	staticData.attributes = [{ id: 1, code: 'END', name: 'Endurance' }] as unknown as NonNullable<

--- a/UI/src/tests/routes/select/class-summary.test.ts
+++ b/UI/src/tests/routes/select/class-summary.test.ts
@@ -8,23 +8,12 @@ import {
 } from '$lib/api';
 import { passiveSummary, weaponFirst } from '$routes/select/class-summary';
 import { makeAttribute } from '../../fixtures/attributes';
+import { makeCreatableClass } from '../../fixtures/classes';
 
-/* Deliberately partial: `ICreatableClass` has no shared fixture yet (#2456). */
+/* `passiveAmount` diverges from the fixture's inert 0: every case here reads the summary phrasing built
+   from a real passive. */
 const cls = (overrides: Partial<ICreatableClass> = {}): ICreatableClass =>
-	({
-		id: 0,
-		name: 'Warrior',
-		description: '',
-		word: 'kor',
-		passiveAttributeId: EAttribute.Endurance,
-		passiveAmount: 8,
-		passiveScalingAmount: 0,
-		passiveModifierType: EModifierType.Additive,
-		attributeDistributions: [],
-		starterSkills: [],
-		starterEquipment: [],
-		...overrides
-	}) as ICreatableClass;
+	makeCreatableClass({ id: 0, name: 'Warrior', word: 'kor', passiveAmount: 8, ...overrides });
 
 const attributes = [
 	makeAttribute(EAttribute.Endurance, 'Endurance', { code: 'END' }),

--- a/UI/src/tests/routes/select/class-summary.test.ts
+++ b/UI/src/tests/routes/select/class-summary.test.ts
@@ -13,7 +13,7 @@ import { makeCreatableClass } from '../../fixtures/classes';
 /* `passiveAmount` diverges from the fixture's inert 0: every case here reads the summary phrasing built
    from a real passive. */
 const cls = (overrides: Partial<ICreatableClass> = {}): ICreatableClass =>
-	makeCreatableClass({ id: 0, name: 'Warrior', word: 'kor', passiveAmount: 8, ...overrides });
+	makeCreatableClass({ id: 0, name: 'Warrior', passiveAmount: 8, ...overrides });
 
 const attributes = [
 	makeAttribute(EAttribute.Endurance, 'Endurance', { code: 'END' }),

--- a/UI/src/tests/routes/select/player-select-view.test.ts
+++ b/UI/src/tests/routes/select/player-select-view.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PlayerSelectView, type PlayerSelectDeps } from '$routes/select/player-select-view.svelte';
 import type { ICreatableClass, IPlayerData, IPlayerSummary } from '$lib/api';
+import { makeCreatableClass } from '../../fixtures/classes';
 
 const summary = (id: number, name = `Hero${id}`): IPlayerSummary => ({
 	id,
@@ -15,15 +16,7 @@ const summary = (id: number, name = `Hero${id}`): IPlayerSummary => ({
    shared fixture would be ceremony for one consumer. */
 const player = (id: number): IPlayerData => ({ id, name: `Hero${id}` }) as IPlayerData;
 
-/* Deliberately partial: `ICreatableClass` has no shared fixture yet (#2456). */
-const creatable = (id: number): ICreatableClass =>
-	({
-		id,
-		name: `Class${id}`,
-		starterSkills: [],
-		starterEquipment: [],
-		attributeDistributions: []
-	}) as unknown as ICreatableClass;
+const creatable = (id: number): ICreatableClass => makeCreatableClass({ id, name: `Class${id}` });
 
 const makeDeps = (overrides: Partial<PlayerSelectDeps> = {}): PlayerSelectDeps => ({
 	selectPlayer: vi.fn().mockResolvedValue({ ok: true, player: player(1) }),


### PR DESCRIPTION
Closes #2456.

Test-only: no production code, no behaviour change. Adds `UI/src/tests/fixtures/challenges.ts` (`makeChallenge`) and `UI/src/tests/fixtures/classes.ts` (`makeCreatableClass`), and converts every hand-rolled builder for the two contracts onto them.

## Verification (the point of the exercise)

The target set was confirmed with the throwaway-required-field probe rather than the issue's grep. Adding a required field to `IChallenge` **before** this change flushed out four suites and, separately, silently compiled at nine cast sites. **After**, the same probe produces exactly one test-file error:

```
src/routes/admin/workbench/entities/challenge.ts   ← production blank record (correctly stays a literal)
src/tests/fixtures/challenges.ts                   ← the only test-side edit
src/tests/fixtures/classes.ts                      ← ICreatableClass, previously 0 errors (all 3 sites cast-silenced)
```

`ICreatableClass` is the more interesting half: all three of its sites asserted their literal, so the contract had **no** test-side drift detection at all — the probe found nothing to report.

## Where the issue's scope needed adjusting

The issue lists 15 suites that "construct an `IChallenge`". Two of those groups are excluded on purpose, matching the precedents the series already set:

- **`entities/challenge.test.ts`** spreads the production `challengeEntity.newItem(...)` rather than hand-rolling a record. That's the authoritative shape (the `fixtures/item-mods.ts` exclusion for the same reason), so it stays.
- **`Codex.test.ts` / `codex-view.svelte.test.ts`** seed `staticData: {} as any`. An untyped mock never sees a new required field, and filling its previously-`undefined` fields could change what the suite renders.

The `challenges: [] as IChallenge[]` annotations in the skills/fight suites are empty-array *type annotations*, not literals — nothing to convert.

One extra cleanup folded in: `GoalField.test.ts:75` asserted `{ ...challenge, progressGoal: 99 } as IChallenge` — a spread of an already-complete record, so the cast was pure redundancy and is now a plain annotation.

## Defaults, and where suites deliberately diverge

`challengeTypeId` defaults to `EnemiesKilled` (matching the workbench blank record) but `entityType` defaults to `None` rather than the `Enemy` dimension that type implies — `None` is the inert scope, so a suite that doesn't care about scope gets no scope behaviour for free.

Per the issue's warning about load-bearing defaults, every suite that asserts on behaviour those two drive states them **explicitly** instead of inheriting, with a one-line note at the wrapper:

| Suite | Stated rather than inherited |
|---|---|
| `ChallengeConditionSection` | the full condition dimension — it asserts all four fields re-derive on a type change |
| `ScopeField` | type + entity dimension — every case turns on the scope they drive |
| `GoalField` | type — it selects the goal comparison and unit |
| `ChallengeTooltip` | type — it asserts the type label and accent colour |
| `challenge-helpers` | statistic/entity — the suite's subject *is* the type→statistic derivation |
| `Challenges`, `challenges-view` | `challengeTypeId` stays required in the wrapper signature; description generated from the name so cards render real prose |
| `ClassPicker`, `class-summary` | a real passive (the fixture's is inert at 0), which the chip/summary assertions read |

## Test plan

- [x] `npm run lint` (eslint + svelte-check) — clean, 1229 files, 0 errors/warnings
- [x] `npx vitest --run` — **312 files, 4051 tests, all passing**
- [x] Each converted suite run individually as it was converted
- [x] Probe re-run to confirm drift detection collapsed to one site per contract (output above), contract file restored afterwards

Backend untouched, so no `dotnet` run was needed.

## Follow-up

Six workbench suites duplicate a near-identical ~14-line `config()` factory ending in `as unknown as EntityConfig<Identified>`. That's the same class of duplication as this issue but a different contract, so it's filed separately rather than widened into this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EckyjM3GF7a2iXYRgyBgGu)_