### PR TITLE
Enable the Globalization CA analyzers for casing and comparison (#2491)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -50,9 +50,10 @@ dotnet_diagnostic.CA1307.severity = none
 # 35 of its 38 hits were: interpolated StringBuilder.Append calls whose holes are all strings, since the
 # rule fires on the interpolation overload regardless of hole type. Keeping it live over the rest buys a
 # real guard on the data tier and API, where a `.ToString()` on an id reaching a persisted key or a wire
-# value would land. Note the limit: CA1305 does not fire on a bare `$"..."` assigned to string (there is
-# no IFormatProvider overload to suggest), so it covers the .ToString()/string.Format half only — the
-# interpolated cache-key builders are held by convention and comment, not by the analyzer.
+# value would land. Note the limits — it covers .ToString()/string.Format/Parse only, and is blind to two
+# shapes this codebase uses a lot: a bare `$"..."` assigned to string (no IFormatProvider overload to
+# suggest), and TryParse (verified — it fires on int.Parse(s) but not int.TryParse(s, out v)). So the
+# interpolated cache-key builders and the claim parses are held by convention and comment, not the analyzer.
 dotnet_diagnostic.CA1305.severity = warning
 
 # CA1308: normalize strings to uppercase. Off — the one hit is CodeGenExtensions.SnakeCase, which

--- a/.editorconfig
+++ b/.editorconfig
@@ -46,16 +46,27 @@ dotnet_diagnostic.CA1310.severity = warning
 # actually culture-sensitive by default.
 dotnet_diagnostic.CA1307.severity = none
 
-# CA1305: IFormatProvider. Deliberately off — 35 of its 38 hits are interpolated StringBuilder.Append
-# calls in the codegen writers whose holes are all strings (the rule fires on the interpolation
-# overload regardless of hole type), so it is noise here rather than signal. The genuinely numeric
-# wire/persistence sites format invariantly by construction instead; revisit if that stops holding.
-dotnet_diagnostic.CA1305.severity = none
+# CA1305: IFormatProvider. On everywhere except the codegen writers (scoped off below), which is where
+# 35 of its 38 hits were: interpolated StringBuilder.Append calls whose holes are all strings, since the
+# rule fires on the interpolation overload regardless of hole type. Keeping it live over the rest buys a
+# real guard on the data tier and API, where a `.ToString()` on an id reaching a persisted key or a wire
+# value would land. Note the limit: CA1305 does not fire on a bare `$"..."` assigned to string (there is
+# no IFormatProvider overload to suggest), so it covers the .ToString()/string.Format half only — the
+# interpolated cache-key builders are held by convention and comment, not by the analyzer.
+dotnet_diagnostic.CA1305.severity = warning
 
 # CA1308: normalize strings to uppercase. Off — the one hit is CodeGenExtensions.SnakeCase, which
 # lowercases invariantly to emit kebab-case *filenames*. The rule guards round-tripping a comparison
 # key, which this is not.
 dotnet_diagnostic.CA1308.severity = none
+
+# The codegen writers build TypeScript by interpolating already-formatted strings into StringBuilder,
+# which trips CA1305 on every such call with no numeric hole to guard. Numbers that genuinely reach the
+# emitted output are converted with InvariantCulture at the point of conversion instead, pinned by the
+# sv-SE tests in ConstantsWriterTests/StaticModifierWriterTests (locale-dependent output would be a TS
+# syntax change, not just different bytes — see docs/infrastructure.md).
+[Game.Api/CodeGen/**.cs]
+dotnet_diagnostic.CA1305.severity = none
 
 # Apply Windows-style CRLF line endings specifically to batch files
 [*.bat]

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,42 @@ dotnet_diagnostic.IDE0305.severity = none
 # is exercised directly by DataAccessCancellationTests.
 dotnet_diagnostic.xUnit1051.severity = none
 
+# ── Globalization (CA13xx) ──────────────────────────────────────────────────────────────────────
+# The whole category is off in the analyzers' default mode, so the same culture-sensitive-casing bug
+# was fixed three times by review alone (#2464/#2471, #2472/#2490). These are enabled per-rule rather
+# than via AnalysisMode=All so the list records exactly which risks we buy, and so an SDK adding a
+# rule to the category can't fail the build unannounced. CI builds with -warnaserror, so `warning` is
+# already fatal there — that single lever stays the enforcement mechanism.
+
+# CA1304/CA1311: ToUpper/ToLower without an explicit culture. This pair is what catches the recurring
+# bug — casing feeds persisted seed data and codegen'd client identifiers, so a tr-TR host must not be
+# able to change the value (leading "i" → dotted "İ", "Id" → dotless "ıd").
+dotnet_diagnostic.CA1304.severity = warning
+dotnet_diagnostic.CA1311.severity = warning
+
+# CA1309/CA1310: comparison that is culture-sensitive by *default* (StartsWith/EndsWith/IndexOf/Compare)
+# or explicitly culture-ordered when ordinal was meant. The project's standard is ordinal everywhere —
+# no string comparison here is a linguistic one.
+dotnet_diagnostic.CA1309.severity = warning
+dotnet_diagnostic.CA1310.severity = warning
+
+# CA1307: the *clarity* half of the same family (Equals/Contains/Replace/GetHashCode). Deliberately
+# off: those overloads already default to ordinal, so all 341 hits are correct as written and
+# annotating them would be pure churn with no behaviour change. CA1310 above covers the half that is
+# actually culture-sensitive by default.
+dotnet_diagnostic.CA1307.severity = none
+
+# CA1305: IFormatProvider. Deliberately off — 35 of its 38 hits are interpolated StringBuilder.Append
+# calls in the codegen writers whose holes are all strings (the rule fires on the interpolation
+# overload regardless of hole type), so it is noise here rather than signal. The genuinely numeric
+# wire/persistence sites format invariantly by construction instead; revisit if that stops holding.
+dotnet_diagnostic.CA1305.severity = none
+
+# CA1308: normalize strings to uppercase. Off — the one hit is CodeGenExtensions.SnakeCase, which
+# lowercases invariantly to emit kebab-case *filenames*. The rule guards round-tripping a comparison
+# key, which this is not.
+dotnet_diagnostic.CA1308.severity = none
+
 # Apply Windows-style CRLF line endings specifically to batch files
 [*.bat]
 end_of_line = crlf

--- a/.editorconfig
+++ b/.editorconfig
@@ -50,10 +50,11 @@ dotnet_diagnostic.CA1307.severity = none
 # 35 of its 38 hits were: interpolated StringBuilder.Append calls whose holes are all strings, since the
 # rule fires on the interpolation overload regardless of hole type. Keeping it live over the rest buys a
 # real guard on the data tier and API, where a `.ToString()` on an id reaching a persisted key or a wire
-# value would land. Note the limits — it covers .ToString()/string.Format/Parse only, and is blind to two
-# shapes this codebase uses a lot: a bare `$"..."` assigned to string (no IFormatProvider overload to
-# suggest), and TryParse (verified — it fires on int.Parse(s) but not int.TryParse(s, out v)). So the
-# interpolated cache-key builders and the claim parses are held by convention and comment, not the analyzer.
+# value would land. Note the limits — it only fires where an IFormatProvider overload exists to suggest
+# (.ToString()/string.Format/Parse/Convert.To*), so it is blind to two shapes this codebase uses a lot:
+# a bare `$"..."` assigned to string, and TryParse (verified — it fires on int.Parse(s) but not on
+# int.TryParse(s, out v)). So the interpolated cache-key builders and the claim parses are held by
+# convention and comment, not the analyzer.
 dotnet_diagnostic.CA1305.severity = warning
 
 # CA1308: normalize strings to uppercase. Off — the one hit is CodeGenExtensions.SnakeCase, which

--- a/Game.Api.Tests/CodeGen/ApiInterfaceWriterTests.cs
+++ b/Game.Api.Tests/CodeGen/ApiInterfaceWriterTests.cs
@@ -282,7 +282,7 @@ namespace Game.Api.Tests.CodeGen
             var files = Directory.GetFiles(Path.Combine(_options.TargetDirectory, "interfaces"), "*.ts");
             var content = File.ReadAllText(files[0]);
             Assert.StartsWith(customComment, content);
-            Assert.False(content.StartsWith(defaultComment));
+            Assert.False(content.StartsWith(defaultComment, StringComparison.Ordinal));
         }
 
         [Fact]

--- a/Game.Api.Tests/CodeGen/ApiMapWriterTests.cs
+++ b/Game.Api.Tests/CodeGen/ApiMapWriterTests.cs
@@ -81,8 +81,8 @@ namespace Game.Api.Tests.CodeGen
             writer.WriteApiMap(endpoints, "// Auto-generated");
 
             var content = File.ReadAllText(Path.Combine(_options.TargetDirectory, "api-type-map.ts"));
-            var alphaIndex = content.IndexOf("'Alpha'");
-            var zebraIndex = content.IndexOf("'Zebra'");
+            var alphaIndex = content.IndexOf("'Alpha'", StringComparison.Ordinal);
+            var zebraIndex = content.IndexOf("'Zebra'", StringComparison.Ordinal);
             Assert.True(alphaIndex < zebraIndex);
         }
 
@@ -179,7 +179,7 @@ namespace Game.Api.Tests.CodeGen
 
             var content = File.ReadAllText(Path.Combine(_options.TargetDirectory, "api-type-map.ts"));
             Assert.StartsWith(customComment, content);
-            Assert.False(content.StartsWith(defaultComment));
+            Assert.False(content.StartsWith(defaultComment, StringComparison.Ordinal));
         }
 
         [Fact]

--- a/Game.Api.Tests/CodeGen/CodeGenTypeFormatterTests.cs
+++ b/Game.Api.Tests/CodeGen/CodeGenTypeFormatterTests.cs
@@ -259,7 +259,7 @@ namespace Game.Api.Tests.CodeGen
             var endpoint = new EndpointMetadata(method) { Endpoint = "Test" };
             var result = CodeGenTypeFormatter.GetParametersTypeText(endpoint);
             // id is not nullable/default, so not all params are optional
-            Assert.False(result.EndsWith("| undefined"));
+            Assert.False(result.EndsWith("| undefined", StringComparison.Ordinal));
         }
 
         [Fact]

--- a/Game.Api.Tests/CodeGen/ConstantsWriterTests.cs
+++ b/Game.Api.Tests/CodeGen/ConstantsWriterTests.cs
@@ -37,6 +37,8 @@ namespace Game.Api.Tests.CodeGen
             public const bool FlagEnabled = true;
             public const string Label = "hello";
             public const string Tricky = "a'b\\c";
+            public const int NegativeOffset = -5;
+            public const double FractionalRate = 1.5;
         }
 
         private static FieldInfo[] SampleFields =>
@@ -86,6 +88,20 @@ namespace Game.Api.Tests.CodeGen
         public void ToScreamingSnakeCase_ConvertsPascalCaseNames(string pascalCase, string expected)
         {
             Assert.Equal(expected, ConstantsWriter.ToScreamingSnakeCase(pascalCase));
+        }
+
+        [Fact]
+        public void WriteConstants_SwedishCulture_RendersNumbersInvariantly()
+        {
+            // The numeric sibling of the tr-TR casing guards below. sv-SE writes the decimal separator as
+            // "," and the negative sign as U+2212 MINUS SIGN, so a current-culture render would emit
+            // "= 1,5" (a TS syntax change) and a non-ASCII minus into the byte-compared game-constants.ts.
+            using var culture = new CultureScope("sv-SE");
+
+            var content = WriteAndRead(SampleFields);
+
+            Assert.Contains("export const FRACTIONAL_RATE = 1.5;", content, StringComparison.Ordinal);
+            Assert.Contains("export const NEGATIVE_OFFSET = -5;", content, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/Game.Api.Tests/CodeGen/SocketMapWriterTests.cs
+++ b/Game.Api.Tests/CodeGen/SocketMapWriterTests.cs
@@ -75,7 +75,7 @@ namespace Game.Api.Tests.CodeGen
             // Should appear in response types (with undefined since no response descriptor)
             Assert.Contains($"'{metadata.CommandName}': undefined;", content);
             // Request section should be empty (no entry for this command)
-            var requestSection = content[(content.IndexOf("ApiSocketRequestTypes") + 1)..];
+            var requestSection = content[(content.IndexOf("ApiSocketRequestTypes", StringComparison.Ordinal) + 1)..];
             Assert.DoesNotContain(metadata.CommandName, requestSection);
         }
 
@@ -105,8 +105,8 @@ namespace Game.Api.Tests.CodeGen
             writer.WriteSocketMap(metadata, "// Auto-generated");
 
             var content = File.ReadAllText(Path.Combine(_options.TargetDirectory, "api-socket-type-map.ts"));
-            var basicIndex = content.IndexOf("TestSocketCommandBasic");
-            var responseIndex = content.IndexOf("TestSocketCommandWithResponse");
+            var basicIndex = content.IndexOf("TestSocketCommandBasic", StringComparison.Ordinal);
+            var responseIndex = content.IndexOf("TestSocketCommandWithResponse", StringComparison.Ordinal);
             Assert.True(basicIndex < responseIndex);
         }
 
@@ -159,7 +159,7 @@ namespace Game.Api.Tests.CodeGen
 
             var content = File.ReadAllText(Path.Combine(_options.TargetDirectory, "api-socket-type-map.ts"));
             Assert.StartsWith(customComment, content);
-            Assert.False(content.StartsWith(defaultComment));
+            Assert.False(content.StartsWith(defaultComment, StringComparison.Ordinal));
         }
 
         [Fact]

--- a/Game.Api.Tests/CodeGen/StaticModifierWriterTests.cs
+++ b/Game.Api.Tests/CodeGen/StaticModifierWriterTests.cs
@@ -2,6 +2,7 @@ using Game.Api.CodeGen;
 using Game.Api.CodeGen.Writers;
 using Game.Core;
 using Game.Core.Attributes.Modifiers;
+using Game.Core.TestInfrastructure.Helpers;
 using Xunit;
 
 namespace Game.Api.Tests.CodeGen
@@ -38,6 +39,27 @@ namespace Game.Api.Tests.CodeGen
             Assert.Contains("import { EAttribute, EAttributeModifierSource, EModifierType } from './enums.ts';", content);
             Assert.Contains("export const STATIC_ATTRIBUTE_MODIFIERS = [", content);
             Assert.EndsWith("] as const;", content);
+        }
+
+        [Fact]
+        public void WriteStaticModifiers_SwedishCulture_RendersAmountInvariantly()
+        {
+            // A modifier amount is a double and may be negative, and sv-SE renders "-1.5" as "−1,5"
+            // (comma separator, U+2212 minus) — which would both break the emitted TS object literal and
+            // make the byte-compared output depend on the generating machine's locale.
+            using var culture = new CultureScope("sv-SE");
+
+            var modifier = new AttributeModifier
+            {
+                Attribute = EAttribute.MaxHealth,
+                Amount = -1.5,
+                Type = EModifierType.Additive,
+                Source = EAttributeModifierSource.BaseValue
+            };
+
+            var content = WriteAndRead([modifier]);
+
+            Assert.Contains("amount: -1.5,", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -101,7 +123,7 @@ namespace Game.Api.Tests.CodeGen
 
             var content = WriteAndRead([first, second]);
 
-            Assert.True(content.IndexOf("EAttribute.Strength") < content.IndexOf("EAttribute.Agility"));
+            Assert.True(content.IndexOf("EAttribute.Strength", StringComparison.Ordinal) < content.IndexOf("EAttribute.Agility", StringComparison.Ordinal));
         }
 
         private string WriteAndRead(IReadOnlyList<AttributeModifier> modifiers)

--- a/Game.Api.Tests/Integration/AuthRateLimitLoggingTests.cs
+++ b/Game.Api.Tests/Integration/AuthRateLimitLoggingTests.cs
@@ -5,6 +5,7 @@ using Game.TestInfrastructure.Helpers;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using System.Globalization;
 using System.Net.Http.Json;
 using Xunit;
 
@@ -72,7 +73,7 @@ namespace Game.Api.Tests.Integration
                 {
                     config.AddInMemoryCollection(new Dictionary<string, string?>
                     {
-                        ["RateLimiting:Auth:PermitLimit"] = PermitLimit.ToString(),
+                        ["RateLimiting:Auth:PermitLimit"] = PermitLimit.ToString(CultureInfo.InvariantCulture),
                         ["RateLimiting:Auth:WindowSeconds"] = "60",
                     });
                 });

--- a/Game.Api.Tests/Integration/AuthRateLimitingTests.cs
+++ b/Game.Api.Tests/Integration/AuthRateLimitingTests.cs
@@ -3,6 +3,7 @@ using Game.TestInfrastructure.Base;
 using Game.TestInfrastructure.Fixtures;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
 using Xunit;
@@ -136,7 +137,7 @@ namespace Game.Api.Tests.Integration
                 {
                     config.AddInMemoryCollection(new Dictionary<string, string?>
                     {
-                        ["RateLimiting:Auth:PermitLimit"] = PermitLimit.ToString(),
+                        ["RateLimiting:Auth:PermitLimit"] = PermitLimit.ToString(CultureInfo.InvariantCulture),
                         ["RateLimiting:Auth:WindowSeconds"] = "60",
                     });
                 });

--- a/Game.Api.Tests/Integration/ForwardedHeadersTrustTests.cs
+++ b/Game.Api.Tests/Integration/ForwardedHeadersTrustTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Globalization;
 using System.Net;
 using Xunit;
 
@@ -98,7 +99,7 @@ namespace Game.Api.Tests.Integration
                         }
                         if (forwardLimit is not null)
                         {
-                            settings["ForwardedHeaders:ForwardLimit"] = forwardLimit.Value.ToString();
+                            settings["ForwardedHeaders:ForwardLimit"] = forwardLimit.Value.ToString(CultureInfo.InvariantCulture);
                         }
                         config.AddInMemoryCollection(settings);
                     });

--- a/Game.Api.Tests/Integration/RequestLoggingTests.cs
+++ b/Game.Api.Tests/Integration/RequestLoggingTests.cs
@@ -35,7 +35,7 @@ namespace Game.Api.Tests.Integration
             await Client.GetAsync("/api/Auth/Status", CancellationToken);
 
             var entries = GetMiddlewareEntries(startIndex);
-            var startEntry = Assert.Single(entries, e => e.Message.StartsWith("Request Start"));
+            var startEntry = Assert.Single(entries, e => e.Message.StartsWith("Request Start", StringComparison.Ordinal));
             var scope = Assert.IsType<Dictionary<string, object?>>(startEntry.ScopeStates.Single());
             Assert.Equal("GET", scope["Method"]);
             Assert.Equal("/api/Auth/Status", scope["Path"]);
@@ -53,7 +53,7 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
 
             var entries = GetMiddlewareEntries(startIndex);
-            var endedEntry = Assert.Single(entries, e => e.Message.StartsWith("Request Ended"));
+            var endedEntry = Assert.Single(entries, e => e.Message.StartsWith("Request Ended", StringComparison.Ordinal));
             Assert.Equal(LogLevel.Information, endedEntry.Level);
 
             var statusCode = (int)endedEntry.Properties.Single(p => p.Key == "StatusCode").Value!;
@@ -76,7 +76,7 @@ namespace Game.Api.Tests.Integration
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             var entries = GetMiddlewareEntries(startIndex);
-            var startEntry = Assert.Single(entries, e => e.Message.StartsWith("Request Start"));
+            var startEntry = Assert.Single(entries, e => e.Message.StartsWith("Request Start", StringComparison.Ordinal));
             var scope = Assert.IsType<Dictionary<string, object?>>(startEntry.ScopeStates.Single());
             Assert.Equal(userId, scope["UserId"]);
         }
@@ -92,7 +92,7 @@ namespace Game.Api.Tests.Integration
             await authClient.GetAsync("/api/Auth/Status", CancellationToken);
 
             var entries = GetMiddlewareEntries(startIndex);
-            var endedEntry = Assert.Single(entries, e => e.Message.StartsWith("Request Ended"));
+            var endedEntry = Assert.Single(entries, e => e.Message.StartsWith("Request Ended", StringComparison.Ordinal));
             var statusCode = (int)endedEntry.Properties.Single(p => p.Key == "StatusCode").Value!;
             Assert.Equal(200, statusCode);
         }

--- a/Game.Api.Tests/Unit/ExceptionHandlingMiddlewareTests.cs
+++ b/Game.Api.Tests/Unit/ExceptionHandlingMiddlewareTests.cs
@@ -156,7 +156,7 @@ namespace Game.Api.Tests.Unit
             var loggingCategory = typeof(RequestLoggingMiddleware).FullName!;
             var endedEntry = Assert.Single(
                 capturingProvider.Entries.Where(e => e.Category == loggingCategory),
-                e => e.Message.StartsWith("Request Ended"));
+                e => e.Message.StartsWith("Request Ended", StringComparison.Ordinal));
             var statusCode = (int)endedEntry.Properties.Single(p => p.Key == "StatusCode").Value!;
             Assert.Equal(500, statusCode);
 

--- a/Game.Api.Tests/Unit/RequestLoggingMiddlewareTests.cs
+++ b/Game.Api.Tests/Unit/RequestLoggingMiddlewareTests.cs
@@ -38,9 +38,9 @@ namespace Game.Api.Tests.Unit
             Assert.NotNull(category);
             var entries = capturingProvider.Entries.Where(e => e.Category == category).ToList();
 
-            Assert.Single(entries, e => e.Message.StartsWith("Request Start"));
+            Assert.Single(entries, e => e.Message.StartsWith("Request Start", StringComparison.Ordinal));
 
-            var endedEntry = Assert.Single(entries, e => e.Message.StartsWith("Request Ended"));
+            var endedEntry = Assert.Single(entries, e => e.Message.StartsWith("Request Ended", StringComparison.Ordinal));
             Assert.Equal(LogLevel.Information, endedEntry.Level);
             var statusCode = (int)Assert.IsType<int>(endedEntry.Properties.Single(p => p.Key == "StatusCode").Value);
             Assert.Equal(500, statusCode);

--- a/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
+++ b/Game.Api.Tests/Unit/SocketCommandProcessorTests.cs
@@ -201,14 +201,14 @@ namespace Game.Api.Tests.Unit
             Assert.Equal(2, cache.CompareAndSets.Count);
             Assert.Equal(2, cache.CompareAndDeletes.Count);
 
-            var presenceClaim = Assert.Single(cache.CompareAndSets, c => c.Key.StartsWith(Constants.CACHE_PLAYER_SOCKET_PREFIX));
-            var presenceRelease = Assert.Single(cache.CompareAndDeletes, c => c.Key.StartsWith(Constants.CACHE_PLAYER_SOCKET_PREFIX));
+            var presenceClaim = Assert.Single(cache.CompareAndSets, c => c.Key.StartsWith(Constants.CACHE_PLAYER_SOCKET_PREFIX, StringComparison.Ordinal));
+            var presenceRelease = Assert.Single(cache.CompareAndDeletes, c => c.Key.StartsWith(Constants.CACHE_PLAYER_SOCKET_PREFIX, StringComparison.Ordinal));
             Assert.Equal(presenceClaim.Key, presenceRelease.Key);
             Assert.Equal(presenceClaim.NewValue, presenceRelease.DeleteIfValue);
             Assert.Equal($"{Constants.CACHE_PLAYER_SOCKET_PREFIX}_42", presenceRelease.Key);
 
-            var accountClaim = Assert.Single(cache.CompareAndSets, c => c.Key.StartsWith(Constants.CACHE_ACCOUNT_SOCKET_PREFIX));
-            var accountRelease = Assert.Single(cache.CompareAndDeletes, c => c.Key.StartsWith(Constants.CACHE_ACCOUNT_SOCKET_PREFIX));
+            var accountClaim = Assert.Single(cache.CompareAndSets, c => c.Key.StartsWith(Constants.CACHE_ACCOUNT_SOCKET_PREFIX, StringComparison.Ordinal));
+            var accountRelease = Assert.Single(cache.CompareAndDeletes, c => c.Key.StartsWith(Constants.CACHE_ACCOUNT_SOCKET_PREFIX, StringComparison.Ordinal));
             Assert.Equal(accountClaim.Key, accountRelease.Key);
             Assert.Equal(accountClaim.NewValue, accountRelease.DeleteIfValue);
             Assert.Equal($"{Constants.CACHE_ACCOUNT_SOCKET_PREFIX}_1", accountRelease.Key);
@@ -286,7 +286,7 @@ namespace Game.Api.Tests.Unit
 
             Assert.NotNull(context);
             Assert.Equal(3, cache.PresenceGetCalls);
-            var presenceClaim = Assert.Single(cache.CompareAndSets, c => c.Key.StartsWith(Constants.CACHE_PLAYER_SOCKET_PREFIX));
+            var presenceClaim = Assert.Single(cache.CompareAndSets, c => c.Key.StartsWith(Constants.CACHE_PLAYER_SOCKET_PREFIX, StringComparison.Ordinal));
             Assert.Null(presenceClaim.ExpectedValue);
         }
 
@@ -334,11 +334,11 @@ namespace Game.Api.Tests.Unit
             // (#1817) were still released via a compare-and-delete keyed on what each was claimed with (so a
             // newer owner's key would be left intact).
             Assert.Equal(2, cache.CompareAndDeletes.Count);
-            var presenceRelease = Assert.Single(cache.CompareAndDeletes, c => c.Key.StartsWith(Constants.CACHE_PLAYER_SOCKET_PREFIX));
+            var presenceRelease = Assert.Single(cache.CompareAndDeletes, c => c.Key.StartsWith(Constants.CACHE_PLAYER_SOCKET_PREFIX, StringComparison.Ordinal));
             Assert.Equal($"{Constants.CACHE_PLAYER_SOCKET_PREFIX}_77", presenceRelease.Key);
             Assert.Equal(context.SocketId, presenceRelease.DeleteIfValue);
 
-            var accountRelease = Assert.Single(cache.CompareAndDeletes, c => c.Key.StartsWith(Constants.CACHE_ACCOUNT_SOCKET_PREFIX));
+            var accountRelease = Assert.Single(cache.CompareAndDeletes, c => c.Key.StartsWith(Constants.CACHE_ACCOUNT_SOCKET_PREFIX, StringComparison.Ordinal));
             Assert.Equal($"{Constants.CACHE_ACCOUNT_SOCKET_PREFIX}_1", accountRelease.Key);
             Assert.Equal($"77:{context.SocketId}", accountRelease.DeleteIfValue);
             Assert.Contains(_logs.Entries, e => e.Level == LogLevel.Error && e.Message.Contains("unsubscribe"));

--- a/Game.Api/Auth/JwtTokenService.cs
+++ b/Game.Api/Auth/JwtTokenService.cs
@@ -2,6 +2,7 @@ using Game.Abstractions.Auth;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
+using System.Globalization;
 using System.Security.Claims;
 using System.Text;
 
@@ -45,13 +46,13 @@ namespace Game.Api.Auth
             var now = DateTime.UtcNow;
             var claims = new List<Claim>
             {
-                new(JwtRegisteredClaimNames.Sub, userId.ToString()),
+                new(JwtRegisteredClaimNames.Sub, userId.ToString(CultureInfo.InvariantCulture)),
                 new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
             };
             claims.AddRange(roles.Select(role => new Claim(RoleClaimType, role)));
             if (playerId is int selectedPlayerId)
             {
-                claims.Add(new Claim(PlayerIdClaimType, selectedPlayerId.ToString()));
+                claims.Add(new Claim(PlayerIdClaimType, selectedPlayerId.ToString(CultureInfo.InvariantCulture)));
             }
 
             var descriptor = new SecurityTokenDescriptor

--- a/Game.Api/Middleware/SessionLoaderMiddleware.cs
+++ b/Game.Api/Middleware/SessionLoaderMiddleware.cs
@@ -1,6 +1,7 @@
 using Game.Api.Auth;
 using Game.Api.Services;
 using Microsoft.IdentityModel.JsonWebTokens;
+using System.Globalization;
 using System.Security.Claims;
 
 namespace Game.Api.Middleware
@@ -21,11 +22,11 @@ namespace Game.Api.Middleware
         {
             var principal = context.User;
             if (principal.Identity?.IsAuthenticated == true
-                && int.TryParse(principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value, out var userId))
+                && int.TryParse(principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value, CultureInfo.InvariantCulture, out var userId))
             {
                 // The selected-player claim is present only once a player has been chosen (post-SelectPlayer);
                 // a pre-selection token carries none, leaving the request unbound until selection.
-                var selectedPlayerId = int.TryParse(principal.FindFirst(JwtTokenService.PlayerIdClaimType)?.Value, out var playerId)
+                var selectedPlayerId = int.TryParse(principal.FindFirst(JwtTokenService.PlayerIdClaimType)?.Value, CultureInfo.InvariantCulture, out var playerId)
                     ? playerId
                     : (int?)null;
                 sessionService.SetAuthenticatedUser(userId, selectedPlayerId);

--- a/Game.Api/Services/SocketManagerService.cs
+++ b/Game.Api/Services/SocketManagerService.cs
@@ -683,13 +683,13 @@ namespace Game.Api.Services
 
         private static string CurrentSocketKey(int playerId)
         {
-            return $"{Constants.CACHE_PLAYER_SOCKET_PREFIX}_{playerId}";
+            return string.Create(CultureInfo.InvariantCulture, $"{Constants.CACHE_PLAYER_SOCKET_PREFIX}_{playerId}");
         }
 
         /// <summary>The account-level "current live character" key <see cref="ClaimAccountPresence"/> claims.</summary>
         private static string AccountSocketKey(int userId)
         {
-            return $"{Constants.CACHE_ACCOUNT_SOCKET_PREFIX}_{userId}";
+            return string.Create(CultureInfo.InvariantCulture, $"{Constants.CACHE_ACCOUNT_SOCKET_PREFIX}_{userId}");
         }
 
         private static string PlayerIdValue(int playerId) => playerId.ToString(CultureInfo.InvariantCulture);

--- a/Game.Application.Tests/DataAccess/ChildCollectionReconcilerTests.cs
+++ b/Game.Application.Tests/DataAccess/ChildCollectionReconcilerTests.cs
@@ -1,6 +1,7 @@
 using Game.Abstractions.DataAccess.Admin;
 using Game.DataAccess.Repositories.Admin;
 using Xunit;
+using System.Globalization;
 
 namespace Game.Application.Tests.DataAccess
 {
@@ -29,7 +30,7 @@ namespace Game.Application.Tests.DataAccess
                 existing: existing,
                 desired: desired,
                 existingKey: e => e.Key,
-                desiredKey: d => int.Parse(d.Key),
+                desiredKey: d => int.Parse(d.Key, CultureInfo.InvariantCulture),
                 delete: e => recorder.Deleted.Add(e.Key),
                 insert: d => recorder.Inserted.Add(d.Payload),
                 resourceName: "child",
@@ -161,7 +162,7 @@ namespace Game.Application.Tests.DataAccess
                 existing: existing,
                 desired: desired,
                 existingKey: e => e.Key,
-                desiredKey: d => int.Parse(d.Key),
+                desiredKey: d => int.Parse(d.Key, CultureInfo.InvariantCulture),
                 delete: e => deletedChild = e,
                 insert: d => insertedItem = d,
                 resourceName: "child",

--- a/Game.Application.Tests/DataAccess/ReferenceSnapshotExtensionsTests.cs
+++ b/Game.Application.Tests/DataAccess/ReferenceSnapshotExtensionsTests.cs
@@ -1,3 +1,4 @@
+using Game.Core.TestInfrastructure.Helpers;
 using Game.DataAccess.Repositories;
 using Game.Infrastructure.Entities;
 using Xunit;
@@ -55,11 +56,19 @@ namespace Game.Application.Tests.DataAccess
         [InlineData(int.MaxValue)]
         public void GetById_IdOutOfRange_ThrowsDescriptiveArgumentOutOfRange(int id)
         {
+            // The message under assertion is built by a bare interpolation, so it formats the id under the
+            // ambient culture. Pinning the culture keeps both halves of the comparison on one rulebook —
+            // otherwise the -1 case fails on a host whose negative sign isn't ASCII (sv-SE renders U+2212).
+            // Exception text is a diagnostic, not a persisted key or wire value, so it is deliberately
+            // outside the invariant-formatting convention in docs/backend.md; the test absorbs the
+            // difference rather than the convention widening to every message in the codebase.
+            using var culture = new CultureScope(CultureInfo.InvariantCulture.Name);
+
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => Snapshot.GetById(id, "widget"));
 
             Assert.Equal(id, ex.ActualValue);
-            Assert.Contains("widget", ex.Message);
-            Assert.Contains(id.ToString(CultureInfo.InvariantCulture), ex.Message);
+            Assert.Contains("widget", ex.Message, StringComparison.Ordinal);
+            Assert.Contains(id.ToString(CultureInfo.InvariantCulture), ex.Message, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/Game.Application.Tests/DataAccess/ReferenceSnapshotExtensionsTests.cs
+++ b/Game.Application.Tests/DataAccess/ReferenceSnapshotExtensionsTests.cs
@@ -1,6 +1,7 @@
 using Game.DataAccess.Repositories;
 using Game.Infrastructure.Entities;
 using Xunit;
+using System.Globalization;
 
 namespace Game.Application.Tests.DataAccess
 {
@@ -58,7 +59,7 @@ namespace Game.Application.Tests.DataAccess
 
             Assert.Equal(id, ex.ActualValue);
             Assert.Contains("widget", ex.Message);
-            Assert.Contains(id.ToString(), ex.Message);
+            Assert.Contains(id.ToString(CultureInfo.InvariantCulture), ex.Message);
         }
 
         [Fact]

--- a/Game.DataAccess/Repositories/Admin/AdminSkillRecipes.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminSkillRecipes.cs
@@ -4,6 +4,7 @@ using Game.Core;
 using Game.DataAccess.Repositories.Caching;
 using Contracts = Game.Abstractions.Contracts;
 using Entities = Game.Infrastructure.Entities;
+using System.Globalization;
 
 namespace Game.DataAccess.Repositories.Admin
 {
@@ -254,7 +255,7 @@ namespace Game.DataAccess.Repositories.Admin
 
             var skill = _skills.LookupSkill(duplicate.Key);
             return AdminSaveResult.Failure(
-                $"Skill '{skill?.Name ?? duplicate.Key.ToString()}' would be produced by more than one active recipe; each skill may have only one producing recipe.");
+                $"Skill '{skill?.Name ?? duplicate.Key.ToString(CultureInfo.InvariantCulture)}' would be produced by more than one active recipe; each skill may have only one producing recipe.");
         }
 
         /// <summary>The live recipe graph as (result, inputs) pairs keyed by recipe id — the base every

--- a/Game.DataAccess/Repositories/Admin/ReferenceFieldValidation.cs
+++ b/Game.DataAccess/Repositories/Admin/ReferenceFieldValidation.cs
@@ -42,6 +42,11 @@ namespace Game.DataAccess.Repositories.Admin
                 var value = field(change.Item);
                 if (!Enum.IsDefined(value))
                 {
+                    // The InvariantCulture argument satisfies CA1305 but does nothing: Enum's IConvertible
+                    // ignores the provider, and the resulting int is then formatted by the interpolation
+                    // under the ambient culture. Unlike the load-bearing annotations on the cache-key
+                    // builders, this one is analyzer-appeasement — the message is a diagnostic, not a
+                    // persisted key, so it is deliberately left outside the invariant convention.
                     return AdminSaveResult.Failure(
                         $"{Convert.ToInt32(value, CultureInfo.InvariantCulture)} is not a valid {fieldName}.");
                 }

--- a/Game.DataAccess/Repositories/Admin/ReferenceFieldValidation.cs
+++ b/Game.DataAccess/Repositories/Admin/ReferenceFieldValidation.cs
@@ -1,6 +1,7 @@
 using Game.Abstractions;
 using Game.Abstractions.Contracts.Admin;
 using Game.Abstractions.DataAccess.Admin;
+using System.Globalization;
 
 namespace Game.DataAccess.Repositories.Admin
 {
@@ -42,7 +43,7 @@ namespace Game.DataAccess.Repositories.Admin
                 if (!Enum.IsDefined(value))
                 {
                     return AdminSaveResult.Failure(
-                        $"{Convert.ToInt32(value)} is not a valid {fieldName}.");
+                        $"{Convert.ToInt32(value, CultureInfo.InvariantCulture)} is not a valid {fieldName}.");
                 }
             }
 

--- a/Game.DataAccess/Repositories/PlayerProgressRepository.cs
+++ b/Game.DataAccess/Repositories/PlayerProgressRepository.cs
@@ -394,10 +394,12 @@ namespace Game.DataAccess.Repositories
         // FromHashFields never needs the caller to track kind alongside field name. The row's natural key
         // (type+entity / challenge id / proficiency id) makes each field name stable and collision-free across
         // saves, so a later HSET on the same row always overwrites the same field rather than appending a
-        // duplicate.
-        private static string StatField(int statisticTypeId, int? entityId) => $"S_{statisticTypeId}_{entityId?.ToString() ?? "n"}";
-        private static string ChallengeField(int challengeId) => $"C_{challengeId}";
-        private static string ProficiencyField(int proficiencyId) => $"P_{proficiencyId}";
+        // duplicate. The ids are formatted invariantly because the field name is a persisted key every
+        // instance in the fleet has to reproduce byte-for-byte, so it must not depend on the host locale.
+        private static string StatField(int statisticTypeId, int? entityId) =>
+            string.Create(CultureInfo.InvariantCulture, $"S_{statisticTypeId}_{entityId?.ToString(CultureInfo.InvariantCulture) ?? "n"}");
+        private static string ChallengeField(int challengeId) => string.Create(CultureInfo.InvariantCulture, $"C_{challengeId}");
+        private static string ProficiencyField(int proficiencyId) => string.Create(CultureInfo.InvariantCulture, $"P_{proficiencyId}");
 
         // Aggregate-level state rather than a row, so it gets a reserved field name outside the row-kind
         // prefixes (S_/C_/P_) — grouping with the "_" presence marker, and ignored by FromHashFields' row

--- a/Game.DataAccess/Repositories/PlayerProgressRepository.cs
+++ b/Game.DataAccess/Repositories/PlayerProgressRepository.cs
@@ -39,7 +39,7 @@ namespace Game.DataAccess.Repositories
         // session caches (AuthConstants.RefreshTokenLifetime) so a retune of that budget keeps them aligned.
         private static readonly TimeSpan ProgressCacheTtl = AuthConstants.RefreshTokenLifetime;
 
-        private static string ProgressKey(int playerId) => $"{Constants.CACHE_PROGRESS_PREFIX}_{playerId}";
+        private static string ProgressKey(int playerId) => string.Create(CultureInfo.InvariantCulture, $"{Constants.CACHE_PROGRESS_PREFIX}_{playerId}");
 
         // Per-scope read memo (#1820): a socket command opens one DI scope, so this repository instance is
         // shared by every read/save within that single command. Battle-lifecycle commands read the same
@@ -396,6 +396,8 @@ namespace Game.DataAccess.Repositories
         // saves, so a later HSET on the same row always overwrites the same field rather than appending a
         // duplicate. The ids are formatted invariantly because the field name is a persisted key every
         // instance in the fleet has to reproduce byte-for-byte, so it must not depend on the host locale.
+        // Both of StatField's InvariantCulture arguments are load-bearing: `??` resolves the hole to a
+        // string before string.Create sees it, so the inner one is what actually formats entityId.
         private static string StatField(int statisticTypeId, int? entityId) =>
             string.Create(CultureInfo.InvariantCulture, $"S_{statisticTypeId}_{entityId?.ToString(CultureInfo.InvariantCulture) ?? "n"}");
         private static string ChallengeField(int challengeId) => string.Create(CultureInfo.InvariantCulture, $"C_{challengeId}");

--- a/Game.DataAccess/Repositories/PlayerRepository.cs
+++ b/Game.DataAccess/Repositories/PlayerRepository.cs
@@ -7,6 +7,7 @@ using Game.DataAccess.Mapping;
 using Game.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using System.Globalization;
 using System.Text.Json;
 
 namespace Game.DataAccess.Repositories
@@ -14,6 +15,10 @@ namespace Game.DataAccess.Repositories
     internal class PlayerRepository : IPlayerRepository
     {
         private static string PlayerPrefix => Constants.CACHE_PLAYER_PREFIX;
+
+        // Invariant for the same reason as the other fleet-shared cache keys: every instance has to
+        // reproduce the key byte-for-byte, so it must not depend on the host locale.
+        private static string PlayerKey(int playerId) => string.Create(CultureInfo.InvariantCulture, $"{PlayerPrefix}_{playerId}");
 
         /// <summary>
         /// Idle TTL for the cached player aggregate. It is written on every save and load-miss re-cache
@@ -63,7 +68,7 @@ namespace Game.DataAccess.Repositories
 
         public async Task<Player?> GetPlayer(int playerId, CancellationToken cancellationToken = default)
         {
-            var playerKey = $"{PlayerPrefix}_{playerId}";
+            var playerKey = PlayerKey(playerId);
             // The cache and the database both yield the lean PlayerCacheModel, so the reference graph is
             // re-resolved from the in-memory catalogs through one rehydration path regardless of the source —
             // a cached player can never serve stale reference data (#1155).
@@ -162,7 +167,7 @@ namespace Game.DataAccess.Repositories
                 throw new PlayerPersistenceFlushFailedException(ex);
             }
 
-            var playerKey = $"{PlayerPrefix}_{player.Id}";
+            var playerKey = PlayerKey(player.Id);
 
             // Serialize the lean model rather than the aggregate, so the cached blob never holds reference data.
             // Deliberately fire-and-forget: the in-memory aggregate (not this blob) is the read-modify-write base

--- a/Game.DataAccess/Repositories/SessionStore.cs
+++ b/Game.DataAccess/Repositories/SessionStore.cs
@@ -3,6 +3,7 @@ using Game.Abstractions.DataAccess;
 using Game.Abstractions.Infrastructure;
 using Game.Core.Players;
 using Microsoft.Extensions.Logging;
+using System.Globalization;
 using System.Text.Json;
 
 
@@ -78,6 +79,8 @@ namespace Game.DataAccess.Repositories
             _cache.DeleteAndForget(SessionKey(userId));
         }
 
-        private static string SessionKey(int userId) => $"{SessionPrefix}_{userId}";
+        // Invariant for the same reason as the other fleet-shared cache keys: every instance has to
+        // reproduce the key byte-for-byte, so it must not depend on the host locale.
+        private static string SessionKey(int userId) => string.Create(CultureInfo.InvariantCulture, $"{SessionPrefix}_{userId}");
     }
 }

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -15,6 +15,7 @@ Four `*.Tests` projects cover the layers (`Api`/`Application`/`Core`/`Infrastruc
 
 - Repositories create and persist domain objects and dispatch domain events before persisting. They contain no domain logic and never return entity models or DB DTOs — mapping between domain objects, entities, and DTOs lives in `Game.DataAccess/Mapping`.
 - Domain logic lives in `Game.Core`. The application layer only orchestrates; the API layer only handles requests, validates input, and returns responses.
+- **String handling is ordinal and culture-invariant everywhere** — no comparison here is a linguistic one, and anything that reaches a persisted key, a cache/channel name, or the wire must render identically on every host locale. Casing and comparison are enforced by the Globalization analyzers (`.editorconfig` records which rules are on and why); number formatting in interpolated keys is convention, so build them with `string.Create(CultureInfo.InvariantCulture, $"…")`.
 
 ## Testing Guidelines
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -17,7 +17,7 @@ dotnet run --project Game.Api -- codegen [outputDirectory]
 
 The output is byte-identical to the dev-time generation, so CI can run the command and assert a clean `git diff` to catch api model/client drift.
 
-**The generated output must depend only on the sources, never on the generating machine.** The drift guard compares bytes, so every casing and ordering decision in the codegen is culture-independent — culture-aware casing and collation differ by locale *and* by ICU version, so a default comparer would regenerate different bytes on another developer's machine and fail the guard spuriously.
+**The generated output must depend only on the sources, never on the generating machine.** The drift guard compares bytes, so every casing, ordering, and **number-formatting** decision in the codegen is culture-independent — culture-aware casing and collation differ by locale *and* by ICU version, and a locale's decimal separator/negative sign would emit `1,5` or a U+2212 minus straight into the TypeScript (a syntax change, not just different bytes). So a default comparer or a bare `ToString()` would regenerate differently on another developer's machine. The casing/comparison half of this is enforced at build time by the Globalization analyzers enabled in `.editorconfig` (which records per-rule what is on and why); the number-formatting half has no analyzer covering it and is pinned by locale regression tests instead.
 
 ### Generated domain constants (not just DTOs)
 


### PR DESCRIPTION
Closes #2491.

Turns the recurring culture-sensitive-casing bug (#2464 → #2471, #2472 → #2490) from a review-time catch into a build-time one.

> **Updated through three review rounds.** `726759a` rescoped CA1305 from globally off to on-with-an-exclusion and applied the persistence-key rule consistently; `b69a7ac` fixed an sv-SE regression that first round introduced; `e999c7a` widened the config's recorded limit to what the rule actually covers. Tables below reflect the final state.

## What's enabled, and why per-rule

Severities go in `.editorconfig` rather than `AnalysisMode=All` in `Directory.Build.props`, for the reason the issue anticipated: the list records exactly which risks we buy, and an SDK moving a new rule into the category can't fail the build unannounced. `.editorconfig` is also already where this project's other per-rule decisions live (`IDE0290`, `xUnit1051`).

Severity is `warning`, not `error` — CI builds with `dotnet build -warnaserror`, so that single lever stays the enforcement mechanism rather than these rules diverging from every other diagnostic in the repo.

| Rule | Hits | Call |
|---|---|---|
| **CA1304 / CA1311** — casing without an explicit culture | 0 | **on** — the pair that catches the recurring bug |
| **CA1309 / CA1310** — culture-ordered, or culture-sensitive-by-default, comparison | 25 | **on**, all 25 fixed |
| **CA1305** — `IFormatProvider` | 38 | **on**, with `none` scoped to `[Game.Api/CodeGen/**.cs]`; the 8 hits outside the codegen are fixed |
| CA1307 — comparison "for clarity" | 341 | **off** |
| CA1308 — normalize to uppercase | 1 | **off** |

Every "off" carries its reason inline in `.editorconfig`, per the issue's closing note that an ignored category is worse than a disabled one:

- **CA1307** is the *clarity* half of the comparison family (`Equals`/`Contains`/`Replace`/`GetHashCode`). Those overloads **already default to ordinal**, so all 341 hits are correct as written and annotating them would be churn with no behaviour change. CA1310 covers the half that is genuinely culture-sensitive by default.
- **CA1308**'s single hit is `CodeGenExtensions.SnakeCase`, which lowercases invariantly to emit kebab-case *filenames*. The rule guards round-tripping a comparison key, which this is not.
- **CA1305's scoped exclusion** covers the codegen writers, where 35 of the 38 hits were: interpolated `StringBuilder.Append` calls whose holes are all strings, since the rule fires on the interpolation overload regardless of hole type. Keeping it live everywhere else guards the data tier and API. Verified by probe rather than inferred from a clean build — including the nested-directory case, since every writer lives below `CodeGen/`.

### What the analyzer does *not* catch

Worth stating plainly, because it defines what's convention rather than enforcement. CA1305 fires wherever an `IFormatProvider` overload exists for it to suggest — `.ToString()`, `string.Format`, `Parse`, `Convert.To*` — and is therefore blind to two shapes this codebase uses heavily:

- a bare `$"..."` assigned to a string (no `IFormatProvider` overload for it to suggest), and
- `TryParse` — it fires on `int.Parse(s)` but not `int.TryParse(s, out v)`.

So the interpolated cache-key builders **and** the claim parses below are held by convention and comment, not by the build. (An earlier revision of this PR claimed the claim parses were analyzer-covered; they never were. A later one described the coverage as `.ToString()`/`string.Format`/`Parse` *only*, which the `Convert.ToInt32` fix in this same PR contradicts — `e999c7a` states the rule instead of listing part of it.)

## Acceptance criteria

- ✅ Severities configured deliberately, with a comment recording what and why.
- ✅ `dotnet build -warnaserror` is clean (0 warnings, 0 errors), and `dotnet format --verify-no-changes` passes.
- ✅ **Reverting either prior fix now fails the build.** Verified against the final config, not assumed:

```
Game.Core/Extensions.cs(99,58): error CA1304: The behavior of 'char.ToUpper(char)' could vary
  based on the current user's locale settings. ... in 'string.Capitalize()'
Game.Api/CodeGen/Extensions.cs(16,58): error CA1304: The behavior of 'char.ToLower(char)' could
  vary ... in 'string.Decapitalize()'
```

## Two things triage turned up that the issue didn't anticipate

**1. The exposure is number formatting, not just casing — and it's a mainstream locale.** I measured `int.ToString()` across eight cultures. Positive integers are identical everywhere (.NET never applies digit substitution), but negatives are not:

| Culture | `(-42).ToString()` |
|---|---|
| en-US, tr-TR, bn-IN, th-TH | `-42` |
| **sv-SE** | `−42` (U+2212 MINUS SIGN) |
| fa-IR | U+200E + U+2212 |
| ar-SA | U+061C + `-` |

sv-SE is not an exotic edge, and it also uses `,` as the decimal separator. A codegen writer emitting `amount: 1,5` or a U+2212 minus into TypeScript would be a **syntax change**, and would flip the byte-comparing codegen drift guard based on the developer's locale.

`ConstantsWriter.RenderValue` and `StaticModifierWriter.RenderModifier` both already format invariantly, deliberately — but **nothing pinned it**, and no analyzer covers it. So both writers gain an sv-SE regression test alongside the existing tr-TR casing guards. I verified they're real guards: dropping `CultureInfo.InvariantCulture` from either writer fails them.

**2. Issue item 4 (ordinal-vs-culture sorting) needs no code.** Production in-memory sorts already pass `StringComparer.Ordinal` explicitly (15 call sites, from #2464's fix). The one bare `OrderBy(u => u.Username)` is on an EF `IQueryable`, so Postgres collation orders it — not a .NET culture surface. Filed as #2516 rather than papered over here.

## Fleet-shared keys formatted invariantly

**Hardening, not bug fixes** — the ids are non-negative, so the output is byte-identical on every locale and no key format changes (i.e. no cache-invalidation event on deploy). They're here because a persisted key has to be reproduced byte-for-byte by every instance, and the file shouldn't teach two different rules a few lines apart:

- `PlayerProgressRepository` — `ProgressKey` plus the `StatField`/`ChallengeField`/`ProficiencyField` hash field names.
- `SessionStore.SessionKey`, and `PlayerRepository`'s player cache key (built inline in two places, now one `PlayerKey` helper).
- `SocketManagerService` — `CurrentSocketKey` and `AccountSocketKey`. `SocketQueueName`/`SocketChannel` are deliberately **unchanged**: they interpolate a `string socketId`, so there is no locale dependency to remove and annotating them would imply a numeric hole that isn't there. Same for `RefreshTokenStore`/`LoginBackoffStore`, which interpolate a hex hash.
- `JwtTokenService` writes the `sub`/`player_id` claims invariantly and `SessionLoaderMiddleware` parses them the same way, so both halves of the round-trip use one rulebook.

**Exception messages are deliberately out of scope.** They're diagnostics, not keys or wire values, and there are 29 bare-interpolated ones in production — converting a single one would recreate the same inconsistency this PR is fixing elsewhere. Where a test asserts on such a message, the *test* pins the culture (`ReferenceSnapshotExtensionsTests`) so both halves agree on any host.

## Test plan

- ✅ `dotnet build Game.sln -warnaserror` — 0 warnings, 0 errors.
- ✅ `dotnet format --verify-no-changes --no-restore` — clean.
- ✅ Codegen drift check (`dotnet run --project Game.Api -- codegen` + `git diff`) — no drift.
- ✅ `dotnet test Game.sln` — **3,658 tests**, run under **three locales**: default, `sv_SE.UTF-8`, and `tr_TR.UTF-8`. The multi-locale run is new in `b69a7ac` and is what caught (and now pins) the regression. The only failure in any of the three runs is `OfflineProgressServiceIntegrationTests.SimulateOfflineProgress_StaleBattleSettles_DeductsItsSpanFromTheAwayBudget`, which reproduces identically on the merge-base `dea2b93` and is tracked as #2532 — unrelated to this PR and green in CI.
- ✅ Both acceptance-criterion reverts fail the build; both new locale tests fail when the invariant formatting is removed; the `ReferenceSnapshotExtensionsTests` culture pin fails under sv-SE when removed; CA1305 path scoping, the `TryParse` blind spot, and the `Convert.To*` coverage all verified by probe.

No frontend files are touched, so the UI suites aren't affected.