### PR TITLE
Block Multiplicative DoT-accumulator skill effects in the Workbench (#2520)

### DIFF
--- a/Game.Core/Battle/BattleContext.cs
+++ b/Game.Core/Battle/BattleContext.cs
@@ -72,8 +72,9 @@ namespace Game.Core.Battle
         /// accumulated DoT carries the caster's amplification while the defender's resistance is sampled live
         /// each tick by <see cref="Battler.ApplyDamageOverTime"/>. That freeze reads as a per-second rate only
         /// for an <see cref="EModifierType.Additive"/> effect, which is why a Multiplicative DoT-accumulator
-        /// effect is unauthorable (#2169: <c>AdminSkills.SetEffects</c>, the <c>SkillEffectDotModifier</c> lint
-        /// and the Workbench's blocking warn) rather than special-cased here.
+        /// effect is unauthorable for a live skill (#2169: <c>AdminSkills.SetEffects</c>, the
+        /// <c>SkillEffectDotModifier</c> lint and the Workbench's blocking warn) rather than special-cased
+        /// here. The lint's retired-skill gap is tracked with #2537.
         /// </summary>
         public void ApplySkillEffect(SkillEffect effect)
         {

--- a/Game.Core/Battle/BattleContext.cs
+++ b/Game.Core/Battle/BattleContext.cs
@@ -70,7 +70,10 @@ namespace Game.Core.Battle
         /// per-second accumulator, the caster's typed amplification is then <b>frozen</b> into the magnitude at
         /// apply time (spike #1320, Area C) — consistent with how the caster scaling already freezes — so the
         /// accumulated DoT carries the caster's amplification while the defender's resistance is sampled live
-        /// each tick by <see cref="Battler.ApplyDamageOverTime"/>.
+        /// each tick by <see cref="Battler.ApplyDamageOverTime"/>. That freeze reads as a per-second rate only
+        /// for an <see cref="EModifierType.Additive"/> effect, which is why a Multiplicative DoT-accumulator
+        /// effect is unauthorable (#2169: <c>AdminSkills.SetEffects</c>, the <c>SkillEffectDotModifier</c> lint
+        /// and the Workbench's blocking warn) rather than special-cased here.
         /// </summary>
         public void ApplySkillEffect(SkillEffect effect)
         {

--- a/Game.Core/Battle/CombatRating.cs
+++ b/Game.Core/Battle/CombatRating.cs
@@ -235,8 +235,8 @@ namespace Game.Core.Battle
                     // scaling attribute is read off the original battler, not effectiveCaster — mirroring
                     // FoldedEffectMagnitude's "the caster's ORIGINAL attribute" rule, so the two DoT-adjacent
                     // reads agree. Pricing the magnitude as a flat per-second rate needs no ModifierType check:
-                    // a Multiplicative DoT-accumulator effect is unauthorable (#2169), so every effect reaching
-                    // here is Additive.
+                    // a Multiplicative DoT-accumulator effect is unauthorable for a live skill (#2169; the
+                    // lint's retired-skill gap is tracked with #2537).
                     var magnitude = effect.Amount + battler.GetAttributeValue(effect.ScalingAttributeId) * effect.ScalingAmount;
                     var ampedMagnitude = effectiveCaster.AmplifyDamage(magnitude, dotType);
                     var durationSec = Math.Min(effect.DurationMs / 1000.0, ServerGameConstants.RefFightDuration / 2.0);

--- a/Game.Core/Battle/CombatRating.cs
+++ b/Game.Core/Battle/CombatRating.cs
@@ -234,7 +234,9 @@ namespace Game.Core.Battle
                     // reference Toughness (its real property), so no mitigation term applies here. The
                     // scaling attribute is read off the original battler, not effectiveCaster — mirroring
                     // FoldedEffectMagnitude's "the caster's ORIGINAL attribute" rule, so the two DoT-adjacent
-                    // reads agree.
+                    // reads agree. Pricing the magnitude as a flat per-second rate needs no ModifierType check:
+                    // a Multiplicative DoT-accumulator effect is unauthorable (#2169), so every effect reaching
+                    // here is Additive.
                     var magnitude = effect.Amount + battler.GetAttributeValue(effect.ScalingAttributeId) * effect.ScalingAmount;
                     var ampedMagnitude = effectiveCaster.AmplifyDamage(magnitude, dotType);
                     var durationSec = Math.Min(effect.DurationMs / 1000.0, ServerGameConstants.RefFightDuration / 2.0);

--- a/UI/src/lib/battle/skill.ts
+++ b/UI/src/lib/battle/skill.ts
@@ -84,7 +84,8 @@ export class Skill implements ISkill {
 	 *  lands on — mirroring the backend `BattleContext.ApplySkillEffect`. When the effect targets a DoT
 	 *  per-second accumulator, the caster's typed amplification is then frozen into the magnitude at apply
 	 *  time (#1320, Area C), so the accumulated DoT carries the caster's amplification while the defender's
-	 *  resistance is sampled live each tick. The optional `onApplied` callback — supplied only by the live
+	 *  resistance is sampled live each tick. That freeze assumes an Additive modifier, which authoring
+	 *  enforces (#2169) rather than the engine special-casing it here. The optional `onApplied` callback — supplied only by the live
 	 *  engine, never the headless simulator — is invoked for every application (each one stacks) with the
 	 *  battler it landed on and the resolved amount, so the combat log can announce it. */
 	public applyEffects(opponent: Battler, onApplied?: (effect: ISkillEffect, target: Battler, amount: number) => void) {

--- a/UI/src/lib/battle/skill.ts
+++ b/UI/src/lib/battle/skill.ts
@@ -85,9 +85,10 @@ export class Skill implements ISkill {
 	 *  per-second accumulator, the caster's typed amplification is then frozen into the magnitude at apply
 	 *  time (#1320, Area C), so the accumulated DoT carries the caster's amplification while the defender's
 	 *  resistance is sampled live each tick. That freeze assumes an Additive modifier, which authoring
-	 *  enforces (#2169) rather than the engine special-casing it here. The optional `onApplied` callback — supplied only by the live
-	 *  engine, never the headless simulator — is invoked for every application (each one stacks) with the
-	 *  battler it landed on and the resolved amount, so the combat log can announce it. */
+	 *  enforces for a live skill (#2169; the retired-skill lint gap is tracked with #2537) rather than the
+	 *  engine special-casing it here. The optional `onApplied` callback — supplied only by the live engine,
+	 *  never the headless simulator — is invoked for every application (each one stacks) with the battler it
+	 *  landed on and the resolved amount, so the combat log can announce it. */
 	public applyEffects(opponent: Battler, onApplied?: (effect: ISkillEffect, target: Battler, amount: number) => void) {
 		for (const effect of this.effects) {
 			const target = effect.target === ESkillEffectTarget.Self ? this.owner : opponent;

--- a/UI/src/routes/admin/workbench/entities/skill.ts
+++ b/UI/src/routes/admin/workbench/entities/skill.ts
@@ -10,6 +10,7 @@ import {
 	type ISkill
 } from '$lib/api';
 import { MIN_SKILL_COOLDOWN_MS } from '$lib/api/types/game-constants';
+import { dotTypeForAccumulator } from '$lib/battle/damage-types';
 import { staticData } from '$stores';
 import { reference } from '../reference.svelte';
 import {
@@ -237,6 +238,16 @@ export const skillEntity: EntityConfig<ISkill> = {
 			glyph: 'bolt',
 			desc: 'Timed attribute buffs/debuffs applied when the skill fires',
 			count: (s) => s.effects.length,
+			// A DoT-accumulator effect's magnitude is frozen with the caster's typed amplification at apply
+			// time (#1320 Area C), which only reads as a per-second rate when the modifier is Additive — a
+			// Multiplicative one would compound that amplification again. Hard-rejected by
+			// AdminSkills.SetEffects (#2169), so it blocks Save (#2520).
+			warn: (s) =>
+				s.effects.some(
+					(e) => e.modifierTypeId === EModifierType.Multiplicative && dotTypeForAccumulator(e.attributeId) !== undefined
+				)
+					? { message: 'A DoT-accumulator effect must be Additive', blocking: true }
+					: null,
 			kind: 'table',
 			itemsKey: 'effects',
 			rowKey: 'id',

--- a/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
@@ -340,18 +340,21 @@ describe('skillEntity', () => {
 		const withEffects = (effects: ISkill['effects']): ISkill => ({ ...skillEntity.newItem(1), effects });
 
 		// Driven off the generated accumulator table rather than an enumerated list, so a new DoT type is
-		// covered without remembering to widen this test.
-		it.each(dotAccumulators().map((a) => a.accumulator))(
-			'blocks Save for a Multiplicative effect on DoT accumulator %i (backend-enforced)',
-			(accumulator) => {
+		// covered without remembering to widen this test. The reverse-mapped enum name rides along so a
+		// failing case names the attribute rather than its raw id.
+		const accumulatorCases = dotAccumulators().map((a) => [EAttribute[a.accumulator], a.accumulator] as const);
+
+		it.each(accumulatorCases)(
+			'blocks Save for a Multiplicative effect on DoT accumulator %s (backend-enforced)',
+			(_name, accumulator) => {
 				const skill = withEffects([effect({ attributeId: accumulator, modifierTypeId: EModifierType.Multiplicative })]);
 				expect(effectsWarn?.(skill)).toEqual(blocking);
 			}
 		);
 
-		it.each(dotAccumulators().map((a) => a.accumulator))(
-			'passes for an Additive effect on DoT accumulator %i — the shape the engine and rating assume',
-			(accumulator) => {
+		it.each(accumulatorCases)(
+			'passes for an Additive effect on DoT accumulator %s — the shape the engine and rating assume',
+			(_name, accumulator) => {
 				const skill = withEffects([effect({ attributeId: accumulator, modifierTypeId: EModifierType.Additive })]);
 				expect(effectsWarn?.(skill)).toBeNull();
 			}

--- a/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
+++ b/UI/src/tests/routes/admin/workbench/entities/skill.test.ts
@@ -12,6 +12,7 @@ import {
 import type { TableSectionConfig } from '$routes/admin/workbench/entities/types';
 import { makeSkill } from '../../../../fixtures/skills';
 import { MIN_SKILL_COOLDOWN_MS } from '$lib/api/types/game-constants';
+import { dotAccumulators } from '$lib/battle/damage-types';
 
 /* Skill config transforms: `newItem` defaults, the derived meta line, the effects
    `newRow` defaults, and the persist path — a child-only change (effects or
@@ -171,6 +172,8 @@ describe('skillEntity', () => {
 		expect(multipliers.count?.(filled)).toBe(1);
 		expect(multipliers.warn?.(filled)).toBeNull();
 		expect(effects.count?.(filled)).toBe(2);
+		// Both fixture effects are Multiplicative on Toughness — not a DoT accumulator, so nothing warns.
+		expect(effects.warn?.(filled)).toBeNull();
 	});
 
 	it('portions newRow picks the first free damage type with a default weight of 1', () => {
@@ -328,6 +331,61 @@ describe('skillEntity', () => {
 
 		it('passes for a new skill, whose default cooldown is well above the floor', () => {
 			expect(identityWarn?.(skillEntity.newItem(1))).toBeNull();
+		});
+	});
+
+	describe('effects section warn (DoT-accumulator modifier shape, #2520)', () => {
+		const effectsWarn = tableSection('effects').warn;
+		const blocking = { message: 'A DoT-accumulator effect must be Additive', blocking: true };
+		const withEffects = (effects: ISkill['effects']): ISkill => ({ ...skillEntity.newItem(1), effects });
+
+		// Driven off the generated accumulator table rather than an enumerated list, so a new DoT type is
+		// covered without remembering to widen this test.
+		it.each(dotAccumulators().map((a) => a.accumulator))(
+			'blocks Save for a Multiplicative effect on DoT accumulator %i (backend-enforced)',
+			(accumulator) => {
+				const skill = withEffects([effect({ attributeId: accumulator, modifierTypeId: EModifierType.Multiplicative })]);
+				expect(effectsWarn?.(skill)).toEqual(blocking);
+			}
+		);
+
+		it.each(dotAccumulators().map((a) => a.accumulator))(
+			'passes for an Additive effect on DoT accumulator %i — the shape the engine and rating assume',
+			(accumulator) => {
+				const skill = withEffects([effect({ attributeId: accumulator, modifierTypeId: EModifierType.Additive })]);
+				expect(effectsWarn?.(skill)).toBeNull();
+			}
+		);
+
+		it('passes for a Multiplicative effect on a non-accumulator attribute', () => {
+			const skill = withEffects([
+				effect({ attributeId: EAttribute.Toughness, modifierTypeId: EModifierType.Multiplicative })
+			]);
+			expect(effectsWarn?.(skill)).toBeNull();
+		});
+
+		it('flags the skill when only one of several effects carries the bad shape', () => {
+			const skill = withEffects([
+				effect({ id: 1, attributeId: EAttribute.Toughness, modifierTypeId: EModifierType.Multiplicative }),
+				effect({ id: 2, attributeId: EAttribute.BleedDamagePerSecond, modifierTypeId: EModifierType.Additive }),
+				effect({ id: 3, attributeId: EAttribute.PoisonDamagePerSecond, modifierTypeId: EModifierType.Multiplicative })
+			]);
+			expect(effectsWarn?.(skill)).toEqual(blocking);
+		});
+
+		it('flags a Self-targeted effect too — the freeze is target-independent', () => {
+			const skill = withEffects([
+				effect({
+					target: ESkillEffectTarget.Self,
+					attributeId: EAttribute.BurnDamagePerSecond,
+					modifierTypeId: EModifierType.Multiplicative
+				})
+			]);
+			expect(effectsWarn?.(skill)).toEqual(blocking);
+		});
+
+		it('passes for a skill with no effects', () => {
+			expect(effectsWarn?.(skillEntity.newItem(1))).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
Closes #2520.

## Summary

The issue's suggested fix was *"admin-save validation + a Content Health lint requiring `Additive` on DoT-accumulator targets."* **Both already exist**, and both are tested — #2169 landed them before this issue was filed:

- `AdminSkills.SetEffects` rejects the combination up front (`AdminSkillsIntegrationTests.cs:390`).
- `ProgressionGraphChecker.CheckSkills` raises `SkillEffectDotModifier` over the committed content export, covering the seeder path the admin guard can't see (`ProgressionGraphCheckerTests.cs:796`).

So the issue's opening claim — *"Nothing prevents authoring a skill effect that targets a DoT accumulator with `ModifierType = Multiplicative`"* — was stale. What was genuinely missing is the **third** enforcement point the #2519 cooldown fix established: the Workbench had no client-side warn.

That gap is not cosmetic. `persistEntity` posts the identity batch, then runs each section's child saver in sequence, so a rejection from the effects saver lands *after* the primary save (and portions, and multipliers) has already committed — a `PersistFailedError` forcing a rebase. `docs/frontend-admin.md` names this exact scenario as what blocking warns are for: *"a predictable save failure never reaches the partial-failure rebase path in the first place."*

## Changes

**The fix** — `UI/src/routes/admin/workbench/entities/skill.ts`: the `effects` section gains a blocking `warn` when any effect is `Multiplicative` on a DoT accumulator. It's derived from the generated `dotTypeForAccumulator` table rather than an enumerated attribute list, so a future DoT type is covered without remembering to widen it (the same "derive, don't enumerate" argument made in #2500's comments about the watermark seed set).

**Invariant comments** — the issue's bullets 1 and 3 say `BattleContext.ApplySkillEffect` and `CombatRating.OffenseRate` "silently assume Additive" and are "wrong on both sides". With the authoring guards in place they aren't wrong, they're *constrained*: no authored effect on a live skill can reach them in the Multiplicative shape. Both sites (plus the frontend mirror `UI/src/lib/battle/skill.ts`) now record that, so the next health review doesn't re-file this. This mirrors #2519 correcting `CombatRating`'s degenerate cooldown-guard comment for the same reason. No behaviour change — I agree with the issue that teaching the engine multiplicative-DoT semantics "buys little" against a base that is almost always 0.

## Test plan

- [x] `npm run lint` (eslint + `svelte-check`) — clean, 0 errors / 0 warnings across 1232 files
- [x] `npm run test:unit:ci` — **313 files, 4075 tests passed**
- [x] `dotnet build` — succeeded, **0 warnings** (verifies the new `<see cref>` doc references resolve)
- [x] `dotnet test Game.Core.Tests` — 1510 passed

New frontend coverage in `UI/src/tests/routes/admin/workbench/entities/skill.test.ts`:

- blocks Save for a Multiplicative effect on **each** DoT accumulator (data-driven over `dotAccumulators()`)
- passes for an Additive effect on each accumulator — the shape the engine and rating assume
- passes for a Multiplicative effect on a non-accumulator attribute (`Toughness`)
- flags the skill when only one of several effects carries the bad shape
- flags a `Self`-targeted effect too, since the amplification freeze is target-independent
- passes for a skill with no effects

No new backend tests: the backend diff is comments only, and both server-side guards already have theirs.

## Note for review

Since the two server-side halves already existed, the reasonable alternative was to close #2520 as already-fixed rather than open this. I went with the Workbench third because it's the enforcement point the project's own admin doc calls for and the #2519 precedent set — but if you'd rather have had the issue simply closed, this is easy to drop.

One thing I deliberately left out of scope: `ProgressionGraphChecker.CheckSkills` iterates `Live(...)`, so a **retired** skill's effects are never linted, while a retired skill stays resolvable by id and still fires for a player who already has it selected. That's the same pattern as the open #2537 (zone lint skips retired zones but the zone cache maps them), so it belongs with that issue's resolution rather than being fixed piecemeal here. The invariant comments above are scoped to live skills and point at #2537 accordingly.