### PR TITLE
Guard the remaining single-row write-behind handlers with PlayerWriteWatermark (#2496)

### DIFF
--- a/Game.Application.Tests/DataAccess/PlayerUpdateHandlerIdempotencyIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerUpdateHandlerIdempotencyIntegrationTests.cs
@@ -732,8 +732,9 @@ namespace Game.Application.Tests.DataAccess
         public async Task LessonRead_AppliedConcurrently_InsertsOneRowWithoutThrowing()
         {
             // No PlayerLesson row exists yet, so every concurrent apply's absolute-update misses and falls
-            // through to insert; only one insert wins and the rest hit the unique-violation catch, clear their
-            // tracker, and re-run the absolute update against the now-existing row.
+            // through to insert; only one insert wins and the rest are restarted by the guard, which clears the
+            // tracker and re-runs the attempt so the absolute update finds the now-existing row. These applies
+            // are unsequenced, so they bypass the watermark comparison and race exactly as they did before it.
             var playerId = await SeedPlayerAsync();
             var lessonId = await SeedLessonAsync();
             var unlockedAt = new DateTime(2026, 7, 16, 8, 0, 0, DateTimeKind.Utc);

--- a/Game.Application.Tests/DataAccess/PlayerWriteWatermarkIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerWriteWatermarkIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Game.Core;
 using Game.Core.Players.Events;
 using Game.DataAccess;
@@ -15,7 +16,7 @@ namespace Game.Application.Tests.DataAccess
 {
     /// <summary>
     /// Verifies the <see cref="PlayerWriteWatermark"/> guard on the absolute-value write-behind handlers
-    /// (#2474): a write older than what its target already holds is skipped instead of durably regressing the
+    /// (#2474, #2496): a write older than what its target already holds is skipped instead of durably regressing the
     /// row, equal sequences still apply, and an unsequenced envelope bypasses the comparison entirely. Each
     /// apply runs through its own DI scope (its own <see cref="GameContext"/>), mirroring the synchronizer's
     /// per-event scope, with the envelope's sequence published onto the scope the way the dispatcher does.
@@ -25,6 +26,9 @@ namespace Game.Application.Tests.DataAccess
     {
         // TestDataSeeder.CreatePlayerAsync's default, asserted where a rolled-back apply must leave the row as seeded.
         private const int SeededLevel = 5;
+
+        // Fixed so a lesson's ReadAt is asserted as an offset from a known instant rather than from "now".
+        private static readonly DateTime LessonUnlockedAt = new(2026, 7, 16, 8, 0, 0, DateTimeKind.Utc);
 
         public PlayerWriteWatermarkIntegrationTests(IntegrationTestContainers containers, ITestOutputHelper testOutputHelper)
             : base(containers, testOutputHelper) { }
@@ -270,6 +274,341 @@ namespace Game.Application.Tests.DataAccess
             Assert.Equal(4, await ReadWatermarkAsync(playerId, PlayerWriteStream.Progress, target));
         }
 
+        [Fact]
+        public async Task AttributeAllocationsChanged_OlderSequenceAfterNewer_IsSkippedAndLeavesTheWatermark()
+        {
+            var playerId = await SeedPlayerAsync();
+
+            await ApplyAsync(AllocationEvent(playerId, strength: 20d), sequence: 2);
+            var rejected = await ApplyAsync(AllocationEvent(playerId, strength: 5d), sequence: 1);
+
+            // The consequential one: a stale apply reverts spent stat points while the player row's
+            // StatPointsUsed may already hold the newer value, leaving the two disagreeing.
+            Assert.Equal(1, rejected);
+            Assert.Equal(20m, await ReadAllocationAsync(playerId, EAttribute.Strength));
+            Assert.Equal(2, await ReadWatermarkAsync(playerId, PlayerWriteStream.AttributeAllocations, PlayerWriteWatermarkGuard.PlayerScopedTarget));
+        }
+
+        [Fact]
+        public async Task AttributeAllocationsChanged_EqualSequence_Applies()
+        {
+            var playerId = await SeedPlayerAsync();
+
+            await ApplyAsync(AllocationEvent(playerId, strength: 20d), sequence: 3);
+            var rejected = await ApplyAsync(AllocationEvent(playerId, strength: 21d), sequence: 3);
+
+            Assert.Equal(0, rejected);
+            Assert.Equal(21m, await ReadAllocationAsync(playerId, EAttribute.Strength));
+        }
+
+        [Fact]
+        public async Task AttributeAllocationsChanged_NewerSequence_AppliesAndAdvancesTheWatermark()
+        {
+            var playerId = await SeedPlayerAsync();
+
+            await ApplyAsync(AllocationEvent(playerId, strength: 5d), sequence: 1);
+            var rejected = await ApplyAsync(AllocationEvent(playerId, strength: 20d), sequence: 2);
+
+            Assert.Equal(0, rejected);
+            Assert.Equal(20m, await ReadAllocationAsync(playerId, EAttribute.Strength));
+            Assert.Equal(2, await ReadWatermarkAsync(playerId, PlayerWriteStream.AttributeAllocations, PlayerWriteWatermarkGuard.PlayerScopedTarget));
+        }
+
+        [Fact]
+        public async Task AttributeAllocationsChanged_UnsequencedEvent_AppliesAgainstAnAdvancedWatermarkAndLeavesItUnchanged()
+        {
+            var playerId = await SeedPlayerAsync();
+
+            await ApplyAsync(AllocationEvent(playerId, strength: 20d), sequence: 5);
+            var rejected = await ApplyAsync(AllocationEvent(playerId, strength: 3d), sequence: DomainEventEnvelope.Unsequenced);
+
+            Assert.Equal(0, rejected);
+            Assert.Equal(3m, await ReadAllocationAsync(playerId, EAttribute.Strength));
+            Assert.Equal(5, await ReadWatermarkAsync(playerId, PlayerWriteStream.AttributeAllocations, PlayerWriteWatermarkGuard.PlayerScopedTarget));
+        }
+
+        [Fact]
+        public async Task SelectedSkillsChanged_OlderSequenceAfterNewer_IsSkippedAndLeavesTheWatermark()
+        {
+            var playerId = await SeedPlayerAsync();
+            var firstSkillId = await SeedSkillAsync();
+            var secondSkillId = await SeedSkillAsync();
+
+            await ApplyAsync(new SelectedSkillsChangedEvent(playerId, [secondSkillId]), sequence: 2);
+            var rejected = await ApplyAsync(new SelectedSkillsChangedEvent(playerId, [firstSkillId]), sequence: 1);
+
+            // The whole loadout is one target: applying the older rebuild would restore a loadout the player
+            // has already replaced, deselecting the skill the newer event equipped.
+            Assert.Equal(1, rejected);
+            Assert.Equal([secondSkillId], await ReadSelectedSkillIdsAsync(playerId));
+            Assert.Equal(2, await ReadWatermarkAsync(playerId, PlayerWriteStream.SelectedSkills, PlayerWriteWatermarkGuard.PlayerScopedTarget));
+        }
+
+        [Fact]
+        public async Task SelectedSkillsChanged_EqualSequence_Applies()
+        {
+            var playerId = await SeedPlayerAsync();
+            var firstSkillId = await SeedSkillAsync();
+            var secondSkillId = await SeedSkillAsync();
+
+            await ApplyAsync(new SelectedSkillsChangedEvent(playerId, [firstSkillId]), sequence: 3);
+            var rejected = await ApplyAsync(new SelectedSkillsChangedEvent(playerId, [firstSkillId, secondSkillId]), sequence: 3);
+
+            Assert.Equal(0, rejected);
+            Assert.Equal([firstSkillId, secondSkillId], await ReadSelectedSkillIdsAsync(playerId));
+        }
+
+        [Fact]
+        public async Task SelectedSkillsChanged_NewerSequence_AppliesAndAdvancesTheWatermark()
+        {
+            var playerId = await SeedPlayerAsync();
+            var firstSkillId = await SeedSkillAsync();
+            var secondSkillId = await SeedSkillAsync();
+
+            await ApplyAsync(new SelectedSkillsChangedEvent(playerId, [firstSkillId]), sequence: 1);
+            var rejected = await ApplyAsync(new SelectedSkillsChangedEvent(playerId, [secondSkillId]), sequence: 2);
+
+            Assert.Equal(0, rejected);
+            Assert.Equal([secondSkillId], await ReadSelectedSkillIdsAsync(playerId));
+            Assert.Equal(2, await ReadWatermarkAsync(playerId, PlayerWriteStream.SelectedSkills, PlayerWriteWatermarkGuard.PlayerScopedTarget));
+        }
+
+        [Fact]
+        public async Task SelectedSkillsChanged_UnsequencedEvent_AppliesAgainstAnAdvancedWatermarkAndLeavesItUnchanged()
+        {
+            var playerId = await SeedPlayerAsync();
+            var firstSkillId = await SeedSkillAsync();
+            var secondSkillId = await SeedSkillAsync();
+
+            await ApplyAsync(new SelectedSkillsChangedEvent(playerId, [secondSkillId]), sequence: 5);
+            var rejected = await ApplyAsync(new SelectedSkillsChangedEvent(playerId, [firstSkillId]), sequence: DomainEventEnvelope.Unsequenced);
+
+            Assert.Equal(0, rejected);
+            Assert.Equal([firstSkillId], await ReadSelectedSkillIdsAsync(playerId));
+            Assert.Equal(5, await ReadWatermarkAsync(playerId, PlayerWriteStream.SelectedSkills, PlayerWriteWatermarkGuard.PlayerScopedTarget));
+        }
+
+        [Fact]
+        public async Task LogPreferenceChanged_OlderSequenceAfterNewer_IsSkippedAndLeavesTheWatermark()
+        {
+            var playerId = await SeedPlayerAsync();
+
+            await ApplyAsync(new LogPreferenceChangedEvent(playerId, ELogType.Damage, Enabled: false), sequence: 2);
+            var rejected = await ApplyAsync(new LogPreferenceChangedEvent(playerId, ELogType.Damage, Enabled: true), sequence: 1);
+
+            Assert.Equal(1, rejected);
+            Assert.False(await ReadLogPreferenceAsync(playerId, ELogType.Damage));
+            Assert.Equal(2, await ReadWatermarkAsync(playerId, PlayerWriteStream.LogPreference, LogTarget(ELogType.Damage)));
+        }
+
+        [Fact]
+        public async Task LogPreferenceChanged_EqualSequence_Applies()
+        {
+            var playerId = await SeedPlayerAsync();
+
+            await ApplyAsync(new LogPreferenceChangedEvent(playerId, ELogType.Damage, Enabled: false), sequence: 3);
+            var rejected = await ApplyAsync(new LogPreferenceChangedEvent(playerId, ELogType.Damage, Enabled: true), sequence: 3);
+
+            Assert.Equal(0, rejected);
+            Assert.True(await ReadLogPreferenceAsync(playerId, ELogType.Damage));
+        }
+
+        [Fact]
+        public async Task LogPreferenceChanged_NewerSequence_AppliesAndAdvancesTheWatermark()
+        {
+            var playerId = await SeedPlayerAsync();
+
+            await ApplyAsync(new LogPreferenceChangedEvent(playerId, ELogType.Damage, Enabled: true), sequence: 1);
+            var rejected = await ApplyAsync(new LogPreferenceChangedEvent(playerId, ELogType.Damage, Enabled: false), sequence: 2);
+
+            Assert.Equal(0, rejected);
+            Assert.False(await ReadLogPreferenceAsync(playerId, ELogType.Damage));
+            Assert.Equal(2, await ReadWatermarkAsync(playerId, PlayerWriteStream.LogPreference, LogTarget(ELogType.Damage)));
+        }
+
+        [Fact]
+        public async Task LogPreferenceChanged_UnsequencedEvent_AppliesAgainstAnAdvancedWatermarkAndLeavesItUnchanged()
+        {
+            var playerId = await SeedPlayerAsync();
+
+            await ApplyAsync(new LogPreferenceChangedEvent(playerId, ELogType.Damage, Enabled: false), sequence: 5);
+            var rejected = await ApplyAsync(new LogPreferenceChangedEvent(playerId, ELogType.Damage, Enabled: true), sequence: DomainEventEnvelope.Unsequenced);
+
+            Assert.Equal(0, rejected);
+            Assert.True(await ReadLogPreferenceAsync(playerId, ELogType.Damage));
+            Assert.Equal(5, await ReadWatermarkAsync(playerId, PlayerWriteStream.LogPreference, LogTarget(ELogType.Damage)));
+        }
+
+        [Fact]
+        public async Task LogPreferenceChanged_OlderEventForADifferentLogType_IsNotRejectedByTheNewerOne()
+        {
+            var playerId = await SeedPlayerAsync();
+
+            await ApplyAsync(new LogPreferenceChangedEvent(playerId, ELogType.Damage, Enabled: false), sequence: 2);
+            var rejected = await ApplyAsync(new LogPreferenceChangedEvent(playerId, ELogType.Exp, Enabled: false), sequence: 1);
+
+            // Each event carries one log type's flag, so the key has to be per type: a per-player watermark
+            // would discard this still-current change to Exp purely because Damage was written more recently.
+            Assert.Equal(0, rejected);
+            Assert.False(await ReadLogPreferenceAsync(playerId, ELogType.Exp));
+            Assert.False(await ReadLogPreferenceAsync(playerId, ELogType.Damage));
+        }
+
+        [Fact]
+        public async Task ItemFavoriteChanged_OlderSequenceAfterNewer_IsSkippedAndLeavesTheWatermark()
+        {
+            var playerId = await SeedPlayerAsync();
+            var itemId = await SeedItemAsync();
+
+            await ApplyAsync(new ItemFavoriteChangedEvent(playerId, itemId, Favorite: true), sequence: 2);
+            var rejected = await ApplyAsync(new ItemFavoriteChangedEvent(playerId, itemId, Favorite: false), sequence: 1);
+
+            Assert.Equal(1, rejected);
+            Assert.True(await ReadFavoriteAsync(playerId, itemId));
+            Assert.Equal(2, await ReadWatermarkAsync(playerId, PlayerWriteStream.ItemFavorite, ItemTarget(itemId)));
+        }
+
+        [Fact]
+        public async Task ItemFavoriteChanged_EqualSequence_Applies()
+        {
+            var playerId = await SeedPlayerAsync();
+            var itemId = await SeedItemAsync();
+
+            await ApplyAsync(new ItemFavoriteChangedEvent(playerId, itemId, Favorite: true), sequence: 3);
+            var rejected = await ApplyAsync(new ItemFavoriteChangedEvent(playerId, itemId, Favorite: false), sequence: 3);
+
+            Assert.Equal(0, rejected);
+            Assert.False(await ReadFavoriteAsync(playerId, itemId));
+        }
+
+        [Fact]
+        public async Task ItemFavoriteChanged_NewerSequence_AppliesAndAdvancesTheWatermark()
+        {
+            var playerId = await SeedPlayerAsync();
+            var itemId = await SeedItemAsync();
+
+            await ApplyAsync(new ItemFavoriteChangedEvent(playerId, itemId, Favorite: false), sequence: 1);
+            var rejected = await ApplyAsync(new ItemFavoriteChangedEvent(playerId, itemId, Favorite: true), sequence: 2);
+
+            Assert.Equal(0, rejected);
+            Assert.True(await ReadFavoriteAsync(playerId, itemId));
+            Assert.Equal(2, await ReadWatermarkAsync(playerId, PlayerWriteStream.ItemFavorite, ItemTarget(itemId)));
+        }
+
+        [Fact]
+        public async Task ItemFavoriteChanged_UnsequencedEvent_AppliesAgainstAnAdvancedWatermarkAndLeavesItUnchanged()
+        {
+            var playerId = await SeedPlayerAsync();
+            var itemId = await SeedItemAsync();
+
+            await ApplyAsync(new ItemFavoriteChangedEvent(playerId, itemId, Favorite: true), sequence: 5);
+            var rejected = await ApplyAsync(new ItemFavoriteChangedEvent(playerId, itemId, Favorite: false), sequence: DomainEventEnvelope.Unsequenced);
+
+            Assert.Equal(0, rejected);
+            Assert.False(await ReadFavoriteAsync(playerId, itemId));
+            Assert.Equal(5, await ReadWatermarkAsync(playerId, PlayerWriteStream.ItemFavorite, ItemTarget(itemId)));
+        }
+
+        [Fact]
+        public async Task ItemFavoriteChanged_OlderEventForADifferentItem_IsNotRejectedByTheNewerOne()
+        {
+            var playerId = await SeedPlayerAsync();
+            var favoritedItemId = await SeedItemAsync();
+            var otherItemId = await SeedItemAsync();
+
+            await ApplyAsync(new ItemFavoriteChangedEvent(playerId, favoritedItemId, Favorite: true), sequence: 2);
+            var rejected = await ApplyAsync(new ItemFavoriteChangedEvent(playerId, otherItemId, Favorite: true), sequence: 1);
+
+            Assert.Equal(0, rejected);
+            Assert.True(await ReadFavoriteAsync(playerId, otherItemId));
+            Assert.True(await ReadFavoriteAsync(playerId, favoritedItemId));
+        }
+
+        [Fact]
+        public async Task LessonRead_OlderSequenceAfterNewer_IsSkippedAndLeavesTheWatermark()
+        {
+            var playerId = await SeedPlayerAsync();
+            var lessonId = await SeedLessonAsync();
+
+            await ApplyAsync(ReadLesson(playerId, lessonId, readAtMinute: 20), sequence: 2);
+            var rejected = await ApplyAsync(ReadLesson(playerId, lessonId, readAtMinute: 5), sequence: 1);
+
+            Assert.Equal(1, rejected);
+            Assert.Equal(LessonUnlockedAt.AddMinutes(20), await ReadLessonReadAtAsync(playerId, lessonId));
+            Assert.Equal(2, await ReadWatermarkAsync(playerId, PlayerWriteStream.LessonRead, LessonTarget(lessonId)));
+        }
+
+        [Fact]
+        public async Task LessonRead_EqualSequence_Applies()
+        {
+            var playerId = await SeedPlayerAsync();
+            var lessonId = await SeedLessonAsync();
+
+            await ApplyAsync(ReadLesson(playerId, lessonId, readAtMinute: 5), sequence: 3);
+            var rejected = await ApplyAsync(ReadLesson(playerId, lessonId, readAtMinute: 20), sequence: 3);
+
+            Assert.Equal(0, rejected);
+            Assert.Equal(LessonUnlockedAt.AddMinutes(20), await ReadLessonReadAtAsync(playerId, lessonId));
+        }
+
+        [Fact]
+        public async Task LessonRead_NewerSequence_AppliesAndAdvancesTheWatermark()
+        {
+            var playerId = await SeedPlayerAsync();
+            var lessonId = await SeedLessonAsync();
+
+            await ApplyAsync(ReadLesson(playerId, lessonId, readAtMinute: 5), sequence: 1);
+            var rejected = await ApplyAsync(ReadLesson(playerId, lessonId, readAtMinute: 20), sequence: 2);
+
+            Assert.Equal(0, rejected);
+            Assert.Equal(LessonUnlockedAt.AddMinutes(20), await ReadLessonReadAtAsync(playerId, lessonId));
+            Assert.Equal(2, await ReadWatermarkAsync(playerId, PlayerWriteStream.LessonRead, LessonTarget(lessonId)));
+        }
+
+        [Fact]
+        public async Task LessonRead_UnsequencedEvent_AppliesAgainstAnAdvancedWatermarkAndLeavesItUnchanged()
+        {
+            var playerId = await SeedPlayerAsync();
+            var lessonId = await SeedLessonAsync();
+
+            await ApplyAsync(ReadLesson(playerId, lessonId, readAtMinute: 20), sequence: 5);
+            var rejected = await ApplyAsync(ReadLesson(playerId, lessonId, readAtMinute: 5), sequence: DomainEventEnvelope.Unsequenced);
+
+            Assert.Equal(0, rejected);
+            Assert.Equal(LessonUnlockedAt.AddMinutes(5), await ReadLessonReadAtAsync(playerId, lessonId));
+            Assert.Equal(5, await ReadWatermarkAsync(playerId, PlayerWriteStream.LessonRead, LessonTarget(lessonId)));
+        }
+
+        [Fact]
+        public async Task LessonRead_OlderEventForADifferentLesson_IsNotRejectedByTheNewerOne()
+        {
+            var playerId = await SeedPlayerAsync();
+            var readLessonId = await SeedLessonAsync("read-lesson");
+            var otherLessonId = await SeedLessonAsync("other-lesson");
+
+            await ApplyAsync(ReadLesson(playerId, readLessonId, readAtMinute: 20), sequence: 2);
+            var rejected = await ApplyAsync(ReadLesson(playerId, otherLessonId, readAtMinute: 5), sequence: 1);
+
+            Assert.Equal(0, rejected);
+            Assert.Equal(LessonUnlockedAt.AddMinutes(5), await ReadLessonReadAtAsync(playerId, otherLessonId));
+            Assert.Equal(LessonUnlockedAt.AddMinutes(20), await ReadLessonReadAtAsync(playerId, readLessonId));
+        }
+
+        [Fact]
+        public async Task PlayerProducedStreams_AreIndependent_SoOneStreamsWriteDoesNotBlockAnOlderWriteOnAnother()
+        {
+            var playerId = await SeedPlayerAsync();
+
+            // Every stream the Player aggregate produces shares one counter, so a later save's sequence is
+            // genuinely higher — but the streams write disjoint targets, and an older event on one of them is
+            // only stale relative to its own target. Sharing a watermark across them would drop it.
+            await ApplyAsync(AllocationEvent(playerId, strength: 20d), sequence: 9);
+            var rejected = await ApplyAsync(new LogPreferenceChangedEvent(playerId, ELogType.Damage, Enabled: false), sequence: 1);
+
+            Assert.Equal(0, rejected);
+            Assert.False(await ReadLogPreferenceAsync(playerId, ELogType.Damage));
+        }
+
         // A separate scope means a separate GameContext on its own connection, so this commits independently
         // of the guard's in-flight transaction rather than joining it.
         private async Task InsertGlobalKillsFromAnotherScopeAsync(int playerId, decimal value)
@@ -288,6 +627,24 @@ namespace Game.Application.Tests.DataAccess
 
         private static PlayerCoreUpdatedEvent CoreEvent(int playerId, int level, int exp)
             => new(playerId, level, exp, 0, 100, 100, DateTime.UtcNow, false, null);
+
+        // The event always carries the player's complete spread, which is what makes its player-scoped
+        // watermark key defensible — so the fixture states every allocation rather than just the varying one.
+        private static AttributeAllocationsChangedEvent AllocationEvent(int playerId, double strength) => new(
+            playerId,
+            [
+                new AttributeAllocationEntry(EAttribute.Strength, strength),
+                new AttributeAllocationEntry(EAttribute.Intellect, 0d),
+            ]);
+
+        private static LessonReadEvent ReadLesson(int playerId, int lessonId, int readAtMinute)
+            => new(playerId, lessonId, LessonUnlockedAt, LessonUnlockedAt.AddMinutes(readAtMinute));
+
+        // The target keys the guarded handlers derive, restated here so a test asserts against the format the
+        // stream documents rather than against whatever the handler happens to produce.
+        private static string LogTarget(ELogType logType) => ((int)logType).ToString(CultureInfo.InvariantCulture);
+        private static string ItemTarget(int itemId) => itemId.ToString(CultureInfo.InvariantCulture);
+        private static string LessonTarget(int lessonId) => lessonId.ToString(CultureInfo.InvariantCulture);
 
         private static CachedPlayerStatistic GlobalKills(decimal value) => new()
         {
@@ -377,6 +734,75 @@ namespace Game.Application.Tests.DataAccess
             var user = await TestDataSeeder.CreateUserAsync(context);
             var player = await TestDataSeeder.CreatePlayerAsync(context, user.Id);
             return player.Id;
+        }
+
+        private async Task<decimal?> ReadAllocationAsync(int playerId, EAttribute attribute)
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var row = await context.PlayerAttributes.AsNoTracking()
+                .SingleOrDefaultAsync(pa => pa.PlayerId == playerId && pa.AttributeId == (int)attribute, CancellationToken);
+            return row?.Amount;
+        }
+
+        private async Task<List<int>> ReadSelectedSkillIdsAsync(int playerId)
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            return await context.PlayerSkills.AsNoTracking()
+                .Where(ps => ps.PlayerId == playerId && ps.Selected)
+                .OrderBy(ps => ps.Order)
+                .Select(ps => ps.SkillId)
+                .ToListAsync(CancellationToken);
+        }
+
+        private async Task<bool?> ReadLogPreferenceAsync(int playerId, ELogType logType)
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var row = await context.LogPreferences.AsNoTracking()
+                .SingleOrDefaultAsync(lp => lp.PlayerId == playerId && lp.LogTypeId == (int)logType, CancellationToken);
+            return row?.Enabled;
+        }
+
+        private async Task<bool?> ReadFavoriteAsync(int playerId, int itemId)
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var row = await context.UnlockedItems.AsNoTracking()
+                .SingleOrDefaultAsync(ui => ui.PlayerId == playerId && ui.ItemId == itemId, CancellationToken);
+            return row?.Favorite;
+        }
+
+        private async Task<DateTime?> ReadLessonReadAtAsync(int playerId, int lessonId)
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            var row = await context.PlayerLessons.AsNoTracking()
+                .SingleOrDefaultAsync(pl => pl.PlayerId == playerId && pl.LessonId == lessonId, CancellationToken);
+            return row?.ReadAt;
+        }
+
+        private async Task<int> SeedSkillAsync()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            return (await TestDataSeeder.CreateSkillAsync(context)).Id;
+        }
+
+        private async Task<int> SeedItemAsync()
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            return (await TestDataSeeder.CreateItemAsync(context)).Id;
+        }
+
+        // Lesson keys are globally unique, so a test seeding two lessons has to name them apart.
+        private async Task<int> SeedLessonAsync(string key = "test-lesson")
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            return (await TestDataSeeder.CreateLessonAsync(context, key)).Id;
         }
 
         private async Task<int> SeedEnemyAsync()

--- a/Game.Application.Tests/DataAccess/PlayerWriteWatermarkIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerWriteWatermarkIntegrationTests.cs
@@ -673,7 +673,7 @@ namespace Game.Application.Tests.DataAccess
         /// </summary>
         private static Task RaceAsync(Func<Task<int>> guarded, Func<Task<int>> unguardedSibling)
             => Task.WhenAll(Enumerable.Range(0, Parallelism)
-                .Select(i => i % 2 == 0 ? guarded() : unguardedSibling()));
+                .SelectMany(_ => new[] { guarded(), unguardedSibling() }));
 
         private async Task<int> CountUnlockedItemsAsync(int playerId, int itemId)
         {

--- a/Game.Application.Tests/DataAccess/PlayerWriteWatermarkIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerWriteWatermarkIntegrationTests.cs
@@ -27,6 +27,10 @@ namespace Game.Application.Tests.DataAccess
         // TestDataSeeder.CreatePlayerAsync's default, asserted where a rolled-back apply must leave the row as seeded.
         private const int SeededLevel = 5;
 
+        // Enough concurrent applies that several pass their existence check before any insert commits, so the
+        // guard's restart is exercised rather than only the uncontended path. Mirrors the idempotency suite.
+        private const int Parallelism = 8;
+
         // Fixed so a lesson's ReadAt is asserted as an offset from a known instant rather than from "now".
         private static readonly DateTime LessonUnlockedAt = new(2026, 7, 16, 8, 0, 0, DateTimeKind.Utc);
 
@@ -607,6 +611,76 @@ namespace Game.Application.Tests.DataAccess
 
             Assert.Equal(0, rejected);
             Assert.False(await ReadLogPreferenceAsync(playerId, ELogType.Damage));
+        }
+
+        [Fact]
+        public async Task GuardedItemFavorite_RacingItsUnguardedUnlockSibling_ConvergesWithoutThrowing()
+        {
+            var playerId = await SeedPlayerAsync();
+            var itemId = await SeedItemAsync();
+
+            // The five handlers guarded here lost their own unique-violation catches, so the guard's restart is
+            // now the only thing absorbing a concurrent insert. Two sequenced applies of the same target can't
+            // collide (they queue on the watermark row), so the race that still reaches the data row is against
+            // the *unguarded* insert-if-missing sibling, which bypasses the watermark entirely.
+            await RaceAsync(
+                () => ApplyAsync(new ItemFavoriteChangedEvent(playerId, itemId, Favorite: true), sequence: 4),
+                () => ApplyAsync(new ItemUnlockedEvent(playerId, itemId), sequence: DomainEventEnvelope.Unsequenced));
+
+            Assert.True(await ReadFavoriteAsync(playerId, itemId));
+            Assert.Equal(1, await CountUnlockedItemsAsync(playerId, itemId));
+            Assert.Equal(4, await ReadWatermarkAsync(playerId, PlayerWriteStream.ItemFavorite, ItemTarget(itemId)));
+        }
+
+        [Fact]
+        public async Task GuardedLessonRead_RacingItsUnguardedUnlockSibling_ConvergesWithoutThrowing()
+        {
+            var playerId = await SeedPlayerAsync();
+            var lessonId = await SeedLessonAsync();
+
+            // The other apply shape: an update-first fast path whose miss falls through to an insert, so the
+            // sibling's row can land in the window between them. The restart re-runs the update, which finds it.
+            await RaceAsync(
+                () => ApplyAsync(ReadLesson(playerId, lessonId, readAtMinute: 5), sequence: 4),
+                () => ApplyAsync(new LessonUnlockedEvent(playerId, lessonId, LessonUnlockedAt), sequence: DomainEventEnvelope.Unsequenced));
+
+            Assert.Equal(LessonUnlockedAt.AddMinutes(5), await ReadLessonReadAtAsync(playerId, lessonId));
+            Assert.Equal(4, await ReadWatermarkAsync(playerId, PlayerWriteStream.LessonRead, LessonTarget(lessonId)));
+        }
+
+        [Fact]
+        public async Task GuardedSelectedSkills_RacingItsUnguardedUnlockSibling_ConvergesWithoutThrowing()
+        {
+            var playerId = await SeedPlayerAsync();
+            var skillId = await SeedSkillAsync();
+
+            // The multi-row shape: the rebuild inserts a row for a loadout skill whose SkillUnlockedEvent
+            // hasn't been applied yet, which is exactly the row the sibling is racing it to insert.
+            await RaceAsync(
+                () => ApplyAsync(new SelectedSkillsChangedEvent(playerId, [skillId]), sequence: 4),
+                () => ApplyAsync(new SkillUnlockedEvent(playerId, skillId), sequence: DomainEventEnvelope.Unsequenced));
+
+            Assert.Equal([skillId], await ReadSelectedSkillIdsAsync(playerId));
+            Assert.Equal(4, await ReadWatermarkAsync(playerId, PlayerWriteStream.SelectedSkills, PlayerWriteWatermarkGuard.PlayerScopedTarget));
+        }
+
+        /// <summary>
+        /// Runs both applies <see cref="Parallelism"/> times each, all at once, so several pass their
+        /// existence check before any insert commits. Whether the violation actually happens is a timing
+        /// race — the assertions are on convergence, which must hold either way — so this is a probabilistic
+        /// guard on top of <c>GuardedApply_UniqueViolationInsideTheTransaction_…</c>, which forces the same
+        /// restart deterministically.
+        /// </summary>
+        private static Task RaceAsync(Func<Task<int>> guarded, Func<Task<int>> unguardedSibling)
+            => Task.WhenAll(Enumerable.Range(0, Parallelism)
+                .Select(i => i % 2 == 0 ? guarded() : unguardedSibling()));
+
+        private async Task<int> CountUnlockedItemsAsync(int playerId, int itemId)
+        {
+            using var scope = CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<GameContext>();
+            return await context.UnlockedItems.AsNoTracking()
+                .CountAsync(ui => ui.PlayerId == playerId && ui.ItemId == itemId, CancellationToken);
         }
 
         // A separate scope means a separate GameContext on its own connection, so this commits independently

--- a/Game.DataAccess/PlayerUpdates/Handlers/AttributeAllocationsChangedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/AttributeAllocationsChangedHandler.cs
@@ -5,26 +5,22 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Game.DataAccess.PlayerUpdates.Handlers
 {
-    internal sealed class AttributeAllocationsChangedHandler(GameContext context) : IPlayerUpdateHandler<AttributeAllocationsChangedEvent>
+    internal sealed class AttributeAllocationsChangedHandler(PlayerWriteWatermarkGuard guard) : IPlayerUpdateHandler<AttributeAllocationsChangedEvent>
     {
-        public async Task HandleAsync(AttributeAllocationsChangedEvent evt)
-        {
-            // The load-then-upsert isn't atomic, so a concurrent apply of the same at-least-once event can
-            // insert a (player, attribute) row between our load and save. On the resulting unique violation,
-            // clear and re-run once: the now-existing row loads as an update, so the second pass carries no
-            // conflicting insert. A second failure propagates to the queue's retry policy rather than looping.
-            try
-            {
-                await ApplyAsync(evt);
-            }
-            catch (DbUpdateException ex) when (ex.IsUniqueViolation())
-            {
-                context.ChangeTracker.Clear();
-                await ApplyAsync(evt);
-            }
-        }
+        // Absolute writes over the player's whole allocation spread, so a stale replay would durably revert
+        // spent stat points while Player.StatPointsUsed may already hold the newer value — the two then
+        // disagree until the player reallocates. One player-scoped target: the event carries the complete
+        // spread rather than a dirty subset (Player.TryUpdateAttributes projects every allocation), so there
+        // is nothing finer for a per-attribute key to protect. The guard owns the transaction, the context the
+        // write must be issued on, and the unique-violation restart the load-then-upsert below needs.
+        public Task HandleAsync(AttributeAllocationsChangedEvent evt)
+            => guard.ExecuteGuardedAsync(
+                evt.PlayerId,
+                PlayerWriteStream.AttributeAllocations,
+                [PlayerWriteWatermarkGuard.PlayerScopedTarget],
+                (context, _) => ApplyAsync(context, evt));
 
-        private async Task ApplyAsync(AttributeAllocationsChangedEvent evt)
+        private static async Task ApplyAsync(GameContext context, AttributeAllocationsChangedEvent evt)
         {
             var currentRows = await context.PlayerAttributes
                 .Where(pa => pa.PlayerId == evt.PlayerId)

--- a/Game.DataAccess/PlayerUpdates/Handlers/AttributeAllocationsChangedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/AttributeAllocationsChangedHandler.cs
@@ -7,12 +7,10 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
 {
     internal sealed class AttributeAllocationsChangedHandler(PlayerWriteWatermarkGuard guard) : IPlayerUpdateHandler<AttributeAllocationsChangedEvent>
     {
-        // Absolute writes over the player's whole allocation spread, so a stale replay would durably revert
-        // spent stat points while Player.StatPointsUsed may already hold the newer value — the two then
-        // disagree until the player reallocates. One player-scoped target: the event carries the complete
-        // spread rather than a dirty subset (Player.TryUpdateAttributes projects every allocation), so there
-        // is nothing finer for a per-attribute key to protect. The guard owns the transaction, the context the
-        // write must be issued on, and the unique-violation restart the load-then-upsert below needs.
+        // A stale replay durably reverts spent stat points while Player.StatPointsUsed may already hold the
+        // newer value, leaving the two disagreeing until the player reallocates. Player-scoped — see
+        // PlayerWriteStream.AttributeAllocations. The guard owns the transaction, the context the write must
+        // be issued on, and the unique-violation restart the load-then-upsert below needs.
         public Task HandleAsync(AttributeAllocationsChangedEvent evt)
             => guard.ExecuteGuardedAsync(
                 evt.PlayerId,

--- a/Game.DataAccess/PlayerUpdates/Handlers/ItemFavoriteChangedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/ItemFavoriteChangedHandler.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Game.Core.Players.Events;
 using Game.Infrastructure.Database;
 using Game.Infrastructure.Entities;
@@ -5,27 +6,20 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Game.DataAccess.PlayerUpdates.Handlers
 {
-    internal sealed class ItemFavoriteChangedHandler(GameContext context) : IPlayerUpdateHandler<ItemFavoriteChangedEvent>
+    internal sealed class ItemFavoriteChangedHandler(PlayerWriteWatermarkGuard guard) : IPlayerUpdateHandler<ItemFavoriteChangedEvent>
     {
-        public async Task HandleAsync(ItemFavoriteChangedEvent evt)
-        {
-            // The load-then-upsert isn't atomic, so a concurrent apply of the same at-least-once event — or an
-            // ItemUnlockedEvent reordered behind this one — can insert the (player, item) row between our load
-            // and save. On the resulting unique violation, clear and re-run once: the now-existing row loads as
-            // an update, so the second pass carries no conflicting insert. A second failure propagates to the
-            // queue's retry policy rather than looping. (Mirrors AttributeAllocationsChangedHandler.)
-            try
-            {
-                await ApplyAsync(evt);
-            }
-            catch (DbUpdateException ex) when (ex.IsUniqueViolation())
-            {
-                context.ChangeTracker.Clear();
-                await ApplyAsync(evt);
-            }
-        }
+        // Keyed per item: each event carries one item's flag, so a per-player key would discard an older
+        // change to item A merely because a newer change to item B landed first. Formatted invariantly
+        // because the key is a persisted comparison key — a culture that renders digits differently would
+        // write a second watermark row and the guard would silently stop seeing the first.
+        public Task HandleAsync(ItemFavoriteChangedEvent evt)
+            => guard.ExecuteGuardedAsync(
+                evt.PlayerId,
+                PlayerWriteStream.ItemFavorite,
+                [evt.ItemId.ToString(CultureInfo.InvariantCulture)],
+                (context, _) => ApplyAsync(context, evt));
 
-        private async Task ApplyAsync(ItemFavoriteChangedEvent evt)
+        private static async Task ApplyAsync(GameContext context, ItemFavoriteChangedEvent evt)
         {
             // Absolute upsert of the favorite flag. A favorite presupposes ownership, so a missing row means the
             // item's ItemUnlockedEvent was reordered behind this event under best-effort cross-instance ordering

--- a/Game.DataAccess/PlayerUpdates/Handlers/ItemFavoriteChangedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/ItemFavoriteChangedHandler.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Game.Core.Players.Events;
 using Game.Infrastructure.Database;
 using Game.Infrastructure.Entities;
@@ -8,15 +7,12 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
 {
     internal sealed class ItemFavoriteChangedHandler(PlayerWriteWatermarkGuard guard) : IPlayerUpdateHandler<ItemFavoriteChangedEvent>
     {
-        // Keyed per item: each event carries one item's flag, so a per-player key would discard an older
-        // change to item A merely because a newer change to item B landed first. Formatted invariantly
-        // because the key is a persisted comparison key — a culture that renders digits differently would
-        // write a second watermark row and the guard would silently stop seeing the first.
+        // Keyed per item — see PlayerWriteStream.ItemFavorite for why that granularity is the contract.
         public Task HandleAsync(ItemFavoriteChangedEvent evt)
             => guard.ExecuteGuardedAsync(
                 evt.PlayerId,
                 PlayerWriteStream.ItemFavorite,
-                [evt.ItemId.ToString(CultureInfo.InvariantCulture)],
+                [PlayerWriteWatermarkGuard.Target(evt.ItemId)],
                 (context, _) => ApplyAsync(context, evt));
 
         private static async Task ApplyAsync(GameContext context, ItemFavoriteChangedEvent evt)

--- a/Game.DataAccess/PlayerUpdates/Handlers/LessonReadHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/LessonReadHandler.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Game.Core.Players.Events;
 using Game.Infrastructure.Database;
 using Game.Infrastructure.Entities;
@@ -8,14 +7,12 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
 {
     internal sealed class LessonReadHandler(PlayerWriteWatermarkGuard guard) : IPlayerUpdateHandler<LessonReadEvent>
     {
-        // Keyed per lesson, for the same reason as the log-preference stream: each event carries one lesson's
-        // read state, so a per-player key would discard an older lesson's read merely because a newer one
-        // landed first. Formatted invariantly because the key is a persisted comparison key.
+        // Keyed per lesson — see PlayerWriteStream.LessonRead for why that granularity is the contract.
         public Task HandleAsync(LessonReadEvent evt)
             => guard.ExecuteGuardedAsync(
                 evt.PlayerId,
                 PlayerWriteStream.LessonRead,
-                [evt.LessonId.ToString(CultureInfo.InvariantCulture)],
+                [PlayerWriteWatermarkGuard.Target(evt.LessonId)],
                 (context, _) => ApplyAsync(context, evt));
 
         private static async Task ApplyAsync(GameContext context, LessonReadEvent evt)

--- a/Game.DataAccess/PlayerUpdates/Handlers/LessonReadHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/LessonReadHandler.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Game.Core.Players.Events;
 using Game.Infrastructure.Database;
 using Game.Infrastructure.Entities;
@@ -5,14 +6,25 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Game.DataAccess.PlayerUpdates.Handlers
 {
-    internal sealed class LessonReadHandler(GameContext context) : IPlayerUpdateHandler<LessonReadEvent>
+    internal sealed class LessonReadHandler(PlayerWriteWatermarkGuard guard) : IPlayerUpdateHandler<LessonReadEvent>
     {
-        public async Task HandleAsync(LessonReadEvent evt)
+        // Keyed per lesson, for the same reason as the log-preference stream: each event carries one lesson's
+        // read state, so a per-player key would discard an older lesson's read merely because a newer one
+        // landed first. Formatted invariantly because the key is a persisted comparison key.
+        public Task HandleAsync(LessonReadEvent evt)
+            => guard.ExecuteGuardedAsync(
+                evt.PlayerId,
+                PlayerWriteStream.LessonRead,
+                [evt.LessonId.ToString(CultureInfo.InvariantCulture)],
+                (context, _) => ApplyAsync(context, evt));
+
+        private static async Task ApplyAsync(GameContext context, LessonReadEvent evt)
         {
             // Absolute upsert (mirroring LogPreferenceChangedHandler): update first; if no row exists yet — a
             // screen-anchored lesson goes straight from locked to read with no prior LessonUnlockedEvent, and a
             // reordered delivery of that event behind this one is also possible — fall through to insert with
-            // both timestamps the domain already resolved.
+            // both timestamps the domain already resolved. Both writes run on the guard's context, inside its
+            // transaction, and a row inserted concurrently in between is absorbed by the guard's restart.
             Task<int> SetReadAsync() => context.PlayerLessons
                 .Where(pl => pl.PlayerId == evt.PlayerId && pl.LessonId == evt.LessonId)
                 .ExecuteUpdateAsync(s => s.SetProperty(pl => pl.ReadAt, evt.ReadAt));
@@ -30,17 +42,7 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
                 ReadAt = evt.ReadAt,
             });
 
-            try
-            {
-                await context.SaveChangesAsync();
-            }
-            catch (DbUpdateException ex) when (ex.IsUniqueViolation())
-            {
-                // Lost the insert race to a concurrently-applied LessonUnlockedEvent; clear the failed insert
-                // and set the now-existing row's ReadAt absolutely.
-                context.ChangeTracker.Clear();
-                await SetReadAsync();
-            }
+            await context.SaveChangesAsync();
         }
     }
 }

--- a/Game.DataAccess/PlayerUpdates/Handlers/LogPreferenceChangedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/LogPreferenceChangedHandler.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Game.Core.Players.Events;
 using Game.Infrastructure.Database;
 using Game.Infrastructure.Entities;
@@ -5,16 +6,28 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Game.DataAccess.PlayerUpdates.Handlers
 {
-    internal sealed class LogPreferenceChangedHandler(GameContext context) : IPlayerUpdateHandler<LogPreferenceChangedEvent>
+    internal sealed class LogPreferenceChangedHandler(PlayerWriteWatermarkGuard guard) : IPlayerUpdateHandler<LogPreferenceChangedEvent>
     {
-        public async Task HandleAsync(LogPreferenceChangedEvent evt)
+        // Keyed per log type: each event carries one type's flag, so a per-player key would discard an older
+        // change to type A merely because a newer change to type B landed first. Formatted invariantly because
+        // the key is a persisted comparison key — a culture that renders digits differently would write a
+        // second watermark row and the guard would silently stop seeing the first.
+        public Task HandleAsync(LogPreferenceChangedEvent evt)
+            => guard.ExecuteGuardedAsync(
+                evt.PlayerId,
+                PlayerWriteStream.LogPreference,
+                [((int)evt.LogType).ToString(CultureInfo.InvariantCulture)],
+                (context, _) => ApplyAsync(context, evt));
+
+        private static async Task ApplyAsync(GameContext context, LogPreferenceChangedEvent evt)
         {
             var logTypeId = (int)evt.LogType;
 
-            // Absolute upsert: attempt the update first as a single self-committing write; if no row exists yet
-            // (rows-affected 0) fall through to the insert. The update and insert aren't atomic together, so a
-            // concurrent apply can insert the row in between — on the unique violation, re-run the absolute
-            // update so this event's value still lands on the now-existing row. Re-applying always converges.
+            // Absolute upsert: attempt the update first; if no row exists yet (rows-affected 0) fall through to
+            // the insert. Both run on the guard's context, so they are inside its transaction rather than each
+            // committing on their own — the watermark advance and this write have to land or roll back together.
+            // The update and insert still aren't atomic against a concurrent apply, which can insert the row in
+            // between; the guard's restart re-runs the whole attempt and the update then finds the row.
             Task<int> SetEnabledAsync() => context.LogPreferences
                 .Where(lp => lp.PlayerId == evt.PlayerId && lp.LogTypeId == logTypeId)
                 .ExecuteUpdateAsync(s => s.SetProperty(lp => lp.Enabled, evt.Enabled));
@@ -31,16 +44,7 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
                 Enabled = evt.Enabled,
             });
 
-            try
-            {
-                await context.SaveChangesAsync();
-            }
-            catch (DbUpdateException ex) when (ex.IsUniqueViolation())
-            {
-                // Lost the insert race; clear the failed insert and set the now-existing row's value absolutely.
-                context.ChangeTracker.Clear();
-                await SetEnabledAsync();
-            }
+            await context.SaveChangesAsync();
         }
     }
 }

--- a/Game.DataAccess/PlayerUpdates/Handlers/LogPreferenceChangedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/LogPreferenceChangedHandler.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Game.Core.Players.Events;
 using Game.Infrastructure.Database;
 using Game.Infrastructure.Entities;
@@ -8,15 +7,12 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
 {
     internal sealed class LogPreferenceChangedHandler(PlayerWriteWatermarkGuard guard) : IPlayerUpdateHandler<LogPreferenceChangedEvent>
     {
-        // Keyed per log type: each event carries one type's flag, so a per-player key would discard an older
-        // change to type A merely because a newer change to type B landed first. Formatted invariantly because
-        // the key is a persisted comparison key — a culture that renders digits differently would write a
-        // second watermark row and the guard would silently stop seeing the first.
+        // Keyed per log type — see PlayerWriteStream.LogPreference for why that granularity is the contract.
         public Task HandleAsync(LogPreferenceChangedEvent evt)
             => guard.ExecuteGuardedAsync(
                 evt.PlayerId,
                 PlayerWriteStream.LogPreference,
-                [((int)evt.LogType).ToString(CultureInfo.InvariantCulture)],
+                [PlayerWriteWatermarkGuard.Target((int)evt.LogType)],
                 (context, _) => ApplyAsync(context, evt));
 
         private static async Task ApplyAsync(GameContext context, LogPreferenceChangedEvent evt)

--- a/Game.DataAccess/PlayerUpdates/Handlers/ProgressUpdatedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/ProgressUpdatedHandler.cs
@@ -9,16 +9,13 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
         // Keyed per row rather than per player: a progress event carries only a save's dirty rows, so a
         // per-player watermark would let a newer event covering statistic Y reject an older event carrying an
         // entirely different, still-current statistic X — silently losing writes on the game's highest-volume
-        // persistence path. The kind prefix keeps the three row families from colliding in one key space, and
-        // the ids are formatted invariantly because the key is a persisted comparison key — a culture that
-        // renders digits differently would write a second watermark row and the guard would silently stop
-        // seeing the first.
+        // persistence path. The kind prefix keeps the three row families from colliding in one key space.
         private static string StatisticTarget(CachedPlayerStatistic stat)
-            => FormattableString.Invariant($"stat:{stat.StatisticTypeId}:{stat.EntityId}");
+            => PlayerWriteWatermarkGuard.Target("stat", stat.StatisticTypeId, stat.EntityId);
         private static string ChallengeTarget(CachedPlayerChallenge challenge)
-            => FormattableString.Invariant($"challenge:{challenge.ChallengeId}");
+            => PlayerWriteWatermarkGuard.Target("challenge", challenge.ChallengeId);
         private static string ProficiencyTarget(CachedPlayerProficiency proficiency)
-            => FormattableString.Invariant($"prof:{proficiency.ProficiencyId}");
+            => PlayerWriteWatermarkGuard.Target("prof", proficiency.ProficiencyId);
 
         public Task HandleAsync(ProgressUpdatedEvent evt)
         {

--- a/Game.DataAccess/PlayerUpdates/Handlers/ProgressUpdatedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/ProgressUpdatedHandler.cs
@@ -9,10 +9,16 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
         // Keyed per row rather than per player: a progress event carries only a save's dirty rows, so a
         // per-player watermark would let a newer event covering statistic Y reject an older event carrying an
         // entirely different, still-current statistic X — silently losing writes on the game's highest-volume
-        // persistence path. The kind prefix keeps the three row families from colliding in one key space.
-        private static string StatisticTarget(CachedPlayerStatistic stat) => $"stat:{stat.StatisticTypeId}:{stat.EntityId}";
-        private static string ChallengeTarget(CachedPlayerChallenge challenge) => $"challenge:{challenge.ChallengeId}";
-        private static string ProficiencyTarget(CachedPlayerProficiency proficiency) => $"prof:{proficiency.ProficiencyId}";
+        // persistence path. The kind prefix keeps the three row families from colliding in one key space, and
+        // the ids are formatted invariantly because the key is a persisted comparison key — a culture that
+        // renders digits differently would write a second watermark row and the guard would silently stop
+        // seeing the first.
+        private static string StatisticTarget(CachedPlayerStatistic stat)
+            => FormattableString.Invariant($"stat:{stat.StatisticTypeId}:{stat.EntityId}");
+        private static string ChallengeTarget(CachedPlayerChallenge challenge)
+            => FormattableString.Invariant($"challenge:{challenge.ChallengeId}");
+        private static string ProficiencyTarget(CachedPlayerProficiency proficiency)
+            => FormattableString.Invariant($"prof:{proficiency.ProficiencyId}");
 
         public Task HandleAsync(ProgressUpdatedEvent evt)
         {

--- a/Game.DataAccess/PlayerUpdates/Handlers/SelectedSkillsChangedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/SelectedSkillsChangedHandler.cs
@@ -5,27 +5,21 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Game.DataAccess.PlayerUpdates.Handlers
 {
-    internal sealed class SelectedSkillsChangedHandler(GameContext context) : IPlayerUpdateHandler<SelectedSkillsChangedEvent>
+    internal sealed class SelectedSkillsChangedHandler(PlayerWriteWatermarkGuard guard) : IPlayerUpdateHandler<SelectedSkillsChangedEvent>
     {
-        public async Task HandleAsync(SelectedSkillsChangedEvent evt)
-        {
-            // The load-then-upsert isn't atomic, so a concurrent apply of the same at-least-once event — or a
-            // SkillUnlockedEvent reordered behind this one — can insert a (player, skill) row between our load
-            // and save. On the resulting unique violation, clear and re-run once: the now-existing row loads as
-            // an update, so the second pass carries no conflicting insert. A second failure propagates to the
-            // queue's retry policy rather than looping. (Mirrors AttributeAllocationsChangedHandler.)
-            try
-            {
-                await ApplyAsync(evt);
-            }
-            catch (DbUpdateException ex) when (ex.IsUniqueViolation())
-            {
-                context.ChangeTracker.Clear();
-                await ApplyAsync(evt);
-            }
-        }
+        // The apply rebuilds every one of the player's Selected/Order columns from the event's full ordered
+        // loadout, so a stale replay durably restores a loadout the player has already replaced. The target is
+        // the loadout as a unit — a per-skill key would let the rows of one event partially win, leaving a
+        // loadout that was never actually selected (a skill deselected by the newer event but re-Selected by
+        // the older one's rebuild). The guard owns the transaction, the context, and the restart.
+        public Task HandleAsync(SelectedSkillsChangedEvent evt)
+            => guard.ExecuteGuardedAsync(
+                evt.PlayerId,
+                PlayerWriteStream.SelectedSkills,
+                [PlayerWriteWatermarkGuard.PlayerScopedTarget],
+                (context, _) => ApplyAsync(context, evt));
 
-        private async Task ApplyAsync(SelectedSkillsChangedEvent evt)
+        private static async Task ApplyAsync(GameContext context, SelectedSkillsChangedEvent evt)
         {
             // Rebuild Selected/Order from the event's full ordered loadout, applied as a single write: fetch the
             // player's skill rows, reset every flag, then mark each id in the loadout Selected = true with its

--- a/Game.DataAccess/PlayerUpdates/Handlers/SelectedSkillsChangedHandler.cs
+++ b/Game.DataAccess/PlayerUpdates/Handlers/SelectedSkillsChangedHandler.cs
@@ -7,11 +7,9 @@ namespace Game.DataAccess.PlayerUpdates.Handlers
 {
     internal sealed class SelectedSkillsChangedHandler(PlayerWriteWatermarkGuard guard) : IPlayerUpdateHandler<SelectedSkillsChangedEvent>
     {
-        // The apply rebuilds every one of the player's Selected/Order columns from the event's full ordered
-        // loadout, so a stale replay durably restores a loadout the player has already replaced. The target is
-        // the loadout as a unit — a per-skill key would let the rows of one event partially win, leaving a
-        // loadout that was never actually selected (a skill deselected by the newer event but re-Selected by
-        // the older one's rebuild). The guard owns the transaction, the context, and the restart.
+        // The apply rebuilds every one of the player's Selected/Order columns, so a stale replay durably
+        // restores a loadout the player has already replaced. Keyed on the loadout as a unit — see
+        // PlayerWriteStream.SelectedSkills. The guard owns the transaction, the context, and the restart.
         public Task HandleAsync(SelectedSkillsChangedEvent evt)
             => guard.ExecuteGuardedAsync(
                 evt.PlayerId,

--- a/Game.DataAccess/PlayerUpdates/PlayerWriteWatermarkGuard.cs
+++ b/Game.DataAccess/PlayerUpdates/PlayerWriteWatermarkGuard.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text;
 using Game.Infrastructure.Database;
 using Game.Infrastructure.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -32,6 +34,39 @@ namespace Game.DataAccess.PlayerUpdates
         /// row itself and there is nothing finer to key on.
         /// </summary>
         public const string PlayerScopedTarget = "";
+
+        /// <summary>
+        /// Formats a target key from the ids that identify it, optionally prefixed by <paramref name="kind"/>
+        /// where one stream keys more than one row family. A <c>null</c> id renders as an empty segment —
+        /// how a global statistic's absent entity id is spelled.
+        /// </summary>
+        /// <remarks>
+        /// Callers go through this rather than interpolating because a target key is a <em>persisted
+        /// comparison key</em>: formatted under a culture whose numeric formatting differs (the negative sign,
+        /// in practice — CA1305), a caller would seed a second watermark row and the guard would silently stop
+        /// seeing the first. Same reasoning as handing the apply callback its <see cref="GameContext"/> — the
+        /// invariant is better held by the guard than by every caller's discipline.
+        /// </remarks>
+        public static string Target(string kind, params ReadOnlySpan<int?> ids)
+        {
+            var key = new StringBuilder(kind);
+            foreach (var id in ids)
+            {
+                key.Append(':');
+                if (id.HasValue)
+                {
+                    key.Append(id.Value.ToString(CultureInfo.InvariantCulture));
+                }
+            }
+
+            return key.ToString();
+        }
+
+        /// <summary>
+        /// Formats the target key of a stream whose targets are identified by a bare id, with no row family
+        /// to disambiguate. See the prefixed overload for why this isn't interpolated at the call site.
+        /// </summary>
+        public static string Target(int id) => id.ToString(CultureInfo.InvariantCulture);
 
         /// <summary>
         /// Advances the watermarks this event is allowed to advance and invokes <paramref name="applyAsync"/>

--- a/Game.Infrastructure/Entities/PlayerWriteStream.cs
+++ b/Game.Infrastructure/Entities/PlayerWriteStream.cs
@@ -24,5 +24,45 @@ namespace Game.Infrastructure.Entities
         /// event covering one row reject an older event covering a different, still-current one.
         /// </summary>
         Progress = 1,
+
+        // 2 and 3 are reserved for the equipment and mod streams (#2495), which are in flight on their own
+        // branch. Two branches appending independently would otherwise both land on 2, and merging them would
+        // give one persisted value two meanings — the one mistake this enum's append-only rule exists to stop.
+
+        /// <summary>
+        /// The player's equipped skill loadout (<c>SelectedSkillsChangedEvent</c>). Player-scoped — the event
+        /// carries the full ordered loadout and the handler rebuilds every one of the player's
+        /// <c>Selected</c>/<c>Order</c> columns from it, so the loadout <em>is</em> the target and a per-skill
+        /// key would let one skill's row accept a write the same event's other rows rejected.
+        /// </summary>
+        SelectedSkills = 4,
+
+        /// <summary>
+        /// A player's log preferences (<c>LogPreferenceChangedEvent</c>), keyed per log type (<c>"{logTypeId}"</c>)
+        /// — each event carries one type's flag, so a per-player key would discard an older change to type A
+        /// merely because a newer change to type B landed first.
+        /// </summary>
+        LogPreference = 5,
+
+        /// <summary>
+        /// The player's stat-point allocations (<c>AttributeAllocationsChangedEvent</c>). Player-scoped: the
+        /// event carries the complete per-attribute spread rather than a dirty subset, so a newer event
+        /// supersedes an older one wholesale and there is nothing finer for a per-attribute key to save.
+        /// </summary>
+        AttributeAllocations = 6,
+
+        /// <summary>
+        /// The favorite flag on a player's unlocked items (<c>ItemFavoriteChangedEvent</c>), keyed per item
+        /// (<c>"{itemId}"</c>). Deliberately its own stream rather than sharing the equipment stream's item key
+        /// (#2495): the two write disjoint columns of the same row, so one key would make a favorite toggle
+        /// reject an equip that is not stale in any sense that matters.
+        /// </summary>
+        ItemFavorite = 7,
+
+        /// <summary>
+        /// The read timestamp on a player's lessons (<c>LessonReadEvent</c>), keyed per lesson
+        /// (<c>"{lessonId}"</c>).
+        /// </summary>
+        LessonRead = 8,
     }
 }


### PR DESCRIPTION
Closes #2496.

Part (c) of the #2474 split: `SelectedSkillsChanged`, `LogPreferenceChanged`, `AttributeAllocationsChanged`, `ItemFavoriteChanged` and `LessonRead` now run behind the guard. The four pure insert-if-missing handlers are deliberately left alone, as the issue asks.

## Verifying the granularity the issue asked me to confirm

Both "confirm that against the event" items check out, and both matter:

- **`AttributeAllocationsChanged` is genuinely player-scoped.** `Player.TryUpdateAttributes` projects `StatPoints.StatAllocations` — the player's *complete* spread — not the attributes that changed. A per-attribute key would only add rows for targets that always move together.
- **`SelectedSkillsChanged` is the loadout as a unit**, and per-skill would actively be wrong rather than merely redundant. The apply *deselects* every row not in the loadout, so a per-skill key would let an older event's rebuild win on the skills the newer event happened not to mention — producing a loadout the player never selected. Whole-loadout rejection is the only outcome that leaves a coherent state.

The three per-row streams each have a test that fails under a coarser key: log preferences per type (the case the issue names), favorites per item, reads per lesson.

## Stream values 4–8, not 2–3

#2495 is in flight on its own branch and appends `Equipment = 2` / `Mods = 3`. Two branches appending independently both land on 2, and merging them gives one persisted value two meanings — exactly what the enum's append-only rule exists to prevent, and not something a build failure would catch. Reserved with a comment; the gap is free, a collision is not.

`ItemFavorite` is also deliberately its own stream rather than sharing that equipment item key: the two write disjoint columns of the same `UnlockedItems` row, so one shared key would make a favorite toggle reject an equip that isn't stale in any sense that matters.

## Removing the try/catch was checked, not assumed

Each handler's `ChangeTracker.Clear()`-then-re-run is gone in favour of the guard's restart, which is a strict superset (it re-runs the watermark advance too, which the handler-side catch couldn't). PR #2501 found one handler whose delete-then-insert *didn't* collapse onto it; none of these five have that shape:

- The three load-then-upserts (allocations, loadout, favorite) are terminal on restart — after the first successful insert the row exists, so the retry loads it as an update.
- The two update-then-insert fast paths (log preference, lesson read) restart into the update, which now finds the row.

The existing `*_AppliedConcurrently_*` idempotency tests still pass at `Parallelism = 8`, though they apply **unsequenced** and so bypass the comparison entirely — they exercise the guard's outer restart, not the guarded path. One stale comment in that suite that described the handler-side catch is corrected rather than left describing code that no longer exists.

The two self-committing fast paths now run inside the guard's transaction, as the issue requires — automatically, since they issue on the context the guard hands them.

## Test plan

`dotnet build` clean (0 warnings), `dotnet test` **3623 passed / 0 failed** across all four projects. `PlayerWriteWatermarkIntegrationTests` is 34 tests (was 11) and was re-run after the final change.

Per handler: older skipped (and the watermark left alone), equal applies, newer applies and advances, sequence-0 applies against an advanced watermark and leaves it unadvanced. Plus the three per-row independence cases above, and one asserting the five new streams don't block each other despite sharing the `Player` aggregate's counter.

## Two things worth flagging

**#2475 is still not actionable after this.** The issue says this is the last step before it, but that assumed #2495 lands first — the parked-lane deferral still covers the equipment and mod handlers until it does. Not a change in scope here, just a correction to the sequencing note.

**This widens #2500's stream set.** All five are `Player`-produced, so the cold-load seed that issue describes has to cover them too. Its "also worth checking" question — widen per issue, or `MAX` across an aggregate's streams generically — now has a third data point in favour of generic: this is the second PR in a row to add streams to that set. Noted on #2500 rather than pre-empted here.

## Minor fix folded in

`ProgressUpdatedHandler`'s target keys were built with culture-sensitive interpolation. They're persisted comparison keys, so a culture rendering digits differently would write a second watermark row and the guard would silently stop seeing the first — the new keys format invariantly and this one now matches. #2491 (enable the Globalization analyzers) would catch the class of it at build time.

---
_Generated by [Claude Code](https://claude.ai/code/session_015c69jWECQnDEarVd1389Yx)_