### PR TITLE
Widen the reconciliation interval in the periodic-wait reset test (#2486)

### DIFF
--- a/Game.Application.Tests/DataAccess/CoalescingReferenceCacheReloaderTests.cs
+++ b/Game.Application.Tests/DataAccess/CoalescingReferenceCacheReloaderTests.cs
@@ -192,7 +192,11 @@ namespace Game.Application.Tests.DataAccess
         public async Task RunAsync_SignalArrivesBeforeReconciliationInterval_ResetsThePeriodicWait()
         {
             var cache = new RecordingCache();
-            var policy = new ReferenceCacheReloadPolicy(TimeSpan.Zero, maxAttempts: 1, baseDelay: TimeSpan.Zero, reconciliationInterval: TimeSpan.FromMilliseconds(200));
+            // The interval only has to outlast the observation window below: the regression this guards
+            // against (a carried-over periodic wait) fires a sweep immediately after the reactive one, so a
+            // generous interval costs no detection power but keeps runner jitter from firing the legitimate
+            // periodic sweep inside the window and failing the test spuriously.
+            var policy = new ReferenceCacheReloadPolicy(TimeSpan.Zero, maxAttempts: 1, baseDelay: TimeSpan.Zero, reconciliationInterval: TimeSpan.FromSeconds(2));
             await using var harness = new Harness(policy, cache);
 
             harness.Reloader.NotifyChanged();

--- a/Game.Application.Tests/DataAccess/CoalescingReferenceCacheReloaderTests.cs
+++ b/Game.Application.Tests/DataAccess/CoalescingReferenceCacheReloaderTests.cs
@@ -192,8 +192,8 @@ namespace Game.Application.Tests.DataAccess
         public async Task RunAsync_SignalArrivesBeforeReconciliationInterval_ResetsThePeriodicWait()
         {
             var cache = new RecordingCache();
-            // The interval only has to outlast the observation window below: the regression this guards
-            // against (a carried-over periodic wait) fires a sweep immediately after the reactive one, so a
+            // The interval only has to outlast the observation window below: a periodic wait that's already
+            // primed when the iteration starts fires a sweep immediately after the reactive one, so a
             // generous interval costs no detection power but keeps runner jitter from firing the legitimate
             // periodic sweep inside the window and failing the test spuriously.
             var policy = new ReferenceCacheReloadPolicy(TimeSpan.Zero, maxAttempts: 1, baseDelay: TimeSpan.Zero, reconciliationInterval: TimeSpan.FromSeconds(2));


### PR DESCRIPTION
Closes #2486.

Test-only, one file, no production code.

## What changed

`RunAsync_SignalArrivesBeforeReconciliationInterval_ResetsThePeriodicWait` configured a **200 ms** `reconciliationInterval` and then observed for **100 ms** after the signal-triggered sweep. That left under 100 ms of scheduling jitter before the *legitimate* periodic sweep fires inside the observation window and trips the `DoesNotContain` assertion — which is exactly what the CI log in the issue shows (`00:00:00.2000000` since the last sweep, i.e. the timer fired right on its configured interval and the window simply overran).

Raised the interval to **2 s**, per the issue's suggested fix. The assertion, the 100 ms delay, and the test's runtime are all unchanged; the jitter budget goes from ~100 ms to ~1.9 s.

## Why this doesn't weaken the test

Worth stating explicitly, since widening a timing window is the classic way to quietly neuter a test.

The regression this test guards against — a carried-over periodic wait that's already primed when the next iteration starts — manifests as a reconciliation sweep logging *immediately* after the reactive sweep, not one interval later. So it lands inside the 100 ms window at any interval value. The 200 ms only ever contributed a false-failure race; it never contributed detection power.

I verified that empirically rather than just asserting it: mutating `WaitForNextSweepAsync` to force the reconciliation branch (`var reconciling = true;`) fails **exactly one** of the 1188 tests in the project — this one. Mutation reverted; the diff is the test file only.

I also checked the two sibling timing tests in the suite and neither has this shape: `RunAsync_NoSignalWithinReconciliationInterval_RunsAPeriodicSweepAnyway` waits *until* a sweep happens (runner slowness only delays it), and `RunAsync_NoReconciliationIntervalConfigured_NeverSweepsWithoutASignal` has reconciliation disabled, so slowness can't manufacture a sweep. No other change needed here.

## Note on the alternative

The issue floats a `TimeProvider`/`FakeTimeProvider` abstraction over the reloader's periodic wait as the way to remove the wall-clock dependency outright, and agrees it's larger than this flake warrants. I left it alone — it's production-code surgery on a background loop to fix a test window, and #2488 is already the open decision on which `FakeTimeProvider` this repo standardizes on. Worth revisiting there rather than pre-empting it here.

## Test plan

- [x] `dotnet build` — clean, 0 warnings, 0 errors.
- [x] `dotnet test Game.Application.Tests` — 1188/1188 passed, run **3×** to shake out the timing dependence (the flake reproduced ~1-in-N on CI, never locally).
- [x] Mutation check above, confirming the assertion is still live.
- [x] Rebuilt and re-ran green after reverting the mutation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X63M7F4avb1BJF6XR2G2Qz)_