### PR TITLE
Reject sub-tick skill cooldowns at authoring time (#2519)

### DIFF
--- a/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
+++ b/Game.Api.Tests/Integration/AdminToolsControllerTests.cs
@@ -876,6 +876,48 @@ namespace Game.Api.Tests.Integration
         }
 
         [Fact]
+        public async Task AddEditSkills_SubTickCooldown_ReturnsBadRequestAndPersistsNothing()
+        {
+            using var authClient = await SetupAuthenticatedClientAsync();
+
+            // A cooldown below one simulation tick is rejected up front and mapped to a 400 carrying the data
+            // tier's message — the engine could not fire it that fast, while the combat rating would price it
+            // as if it could (at 0 it skips the skill entirely and prices it as zero offense).
+            var changes = new[]
+            {
+                new
+                {
+                    Item = new
+                    {
+                        Id = 0,
+                        Name = "Machine Gun Skill",
+                        BaseDamage = 10m,
+                        CooldownMs = 0,
+                        Description = "Should never be saved",
+                        IconPath = "skills/fast.png",
+                        RarityId = (int)ERarity.Common,
+                        Word = "",
+                        DesignerNotes = "",
+                        Pronunciation = "",
+                        Translation = "",
+                        DamagePortions = Array.Empty<object>(),
+                        DamageMultipliers = Array.Empty<object>(),
+                        Effects = Array.Empty<object>()
+                    },
+                    ChangeType = 0 // Add
+                }
+            };
+
+            var response = await authClient.PostAsJsonAsync("/api/AdminTools/AddEditSkills", changes, CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var result = await response.Content.ReadFromJsonAsync<ApiResponse>(CancellationToken);
+            Assert.NotNull(result);
+            Assert.Equal($"Skill cooldown must be at least {GameConstants.MsPerTick}ms.", result.ErrorMessage);
+            Assert.DoesNotContain(GetSkills(), s => s.Name == "Machine Gun Skill");
+        }
+
+        [Fact]
         public async Task AddEditSkills_EditUnknownSkill_ReturnsErrorAndPersistsNothing()
         {
             using var authClient = await SetupAuthenticatedClientAsync();

--- a/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
+++ b/Game.Application.Tests/Content/ProgressionGraphCheckerTests.cs
@@ -819,6 +819,47 @@ namespace Game.Application.Tests.Content
             Assert.DoesNotContain(findings, f => f.Check == "SkillEffectDotModifier");
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(GameConstants.MsPerTick - 1)]
+        public void Skill_CooldownBelowOneTick_IsError(int cooldownMs)
+        {
+            // The admin save rejects this, but the content seeder imports content/*.json straight into the
+            // database without passing through that guard — so this lint is the only cover on the seed path.
+            var graph = HealthyGraph() with
+            {
+                Skills = HealthyGraph().Skills.Append(Skill(6, ESkillAcquisition.Player, cooldownMs: cooldownMs)).ToList(),
+            };
+            AssertHasFinding(graph, "SkillCooldownFloor", ContentGraphSeverity.Error, "Skill", 6);
+        }
+
+        [Fact]
+        public void Skill_CooldownAtOneTick_ProducesNoFinding()
+        {
+            var graph = HealthyGraph() with
+            {
+                Skills = HealthyGraph().Skills
+                    .Append(Skill(6, ESkillAcquisition.Player, cooldownMs: GameConstants.MsPerTick))
+                    .ToList(),
+            };
+            Assert.DoesNotContain(_checker.Check(graph), f => f.Check == "SkillCooldownFloor");
+        }
+
+        [Fact]
+        public void Skill_RetiredWithSubTickCooldown_ProducesNoFinding()
+        {
+            // A retired skill is out of circulation, so it never reaches a battler — the lint checks live
+            // sources only, matching every other check in the pass.
+            var graph = HealthyGraph() with
+            {
+                Skills = HealthyGraph().Skills
+                    .Append(Skill(6, ESkillAcquisition.Player, retiredAt: Retired, cooldownMs: 0))
+                    .ToList(),
+            };
+            Assert.DoesNotContain(_checker.Check(graph), f => f.Check == "SkillCooldownFloor");
+        }
+
         // --- Skill recipes ----------------------------------------------------------------------------
 
         [Fact]
@@ -1379,7 +1420,8 @@ namespace Game.Application.Tests.Content
             EDamageType primaryType = EDamageType.Physical,
             (EAttribute attributeId, decimal multiplier)[]? damageMultipliers = null,
             (EAttribute attributeId, decimal scalingAmount)[]? effectScaling = null,
-            IReadOnlyList<Contracts.SkillEffect>? effects = null) => new()
+            IReadOnlyList<Contracts.SkillEffect>? effects = null,
+            int cooldownMs = 1000) => new()
             {
                 Id = id,
                 Name = $"Skill {id}",
@@ -1399,7 +1441,7 @@ namespace Game.Application.Tests.Content
                 .ToList(),
                 DamagePortions = [new Contracts.SkillDamagePortion { Type = primaryType, Weight = 1 }],
                 Description = "",
-                CooldownMs = 1000,
+                CooldownMs = cooldownMs,
                 IconPath = "",
                 RarityId = ERarity.Common,
                 Word = "",

--- a/Game.Application.Tests/DataAccess/AdminSkillsIntegrationTests.cs
+++ b/Game.Application.Tests/DataAccess/AdminSkillsIntegrationTests.cs
@@ -551,7 +551,150 @@ namespace Game.Application.Tests.DataAccess
             Assert.Equal("0 is not a valid skill rarity.", result.ErrorMessage);
         }
 
-        private static Contracts.Skill NewSkill(string name, ERarity rarity, int id = 0)
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(GameConstants.MsPerTick - 1)]
+        [InlineData(-1)]
+        public async Task SaveSkills_SubTickCooldown_ReturnsFailureWithoutPersisting(int cooldownMs)
+        {
+            // A sub-tick cooldown makes the engine and the combat rating disagree about the same skill, so the
+            // up-front guard rejects it. A valid sibling Add in the same batch must not persist either — the
+            // pre-pass runs before the change-set processor stages anything.
+            using (var scope = CreateScope())
+            {
+                var admin = scope.ServiceProvider.GetRequiredService<IAdminSkills>();
+
+                var result = admin.SaveSkills(
+                [
+                    new Change<Contracts.Skill>
+                    {
+                        ChangeType = EChangeType.Add,
+                        Item = NewSkill("Valid Sibling Skill", ERarity.Common),
+                    },
+                    new Change<Contracts.Skill>
+                    {
+                        ChangeType = EChangeType.Add,
+                        Item = NewSkill("Too Fast Skill", ERarity.Common, cooldownMs: cooldownMs),
+                    },
+                ]);
+
+                Assert.False(result.Succeeded);
+                Assert.Equal($"Skill cooldown must be at least {GameConstants.MsPerTick}ms.", result.ErrorMessage);
+                await scope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                Assert.False(await context.Skills.AnyAsync(s => s.Name == "Too Fast Skill", CancellationToken));
+                Assert.False(await context.Skills.AnyAsync(s => s.Name == "Valid Sibling Skill", CancellationToken));
+            }
+        }
+
+        [Fact]
+        public async Task SaveSkills_EditToSubTickCooldown_IsRejectedAndLeavesTheSkillIntact()
+        {
+            // The Edit path is the one that could actually persist a bad value: EF tracks an edited entity as
+            // Modified and writes every property through, so without the guard this payload would durably
+            // overwrite a healthy cooldown.
+            int skillId;
+            using (var addScope = CreateScope())
+            {
+                var admin = addScope.ServiceProvider.GetRequiredService<IAdminSkills>();
+                Assert.True(admin.SaveSkills(
+                [
+                    new Change<Contracts.Skill>
+                    {
+                        ChangeType = EChangeType.Add,
+                        Item = NewSkill("Editable Cooldown Skill", ERarity.Common, cooldownMs: 1500),
+                    },
+                ]).Succeeded);
+                await addScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var idScope = CreateScope())
+            {
+                var context = idScope.ServiceProvider.GetRequiredService<GameContext>();
+                skillId = (await context.Skills.SingleAsync(s => s.Name == "Editable Cooldown Skill", CancellationToken)).Id;
+            }
+            await ReloadReferenceCachesAsync();
+
+            using (var editScope = CreateScope())
+            {
+                var admin = editScope.ServiceProvider.GetRequiredService<IAdminSkills>();
+                var result = admin.SaveSkills(
+                [
+                    new Change<Contracts.Skill>
+                    {
+                        ChangeType = EChangeType.Edit,
+                        Item = NewSkill("Editable Cooldown Skill", ERarity.Common, id: skillId, cooldownMs: 0),
+                    },
+                ]);
+
+                Assert.False(result.Succeeded);
+                Assert.Equal($"Skill cooldown must be at least {GameConstants.MsPerTick}ms.", result.ErrorMessage);
+                await editScope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var skill = await context.Skills.SingleAsync(s => s.Id == skillId, CancellationToken);
+                Assert.Equal(1500, skill.CooldownMs);
+            }
+        }
+
+        [Fact]
+        public void SaveSkills_DeleteCarryingASubTickCooldown_ReportsTheUnsupportedDelete()
+        {
+            // The cooldown pre-pass skips deletes so the more accurate rejection wins: skills are a retire-only
+            // set, and the delete would never have written the payload's cooldown anyway.
+            using var scope = CreateScope();
+            var admin = scope.ServiceProvider.GetRequiredService<IAdminSkills>();
+
+            var result = admin.SaveSkills(
+            [
+                new Change<Contracts.Skill>
+                {
+                    ChangeType = EChangeType.Delete,
+                    Item = NewSkill("Doomed Skill", ERarity.Common, id: 0, cooldownMs: 0),
+                },
+            ]);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("Delete is not supported for Skill: reference records are retired, not deleted.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SaveSkills_CooldownAtTheFloor_PersistsAndSurvivesACacheReload()
+        {
+            // The boundary is inclusive: exactly one tick is the fastest legal skill, and it must round-trip
+            // through the reference cache rebuild every admin write triggers.
+            using (var scope = CreateScope())
+            {
+                var admin = scope.ServiceProvider.GetRequiredService<IAdminSkills>();
+                Assert.True(admin.SaveSkills(
+                [
+                    new Change<Contracts.Skill>
+                    {
+                        ChangeType = EChangeType.Add,
+                        Item = NewSkill("Floor Cooldown Skill", ERarity.Common, cooldownMs: GameConstants.MsPerTick),
+                    },
+                ]).Succeeded);
+                await scope.ServiceProvider.GetRequiredService<IUnitOfWork>().CommitAsync();
+            }
+            await ReloadReferenceCachesAsync();
+
+            using (var assertScope = CreateScope())
+            {
+                var context = assertScope.ServiceProvider.GetRequiredService<GameContext>();
+                var skill = await context.Skills.SingleAsync(s => s.Name == "Floor Cooldown Skill", CancellationToken);
+                Assert.Equal(GameConstants.MsPerTick, skill.CooldownMs);
+            }
+        }
+
+        private static Contracts.Skill NewSkill(string name, ERarity rarity, int id = 0, int cooldownMs = 1000)
         {
             return new Contracts.Skill
             {
@@ -560,7 +703,7 @@ namespace Game.Application.Tests.DataAccess
                 BaseDamage = 5m,
                 Description = "",
                 DesignerNotes = "",
-                CooldownMs = 1000,
+                CooldownMs = cooldownMs,
                 IconPath = "",
                 Word = "",
                 Pronunciation = "",

--- a/Game.Application/Content/ProgressionGraphChecker.cs
+++ b/Game.Application/Content/ProgressionGraphChecker.cs
@@ -86,7 +86,7 @@ namespace Game.Application.Content
                 CheckItems();
                 CheckItemMods();
                 CheckProficiencies();
-                CheckSkillEffects();
+                CheckSkills();
                 CheckSkillRecipes();
                 CheckOrphanSkills();
                 CheckRecipeInputOwnability();
@@ -661,20 +661,32 @@ namespace Game.Application.Content
                 }
             }
 
-            // --- Skill effects (DoT-accumulator modifier shape) -------------------------------------------
+            // --- Skills (cooldown floor, DoT-accumulator effect modifier shape) ---------------------------
 
             /// <summary>
-            /// A DoT-accumulator effect's magnitude is frozen with the caster's typed amplification at apply
-            /// time (spike #1320 Area C, <see cref="BattleContext.ApplySkillEffect"/>). That's correct for an
-            /// Additive effect, but a Multiplicative one would compound the amplification a second time when
-            /// it folds into the stack (#2169). The admin save path already rejects this combination
-            /// (<c>AdminSkills.SetEffects</c>), so this is a defense-in-depth backstop rather than a reachable
-            /// gap — matching the same-path-prerequisite pattern.
+            /// Two authored-shape checks over a live skill.
+            /// <para><b>Cooldown floor.</b> A sub-tick cooldown makes the battle engine and the combat rating
+            /// disagree about the same skill (see <see cref="SkillCooldownRules.MinSkillCooldownMs"/>).
+            /// <c>AdminSkills.SaveSkills</c> rejects it, but the content seeder imports
+            /// <c>content/*.json</c> straight into the database without passing through that guard, so this
+            /// check — which runs over the committed export in CI — is the only cover on that path.</para>
+            /// <para><b>Effect modifier shape.</b> A DoT-accumulator effect's magnitude is frozen with the
+            /// caster's typed amplification at apply time (spike #1320 Area C,
+            /// <see cref="BattleContext.ApplySkillEffect"/>). That's correct for an Additive effect, but a
+            /// Multiplicative one would compound the amplification a second time when it folds into the stack
+            /// (#2169). The admin save path already rejects this combination (<c>AdminSkills.SetEffects</c>),
+            /// so this half is a defense-in-depth backstop — matching the same-path-prerequisite pattern.</para>
             /// </summary>
-            private void CheckSkillEffects()
+            private void CheckSkills()
             {
                 foreach (var skill in Live(_graph.Skills, s => s.RetiredAt))
                 {
+                    if (!SkillCooldownRules.IsValidCooldown(skill.CooldownMs))
+                    {
+                        Error("SkillCooldownFloor", "Skill", skill.Id,
+                            $"has a cooldown of {skill.CooldownMs}ms, below the {SkillCooldownRules.MinSkillCooldownMs}ms one-tick floor — the engine cannot fire it that fast, but the combat rating prices it as if it could.");
+                    }
+
                     foreach (var effect in skill.Effects)
                     {
                         if (effect.ModifierTypeId == EModifierType.Multiplicative

--- a/Game.Core.Tests/Skills/SkillCooldownRulesTests.cs
+++ b/Game.Core.Tests/Skills/SkillCooldownRulesTests.cs
@@ -1,0 +1,42 @@
+using Game.Core;
+using Game.Core.Skills;
+using Xunit;
+
+namespace Game.Core.Tests.Skills
+{
+    /// <summary>
+    /// The authoring floor on <see cref="Skill.CooldownMs"/>. The rule is a pure predicate so the admin save
+    /// guard, the content-health lint, and the Workbench all price the boundary identically.
+    /// </summary>
+    public class SkillCooldownRulesTests
+    {
+        [Fact]
+        public void MinSkillCooldownMs_IsOneSimulationTick()
+        {
+            // The floor is the tick, not an arbitrary constant: the engine charges by MsPerTick and resets on
+            // fire, so it can never fire a skill faster than once per tick, while CombatRating divides by the
+            // authored cooldown. Anything below a tick makes the two disagree.
+            Assert.Equal(GameConstants.MsPerTick, SkillCooldownRules.MinSkillCooldownMs);
+        }
+
+        [Theory]
+        [InlineData(GameConstants.MsPerTick)]
+        [InlineData(GameConstants.MsPerTick + 1)]
+        [InlineData(1000)]
+        [InlineData(int.MaxValue)]
+        public void IsValidCooldown_AtOrAboveTheFloor_IsValid(int cooldownMs)
+        {
+            Assert.True(SkillCooldownRules.IsValidCooldown(cooldownMs));
+        }
+
+        [Theory]
+        [InlineData(GameConstants.MsPerTick - 1)]
+        [InlineData(1)]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void IsValidCooldown_BelowTheFloor_IsInvalid(int cooldownMs)
+        {
+            Assert.False(SkillCooldownRules.IsValidCooldown(cooldownMs));
+        }
+    }
+}

--- a/Game.Core/Battle/CombatRating.cs
+++ b/Game.Core/Battle/CombatRating.cs
@@ -203,8 +203,9 @@ namespace Game.Core.Battle
                 var effectiveCooldownSec = skill.CooldownMs / effectiveCaster.GetCooldownMultiplier() / 1000.0;
                 if (effectiveCooldownSec <= 0)
                 {
-                    // Degenerate guard: unreachable through authored content (CooldownRecovery's static base
-                    // alone is already 1), but a debuffed-to-zero-or-below multiplier must not divide by zero.
+                    // Degenerate guard: unreachable through authored content (an authored cooldown is at least
+                    // one tick — SkillCooldownRules — and CooldownRecovery's static base alone is already 1),
+                    // but a debuffed-to-zero-or-below multiplier must not divide by zero.
                     continue;
                 }
 

--- a/Game.Core/Skills/SkillCooldownRules.cs
+++ b/Game.Core/Skills/SkillCooldownRules.cs
@@ -1,0 +1,28 @@
+namespace Game.Core.Skills
+{
+    /// <summary>
+    /// The authoring rules for <see cref="Skill.CooldownMs"/>, kept as pure predicates so the admin save
+    /// guard, the content-health lint, and the Workbench all apply one definition instead of restating the
+    /// comparison. Marked <see cref="ClientMirroredAttribute"/> so <see cref="MinSkillCooldownMs"/> is
+    /// emitted into <c>game-constants.ts</c> for the Workbench to read (the
+    /// <see cref="ContentFieldLengths"/> convention: a hand-copied bound is what drifts).
+    /// </summary>
+    [ClientMirrored]
+    public static class SkillCooldownRules
+    {
+        /// <summary>
+        /// The shortest authorable cooldown: one simulation tick. Below this the two consumers of
+        /// <see cref="Skill.CooldownMs"/> stop agreeing, in both directions. The engine charges by
+        /// <see cref="GameConstants.MsPerTick"/> per tick and resets on fire
+        /// (<see cref="Battle.BattleSkill.Update"/>), so it can never fire faster than once per tick — while
+        /// <see cref="Battle.CombatRating"/> prices offense as <c>hit ÷ authoredCooldown</c>, which a sub-tick
+        /// cooldown inflates without bound. At exactly <c>0</c> the divergence flips: the rating's
+        /// divide-by-zero guard skips the skill entirely, pricing the engine's strongest possible skill as
+        /// zero offense.
+        /// </summary>
+        public const int MinSkillCooldownMs = GameConstants.MsPerTick;
+
+        /// <summary>Whether an authored cooldown is at or above <see cref="MinSkillCooldownMs"/>.</summary>
+        public static bool IsValidCooldown(int cooldownMs) => cooldownMs >= MinSkillCooldownMs;
+    }
+}

--- a/Game.DataAccess/Repositories/Admin/AdminSkills.cs
+++ b/Game.DataAccess/Repositories/Admin/AdminSkills.cs
@@ -2,6 +2,7 @@ using Game.Abstractions.Contracts.Admin;
 using Game.Abstractions.DataAccess.Admin;
 using Game.Core;
 using Game.Core.Attributes;
+using Game.Core.Skills;
 using Contracts = Game.Abstractions.Contracts;
 using Entities = Game.Infrastructure.Entities;
 
@@ -26,6 +27,11 @@ namespace Game.DataAccess.Repositories.Admin
                 return rejection;
             }
 
+            if (FindSubTickCooldown(changes) is { } cooldownRejection)
+            {
+                return cooldownRejection;
+            }
+
             return ChangeSetProcessor.Apply(changes,
                 add: item => _entityStore.Insert(ToEntity(item)),
                 edit: item =>
@@ -40,6 +46,34 @@ namespace Game.DataAccess.Repositories.Admin
                 // An edit must target an existing skill; a missing id is a not-found rejection (matching the
                 // relationship setters), validated up front by the processor before anything is staged.
                 editExists: item => _skills.LookupSkill(item.Id) is not null);
+        }
+
+        /// <summary>
+        /// Returns a rejection for the first added/edited skill whose cooldown is below
+        /// <see cref="SkillCooldownRules.MinSkillCooldownMs"/>, or <c>null</c> when every change is in range.
+        /// A sub-tick cooldown is not merely extreme — it makes the battle engine and the combat rating
+        /// disagree about the same skill (see <see cref="SkillCooldownRules.MinSkillCooldownMs"/>), so it is
+        /// rejected here rather than persisted and paid for at runtime. Deletes are skipped so a delete
+        /// (unsupported for this retire-only set) still reports that, rather than being masked by a cooldown
+        /// complaint about a value the change would never have written.
+        /// </summary>
+        private static AdminSaveResult? FindSubTickCooldown(IReadOnlyList<Change<Contracts.Skill>> changes)
+        {
+            foreach (var change in changes)
+            {
+                if (change.ChangeType == EChangeType.Delete)
+                {
+                    continue;
+                }
+
+                if (!SkillCooldownRules.IsValidCooldown(change.Item.CooldownMs))
+                {
+                    return AdminSaveResult.Failure(
+                        $"Skill cooldown must be at least {SkillCooldownRules.MinSkillCooldownMs}ms.");
+                }
+            }
+
+            return null;
         }
 
         private static Entities.Skill ToEntity(Contracts.Skill item)

--- a/UI/src/lib/api/types/game-constants.ts
+++ b/UI/src/lib/api/types/game-constants.ts
@@ -52,3 +52,4 @@ export const MS_PER_TICK = 40;
 export const PUNCH_SKILL_ID = 0;
 export const STAT_POINTS_PER_LEVEL = 2;
 export const TOUGHNESS_MITIGATION_CONSTANT = 200;
+export const MIN_SKILL_COOLDOWN_MS = 40;

--- a/UI/src/routes/admin/workbench/entities/skill.ts
+++ b/UI/src/routes/admin/workbench/entities/skill.ts
@@ -9,6 +9,7 @@ import {
 	fetchSocketData,
 	type ISkill
 } from '$lib/api';
+import { MIN_SKILL_COOLDOWN_MS } from '$lib/api/types/game-constants';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import {
@@ -70,6 +71,13 @@ export const skillEntity: EntityConfig<ISkill> = {
 			glyph: 'tag',
 			desc: 'Name, damage, cooldown & description',
 			kind: 'fields',
+			// A cooldown below one simulation tick makes the engine and the combat rating disagree about the
+			// skill (the engine can't fire faster than a tick; the rating prices the authored value, and at 0
+			// skips the skill as zero offense). Hard-rejected by AdminSkills.SaveSkills, so it blocks Save.
+			warn: (s) =>
+				s.cooldownMs < MIN_SKILL_COOLDOWN_MS
+					? { message: `Cooldown must be at least ${MIN_SKILL_COOLDOWN_MS}ms`, blocking: true }
+					: null,
 			fields: [
 				{
 					key: 'name',

--- a/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
@@ -11,6 +11,7 @@ import {
 } from '$lib/api';
 import type { TableSectionConfig } from '$routes/admin/workbench/entities/types';
 import { makeSkill } from '../../../../fixtures/skills';
+import { MIN_SKILL_COOLDOWN_MS } from '$lib/api/types/game-constants';
 
 /* Skill config transforms: `newItem` defaults, the derived meta line, the effects
    `newRow` defaults, and the persist path — a child-only change (effects or
@@ -303,6 +304,30 @@ describe('skillEntity', () => {
 		expect(postBodyTo('AdminTools/SetSkillEffects')).toMatchObject({
 			id: 7,
 			changes: [{ changeType: EChangeType.Add, item: { id: 0, target: ESkillEffectTarget.Opponent } }]
+		});
+	});
+
+	describe('identity section warn (cooldown floor, #2519)', () => {
+		const identityWarn = skillEntity.sections.find((s) => s.key === 'identity')?.warn;
+
+		it.each([0, 1, MIN_SKILL_COOLDOWN_MS - 1, -1])(
+			'blocks Save for a cooldown of %ims, below the one-tick floor (backend-enforced)',
+			(cooldownMs) => {
+				const s = { ...skillEntity.newItem(1), cooldownMs };
+				expect(identityWarn?.(s)).toEqual({
+					message: `Cooldown must be at least ${MIN_SKILL_COOLDOWN_MS}ms`,
+					blocking: true
+				});
+			}
+		);
+
+		it('passes at exactly the one-tick floor', () => {
+			const s = { ...skillEntity.newItem(1), cooldownMs: MIN_SKILL_COOLDOWN_MS };
+			expect(identityWarn?.(s)).toBeNull();
+		});
+
+		it('passes for a new skill, whose default cooldown is well above the floor', () => {
+			expect(identityWarn?.(skillEntity.newItem(1))).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
Closes #2519.

I verified the issue's claims against the code rather than taking them as given. Both hold — and measuring them turned up a case the issue's suggested fix would have missed, which changed the floor.

## The measurement

I probed `CombatRating.Rate` and the engine's fire count directly (throwaway test, removed before commit):

| authored cooldown | engine fires per 1000 ms | `CombatRating` |
|---|---|---|
| **0** | **25** (every tick) | **0.01** — skill skipped entirely |
| **1** | 25 (identical) | **894.43** |
| 39 | 25 (identical) | 143.22 |
| 40 | 25 | 141.42 |
| 1000 | 1 | 28.28 |

Row 1 is the issue: the strongest thing the engine can produce, priced as zero offense, so it mints no XP bounty and (player-side) shrinks nothing via the difficulty ratio.

Row 2 is why **the issue's suggested `CooldownMs < 1` floor is not enough**. A 1 ms skill fires exactly as often as a 40 ms one — the engine charges by `MsPerTick` and resets on fire, so it physically cannot fire faster than once per tick — but the rating divides by the authored value and prices it 6.3× higher. That is the same engine/rating disagreement in the opposite direction, and it survives a `>= 1` floor untouched.

So the floor is **one simulation tick**, not 1. At exactly `MsPerTick` the two agree, which is what makes it the right boundary rather than an arbitrary one.

## Changes

**`Game.Core/Skills/SkillCooldownRules.cs` (new)** — `MinSkillCooldownMs = GameConstants.MsPerTick` plus the predicate, so the admin guard, the lint, and the Workbench share one definition instead of three restatements of `>=`. `[ClientMirrored]`, so the bound reaches the Workbench as a generated constant rather than a hand-copied literal — the `ContentFieldLengths` convention from `docs/frontend-admin.md`. The only generated-file change is the one new constant.

**`AdminSkills.SaveSkills`** rejects it in the up-front pre-pass via `AdminSaveResult.Failure`, before the change-set processor stages anything — the graceful-rejection convention in `docs/backend-admin.md`, and the same shape as the sibling `SetPortions` weight guard a few lines below. Deletes are skipped deliberately: skills are a retire-only set, so a delete already has a more accurate rejection, and masking it with a complaint about a cooldown the change would never have written would be worse. There's a test pinning that precedence.

**`ProgressionGraphChecker` gains a `SkillCooldownFloor` error.** This is not just defense-in-depth like its `SkillEffectDotModifier` neighbour — it's the only cover on a real second path. The content seeder is *"a dedicated bulk seeder, not a replay through the admin repos"* (`docs/backend-content.md`), writing `content/*.json` straight to the database, so a bad cooldown committed to the export would never meet the admin guard. `ContentGraphLintTests` runs the checker over the committed export in CI, which closes that. `CheckSkillEffects` became `CheckSkills` and now hosts both checks on one pass over live skills rather than opening a second identical loop.

**The `CombatRating` guard comment is now true.** It claimed the degenerate case was "unreachable through authored content", which was false; it now names the authoring floor as the reason, and keeps the real reason the guard stays (a debuffed-to-negative cooldown multiplier, which is still reachable).

**Workbench** blocks Save on the same rule, on the identity section.

## Verified, not assumed

I disabled each guard and re-ran rather than trusting the tests to be load-bearing: with the admin pre-pass off, 5 of the new integration assertions fail; with the lint check off, 3 checker tests fail. Both restored, and the final runs below are from the restored code.

## Test plan

Mirrored across both stacks, same scenarios and expected messages:

- **`Game.Core.Tests/Skills/SkillCooldownRulesTests.cs`** — the predicate, the boundary (`MsPerTick` accepted, `MsPerTick - 1` rejected), and that the constant *is* the tick rather than a coincidentally-equal literal.
- **`AdminSkillsIntegrationTests`** — a `[Theory]` over 0/1/39/-1; rejection before staging (a valid sibling Add in the same batch persists nothing); the Edit path specifically (EF writes every property through on a `Modified` entity, so that's the one that could durably overwrite a healthy cooldown); delete-precedence; and an at-floor save that survives a real cache reload.
- **`AdminToolsControllerTests`** — end-to-end 400 + `AdminSaveResult` message mapping.
- **`ProgressionGraphCheckerTests`** — the three sub-tick cases, the at-floor negative, and a retired skill producing no finding (live-sources-only, matching every other check in the pass).
- **`skill.test.ts`** — the same rejection cases, the boundary, and that a new skill's default is clear of it.

- ✅ `dotnet build Game.sln -warnaserror` — 0 warnings, 0 errors.
- ✅ `dotnet test Game.sln` — **3,681 passed, 0 failed** (1510 Core, 1202 Application, 894 Api, 75 Infrastructure).
- ✅ `dotnet format --verify-no-changes --no-restore` — clean.
- ✅ Codegen — only the intended `MIN_SKILL_COOLDOWN_MS` addition, no other drift.
- ✅ `npm run lint` (eslint + `svelte-check`) — 1232 files, 0 errors, 0 warnings.
- ✅ `npm run test:unit:ci` — **4,065 passed, 0 failed** (313 files).

No battle-logic surface is touched, so the mirrored FE/BE battle-scenario rule doesn't apply; the authoring rule is nonetheless mirrored across both suites as described.

## Notes for review

**No docs change.** This adds a guard that conforms to the already-documented admin-save and content-lint conventions rather than establishing new architecture, and the lint's Error examples in `docs/backend-content.md` are already illustrative rather than exhaustive (they omit `ZoneLevelRange` and `SkillEffectDotModifier` too). Happy to add a line if you'd rather that list be complete.

**Follow-up filed: #2536.** The engine discards charge overflow on fire (`ChargeTime = 0.0`), so it quantizes every cooldown up to a tick multiple while `CombatRating` prices the raw authored value. Seeded content already has one instance — `Cleave` is authored at 1500 ms and actually fires every 1520 ms. Same engine-vs-rating family as this issue but a separate mechanism, and a floor doesn't address it, so it's its own issue rather than scope creep here.

**Not filed, because I checked and it's fine:** the entity configs hard-code `maxLength: 50` rather than importing the mirrored constants, which looks like a violation of the `docs/frontend-admin.md` rule — but `field-lengths.test.ts` cross-checks every one of those literals against `ContentFieldLengths` in CI, which is exactly what that doc describes. No drift risk, nothing to fix.

**Adjacent, deliberately untouched:** #2533 (open) applies the same missing-numeric-validation pattern to zone levels. The two don't overlap in files. If both land, consolidating the numeric authoring pre-passes into a shared helper alongside `ReferenceFieldValidation` would be a reasonable cleanup — I left it alone rather than building against an unmerged branch.