### PR TITLE
Consolidate the remaining duplicated test doubles (#2488)

### DIFF
--- a/Game.Api.Tests/Unit/LoginTrackingMiddlewareTests.cs
+++ b/Game.Api.Tests/Unit/LoginTrackingMiddlewareTests.cs
@@ -214,47 +214,5 @@ namespace Game.Api.Tests.Unit
             return context;
         }
 
-        // Records how many times RecordConnection was actually invoked, so tests can tell whether the
-        // dedupe memo skipped the DB round-trip. ThrowOnRecordConnection lets a test pin the failure path.
-        // OnRecordConnection lets a test observe when the call happened relative to other events.
-        private sealed class FakeUserLogins : IUserLogins
-        {
-            public int RecordConnectionCallCount { get; private set; }
-            public bool ThrowOnRecordConnection { get; set; }
-            public Action? OnRecordConnection { get; set; }
-
-            public Task RecordConnection(
-                int userId,
-                string ipAddress,
-                string deviceFingerprintHash,
-                string userAgent,
-                string? secChUa,
-                string? secChUaMobile,
-                string? secChUaPlatform,
-                CancellationToken cancellationToken = default)
-            {
-                RecordConnectionCallCount++;
-                OnRecordConnection?.Invoke();
-                if (ThrowOnRecordConnection)
-                {
-                    throw new InvalidOperationException("simulated tracking failure");
-                }
-
-                return Task.CompletedTask;
-            }
-
-            public Task SaveDeviceInfo(
-                int userId,
-                string deviceFingerprintHash,
-                string? secChUa,
-                string? secChUaMobile,
-                string? secChUaPlatform,
-                double? deviceMemory,
-                int? hardwareConcurrency,
-                CancellationToken cancellationToken = default)
-            {
-                throw new NotSupportedException();
-            }
-        }
     }
 }

--- a/Game.Api.Tests/Unit/LoginTrackingMiddlewareTests.cs
+++ b/Game.Api.Tests/Unit/LoginTrackingMiddlewareTests.cs
@@ -213,6 +213,5 @@ namespace Game.Api.Tests.Unit
 
             return context;
         }
-
     }
 }

--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -759,16 +759,6 @@ namespace Game.Api.Tests.Unit
             public void HashSetIfExistsAndForget(string key, IReadOnlyDictionary<string, string> fields, TimeSpan expiry) => throw new NotSupportedException();
         }
 
-        /// <summary>A controllable <see cref="TimeProvider"/> so the switch-credit wait deadline can be
-        /// crossed deterministically instead of relying on wall-clock delays.</summary>
-        private sealed class FakeTimeProvider(DateTimeOffset start) : TimeProvider
-        {
-            private DateTimeOffset _now = start;
-
-            public override DateTimeOffset GetUtcNow() => _now;
-            public void Advance(TimeSpan delta) => _now += delta;
-        }
-
         private sealed class NoOpHostLifetime : IHostApplicationLifetime
         {
             public CancellationToken ApplicationStarted => CancellationToken.None;

--- a/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
+++ b/Game.Application.Tests/DataAccess/DataProviderSynchronizerTests.cs
@@ -1149,7 +1149,7 @@ namespace Game.Application.Tests.DataAccess
         {
             using var scope = CreateScope();
             var logger = new CapturingLogger<DataProviderSynchronizer>();
-            var throwingPubSub = new ThrowingPubSubService();
+            var throwingPubSub = new SubscribeThrowingPubSubService();
             var synchronizer = new DataProviderSynchronizer(scope.ServiceProvider, throwingPubSub, logger, TestRetryPolicy);
 
             await Assert.ThrowsAsync<InvalidOperationException>(() => synchronizer.StartAsync(CancellationToken.None));
@@ -2490,7 +2490,7 @@ namespace Game.Application.Tests.DataAccess
         /// A minimal <see cref="IPubSubService"/> stub whose <c>Subscribe</c> overloads always throw, used to verify
         /// that <see cref="DataProviderSynchronizer.StartAsync"/> propagates a subscribe failure rather than swallowing it.
         /// </summary>
-        private sealed class ThrowingPubSubService : NotSupportedPubSubService
+        private sealed class SubscribeThrowingPubSubService : NotSupportedPubSubService
         {
             public override Task Subscribe(string channel, Action<(string message, string channel)> action, string? id = null) => throw new InvalidOperationException("Simulated subscribe failure.");
             public override Task Subscribe(string channel, string queueName, Func<(IPubSubQueue queue, string channel), Task> action, string id) => throw new InvalidOperationException("Simulated subscribe failure.");
@@ -2741,16 +2741,6 @@ namespace Game.Application.Tests.DataAccess
             public Task AddToQueueAsync(string value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task AddRangeToQueueAsync(IEnumerable<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
             public Task<long> RemoveRangeAsync(IReadOnlyList<string> values, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-        }
-
-        /// <summary>A controllable <see cref="TimeProvider"/> so the opportunistic-reclaim grace period can be
-        /// crossed deterministically instead of relying on wall-clock delays.</summary>
-        private sealed class FakeTimeProvider(DateTimeOffset start) : TimeProvider
-        {
-            private DateTimeOffset _now = start;
-
-            public override DateTimeOffset GetUtcNow() => _now;
-            public void Advance(TimeSpan delta) => _now += delta;
         }
 
         private sealed class CapturingLogger<T> : ILogger<T>

--- a/Game.Application.Tests/DataAccess/PlayerUpdateBatchTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerUpdateBatchTests.cs
@@ -227,6 +227,5 @@ namespace Game.Application.Tests.DataAccess
                 return Task.CompletedTask;
             }
         }
-
     }
 }

--- a/Game.Application.Tests/DataAccess/PlayerUpdateBatchTests.cs
+++ b/Game.Application.Tests/DataAccess/PlayerUpdateBatchTests.cs
@@ -228,10 +228,5 @@ namespace Game.Application.Tests.DataAccess
             }
         }
 
-        private sealed class ThrowingPubSubService : NotSupportedPubSubService
-        {
-            public override Task PublishBatch<T>(string channel, string queueName, IEnumerable<T> queueData, CancellationToken cancellationToken = default)
-                => throw new InvalidOperationException("Simulated transient publish failure.");
-        }
     }
 }

--- a/Game.Application.Tests/Services/LoginTrackingServiceTests.cs
+++ b/Game.Application.Tests/Services/LoginTrackingServiceTests.cs
@@ -34,6 +34,5 @@ namespace Game.Application.Tests.Services
 
             Assert.Equal(cts.Token, userLogins.LastSaveToken);
         }
-
     }
 }

--- a/Game.Application.Tests/Services/LoginTrackingServiceTests.cs
+++ b/Game.Application.Tests/Services/LoginTrackingServiceTests.cs
@@ -1,5 +1,5 @@
-using Game.Abstractions.DataAccess;
 using Game.Application.Services;
+using Game.TestInfrastructure.Helpers;
 using Xunit;
 
 namespace Game.Application.Tests.Services
@@ -35,38 +35,5 @@ namespace Game.Application.Tests.Services
             Assert.Equal(cts.Token, userLogins.LastSaveToken);
         }
 
-        private sealed class FakeUserLogins : IUserLogins
-        {
-            public CancellationToken LastRecordToken { get; private set; }
-            public CancellationToken LastSaveToken { get; private set; }
-
-            public Task RecordConnection(
-                int userId,
-                string ipAddress,
-                string deviceFingerprintHash,
-                string userAgent,
-                string? secChUa,
-                string? secChUaMobile,
-                string? secChUaPlatform,
-                CancellationToken cancellationToken = default)
-            {
-                LastRecordToken = cancellationToken;
-                return Task.CompletedTask;
-            }
-
-            public Task SaveDeviceInfo(
-                int userId,
-                string deviceFingerprintHash,
-                string? secChUa,
-                string? secChUaMobile,
-                string? secChUaPlatform,
-                double? deviceMemory,
-                int? hardwareConcurrency,
-                CancellationToken cancellationToken = default)
-            {
-                LastSaveToken = cancellationToken;
-                return Task.CompletedTask;
-            }
-        }
     }
 }

--- a/Game.TestInfrastructure/Helpers/FakeTimeProvider.cs
+++ b/Game.TestInfrastructure/Helpers/FakeTimeProvider.cs
@@ -1,0 +1,19 @@
+namespace Game.TestInfrastructure.Helpers
+{
+    /// <summary>
+    /// The canonical <see cref="TimeProvider"/> test double: a clock that only moves when a test moves it, so
+    /// a deadline or grace period can be crossed deterministically instead of via wall-clock delays.
+    /// </summary>
+    /// <remarks>
+    /// Hand-rolled rather than taken from <c>Microsoft.Extensions.TimeProvider.Testing</c>: no caller needs that
+    /// package's timer support, and the dependency would buy nothing the four lines below don't already give.
+    /// </remarks>
+    public sealed class FakeTimeProvider(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan delta) => _now += delta;
+    }
+}

--- a/Game.TestInfrastructure/Helpers/FakeUserLogins.cs
+++ b/Game.TestInfrastructure/Helpers/FakeUserLogins.cs
@@ -1,0 +1,64 @@
+using Game.Abstractions.DataAccess;
+
+namespace Game.TestInfrastructure.Helpers
+{
+    /// <summary>
+    /// The canonical <see cref="IUserLogins"/> test double: records every call and the token it arrived under,
+    /// so a test can assert the dedupe memo skipped a DB round-trip (<see cref="RecordConnectionCallCount"/>),
+    /// that the request's token reached the data tier (<see cref="LastRecordToken"/>,
+    /// <see cref="LastSaveToken"/>), or when the call happened relative to other events
+    /// (<see cref="OnRecordConnection"/>) — and ignore the rest.
+    /// <see cref="ThrowOnRecordConnection"/> pins the failure path.
+    /// </summary>
+    public sealed class FakeUserLogins : IUserLogins
+    {
+        public int RecordConnectionCallCount { get; private set; }
+        public int SaveDeviceInfoCallCount { get; private set; }
+
+        /// <summary>The token of the most recent call; <see cref="CancellationToken.None"/> if none has run.</summary>
+        public CancellationToken LastRecordToken { get; private set; }
+        public CancellationToken LastSaveToken { get; private set; }
+
+        /// <summary>When set, <see cref="RecordConnection"/> throws after recording the attempt.</summary>
+        public bool ThrowOnRecordConnection { get; set; }
+
+        /// <summary>Invoked at the start of <see cref="RecordConnection"/>, before any configured throw.</summary>
+        public Action? OnRecordConnection { get; set; }
+
+        public Task RecordConnection(
+            int userId,
+            string ipAddress,
+            string deviceFingerprintHash,
+            string userAgent,
+            string? secChUa,
+            string? secChUaMobile,
+            string? secChUaPlatform,
+            CancellationToken cancellationToken = default)
+        {
+            RecordConnectionCallCount++;
+            LastRecordToken = cancellationToken;
+            OnRecordConnection?.Invoke();
+            if (ThrowOnRecordConnection)
+            {
+                throw new InvalidOperationException("simulated tracking failure");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task SaveDeviceInfo(
+            int userId,
+            string deviceFingerprintHash,
+            string? secChUa,
+            string? secChUaMobile,
+            string? secChUaPlatform,
+            double? deviceMemory,
+            int? hardwareConcurrency,
+            CancellationToken cancellationToken = default)
+        {
+            SaveDeviceInfoCallCount++;
+            LastSaveToken = cancellationToken;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Closes #2488.

Test-only. Applies the `docs/backend.md` → Testing Guidelines rule from #2487 (**one canonical double per interface**, in the shared test-infrastructure project) to the two cross-project duplicates that predated it.

## `FakeTimeProvider` — option 1 (move, don't take the package)

New `Game.TestInfrastructure/Helpers/FakeTimeProvider.cs`; the byte-identical copies in `SocketCommandProcessorTests` and `DataProviderSynchronizerTests` are gone. Both files already imported `Game.TestInfrastructure.Helpers`, so no call site changed.

I went with option 1 over `Microsoft.Extensions.TimeProvider.Testing`. The issue framed option 2 as "probably right if the timer support is ever wanted" — it isn't, at either call site. Both use exactly `GetUtcNow()` + `Advance(TimeSpan)` to cross a deadline deterministically, `Directory.Packages.props` has no other candidate consumer, and the class is four lines. Taking a package reference on two test projects to delete four lines is the wrong trade today; the reasoning is recorded in the class's `<remarks>` so switching later is a one-file change if timers ever matter.

## `FakeUserLogins` — merged

New `Game.TestInfrastructure/Helpers/FakeUserLogins.cs` records everything and is read selectively: `RecordConnectionCallCount` / `SaveDeviceInfoCallCount`, `LastRecordToken` / `LastSaveToken`, `ThrowOnRecordConnection`, `OnRecordConnection`.

I read the carve-out as *not* applying. It covers a double that **scripts a sequence** specific to one test class (the `FakePlayerRepository` null-then-recovers example); neither copy scripts anything — one counts calls, the other captures tokens. That's exactly the case the same paragraph already rules on: *"prefer one double that records everything and is read selectively over a no-op/recording pair."* `IUserLogins` has two eight-parameter members, so this is the shape that costs two edits per interface change. Merging is the rule as written, so no doc change is needed — the `docs/backend.md` note is only required if a duplicate stays on purpose, and neither does.

One behaviour note: the middleware copy threw `NotSupportedException` from `SaveDeviceInfo`. The merged double records instead. No test asserted that throw, and a canonical double that records is more useful than one that traps.

## Two extras found while scanning (minor, folded in)

Scanning for other cross-project duplicates turned up that **`ThrowingPubSubService` already has a canonical helper** — and two `Game.Application.Tests` classes were shadowing it:

- `PlayerUpdateBatchTests` nested a **byte-identical** private copy, in a file that already imports the helpers namespace. Deleted; it now binds to the canonical one.
- `DataProviderSynchronizerTests` nested a **same-named but unrelated** double (throws on `Subscribe`, not `PublishBatch`). Renamed to `SubscribeThrowingPubSubService` — same name, different behaviour, shadowing the real helper is a live trap for the next reader.

Both are one-line-scale and directly on this issue's theme, so they're here rather than in a follow-up.

## Follow-up filed

`RecordingCache` (`IReloadableReferenceCache`) is duplicated across `Game.Api.Tests` and `Game.Application.Tests` with genuinely different recording surfaces — the same judgement call as `FakeUserLogins`, but a different interface and outside this issue's stated scope. Filed separately rather than folded in.

## Test plan

- [x] `dotnet build` — clean, 0 warnings / 0 errors
- [x] `dotnet test --no-build --no-restore` — **3,656 passed, 0 failed** (Core 1501, Application 1188, Api 893, Infrastructure 74)
- [x] No production code touched; no new tests — the existing suites are the regression guard, as the issue specifies
- [x] No frontend changes, so `npm run lint` / `test:unit:ci` not applicable

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdR1bBZ685GrycqmGS3rSM)_