### PR TITLE
Consolidate the workbench EntityConfig test factories onto a shared builder (#2481)

### DIFF
--- a/UI/src/tests/fixtures/workbench-config.ts
+++ b/UI/src/tests/fixtures/workbench-config.ts
@@ -1,0 +1,38 @@
+import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+
+/* Shared `EntityConfig` test builder (#2481), following the `fixtures/items.ts` convention.
+
+   Unlike the other modules here, `EntityConfig` is an internal workbench contract rather than a
+   reference-data one, and its hand-rolled copies were all asserted `as unknown as EntityConfig<T>` —
+   so none of them saw a new required field. The double cast was load-bearing for exactly one reason:
+   the literals returned `persist: async () => []` instead of the `{ records, idMap }` shape. Spelling
+   that shape out is enough to drop both casts, so this builder is genuinely typed and a new required
+   member is one edit here rather than a dozen silent ones.
+
+   `newItem` is required rather than defaulted: it is the one member the builder cannot neutrally
+   default for an unknown `T` without casting a bare `{ id }` back to it — which would re-open the hole
+   this module closes. Every call site already states its blank record, so nothing is lost. */
+
+/**
+ * Builds an {@link EntityConfig} for workbench tests. The display fields default to neutral
+ * placeholders and the lifecycle members to no-ops, so a suite states only its blank record plus
+ * whatever it asserts on.
+ *
+ * State a value at the call site when the suite asserts on it (a `label` read back as the list header,
+ * a `blankName` rendered as the placeholder) even where it matches a default — the assertion should be
+ * readable next to the config it reads from.
+ */
+export const makeEntityConfig = <T extends Identified>(
+	overrides: Partial<EntityConfig<T>> & Pick<EntityConfig<T>, 'newItem'>
+): EntityConfig<T> => ({
+	key: 'rows',
+	label: 'Rows',
+	singular: 'Row',
+	glyph: 'box',
+	blankName: 'Unnamed',
+	meta: () => [],
+	sections: [],
+	refresh: async () => [],
+	persist: async () => ({ records: [], idMap: new Map() }),
+	...overrides
+});

--- a/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/ChipsSection.test.ts
@@ -5,7 +5,8 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 
 import ChipsSection from '$routes/admin/workbench/components/ChipsSection.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
-import type { ChipsSectionConfig, EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+import type { ChipsSectionConfig, Identified } from '$routes/admin/workbench/entities/types';
+import { makeEntityConfig } from '../../../fixtures/workbench-config';
 
 interface Row extends Identified {
 	skillPool: number[];
@@ -41,19 +42,7 @@ const section: ChipsSectionConfig<Row, SkillEntry> = {
 	addLabel: 'Add skill…'
 };
 
-const config = (): EntityConfig<Row> =>
-	({
-		key: 'rows',
-		label: 'Rows',
-		singular: 'Row',
-		glyph: 'box',
-		blankName: 'Unnamed',
-		newItem: (id: number) => ({ id, skillPool: [] }),
-		meta: () => [],
-		sections: [section],
-		refresh: async () => [],
-		persist: async () => []
-	}) as unknown as EntityConfig<Row>;
+const config = () => makeEntityConfig<Row>({ newItem: (id) => ({ id, skillPool: [] }), sections: [section] });
 
 const setup = (skillPool: number[]) => {
 	const store = new EntityStore(config(), [{ id: 1, skillPool }]);

--- a/UI/src/tests/routes/admin/workbench/FieldControl.test.ts
+++ b/UI/src/tests/routes/admin/workbench/FieldControl.test.ts
@@ -6,7 +6,8 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 
 import FieldControl from '$routes/admin/workbench/components/FieldControl.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
-import type { EntityConfig, FieldConfig, Identified } from '$routes/admin/workbench/entities/types';
+import type { FieldConfig, Identified } from '$routes/admin/workbench/entities/types';
+import { makeEntityConfig } from '../../../fixtures/workbench-config';
 
 interface Row extends Identified {
 	name: string;
@@ -16,19 +17,8 @@ interface Row extends Identified {
 	choice: number;
 }
 
-const config = (): EntityConfig<Row> =>
-	({
-		key: 'rows',
-		label: 'Rows',
-		singular: 'Row',
-		glyph: 'box',
-		blankName: 'Unnamed',
-		newItem: (id: number) => ({ id, name: '', count: 0, enabled: false, notes: '', choice: 1 }),
-		meta: () => [],
-		sections: [],
-		refresh: async () => [],
-		persist: async () => []
-	}) as unknown as EntityConfig<Row>;
+const config = () =>
+	makeEntityConfig<Row>({ newItem: (id) => ({ id, name: '', count: 0, enabled: false, notes: '', choice: 1 }) });
 
 const seed = (): Row[] => [{ id: 1, name: 'Alpha', count: 5, enabled: false, notes: 'hi', choice: 1 }];
 

--- a/UI/src/tests/routes/admin/workbench/SectionRenderer.test.ts
+++ b/UI/src/tests/routes/admin/workbench/SectionRenderer.test.ts
@@ -24,7 +24,8 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 
 import SectionRenderer from '$routes/admin/workbench/components/SectionRenderer.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
-import type { EntityConfig, Identified, SectionConfig } from '$routes/admin/workbench/entities/types';
+import type { Identified, SectionConfig } from '$routes/admin/workbench/entities/types';
+import { makeEntityConfig } from '../../../fixtures/workbench-config';
 
 // A record carrying every field the various section kinds read.
 const RECORD = {
@@ -41,19 +42,7 @@ const RECORD = {
 	progressGoal: 10
 };
 
-const config = (): EntityConfig<Identified> =>
-	({
-		key: 'rows',
-		label: 'Rows',
-		singular: 'Row',
-		glyph: 'box',
-		blankName: 'Unnamed',
-		newItem: (id: number) => ({ ...RECORD, id }),
-		meta: () => [],
-		sections: [],
-		refresh: async () => [],
-		persist: async () => []
-	}) as unknown as EntityConfig<Identified>;
+const config = () => makeEntityConfig<Identified>({ newItem: (id) => ({ ...RECORD, id }) });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const renderKind = (section: SectionConfig<any>) => {

--- a/UI/src/tests/routes/admin/workbench/SectionTable.test.ts
+++ b/UI/src/tests/routes/admin/workbench/SectionTable.test.ts
@@ -5,7 +5,8 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 
 import SectionTable from '$routes/admin/workbench/components/SectionTable.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
-import type { EntityConfig, Identified, TableSectionConfig } from '$routes/admin/workbench/entities/types';
+import type { Identified, TableSectionConfig } from '$routes/admin/workbench/entities/types';
+import { makeEntityConfig } from '../../../fixtures/workbench-config';
 
 interface Spawn {
 	zoneId: number;
@@ -39,19 +40,7 @@ const section: TableSectionConfig<Row> = {
 	]
 };
 
-const config = (): EntityConfig<Row> =>
-	({
-		key: 'rows',
-		label: 'Rows',
-		singular: 'Row',
-		glyph: 'box',
-		blankName: 'Unnamed',
-		newItem: (id: number) => ({ id, spawns: [] }),
-		meta: () => [],
-		sections: [section],
-		refresh: async () => [],
-		persist: async () => []
-	}) as unknown as EntityConfig<Row>;
+const config = () => makeEntityConfig<Row>({ newItem: (id) => ({ id, spawns: [] }), sections: [section] });
 
 const setup = (spawns: Spawn[]) => {
 	const store = new EntityStore(config(), [{ id: 1, spawns }]);
@@ -198,19 +187,8 @@ const effectSection: TableSectionConfig<EffectRow> = {
 };
 
 describe('SectionTable — surrogate-id collections', () => {
-	const config = (): EntityConfig<EffectRow> =>
-		({
-			key: 'rows',
-			label: 'Rows',
-			singular: 'Row',
-			glyph: 'box',
-			blankName: 'Unnamed',
-			newItem: (id: number) => ({ id, effects: [] }),
-			meta: () => [],
-			sections: [effectSection],
-			refresh: async () => [],
-			persist: async () => []
-		}) as unknown as EntityConfig<EffectRow>;
+	const config = () =>
+		makeEntityConfig<EffectRow>({ newItem: (id) => ({ id, effects: [] }), sections: [effectSection] });
 
 	it('assigns each new row a unique negative id so identities never collide', async () => {
 		const store = new EntityStore(config(), [{ id: 1, effects: [] }]);
@@ -265,19 +243,7 @@ const stepSection: TableSectionConfig<StepRow> = {
 };
 
 describe('SectionTable — editable-identity (rowKey) collections', () => {
-	const config = (): EntityConfig<StepRow> =>
-		({
-			key: 'rows',
-			label: 'Rows',
-			singular: 'Row',
-			glyph: 'box',
-			blankName: 'Unnamed',
-			newItem: (id: number) => ({ id, steps: [] }),
-			meta: () => [],
-			sections: [stepSection],
-			refresh: async () => [],
-			persist: async () => []
-		}) as unknown as EntityConfig<StepRow>;
+	const config = () => makeEntityConfig<StepRow>({ newItem: (id) => ({ id, steps: [] }), sections: [stepSection] });
 
 	it('swaps identities instead of duplicating them when an edit collides with a sibling row', async () => {
 		const store = new EntityStore(config(), [

--- a/UI/src/tests/routes/admin/workbench/TagsSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/TagsSection.test.ts
@@ -21,7 +21,8 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 
 import TagsSection from '$routes/admin/workbench/components/TagsSection.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
-import type { EntityConfig, Identified, TagsSectionConfig } from '$routes/admin/workbench/entities/types';
+import type { Identified, TagsSectionConfig } from '$routes/admin/workbench/entities/types';
+import { makeEntityConfig } from '../../../fixtures/workbench-config';
 
 interface Row extends Identified {
 	tags: number[];
@@ -40,19 +41,7 @@ const section: TagsSectionConfig<Row> = {
 	itemsKey: 'tags'
 };
 
-const config = (): EntityConfig<Row> =>
-	({
-		key: 'rows',
-		label: 'Rows',
-		singular: 'Row',
-		glyph: 'box',
-		blankName: 'Unnamed',
-		newItem: (id: number) => ({ id, tags: [] }),
-		meta: () => [],
-		sections: [section],
-		refresh: async () => [],
-		persist: async () => []
-	}) as unknown as EntityConfig<Row>;
+const config = () => makeEntityConfig<Row>({ newItem: (id) => ({ id, tags: [] }), sections: [section] });
 
 const setup = (tags: number[]) => {
 	const store = new EntityStore(config(), [{ id: 1, tags }]);

--- a/UI/src/tests/routes/admin/workbench/Workbench.test.ts
+++ b/UI/src/tests/routes/admin/workbench/Workbench.test.ts
@@ -21,33 +21,30 @@ vi.mock('$stores', () => ({
 import Workbench from '$routes/admin/workbench/Workbench.svelte';
 import { workbenchDirty } from '$routes/admin/workbench/dirty.svelte';
 import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+import { makeEntityConfig } from '../../../fixtures/workbench-config';
 
 const seed: Identified[] = [
 	{ id: 1, name: 'Alpha' },
 	{ id: 2, name: 'Beta' }
 ];
 
-const makeConfig = (overrides: Partial<EntityConfig<Identified>> = {}): EntityConfig<Identified> => ({
-	key: 'rows',
-	label: 'Enemies',
-	singular: 'Enemy',
-	glyph: 'box',
-	blankName: 'Unnamed',
-	newItem: (id) => ({ id, name: '' }),
-	meta: () => [],
-	sections: [
-		{
-			key: 'identity',
-			label: 'Identity',
-			glyph: 'box',
-			kind: 'fields',
-			fields: [{ key: 'name', label: 'Name', type: 'text' }]
-		}
-	],
-	refresh: async () => seed,
-	persist: async () => ({ records: [], idMap: new Map() }),
-	...overrides
-});
+const makeConfig = (overrides: Partial<EntityConfig<Identified>> = {}) =>
+	makeEntityConfig<Identified>({
+		label: 'Enemies',
+		singular: 'Enemy',
+		newItem: (id) => ({ id, name: '' }),
+		sections: [
+			{
+				key: 'identity',
+				label: 'Identity',
+				glyph: 'box',
+				kind: 'fields',
+				fields: [{ key: 'name', label: 'Name', type: 'text' }]
+			}
+		],
+		refresh: async () => seed,
+		...overrides
+	});
 
 afterEach(cleanup);
 

--- a/UI/src/tests/routes/admin/workbench/WorkbenchDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/WorkbenchDetail.test.ts
@@ -20,22 +20,24 @@ vi.mock('$stores', () => ({ staticData, toastError: vi.fn(), dangerModal }));
 
 import WorkbenchDetail from '$routes/admin/workbench/components/WorkbenchDetail.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
-import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+import type { Identified } from '$routes/admin/workbench/entities/types';
+import { makeEntityConfig } from '../../../fixtures/workbench-config';
 
+/* The extra field is optional so `Row` stays interchangeable with the bare `Identified` the detail
+   pane and store are typed against — a required one would make a `Row`-typed config invariant against
+   them (through `listBadge`) and force a cast back at every render site. */
 interface Row extends Identified {
-	value: number;
+	value?: number;
 }
 
-const makeConfig = (retireable = false, key = 'rows'): EntityConfig<Identified> =>
-	({
+const makeConfig = (retireable = false, key = 'rows') =>
+	makeEntityConfig<Row>({
 		key,
+		// The empty-state copy ("No skills left" / "New Skill") is derived from these, and asserted below.
 		label: 'Skills',
 		singular: 'Skill',
-		glyph: 'box',
-		blankName: 'Unnamed',
 		retireable,
-		newItem: (id: number) => ({ id, name: '', value: 0 }),
-		meta: () => [],
+		newItem: (id) => ({ id, name: '', value: 0 }),
 		sections: [
 			{
 				key: 'identity',
@@ -48,10 +50,8 @@ const makeConfig = (retireable = false, key = 'rows'): EntityConfig<Identified> 
 				]
 			}
 		],
-		listBadge: (rec: Row) => rec.name ?? null,
-		refresh: async () => [],
-		persist: async () => []
-	}) as unknown as EntityConfig<Identified>;
+		listBadge: (rec) => rec.name ?? null
+	});
 
 const seed: Row[] = [{ id: 1, name: 'Fireball', value: 50 }];
 
@@ -190,7 +190,7 @@ describe('WorkbenchDetail — with a record', () => {
 });
 
 describe('WorkbenchDetail — retire lifecycle', () => {
-	const renderWith = (s: EntityStore<Identified>, rec: Identified) =>
+	const renderWith = (s: EntityStore<Row>, rec: Row) =>
 		render(WorkbenchDetail, {
 			props: {
 				entity: makeConfig(true),
@@ -242,7 +242,7 @@ describe('WorkbenchDetail — retire lifecycle', () => {
 });
 
 describe('WorkbenchDetail — retire confirm dialog', () => {
-	const renderEnemy = (s: EntityStore<Identified>, rec: Identified) =>
+	const renderEnemy = (s: EntityStore<Row>, rec: Row) =>
 		render(WorkbenchDetail, {
 			props: {
 				entity: makeConfig(true, 'enemies'),
@@ -303,7 +303,7 @@ describe('WorkbenchDetail — retire confirm dialog', () => {
 });
 
 describe('WorkbenchDetail — delete confirm dialog (tags)', () => {
-	const renderTag = (s: EntityStore<Identified>, rec: Identified) =>
+	const renderTag = (s: EntityStore<Row>, rec: Row) =>
 		render(WorkbenchDetail, {
 			props: {
 				entity: makeConfig(false, 'tags'),

--- a/UI/src/tests/routes/admin/workbench/WorkbenchDetail.test.ts
+++ b/UI/src/tests/routes/admin/workbench/WorkbenchDetail.test.ts
@@ -23,9 +23,12 @@ import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
 import type { Identified } from '$routes/admin/workbench/entities/types';
 import { makeEntityConfig } from '../../../fixtures/workbench-config';
 
-/* The extra field is optional so `Row` stays interchangeable with the bare `Identified` the detail
-   pane and store are typed against — a required one would make a `Row`-typed config invariant against
-   them (through `listBadge`) and force a cast back at every render site. */
+/* The extra field is optional so `Row` stays interchangeable with the bare `Identified` the detail pane
+   and store are typed against. `EntityConfig<T>` puts `T` in contravariant positions — `listBadge`'s
+   parameter and every `FieldConfig.key` (`keyof T & string`) — so widening a `Row` config to an
+   `Identified` one needs `Identified` assignable to `Row`, which holds only while `value` is optional.
+   A required one fails (the compiler names `listBadge`, the first such member it reaches) and would
+   force a cast back at every render site, which is what production's `asEntity` does. */
 interface Row extends Identified {
 	value?: number;
 }

--- a/UI/src/tests/routes/admin/workbench/WorkbenchList.test.ts
+++ b/UI/src/tests/routes/admin/workbench/WorkbenchList.test.ts
@@ -22,20 +22,18 @@ vi.mock('$stores', () => ({
 import WorkbenchList from '$routes/admin/workbench/components/WorkbenchList.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
 import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+import { makeEntityConfig } from '../../../fixtures/workbench-config';
 
-const makeConfig = (retireable = false): EntityConfig<Identified> => ({
-	key: 'rows',
-	label: 'Enemies',
-	singular: 'Enemy',
-	glyph: 'box',
-	blankName: 'Unnamed',
-	retireable,
-	newItem: (id) => ({ id, name: '' }),
-	meta: () => [],
-	sections: [],
-	refresh: async () => [],
-	persist: async () => ({ records: [], idMap: new Map() })
-});
+const makeConfig = (retireable = false) =>
+	makeEntityConfig<Identified>({
+		// Both are read back by assertions below: the label as the list header, blankName as the
+		// placeholder a nameless row falls back to.
+		label: 'Enemies',
+		blankName: 'Unnamed',
+		singular: 'Enemy',
+		retireable,
+		newItem: (id) => ({ id, name: '' })
+	});
 
 const seed: Identified[] = [
 	{ id: 1, name: 'Goblin' },

--- a/UI/src/tests/routes/admin/workbench/challenge/ChallengeConditionSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ChallengeConditionSection.test.ts
@@ -18,8 +18,9 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 
 import ChallengeConditionSection from '$routes/admin/workbench/components/challenge/ChallengeConditionSection.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
-import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+import type { Identified } from '$routes/admin/workbench/entities/types';
 import { makeChallenge } from '../../../../fixtures/challenges';
+import { makeEntityConfig } from '../../../../fixtures/workbench-config';
 
 const CHALLENGE_TYPES = [
 	{
@@ -31,19 +32,13 @@ const CHALLENGE_TYPES = [
 	{ id: EChallengeType.LevelReached, name: 'Level Reached', goalComparison: 1, statisticType: null }
 ];
 
-const config = (): EntityConfig<Identified> =>
-	({
+const config = () =>
+	makeEntityConfig<Identified>({
 		key: 'challenges',
 		label: 'Challenges',
 		singular: 'Challenge',
-		glyph: 'box',
-		blankName: 'Unnamed',
-		newItem: (id: number) => ({ id }),
-		meta: () => [],
-		sections: [],
-		refresh: async () => [],
-		persist: async () => []
-	}) as unknown as EntityConfig<Identified>;
+		newItem: (id) => ({ id })
+	});
 
 const setup = (over: Partial<IChallenge> = {}) => {
 	/* The condition dimension is stated in full rather than inherited: the suite asserts these four fields

--- a/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ChallengeRewardSection.test.ts
@@ -31,22 +31,17 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 
 import ChallengeRewardSection from '$routes/admin/workbench/components/challenge/ChallengeRewardSection.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
-import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+import type { Identified } from '$routes/admin/workbench/entities/types';
 import { makeChallenge } from '../../../../fixtures/challenges';
+import { makeEntityConfig } from '../../../../fixtures/workbench-config';
 
-const config = (): EntityConfig<Identified> =>
-	({
+const config = () =>
+	makeEntityConfig<Identified>({
 		key: 'challenges',
 		label: 'Challenges',
 		singular: 'Challenge',
-		glyph: 'box',
-		blankName: 'Unnamed',
-		newItem: (id: number) => ({ id }),
-		meta: () => [],
-		sections: [],
-		refresh: async () => [],
-		persist: async () => []
-	}) as unknown as EntityConfig<Identified>;
+		newItem: (id) => ({ id })
+	});
 
 const setup = (over: Partial<IChallenge> = {}) => {
 	const challenge = makeChallenge({ id: 1, name: 'Test', ...over });

--- a/UI/src/tests/routes/admin/workbench/challenge/GoalField.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/GoalField.test.ts
@@ -12,22 +12,17 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 
 import GoalField from '$routes/admin/workbench/components/challenge/GoalField.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
-import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+import type { Identified } from '$routes/admin/workbench/entities/types';
 import { makeChallenge } from '../../../../fixtures/challenges';
+import { makeEntityConfig } from '../../../../fixtures/workbench-config';
 
-const config = (): EntityConfig<Identified> =>
-	({
+const config = () =>
+	makeEntityConfig<Identified>({
 		key: 'challenges',
 		label: 'Challenges',
 		singular: 'Challenge',
-		glyph: 'box',
-		blankName: 'Unnamed',
-		newItem: (id: number) => ({ id }),
-		meta: () => [],
-		sections: [],
-		refresh: async () => [],
-		persist: async () => []
-	}) as unknown as EntityConfig<Identified>;
+		newItem: (id) => ({ id })
+	});
 
 const setup = (over: Partial<IChallenge>) => {
 	/* The type is stated rather than inherited: it selects the goal comparison and unit under test. */

--- a/UI/src/tests/routes/admin/workbench/challenge/ScopeField.test.ts
+++ b/UI/src/tests/routes/admin/workbench/challenge/ScopeField.test.ts
@@ -17,22 +17,17 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 
 import ScopeField from '$routes/admin/workbench/components/challenge/ScopeField.svelte';
 import { EntityStore } from '$routes/admin/workbench/entity-store.svelte';
-import type { EntityConfig, Identified } from '$routes/admin/workbench/entities/types';
+import type { Identified } from '$routes/admin/workbench/entities/types';
 import { makeChallenge } from '../../../../fixtures/challenges';
+import { makeEntityConfig } from '../../../../fixtures/workbench-config';
 
-const config = (): EntityConfig<Identified> =>
-	({
+const config = () =>
+	makeEntityConfig<Identified>({
 		key: 'challenges',
 		label: 'Challenges',
 		singular: 'Challenge',
-		glyph: 'box',
-		blankName: 'Unnamed',
-		newItem: (id: number) => ({ id }),
-		meta: () => [],
-		sections: [],
-		refresh: async () => [],
-		persist: async () => []
-	}) as unknown as EntityConfig<Identified>;
+		newItem: (id) => ({ id })
+	});
 
 const setup = (over: Partial<IChallenge>) => {
 	/* The type and entity dimension are stated rather than inherited: every case here turns on the scope

--- a/UI/src/tests/routes/admin/workbench/entity-store.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entity-store.test.ts
@@ -5,6 +5,7 @@ vi.mock('$stores', () => ({ toastError: vi.fn() }));
 import { EntityStore } from '../../../../routes/admin/workbench/entity-store.svelte';
 import { PersistFailedError } from '../../../../routes/admin/workbench/save-helpers';
 import type { EntityConfig, Identified, SaveDiff } from '../../../../routes/admin/workbench/entities/types';
+import { makeEntityConfig } from '../../../fixtures/workbench-config';
 
 interface Row extends Identified {
 	id: number;
@@ -18,18 +19,7 @@ const persistResult = (records: Row[], idMap = new Map<number, number>()) => ({ 
 const makeConfig = (
 	persist: (diff: SaveDiff<Row>) => Promise<{ records: Row[]; idMap: Map<number, number> }> = async () =>
 		persistResult([])
-): EntityConfig<Row> => ({
-	key: 'rows',
-	label: 'Rows',
-	singular: 'Row',
-	glyph: 'box',
-	blankName: 'Unnamed',
-	newItem: (id) => ({ id, name: '', value: 0 }),
-	meta: () => [],
-	sections: [],
-	refresh: async () => [],
-	persist
-});
+) => makeEntityConfig<Row>({ newItem: (id) => ({ id, name: '', value: 0 }), persist });
 
 const seed: Row[] = [
 	{ id: 0, name: 'Alpha', value: 1 },

--- a/UI/src/tests/routes/admin/workbench/validation.test.ts
+++ b/UI/src/tests/routes/admin/workbench/validation.test.ts
@@ -6,7 +6,8 @@ import {
 	sectionBlockingWarning,
 	sectionWarnings
 } from '../../../../routes/admin/workbench/validation';
-import type { EntityConfig, FieldConfig, Identified } from '../../../../routes/admin/workbench/entities/types';
+import type { FieldConfig, Identified, SectionConfig } from '../../../../routes/admin/workbench/entities/types';
+import { makeEntityConfig } from '../../../fixtures/workbench-config';
 
 interface Thing extends Identified {
 	id: number;
@@ -40,19 +41,22 @@ describe('fieldWarn', () => {
 	});
 });
 
-const entity = {
+/* Only the fields/non-fields split matters to these helpers — a `fields` section warns per required
+   field, everything else warns solely through its `warn` predicate — so the non-field sections here are
+   the `usage` kind, which carries a `warn` without a table's row plumbing. */
+const entity = makeEntityConfig<Thing>({
+	newItem: (id) => ({ id, name: '', icon: '', rows: [] }),
 	sections: [
 		{ key: 'identity', label: 'Identity', glyph: 'tag', kind: 'fields', fields: [nameField, iconField] },
 		{
 			key: 'rows',
 			label: 'Rows',
 			glyph: 'bars',
-			kind: 'table',
-			itemsKey: 'rows',
-			warn: (t: Thing) => (t.rows.length ? null : 'No rows')
+			kind: 'usage',
+			warn: (t) => (t.rows.length ? null : 'No rows')
 		}
 	]
-} as unknown as EntityConfig<Thing>;
+});
 
 describe('sectionWarnings', () => {
 	it('collects each failing required field in a fields section', () => {
@@ -66,14 +70,14 @@ describe('sectionWarnings', () => {
 	});
 
 	it('also surfaces a fields section warn (a cross-field rule), after its field warns', () => {
-		const section = {
+		const section: SectionConfig<Thing> = {
 			key: 'identity',
 			label: 'Identity',
 			glyph: 'tag',
 			kind: 'fields',
 			fields: [nameField],
-			warn: (t: Thing) => (t.icon ? null : 'No icon set')
-		} as unknown as EntityConfig<Thing>['sections'][number];
+			warn: (t) => (t.icon ? null : 'No icon set')
+		};
 		// Both the failing required field and the section warn surface, field warns first.
 		expect(sectionWarnings(section, { id: 1, name: '', icon: '', rows: [] })).toEqual(['Missing name', 'No icon set']);
 		// Section warn alone when the required field passes.
@@ -83,17 +87,15 @@ describe('sectionWarnings', () => {
 	});
 
 	it('passes the baseline through to the warn predicate', () => {
-		const section = {
+		const section: SectionConfig<Thing> = {
 			key: 'rows',
 			label: 'Rows',
 			glyph: 'bars',
-			kind: 'table',
-			itemsKey: 'rows',
+			kind: 'usage',
 			// Mirrors zone.ts's isHome gap: the pending record alone can't tell whether this is a
 			// same-save clear, only comparing against the persisted baseline can.
-			warn: (t: Thing, baseline: Thing | undefined) =>
-				!t.rows.length && baseline?.rows.length ? 'Cleared this save' : null
-		} as unknown as EntityConfig<Thing>['sections'][number];
+			warn: (t, baseline) => (!t.rows.length && baseline?.rows.length ? 'Cleared this save' : null)
+		};
 		const rec = { id: 1, name: 'x', icon: 'x', rows: [] };
 		expect(sectionWarnings(section, rec)).toEqual([]);
 		expect(sectionWarnings(section, rec, { id: 1, name: 'x', icon: 'x', rows: [] })).toEqual([]);
@@ -116,23 +118,21 @@ describe('entityWarnings', () => {
 });
 
 describe('sectionBlockingWarning', () => {
-	const blockingSection = {
+	const blockingSection: SectionConfig<Thing> = {
 		key: 'rows',
 		label: 'Rows',
 		glyph: 'bars',
-		kind: 'table',
-		itemsKey: 'rows',
-		warn: (t: Thing) => (t.rows.length ? null : { message: 'No rows', blocking: true })
-	} as unknown as EntityConfig<Thing>['sections'][number];
+		kind: 'usage',
+		warn: (t) => (t.rows.length ? null : { message: 'No rows', blocking: true })
+	};
 
-	const advisorySection = {
+	const advisorySection: SectionConfig<Thing> = {
 		key: 'rows',
 		label: 'Rows',
 		glyph: 'bars',
-		kind: 'table',
-		itemsKey: 'rows',
-		warn: (t: Thing) => (t.rows.length ? null : 'No rows')
-	} as unknown as EntityConfig<Thing>['sections'][number];
+		kind: 'usage',
+		warn: (t) => (t.rows.length ? null : 'No rows')
+	};
 
 	it('returns the message when the warn is flagged blocking', () => {
 		expect(sectionBlockingWarning(blockingSection, { id: 1, name: 'x', icon: 'x', rows: [] })).toBe('No rows');
@@ -147,32 +147,32 @@ describe('sectionBlockingWarning', () => {
 	});
 
 	it('a fields section warn can also be flagged blocking, independent of its required-field warnings', () => {
-		const section = {
+		const section: SectionConfig<Thing> = {
 			key: 'identity',
 			label: 'Identity',
 			glyph: 'tag',
 			kind: 'fields',
 			fields: [nameField],
-			warn: (t: Thing) => (t.icon ? null : { message: 'No icon set', blocking: true })
-		} as unknown as EntityConfig<Thing>['sections'][number];
+			warn: (t) => (t.icon ? null : { message: 'No icon set', blocking: true })
+		};
 		expect(sectionBlockingWarning(section, { id: 1, name: '', icon: '', rows: [] })).toBe('No icon set');
 	});
 });
 
 describe('entityBlockingWarnings', () => {
-	const mixedEntity = {
+	const mixedEntity = makeEntityConfig<Thing>({
+		newItem: (id) => ({ id, name: '', icon: '', rows: [] }),
 		sections: [
 			{ key: 'identity', label: 'Identity', glyph: 'tag', kind: 'fields', fields: [nameField, iconField] },
 			{
 				key: 'rows',
 				label: 'Rows',
 				glyph: 'bars',
-				kind: 'table',
-				itemsKey: 'rows',
-				warn: (t: Thing) => (t.rows.length ? null : { message: 'No rows', blocking: true })
+				kind: 'usage',
+				warn: (t) => (t.rows.length ? null : { message: 'No rows', blocking: true })
 			}
 		]
-	} as unknown as EntityConfig<Thing>;
+	});
 
 	it('only collects the blocking warnings, skipping required-field (always advisory) warnings', () => {
 		expect(entityBlockingWarnings(mixedEntity, { id: 1, name: '', icon: '', rows: [] })).toEqual(['No rows']);

--- a/UI/src/tests/routes/admin/workbench/validation.test.ts
+++ b/UI/src/tests/routes/admin/workbench/validation.test.ts
@@ -91,6 +91,7 @@ describe('sectionWarnings', () => {
 			key: 'rows',
 			label: 'Rows',
 			glyph: 'bars',
+			// `usage` rather than the `table` its production counterpart uses — see the note above.
 			kind: 'usage',
 			// Mirrors zone.ts's isHome gap: the pending record alone can't tell whether this is a
 			// same-save clear, only comparing against the persisted baseline can.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -22,7 +22,7 @@ All frontend code lives in `UI`:
 
 Unit-test all UI logic (pages/components) and lib code; simple non-interactive display components don't need tests. Place tests under `tests` mirroring the source structure. Use Playwright e2e tests only for critical user flows, written from the user's perspective — they're costly to write and run.
 
-Shared contract builders for reference-data types (`IAttribute`, `IProficiency`, `ISkill`, …) live in `UI/src/tests/fixtures/`, one module per contract exporting a `make<Contract>(overrides)` with neutral defaults. Build on those rather than hand-rolling a contract literal per suite, so a new required field is one edit instead of dozens; where a suite needs different defaults, wrap the shared builder and state only the divergence.
+Shared contract builders live in `UI/src/tests/fixtures/`, one module per contract exporting a `make<Contract>(overrides)` with neutral defaults — for reference-data types (`IAttribute`, `IProficiency`, `ISkill`, …) and for internal contracts a suite has to construct wholesale (the workbench's `EntityConfig`). Build on those rather than hand-rolling a contract literal per suite, so a new required field is one edit instead of dozens; where a suite needs different defaults, wrap the shared builder and state only the divergence.
 
 A test that reads committed content directly (e.g. asserting `content/lessons.json` only references real frontend keys) imports it via the `$content` alias (`kit.alias` in `svelte.config.js`, pointing at the repo-root `content/` folder) rather than a deep relative path out of the `UI/` package root.
 


### PR DESCRIPTION
Closes #2481.

Test-only. No production code, no behaviour change.

## What the cast was actually hiding

The issue lists six suites; the throwaway-required-field probe it asks for finds **nine factories across ten suites**, all asserted `as unknown as EntityConfig<T>` — `ChipsSection`, `FieldControl`, `TagsSection`, `SectionTable` (×3), and `validation.test.ts` were missing from the list, and `validation.test.ts` additionally casts five standalone section literals.

The double cast turned out to be load-bearing for exactly **one** reason: every literal returned `persist: async () => []` instead of the contract's `{ records, idMap }` shape. Nothing else in them was unsatisfiable. Spelling that shape out once in the fixture drops both casts, so `fixtures/workbench-config.ts` lands **fully typed** — the issue's preferred outcome rather than its fallback.

## `newItem` is required, not defaulted

It is the one member a builder can't neutrally default for an unknown `T` without casting a bare `{ id }` back to it — which is the same hole, relocated. Requiring it costs nothing: every call site already stated its blank record, and it keeps the module cast-free.

## Also folded in

- **The three already-typed factories** (`Workbench`, `WorkbenchList`, `entity-store`). They paid the drift tax correctly but duplicated the same body; they're the same class of duplication the `fixtures/` series exists to remove.
- **`validation.test.ts`.** Its two `EntityConfig<Thing>` carriers and five section literals were all casts. The non-field sections become `usage` rather than `table`: the validation helpers only branch on `kind === 'fields'`, so `usage` — which carries a `warn` without a table's `rowKey`/`columns`/`newRow` plumbing — types cleanly, where a genuine `TableSectionConfig` would have meant seven unused members per site purely to satisfy the compiler.

## One judgement call worth a look

`WorkbenchDetail.test.ts`'s local `Row` gains an optional `value?: number` (was required). With a required extra field, a `Row`-typed config is **invariant** against the `Identified`-typed detail pane and store through `listBadge`'s parameter, which would have forced a cast back at all ten render sites — trading one hole for ten. Making the field optional keeps `Row` interchangeable with `Identified` and the suite cast-free; the reasoning is stated in-place. Nothing in the suite asserts on `value`.

## Test plan

- `npx svelte-check` — 1231 files, **0 errors, 0 warnings**.
- `npm run test:unit:ci` — **4059 passed, 0 failed** (workbench suites alone: 54 files / 743 tests).
- `npx eslint .` clean; prettier clean.
- **Drift probe:** a throwaway required member added to `EntityConfig` now surfaces at `fixtures/workbench-config.ts` plus the ten production entity configs (`entities/*.ts`, the authoritative shapes) — and **nowhere else**. Before this change none of the converted suites would have reported it.

`docs/frontend.md`'s fixture line said the builders are for reference-data types; it now also covers an internal contract a suite constructs wholesale, so that sentence was widened to stay true. The general contract-drift prose is deliberately untouched — that's #2482's job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrpquteUCnHyb1rxdPVaRt)_