### PR TITLE
Take the engines' per-tick internals out of the statify proxy (#2462)

### DIFF
--- a/UI/src/lib/common/zone-progression.ts
+++ b/UI/src/lib/common/zone-progression.ts
@@ -29,9 +29,13 @@ export function isZoneUnlocked(zone: IZone, isChallengeCompleted: (challengeId: 
 	return zone.unlockChallengeId == null || isChallengeCompleted(zone.unlockChallengeId);
 }
 
-/** The zone immediately after the given zone in authored order, or undefined if it is the last. */
-export function nextZoneByOrder(zones: IZone[], currentZoneId: number): IZone | undefined {
-	const ordered = zonesByOrder(zones);
+/**
+ * The zone immediately after the given zone among the navigable ones, or undefined if it is the last
+ * (or is itself retired/unknown). Retired zones are skipped here rather than by the caller, so no
+ * caller can accidentally advance progression into one — and the ordering pass happens once.
+ */
+export function nextNavigableZone(zones: IZone[], currentZoneId: number): IZone | undefined {
+	const ordered = navigableZones(zones);
 	const idx = ordered.findIndex((z) => z.id === currentZoneId);
 	return idx >= 0 ? ordered[idx + 1] : undefined;
 }

--- a/UI/src/lib/engine/battle/enemy-manager.ts
+++ b/UI/src/lib/engine/battle/enemy-manager.ts
@@ -1,5 +1,5 @@
 import { apiSocket, ELogType, IEnemyInstance } from '$lib/api';
-import { Action, createHook, delay, isZoneUnlocked, navigableZones, nextZoneByOrder } from '$lib/common';
+import { Action, createHook, delay, isZoneUnlocked, nextNavigableZone } from '$lib/common';
 import { staticData, statistics, playerChallenges } from '$stores';
 import {
 	battleEngine,
@@ -709,7 +709,7 @@ export class EnemyManager {
 		// completes the gating challenge during claimVictory) and check whether it flipped open. Skipping
 		// the refresh when nothing could change keeps auto-fight re-farming from spamming the endpoint.
 		const completed = (id: number) => playerChallenges.isChallengeCompleted(id);
-		const nextZone = nextZoneByOrder(navigableZones(staticData.zones ?? []), clearedZoneId);
+		const nextZone = nextNavigableZone(staticData.zones ?? [], clearedZoneId);
 		const nextWasLocked = nextZone != null && !isZoneUnlocked(nextZone, completed);
 		if (nextWasLocked) {
 			await playerChallenges.load(true);

--- a/UI/src/lib/engine/logical-engine.ts
+++ b/UI/src/lib/engine/logical-engine.ts
@@ -18,58 +18,66 @@ const notifyIdleTimeLost = idleTimeLostHook.notify;
 export const onIdleTimeLost = idleTimeLostHook.onNotified;
 
 export class LogicalEngine {
-	public time = 0;
+	/** The measured tick rate, the one field with a reactive consumer (the nav sidebar's readout). */
 	public tickRate = 0;
 
-	private lastTime = 0;
-	private timeBank = 0;
-	private countTick = getEventCounter((t) => (this.tickRate = Math.round(t)));
-	private tickSource?: TickSource;
+	// Per-tick internals are `#`-private so statify never proxies them (#2123): `#time` advances every
+	// tick and `#lastTime`/`#timeBank` on every poll (~10ms), and nothing reads them reactively.
+	#time = 0;
+	#lastTime = 0;
+	#timeBank = 0;
+	#countTick = getEventCounter((t) => (this.tickRate = Math.round(t)));
+	#tickSource?: TickSource;
+
+	/** The logical clock in `performance.now()` terms. Deliberately non-reactive — poll it, don't `$derived` it. */
+	public get time() {
+		return this.#time;
+	}
 
 	public start() {
-		if (this.tickSource) {
+		if (this.#tickSource) {
 			return;
 		}
 
-		this.lastTime = performance.now();
-		this.time = this.lastTime;
+		this.#lastTime = performance.now();
+		this.#time = this.#lastTime;
 
-		this.tickSource = createTickSource(() => this.logicLoop());
+		this.#tickSource = createTickSource(() => this.logicLoop());
 	}
 
 	public stop() {
-		if (!this.tickSource) {
+		if (!this.#tickSource) {
 			return;
 		}
 
-		this.tickSource.stop();
-		this.tickSource = undefined;
-		this.lastTime = 0;
-		this.timeBank = 0;
-		this.time = 0;
+		this.#tickSource.stop();
+		this.#tickSource = undefined;
+		this.#lastTime = 0;
+		this.#timeBank = 0;
+		this.#time = 0;
 		this.tickRate = 0;
 	}
 
 	private logicLoop() {
 		const now = performance.now();
-		const ts = now - this.lastTime;
-		this.lastTime = now;
+		const ts = now - this.#lastTime;
+		this.#lastTime = now;
 		this.update(ts);
 	}
 
 	private update(timeDelta: number) {
 		if (timeDelta > tickSizeX5) {
 			const lostTime = timeDelta - tickSizeX5;
-			this.time += lostTime;
+			this.#time += lostTime;
 			timeDelta = tickSizeX5;
 			notifyIdleTimeLost(lostTime);
 		}
 
-		this.timeBank += timeDelta;
-		while (this.timeBank >= tickSize) {
-			this.timeBank -= tickSize;
-			this.time += tickSize;
-			this.countTick();
+		this.#timeBank += timeDelta;
+		while (this.#timeBank >= tickSize) {
+			this.#timeBank -= tickSize;
+			this.#time += tickSize;
+			this.#countTick();
 			notifyLogicalUpdate(tickSize);
 		}
 	}

--- a/UI/src/lib/engine/logical-engine.ts
+++ b/UI/src/lib/engine/logical-engine.ts
@@ -29,7 +29,10 @@ export class LogicalEngine {
 	#countTick = getEventCounter((t) => (this.tickRate = Math.round(t)));
 	#tickSource?: TickSource;
 
-	/** The logical clock in `performance.now()` terms. Deliberately non-reactive — poll it, don't `$derived` it. */
+	/**
+	 * The logical clock in `performance.now()` terms, read across the class boundary by `RenderEngine`
+	 * to derive its interpolation lead. Deliberately non-reactive — poll it, don't `$derived` it.
+	 */
 	public get time() {
 		return this.#time;
 	}

--- a/UI/src/lib/engine/render-engine.ts
+++ b/UI/src/lib/engine/render-engine.ts
@@ -6,53 +6,66 @@ const notifyRenderUpdate = renderUpdateHook.notify;
 export const onRenderUpdate = renderUpdateHook.onNotified;
 
 export class RenderEngine {
-	public time = 0;
-	public logicalDelta = 0;
+	/** The measured frame rate, the one field with a reactive consumer (the nav sidebar's readout). */
 	public tickRate = 0;
 
-	private running = false;
-	private rafHandle?: number;
-	private countTick = getEventCounter((t) => (this.tickRate = Math.round(t)));
+	// Per-frame internals are `#`-private so statify never proxies them (#2123): all of these are written
+	// on every animation frame, and nothing reads them reactively.
+	#time = 0;
+	#logicalDelta = 0;
+	#running = false;
+	#rafHandle?: number;
+	#countTick = getEventCounter((t) => (this.tickRate = Math.round(t)));
+
+	/** The render clock in `performance.now()` terms. Deliberately non-reactive — poll it, don't `$derived` it. */
+	public get time() {
+		return this.#time;
+	}
+
+	/** How far the render clock leads the logical clock (floored at 0). Non-reactive, like `time`. */
+	public get logicalDelta() {
+		return this.#logicalDelta;
+	}
 
 	public start() {
-		if (!this.running) {
+		if (!this.#running) {
 			// Re-seed the clock so the first frame's delta is ~one frame, not the entire wall-clock gap
 			// the engine was stopped (mirrors LogicalEngine.start, which resets its clock to avoid this).
-			this.time = performance.now();
-			this.running = true;
+			this.#time = performance.now();
+			this.#running = true;
 			this.renderLoop();
 		}
 	}
 
 	public stop() {
-		this.running = false;
+		this.#running = false;
 		// Cancel the pending frame so a start() within the same frame can't leave the old callback
 		// running alongside the new loop (mirrors LogicalEngine.stop clearing its tickSource handle).
-		if (this.rafHandle !== undefined) {
-			window.cancelAnimationFrame(this.rafHandle);
-			this.rafHandle = undefined;
+		if (this.#rafHandle !== undefined) {
+			window.cancelAnimationFrame(this.#rafHandle);
+			this.#rafHandle = undefined;
 		}
 	}
 
 	//use performance.now instead of animation frame timestamp, because frame stamp is before some amount of processing.
 	//using frame timestamp can cause render loop to appear behind logical loop
 	private renderLoop() {
-		if (this.running) {
+		if (this.#running) {
 			this.update();
-			this.rafHandle = window.requestAnimationFrame(() => this.renderLoop());
+			this.#rafHandle = window.requestAnimationFrame(() => this.renderLoop());
 		}
 	}
 
-	private update = () => {
-		this.countTick();
+	private update() {
+		this.#countTick();
 		const newTime = performance.now();
-		const delta = newTime - this.time;
-		this.time = newTime;
+		const delta = newTime - this.#time;
+		this.#time = newTime;
 		// Floor at 0: the logical engine's tab-background catch-up branch advances logicEngine.time by the
 		// discarded excess, which can momentarily push it past the render clock. A negative logicalDelta
 		// would drive the render-only charge/effect interpolation backwards for a frame (purely cosmetic —
 		// logical state and battle parity are unaffected).
-		this.logicalDelta = Math.max(0, newTime - logicEngine.time);
-		notifyRenderUpdate(delta, this.logicalDelta);
-	};
+		this.#logicalDelta = Math.max(0, newTime - logicEngine.time);
+		notifyRenderUpdate(delta, this.#logicalDelta);
+	}
 }

--- a/UI/src/lib/engine/render-engine.ts
+++ b/UI/src/lib/engine/render-engine.ts
@@ -17,12 +17,17 @@ export class RenderEngine {
 	#rafHandle?: number;
 	#countTick = getEventCounter((t) => (this.tickRate = Math.round(t)));
 
-	/** The render clock in `performance.now()` terms. Deliberately non-reactive — poll it, don't `$derived` it. */
+	// Both getters are observability only — unlike `LogicalEngine.time` (which `update` below reads across
+	// the class boundary), nothing in production reads either: consumers take the frame delta and the
+	// interpolation lead from the `onRenderUpdate` payload. Kept for debugging and the clock assertions,
+	// and non-reactive by construction, since a prototype accessor stays out of the statify proxy.
+
+	/** The render clock in `performance.now()` terms. */
 	public get time() {
 		return this.#time;
 	}
 
-	/** How far the render clock leads the logical clock (floored at 0). Non-reactive, like `time`. */
+	/** How far the render clock leads the logical clock (floored at 0). */
 	public get logicalDelta() {
 		return this.#logicalDelta;
 	}

--- a/UI/src/tests/lib/common/zone-progression.test.ts
+++ b/UI/src/tests/lib/common/zone-progression.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { IZone } from '$lib/api';
-import { isZoneUnlocked, navigableZones, nextZoneByOrder, zonesByOrder } from '$lib/common/zone-progression';
+import { isZoneUnlocked, navigableZones, nextNavigableZone, zonesByOrder } from '$lib/common/zone-progression';
 import { makeZone } from '../../fixtures/zones';
 
 const zone = (id: number, order: number, unlockChallengeId?: number, retiredAt?: string): IZone =>
@@ -49,19 +49,32 @@ describe('isZoneUnlocked', () => {
 	});
 });
 
-describe('nextZoneByOrder', () => {
+describe('nextNavigableZone', () => {
 	const zones = [zone(30, 3), zone(10, 1), zone(20, 2)];
 
 	it('returns the next zone in authored order', () => {
-		expect(nextZoneByOrder(zones, 10)?.id).toBe(20);
-		expect(nextZoneByOrder(zones, 20)?.id).toBe(30);
+		expect(nextNavigableZone(zones, 10)?.id).toBe(20);
+		expect(nextNavigableZone(zones, 20)?.id).toBe(30);
 	});
 
 	it('returns undefined past the last zone', () => {
-		expect(nextZoneByOrder(zones, 30)).toBeUndefined();
+		expect(nextNavigableZone(zones, 30)).toBeUndefined();
 	});
 
 	it('returns undefined for an unknown current zone', () => {
-		expect(nextZoneByOrder(zones, 999)).toBeUndefined();
+		expect(nextNavigableZone(zones, 999)).toBeUndefined();
+	});
+
+	it('skips a retired zone rather than returning it as the next zone', () => {
+		const withRetiredMiddle = [zone(30, 3), zone(10, 1), zone(20, 2, undefined, '2026-01-01T00:00:00Z')];
+
+		expect(nextNavigableZone(withRetiredMiddle, 10)?.id).toBe(30);
+	});
+
+	it('returns undefined when the current zone is itself retired', () => {
+		// A player is lazily relocated out of a retired zone, so it has no "next" to advance into.
+		const retiredCurrent = [zone(10, 1, undefined, '2026-01-01T00:00:00Z'), zone(20, 2)];
+
+		expect(nextNavigableZone(retiredCurrent, 10)).toBeUndefined();
 	});
 });

--- a/UI/src/tests/lib/engine/engine-statify.svelte.test.ts
+++ b/UI/src/tests/lib/engine/engine-statify.svelte.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync } from 'svelte';
+import { statify } from '$lib/common';
+
+// RenderEngine reads the shared logical clock; the real module pulls in the whole engine graph.
+const logicEngineStub = vi.hoisted(() => ({ time: 0 }));
+vi.mock('$lib/engine/engine', () => ({ logicEngine: logicEngineStub }));
+
+const rafCallbacks: (() => void)[] = [];
+vi.stubGlobal('window', {
+	requestAnimationFrame: vi.fn((cb: () => void) => {
+		rafCallbacks.push(cb);
+		return rafCallbacks.length;
+	}),
+	cancelAnimationFrame: vi.fn(),
+	setInterval: (...args: Parameters<typeof setInterval>) => globalThis.setInterval(...args),
+	clearInterval: (...args: Parameters<typeof clearInterval>) => globalThis.clearInterval(...args)
+});
+
+import { LogicalEngine, tickSize } from '$lib/engine/logical-engine';
+import { RenderEngine } from '$lib/engine/render-engine';
+
+/** Whether `statify` installed a `$state`-backed accessor for the field on this instance. */
+const isStatified = (instance: object, field: string) =>
+	Object.getOwnPropertyDescriptor(instance, field)?.get !== undefined;
+
+// Both engines are wrapped in `statify` (`$lib/engine/engine.ts`), which turns every *enumerable* field
+// into a `$state` accessor. Their clocks and loop bookkeeping are written on every tick/frame with no
+// reactive consumer, so they are `#`-private to stay out of the proxy (#2123) — `tickRate` is the sole
+// reactive field (the nav sidebar's rate readout). These pin that split, which is invisible at the call
+// site: a `#`-field silently promoted back to a public one would still pass every other engine test.
+describe('engine internals under statify (#2123)', () => {
+	describe('LogicalEngine', () => {
+		let engine: LogicalEngine;
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+			engine = statify(new LogicalEngine());
+		});
+
+		afterEach(() => {
+			engine.stop();
+			vi.useRealTimers();
+		});
+
+		it('statifies tickRate and nothing else', () => {
+			expect(isStatified(engine, 'tickRate')).toBe(true);
+			// `time` is a prototype getter over a `#`-private field, so statify never enumerated it.
+			expect(Object.getOwnPropertyDescriptor(engine, 'time')).toBeUndefined();
+		});
+
+		it('advances the logical clock without notifying a $derived that reads it', () => {
+			let observed = -1;
+			const cleanup = $effect.root(() => {
+				const time = $derived(engine.time);
+				$effect(() => {
+					observed = time;
+				});
+			});
+			flushSync();
+			expect(observed).toBe(0);
+
+			engine.start();
+			vi.advanceTimersByTime(tickSize * 3);
+			flushSync();
+
+			// The clock really did move; the proxy simply never saw it.
+			expect(engine.time).toBeGreaterThan(0);
+			expect(observed).toBe(0);
+
+			cleanup();
+		});
+
+		it('keeps tickRate reactive', () => {
+			let observed = -1;
+			const cleanup = $effect.root(() => {
+				const rate = $derived(engine.tickRate);
+				$effect(() => {
+					observed = rate;
+				});
+			});
+			flushSync();
+			expect(observed).toBe(0);
+
+			engine.tickRate = 25;
+			flushSync();
+			expect(observed).toBe(25);
+
+			cleanup();
+		});
+	});
+
+	describe('RenderEngine', () => {
+		let engine: RenderEngine;
+		let performanceNow: number;
+
+		beforeEach(() => {
+			rafCallbacks.length = 0;
+			logicEngineStub.time = 0;
+			performanceNow = 0;
+			vi.spyOn(performance, 'now').mockImplementation(() => performanceNow);
+			engine = statify(new RenderEngine());
+		});
+
+		afterEach(() => {
+			engine.stop();
+			vi.restoreAllMocks();
+		});
+
+		it('statifies tickRate and nothing else', () => {
+			expect(isStatified(engine, 'tickRate')).toBe(true);
+			expect(Object.getOwnPropertyDescriptor(engine, 'time')).toBeUndefined();
+			expect(Object.getOwnPropertyDescriptor(engine, 'logicalDelta')).toBeUndefined();
+		});
+
+		it('advances the render clock and logicalDelta without notifying a $derived that reads them', () => {
+			let observedTime = -1;
+			let observedDelta = -1;
+			const cleanup = $effect.root(() => {
+				const time = $derived(engine.time);
+				const logicalDelta = $derived(engine.logicalDelta);
+				$effect(() => {
+					observedTime = time;
+					observedDelta = logicalDelta;
+				});
+			});
+			flushSync();
+			expect(observedTime).toBe(0);
+			expect(observedDelta).toBe(0);
+
+			performanceNow = 1000;
+			logicEngineStub.time = 960;
+			engine.start(); // first frame
+			performanceNow = 1016;
+			rafCallbacks.shift()?.(); // second frame
+			flushSync();
+
+			expect(engine.time).toBe(1016);
+			expect(engine.logicalDelta).toBe(56); // 1016 − 960
+			expect(observedTime).toBe(0);
+			expect(observedDelta).toBe(0);
+
+			cleanup();
+		});
+
+		it('keeps tickRate reactive', () => {
+			let observed = -1;
+			const cleanup = $effect.root(() => {
+				const rate = $derived(engine.tickRate);
+				$effect(() => {
+					observed = rate;
+				});
+			});
+			flushSync();
+			expect(observed).toBe(0);
+
+			engine.tickRate = 60;
+			flushSync();
+			expect(observed).toBe(60);
+
+			cleanup();
+		});
+	});
+});

--- a/UI/src/tests/lib/engine/engine-statify.svelte.test.ts
+++ b/UI/src/tests/lib/engine/engine-statify.svelte.test.ts
@@ -7,10 +7,13 @@ const logicEngineStub = vi.hoisted(() => ({ time: 0 }));
 vi.mock('$lib/engine/engine', () => ({ logicEngine: logicEngineStub }));
 
 const rafCallbacks: (() => void)[] = [];
+// Monotonic, not `rafCallbacks.length`: the tests `shift()` callbacks off the front, which would hand
+// out the same handle twice (matching `render-engine.test.ts`, the other rAF stub).
+let rafHandleCounter = 0;
 vi.stubGlobal('window', {
 	requestAnimationFrame: vi.fn((cb: () => void) => {
 		rafCallbacks.push(cb);
-		return rafCallbacks.length;
+		return ++rafHandleCounter;
 	}),
 	cancelAnimationFrame: vi.fn(),
 	setInterval: (...args: Parameters<typeof setInterval>) => globalThis.setInterval(...args),
@@ -96,6 +99,7 @@ describe('engine internals under statify (#2123)', () => {
 
 		beforeEach(() => {
 			rafCallbacks.length = 0;
+			rafHandleCounter = 0;
 			logicEngineStub.time = 0;
 			performanceNow = 0;
 			vi.spyOn(performance, 'now').mockImplementation(() => performanceNow);


### PR DESCRIPTION
Closes #2462.

Frontend only — no backend, battle-logic, or content changes.

## What's in it

`LogicalEngine` and `RenderEngine` predate the #2123 convention (documented in `docs/frontend.md`) that non-reactive hot-path fields on a statify'd class use `#`-private, so their loop bookkeeping was a set of `$state` accessors with no subscriber.

- **`logical-engine.ts`** — `time`, `lastTime`, `timeBank`, plus the tick counter and tick-source handle are now `#`-private. `tickRate` stays public and reactive.
- **`render-engine.ts`** — same for `time`, `logicalDelta`, `running`, `rafHandle` and the frame counter.
- **`time` (and `logicalDelta`) are exposed as read-only getters** rather than dropped: the render loop reads `logicEngine.time` across the class boundary, and the existing suites assert on both. A class accessor lives on the prototype and is non-enumerable, so statify's `for...in` walk never sees it — the same `#`-field-behind-a-getter shape the statify regression test already pins.
- `RenderEngine.update` became a normal private method while it was being touched (it was an arrow-function field, invoked only as `this.update()`), matching `LogicalEngine`.

**Precisely what the proxy loses:** the seven number/boolean/object fields above. The two function-valued fields (`countTick`, and `update` on the render side) were never proxied — `statify` skips functions outright (`statify.svelte.ts:34-36`) — so converting them is a consistency call about where loop internals live, not a removed signal write.

Nothing outside the classes ever wrote any of these, so the getters cost no call site.

## The bonus fix, done slightly differently than the issue suggested

The issue flagged `resolveBossVictory`'s double sort — `nextZoneByOrder(navigableZones(...))`, where `nextZoneByOrder` re-sorts its already-sorted input. Deduping purely at the call site isn't possible (the retired filter is still needed), so the helper now does the filtering itself and is renamed **`nextNavigableZone`** to say so.

That's a small semantic change beyond the sort, and it's the reason I went this way: the old signature would happily return a **retired** zone if any caller passed an unfiltered list, and "the next zone to unlock" should never be one. It's the only caller, so the fix is contained; the ordering pass now happens once.

## Test plan

- **New `src/tests/lib/engine/engine-statify.svelte.test.ts`** — pins the split for both engines: `tickRate` has a statify-installed accessor, `time`/`logicalDelta` have no own descriptor, and behaviourally the clocks advance (real ticks / real frames) while a `$derived` reading them never re-runs, whereas a `tickRate` write does notify. Worth having as its own suite because a `#`-field silently promoted back to public would pass every other engine test unchanged.
- **`zone-progression.test.ts`** — renamed suite, plus two new cases for the folded-in semantics: a retired middle zone is skipped rather than returned, and a retired *current* zone yields `undefined`.
- `npm run lint` — clean (eslint + svelte-check: 1230 files, 0 errors, 0 warnings).
- `npm run test:unit:ci` — **313 files / 4059 tests passing**, coverage thresholds met.
- Backend build/tests not run: no C# files are touched.

## Review follow-ups

- The new suite's rAF stub now uses a monotonic handle counter instead of `rafCallbacks.length`, which repeated a handle once a test shifted a callback off the front.
- `RenderEngine`'s two getters carry a comment saying they are observability only — nothing in production reads them, unlike `LogicalEngine.time`, whose cross-class reader is `RenderEngine.update`. Kept rather than made `#`-only: the absolute-clock assertions can't be reconstructed from the `onRenderUpdate` payload (it carries deltas), and a prototype accessor costs nothing reactively.
- The third copy of the engine `window` stub is filed as #2489 rather than folded in — consolidating it edits two suites this PR doesn't otherwise touch.

## Note

This is a convention/consistency fix, as the issue says — the removed signal writes were cheap in absolute terms, so I'd not expect a measurable frame-time difference, and none is claimed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5zBMDeZe3EBP8yiL6tWpL)_